### PR TITLE
feat: Phase 0 server-side tool optimizations from the #1813 audit

### DIFF
--- a/src/ha_mcp/client/rest_client.py
+++ b/src/ha_mcp/client/rest_client.py
@@ -1642,9 +1642,17 @@ class HomeAssistantClient:
             )
         return bare_id
 
-    async def get_scene_config(self, scene_id: str) -> dict[str, Any]:
-        """Get Home Assistant scene configuration by scene_id."""
-        resolved_id = await self.resolve_scene_id(scene_id)
+    async def get_scene_config(
+        self, scene_id: str, *, _resolved: bool = False
+    ) -> dict[str, Any]:
+        """Get Home Assistant scene configuration by scene_id.
+
+        ``_resolved=True`` signals ``scene_id`` is already the resolved storage
+        key (the caller ran :meth:`resolve_scene_id`), skipping the redundant
+        registry lookup. ``resolve_scene_id`` is idempotent, so the result is
+        identical either way.
+        """
+        resolved_id = scene_id if _resolved else await self.resolve_scene_id(scene_id)
         try:
             endpoint = f"config/scene/config/{resolved_id}"
             response = await self._request("GET", endpoint)
@@ -1662,10 +1670,15 @@ class HomeAssistantClient:
             raise
 
     async def upsert_scene_config(
-        self, config: dict[str, Any], scene_id: str
+        self, config: dict[str, Any], scene_id: str, *, _resolved: bool = False
     ) -> dict[str, Any]:
-        """Create or update Home Assistant scene configuration."""
-        resolved_id = await self.resolve_scene_id(scene_id)
+        """Create or update Home Assistant scene configuration.
+
+        ``_resolved=True`` signals ``scene_id`` is already the resolved storage
+        key, skipping the redundant registry lookup (``resolve_scene_id`` is
+        idempotent, so the endpoint id is unchanged).
+        """
+        resolved_id = scene_id if _resolved else await self.resolve_scene_id(scene_id)
         try:
             endpoint = f"config/scene/config/{resolved_id}"
 
@@ -1699,9 +1712,16 @@ class HomeAssistantClient:
             logger.error(f"Failed to upsert scene config for {scene_id}: {e}")
             raise
 
-    async def delete_scene_config(self, scene_id: str) -> dict[str, Any]:
-        """Delete Home Assistant scene configuration."""
-        resolved_id = await self.resolve_scene_id(scene_id)
+    async def delete_scene_config(
+        self, scene_id: str, *, _resolved: bool = False
+    ) -> dict[str, Any]:
+        """Delete Home Assistant scene configuration.
+
+        ``_resolved=True`` signals ``scene_id`` is already the resolved storage
+        key, skipping the redundant registry lookup (``resolve_scene_id`` is
+        idempotent, so the endpoint id is unchanged).
+        """
+        resolved_id = scene_id if _resolved else await self.resolve_scene_id(scene_id)
         try:
             endpoint = f"config/scene/config/{resolved_id}"
             response = await self._request("DELETE", endpoint)

--- a/src/ha_mcp/client/rest_client.py
+++ b/src/ha_mcp/client/rest_client.py
@@ -1388,8 +1388,12 @@ class HomeAssistantClient:
         for attempt in range(max_retries):
             try:
                 # Use per-client WebSocket keyed to this client's credentials
+                # (verify_ssl included so a verify_ssl=False client never
+                # shares a default-verification pooled connection).
                 ws_client = await get_websocket_client(
-                    url=self.base_url, token=self.token
+                    url=self.base_url,
+                    token=self.token,
+                    verify_ssl=self.verify_ssl,
                 )
 
                 # Special handling for render_template which returns an event with the actual result

--- a/src/ha_mcp/client/websocket_client.py
+++ b/src/ha_mcp/client/websocket_client.py
@@ -1037,7 +1037,7 @@ class WebSocketManager:
     _current_loop: asyncio.AbstractEventLoop | None = None
     _lock: asyncio.Lock | None = None
     _lock_loop: asyncio.AbstractEventLoop | None = None
-    _client_factory: Callable[[str, str], HomeAssistantWebSocketClient] | None = None
+    _client_factory: Callable[..., HomeAssistantWebSocketClient] | None = None
 
     def __new__(cls) -> "WebSocketManager":
         if cls._instance is None:
@@ -1052,8 +1052,7 @@ class WebSocketManager:
     def configure(
         self,
         *,
-        client_factory: Callable[[str, str], HomeAssistantWebSocketClient]
-        | None = None,
+        client_factory: Callable[..., HomeAssistantWebSocketClient] | None = None,
     ) -> None:
         """Configure the manager with injectable dependencies."""
         if client_factory is not None:
@@ -1088,6 +1087,7 @@ class WebSocketManager:
         self,
         url: str | None = None,
         token: str | None = None,
+        verify_ssl: bool | None = None,
     ) -> HomeAssistantWebSocketClient:
         """Get WebSocket client, creating connection if needed.
 
@@ -1100,6 +1100,10 @@ class WebSocketManager:
                  credentials instead of global settings. This is required
                  for OAuth mode where each request has its own credentials.
             token: Optional HA token. Must be provided with url.
+            verify_ssl: TLS verification override, keyed into the pool so a
+                 ``HomeAssistantClient(verify_ssl=False)`` caller never shares
+                 a connection built with default verification. ``None`` keeps
+                 the client's own settings-based default.
         """
         current_loop = asyncio.get_event_loop()
 
@@ -1135,6 +1139,8 @@ class WebSocketManager:
                 ws_token = settings.homeassistant_token
 
             key = self._client_key(ws_url, ws_token)
+            if verify_ssl is not None:
+                key = f"{key}|verify_ssl={verify_ssl}"
 
             # Return existing connected client for these credentials
             existing = self._clients.get(key)
@@ -1148,7 +1154,11 @@ class WebSocketManager:
                 self._last_used.pop(key, None)
 
             factory = self._client_factory or HomeAssistantWebSocketClient
-            client = factory(ws_url, ws_token)
+            client = (
+                factory(ws_url, ws_token)
+                if verify_ssl is None
+                else factory(ws_url, ws_token, verify_ssl=verify_ssl)
+            )
 
             connected = await client.connect()
             if not connected:
@@ -1210,11 +1220,16 @@ websocket_manager = WebSocketManager()
 async def get_websocket_client(
     url: str | None = None,
     token: str | None = None,
+    verify_ssl: bool | None = None,
 ) -> HomeAssistantWebSocketClient:
     """Get the global WebSocket client instance.
 
     Args:
         url: Optional HA URL for per-client credentials (OAuth mode).
         token: Optional HA token for per-client credentials (OAuth mode).
+        verify_ssl: Optional TLS-verification override propagated into the
+            pool key and client construction (None = settings default).
     """
-    return await websocket_manager.get_client(url=url, token=token)
+    return await websocket_manager.get_client(
+        url=url, token=token, verify_ssl=verify_ssl
+    )

--- a/src/ha_mcp/smoke_test.py
+++ b/src/ha_mcp/smoke_test.py
@@ -8,8 +8,8 @@ from typing import Any
 
 # Force UTF-8 encoding on Windows for Unicode output
 if sys.platform == "win32":
-    sys.stdout.reconfigure(encoding="utf-8", errors="replace")
-    sys.stderr.reconfigure(encoding="utf-8", errors="replace")
+    sys.stdout.reconfigure(encoding="utf-8", errors="replace")  # type: ignore[union-attr,unused-ignore]
+    sys.stderr.reconfigure(encoding="utf-8", errors="replace")  # type: ignore[union-attr,unused-ignore]
 
 # Set dummy credentials before any imports try to use them
 os.environ.setdefault("HOMEASSISTANT_URL", "http://smoke-test:8123")

--- a/src/ha_mcp/stdio_settings_sidecar.py
+++ b/src/ha_mcp/stdio_settings_sidecar.py
@@ -125,7 +125,7 @@ def _pid_alive(pid: int) -> bool:
         # ctypes.windll.kernel32 (no external deps).
         import ctypes
 
-        kernel32 = ctypes.windll.kernel32  # type: ignore[attr-defined]
+        kernel32 = ctypes.windll.kernel32  # type: ignore[attr-defined,unused-ignore]
         SYNCHRONIZE = 0x00100000
         handle = kernel32.OpenProcess(SYNCHRONIZE, False, pid)
         if not handle:
@@ -394,13 +394,13 @@ def _do_spawn() -> None:
         # mode the user saw.
         pythonw = Path(sys.executable).with_name("pythonw.exe")
         cmd_python = str(pythonw) if pythonw.exists() else sys.executable
-        startupinfo = subprocess.STARTUPINFO()  # type: ignore[attr-defined]
-        startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW  # type: ignore[attr-defined]
-        startupinfo.wShowWindow = subprocess.SW_HIDE  # type: ignore[attr-defined]
+        startupinfo = subprocess.STARTUPINFO()  # type: ignore[attr-defined,unused-ignore]
+        startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW  # type: ignore[attr-defined,unused-ignore]
+        startupinfo.wShowWindow = subprocess.SW_HIDE  # type: ignore[attr-defined,unused-ignore]
         popen_kwargs["startupinfo"] = startupinfo
         popen_kwargs["creationflags"] = (
-            subprocess.CREATE_NEW_PROCESS_GROUP  # type: ignore[attr-defined]
-            | subprocess.CREATE_NO_WINDOW  # type: ignore[attr-defined]
+            subprocess.CREATE_NEW_PROCESS_GROUP  # type: ignore[attr-defined,unused-ignore]
+            | subprocess.CREATE_NO_WINDOW  # type: ignore[attr-defined,unused-ignore]
         )
         cmd = [cmd_python, "-m", "ha_mcp.stdio_settings_sidecar"]
     else:

--- a/src/ha_mcp/tools/backup.py
+++ b/src/ha_mcp/tools/backup.py
@@ -899,22 +899,15 @@ async def list_backups(client: HomeAssistantClient, limit: int = 200) -> dict[st
     confirm a specific backup landed; they had to already know the ID. Newest
     first. Read-only: no safety backup, no restart.
     """
-    ws_client = None
     try:
-        ws_client, error = await get_connected_ws_client(
-            client.base_url, client.token, verify_ssl=client.verify_ssl
-        )
-        if error:
-            raise_tool_error(
-                error
-                or create_error_response(
-                    ErrorCode.CONNECTION_FAILED,
-                    "Failed to connect to Home Assistant WebSocket to list backups",
-                )
-            )
-        ws_client = cast(HomeAssistantWebSocketClient, ws_client)
-
-        info = await ws_client.send_command("backup/info")
+        # Route through the shared pooled WebSocket (issue #1813) rather than a
+        # dedicated connect/auth handshake per call. ``list_backups`` issues a
+        # single request/response ``backup/info`` command; the pooled client
+        # owns the connection lifecycle, so there is no per-call connect or
+        # disconnect. A failed command surfaces as ``success=False`` and is
+        # handled by the guard below (send_websocket_message never raises for
+        # WS command failures).
+        info = await client.send_websocket_message({"type": "backup/info"})
         if not info.get("success"):
             raise_tool_error(
                 create_error_response(
@@ -955,18 +948,6 @@ async def list_backups(client: HomeAssistantClient, limit: int = 200) -> dict[st
             suggestions=["Check Home Assistant connection and the backup integration"],
         )
         return None  # unreachable: exception_to_structured_error always raises
-    finally:
-        # Always disconnect WebSocket — narrow to transport errors; a
-        # programming error during cleanup should still surface.
-        if ws_client:
-            try:
-                await ws_client.disconnect()
-            except (TimeoutError, OSError, ConnectionError) as err:
-                logger.debug(
-                    "ws disconnect (cleanup) transport error: %s: %s",
-                    type(err).__name__,
-                    err,
-                )
 
 
 # Valid (scope, action) combinations. Anything outside this set is

--- a/src/ha_mcp/tools/tools_addons.py
+++ b/src/ha_mcp/tools/tools_addons.py
@@ -22,10 +22,9 @@ from pydantic import Field
 from websockets.asyncio.client import ClientConnection
 
 from .._version import is_running_in_addon
-from ..client.rest_client import HomeAssistantClient
+from ..client.rest_client import HomeAssistantClient, HomeAssistantCommandError
 from ..errors import (
     ErrorCode,
-    create_connection_error,
     create_error_response,
     create_validation_error,
 )
@@ -36,7 +35,6 @@ from ..utils.python_sandbox import (
 )
 from .helpers import (
     exception_to_structured_error,
-    get_connected_ws_client,
     log_tool_usage,
     raise_tool_error,
     validate_identifier_not_empty,
@@ -233,16 +231,7 @@ async def _supervisor_api_call(
     Returns:
         The "result" field from a successful response, or an error dict.
     """
-    ws_client = None
     try:
-        ws_client, error = await get_connected_ws_client(
-            client.base_url, client.token, verify_ssl=client.verify_ssl
-        )
-        if error or ws_client is None:
-            return error or create_connection_error(
-                "Failed to establish WebSocket connection",
-            )
-
         kwargs: dict[str, Any] = {"endpoint": endpoint, "method": method}
         if data is not None:
             kwargs["data"] = data
@@ -256,29 +245,20 @@ async def _supervisor_api_call(
             kwargs["timeout"] = timeout
             wait_timeout = float(timeout) + 15.0
 
-        result = await ws_client.send_command(
-            "supervisor/api", _wait_timeout=wait_timeout, **kwargs
+        # Route through the shared pooled WebSocket (issue #1813) rather than
+        # opening a dedicated connect/auth handshake per call. ``_wait_timeout``
+        # is consumed by send_command (it never reaches Home Assistant). The
+        # pooled path collapses a failed WS command into
+        # ``{"success": False, "error": ...}``; re-raise it as the same
+        # ``HomeAssistantCommandError`` the dedicated send_command used to raise
+        # so the classifier below maps schema/not-found/etc. identically.
+        result = await client.send_websocket_message(
+            {"type": "supervisor/api", "_wait_timeout": wait_timeout, **kwargs}
         )
 
         if not result.get("success"):
-            error_msg = str(result.get("error", ""))
-            if "not_found" in error_msg.lower() or "unknown" in error_msg.lower():
-                raise_tool_error(
-                    create_error_response(
-                        ErrorCode.RESOURCE_NOT_FOUND,
-                        "Supervisor API not available",
-                        details=str(result),
-                        suggestions=[
-                            "This feature requires Home Assistant OS or Supervised installation",
-                        ],
-                    )
-                )
-            raise_tool_error(
-                create_error_response(
-                    ErrorCode.SERVICE_CALL_FAILED,
-                    f"Supervisor API call failed: {endpoint}",
-                    details=str(result),
-                )
+            raise HomeAssistantCommandError(
+                str(result.get("error", f"Supervisor API call failed: {endpoint}"))
             )
 
         return {"success": True, "result": result.get("result", {})}
@@ -293,14 +273,6 @@ async def _supervisor_api_call(
             suggestions=["Check Home Assistant connection and Supervisor availability"],
         )
         return None  # unreachable: exception_to_structured_error always raises
-    finally:
-        if ws_client:
-            try:
-                await ws_client.disconnect()
-            except Exception:
-                # Best-effort cleanup: the WS connection is being torn down, so a
-                # disconnect failure is non-fatal and must not mask the real result.
-                pass
 
 
 def _addon_connection_failure_suggestions(

--- a/src/ha_mcp/tools/tools_bug_report.py
+++ b/src/ha_mcp/tools/tools_bug_report.py
@@ -32,6 +32,7 @@ from ..utils.usage_logger import (
     get_recent_logs,
     get_startup_logs,
 )
+from .component_api import get_component_caps
 from .helpers import log_tool_usage, register_tool_methods
 from .util_helpers import ANSI_ESCAPE_RE
 
@@ -613,11 +614,21 @@ class BugReportTools:
     async def _detect_component_version(self) -> str | None:
         """Read the ha_mcp_tools custom component's version, best-effort.
 
-        Uses the component's ``get_caller_token`` bootstrap service, whose
-        response carries the manifest version (the same field the filesystem
-        tools' version gate reads). Returns None when the component is not
-        installed or the call fails — the report path must never break on it.
+        Prefers the shared cached capability probe (``get_component_caps`` — one
+        ``ha_mcp_tools/info`` round-trip per client): a component new enough to
+        answer it (1.1.0+) reports its version there, so the report reuses that
+        cached probe instead of a bespoke round-trip. A component in the
+        0.11.0-1.1.0 band has services but no ``info`` command (caps is None),
+        so it falls back to the ``get_caller_token`` bootstrap service, whose
+        response also carries the manifest version. Returns None when the
+        component is not installed or the call fails — the report path must
+        never break on it.
         """
+        # get_component_caps never raises (it caches/returns None on every
+        # failure mode), so no guard is needed around it.
+        caps = await get_component_caps(self._client)
+        if caps is not None:
+            return caps.component_version or None
         try:
             resp = await self._client.call_service(
                 "ha_mcp_tools", "get_caller_token", {}, return_response=True

--- a/src/ha_mcp/tools/tools_calendar.py
+++ b/src/ha_mcp/tools/tools_calendar.py
@@ -15,11 +15,11 @@ from fastmcp.exceptions import ToolError
 from fastmcp.tools import tool
 from pydantic import Field
 
+from ..client.rest_client import HomeAssistantCommandError
 from ..errors import ErrorCode, create_error_response
 from .auto_backup import with_auto_backup
 from .helpers import (
     exception_to_structured_error,
-    get_connected_ws_client,
     log_tool_usage,
     raise_tool_error,
     register_tool_methods,
@@ -199,35 +199,20 @@ class CalendarTools:
         if location is not None:
             event["location"] = location
 
-        ws_client, conn_error = await get_connected_ws_client(
-            self._client.base_url,
-            self._client.token,
-            verify_ssl=self._client.verify_ssl,
+        # Route through the shared pooled WebSocket (issue #1813) instead of a
+        # dedicated connect/auth handshake per call. The pooled path collapses a
+        # failed WS command into ``{"success": False, "error": ...}``; re-raise
+        # it as the same ``HomeAssistantCommandError`` the dedicated send_command
+        # used to raise so the caller's error handler still attaches the
+        # rrule-specific suggestions.
+        result = await self._client.send_websocket_message(
+            {"type": "calendar/event/create", "entity_id": entity_id, "event": event}
         )
-        if conn_error or ws_client is None:
-            raise_tool_error(
-                conn_error
-                or create_error_response(
-                    ErrorCode.CONNECTION_FAILED,
-                    "Failed to connect to Home Assistant WebSocket",
-                    context={"entity_id": entity_id},
-                )
+        if not result.get("success"):
+            raise HomeAssistantCommandError(
+                str(result.get("error", "calendar/event/create failed"))
             )
-
-        try:
-            return await ws_client.send_command(
-                "calendar/event/create", entity_id=entity_id, event=event
-            )
-        finally:
-            # Guard disconnect: a transport-teardown error here would
-            # otherwise replace the original send_command exception.
-            try:
-                await ws_client.disconnect()
-            except Exception as disconnect_error:
-                logger.debug(
-                    f"WebSocket disconnect after create_event for "
-                    f"{entity_id}: {disconnect_error}"
-                )
+        return result
 
     async def _create_simple_calendar_event(
         self,
@@ -541,35 +526,18 @@ class CalendarTools:
             if recurrence_range:
                 ws_kwargs["recurrence_range"] = recurrence_range
 
-            ws_client, conn_error = await get_connected_ws_client(
-                self._client.base_url,
-                self._client.token,
-                verify_ssl=self._client.verify_ssl,
+            # Route through the shared pooled WebSocket (issue #1813) instead of a
+            # dedicated connect/auth handshake per call. Re-raise a failed WS
+            # command as the same ``HomeAssistantCommandError`` the dedicated
+            # send_command used to raise so the outer handler builds the
+            # delete-specific suggestions (404 / not-supported).
+            result = await self._client.send_websocket_message(
+                {"type": "calendar/event/delete", **ws_kwargs}
             )
-            if conn_error or ws_client is None:
-                raise_tool_error(
-                    conn_error
-                    or create_error_response(
-                        ErrorCode.CONNECTION_FAILED,
-                        "Failed to connect to Home Assistant WebSocket",
-                        context={"entity_id": entity_id, "uid": uid},
-                    )
+            if not result.get("success"):
+                raise HomeAssistantCommandError(
+                    str(result.get("error", "calendar/event/delete failed"))
                 )
-
-            try:
-                result = await ws_client.send_command(
-                    "calendar/event/delete", **ws_kwargs
-                )
-            finally:
-                # Guard disconnect: a transport-teardown error here would
-                # otherwise replace the original send_command exception.
-                try:
-                    await ws_client.disconnect()
-                except Exception as disconnect_error:
-                    logger.debug(
-                        f"WebSocket disconnect after delete_event for "
-                        f"{entity_id} uid={uid}: {disconnect_error}"
-                    )
 
             return {
                 "success": True,

--- a/src/ha_mcp/tools/tools_config_helpers.py
+++ b/src/ha_mcp/tools/tools_config_helpers.py
@@ -3898,11 +3898,12 @@ class HelperConfigTools:
         :func:`_raise_all_requires_component` rather than returning an empty list.
         """
         caps = await get_component_caps(self._client)
+        response = None
         if component_supports(caps, "helpers_list"):
             response = await self._all_helpers_via_component()
-            if response is not None:
-                return response
-        _raise_all_requires_component()
+        if response is None:
+            _raise_all_requires_component()
+        return response
 
     async def _all_helpers_via_component(self) -> dict[str, Any] | None:
         """Serve all-types from the component; ``None`` ⇒ raise component-required.

--- a/src/ha_mcp/tools/tools_config_helpers.py
+++ b/src/ha_mcp/tools/tools_config_helpers.py
@@ -3896,11 +3896,25 @@ class HelperConfigTools:
         ``helpers_list`` it serves the merged listing; otherwise — or if the
         component call fails — this raises COMPONENT_NOT_INSTALLED via
         :func:`_raise_all_requires_component` rather than returning an empty list.
+        A raw transport failure (e.g. the WS cannot connect right after an HA
+        restart) becomes the structured error the rest of the tool uses — never
+        an unclassified exception.
         """
-        caps = await get_component_caps(self._client)
-        response = None
-        if component_supports(caps, "helpers_list"):
-            response = await self._all_helpers_via_component()
+        response: dict[str, Any] | None = None
+        try:
+            caps = await get_component_caps(self._client)
+            if component_supports(caps, "helpers_list"):
+                response = await self._all_helpers_via_component()
+        except ToolError:
+            raise
+        except Exception as e:
+            exception_to_structured_error(
+                e,
+                context={"helper_type": "all"},
+                suggestions=[
+                    "Home Assistant may be restarting or unreachable — retry shortly",
+                ],
+            )
         if response is None:
             _raise_all_requires_component()
         return response
@@ -3930,7 +3944,9 @@ class HelperConfigTools:
         (``type_filter=None`` component-side).
         """
         ws = await get_websocket_client(
-            url=self._client.base_url, token=self._client.token
+            url=self._client.base_url,
+            token=self._client.token,
+            verify_ssl=getattr(self._client, "verify_ssl", None),
         )
         return await ws.send_command(
             "ha_mcp_tools/helpers_list",
@@ -3966,14 +3982,33 @@ class HelperConfigTools:
                 helpers.append(shaped)
 
         covered = result.get("covered_types")
-        if isinstance(covered, list):
-            for helper_type in sorted(SIMPLE_HELPER_TYPES - set(covered)):
-                legacy = await self._legacy_helper_list(helper_type)
-                for item in legacy.get("helpers", []):
-                    if isinstance(item, dict):
-                        row = dict(item)
-                        row.setdefault("helper_type", helper_type)
-                        helpers.append(row)
+        covered_set = set(covered) if isinstance(covered, list) else set()
+        # Flow helper types have no legacy ``{type}/list`` fallback — if the
+        # component did not authoritatively cover one, a "successful" merged
+        # listing would silently omit it. Mirror the single-type taxonomy:
+        # hard error, never a partial inventory reported as complete.
+        uncovered_flow = sorted(FLOW_HELPER_TYPES - covered_set)
+        if uncovered_flow:
+            raise_tool_error(
+                create_error_response(
+                    ErrorCode.COMPONENT_NOT_INSTALLED,
+                    "The ha_mcp_tools component response did not cover flow "
+                    f"helper type(s): {', '.join(uncovered_flow)} — cannot "
+                    "return a complete all-types listing.",
+                    context={"helper_type": "all", "uncovered": uncovered_flow},
+                    suggestions=[
+                        "Update the ha_mcp_tools custom component",
+                        "List helper types individually instead of 'all'",
+                    ],
+                )
+            )
+        for helper_type in sorted(SIMPLE_HELPER_TYPES - covered_set):
+            legacy = await self._legacy_helper_list(helper_type)
+            for item in legacy.get("helpers", []):
+                if isinstance(item, dict):
+                    row = dict(item)
+                    row.setdefault("helper_type", helper_type)
+                    helpers.append(row)
 
         return {
             "success": True,

--- a/src/ha_mcp/tools/tools_config_helpers.py
+++ b/src/ha_mcp/tools/tools_config_helpers.py
@@ -3578,6 +3578,26 @@ def _raise_flow_requires_component(helper_type: str) -> NoReturn:
     )
 
 
+def _raise_all_requires_component() -> NoReturn:
+    """Raise the structured error for all-types listing with no component path.
+
+    ``helper_type="all"`` has no legacy equivalent — there is no single WS
+    command that enumerates every helper type — so, like a flow-based type, it
+    is served exclusively through the ha_mcp_tools component. When the component
+    is absent, downlevel, or its call fails, this is a hard error: never a
+    silent empty list, never a partial legacy fallback.
+    """
+    raise_tool_error(
+        create_error_response(
+            ErrorCode.COMPONENT_NOT_INSTALLED,
+            "Listing all helper types in one call (helper_type='all') requires "
+            "the ha_mcp_tools custom component (>= 1.1.0); without it, list a "
+            "specific helper_type instead.",
+            context={"helper_type": "all"},
+        )
+    )
+
+
 class HelperConfigTools:
     """Encapsulates helper configuration tools for ha_config_list_helpers and ha_config_set_helper."""
 
@@ -3610,13 +3630,15 @@ class HelperConfigTools:
                 "zone",
                 "person",
                 "tag",
+                "all",
             ]
             | SUPPORTED_HELPERS,
             Field(
                 description=(
                     "Helper type to list. Storage types are listed on all "
                     "installs; flow-based types require the ha_mcp_tools "
-                    "custom component."
+                    "custom component. Pass 'all' to list every helper type in "
+                    "one call (also requires the ha_mcp_tools component)."
                 )
             ),
         ],
@@ -3658,6 +3680,7 @@ class HelperConfigTools:
         - List all zones: ha_config_list_helpers("zone")
         - List all persons: ha_config_list_helpers("person")
         - List all tags: ha_config_list_helpers("tag")
+        - List every helper type at once: ha_config_list_helpers("all")
 
         **NOTE:** This only returns storage-based helpers (created via UI/API), not YAML-defined helpers.
 
@@ -3666,8 +3689,20 @@ class HelperConfigTools:
         through it; storage types are listed on all installs. Requesting a flow
         type without the component returns a COMPONENT_NOT_INSTALLED error.
 
+        Pass helper_type="all" to enumerate every helper type in a single call.
+        Each record carries its own ``helper_type``. This mode is component-only
+        (there is no single built-in command that lists all types): without the
+        ha_mcp_tools component it returns a COMPONENT_NOT_INSTALLED error rather
+        than a partial or empty list.
+
         For detailed helper documentation, use ha_get_skill_guide.
         """
+        # All-types mode: one merged component listing across every helper type.
+        # No legacy equivalent exists (no single WS command enumerates all
+        # types), so it is component-only — see ``_list_all_helpers``.
+        if helper_type == "all":
+            return await self._list_all_helpers()
+
         # Flow-based helper types have no ``{type}/list`` command, so only the
         # component's ``helpers_list`` can enumerate them: they are served
         # exclusively through the component path (never the legacy body, never a
@@ -3851,6 +3886,100 @@ class HelperConfigTools:
             "count": len(items),
             "helpers": items,
             "message": f"Found {len(items)} {helper_type} helper(s)",
+        }
+
+    async def _list_all_helpers(self) -> dict[str, Any]:
+        """Serve ``helper_type="all"``: one merged component listing, or a hard error.
+
+        All-types mode has no legacy equivalent, so it is component-only
+        (mirroring the flow-helper precedent). When the component advertises
+        ``helpers_list`` it serves the merged listing; otherwise — or if the
+        component call fails — this raises COMPONENT_NOT_INSTALLED via
+        :func:`_raise_all_requires_component` rather than returning an empty list.
+        """
+        caps = await get_component_caps(self._client)
+        if component_supports(caps, "helpers_list"):
+            response = await self._all_helpers_via_component()
+            if response is not None:
+                return response
+        _raise_all_requires_component()
+
+    async def _all_helpers_via_component(self) -> dict[str, Any] | None:
+        """Serve all-types from the component; ``None`` ⇒ raise component-required.
+
+        There is no legacy all-types path, so — unlike single-type storage
+        listing — every component failure resolves to the same hard error the
+        caller raises (mirroring the flow-helper taxonomy). ``unknown_command``
+        additionally invalidates the now-stale positive caps.
+        """
+        try:
+            raw = await self._send_component_all_helpers()
+        except (HomeAssistantCommandError, HomeAssistantCommandTimeout) as exc:
+            if is_unknown_command(exc):
+                invalidate_caps(self._client)
+            logger.warning("ha_mcp_tools/helpers_list (all) failed: %r", exc)
+            return None
+        return await self._shape_all_helpers_response(raw.get("result") or {})
+
+    async def _send_component_all_helpers(self) -> dict[str, Any]:
+        """Send one all-types ``ha_mcp_tools/helpers_list`` command (no type filter).
+
+        Omitting ``helper_types`` makes the component return every storage +
+        flow helper it can enumerate in a single round-trip
+        (``type_filter=None`` component-side).
+        """
+        ws = await get_websocket_client(
+            url=self._client.base_url, token=self._client.token
+        )
+        return await ws.send_command(
+            "ha_mcp_tools/helpers_list",
+            include_flow_helpers=True,
+        )
+
+    async def _shape_all_helpers_response(
+        self, result: dict[str, Any]
+    ) -> dict[str, Any]:
+        """Map an all-types ``helpers_list`` result into the merged listing envelope.
+
+        Each record is shaped by kind (flow → ``_shape_flow_helper_record``,
+        collection → ``_shape_collection_helper_record``) and stamped with its
+        own ``helper_type`` so records of different types stay distinguishable in
+        the flat list. Respecting ``covered_types`` (mirroring the single-type
+        path): a simple type the component could not enumerate from the state
+        machine — ``tag`` has no state entity — is fetched per-type via its
+        legacy ``{type}/list`` and merged, so ``all`` never silently drops it.
+        """
+        raw = result.get("helpers")
+        records = raw if isinstance(raw, list) else []
+        helpers: list[dict[str, Any]] = []
+        for rec in records:
+            if not isinstance(rec, dict):
+                continue
+            if rec.get("kind") == "flow":
+                helpers.append(_shape_flow_helper_record(rec))
+            else:
+                shaped = _shape_collection_helper_record(rec)
+                # All-types records span many types, so each self-describes its
+                # type (single-type mode carries it at the envelope top instead).
+                shaped["helper_type"] = rec.get("helper_type")
+                helpers.append(shaped)
+
+        covered = result.get("covered_types")
+        if isinstance(covered, list):
+            for helper_type in sorted(SIMPLE_HELPER_TYPES - set(covered)):
+                legacy = await self._legacy_helper_list(helper_type)
+                for item in legacy.get("helpers", []):
+                    if isinstance(item, dict):
+                        row = dict(item)
+                        row.setdefault("helper_type", helper_type)
+                        helpers.append(row)
+
+        return {
+            "success": True,
+            "helper_type": "all",
+            "count": len(helpers),
+            "helpers": helpers,
+            "message": f"Found {len(helpers)} helper(s)",
         }
 
     @tool(

--- a/src/ha_mcp/tools/tools_config_scenes.py
+++ b/src/ha_mcp/tools/tools_config_scenes.py
@@ -323,7 +323,7 @@ class ConfigSceneTools:
         return response
 
     async def _get_scene_config_internal(
-        self, scene_id: str
+        self, scene_id: str, *, _resolved: bool = False
     ) -> tuple[dict[str, Any], str, str]:
         """Fetch scene config without logging or category injection.
 
@@ -331,8 +331,12 @@ class ConfigSceneTools:
         ``actual_config`` is the inner scene body (not the REST wrapper) and
         ``resolved_id`` is the storage key the rest-client resolved the input
         to (issue #1168 R3 blocker 6). Used by ``_fetch_and_verify_hash``.
+
+        ``_resolved=True`` forwards to ``get_scene_config`` that ``scene_id`` is
+        already a resolved storage key, so the redundant registry lookup is
+        skipped (e.g. the python_transform re-fetch, which already resolved).
         """
-        envelope = await self._client.get_scene_config(scene_id)
+        envelope = await self._client.get_scene_config(scene_id, _resolved=_resolved)
         actual_config = envelope.get("config", envelope)
         resolved_id = envelope.get("scene_id", scene_id.removeprefix("scene."))
         config_hash_value = compute_config_hash(actual_config)
@@ -760,12 +764,13 @@ class ConfigSceneTools:
                     await self._validate_category_id(category)
 
                 result = await self._client.upsert_scene_config(
-                    transformed_config, resolved_id
+                    transformed_config, resolved_id, _resolved=True
                 )
 
                 # Re-fetch to get authoritative hash (HA may normalise after save).
+                # ``resolved_id`` is already the storage key, so skip the re-resolve.
                 _, new_config_hash, _ = await self._get_scene_config_internal(
-                    resolved_id
+                    resolved_id, _resolved=True
                 )
 
                 # Resolve actual entity_id and apply wait + category — same
@@ -887,7 +892,11 @@ class ConfigSceneTools:
                 self._client, config_dict
             )
 
-            result = await self._client.upsert_scene_config(config_dict, resolved_id)
+            # ``resolved_id`` is already the storage key (from the hash-verify
+            # fetch or the resolve above), so skip the redundant re-resolve.
+            result = await self._client.upsert_scene_config(
+                config_dict, resolved_id, _resolved=True
+            )
 
             # Resolve actual entity_id via registry — HA derives scene
             # entity_ids from the 'name' slug, not the scene_id storage key,
@@ -1033,7 +1042,9 @@ class ConfigSceneTools:
             # matching unique_id (e.g. scene_id-as-entity-id slug case).
             entity_id = await self._resolve_scene_entity_id(resolved_id)
 
-            result = await self._client.delete_scene_config(resolved_id)
+            # ``resolved_id`` is already the storage key (resolved above), so
+            # skip the redundant re-resolve inside delete_scene_config.
+            result = await self._client.delete_scene_config(resolved_id, _resolved=True)
 
             if wait:
                 try:

--- a/src/ha_mcp/tools/tools_entities.py
+++ b/src/ha_mcp/tools/tools_entities.py
@@ -1021,6 +1021,7 @@ class EntityTools:
         """
         expose_true = [a for a, v in parsed_expose_to.items() if v]
         expose_false = [a for a, v in parsed_expose_to.items() if not v]
+        applied: list[str] = []
         for assistants, should_expose in [(expose_true, True), (expose_false, False)]:
             if not assistants:
                 continue
@@ -1037,7 +1038,17 @@ class EntityTools:
                 }
             )
             if not result.get("success"):
-                return _extract_ws_error(result)
+                error = _extract_ws_error(result)
+                if applied:
+                    # The earlier assistant group already changed — say so, or
+                    # the all-failed report implies no exposure was touched.
+                    error = (
+                        f"{error} (note: expose changes for "
+                        f"{', '.join(applied)} were already applied before "
+                        "this failure)"
+                    )
+                return error
+            applied.extend(assistants)
         return None
 
     async def _bulk_registry_phase(
@@ -1089,6 +1100,9 @@ class EntityTools:
             return_exceptions=True,
         )
         for eid, result in zip(entity_ids, results, strict=True):
+            if isinstance(result, BaseException) and not isinstance(result, Exception):
+                # Never swallow cancellation/shutdown into per-entity errors.
+                raise result
             if isinstance(result, BaseException):
                 error_msg = (
                     extract_tool_error_message(result)
@@ -1259,6 +1273,9 @@ class EntityTools:
             return_exceptions=True,
         )
         for chunk, resp in zip(chunks, responses, strict=True):
+            if isinstance(resp, BaseException) and not isinstance(resp, Exception):
+                # Never swallow cancellation/shutdown into per-entity errors.
+                raise resp
             if isinstance(resp, dict) and resp.get("success"):
                 result_map = resp.get("result") or {}
                 for eid in chunk:

--- a/src/ha_mcp/tools/tools_entities.py
+++ b/src/ha_mcp/tools/tools_entities.py
@@ -18,6 +18,7 @@ from ..errors import ErrorCode, create_error_response
 from .auto_backup import with_auto_backup
 from .helpers import (
     exception_to_structured_error,
+    extract_tool_error_message,
     log_tool_usage,
     raise_tool_error,
     register_tool_methods,
@@ -234,33 +235,32 @@ def _parse_get_entity_ids(
     """Parse entity_id into (entity_ids, is_bulk, early_response). early_response is non-None for empty list."""
     if isinstance(entity_id, str):
         return [entity_id], False, None
-    elif isinstance(entity_id, list):
-        if not entity_id:
-            return (
-                [],
-                False,
-                {
-                    "success": True,
-                    "entity_entries": [],
-                    "count": 0,
-                    "message": "No entities requested",
-                },
-            )
-        if not all(isinstance(e, str) for e in entity_id):
-            raise_tool_error(
-                create_error_response(
-                    ErrorCode.VALIDATION_INVALID_PARAMETER,
-                    "All entity_id values must be strings",
-                )
-            )
-        return entity_id, True, None
-    else:
+    if not isinstance(entity_id, list):
         raise_tool_error(
             create_error_response(
                 ErrorCode.VALIDATION_INVALID_PARAMETER,
                 f"entity_id must be string or list of strings, got {type(entity_id).__name__}",
             )
         )
+    if not entity_id:
+        return (
+            [],
+            False,
+            {
+                "success": True,
+                "entity_entries": [],
+                "count": 0,
+                "message": "No entities requested",
+            },
+        )
+    if not all(isinstance(e, str) for e in entity_id):
+        raise_tool_error(
+            create_error_response(
+                ErrorCode.VALIDATION_INVALID_PARAMETER,
+                "All entity_id values must be strings",
+            )
+        )
+    return entity_id, True, None
 
 
 def _validate_enabled_constraint(
@@ -1090,7 +1090,12 @@ class EntityTools:
         )
         for eid, result in zip(entity_ids, results, strict=True):
             if isinstance(result, BaseException):
-                failed.append({"entity_id": eid, "error": str(result)})
+                error_msg = (
+                    extract_tool_error_message(result)
+                    if isinstance(result, ToolError)
+                    else str(result)
+                )
+                failed.append({"entity_id": eid, "error": error_msg})
             else:
                 # _update_single_entity returns success-shape or raises
                 # ToolError (caught above as BaseException).
@@ -1318,7 +1323,7 @@ class EntityTools:
                     context=filters,
                     suggestions=[
                         "unique_id must match exactly — it is the integration's "
-                        "internal id, not the entity_id",
+                        + "internal id, not the entity_id",
                         "Drop the domain/platform filters if you set them",
                         "Use ha_search() to browse entities and their platforms",
                     ],

--- a/src/ha_mcp/tools/tools_entities.py
+++ b/src/ha_mcp/tools/tools_entities.py
@@ -1149,13 +1149,34 @@ class EntityTools:
         for eid in eligible_ids:
             if eid in refetched_raw:
                 entry_by_id[eid] = _format_entity_entry(refetched_raw[eid])
+        # An id whose refetch failed AND that has no earlier registry snapshot
+        # (expose-only bulk never populates one) would otherwise be reported
+        # as a success row with entity_entry=None — e.g. a typo'd or deleted
+        # entity. The old per-entity path raised for exactly this case.
+        still_eligible: list[str] = []
+        newly_failed: list[dict[str, Any]] = []
+        for eid in eligible_ids:
+            if eid in refetch_errors and entry_by_id.get(eid) is None:
+                newly_failed.append(
+                    {
+                        "entity_id": eid,
+                        "error": (
+                            "Exposure command was sent, but the entity could "
+                            "not be verified in the registry: "
+                            f"{refetch_errors[eid]}"
+                        ),
+                    }
+                )
+            else:
+                still_eligible.append(eid)
         if refetch_errors:
             logger.warning(
                 "Bulk exposure applied but post-exposure refresh failed "
-                "for %d id(s); returning pre-exposure snapshot",
+                "for %d id(s); %d had a pre-exposure snapshot to return",
                 len(refetch_errors),
+                len(refetch_errors) - len(newly_failed),
             )
-        return eligible_ids, []
+        return still_eligible, newly_failed
 
     async def _bulk_update_entities(
         self,

--- a/src/ha_mcp/tools/tools_entities.py
+++ b/src/ha_mcp/tools/tools_entities.py
@@ -32,6 +32,69 @@ from .util_helpers import (
 
 logger = logging.getLogger(__name__)
 
+# Bounds the per-frame size of a bulk config/entity_registry/get_entries call
+# (extended entries, ~1KB each) so a large id list can't produce an over-cap
+# WebSocket frame. Matches the chunk size smart_search uses for the same
+# command. Typical bulk calls fit in a single chunk (one WS message).
+_GET_ENTRIES_CHUNK_SIZE = 500
+
+# Max entity IDs accepted by the bulk-removal path of ha_remove_entity. Mirrors
+# the cap the other bulk tools use (ha_get_state's _get_bulk_entity_states).
+_MAX_BULK_REMOVE = 100
+
+
+def _format_fetched_entity(entry: dict[str, Any]) -> dict[str, Any]:
+    """Project a raw HA entity-registry extended dict into ha_get_entity's shape.
+
+    Shared by the single-entity get, the bulk get_entries backend, and the
+    unique_id resolver so every ha_get_entity response carries the same keys.
+    """
+    return {
+        "entity_id": entry.get("entity_id"),
+        "name": entry.get("name"),
+        "original_name": entry.get("original_name"),
+        "icon": entry.get("icon"),
+        "area_id": entry.get("area_id"),
+        "disabled_by": entry.get("disabled_by"),
+        "hidden_by": entry.get("hidden_by"),
+        "enabled": entry.get("disabled_by") is None,
+        "hidden": entry.get("hidden_by") is not None,
+        "aliases": entry.get("aliases", []),
+        "labels": entry.get("labels", []),
+        "categories": entry.get("categories", {}),
+        "device_class": entry.get("device_class"),
+        "original_device_class": entry.get("original_device_class"),
+        "options": entry.get("options", {}),
+        "platform": entry.get("platform"),
+        "device_id": entry.get("device_id"),
+        "config_entry_id": entry.get("config_entry_id"),
+        "unique_id": entry.get("unique_id"),
+    }
+
+
+def _match_registry_by_unique_id(
+    entries: list[dict[str, Any]],
+    unique_id: str,
+    domain: str | None,
+    platform: str | None,
+) -> list[dict[str, Any]]:
+    """Return formatted registry entries matching unique_id (+ optional filters).
+
+    ``domain`` is compared against the entity_id prefix (the registry's unique
+    key uses the entity domain); ``platform`` against the entry's platform.
+    """
+    matches: list[dict[str, Any]] = []
+    for entry in entries:
+        if entry.get("unique_id") != unique_id:
+            continue
+        entry_domain = (entry.get("entity_id") or "").split(".")[0]
+        if domain is not None and entry_domain != domain:
+            continue
+        if platform is not None and entry.get("platform") != platform:
+            continue
+        matches.append(_format_fetched_entity(entry))
+    return matches
+
 
 def _format_entity_entry(entry: dict[str, Any]) -> dict[str, Any]:
     """Format entity registry entry for API response."""
@@ -942,6 +1005,207 @@ class EntityTools:
             device_rename_result,
         )
 
+    async def _bulk_apply_expose(
+        self,
+        entity_ids: list[str],
+        parsed_expose_to: dict[str, bool],
+    ) -> str | None:
+        """Expose/hide many entities in one homeassistant/expose_entity call per set.
+
+        The command's schema accepts the full entity_ids list, so bulk exposure
+        needs at most two WS calls (one for the assistants being turned on, one
+        for those being turned off) regardless of entity count — not one per
+        entity. Returns None on success, or the error message on the first
+        failing set. A failure is batch-level: it applies to every id in the
+        list, so the caller maps the returned message onto all of them.
+        """
+        expose_true = [a for a, v in parsed_expose_to.items() if v]
+        expose_false = [a for a, v in parsed_expose_to.items() if not v]
+        for assistants, should_expose in [(expose_true, True), (expose_false, False)]:
+            if not assistants:
+                continue
+            logger.info(
+                f"{'Exposing' if should_expose else 'Hiding'} {len(entity_ids)} "
+                f"entities {'to' if should_expose else 'from'} {assistants}"
+            )
+            result = await self._client.send_websocket_message(
+                {
+                    "type": "homeassistant/expose_entity",
+                    "assistants": assistants,
+                    "entity_ids": entity_ids,
+                    "should_expose": should_expose,
+                }
+            )
+            if not result.get("success"):
+                return _extract_ws_error(result)
+        return None
+
+    async def _bulk_registry_phase(
+        self,
+        entity_ids: list[str],
+        parsed_categories: dict[str, str | None] | None,
+        parsed_labels: list[str] | None,
+        label_operation: str,
+    ) -> tuple[
+        dict[str, dict[str, Any] | None],
+        dict[str, list[str]],
+        list[dict[str, Any]],
+        list[str],
+    ]:
+        """Per-entity label/category updates (no expose).
+
+        HA's entity_registry/update is single-entity, so this stays a
+        per-entity fan-out. Returns (entry_by_id, updates_by_id, failed,
+        eligible_ids); eligible_ids are the ids whose registry update
+        succeeded (all ids when there is no registry work — expose-only bulk).
+        """
+        entry_by_id: dict[str, dict[str, Any] | None] = {}
+        updates_by_id: dict[str, list[str]] = {}
+        failed: list[dict[str, Any]] = []
+
+        if parsed_labels is None and parsed_categories is None:
+            for eid in entity_ids:
+                updates_by_id[eid] = []
+            return entry_by_id, updates_by_id, failed, list(entity_ids)
+
+        eligible_ids: list[str] = []
+        results = await asyncio.gather(
+            *[
+                self._update_single_entity(
+                    eid,
+                    None,  # area_id not supported in bulk
+                    None,  # name not supported in bulk
+                    None,  # icon not supported in bulk
+                    None,  # enabled not supported in bulk
+                    None,  # hidden not supported in bulk
+                    None,  # aliases not supported in bulk
+                    parsed_categories,
+                    parsed_labels,
+                    label_operation,
+                    None,  # expose_to batched separately below
+                )
+                for eid in entity_ids
+            ],
+            return_exceptions=True,
+        )
+        for eid, result in zip(entity_ids, results, strict=True):
+            if isinstance(result, BaseException):
+                failed.append({"entity_id": eid, "error": str(result)})
+            else:
+                # _update_single_entity returns success-shape or raises
+                # ToolError (caught above as BaseException).
+                entry_by_id[eid] = result.get("entity_entry")
+                updates_by_id[eid] = list(result.get("updates") or [])
+                eligible_ids.append(eid)
+        return entry_by_id, updates_by_id, failed, eligible_ids
+
+    async def _bulk_expose_phase(
+        self,
+        eligible_ids: list[str],
+        parsed_expose_to: dict[str, bool],
+        entry_by_id: dict[str, dict[str, Any] | None],
+        updates_by_id: dict[str, list[str]],
+    ) -> tuple[list[str], list[dict[str, Any]]]:
+        """Batch-expose eligible_ids, then refetch their post-exposure state.
+
+        Returns (still_eligible_ids, newly_failed). A batched-expose failure
+        is reported against every eligible id (the command acts on the whole
+        list atomically) — matching the old per-entity path where each entity
+        raised on its own expose failure — and clears eligibility. On success,
+        options mutate, so a single get_entries refetch refreshes each
+        entity_entry; a refetch failure keeps the pre-exposure snapshot since
+        the exposure already committed.
+        """
+        expose_error = await self._bulk_apply_expose(eligible_ids, parsed_expose_to)
+        if expose_error is not None:
+            failed = [
+                {"entity_id": eid, "error": f"Exposure failed: {expose_error}"}
+                for eid in eligible_ids
+            ]
+            return [], failed
+
+        for eid in eligible_ids:
+            updates_by_id[eid].append(f"expose_to={parsed_expose_to}")
+        refetched_raw, refetch_errors = await self._get_entries_raw(eligible_ids)
+        for eid in eligible_ids:
+            if eid in refetched_raw:
+                entry_by_id[eid] = _format_entity_entry(refetched_raw[eid])
+        if refetch_errors:
+            logger.warning(
+                "Bulk exposure applied but post-exposure refresh failed "
+                "for %d id(s); returning pre-exposure snapshot",
+                len(refetch_errors),
+            )
+        return eligible_ids, []
+
+    async def _bulk_update_entities(
+        self,
+        entity_ids: list[str],
+        parsed_categories: dict[str, str | None] | None,
+        parsed_labels: list[str] | None,
+        label_operation: str,
+        parsed_expose_to: dict[str, bool] | None,
+    ) -> dict[str, Any]:
+        """Apply bulk label/category/expose updates across many entities.
+
+        Registry work runs per-entity (_bulk_registry_phase); only the
+        expose_to phase is batched into one homeassistant/expose_entity call
+        per assistant-set (_bulk_expose_phase).
+        """
+        logger.info(f"Bulk updating {len(entity_ids)} entities")
+        if (
+            parsed_labels is None
+            and parsed_categories is None
+            and parsed_expose_to is None
+        ):
+            raise_tool_error(
+                create_error_response(
+                    ErrorCode.VALIDATION_INVALID_PARAMETER,
+                    "No updates specified",
+                    suggestions=[
+                        "Provide at least one of: labels, categories, or expose_to"
+                    ],
+                )
+            )
+
+        (
+            entry_by_id,
+            updates_by_id,
+            failed,
+            eligible_ids,
+        ) = await self._bulk_registry_phase(
+            entity_ids, parsed_categories, parsed_labels, label_operation
+        )
+
+        if parsed_expose_to is not None and eligible_ids:
+            eligible_ids, expose_failed = await self._bulk_expose_phase(
+                eligible_ids, parsed_expose_to, entry_by_id, updates_by_id
+            )
+            failed.extend(expose_failed)
+
+        succeeded_ids = set(eligible_ids)
+        succeeded_list = [
+            {
+                "entity_id": eid,
+                "entity_entry": entry_by_id.get(eid),
+                "updates": updates_by_id.get(eid, []),
+            }
+            for eid in entity_ids
+            if eid in succeeded_ids
+        ]
+
+        response: dict[str, Any] = {
+            "success": len(failed) == 0,
+            "total": len(entity_ids),
+            "succeeded_count": len(succeeded_list),
+            "failed_count": len(failed),
+            "succeeded": succeeded_list,
+        }
+        if failed:
+            response["failed"] = failed
+            response["partial"] = len(succeeded_list) > 0
+        return response
+
     async def _fetch_entity(self, eid: str) -> dict[str, Any]:
         """Fetch a single entity from the registry."""
         message: dict[str, Any] = {
@@ -953,28 +1217,129 @@ class EntityTools:
         if not result.get("success"):
             raise ValueError(_extract_ws_error(result))
 
-        entry = result.get("result") or {}
-        return {
-            "entity_id": entry.get("entity_id"),
-            "name": entry.get("name"),
-            "original_name": entry.get("original_name"),
-            "icon": entry.get("icon"),
-            "area_id": entry.get("area_id"),
-            "disabled_by": entry.get("disabled_by"),
-            "hidden_by": entry.get("hidden_by"),
-            "enabled": entry.get("disabled_by") is None,
-            "hidden": entry.get("hidden_by") is not None,
-            "aliases": entry.get("aliases", []),
-            "labels": entry.get("labels", []),
-            "categories": entry.get("categories", {}),
-            "device_class": entry.get("device_class"),
-            "original_device_class": entry.get("original_device_class"),
-            "options": entry.get("options", {}),
-            "platform": entry.get("platform"),
-            "device_id": entry.get("device_id"),
-            "config_entry_id": entry.get("config_entry_id"),
-            "unique_id": entry.get("unique_id"),
+        return _format_fetched_entity(result.get("result") or {})
+
+    async def _get_entries_raw(
+        self, entity_ids: list[str]
+    ) -> tuple[dict[str, dict[str, Any]], dict[str, str]]:
+        """Bulk-fetch registry entries via chunked config/entity_registry/get_entries.
+
+        Returns ``(raw_entries, errors)``: ``raw_entries`` maps a found
+        entity_id to HA's raw extended registry dict; ``errors`` maps a failed
+        entity_id to a message. A ``null`` in HA's entries map (id not in the
+        registry) and a chunk-level WS failure both land in ``errors`` — this
+        reproduces the per-id not-found contract of the old one-get-per-id
+        fan-out, where every id got its own error. Callers project the raw
+        entries through whichever formatter their response shape needs.
+        """
+        raw: dict[str, dict[str, Any]] = {}
+        errors: dict[str, str] = {}
+        if not entity_ids:
+            return raw, errors
+
+        chunks = [
+            entity_ids[i : i + _GET_ENTRIES_CHUNK_SIZE]
+            for i in range(0, len(entity_ids), _GET_ENTRIES_CHUNK_SIZE)
+        ]
+        responses = await asyncio.gather(
+            *(
+                self._client.send_websocket_message(
+                    {
+                        "type": "config/entity_registry/get_entries",
+                        "entity_ids": chunk,
+                    }
+                )
+                for chunk in chunks
+            ),
+            return_exceptions=True,
+        )
+        for chunk, resp in zip(chunks, responses, strict=True):
+            if isinstance(resp, dict) and resp.get("success"):
+                result_map = resp.get("result") or {}
+                for eid in chunk:
+                    entry = result_map.get(eid)
+                    if entry is None:
+                        errors[eid] = "Entity not found"
+                    else:
+                        raw[eid] = entry
+                continue
+            # Whole-chunk failure (WS raised, or success=False): every id in
+            # the chunk failed, mirroring the old per-id fan-out behaviour.
+            msg = _extract_ws_error(resp) if isinstance(resp, dict) else str(resp)
+            for eid in chunk:
+                errors[eid] = msg
+        return raw, errors
+
+    async def _resolve_by_unique_id(
+        self,
+        unique_id: str,
+        domain: str | None,
+        platform: str | None,
+    ) -> dict[str, Any]:
+        """Resolve a stable unique_id to its entity_id(s) via one registry list.
+
+        The registry's unique key is (domain, platform, unique_id), so the same
+        unique_id can appear under multiple platforms — every match is returned
+        with a ``matches`` count so callers can disambiguate. ``domain`` /
+        ``platform`` narrow the match set when provided.
+        """
+        list_resp = await self._client.send_websocket_message(
+            {"type": "config/entity_registry/list"}
+        )
+        if not list_resp.get("success"):
+            raise_tool_error(
+                create_error_response(
+                    ErrorCode.SERVICE_CALL_FAILED,
+                    f"Failed to list entity registry: {_extract_ws_error(list_resp)}",
+                    context={"unique_id": unique_id},
+                    suggestions=["Check Home Assistant connection and retry"],
+                )
+            )
+
+        matches = _match_registry_by_unique_id(
+            list_resp.get("result") or [], unique_id, domain, platform
+        )
+
+        if not matches:
+            filters = {"unique_id": unique_id}
+            if domain is not None:
+                filters["domain"] = domain
+            if platform is not None:
+                filters["platform"] = platform
+            raise_tool_error(
+                create_error_response(
+                    ErrorCode.ENTITY_NOT_FOUND,
+                    f"No entity found with unique_id '{unique_id}'"
+                    + (
+                        f" (domain={domain}, platform={platform})"
+                        if domain is not None or platform is not None
+                        else ""
+                    ),
+                    context=filters,
+                    suggestions=[
+                        "unique_id must match exactly — it is the integration's "
+                        "internal id, not the entity_id",
+                        "Drop the domain/platform filters if you set them",
+                        "Use ha_search() to browse entities and their platforms",
+                    ],
+                )
+            )
+
+        # config/entity_registry/list carries as_partial_dict, which omits
+        # aliases and the device_class override — those come back as their
+        # defaults ([] / None) in resolver mode. Callers needing them can
+        # re-query ha_get_entity(entity_id=...) with a resolved id.
+        response: dict[str, Any] = {
+            "success": True,
+            "unique_id": unique_id,
+            "matches": len(matches),
+            "entity_entries": matches,
         }
+        if domain is not None:
+            response["domain"] = domain
+        if platform is not None:
+            response["platform"] = platform
+        return response
 
     @tool(
         name="ha_set_entity",
@@ -1295,57 +1660,14 @@ class EntityTools:
                     parsed_options=parsed_options,
                 )
 
-            # Bulk case - process each entity
-            logger.info(f"Bulk updating {len(entity_ids)} entities")
-            results = await asyncio.gather(
-                *[
-                    self._update_single_entity(
-                        eid,
-                        None,  # area_id not supported in bulk
-                        None,  # name not supported in bulk
-                        None,  # icon not supported in bulk
-                        None,  # enabled not supported in bulk
-                        None,  # hidden not supported in bulk
-                        None,  # aliases not supported in bulk
-                        parsed_categories,
-                        parsed_labels,
-                        label_operation,
-                        parsed_expose_to,
-                    )
-                    for eid in entity_ids
-                ],
-                return_exceptions=True,
+            # Bulk case
+            return await self._bulk_update_entities(
+                entity_ids,
+                parsed_categories,
+                parsed_labels,
+                label_operation,
+                parsed_expose_to,
             )
-
-            # Aggregate results
-            succeeded_list: list[dict[str, Any]] = []
-            failed: list[dict[str, Any]] = []
-            for eid, result in zip(entity_ids, results, strict=True):
-                if isinstance(result, BaseException):
-                    failed.append({"entity_id": eid, "error": str(result)})
-                else:
-                    # _update_single_entity always returns success-shape or
-                    # raises ToolError (caught above as BaseException), so the
-                    # `result.get("success") is False` branch is unreachable.
-                    succeeded_list.append(
-                        {
-                            "entity_id": eid,
-                            "entity_entry": result.get("entity_entry"),
-                            "updates": result.get("updates"),
-                        }
-                    )
-
-            response: dict[str, Any] = {
-                "success": len(failed) == 0,
-                "total": len(entity_ids),
-                "succeeded_count": len(succeeded_list),
-                "failed_count": len(failed),
-                "succeeded": succeeded_list,
-            }
-            if failed:
-                response["failed"] = failed
-                response["partial"] = len(succeeded_list) > 0
-            return response
 
         except ToolError:
             raise
@@ -1367,17 +1689,51 @@ class EntityTools:
     async def ha_get_entity(
         self,
         entity_id: Annotated[
-            str | list[str],
+            str | list[str] | None,
             JSON_STRING_COERCION,
             Field(
-                description="Entity ID or list of entity IDs to retrieve (e.g., 'sensor.temperature' or ['light.living_room', 'switch.porch'])"
+                description="Entity ID or list of entity IDs to retrieve (e.g., 'sensor.temperature' or ['light.living_room', 'switch.porch']). Mutually exclusive with unique_id.",
+                default=None,
             ),
-        ],
+        ] = None,
+        unique_id: Annotated[
+            str | None,
+            Field(
+                description=(
+                    "Resolve a stable integration unique_id to its entity_id(s) "
+                    "(entity_id is mutable, unique_id is not). Mutually exclusive "
+                    "with entity_id. Optionally narrow with domain/platform."
+                ),
+                default=None,
+            ),
+        ] = None,
+        domain: Annotated[
+            str | None,
+            Field(
+                description="Resolver filter (unique_id mode only): restrict matches to this entity domain, e.g. 'sensor'.",
+                default=None,
+            ),
+        ] = None,
+        platform: Annotated[
+            str | None,
+            Field(
+                description="Resolver filter (unique_id mode only): restrict matches to this integration platform, e.g. 'hue'.",
+                default=None,
+            ),
+        ] = None,
     ) -> dict[str, Any]:
         """Get entity registry information for one or more entities.
 
         Returns detailed entity registry metadata including area assignment,
         custom name/icon, enabled/hidden state, aliases, labels, and more.
+
+        RESOLVER MODE:
+        Pass unique_id (instead of entity_id) to resolve a stable integration
+        unique_id to its entity_id(s). Since the registry's unique key is
+        (domain, platform, unique_id), the same unique_id can match multiple
+        platforms — all matches are returned in entity_entries with a `matches`
+        count. Narrow with domain/platform. Resolver reads as_partial_dict, so
+        aliases and the device_class override come back as defaults ([]/null).
 
         RELATED TOOLS:
         - ha_set_entity(): Modify entity properties (area, name, icon, enabled, hidden, aliases)
@@ -1417,62 +1773,47 @@ class EntityTools:
         - unique_id: Integration's unique identifier
         """
         try:
-            entity_ids, is_bulk, early_response = _parse_get_entity_ids(entity_id)
-            if early_response is not None:
-                return early_response
-
-            # Single entity case
-            if not is_bulk:
-                eid = entity_ids[0]
-                logger.info(f"Getting entity registry entry for {eid}")
-                try:
-                    result = await self._fetch_entity(eid)
-                except ValueError as e:
+            # Resolver mode (unique_id) is mutually exclusive with entity_id.
+            if unique_id is not None:
+                if entity_id is not None:
                     raise_tool_error(
                         create_error_response(
-                            ErrorCode.SERVICE_CALL_FAILED,
-                            f"Entity not found: {e}",
-                            context={"entity_id": eid},
+                            ErrorCode.VALIDATION_INVALID_PARAMETER,
+                            "Provide exactly one of entity_id or unique_id, not both.",
                             suggestions=[
-                                "Use ha_search() to find valid entity IDs",
-                                "Check the entity_id spelling and format (e.g., 'sensor.temperature')",
+                                "Pass unique_id alone to resolve it to entity_id(s)",
+                                "Pass entity_id alone to look an entity up directly",
                             ],
                         )
                     )
-                return {
-                    "success": True,
-                    "entity_id": eid,
-                    "entity_entry": result,
-                }
+                logger.info(f"Resolving unique_id '{unique_id}' to entity_id(s)")
+                return await self._resolve_by_unique_id(unique_id, domain, platform)
 
-            # Bulk case - fetch all entities
-            logger.info(
-                f"Getting entity registry entries for {len(entity_ids)} entities"
-            )
-            results = await asyncio.gather(
-                *[self._fetch_entity(eid) for eid in entity_ids],
-                return_exceptions=True,
-            )
+            if entity_id is None:
+                raise_tool_error(
+                    create_error_response(
+                        ErrorCode.VALIDATION_MISSING_PARAMETER,
+                        "Provide entity_id (an id or list) or unique_id.",
+                        suggestions=[
+                            "ha_get_entity('sensor.temperature')",
+                            "ha_get_entity(unique_id='abc123') to resolve a unique_id",
+                        ],
+                    )
+                )
+            # domain/platform are resolver-only filters (unique_id is None here).
+            if domain is not None or platform is not None:
+                raise_tool_error(
+                    create_error_response(
+                        ErrorCode.VALIDATION_INVALID_PARAMETER,
+                        "domain/platform are resolver filters — they only apply "
+                        "when unique_id is provided.",
+                        suggestions=[
+                            "Drop domain/platform, or pass unique_id to use them",
+                        ],
+                    )
+                )
 
-            entity_entries: list[dict[str, Any]] = []
-            errors: list[dict[str, Any]] = []
-            for eid, fetch_result in zip(entity_ids, results, strict=True):
-                if isinstance(fetch_result, BaseException):
-                    errors.append({"entity_id": eid, "error": str(fetch_result)})
-                else:
-                    entity_entries.append(fetch_result)
-
-            response: dict[str, Any] = {
-                "success": True,
-                "count": len(entity_entries),
-                "entity_entries": entity_entries,
-            }
-            if errors:
-                response["errors"] = errors
-                response["suggestions"] = [
-                    "Use ha_search() to find valid entity IDs for failed lookups"
-                ]
-            return response
+            return await self._get_by_entity_id(entity_id)
 
         except ToolError:
             raise
@@ -1484,6 +1825,148 @@ class EntityTools:
             )
             return None  # unreachable: exception_to_structured_error always raises
 
+    async def _get_by_entity_id(self, entity_id: str | list[str]) -> dict[str, Any]:
+        """Look up entities by entity_id (single or bulk list)."""
+        entity_ids, is_bulk, early_response = _parse_get_entity_ids(entity_id)
+        if early_response is not None:
+            return early_response
+
+        # Single entity case
+        if not is_bulk:
+            eid = entity_ids[0]
+            logger.info(f"Getting entity registry entry for {eid}")
+            try:
+                result = await self._fetch_entity(eid)
+            except ValueError as e:
+                raise_tool_error(
+                    create_error_response(
+                        ErrorCode.SERVICE_CALL_FAILED,
+                        f"Entity not found: {e}",
+                        context={"entity_id": eid},
+                        suggestions=[
+                            "Use ha_search() to find valid entity IDs",
+                            "Check the entity_id spelling and format (e.g., 'sensor.temperature')",
+                        ],
+                    )
+                )
+            return {
+                "success": True,
+                "entity_id": eid,
+                "entity_entry": result,
+            }
+
+        # Bulk case - fetch all entities in one chunked get_entries call
+        # (native HA bulk command) instead of one registry get per id.
+        logger.info(f"Getting entity registry entries for {len(entity_ids)} entities")
+        raw_map, error_map = await self._get_entries_raw(entity_ids)
+
+        # Iterate the requested ids (not the map) to preserve request order and
+        # duplicate handling; each id is classified found/error exactly as the
+        # old per-id fan-out did.
+        entity_entries: list[dict[str, Any]] = []
+        errors: list[dict[str, Any]] = []
+        for eid in entity_ids:
+            raw = raw_map.get(eid)
+            if raw is not None:
+                entity_entries.append(_format_fetched_entity(raw))
+            else:
+                errors.append(
+                    {
+                        "entity_id": eid,
+                        "error": error_map.get(eid, "Entity not found"),
+                    }
+                )
+
+        response: dict[str, Any] = {
+            "success": True,
+            "count": len(entity_entries),
+            "entity_entries": entity_entries,
+        }
+        if errors:
+            response["errors"] = errors
+            response["suggestions"] = [
+                "Use ha_search() to find valid entity IDs for failed lookups"
+            ]
+        return response
+
+    async def _bulk_remove_entities(self, entity_ids: list[str]) -> dict[str, Any]:
+        """Remove many entities sequentially, classifying each outcome.
+
+        Registry writes are NOT parallelized (per the removal WS command's
+        write semantics). Each id lands in exactly one bucket: ``removed``,
+        ``skipped`` (not-found is idempotent success, not an error), or
+        ``errors`` (any other failure, carrying code + message).
+        """
+        if not isinstance(entity_ids, list):
+            raise_tool_error(
+                create_error_response(
+                    ErrorCode.VALIDATION_INVALID_PARAMETER,
+                    f"entity_id must be a string or list of strings, got "
+                    f"{type(entity_ids).__name__}",
+                )
+            )
+        if not entity_ids:
+            raise_tool_error(
+                create_error_response(
+                    ErrorCode.VALIDATION_INVALID_PARAMETER,
+                    "entity_id list cannot be empty",
+                )
+            )
+        if not all(isinstance(e, str) for e in entity_ids):
+            raise_tool_error(
+                create_error_response(
+                    ErrorCode.VALIDATION_INVALID_PARAMETER,
+                    "All entity_id values must be strings",
+                )
+            )
+        if len(entity_ids) > _MAX_BULK_REMOVE:
+            raise_tool_error(
+                create_error_response(
+                    ErrorCode.VALIDATION_INVALID_PARAMETER,
+                    f"Too many entity IDs: {len(entity_ids)} exceeds maximum "
+                    f"of {_MAX_BULK_REMOVE}",
+                )
+            )
+        for eid in entity_ids:
+            validate_identifier_not_empty(
+                eid,
+                "entity_id",
+                suggestions=["Use ha_search() to find valid entity IDs"],
+            )
+
+        logger.info(f"Bulk removing {len(entity_ids)} entities")
+        removed: list[str] = []
+        skipped: list[str] = []
+        errors: list[dict[str, str]] = []
+        for eid in entity_ids:
+            result = await self._client.send_websocket_message(
+                {"type": "config/entity_registry/remove", "entity_id": eid}
+            )
+            if result.get("success"):
+                removed.append(eid)
+                continue
+            error_msg = _extract_ws_error(result)
+            # Same not-found detection as the single path — HA surfaces the
+            # error as a plain string; already-absent is idempotent success.
+            if "not found" in error_msg.lower():
+                skipped.append(eid)
+            else:
+                errors.append(
+                    {
+                        "entity_id": eid,
+                        "code": ErrorCode.SERVICE_CALL_FAILED.value,
+                        "message": error_msg,
+                    }
+                )
+
+        return {
+            "success": len(errors) == 0,
+            "total": len(entity_ids),
+            "removed": removed,
+            "skipped": skipped,
+            "errors": errors,
+        }
+
     @tool(
         name="ha_remove_entity",
         tags={"Entity Registry"},
@@ -1493,22 +1976,27 @@ class EntityTools:
             "title": "Remove Entity",
         },
     )
+    # Single-entity removal is snapshotted via id_param. A bulk (list) call
+    # stringifies to a non-matching target, so its pre-write snapshot is a
+    # best-effort no-op — bulk removal is not individually backed up (the
+    # decorator captures one entity per call).
     @with_auto_backup(domain="entity", id_param="entity_id")
     @log_tool_usage
     async def ha_remove_entity(
         self,
         entity_id: Annotated[
-            str,
+            str | list[str],
+            JSON_STRING_COERCION,
             Field(
                 description=(
-                    "Entity ID to remove from the entity registry "
-                    "(e.g., 'sensor.old_temperature'). "
-                    "This permanently removes the entity registration."
+                    "Entity ID, or a list of entity IDs, to remove from the "
+                    "entity registry (e.g., 'sensor.old_temperature'). "
+                    "Permanently removes the registration(s)."
                 )
             ),
         ],
     ) -> dict[str, Any]:
-        """Remove an entity from the Home Assistant entity registry.
+        """Remove one or more entities from the Home Assistant entity registry.
 
         Permanently removes the entity registration from Home Assistant.
         The entity will no longer appear in the UI or be available to automations.
@@ -1519,9 +2007,19 @@ class EntityTools:
           may be re-added automatically on the next HA restart or reload
         - This action cannot be undone without restoring from backup
 
+        BULK MODE:
+        Pass a list of entity IDs to remove up to 100 at once — handy for
+        clearing the restored=true orphans an integration leaves behind after
+        its filters change. Removals run sequentially and return:
+          {removed: [...], skipped: [...], errors: [{entity_id, code, message}]}
+        where skipped = ids already absent (not-found is idempotent, not an
+        error). Bulk mode is NOT auto-backed-up (the snapshot is single-entity);
+        single-id removal still is.
+
         EXAMPLES:
         - Remove orphaned sensor: ha_remove_entity("sensor.old_temperature")
         - Remove stale helper entry: ha_remove_entity("input_boolean.deleted_helper")
+        - Bulk cleanup: ha_remove_entity(["sensor.orphan_1", "sensor.orphan_2"])
 
         NOTE: For most use cases, consider disabling instead:
         ha_set_entity(entity_id="sensor.old", enabled=False)
@@ -1531,6 +2029,10 @@ class EntityTools:
         - ha_get_entity: Check entity details before removal
         """
         try:
+            # List mode: bulk removal with a per-id classification envelope.
+            if not isinstance(entity_id, str):
+                return await self._bulk_remove_entities(entity_id)
+
             # Empty/whitespace entity_id would reach the registry-remove WS
             # command and surface as a misleading HA "entity not found".
             validate_identifier_not_empty(

--- a/src/ha_mcp/tools/tools_filesystem.py
+++ b/src/ha_mcp/tools/tools_filesystem.py
@@ -25,6 +25,7 @@ from pydantic import Field
 
 from ..errors import ErrorCode, create_error_response
 from .auto_backup import with_auto_backup
+from .component_api import ComponentCaps, get_component_caps
 from .helpers import (
     exception_to_structured_error,
     log_tool_usage,
@@ -311,13 +312,45 @@ async def _is_mcp_tools_available(client: Any) -> bool:
     )
 
 
+def _assert_caps_version_ok(caps: ComponentCaps) -> None:
+    """Reject a caps-present component below ``MIN_COMPONENT_VERSION``.
+
+    ``get_component_caps`` only returns caps for a component new enough to
+    answer ``ha_mcp_tools/info`` (shipped in 1.1.0, already past the 0.11.0
+    floor), so this is a defensive belt mirroring the authoritative gate in
+    ``_fetch_caller_token`` and never fires in practice. An empty / unparseable
+    ``component_version`` (never emitted by a real caps-present component) is
+    left to that downstream token-fetch gate rather than rejected here.
+    """
+    try:
+        parsed = _version_tuple(caps.component_version)
+    except ValueError:
+        return
+    if parsed < _version_tuple(MIN_COMPONENT_VERSION):
+        _raise_component_too_old(f"reported version is {caps.component_version}")
+
+
 async def _assert_mcp_tools_available(client: Any) -> None:
     """Raise ToolError if ha_mcp_tools is not available.
 
+    Caps-first: a component that answers ``ha_mcp_tools/info``
+    (``get_component_caps`` returns caps) obviously exists — reuse that shared
+    cached probe and enforce ``MIN_COMPONENT_VERSION`` from
+    ``caps.component_version`` (info shipped in 1.1.0, already past the floor).
+    Legacy fallback: caps is None for a component in the 0.11.0-1.1.0 band
+    (services, no info command) or an absent one, so fall back to the per-call
+    ``get_services()`` existence probe.
+
     Must be called within a try block that handles API errors via
     exception_to_structured_error, so connection failures are classified
-    correctly rather than masked as COMPONENT_NOT_INSTALLED.
+    correctly rather than masked as COMPONENT_NOT_INSTALLED. ``get_component_caps``
+    returns None (not raises) on a transport failure, so the legacy
+    ``get_services()`` probe still surfaces the connection error to that handler.
     """
+    caps = await get_component_caps(client)
+    if caps is not None:
+        _assert_caps_version_ok(caps)
+        return
     if not await _is_mcp_tools_available(client):
         raise_tool_error(
             create_error_response(

--- a/src/ha_mcp/tools/tools_history.py
+++ b/src/ha_mcp/tools/tools_history.py
@@ -22,7 +22,6 @@ from pydantic import Field
 from ..errors import ErrorCode, create_error_response, create_validation_error
 from .helpers import (
     exception_to_structured_error,
-    get_connected_ws_client,
     log_tool_usage,
     raise_tool_error,
     register_tool_methods,
@@ -334,21 +333,6 @@ class HistoryTools:
                 message="connecting to Home Assistant WebSocket",
             )
 
-            # Connect to WebSocket (shared by both sources)
-            ws_client, error = await get_connected_ws_client(
-                self._client.base_url,
-                self._client.token,
-                verify_ssl=self._client.verify_ssl,
-            )
-            if error or ws_client is None:
-                raise_tool_error(
-                    error
-                    or create_error_response(
-                        ErrorCode.CONNECTION_FAILED,
-                        "Failed to connect to Home Assistant WebSocket",
-                    )
-                )
-
             await safe_progress(
                 ctx,
                 progress=1,
@@ -356,48 +340,48 @@ class HistoryTools:
                 message=f"querying recorder ({source})",
             )
 
-            try:
-                if source == "statistics":
-                    inner = await _fetch_statistics(
-                        ws_client,
-                        entity_id_list,
-                        start_dt,
-                        end_dt,
-                        period,
-                        statistic_types,
-                        limit,
-                        offset,
-                    )
-                else:
-                    inner = await _fetch_history(
-                        ws_client,
-                        entity_id_list,
-                        start_dt,
-                        end_dt,
-                        minimal_response,
-                        significant_changes_only,
-                        limit,
-                        offset,
-                        _DEFAULT_HISTORY_LIMIT,
-                        _MAX_HISTORY_LIMIT,
-                        order=order,
-                    )
-                await safe_progress(
-                    ctx,
-                    progress=3,
-                    total=3,
-                    message="recorder query complete",
+            # Route through the shared pooled WebSocket (issue #1813) instead of
+            # a dedicated connect/auth handshake per call. Each source issues a
+            # single request/response WS command; the pooled client owns the
+            # connection lifecycle, so there is no per-call connect/disconnect.
+            if source == "statistics":
+                inner = await _fetch_statistics(
+                    self._client,
+                    entity_id_list,
+                    start_dt,
+                    end_dt,
+                    period,
+                    statistic_types,
+                    limit,
+                    offset,
                 )
-                # Wrap first so the outer {"data": ..., "metadata": ...} shape
-                # is always present; then project the inner data dict in-place
-                # when caller requested field projection.
-                _r = await add_timezone_metadata(self._client, inner)
-                if parsed_fields is not None:
-                    _r["data"] = project_fields(_r["data"], parsed_fields)
-                return _r
-            finally:
-                if ws_client:
-                    await ws_client.disconnect()
+            else:
+                inner = await _fetch_history(
+                    self._client,
+                    entity_id_list,
+                    start_dt,
+                    end_dt,
+                    minimal_response,
+                    significant_changes_only,
+                    limit,
+                    offset,
+                    _DEFAULT_HISTORY_LIMIT,
+                    _MAX_HISTORY_LIMIT,
+                    order=order,
+                )
+            await safe_progress(
+                ctx,
+                progress=3,
+                total=3,
+                message="recorder query complete",
+            )
+            # Wrap first so the outer {"data": ..., "metadata": ...} shape
+            # is always present; then project the inner data dict in-place
+            # when caller requested field projection.
+            _r = await add_timezone_metadata(self._client, inner)
+            if parsed_fields is not None:
+                _r["data"] = project_fields(_r["data"], parsed_fields)
+            return _r
 
         except ToolError:
             raise
@@ -507,7 +491,7 @@ def _parse_time_range(
 
 
 async def _fetch_history(
-    ws_client: Any,
+    client: Any,
     entity_id_list: list[str],
     start_dt: datetime,
     end_dt: datetime,
@@ -539,8 +523,8 @@ async def _fetch_history(
         "no_attributes": minimal_response,
     }
 
-    response = await ws_client.send_command(
-        "history/history_during_period", **command_params
+    response = await client.send_websocket_message(
+        {"type": "history/history_during_period", **command_params}
     )
 
     if not response.get("success"):
@@ -624,7 +608,7 @@ async def _fetch_history(
 
 
 async def _fetch_statistics(
-    ws_client: Any,
+    client: Any,
     entity_id_list: list[str],
     start_dt: datetime,
     end_dt: datetime,
@@ -705,8 +689,8 @@ async def _fetch_statistics(
     if stat_types_list is not None:
         command_params["types"] = stat_types_list
 
-    response = await ws_client.send_command(
-        "recorder/statistics_during_period", **command_params
+    response = await client.send_websocket_message(
+        {"type": "recorder/statistics_during_period", **command_params}
     )
 
     if not response.get("success"):

--- a/src/ha_mcp/tools/tools_history.py
+++ b/src/ha_mcp/tools/tools_history.py
@@ -490,6 +490,52 @@ def _parse_time_range(
     return start_dt, end_dt
 
 
+_WS_CONNECTION_SIGNATURES = (
+    "failed to connect",
+    "timed out",
+    "timeout",
+    "connection closed",
+    "disconnected",
+    "not connected",
+)
+
+
+def _raise_recorder_ws_failure(
+    kind: str,
+    error_msg: str,
+    entity_id_list: list[str],
+    suggestions: list[str],
+) -> None:
+    """Raise the structured error for a failed recorder WS call.
+
+    The pooled ``send_websocket_message`` collapses transport failures into
+    ``{"success": False, "error": ...}`` — classify connection-shaped errors
+    as CONNECTION_FAILED (retry/connectivity guidance) instead of presenting
+    recorder-retention suggestions during an HA restart or WS outage.
+    """
+    lowered = error_msg.lower()
+    if any(sig in lowered for sig in _WS_CONNECTION_SIGNATURES):
+        raise_tool_error(
+            create_error_response(
+                ErrorCode.CONNECTION_FAILED,
+                f"Failed to retrieve {kind}: {error_msg}",
+                context={"entity_ids": entity_id_list},
+                suggestions=[
+                    "Home Assistant may be restarting or unreachable — retry shortly",
+                    "Check the connection to Home Assistant",
+                ],
+            )
+        )
+    raise_tool_error(
+        create_error_response(
+            ErrorCode.SERVICE_CALL_FAILED,
+            f"Failed to retrieve {kind}: {error_msg}",
+            context={"entity_ids": entity_id_list},
+            suggestions=suggestions,
+        )
+    )
+
+
 async def _fetch_history(
     client: Any,
     entity_id_list: list[str],
@@ -528,18 +574,15 @@ async def _fetch_history(
     )
 
     if not response.get("success"):
-        error_msg = response.get("error", "Unknown error")
-        raise_tool_error(
-            create_error_response(
-                ErrorCode.SERVICE_CALL_FAILED,
-                f"Failed to retrieve history: {error_msg}",
-                context={"entity_ids": entity_id_list},
-                suggestions=[
-                    "Verify entity IDs exist using ha_search()",
-                    "Check that entities are recorded (not excluded from recorder)",
-                    "Ensure time range is within recorder retention period (~10 days)",
-                ],
-            )
+        _raise_recorder_ws_failure(
+            "history",
+            response.get("error", "Unknown error"),
+            entity_id_list,
+            suggestions=[
+                "Verify entity IDs exist using ha_search()",
+                "Check that entities are recorded (not excluded from recorder)",
+                "Ensure time range is within recorder retention period (~10 days)",
+            ],
         )
 
     result_data = response.get("result", {})
@@ -694,18 +737,15 @@ async def _fetch_statistics(
     )
 
     if not response.get("success"):
-        error_msg = response.get("error", "Unknown error")
-        raise_tool_error(
-            create_error_response(
-                ErrorCode.SERVICE_CALL_FAILED,
-                f"Failed to retrieve statistics: {error_msg}",
-                context={"entity_ids": entity_id_list},
-                suggestions=[
-                    "Verify entities have state_class attribute (measurement, total, total_increasing)",
-                    "Use ha_search() to check entity attributes",
-                    "Statistics are only available for entities that track numeric values",
-                ],
-            )
+        _raise_recorder_ws_failure(
+            "statistics",
+            response.get("error", "Unknown error"),
+            entity_id_list,
+            suggestions=[
+                "Verify entities have state_class attribute (measurement, total, total_increasing)",
+                "Use ha_search() to check entity attributes",
+                "Statistics are only available for entities that track numeric values",
+            ],
         )
 
     result_data = response.get("result", {})

--- a/src/ha_mcp/tools/tools_mcp_component.py
+++ b/src/ha_mcp/tools/tools_mcp_component.py
@@ -18,6 +18,7 @@ from pydantic import Field
 
 from ..client.rest_client import HomeAssistantCommandError
 from ..errors import ErrorCode, create_error_response
+from .component_api import get_component_caps
 from .helpers import (
     exception_to_structured_error,
     log_tool_usage,
@@ -314,13 +315,24 @@ class McpComponentTools:
 
             # If already installed, return success
             if existing_repo and existing_repo.get("installed"):
+                # Caps-first: a loaded 1.1.0+ component reports its running
+                # version via the shared cached ``ha_mcp_tools/info`` probe;
+                # reuse it. Legacy fallback: caps is None for an
+                # installed-but-not-yet-loaded component (needs a restart) or one
+                # too old for the info command, so use HACS's installed_version.
+                caps = await get_component_caps(self._client)
+                version = (
+                    caps.component_version
+                    if caps is not None and caps.component_version
+                    else existing_repo.get("installed_version")
+                )
                 return await add_timezone_metadata(
                     self._client,
                     {
                         "success": True,
                         "already_installed": True,
-                        "version": existing_repo.get("installed_version"),
-                        "message": f"ha_mcp_tools is already installed (version {existing_repo.get('installed_version')})",
+                        "version": version,
+                        "message": f"ha_mcp_tools is already installed (version {version})",
                         "services": [
                             "ha_mcp_tools.list_files - List files in allowed directories",
                         ],

--- a/src/ha_mcp/tools/tools_radio.py
+++ b/src/ha_mcp/tools/tools_radio.py
@@ -50,14 +50,18 @@ class RadioTools:
         self._client = client
 
     async def _resolve_entity_device(self, entity_id: str) -> str:
-        """Resolve an entity_id to its device_id via the entity registry."""
+        """Resolve an entity_id to its device_id via the entity registry.
+
+        Uses HA's targeted ``config/entity_registry/get`` (single-entity
+        lookup) rather than pulling the whole registry list to find one row.
+        """
         result = await self._client.send_websocket_message(
-            {"type": "config/entity_registry/list"}
+            {"type": "config/entity_registry/get", "entity_id": entity_id}
         )
         if result.get("success"):
-            for entry in result.get("result", []):
-                if entry.get("entity_id") == entity_id and entry.get("device_id"):
-                    return str(entry["device_id"])
+            device_id = (result.get("result") or {}).get("device_id")
+            if device_id:
+                return str(device_id)
         raise_tool_error(
             create_error_response(
                 ErrorCode.ENTITY_NOT_FOUND,

--- a/src/ha_mcp/tools/tools_search.py
+++ b/src/ha_mcp/tools/tools_search.py
@@ -3017,22 +3017,21 @@ class SearchTools:
         feeds those slices into its **unchanged** assembly
         (``get_system_overview`` + ``system_info`` / ``notifications`` /
         ``repairs``), so the two paths are byte-identical by construction. Routed
-        all-or-nothing per the ``ha_search`` precedent: gated on the ``overview``
-        capability AND an inactive entity-visibility filter. The filter is applied
-        server-side over the slices either way, so the bypass is a simplification,
-        not a correctness requirement — an active filter that respects Assist
-        exposure would need extra WS reads inside ``load_hidden_set`` that the
-        single round-trip does not carry, so it keeps the legacy path (mirroring
-        search; applying the filter over the slices can come later). The
-        server-side-only fields (``tool_discovery``, ``settings_url``,
+        all-or-nothing per the ``ha_search`` precedent, gated solely on the
+        ``overview`` capability. Unlike ``ha_search``, an active
+        entity-visibility filter does NOT force the legacy path here:
+        ``get_system_overview`` calls ``load_hidden_set`` unconditionally and
+        ``_build_overview_slices`` hands it the same registry + states envelope
+        the legacy fetch produces, so the filter is applied server-side over the
+        component's slices and the output stays byte-identical to legacy
+        (``load_hidden_set`` reaches any extra data it needs — e.g. the
+        Assist-exposure dimension — through the ``client`` it is already passed).
+        The server-side-only fields (``tool_discovery``, ``settings_url``,
         ``read_only_mode``, ``ha_mcp_update``) and the ``fields=`` projection are
         applied by ``ha_get_overview`` after this, identically on both paths.
         """
         caps = await get_component_caps(self._client)
-        if (
-            component_supports(caps, "overview")
-            and not await visibility_filter_active()
-        ):
+        if component_supports(caps, "overview"):
             component_result = await self._overview_via_component(inputs)
             if component_result is not None:
                 return component_result

--- a/src/ha_mcp/tools/tools_system.py
+++ b/src/ha_mcp/tools/tools_system.py
@@ -429,7 +429,7 @@ class SystemTools:
         standard envelope plus ``reloaded``/``entry_id``.
         """
         try:
-            await self._client._request(
+            resp = await self._client._request(
                 "POST", f"/config/config_entries/entry/{entry_id}/reload"
             )
         except ToolError:
@@ -451,6 +451,22 @@ class SystemTools:
                         ],
                     )
                 )
+            if isinstance(e, HomeAssistantAPIError) and e.status_code == 403:
+                # Core returns 403 "Entry cannot be reloaded" for
+                # OperationNotAllowed — an entry whose integration does not
+                # support reload — not an auth problem.
+                raise_tool_error(
+                    create_error_response(
+                        ErrorCode.SERVICE_CALL_FAILED,
+                        f"Config entry {entry_id} cannot be reloaded "
+                        "(the integration does not support reload)",
+                        context={"entry_id": entry_id},
+                        suggestions=[
+                            "Restart Home Assistant (ha_restart) to apply "
+                            "changes to this integration",
+                        ],
+                    )
+                )
             exception_to_structured_error(
                 e,
                 context={"entry_id": entry_id},
@@ -460,10 +476,27 @@ class SystemTools:
                 ],
             )
 
+        # Core reports require_restart=True when the entry could not be
+        # hot-reloaded (its state is not recoverable) — a success response
+        # that still needs a restart to take effect.
+        require_restart = isinstance(resp, dict) and bool(resp.get("require_restart"))
+        if require_restart:
+            return {
+                "success": True,
+                "message": (
+                    f"Config entry {entry_id} cannot be hot-reloaded; "
+                    "a Home Assistant restart is required for changes to "
+                    "take effect"
+                ),
+                "reloaded": False,
+                "require_restart": True,
+                "entry_id": entry_id,
+            }
         return {
             "success": True,
             "message": f"Reloaded config entry {entry_id}",
             "reloaded": True,
+            "require_restart": False,
             "entry_id": entry_id,
         }
 

--- a/src/ha_mcp/tools/tools_system.py
+++ b/src/ha_mcp/tools/tools_system.py
@@ -23,6 +23,7 @@ from .helpers import (
     log_tool_usage,
     raise_tool_error,
     register_tool_methods,
+    validate_identifier_not_empty,
 )
 from .util_helpers import (
     JSON_STRING_COERCION,
@@ -229,6 +230,7 @@ class SystemTools:
     async def ha_reload_core(
         self,
         target: str = "all",
+        entry_id: str | None = None,
     ) -> dict[str, Any]:
         """
         Reload Home Assistant configuration without full restart.
@@ -256,6 +258,11 @@ class SystemTools:
           - "zones": Reload zone configurations
           - "core": Reload core configuration (customize, packages)
           - "themes": Reload frontend themes
+        - entry_id: Reload a SINGLE config entry (one integration instance)
+          instead of sweeping subsystems — the fast path after editing a custom
+          component on disk. Pass it alone (leave `target` at its "all" default);
+          combining it with an explicit `target` is a validation error. Find the
+          id via ha_get_integration.
 
         **Example Usage:**
         ```python
@@ -277,6 +284,36 @@ class SystemTools:
         """
         target = target.lower().strip()
 
+        # Single config-entry reload (issue #1813 fold-in): reload just the
+        # integration instance identified by ``entry_id`` rather than sweeping
+        # every reloadable subsystem — the fast path after editing a custom
+        # component on disk. ``target`` defaults to "all" (meaning "no subsystem
+        # chosen"), so entry_id + the default is an entry-only reload; entry_id
+        # paired with an explicit subsystem target is contradictory.
+        if entry_id is not None:
+            entry_id = validate_identifier_not_empty(
+                entry_id,
+                "entry_id",
+                suggestions=[
+                    "Find the entry_id via ha_get_integration",
+                    "Omit entry_id to reload a whole subsystem via target",
+                ],
+            )
+            if target != "all":
+                raise_tool_error(
+                    create_error_response(
+                        ErrorCode.VALIDATION_INVALID_PARAMETER,
+                        "entry_id cannot be combined with a specific reload "
+                        f"target ('{target}')",
+                        context={"entry_id": entry_id, "target": target},
+                        suggestions=[
+                            "Pass entry_id alone to reload one config entry",
+                            f"Omit entry_id to reload the '{target}' subsystem",
+                        ],
+                    )
+                )
+            return await self._reload_config_entry(entry_id)
+
         if target not in RELOAD_TARGETS:
             raise_tool_error(
                 create_error_response(
@@ -292,23 +329,50 @@ class SystemTools:
 
         try:
             if target == "all":
-                # Reload all reloadable components
+                # Reload all reloadable components. Fire the calls concurrently
+                # but cap the in-flight count with a semaphore so a large
+                # install doesn't hit HA with ~16 simultaneous service calls.
+                # A single failing target must not cancel its siblings, so the
+                # calls are gathered with ``return_exceptions=True`` and
+                # attributed per target below (preserving RELOAD_TARGETS order).
+                reloadable = [
+                    (name, info)
+                    for name, info in RELOAD_TARGETS.items()
+                    if info is not None
+                ]
+                semaphore = asyncio.Semaphore(4)
+
+                async def _reload_one(domain: str, service: str) -> None:
+                    async with semaphore:
+                        await self._client.call_service(domain, service, {})
+
+                outcomes = await asyncio.gather(
+                    *(
+                        _reload_one(domain, service)
+                        for _, (domain, service) in reloadable
+                    ),
+                    return_exceptions=True,
+                )
+
                 results = []
                 errors = []
-
-                for reload_target, service_info in RELOAD_TARGETS.items():
-                    if service_info is None:  # Skip "all" itself
-                        continue
-
-                    domain, service = service_info
-                    try:
-                        await self._client.call_service(domain, service, {})
-                        results.append(reload_target)
-                    except Exception as e:
+                for (reload_target, _), outcome in zip(
+                    reloadable, outcomes, strict=True
+                ):
+                    if isinstance(outcome, BaseException):
+                        # A non-Exception BaseException (CancelledError,
+                        # KeyboardInterrupt, SystemExit) must still unwind the
+                        # request, exactly as the prior sequential
+                        # ``except Exception`` let it propagate — never demote
+                        # it to a per-target warning.
+                        if not isinstance(outcome, Exception):
+                            raise outcome
                         # Some services might not be available in all installations
-                        error_msg = str(e)
+                        error_msg = str(outcome)
                         if "not found" not in error_msg.lower():
                             errors.append(f"{reload_target}: {error_msg}")
+                    else:
+                        results.append(reload_target)
 
                 response: dict[str, Any] = {
                     "success": True,
@@ -353,6 +417,55 @@ class SystemTools:
                 ],
             )
             return None  # unreachable: exception_to_structured_error always raises
+
+    async def _reload_config_entry(self, entry_id: str) -> dict[str, Any]:
+        """Reload a single config entry via the REST config-entries endpoint.
+
+        POSTs to ``/config/config_entries/entry/{entry_id}/reload`` through the
+        REST client's generic request method — the ``/entry/`` path segment the
+        hand-rolled workaround in issue #1813 was easy to get wrong. A 404
+        surfaces as a not-found error naming the ``entry_id``; other failures
+        route through the shared exception classifier. Returns the tool's
+        standard envelope plus ``reloaded``/``entry_id``.
+        """
+        try:
+            await self._client._request(
+                "POST", f"/config/config_entries/entry/{entry_id}/reload"
+            )
+        except ToolError:
+            raise
+        except Exception as e:
+            # Local import mirrors ``_reraise_if_fatal``: rest_client imports
+            # from the tool helpers transitively, so a module-level import
+            # would risk a circular import in the tools package.
+            from ..client.rest_client import HomeAssistantAPIError
+
+            if isinstance(e, HomeAssistantAPIError) and e.status_code == 404:
+                raise_tool_error(
+                    create_error_response(
+                        ErrorCode.RESOURCE_NOT_FOUND,
+                        f"Config entry not found: {entry_id}",
+                        context={"entry_id": entry_id},
+                        suggestions=[
+                            "Verify the entry_id via ha_get_integration",
+                        ],
+                    )
+                )
+            exception_to_structured_error(
+                e,
+                context={"entry_id": entry_id},
+                suggestions=[
+                    "Verify the entry_id via ha_get_integration",
+                    "Check Home Assistant logs for details",
+                ],
+            )
+
+        return {
+            "success": True,
+            "message": f"Reloaded config entry {entry_id}",
+            "reloaded": True,
+            "entry_id": entry_id,
+        }
 
     @tool(
         name="ha_get_system_health",

--- a/src/ha_mcp/tools/tools_zones.py
+++ b/src/ha_mcp/tools/tools_zones.py
@@ -91,11 +91,16 @@ def _shape_component_zone_record(rec: dict[str, Any]) -> dict[str, Any]:
     """
     config = rec.get("config")
     out: dict[str, Any] = dict(config) if isinstance(config, dict) else {}
+    # storage_id is NOT a YAML discriminator: for state-only records the
+    # component backfills it with the registry unique_id or object_id, so a
+    # YAML zone (incl. ``home``) arrives with a non-null storage_id. The
+    # reliable signal is the body itself — a state-attribute body carries
+    # core's ATTR_EDITABLE (False for YAML zones), while a real storage body
+    # never has the key.
+    is_yaml = out.get("editable") is False
     storage_id = rec.get("storage_id")
-    is_yaml = storage_id is None
     # Storage zones keep their storage id (the key ha_get_zone matches on);
-    # YAML zones fall back to the object_id (e.g. "home") so they can still be
-    # fetched by zone_id — mirrors _shape_collection_helper_record.
+    # YAML zones get their object_id so they can still be fetched by zone_id.
     out["id"] = storage_id if storage_id is not None else rec.get("object_id")
     out["editable"] = not is_yaml
     out["source"] = "yaml" if is_yaml else "storage"

--- a/src/ha_mcp/tools/tools_zones.py
+++ b/src/ha_mcp/tools/tools_zones.py
@@ -256,7 +256,9 @@ class ZoneTools:
     async def _send_component_zone_list(self) -> dict[str, Any]:
         """Send one ``ha_mcp_tools/helpers_list`` zone query over the per-client WS."""
         ws = await get_websocket_client(
-            url=self._client.base_url, token=self._client.token
+            url=self._client.base_url,
+            token=self._client.token,
+            verify_ssl=getattr(self._client, "verify_ssl", None),
         )
         return await ws.send_command(
             "ha_mcp_tools/helpers_list",

--- a/src/ha_mcp/tools/tools_zones.py
+++ b/src/ha_mcp/tools/tools_zones.py
@@ -93,10 +93,10 @@ def _shape_component_zone_record(rec: dict[str, Any]) -> dict[str, Any]:
     out: dict[str, Any] = dict(config) if isinstance(config, dict) else {}
     storage_id = rec.get("storage_id")
     is_yaml = storage_id is None
-    if storage_id is not None:
-        # Storage zones keep their storage id (the key ha_get_zone matches on);
-        # the component reads it from the real storage collection.
-        out["id"] = storage_id
+    # Storage zones keep their storage id (the key ha_get_zone matches on);
+    # YAML zones fall back to the object_id (e.g. "home") so they can still be
+    # fetched by zone_id — mirrors _shape_collection_helper_record.
+    out["id"] = storage_id if storage_id is not None else rec.get("object_id")
     out["editable"] = not is_yaml
     out["source"] = "yaml" if is_yaml else "storage"
     return out

--- a/src/ha_mcp/tools/tools_zones.py
+++ b/src/ha_mcp/tools/tools_zones.py
@@ -12,8 +12,19 @@ from fastmcp.exceptions import ToolError
 from fastmcp.tools import tool
 from pydantic import Field
 
+from ..client.rest_client import (
+    HomeAssistantCommandError,
+    HomeAssistantCommandTimeout,
+)
+from ..client.websocket_client import get_websocket_client
 from ..errors import ErrorCode, create_error_response, create_validation_error
 from .auto_backup import with_auto_backup
+from .component_api import (
+    component_supports,
+    get_component_caps,
+    invalidate_caps,
+    is_unknown_command,
+)
 from .helpers import (
     exception_to_structured_error,
     log_tool_usage,
@@ -23,6 +34,83 @@ from .helpers import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+def _build_zone_result(
+    zones: list[dict[str, Any]], zone_id: str | None
+) -> dict[str, Any]:
+    """Assemble the ha_get_zone response from a list of zone records.
+
+    Shared by the legacy ``zone/list`` path and the component ``helpers_list``
+    path so the two produce an identical envelope. Without ``zone_id`` returns
+    the full list; with one, returns that single zone or raises
+    RESOURCE_NOT_FOUND — byte-identical to the original inline logic.
+    """
+    if zone_id is None:
+        return {
+            "success": True,
+            "count": len(zones),
+            "zones": zones,
+            "message": f"Found {len(zones)} zone(s)",
+        }
+
+    zone = next((z for z in zones if z.get("id") == zone_id), None)
+    if zone is None:
+        available_ids = [z.get("id") for z in zones[:10]]  # Show first 10
+        raise_tool_error(
+            create_error_response(
+                ErrorCode.RESOURCE_NOT_FOUND,
+                f"Zone not found: {zone_id}",
+                context={
+                    "zone_id": zone_id,
+                    "available_zone_ids": available_ids,
+                },
+                suggestions=[
+                    "Use ha_get_zone() without zone_id to see all available zones"
+                ],
+            )
+        )
+    return {
+        "success": True,
+        "zone_id": zone_id,
+        "zone": zone,
+    }
+
+
+def _shape_component_zone_record(rec: dict[str, Any]) -> dict[str, Any]:
+    """Map one component ``helpers_list`` zone record onto the legacy zone shape.
+
+    The legacy ``zone/list`` record is the storage body itself (``id`` = storage
+    id, ``name``, ``latitude`` / ``longitude`` / ``radius`` / ``passive`` /
+    ``icon``). The component supplies that same body as ``config`` plus the
+    authoritative ``storage_id`` — ``None`` for a YAML-defined zone, whose config
+    core's ``Zone.__init__`` still retains, so ``home`` and other YAML zones that
+    ``zone/list`` structurally omits come through here. Keep the legacy body and
+    additively stamp an ``editable`` / ``source`` discriminator derived from
+    ``storage_id is None`` (YAML zones are not editable via the storage API).
+    """
+    config = rec.get("config")
+    out: dict[str, Any] = dict(config) if isinstance(config, dict) else {}
+    storage_id = rec.get("storage_id")
+    is_yaml = storage_id is None
+    if storage_id is not None:
+        # Storage zones keep their storage id (the key ha_get_zone matches on);
+        # the component reads it from the real storage collection.
+        out["id"] = storage_id
+    out["editable"] = not is_yaml
+    out["source"] = "yaml" if is_yaml else "storage"
+    return out
+
+
+def _shape_component_zone_rows(result: dict[str, Any]) -> list[dict[str, Any]]:
+    """Reshape the component's zone ``helpers_list`` result into legacy rows."""
+    raw = result.get("helpers")
+    records = raw if isinstance(raw, list) else []
+    return [
+        _shape_component_zone_record(rec)
+        for rec in records
+        if isinstance(rec, dict) and rec.get("helper_type") == "zone"
+    ]
 
 
 class ZoneTools:
@@ -63,10 +151,26 @@ class ZoneTools:
         - List all zones: ha_get_zone()
         - Get specific zone: ha_get_zone(zone_id="abc123")
 
-        **NOTE:** This returns storage-based zones (created via UI/API), not YAML-defined zones.
-        The 'home' zone is typically defined in YAML and may not appear in this list.
+        **NOTE:** With the ha_mcp_tools custom component installed, YAML-defined
+        zones — including the auto-synthesized 'home' zone — are included and
+        marked ``editable=false`` / ``source="yaml"`` (storage zones created via
+        UI/API are ``source="storage"``). Without the component, only storage
+        zones are listed and YAML-defined zones such as 'home' will not appear.
         """
         try:
+            # Prefer the ha_mcp_tools component's helpers_list: core's zone/list
+            # serves only the storage collection, so YAML-defined zones —
+            # including the auto-synthesized 'home' zone — are structurally
+            # absent. The component enumerates them (each with storage_id=None),
+            # filling that gap. Falls back cleanly to the legacy zone/list body
+            # below when the component is absent, downlevel, or errors — the
+            # taxonomy lives in ``_get_zone_via_component``.
+            caps = await get_component_caps(self._client)
+            if component_supports(caps, "helpers_list"):
+                component_response = await self._get_zone_via_component(zone_id)
+                if component_response is not None:
+                    return component_response
+
             message: dict[str, Any] = {
                 "type": "zone/list",
             }
@@ -82,39 +186,7 @@ class ZoneTools:
                     )
                 )
 
-            zones = result.get("result", [])
-
-            if zone_id is None:
-                return {
-                    "success": True,
-                    "count": len(zones),
-                    "zones": zones,
-                    "message": f"Found {len(zones)} zone(s)",
-                }
-
-            zone = next((z for z in zones if z.get("id") == zone_id), None)
-
-            if zone is None:
-                available_ids = [z.get("id") for z in zones[:10]]  # Show first 10
-                raise_tool_error(
-                    create_error_response(
-                        ErrorCode.RESOURCE_NOT_FOUND,
-                        f"Zone not found: {zone_id}",
-                        context={
-                            "zone_id": zone_id,
-                            "available_zone_ids": available_ids,
-                        },
-                        suggestions=[
-                            "Use ha_get_zone() without zone_id to see all available zones"
-                        ],
-                    )
-                )
-
-            return {
-                "success": True,
-                "zone_id": zone_id,
-                "zone": zone,
-            }
+            return _build_zone_result(result.get("result", []), zone_id)
 
         except ToolError:
             raise
@@ -130,6 +202,76 @@ class ZoneTools:
                 ],
             )
             return None  # unreachable: exception_to_structured_error always raises
+
+    async def _get_zone_via_component(
+        self, zone_id: str | None
+    ) -> dict[str, Any] | None:
+        """Serve ha_get_zone from the component's helpers_list; ``None`` ⇒ legacy.
+
+        Error taxonomy mirrors ``_list_helpers_via_component`` in
+        tools_config_helpers (§ 4). ``zone`` is always in the collection
+        universe, so there is a legacy fallback for every failure:
+
+        - ``unknown_command`` (cached caps went stale after a component
+          downgrade): invalidate the caps and return ``None`` so the caller
+          serves the byte-identical legacy ``zone/list`` body, silently.
+        - any other ``HomeAssistantCommandError`` / ``HomeAssistantCommandTimeout``:
+          serve the correct result from the legacy zone list, append a
+          ``warnings[]`` entry, and ``log.warning``.
+        - a response that does not authoritatively enumerate ``zone`` (an older
+          component with no ``covered_types``): fall back to legacy silently.
+        - ``HomeAssistantConnectionError`` (WS down): not caught here, so it
+          propagates to the tool's structured-error handler; the legacy path
+          shares the same socket and would fail identically.
+        """
+        try:
+            raw = await self._send_component_zone_list()
+        except (HomeAssistantCommandError, HomeAssistantCommandTimeout) as exc:
+            if is_unknown_command(exc):
+                invalidate_caps(self._client)
+                return None
+            response = _build_zone_result(await self._legacy_zone_rows(), zone_id)
+            response.setdefault("warnings", []).append(
+                f"component zone listing failed ({exc}); served via legacy path"
+            )
+            logger.warning(
+                "ha_mcp_tools/helpers_list (zone) failed; fell back to legacy: %r",
+                exc,
+            )
+            return response
+        result = raw.get("result") or {}
+        covered = result.get("covered_types")
+        if not (isinstance(covered, list) and "zone" in covered):
+            # The component did not authoritatively enumerate zones (older
+            # component with no covered_types): don't trust its list — fall back
+            # to the legacy storage-only path silently.
+            return None
+        return _build_zone_result(_shape_component_zone_rows(result), zone_id)
+
+    async def _send_component_zone_list(self) -> dict[str, Any]:
+        """Send one ``ha_mcp_tools/helpers_list`` zone query over the per-client WS."""
+        ws = await get_websocket_client(
+            url=self._client.base_url, token=self._client.token
+        )
+        return await ws.send_command(
+            "ha_mcp_tools/helpers_list",
+            helper_types=["zone"],
+            include_flow_helpers=False,
+        )
+
+    async def _legacy_zone_rows(self) -> list[dict[str, Any]]:
+        """Fetch storage zones via the legacy ``zone/list`` WS command."""
+        result = await self._client.send_websocket_message({"type": "zone/list"})
+        if not result.get("success"):
+            raise_tool_error(
+                create_error_response(
+                    ErrorCode.SERVICE_CALL_FAILED,
+                    result.get("error", "Failed to get zones"),
+                    context={},
+                )
+            )
+        rows: list[dict[str, Any]] = result.get("result", [])
+        return rows
 
     @staticmethod
     def _validate_coordinates(

--- a/src/ha_mcp/tools/tools_zones.py
+++ b/src/ha_mcp/tools/tools_zones.py
@@ -394,6 +394,7 @@ class ZoneTools:
                     ],
                     context={"action": "set"},
                 )
+            fields_to_update: dict[str, Any] = {}
             if zone_id:
                 # UPDATE operation
                 operation = "update"

--- a/tests/src/unit/test_backup_agent_lookup.py
+++ b/tests/src/unit/test_backup_agent_lookup.py
@@ -270,106 +270,101 @@ class TestSummarizeBackup:
 
 
 class TestListBackups:
-    """list_backups surfaces HA's backup/info inventory, newest first (#1586)."""
+    """list_backups surfaces HA's backup/info inventory, newest first (#1586).
+
+    Since issue #1813 the single ``backup/info`` query routes through the shared
+    pooled client (``client.send_websocket_message``) instead of a per-call
+    dedicated WebSocket connection.
+    """
 
     @staticmethod
-    def _client() -> MagicMock:
+    def _client(info_response: dict) -> MagicMock:
         client = MagicMock()
         client.base_url = "http://test"
         client.token = "token"
         client.verify_ssl = False
+        client.send_websocket_message = AsyncMock(return_value=info_response)
         return client
 
     @pytest.mark.asyncio
     async def test_lists_backups_newest_first(self):
-        ws = AsyncMock()
-        ws.send_command.return_value = {
-            "success": True,
-            "result": {
-                "backups": [
-                    {
-                        "backup_id": "old",
-                        "name": "Old",
-                        "date": "2026-06-01T00:00:00+00:00",
-                        "agents": {"backup.local": {"size": 10}},
-                    },
-                    {
-                        "backup_id": "new",
-                        "name": "New",
-                        "date": "2026-06-10T00:00:00+00:00",
-                        "agents": {"backup.local": {"size": 20}},
-                    },
-                ]
-            },
-        }
-        with patch(
-            "ha_mcp.tools.backup.get_connected_ws_client",
-            new=AsyncMock(return_value=(ws, None)),
-        ):
-            result = await list_backups(self._client())
+        client = self._client(
+            {
+                "success": True,
+                "result": {
+                    "backups": [
+                        {
+                            "backup_id": "old",
+                            "name": "Old",
+                            "date": "2026-06-01T00:00:00+00:00",
+                            "agents": {"backup.local": {"size": 10}},
+                        },
+                        {
+                            "backup_id": "new",
+                            "name": "New",
+                            "date": "2026-06-10T00:00:00+00:00",
+                            "agents": {"backup.local": {"size": 20}},
+                        },
+                    ]
+                },
+            }
+        )
+        with patch("ha_mcp.tools.backup.get_connected_ws_client") as dedicated:
+            result = await list_backups(client)
 
         assert result["success"] is True
         assert result["count"] == 2
         assert result["total"] == 2
         assert [b["backup_id"] for b in result["backups"]] == ["new", "old"]
-        ws.send_command.assert_awaited_with("backup/info")
+        # Pooled transport, single command, no per-call dedicated connection.
+        client.send_websocket_message.assert_awaited_once_with({"type": "backup/info"})
+        dedicated.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_limit_truncates_but_reports_total(self):
-        ws = AsyncMock()
-        ws.send_command.return_value = {
-            "success": True,
-            "result": {
-                "backups": [
-                    {
-                        "backup_id": f"b{i}",
-                        "date": f"2026-06-{i + 1:02d}T00:00:00+00:00",
-                    }
-                    for i in range(5)
-                ]
-            },
-        }
-        with patch(
-            "ha_mcp.tools.backup.get_connected_ws_client",
-            new=AsyncMock(return_value=(ws, None)),
-        ):
-            result = await list_backups(self._client(), limit=2)
+        client = self._client(
+            {
+                "success": True,
+                "result": {
+                    "backups": [
+                        {
+                            "backup_id": f"b{i}",
+                            "date": f"2026-06-{i + 1:02d}T00:00:00+00:00",
+                        }
+                        for i in range(5)
+                    ]
+                },
+            }
+        )
+        result = await list_backups(client, limit=2)
 
         assert result["count"] == 2
         assert result["total"] == 5
 
     @pytest.mark.asyncio
     async def test_backup_info_failure_raises(self):
-        ws = AsyncMock()
-        ws.send_command.return_value = {"success": False, "error": "nope"}
-        with (
-            patch(
-                "ha_mcp.tools.backup.get_connected_ws_client",
-                new=AsyncMock(return_value=(ws, None)),
-            ),
-            pytest.raises(ToolError),
-        ):
-            await list_backups(self._client())
+        # The pooled client collapses a failed WS command into
+        # ``{"success": False, ...}``; the guard raises a structured ToolError.
+        client = self._client({"success": False, "error": "nope"})
+        with pytest.raises(ToolError):
+            await list_backups(client)
 
     @pytest.mark.asyncio
     async def test_undated_entry_sinks_last(self):
         # An entry with a missing/unparseable date must not crash the sort
         # (datetime vs None) — it sinks below dated entries via the floor.
-        ws = AsyncMock()
-        ws.send_command.return_value = {
-            "success": True,
-            "result": {
-                "backups": [
-                    {"backup_id": "undated"},
-                    {"backup_id": "dated", "date": "2026-06-10T00:00:00+00:00"},
-                ]
-            },
-        }
-        with patch(
-            "ha_mcp.tools.backup.get_connected_ws_client",
-            new=AsyncMock(return_value=(ws, None)),
-        ):
-            result = await list_backups(self._client())
+        client = self._client(
+            {
+                "success": True,
+                "result": {
+                    "backups": [
+                        {"backup_id": "undated"},
+                        {"backup_id": "dated", "date": "2026-06-10T00:00:00+00:00"},
+                    ]
+                },
+            }
+        )
+        result = await list_backups(client)
 
         assert result["success"] is True
         assert [b["backup_id"] for b in result["backups"]] == ["dated", "undated"]

--- a/tests/src/unit/test_context_injection.py
+++ b/tests/src/unit/test_context_injection.py
@@ -130,19 +130,13 @@ async def test_ha_get_history_works_without_ctx() -> None:
     client = _mock_ha_client()
     history_tool = HistoryTools(client).ha_get_history
 
-    fake_ws = AsyncMock()
-    fake_ws.disconnect = AsyncMock()
     fake_result = {"success": True, "source": "history", "entities": []}
 
-    with (
-        patch(
-            "ha_mcp.tools.tools_history.get_connected_ws_client",
-            new=AsyncMock(return_value=(fake_ws, None)),
-        ),
-        patch(
-            "ha_mcp.tools.tools_history._fetch_history",
-            new=AsyncMock(return_value=fake_result),
-        ),
+    # Pooled transport (#1813): ha_get_history calls _fetch_history directly with
+    # the shared client; there is no per-call dedicated connect/disconnect.
+    with patch(
+        "ha_mcp.tools.tools_history._fetch_history",
+        new=AsyncMock(return_value=fake_result),
     ):
         result = await history_tool(entity_ids="sensor.test")
 
@@ -150,7 +144,6 @@ async def test_ha_get_history_works_without_ctx() -> None:
     # — the inner payload must round-trip unchanged under fields=None.
     assert result["data"] == fake_result
     assert "metadata" in result
-    fake_ws.disconnect.assert_awaited_once()
 
 
 @pytest.mark.asyncio
@@ -160,19 +153,11 @@ async def test_ha_get_history_emits_progress_with_ctx() -> None:
     history_tool = HistoryTools(client).ha_get_history
     ctx = _make_ctx()
 
-    fake_ws = AsyncMock()
-    fake_ws.disconnect = AsyncMock()
     fake_result = {"success": True, "source": "history", "entities": []}
 
-    with (
-        patch(
-            "ha_mcp.tools.tools_history.get_connected_ws_client",
-            new=AsyncMock(return_value=(fake_ws, None)),
-        ),
-        patch(
-            "ha_mcp.tools.tools_history._fetch_history",
-            new=AsyncMock(return_value=fake_result),
-        ),
+    with patch(
+        "ha_mcp.tools.tools_history._fetch_history",
+        new=AsyncMock(return_value=fake_result),
     ):
         result = await history_tool(entity_ids="sensor.test", ctx=ctx)
 
@@ -514,19 +499,11 @@ async def test_ha_get_history_statistics_emits_progress() -> None:
     history_tool = HistoryTools(client).ha_get_history
     ctx = _make_ctx()
 
-    fake_ws = AsyncMock()
-    fake_ws.disconnect = AsyncMock()
     fake_result = {"success": True, "source": "statistics", "entities": []}
 
-    with (
-        patch(
-            "ha_mcp.tools.tools_history.get_connected_ws_client",
-            new=AsyncMock(return_value=(fake_ws, None)),
-        ),
-        patch(
-            "ha_mcp.tools.tools_history._fetch_statistics",
-            new=AsyncMock(return_value=fake_result),
-        ),
+    with patch(
+        "ha_mcp.tools.tools_history._fetch_statistics",
+        new=AsyncMock(return_value=fake_result),
     ):
         result = await history_tool(
             entity_ids="sensor.test", source="statistics", period="day", ctx=ctx

--- a/tests/src/unit/test_ha_config_list_helpers_component_routing.py
+++ b/tests/src/unit/test_ha_config_list_helpers_component_routing.py
@@ -44,6 +44,7 @@ from ha_mcp.client.rest_client import (
 )
 from ha_mcp.tools import component_api, tools_config_helpers
 from ha_mcp.tools.tools_config_helpers import (
+    SIMPLE_HELPER_TYPES,
     _shape_collection_helper_record,
     register_config_helper_tools,
 )
@@ -594,3 +595,114 @@ def test_collection_record_falls_back_to_object_id_without_storage_id() -> None:
     }
     out = _shape_collection_helper_record(rec)
     assert out["id"] == "guest_mode"
+
+
+# --- all-types (helper_type="all") bulk mode -------------------------------------
+
+
+def _component_all_result() -> dict[str, Any]:
+    """Merged component output: one collection helper + one flow helper.
+
+    ``covered_types`` is the realistic universe the component enumerates — every
+    simple type EXCEPT ``tag`` (which has no state entity) plus the flow type it
+    returned. So only ``tag`` should fall back to the legacy per-type list.
+    """
+    return {
+        "helpers": [
+            {
+                "helper_type": "input_boolean",
+                "object_id": "abc123",
+                "entity_id": "input_boolean.foo",
+                "name": "New Name",
+                "kind": "collection",
+                "storage_id": "abc123",
+                "config": {"id": "abc123", "name": "Old Name", "icon": "mdi:flash"},
+            },
+            {
+                "helper_type": "template",
+                "entry_id": "cfgentry123",
+                "entity_id": "sensor.templated",
+                "name": "Templated Sensor",
+                "kind": "flow",
+                "options": {"state": "{{ 1 + 1 }}"},
+            },
+        ],
+        "count": 2,
+        "covered_types": sorted((SIMPLE_HELPER_TYPES - {"tag"}) | {"template"}),
+    }
+
+
+@pytest.mark.asyncio
+async def test_all_types_via_component_returns_merged_listing() -> None:
+    """helper_type='all' merges component records + a legacy tag fallback."""
+    ws = make_ws(
+        "ha_mcp_tools/helpers_list",
+        info_result=_CAPS_HELPERS,
+        cmd_result=_component_all_result(),
+    )
+    client = RoutingClient()
+    list_helpers = _build_list_helpers(client)
+
+    with patch_ws(ws, tools_config_helpers):
+        resp = await list_helpers(helper_type="all")
+
+    assert resp["success"] is True
+    assert resp["helper_type"] == "all"
+    # Collection + flow (component) + tag (legacy covered_types fallback).
+    assert resp["count"] == 3
+    by_type = {h.get("helper_type"): h for h in resp["helpers"]}
+    assert set(by_type) == {"input_boolean", "template", "tag"}
+    # Collection record: #1794 shape preserved and self-describes its type.
+    assert by_type["input_boolean"]["id"] == "abc123"
+    assert by_type["input_boolean"]["entity_id"] == "input_boolean.foo"
+    assert by_type["input_boolean"]["name"] == "New Name"
+    # Flow record: entry_id + options carried through.
+    assert by_type["template"]["entry_id"] == "cfgentry123"
+    assert by_type["template"]["options"] == {"state": "{{ 1 + 1 }}"}
+    # Tag came from the legacy fallback (the only uncovered simple type).
+    assert by_type["tag"]["id"] == "tag-42"
+    assert client.list_calls == 1
+    # The component command requests all types (no helper_types filter).
+    (call,) = _helpers_calls(ws)
+    assert "helper_types" not in call.kwargs
+    assert call.kwargs["include_flow_helpers"] is True
+
+
+@pytest.mark.asyncio
+async def test_all_types_without_component_raises_component_required() -> None:
+    """helper_type='all' with no component surface → hard COMPONENT_NOT_INSTALLED."""
+    ws = make_ws(
+        "ha_mcp_tools/helpers_list",
+        info_exc=HomeAssistantCommandError(
+            "Command failed: no info", "unknown_command"
+        ),
+    )
+    client = RoutingClient()
+    list_helpers = _build_list_helpers(client)
+
+    with patch_ws(ws, tools_config_helpers), pytest.raises(ToolError) as excinfo:
+        await list_helpers(helper_type="all")
+
+    assert "COMPONENT_NOT_INSTALLED" in str(excinfo.value)
+    # Never falls back to any legacy list and never issues the component command.
+    assert client.list_calls == 0
+    assert not _helpers_calls(ws)
+
+
+@pytest.mark.asyncio
+async def test_all_types_component_error_raises_component_required() -> None:
+    """A component handler error on helper_type='all' → same hard error, no legacy."""
+    ws = make_ws(
+        "ha_mcp_tools/helpers_list",
+        info_result=_CAPS_HELPERS,
+        cmd_exc=HomeAssistantCommandError("Command failed: boom", "internal_error"),
+    )
+    client = RoutingClient()
+    list_helpers = _build_list_helpers(client)
+
+    with patch_ws(ws, tools_config_helpers), pytest.raises(ToolError) as excinfo:
+        await list_helpers(helper_type="all")
+
+    assert "COMPONENT_NOT_INSTALLED" in str(excinfo.value)
+    # No legacy all-types path exists, so nothing is served from legacy.
+    assert client.list_calls == 0

--- a/tests/src/unit/test_ha_config_list_helpers_component_routing.py
+++ b/tests/src/unit/test_ha_config_list_helpers_component_routing.py
@@ -43,6 +43,7 @@ from ha_mcp.client.rest_client import (
     HomeAssistantCommandTimeout,
 )
 from ha_mcp.tools import component_api, tools_config_helpers
+from ha_mcp.tools.config_entry_flow import FLOW_HELPER_TYPES
 from ha_mcp.tools.tools_config_helpers import (
     SIMPLE_HELPER_TYPES,
     _shape_collection_helper_record,
@@ -603,9 +604,11 @@ def test_collection_record_falls_back_to_object_id_without_storage_id() -> None:
 def _component_all_result() -> dict[str, Any]:
     """Merged component output: one collection helper + one flow helper.
 
-    ``covered_types`` is the realistic universe the component enumerates — every
-    simple type EXCEPT ``tag`` (which has no state entity) plus the flow type it
-    returned. So only ``tag`` should fall back to the legacy per-type list.
+    ``covered_types`` mirrors the real component: every simple type EXCEPT
+    ``tag`` (which has no state entity) plus the FULL flow universe
+    (``covered |= FLOW_HELPER_DOMAINS`` component-side — not just types with
+    instances). So only ``tag`` falls back to the legacy per-type list, and no
+    flow type triggers the incomplete-coverage hard error.
     """
     return {
         "helpers": [
@@ -628,7 +631,7 @@ def _component_all_result() -> dict[str, Any]:
             },
         ],
         "count": 2,
-        "covered_types": sorted((SIMPLE_HELPER_TYPES - {"tag"}) | {"template"}),
+        "covered_types": sorted((SIMPLE_HELPER_TYPES - {"tag"}) | FLOW_HELPER_TYPES),
     }
 
 

--- a/tests/src/unit/test_ha_get_zone_component_routing.py
+++ b/tests/src/unit/test_ha_get_zone_component_routing.py
@@ -76,15 +76,18 @@ def _component_zone_result() -> dict[str, Any]:
                 "entity_id": "zone.home",
                 "object_id": "home",
                 "name": "Home",
-                # YAML/config zone: core retains the config but there is no
-                # storage id (the anti-pattern zone/list can't see).
-                "storage_id": None,
+                # YAML/config zone: state-only record. The component backfills
+                # storage_id with the registry unique_id or object_id (it is
+                # NOT None), and the state-attribute body carries core's
+                # editable=False — the actual YAML discriminator.
+                "storage_id": "home",
                 "config": {
                     "name": "Home",
                     "latitude": 41.0,
                     "longitude": -75.0,
                     "radius": 100,
                     "passive": False,
+                    "editable": False,
                 },
             },
         ],

--- a/tests/src/unit/test_ha_get_zone_component_routing.py
+++ b/tests/src/unit/test_ha_get_zone_component_routing.py
@@ -1,0 +1,366 @@
+"""Routing tests for ``ha_get_zone`` over the ``ha_mcp_tools`` component gate.
+
+Core's ``zone/list`` WS command serves only the storage collection, so
+YAML-defined zones — including the auto-synthesized ``home`` zone — are
+structurally absent from it. When the component advertises the ``helpers_list``
+capability, ``ha_get_zone`` enumerates zones through one
+``ha_mcp_tools/helpers_list`` call instead: YAML zones come back with
+``storage_id=None`` and are surfaced as additive rows carrying an
+``editable`` / ``source`` discriminator, while storage zones keep their exact
+legacy body plus the discriminator.
+
+These tests pin that fast path, the record shape (storage byte-identical modulo
+the additive discriminator; YAML ``home`` present and flagged), get-by-id via the
+component, and the error-taxonomy fallbacks (silent on ``unknown_command``;
+legacy + ``warnings[]`` on any other command error; legacy pin when the
+component has no WS surface or omits ``covered_types``).
+
+The WS client is an ``AsyncMock`` whose ``send_command`` dispatches on the
+command type; the HA client is a spy that tallies the legacy ``zone/list`` fetch
+so a test can assert it never ran on the component path.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastmcp.exceptions import ToolError
+
+from ha_mcp.client.rest_client import (
+    HomeAssistantCommandError,
+    HomeAssistantCommandTimeout,
+)
+from ha_mcp.tools import component_api, tools_zones
+from ha_mcp.tools.tools_zones import register_zone_tools
+
+from ._component_routing_helpers import make_ws, patch_ws
+
+# The single storage zone the legacy ``zone/list`` path can see. Its body is the
+# exact legacy record shape the component supplies as ``config``.
+_LEGACY_STORAGE_ZONE = {
+    "id": "work",
+    "name": "Work",
+    "latitude": 40.0,
+    "longitude": -74.0,
+    "radius": 100,
+    "passive": False,
+    "icon": "mdi:briefcase",
+}
+
+_CAPS_HELPERS = {
+    "schema_version": 1,
+    "component_version": "1.1.0",
+    "capabilities": ["helpers_list"],
+    "limits": {},
+}
+
+
+def _component_zone_result() -> dict[str, Any]:
+    """Component ``helpers_list`` zone output: one storage zone + the YAML home zone."""
+    return {
+        "helpers": [
+            {
+                "helper_type": "zone",
+                "kind": "collection",
+                "entity_id": "zone.work",
+                "object_id": "work",
+                "name": "Work",
+                "storage_id": "work",
+                "config": dict(_LEGACY_STORAGE_ZONE),
+            },
+            {
+                "helper_type": "zone",
+                "kind": "collection",
+                "entity_id": "zone.home",
+                "object_id": "home",
+                "name": "Home",
+                # YAML/config zone: core retains the config but there is no
+                # storage id (the anti-pattern zone/list can't see).
+                "storage_id": None,
+                "config": {
+                    "name": "Home",
+                    "latitude": 41.0,
+                    "longitude": -75.0,
+                    "radius": 100,
+                    "passive": False,
+                },
+            },
+        ],
+        "count": 2,
+        "covered_types": ["input_boolean", "person", "zone"],
+    }
+
+
+class RoutingClient:
+    """Credentialed HA client spy: tallies every legacy ``zone/list`` fetch."""
+
+    def __init__(self) -> None:
+        self.base_url = "http://ha.local:8123"
+        self.token = "tok"
+        self.list_calls = 0
+
+    async def send_websocket_message(self, msg: dict[str, Any]) -> dict[str, Any]:
+        self.list_calls += 1
+        if msg.get("type") == "zone/list":
+            return {"success": True, "result": [dict(_LEGACY_STORAGE_ZONE)]}
+        return {"success": False, "error": "unexpected list type"}
+
+
+def _build_get_zone(client: Any) -> Any:
+    registered: dict[str, Any] = {}
+
+    def capture_add_tool(method: Any) -> None:
+        name = (
+            method.__fastmcp__.name
+            if hasattr(method, "__fastmcp__")
+            else method.__name__
+        )
+        registered[name] = method
+
+    mcp = MagicMock()
+    mcp.add_tool = capture_add_tool
+    register_zone_tools(mcp, client)
+    return registered["ha_get_zone"]
+
+
+@pytest.fixture(autouse=True)
+def _clear_caps_cache() -> Any:
+    """Isolate the module-global caps cache between tests."""
+    component_api._CAPS_CACHE.clear()
+    component_api._CAPS_LOCKS.clear()
+    yield
+    component_api._CAPS_CACHE.clear()
+    component_api._CAPS_LOCKS.clear()
+
+
+def _zone_calls(ws: AsyncMock) -> list[Any]:
+    return [
+        c
+        for c in ws.send_command.call_args_list
+        if c.args[0] == "ha_mcp_tools/helpers_list"
+    ]
+
+
+def _info_calls(ws: AsyncMock) -> list[Any]:
+    return [
+        c for c in ws.send_command.call_args_list if c.args[0] == "ha_mcp_tools/info"
+    ]
+
+
+@pytest.mark.asyncio
+async def test_component_fast_path_lists_yaml_and_storage_zones() -> None:
+    """Component serves the listing: YAML home zone included, no legacy fetch."""
+    ws = make_ws(
+        "ha_mcp_tools/helpers_list",
+        info_result=_CAPS_HELPERS,
+        cmd_result=_component_zone_result(),
+    )
+    client = RoutingClient()
+    get_zone = _build_get_zone(client)
+
+    with patch_ws(ws, tools_zones):
+        resp = await get_zone()
+        resp2 = await get_zone()
+
+    assert resp["success"] is True
+    assert resp["count"] == 2
+    assert resp2["count"] == 2
+    names = {z.get("name") for z in resp["zones"]}
+    assert names == {"Work", "Home"}
+    # The legacy zone/list fetch is never issued on the component path.
+    assert client.list_calls == 0
+    # Exactly one component command per call, one cached info probe.
+    assert len(_zone_calls(ws)) == 2
+    assert len(_info_calls(ws)) == 1
+    # The command asks only for zones, no flow helpers.
+    first = _zone_calls(ws)[0]
+    assert first.kwargs["helper_types"] == ["zone"]
+    assert first.kwargs["include_flow_helpers"] is False
+
+
+@pytest.mark.asyncio
+async def test_storage_zone_byte_identical_plus_discriminator() -> None:
+    """A storage zone keeps its exact legacy body; only the discriminator is added."""
+    ws = make_ws(
+        "ha_mcp_tools/helpers_list",
+        info_result=_CAPS_HELPERS,
+        cmd_result=_component_zone_result(),
+    )
+    get_zone = _build_get_zone(RoutingClient())
+
+    with patch_ws(ws, tools_zones):
+        resp = await get_zone()
+
+    work = next(z for z in resp["zones"] if z.get("id") == "work")
+    assert work["editable"] is True
+    assert work["source"] == "storage"
+    # Stripping the additive discriminator leaves the legacy zone/list body.
+    stripped = {k: v for k, v in work.items() if k not in ("editable", "source")}
+    assert stripped == _LEGACY_STORAGE_ZONE
+
+
+@pytest.mark.asyncio
+async def test_yaml_home_zone_additive_row_with_discriminator() -> None:
+    """The YAML home zone appears as an additive, non-editable row."""
+    ws = make_ws(
+        "ha_mcp_tools/helpers_list",
+        info_result=_CAPS_HELPERS,
+        cmd_result=_component_zone_result(),
+    )
+    get_zone = _build_get_zone(RoutingClient())
+
+    with patch_ws(ws, tools_zones):
+        resp = await get_zone()
+
+    home = next(z for z in resp["zones"] if z.get("name") == "Home")
+    assert home["editable"] is False
+    assert home["source"] == "yaml"
+    assert home["latitude"] == 41.0
+    # YAML zones carry no storage id.
+    assert "id" not in home
+
+
+@pytest.mark.asyncio
+async def test_get_specific_storage_zone_via_component() -> None:
+    """A get-by-id request resolves against the component's storage zone."""
+    ws = make_ws(
+        "ha_mcp_tools/helpers_list",
+        info_result=_CAPS_HELPERS,
+        cmd_result=_component_zone_result(),
+    )
+    client = RoutingClient()
+    get_zone = _build_get_zone(client)
+
+    with patch_ws(ws, tools_zones):
+        resp = await get_zone(zone_id="work")
+
+    assert resp["success"] is True
+    assert resp["zone_id"] == "work"
+    assert resp["zone"]["name"] == "Work"
+    assert resp["zone"]["source"] == "storage"
+    assert client.list_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_get_missing_zone_raises_not_found() -> None:
+    """A get-by-id for an absent zone raises RESOURCE_NOT_FOUND (unchanged)."""
+    ws = make_ws(
+        "ha_mcp_tools/helpers_list",
+        info_result=_CAPS_HELPERS,
+        cmd_result=_component_zone_result(),
+    )
+    get_zone = _build_get_zone(RoutingClient())
+
+    with patch_ws(ws, tools_zones), pytest.raises(ToolError) as excinfo:
+        await get_zone(zone_id="does_not_exist")
+
+    assert "Zone not found" in str(excinfo.value)
+
+
+@pytest.mark.asyncio
+async def test_capsless_component_pins_legacy_path() -> None:
+    """Old component (info unknown_command) → legacy path, only storage zones."""
+    ws = make_ws(
+        "ha_mcp_tools/helpers_list",
+        info_exc=HomeAssistantCommandError(
+            "Command failed: no info", "unknown_command"
+        ),
+    )
+    client = RoutingClient()
+    get_zone = _build_get_zone(client)
+
+    with patch_ws(ws, tools_zones):
+        resp = await get_zone()
+
+    assert resp["success"] is True
+    assert resp["count"] == 1
+    assert resp["zones"] == [dict(_LEGACY_STORAGE_ZONE)]
+    assert client.list_calls == 1
+    # The component listing command must never be attempted without the capability.
+    assert not _zone_calls(ws)
+    assert not any("served via legacy path" in w for w in resp.get("warnings", []))
+
+
+@pytest.mark.asyncio
+async def test_unknown_command_falls_back_silently() -> None:
+    """unknown_command on the zone list call → legacy path, no warning."""
+    ws = make_ws(
+        "ha_mcp_tools/helpers_list",
+        info_result=_CAPS_HELPERS,
+        cmd_exc=HomeAssistantCommandError("Command failed: gone", "unknown_command"),
+    )
+    client = RoutingClient()
+    get_zone = _build_get_zone(client)
+
+    with patch_ws(ws, tools_zones):
+        resp = await get_zone()
+
+    assert resp["success"] is True
+    # Legacy inventory served the request (storage zone only).
+    assert client.list_calls == 1
+    assert resp["count"] == 1
+    assert not any("served via legacy path" in w for w in resp.get("warnings", []))
+
+
+@pytest.mark.asyncio
+async def test_raised_command_falls_back_with_warning() -> None:
+    """A non-unknown command error → legacy path AND a warnings[] entry."""
+    ws = make_ws(
+        "ha_mcp_tools/helpers_list",
+        info_result=_CAPS_HELPERS,
+        cmd_exc=HomeAssistantCommandError("Command failed: boom", "internal_error"),
+    )
+    client = RoutingClient()
+    get_zone = _build_get_zone(client)
+
+    with patch_ws(ws, tools_zones):
+        resp = await get_zone()
+
+    assert resp["success"] is True
+    assert client.list_calls == 1
+    assert resp["count"] == 1
+    assert any("served via legacy path" in w for w in resp["warnings"])
+
+
+@pytest.mark.asyncio
+async def test_command_timeout_falls_back_with_warning() -> None:
+    """A component WS zone-list timeout → legacy path AND a warnings[] entry."""
+    ws = make_ws(
+        "ha_mcp_tools/helpers_list",
+        info_result=_CAPS_HELPERS,
+        cmd_exc=HomeAssistantCommandTimeout("Command timeout"),
+    )
+    client = RoutingClient()
+    get_zone = _build_get_zone(client)
+
+    with patch_ws(ws, tools_zones):
+        resp = await get_zone()
+
+    assert resp["success"] is True
+    assert client.list_calls == 1
+    assert any("served via legacy path" in w for w in resp["warnings"])
+
+
+@pytest.mark.asyncio
+async def test_missing_covered_types_falls_back_to_legacy() -> None:
+    """An older component with no covered_types → conservative legacy fallback."""
+    result = _component_zone_result()
+    del result["covered_types"]
+    ws = make_ws(
+        "ha_mcp_tools/helpers_list", info_result=_CAPS_HELPERS, cmd_result=result
+    )
+    client = RoutingClient()
+    get_zone = _build_get_zone(client)
+
+    with patch_ws(ws, tools_zones):
+        resp = await get_zone()
+
+    # Component consulted once, but its list isn't trusted → legacy serves.
+    assert len(_zone_calls(ws)) == 1
+    assert client.list_calls == 1
+    assert resp["count"] == 1
+    assert resp["zones"][0]["id"] == "work"
+    # Silent conservative fallback: no component-failure warning.
+    assert not any("served via legacy path" in w for w in resp.get("warnings", []))

--- a/tests/src/unit/test_ha_get_zone_component_routing.py
+++ b/tests/src/unit/test_ha_get_zone_component_routing.py
@@ -218,8 +218,8 @@ async def test_yaml_home_zone_additive_row_with_discriminator() -> None:
     assert home["editable"] is False
     assert home["source"] == "yaml"
     assert home["latitude"] == 41.0
-    # YAML zones carry no storage id.
-    assert "id" not in home
+    # YAML zones carry the object_id so they remain fetchable by zone_id.
+    assert home["id"] == "home"
 
 
 @pytest.mark.asyncio

--- a/tests/src/unit/test_ha_overview_component_routing.py
+++ b/tests/src/unit/test_ha_overview_component_routing.py
@@ -385,15 +385,17 @@ async def test_capsless_client_uses_legacy(tmp_path, monkeypatch) -> None:
 
 
 @pytest.mark.asyncio
-async def test_visibility_active_bypasses_component(tmp_path, monkeypatch) -> None:
-    """An ACTIVE entity-visibility filter forces the legacy path.
+async def test_visibility_active_still_routes_through_component(
+    tmp_path, monkeypatch
+) -> None:
+    """An ACTIVE entity-visibility filter still routes through the component.
 
-    The filter is applied server-side over the slices either way, so this is a
-    retained simplification (mirroring search): an active filter with
-    ``respect_assist_exposure`` needs extra WS reads inside ``load_hidden_set``
-    that the single overview round-trip doesn't carry, so a visibility-enabled
-    install keeps the legacy path. Either way the denied entity is excluded from
-    the counts / samples.
+    Unlike ``ha_search``, the overview consumer applies the visibility filter
+    server-side over the component's slices: ``get_system_overview`` calls
+    ``load_hidden_set`` unconditionally and ``_build_overview_slices`` hands it
+    the same registry + states envelope the legacy fetch produces. So a
+    visibility-enabled install still takes the one-round-trip component path,
+    and the denied entity is excluded from the counts / samples all the same.
     """
     save_visibility_config(
         tmp_path,
@@ -416,15 +418,66 @@ async def test_visibility_active_bypasses_component(tmp_path, monkeypatch) -> No
     with patch_ws(ws, tools_search):
         resp = await overview(detail_level="standard")
 
-    # The component overview command must never run while the filter is active.
-    assert not any(
+    # The component overview command runs even with the filter active.
+    assert any(
         c.args[0] == "ha_mcp_tools/overview" for c in ws.send_command.call_args_list
-    ), "component overview must not run while the visibility filter is active"
-    # Legacy inventory served the request, and the denied entity is gone from
-    # the (visibility-filtered) domain stats.
-    assert client.get_states_calls == 1
+    ), "component overview should serve while the visibility filter is active"
+    # No legacy fetch, and the denied entity is gone from the
+    # (server-side visibility-filtered) domain stats.
+    assert client.total_legacy_fetches() == 0
     assert resp["system_summary"]["total_entities"] == 1
     assert "light" not in resp["domain_stats"]
+
+
+@pytest.mark.asyncio
+async def test_component_and_legacy_parity_visibility_active(
+    tmp_path, monkeypatch
+) -> None:
+    """With an ACTIVE filter, the component path is byte-identical to legacy.
+
+    The visibility filter is applied server-side over whichever data source
+    fed the assembly, so the two final responses must be equal even when a
+    hide dimension is active — pinning that routing an active-visibility
+    overview through the component drops or reshapes nothing.
+    """
+    save_visibility_config(
+        tmp_path,
+        VisibilityConfig(
+            enabled=True,
+            exclude_categories=[],
+            deny_entity_ids=["light.kitchen"],
+        ),
+    )
+    monkeypatch.setattr(resolver, "get_data_dir", lambda: tmp_path)
+    _quiet_tail(monkeypatch)
+
+    # Legacy run (info → unknown_command ⇒ no caps ⇒ legacy per-read fetch path).
+    ws_legacy = make_ws(
+        "ha_mcp_tools/overview",
+        info_exc=HomeAssistantCommandError(
+            "Command failed: no info", "unknown_command"
+        ),
+    )
+    client_legacy = OverviewRoutingClient()
+    with patch_ws(ws_legacy, tools_search):
+        legacy = await _build_overview_tool(client_legacy)(detail_level="standard")
+
+    # Component run: the same eight reads, delivered as raw slices in one call.
+    ws_component = make_ws(
+        "ha_mcp_tools/overview",
+        info_result=_CAPS_OVERVIEW,
+        cmd_result=_overview_slices(),
+    )
+    client_component = OverviewRoutingClient()
+    with patch_ws(ws_component, tools_search):
+        component = await _build_overview_tool(client_component)(
+            detail_level="standard"
+        )
+
+    assert component == legacy
+    # The denied entity is excluded on both paths.
+    assert component["system_summary"]["total_entities"] == 1
+    assert client_component.total_legacy_fetches() == 0
 
 
 @pytest.mark.asyncio

--- a/tests/src/unit/test_history_pagination.py
+++ b/tests/src/unit/test_history_pagination.py
@@ -5,8 +5,9 @@ pagination with standardized metadata: total_count, offset, limit, count,
 has_more, next_offset.
 """
 
+import contextlib
 import json
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from fastmcp.exceptions import ToolError
@@ -46,21 +47,25 @@ def _make_stat_rows(n: int) -> list[dict]:
     return [{"start": 1700000000 + i * 300, "mean": float(i)} for i in range(n)]
 
 
-def _make_ws_client_mock(
+def _make_ws_dispatcher(
     history_result: dict | None = None, stat_result: dict | None = None
-) -> MagicMock:
-    ws = MagicMock()
-    ws.disconnect = AsyncMock()
+):
+    """Async ``send_websocket_message`` stand-in dispatching on ``message['type']``.
 
-    async def send_command(cmd, **kwargs):
+    Since issue #1813 the history/statistics tools route their single WS command
+    through the shared pooled ``client.send_websocket_message`` rather than a
+    per-call dedicated connection, so tests configure the client method directly.
+    """
+
+    async def send_websocket_message(message):
+        cmd = message["type"]
         if cmd == "history/history_during_period":
             return {"success": True, "result": history_result or {}}
         if cmd == "recorder/statistics_during_period":
             return {"success": True, "result": stat_result or {}}
         return {"success": False, "error": f"unknown command: {cmd}"}
 
-    ws.send_command = send_command
-    return ws
+    return send_websocket_message
 
 
 # ---------------------------------------------------------------------------
@@ -77,14 +82,16 @@ class TestHistoryPagination:
 
     @pytest.fixture
     def history_tool(self, mock_client):
+        self._mock_client = mock_client
         return HistoryTools(mock_client).ha_get_history
 
     def _patch_ws(self, states: list[dict]):
-        ws = _make_ws_client_mock(history_result={"sensor.test": states})
-        return patch(
-            "ha_mcp.tools.tools_history.get_connected_ws_client",
-            return_value=(ws, None),
+        # Configure the pooled transport on the tool's client; nullcontext keeps
+        # the existing ``with self._patch_ws(...)`` call sites intact.
+        self._mock_client.send_websocket_message = _make_ws_dispatcher(
+            history_result={"sensor.test": states}
         )
+        return contextlib.nullcontext()
 
     @pytest.mark.asyncio
     async def test_default_offset_returns_first_page(self, history_tool):
@@ -206,14 +213,14 @@ class TestStatisticsPagination:
 
     @pytest.fixture
     def history_tool(self, mock_client):
+        self._mock_client = mock_client
         return HistoryTools(mock_client).ha_get_history
 
     def _patch_ws(self, rows: list[dict]):
-        ws = _make_ws_client_mock(stat_result={"sensor.energy": rows})
-        return patch(
-            "ha_mcp.tools.tools_history.get_connected_ws_client",
-            return_value=(ws, None),
+        self._mock_client.send_websocket_message = _make_ws_dispatcher(
+            stat_result={"sensor.energy": rows}
         )
+        return contextlib.nullcontext()
 
     @pytest.mark.asyncio
     async def test_default_limit_applied(self, history_tool):
@@ -431,14 +438,14 @@ class TestMultiEntityOffsetGuard:
 
     @pytest.fixture
     def history_tool(self, mock_client):
+        self._mock_client = mock_client
         return HistoryTools(mock_client).ha_get_history
 
     def _patch_ws(self):
-        ws = _make_ws_client_mock(history_result={})
-        return patch(
-            "ha_mcp.tools.tools_history.get_connected_ws_client",
-            return_value=(ws, None),
+        self._mock_client.send_websocket_message = _make_ws_dispatcher(
+            history_result={}
         )
+        return contextlib.nullcontext()
 
     @pytest.mark.asyncio
     async def test_multi_entity_offset_rejected(self, history_tool):
@@ -463,21 +470,15 @@ class TestMultiEntityOffsetGuard:
     async def test_multi_entity_offset_zero_allowed(self, history_tool):
         """offset=0 (default) with multiple entity_ids is allowed."""
         states = _make_history_states(5)
-        ws = _make_ws_client_mock(
+        self._mock_client.send_websocket_message = _make_ws_dispatcher(
             history_result={
                 "sensor.a": states,
                 "sensor.b": states,
             }
         )
-        with (
-            patch(
-                "ha_mcp.tools.tools_history.get_connected_ws_client",
-                return_value=(ws, None),
-            ),
-            patch(
-                "ha_mcp.tools.tools_history.add_timezone_metadata",
-                side_effect=lambda _c, d, **_kw: d,
-            ),
+        with patch(
+            "ha_mcp.tools.tools_history.add_timezone_metadata",
+            side_effect=lambda _c, d, **_kw: d,
         ):
             result = await history_tool(
                 entity_ids=["sensor.a", "sensor.b"],
@@ -505,14 +506,14 @@ class TestHistoryLimitBoundary:
 
     @pytest.fixture
     def history_tool(self, mock_client):
+        self._mock_client = mock_client
         return HistoryTools(mock_client).ha_get_history
 
     def _patch_ws(self, states):
-        ws = _make_ws_client_mock(history_result={"sensor.test": states})
-        return patch(
-            "ha_mcp.tools.tools_history.get_connected_ws_client",
-            return_value=(ws, None),
+        self._mock_client.send_websocket_message = _make_ws_dispatcher(
+            history_result={"sensor.test": states}
         )
+        return contextlib.nullcontext()
 
     @pytest.mark.asyncio
     async def test_default_limit_applied_history(self, history_tool):

--- a/tests/src/unit/test_oauth.py
+++ b/tests/src/unit/test_oauth.py
@@ -1334,10 +1334,10 @@ class TestOAuthProxyClient:
             await proxy.send_websocket_message({"type": "get_states"})
 
             # WebSocket client must use server-side URL + per-user token
-            mock_get_ws.assert_awaited_once_with(
-                url="http://homeassistant.local:8123",
-                token="test_ha_token_xyz",
-            )
+            mock_get_ws.assert_awaited_once()
+            kwargs = mock_get_ws.await_args.kwargs
+            assert kwargs["url"] == "http://homeassistant.local:8123"
+            assert kwargs["token"] == "test_ha_token_xyz"
 
 
 class TestWebSocketManagerPool:

--- a/tests/src/unit/test_radio_management.py
+++ b/tests/src/unit/test_radio_management.py
@@ -246,9 +246,9 @@ class TestManageRadioDispatcher:
         record: list = []
         client = _client(
             {
-                "config/entity_registry/list": {
+                "config/entity_registry/get": {
                     "success": True,
-                    "result": [{"entity_id": "light.m", "device_id": "m1"}],
+                    "result": {"entity_id": "light.m", "device_id": "m1"},
                 },
                 "matter/node_diagnostics": {"success": True, "result": _DIAG},
             },
@@ -257,6 +257,10 @@ class TestManageRadioDispatcher:
         radio = _capture(register_radio_tools, client)["ha_manage_radio"]
         out = await radio(radio="matter", action="diagnostics", entity_id="light.m")
         assert out["diagnostics"]["network_type"] == "THREAD"
+        # Resolution uses the targeted single-entity get, not a full-list pull.
+        reg = [m for m in record if m["type"] == "config/entity_registry/get"]
+        assert reg and reg[0]["entity_id"] == "light.m"
+        assert not any(m["type"] == "config/entity_registry/list" for m in record)
         diag = [m for m in record if m["type"] == "matter/node_diagnostics"]
         assert diag and diag[0]["device_id"] == "m1"
 
@@ -552,9 +556,12 @@ class TestRadioDispatcherContract:
 
     @pytest.mark.asyncio
     async def test_resolve_entity_device_not_found(self):
-        # An entity_id the registry doesn't contain -> ENTITY_NOT_FOUND.
+        # An entity_id the registry doesn't contain -> ENTITY_NOT_FOUND. The
+        # targeted get returns success=False for an unknown entity_id.
+        record: list = []
         client = _client(
-            {"config/entity_registry/list": {"success": True, "result": []}}
+            {"config/entity_registry/get": {"success": False, "error": "not_found"}},
+            record=record,
         )
         radio = _capture(register_radio_tools, client)["ha_manage_radio"]
         with pytest.raises(ToolError) as exc:
@@ -562,3 +569,6 @@ class TestRadioDispatcherContract:
         msg = str(exc.value)
         assert "light.ghost" in msg
         assert "not found" in msg.lower()
+        # Uses the targeted get keyed by the requested entity_id.
+        reg = [m for m in record if m["type"] == "config/entity_registry/get"]
+        assert reg and reg[0]["entity_id"] == "light.ghost"

--- a/tests/src/unit/test_rest_client_scenes.py
+++ b/tests/src/unit/test_rest_client_scenes.py
@@ -264,3 +264,63 @@ class TestResolveSceneId:
         result = await mock_client.resolve_scene_id("test_scene")
 
         assert result == "test_scene"
+
+
+class TestSceneResolvedShortCircuit:
+    """``_resolved=True`` skips the redundant ``resolve_scene_id`` lookup on the
+    get/upsert/delete scene methods (issue #1813 P5 item 3). ``_make_mock_client``
+    makes ``send_websocket_message`` raise, so ``assert_not_called`` proves the
+    resolver was skipped rather than merely falling back."""
+
+    @pytest.fixture
+    def mock_client(self):
+        return _make_mock_client()
+
+    @pytest.mark.asyncio
+    async def test_get_scene_resolved_skips_lookup(self, mock_client):
+        mock_client._request = AsyncMock(return_value={"name": "S", "entities": {}})
+
+        result = await mock_client.get_scene_config("storage_key", _resolved=True)
+
+        assert result["scene_id"] == "storage_key"
+        mock_client.send_websocket_message.assert_not_called()
+        mock_client._request.assert_called_once_with(
+            "GET", "config/scene/config/storage_key"
+        )
+
+    @pytest.mark.asyncio
+    async def test_upsert_scene_resolved_skips_lookup(self, mock_client):
+        mock_client._request = AsyncMock(return_value={"result": "ok"})
+
+        result = await mock_client.upsert_scene_config(
+            {"entities": {"light.k": {"state": "on"}}}, "storage_key", _resolved=True
+        )
+
+        assert result["scene_id"] == "storage_key"
+        mock_client.send_websocket_message.assert_not_called()
+        assert mock_client._request.call_args[0][1] == "config/scene/config/storage_key"
+
+    @pytest.mark.asyncio
+    async def test_delete_scene_resolved_skips_lookup(self, mock_client):
+        mock_client._request = AsyncMock(return_value={"result": "ok"})
+
+        result = await mock_client.delete_scene_config("storage_key", _resolved=True)
+
+        assert result["scene_id"] == "storage_key"
+        mock_client.send_websocket_message.assert_not_called()
+        mock_client._request.assert_called_once_with(
+            "DELETE", "config/scene/config/storage_key"
+        )
+
+    @pytest.mark.asyncio
+    async def test_delete_scene_default_still_resolves(self, mock_client):
+        """Contrast: without ``_resolved`` the registry resolver is consulted."""
+        mock_client.send_websocket_message = AsyncMock(
+            return_value={"result": {"unique_id": "storage_key"}}
+        )
+        mock_client._request = AsyncMock(return_value={"result": "ok"})
+
+        result = await mock_client.delete_scene_config("movie_night")
+
+        assert result["scene_id"] == "storage_key"
+        mock_client.send_websocket_message.assert_called_once()

--- a/tests/src/unit/test_statistic_types_validation.py
+++ b/tests/src/unit/test_statistic_types_validation.py
@@ -5,8 +5,9 @@ established in test_history_pagination.py, which exercises param coercion, error
 formatting, and source dispatch.
 """
 
+import contextlib
 import json
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from fastmcp.exceptions import ToolError
@@ -21,17 +22,20 @@ def _make_mock_client() -> MagicMock:
     return client
 
 
-def _make_ws_client_mock(stat_result: dict | None = None) -> MagicMock:
-    ws = MagicMock()
-    ws.disconnect = AsyncMock()
+def _make_ws_dispatcher(stat_result: dict | None = None):
+    """Async ``send_websocket_message`` stand-in for the pooled transport (#1813).
 
-    async def send_command(cmd, **kwargs):
-        if cmd == "recorder/statistics_during_period":
+    The statistics tool now issues its single WS command through the shared
+    pooled ``client.send_websocket_message`` rather than a per-call dedicated
+    connection.
+    """
+
+    async def send_websocket_message(message):
+        if message["type"] == "recorder/statistics_during_period":
             return {"success": True, "result": stat_result or {}}
-        return {"success": False, "error": f"unknown command: {cmd}"}
+        return {"success": False, "error": f"unknown command: {message['type']}"}
 
-    ws.send_command = send_command
-    return ws
+    return send_websocket_message
 
 
 class TestStatisticTypesValidation:
@@ -48,14 +52,14 @@ class TestStatisticTypesValidation:
 
     @pytest.fixture
     def history_tool(self, mock_client):
+        self._mock_client = mock_client
         return HistoryTools(mock_client).ha_get_history
 
     def _patch_ws(self, rows: list[dict] | None = None):
-        ws = _make_ws_client_mock(stat_result={"sensor.test": rows or []})
-        return patch(
-            "ha_mcp.tools.tools_history.get_connected_ws_client",
-            return_value=(ws, None),
+        self._mock_client.send_websocket_message = _make_ws_dispatcher(
+            stat_result={"sensor.test": rows or []}
         )
+        return contextlib.nullcontext()
 
     @pytest.mark.asyncio
     async def test_empty_list_raises_tool_error(self, history_tool):
@@ -78,23 +82,16 @@ class TestStatisticTypesValidation:
     @pytest.mark.asyncio
     async def test_none_does_not_set_types_in_command(self, history_tool):
         """statistic_types=None must not include 'types' in the WS command (HA returns all)."""
-        ws = _make_ws_client_mock(stat_result={"sensor.test": []})
-        sent_kwargs = {}
+        sent_message = {}
 
-        async def capturing_send(cmd, **kwargs):
-            sent_kwargs.update(kwargs)
+        async def capturing_send(message):
+            sent_message.update(message)
             return {"success": True, "result": {"sensor.test": []}}
 
-        ws.send_command = capturing_send
-        with (
-            patch(
-                "ha_mcp.tools.tools_history.get_connected_ws_client",
-                return_value=(ws, None),
-            ),
-            patch(
-                "ha_mcp.tools.tools_history.add_timezone_metadata",
-                side_effect=lambda _c, d, **_kw: d,
-            ),
+        self._mock_client.send_websocket_message = capturing_send
+        with patch(
+            "ha_mcp.tools.tools_history.add_timezone_metadata",
+            side_effect=lambda _c, d, **_kw: d,
         ):
             await history_tool(
                 entity_ids="sensor.test",
@@ -102,7 +99,7 @@ class TestStatisticTypesValidation:
                 start_time="7d",
             )
 
-        assert "types" not in sent_kwargs, (
+        assert "types" not in sent_message, (
             "statistic_types=None must not send 'types' to HA — "
             "omitting 'types' lets HA return all available types."
         )
@@ -110,23 +107,16 @@ class TestStatisticTypesValidation:
     @pytest.mark.asyncio
     async def test_valid_list_sets_types_in_command(self, history_tool):
         """statistic_types=['mean', 'sum'] must include types in the WS command."""
-        ws = _make_ws_client_mock(stat_result={"sensor.test": []})
-        sent_kwargs = {}
+        sent_message = {}
 
-        async def capturing_send(cmd, **kwargs):
-            sent_kwargs.update(kwargs)
+        async def capturing_send(message):
+            sent_message.update(message)
             return {"success": True, "result": {"sensor.test": []}}
 
-        ws.send_command = capturing_send
-        with (
-            patch(
-                "ha_mcp.tools.tools_history.get_connected_ws_client",
-                return_value=(ws, None),
-            ),
-            patch(
-                "ha_mcp.tools.tools_history.add_timezone_metadata",
-                side_effect=lambda _c, d, **_kw: d,
-            ),
+        self._mock_client.send_websocket_message = capturing_send
+        with patch(
+            "ha_mcp.tools.tools_history.add_timezone_metadata",
+            side_effect=lambda _c, d, **_kw: d,
         ):
             await history_tool(
                 entity_ids="sensor.test",
@@ -135,29 +125,22 @@ class TestStatisticTypesValidation:
                 statistic_types=["mean", "sum"],
             )
 
-        assert "types" in sent_kwargs
-        assert set(sent_kwargs["types"]) == {"mean", "sum"}
+        assert "types" in sent_message
+        assert set(sent_message["types"]) == {"mean", "sum"}
 
     @pytest.mark.asyncio
     async def test_comma_separated_string_sets_types_in_command(self, history_tool):
         """statistic_types='mean,sum' (comma-separated string) must send correct types."""
-        ws = _make_ws_client_mock(stat_result={"sensor.test": []})
-        sent_kwargs = {}
+        sent_message = {}
 
-        async def capturing_send(cmd, **kwargs):
-            sent_kwargs.update(kwargs)
+        async def capturing_send(message):
+            sent_message.update(message)
             return {"success": True, "result": {"sensor.test": []}}
 
-        ws.send_command = capturing_send
-        with (
-            patch(
-                "ha_mcp.tools.tools_history.get_connected_ws_client",
-                return_value=(ws, None),
-            ),
-            patch(
-                "ha_mcp.tools.tools_history.add_timezone_metadata",
-                side_effect=lambda _c, d, **_kw: d,
-            ),
+        self._mock_client.send_websocket_message = capturing_send
+        with patch(
+            "ha_mcp.tools.tools_history.add_timezone_metadata",
+            side_effect=lambda _c, d, **_kw: d,
         ):
             await history_tool(
                 entity_ids="sensor.test",
@@ -166,8 +149,8 @@ class TestStatisticTypesValidation:
                 statistic_types="mean,sum",
             )
 
-        assert "types" in sent_kwargs
-        assert set(sent_kwargs["types"]) == {"mean", "sum"}
+        assert "types" in sent_message
+        assert set(sent_message["types"]) == {"mean", "sum"}
 
     @pytest.mark.asyncio
     async def test_empty_string_list_notation_raises(self, history_tool):

--- a/tests/src/unit/test_tools_addons.py
+++ b/tests/src/unit/test_tools_addons.py
@@ -3652,28 +3652,27 @@ class TestSupervisorApiCall:
     async def test_schema_error_on_options_endpoint_classified_as_validation_failed(
         self,
     ):
-        """POST /addons/*/options schema reject => VALIDATION_FAILED via classifier."""
-        from ha_mcp.client.rest_client import HomeAssistantCommandError
+        """POST /addons/*/options schema reject => VALIDATION_FAILED via classifier.
+
+        The pooled client (issue #1813) collapses the WS command failure into
+        ``{"success": False, "error": ...}``; _supervisor_api_call re-raises it
+        as HomeAssistantCommandError so the same classifier maps the schema
+        message to VALIDATION_FAILED.
+        """
         from ha_mcp.tools.tools_addons import _supervisor_api_call
 
-        mock_ws = MagicMock()
-        mock_ws.disconnect = AsyncMock()
-        mock_ws.send_command = AsyncMock(
-            side_effect=HomeAssistantCommandError(
-                "Command failed: Missing option 'authorized_keys' in ssh "
+        client = _make_mock_client()
+        client.send_websocket_message = AsyncMock(
+            return_value={
+                "success": False,
+                "error": "Command failed: Missing option 'authorized_keys' in ssh "
                 "in SSH (core_ssh)",
-            )
+            }
         )
 
-        with (
-            patch(
-                "ha_mcp.tools.tools_addons.get_connected_ws_client",
-                return_value=(mock_ws, None),
-            ),
-            pytest.raises(ToolError) as exc_info,
-        ):
+        with pytest.raises(ToolError) as exc_info:
             await _supervisor_api_call(
-                _make_mock_client(),
+                client,
                 "/addons/core_ssh/options",
                 method="POST",
                 data={"options": {"ssh": {"sftp": True}}},
@@ -3691,26 +3690,19 @@ class TestSupervisorApiCall:
         because "authorized_keys" contains "auth"; the phrase-list fix
         in _classify_by_message closes that without endpoint gating.
         """
-        from ha_mcp.client.rest_client import HomeAssistantCommandError
         from ha_mcp.tools.tools_addons import _supervisor_api_call
 
-        mock_ws = MagicMock()
-        mock_ws.disconnect = AsyncMock()
-        mock_ws.send_command = AsyncMock(
-            side_effect=HomeAssistantCommandError(
-                "Command failed: Missing option 'authorized_keys' in ssh",
-            )
+        client = _make_mock_client()
+        client.send_websocket_message = AsyncMock(
+            return_value={
+                "success": False,
+                "error": "Command failed: Missing option 'authorized_keys' in ssh",
+            }
         )
 
-        with (
-            patch(
-                "ha_mcp.tools.tools_addons.get_connected_ws_client",
-                return_value=(mock_ws, None),
-            ),
-            pytest.raises(ToolError) as exc_info,
-        ):
+        with pytest.raises(ToolError) as exc_info:
             await _supervisor_api_call(
-                _make_mock_client(),
+                client,
                 "/addons/core_ssh/info",
                 method="GET",
             )
@@ -3729,31 +3721,34 @@ class TestSupervisorApiCallTimeout:
 
     @pytest.mark.asyncio
     async def test_long_timeout_extends_local_wait(self):
-        """timeout=1800 forwards to Supervisor AND extends the local await."""
+        """timeout=1800 forwards to Supervisor AND extends the local await.
+
+        The control fields ride inside the pooled ``send_websocket_message``
+        payload (issue #1813): ``timeout`` reaches Supervisor, ``_wait_timeout``
+        is consumed by send_command and never leaves the process.
+        """
         from ha_mcp.tools.tools_addons import _supervisor_api_call
 
-        mock_ws = MagicMock()
-        mock_ws.disconnect = AsyncMock()
-        mock_ws.send_command = AsyncMock(return_value={"success": True, "result": {}})
+        client = _make_mock_client()
+        client.send_websocket_message = AsyncMock(
+            return_value={"success": True, "result": {}}
+        )
 
-        with patch(
-            "ha_mcp.tools.tools_addons.get_connected_ws_client",
-            return_value=(mock_ws, None),
-        ):
-            await _supervisor_api_call(
-                _make_mock_client(),
-                "/store/addons/local_ha_mcp_screenshot/install",
-                method="POST",
-                timeout=1800,
-            )
+        await _supervisor_api_call(
+            client,
+            "/store/addons/local_ha_mcp_screenshot/install",
+            method="POST",
+            timeout=1800,
+        )
 
-        kwargs = mock_ws.send_command.call_args.kwargs
+        message = client.send_websocket_message.call_args.args[0]
+        assert message["type"] == "supervisor/api"
         # Supervisor-side proxy timeout is forwarded as the command field...
-        assert kwargs["timeout"] == 1800
+        assert message["timeout"] == 1800
         # ...and the client's own await outlasts it by a margin (the old
         # hard-coded 30s default would have fired ~1770s too early). The
-        # control kwarg is underscored so it can't collide with a message field.
-        assert kwargs["_wait_timeout"] == 1815.0
+        # control key is underscored so it can't collide with a message field.
+        assert message["_wait_timeout"] == 1815.0
 
     @pytest.mark.asyncio
     async def test_no_timeout_keeps_default_local_wait(self):
@@ -3761,19 +3756,16 @@ class TestSupervisorApiCallTimeout:
         and no ``timeout`` field is forwarded to Supervisor."""
         from ha_mcp.tools.tools_addons import _supervisor_api_call
 
-        mock_ws = MagicMock()
-        mock_ws.disconnect = AsyncMock()
-        mock_ws.send_command = AsyncMock(return_value={"success": True, "result": {}})
+        client = _make_mock_client()
+        client.send_websocket_message = AsyncMock(
+            return_value={"success": True, "result": {}}
+        )
 
-        with patch(
-            "ha_mcp.tools.tools_addons.get_connected_ws_client",
-            return_value=(mock_ws, None),
-        ):
-            await _supervisor_api_call(_make_mock_client(), "/addons", method="GET")
+        await _supervisor_api_call(client, "/addons", method="GET")
 
-        kwargs = mock_ws.send_command.call_args.kwargs
-        assert kwargs["_wait_timeout"] == 30.0
-        assert "timeout" not in kwargs
+        message = client.send_websocket_message.call_args.args[0]
+        assert message["_wait_timeout"] == 30.0
+        assert "timeout" not in message
 
 
 class TestManageAddonActionMode:

--- a/tests/src/unit/test_tools_bug_report.py
+++ b/tests/src/unit/test_tools_bug_report.py
@@ -47,6 +47,17 @@ def mock_mcp():
 class TestBugReportTool:
     """Test suite for the ha_report_issue tool."""
 
+    @pytest.fixture(autouse=True)
+    def _stub_component_caps(self):
+        """These tests exercise report assembly, not the component-version
+        probe. Stub the shared caps probe to None so ``_detect_component_version``
+        takes its legacy best-effort path without a live WS round-trip."""
+        with patch(
+            "ha_mcp.tools.tools_bug_report.get_component_caps",
+            AsyncMock(return_value=None),
+        ):
+            yield
+
     @pytest.fixture
     def mock_client(self):
         """Create a mock Home Assistant client."""
@@ -725,6 +736,75 @@ class TestBugReportTool:
         assert result["addon_logs"] == ""
         assert "Add-on Container Logs" not in result["formatted_report"]
         assert "Add-on Container Logs" not in result["runtime_bug_template"]
+
+
+class TestDetectComponentVersion:
+    """``_detect_component_version`` prefers the shared cached caps probe and
+    only falls back to the ``get_caller_token`` bootstrap for a component too
+    old for ``ha_mcp_tools/info`` (issue #1813 P5 item 1a)."""
+
+    @staticmethod
+    def _caps(version: str):
+        from ha_mcp.tools.component_api import ComponentCaps
+
+        return ComponentCaps(
+            schema_version=1,
+            component_version=version,
+            capabilities=frozenset({"search"}),
+            limits={},
+        )
+
+    @pytest.mark.asyncio
+    async def test_caps_hit_uses_caps_version_and_skips_service(self):
+        from ha_mcp.tools.tools_bug_report import BugReportTools
+
+        client = MagicMock()
+        client.call_service = AsyncMock()
+        tools = BugReportTools(client)
+        with patch(
+            "ha_mcp.tools.tools_bug_report.get_component_caps",
+            AsyncMock(return_value=self._caps("1.3.0")),
+        ):
+            version = await tools._detect_component_version()
+
+        assert version == "1.3.0"
+        client.call_service.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_caps_miss_falls_back_to_bootstrap_service(self):
+        from ha_mcp.tools.tools_bug_report import BugReportTools
+
+        client = MagicMock()
+        client.call_service = AsyncMock(
+            return_value={"service_response": {"version": "0.11.0"}}
+        )
+        tools = BugReportTools(client)
+        with patch(
+            "ha_mcp.tools.tools_bug_report.get_component_caps",
+            AsyncMock(return_value=None),
+        ):
+            version = await tools._detect_component_version()
+
+        assert version == "0.11.0"
+        client.call_service.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_caps_hit_empty_version_returns_none_without_service(self):
+        """A caps-present component that reports no version string yields None
+        (guarded even though a real 1.1.0+ component always reports one)."""
+        from ha_mcp.tools.tools_bug_report import BugReportTools
+
+        client = MagicMock()
+        client.call_service = AsyncMock()
+        tools = BugReportTools(client)
+        with patch(
+            "ha_mcp.tools.tools_bug_report.get_component_caps",
+            AsyncMock(return_value=self._caps("")),
+        ):
+            version = await tools._detect_component_version()
+
+        assert version is None
+        client.call_service.assert_not_called()
 
 
 class TestFetchCoreErrorLog:

--- a/tests/src/unit/test_tools_calendar_delete.py
+++ b/tests/src/unit/test_tools_calendar_delete.py
@@ -1,0 +1,93 @@
+"""Unit tests for ``ha_config_remove_calendar_event`` pooled-WS routing (#1813).
+
+``calendar.delete_event`` is not a REST service — delete lives exclusively on
+the WebSocket command ``calendar/event/delete``, now routed through the shared
+pooled client (``client.send_websocket_message``) instead of a per-call
+dedicated connection. A failed WS command comes back as ``{"success": False}``
+and is re-raised so the failure reaches the tool's existing error handler.
+"""
+
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastmcp.exceptions import ToolError
+
+from ha_mcp.tools import tools_calendar
+from ha_mcp.tools.tools_calendar import CalendarTools
+
+
+def _make_mock_client(ws_return: dict | None = None) -> MagicMock:
+    client = MagicMock()
+    client.base_url = "http://ha.local:8123"
+    client.token = "test-token"
+    client.verify_ssl = True
+    client.send_websocket_message = AsyncMock(
+        return_value=ws_return or {"success": True, "result": None}
+    )
+    return client
+
+
+@pytest.mark.asyncio
+async def test_delete_routes_via_pooled_websocket():
+    client = _make_mock_client(ws_return={"success": True, "result": {"ok": True}})
+
+    tools = CalendarTools(client)
+    result = await tools.ha_config_remove_calendar_event(
+        entity_id="calendar.test",
+        uid="evt-123",
+    )
+
+    client.send_websocket_message.assert_awaited_once()
+    message = client.send_websocket_message.await_args.args[0]
+    assert message["type"] == "calendar/event/delete"
+    assert message["entity_id"] == "calendar.test"
+    assert message["uid"] == "evt-123"
+    # recurrence params omitted when unset.
+    assert "recurrence_id" not in message
+    assert "recurrence_range" not in message
+    assert result["success"] is True
+    assert result["uid"] == "evt-123"
+    # The dedicated-connection helper is gone from the module namespace.
+    assert not hasattr(tools_calendar, "get_connected_ws_client")
+
+
+@pytest.mark.asyncio
+async def test_delete_forwards_recurrence_params():
+    client = _make_mock_client()
+
+    tools = CalendarTools(client)
+    await tools.ha_config_remove_calendar_event(
+        entity_id="calendar.test",
+        uid="evt-123",
+        recurrence_id="20260101T100000",
+        recurrence_range="THIS_AND_FUTURE",
+    )
+
+    message = client.send_websocket_message.await_args.args[0]
+    assert message["recurrence_id"] == "20260101T100000"
+    assert message["recurrence_range"] == "THIS_AND_FUTURE"
+
+
+@pytest.mark.asyncio
+async def test_delete_failure_surfaces_structured_error():
+    # Pooled client collapses a failed WS command into {"success": False}; the
+    # tool re-raises so the outer handler builds the delete-specific suggestions.
+    client = _make_mock_client(
+        ws_return={"success": False, "error": "Command failed: event not found"}
+    )
+
+    tools = CalendarTools(client)
+    with pytest.raises(ToolError) as exc_info:
+        await tools.ha_config_remove_calendar_event(
+            entity_id="calendar.test",
+            uid="missing",
+        )
+
+    err = json.loads(str(exc_info.value))["error"]
+    suggestions = err.get("suggestions") or [err.get("suggestion", "")]
+    # The delete handler prepends a not-found hint referencing entity/uid.
+    assert any(
+        "not found" in s.lower() or "uid" in s.lower() or "event" in s.lower()
+        for s in suggestions
+    )

--- a/tests/src/unit/test_tools_calendar_rrule.py
+++ b/tests/src/unit/test_tools_calendar_rrule.py
@@ -1,73 +1,66 @@
 """Unit tests for recurring-event support in ``ha_config_set_calendar_event``.
 
 The ``calendar.create_event`` REST service schema has no ``rrule`` field —
-recurrence is only accepted by the WebSocket command
-``calendar/event/create``. These tests pin the transport routing: ``rrule``
-present → WebSocket command carrying an RFC 5545 event payload
-(``dtstart``/``dtend`` keys); ``rrule`` absent → the pre-existing REST
-service call (``start_date_time``/``end_date_time`` keys), unchanged.
+recurrence is only accepted by the WebSocket command ``calendar/event/create``.
+Since issue #1813 that WS command routes through the shared pooled client
+(``client.send_websocket_message``) rather than a per-call dedicated connection.
 
-They also cover the three failure paths unique to the rrule branch: a
-WebSocket connect failure (both the supplied-error and the synthesised
-``CONNECTION_FAILED`` cases), the guarded disconnect that must not mask the
-original ``send_command`` error, and the rrule-specific error suggestion.
-``raise_tool_error`` serialises the structured error as JSON into the
-``ToolError`` message, so the failure-path tests parse it back to assert on
-code/context/suggestions.
+These tests pin the transport routing: ``rrule`` present → pooled WS command
+carrying an RFC 5545 event payload (``dtstart``/``dtend`` keys); ``rrule``
+absent → the pre-existing REST service call (``start_date_time``/
+``end_date_time`` keys), unchanged.
+
+They also cover the rrule-branch failure path: a failed WS command comes back
+from the pooled client as ``{"success": False, ...}`` and is re-raised so the
+caller's handler still attaches the RRULE-syntax suggestion. ``raise_tool_error``
+serialises the structured error as JSON into the ``ToolError`` message, so the
+failure-path tests parse it back to assert on suggestions.
 """
 
 import json
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from fastmcp.exceptions import ToolError
 
 from ha_mcp.client.rest_client import HomeAssistantCommandError
-from ha_mcp.errors import ErrorCode
+from ha_mcp.tools import tools_calendar
 from ha_mcp.tools.tools_calendar import CalendarTools
 
 
-def _make_mock_client() -> MagicMock:
+def _make_mock_client(ws_return: dict | None = None) -> MagicMock:
     client = MagicMock()
     client.base_url = "http://ha.local:8123"
     client.token = "test-token"
     client.verify_ssl = True
     client.call_service = AsyncMock(return_value={"success": True})
+    client.send_websocket_message = AsyncMock(
+        return_value=ws_return or {"success": True, "result": None}
+    )
     return client
-
-
-def _make_mock_ws() -> AsyncMock:
-    ws = AsyncMock()
-    ws.send_command = AsyncMock(return_value={"success": True, "result": None})
-    return ws
 
 
 @pytest.mark.asyncio
 async def test_rrule_routes_via_websocket_event_create():
-    """rrule present → calendar/event/create WS command, REST service untouched."""
+    """rrule present → calendar/event/create pooled WS command, REST untouched."""
     client = _make_mock_client()
-    ws = _make_mock_ws()
 
-    with patch(
-        "ha_mcp.tools.tools_calendar.get_connected_ws_client",
-        return_value=(ws, None),
-    ):
-        tools = CalendarTools(client)
-        result = await tools.ha_config_set_calendar_event(
-            entity_id="calendar.test",
-            summary="Weekly sync",
-            start="2026-06-15T10:00:00",
-            end="2026-06-15T10:30:00",
-            description="desc",
-            location="loc",
-            rrule="FREQ=WEEKLY;BYDAY=MO;COUNT=10",
-        )
+    tools = CalendarTools(client)
+    result = await tools.ha_config_set_calendar_event(
+        entity_id="calendar.test",
+        summary="Weekly sync",
+        start="2026-06-15T10:00:00",
+        end="2026-06-15T10:30:00",
+        description="desc",
+        location="loc",
+        rrule="FREQ=WEEKLY;BYDAY=MO;COUNT=10",
+    )
 
-    ws.send_command.assert_awaited_once()
-    args, kwargs = ws.send_command.await_args
-    assert args == ("calendar/event/create",)
-    assert kwargs["entity_id"] == "calendar.test"
-    assert kwargs["event"] == {
+    client.send_websocket_message.assert_awaited_once()
+    message = client.send_websocket_message.await_args.args[0]
+    assert message["type"] == "calendar/event/create"
+    assert message["entity_id"] == "calendar.test"
+    assert message["event"] == {
         "summary": "Weekly sync",
         "dtstart": "2026-06-15T10:00:00",
         "dtend": "2026-06-15T10:30:00",
@@ -75,8 +68,10 @@ async def test_rrule_routes_via_websocket_event_create():
         "description": "desc",
         "location": "loc",
     }
-    ws.disconnect.assert_awaited_once()
     client.call_service.assert_not_awaited()
+    # The dedicated-connection helper is gone from the module namespace, so the
+    # tool cannot fall back to a per-call connect/auth handshake.
+    assert not hasattr(tools_calendar, "get_connected_ws_client")
     assert result["success"] is True
     assert result["event"]["rrule"] == "FREQ=WEEKLY;BYDAY=MO;COUNT=10"
 
@@ -85,23 +80,18 @@ async def test_rrule_routes_via_websocket_event_create():
 async def test_rrule_omits_unset_optional_fields_from_ws_event():
     """Unset description/location must not appear in the WS event payload."""
     client = _make_mock_client()
-    ws = _make_mock_ws()
 
-    with patch(
-        "ha_mcp.tools.tools_calendar.get_connected_ws_client",
-        return_value=(ws, None),
-    ):
-        tools = CalendarTools(client)
-        await tools.ha_config_set_calendar_event(
-            entity_id="calendar.test",
-            summary="Bare recurring",
-            start="2026-06-20T09:00:00",
-            end="2026-06-20T09:30:00",
-            rrule="FREQ=MONTHLY;BYDAY=3SA",
-        )
+    tools = CalendarTools(client)
+    await tools.ha_config_set_calendar_event(
+        entity_id="calendar.test",
+        summary="Bare recurring",
+        start="2026-06-20T09:00:00",
+        end="2026-06-20T09:30:00",
+        rrule="FREQ=MONTHLY;BYDAY=3SA",
+    )
 
-    _, kwargs = ws.send_command.await_args
-    assert kwargs["event"] == {
+    message = client.send_websocket_message.await_args.args[0]
+    assert message["event"] == {
         "summary": "Bare recurring",
         "dtstart": "2026-06-20T09:00:00",
         "dtend": "2026-06-20T09:30:00",
@@ -114,26 +104,21 @@ async def test_rrule_forwards_explicit_empty_string_fields_to_ws_event():
     """An explicitly-passed "" must reach HA (it clears the field there),
     unlike an unset (None) field, which is omitted entirely."""
     client = _make_mock_client()
-    ws = _make_mock_ws()
 
-    with patch(
-        "ha_mcp.tools.tools_calendar.get_connected_ws_client",
-        return_value=(ws, None),
-    ):
-        tools = CalendarTools(client)
-        await tools.ha_config_set_calendar_event(
-            entity_id="calendar.test",
-            summary="Bare recurring",
-            start="2026-06-20T09:00:00",
-            end="2026-06-20T09:30:00",
-            description="",
-            location="",
-            rrule="FREQ=MONTHLY;BYDAY=3SA",
-        )
+    tools = CalendarTools(client)
+    await tools.ha_config_set_calendar_event(
+        entity_id="calendar.test",
+        summary="Bare recurring",
+        start="2026-06-20T09:00:00",
+        end="2026-06-20T09:30:00",
+        description="",
+        location="",
+        rrule="FREQ=MONTHLY;BYDAY=3SA",
+    )
 
-    _, kwargs = ws.send_command.await_args
-    assert kwargs["event"]["description"] == ""
-    assert kwargs["event"]["location"] == ""
+    message = client.send_websocket_message.await_args.args[0]
+    assert message["event"]["description"] == ""
+    assert message["event"]["location"] == ""
 
 
 @pytest.mark.asyncio
@@ -141,14 +126,13 @@ async def test_no_rrule_keeps_rest_service_path():
     """rrule absent → existing calendar.create_event service call, no WS."""
     client = _make_mock_client()
 
-    with patch("ha_mcp.tools.tools_calendar.get_connected_ws_client") as ws_factory:
-        tools = CalendarTools(client)
-        result = await tools.ha_config_set_calendar_event(
-            entity_id="calendar.test",
-            summary="One-off",
-            start="2026-06-15T10:00:00",
-            end="2026-06-15T11:00:00",
-        )
+    tools = CalendarTools(client)
+    result = await tools.ha_config_set_calendar_event(
+        entity_id="calendar.test",
+        summary="One-off",
+        start="2026-06-15T10:00:00",
+        end="2026-06-15T11:00:00",
+    )
 
     client.call_service.assert_awaited_once_with(
         "calendar",
@@ -160,7 +144,7 @@ async def test_no_rrule_keeps_rest_service_path():
             "end_date_time": "2026-06-15T11:00:00",
         },
     )
-    ws_factory.assert_not_called()
+    client.send_websocket_message.assert_not_awaited()
     assert result["success"] is True
     assert result["event"]["rrule"] is None
 
@@ -170,16 +154,15 @@ async def test_no_rrule_forwards_explicit_empty_string_fields_to_rest_call():
     """Same "" vs None distinction on the non-rrule REST service path."""
     client = _make_mock_client()
 
-    with patch("ha_mcp.tools.tools_calendar.get_connected_ws_client"):
-        tools = CalendarTools(client)
-        await tools.ha_config_set_calendar_event(
-            entity_id="calendar.test",
-            summary="One-off",
-            start="2026-06-15T10:00:00",
-            end="2026-06-15T11:00:00",
-            description="",
-            location="",
-        )
+    tools = CalendarTools(client)
+    await tools.ha_config_set_calendar_event(
+        entity_id="calendar.test",
+        summary="One-off",
+        start="2026-06-15T10:00:00",
+        end="2026-06-15T11:00:00",
+        description="",
+        location="",
+    )
 
     client.call_service.assert_awaited_once_with(
         "calendar",
@@ -201,148 +184,32 @@ def _structured_error(exc: ToolError) -> dict:
 
 
 # ---------------------------------------------------------------------------
-# Error-path coverage for the rrule WebSocket branch. These three branches are
-# all new with the recurring-event feature and only reachable on the rrule
-# path; the happy-path tests above never exercise them.
+# Error-path coverage for the rrule WebSocket branch. The pooled client
+# collapses a WS command failure into ``{"success": False, ...}``; the tool
+# re-raises so the failure reaches the same handler that used to catch the
+# dedicated ``send_command`` exception.
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_ws_connect_failure_surfaces_supplied_error_verbatim():
-    """rrule path, get_connected_ws_client returns (None, error) → that exact
-    error is raised and the REST service is never touched."""
-    client = _make_mock_client()
-    conn_error = {
-        "success": False,
-        "error": {
-            "code": ErrorCode.CONNECTION_FAILED.value,
-            "message": "ws factory said no",
-        },
-    }
-
-    with patch(
-        "ha_mcp.tools.tools_calendar.get_connected_ws_client",
-        return_value=(None, conn_error),
-    ):
-        tools = CalendarTools(client)
-        with pytest.raises(ToolError) as exc_info:
-            await tools.ha_config_set_calendar_event(
-                entity_id="calendar.test",
-                summary="Weekly sync",
-                start="2026-06-15T10:00:00",
-                end="2026-06-15T10:30:00",
-                rrule="FREQ=WEEKLY;BYDAY=MO;COUNT=10",
-            )
-
-    assert _structured_error(exc_info.value) == conn_error
-    client.call_service.assert_not_awaited()
-
-
-@pytest.mark.asyncio
-async def test_ws_connect_failure_without_error_raises_connection_failed():
-    """rrule path, get_connected_ws_client returns (None, None) → a synthesised
-    CONNECTION_FAILED error carrying the entity_id, REST service untouched."""
-    client = _make_mock_client()
-
-    with patch(
-        "ha_mcp.tools.tools_calendar.get_connected_ws_client",
-        return_value=(None, None),
-    ):
-        tools = CalendarTools(client)
-        with pytest.raises(ToolError) as exc_info:
-            await tools.ha_config_set_calendar_event(
-                entity_id="calendar.test",
-                summary="Weekly sync",
-                start="2026-06-15T10:00:00",
-                end="2026-06-15T10:30:00",
-                rrule="FREQ=WEEKLY;BYDAY=MO;COUNT=10",
-            )
-
-    err = _structured_error(exc_info.value)
-    assert err["error"]["code"] == ErrorCode.CONNECTION_FAILED.value
-    # create_error_response merges context at the top level, not under "error".
-    assert err["entity_id"] == "calendar.test"
-    client.call_service.assert_not_awaited()
-
-
-@pytest.mark.asyncio
-async def test_disconnect_error_does_not_mask_send_command_error():
-    """If send_command AND the guarded disconnect both raise, the caller must
-    see the send_command error, not the teardown error."""
-    client = _make_mock_client()
-    ws = AsyncMock()
-    ws.send_command = AsyncMock(
-        side_effect=HomeAssistantCommandError("Command failed: backend rejected rrule")
+async def test_rrule_failure_prepends_rrule_suggestion():
+    """A failed rrule create surfaces the RRULE-syntax hint as the first suggestion."""
+    client = _make_mock_client(
+        ws_return={
+            "success": False,
+            "error": "Command failed: backend rejected rrule",
+        }
     )
-    ws.disconnect = AsyncMock(side_effect=RuntimeError("socket already torn down"))
 
-    with patch(
-        "ha_mcp.tools.tools_calendar.get_connected_ws_client",
-        return_value=(ws, None),
-    ):
-        tools = CalendarTools(client)
-        with pytest.raises(ToolError) as exc_info:
-            await tools.ha_config_set_calendar_event(
-                entity_id="calendar.test",
-                summary="Weekly sync",
-                start="2026-06-15T10:00:00",
-                end="2026-06-15T10:30:00",
-                rrule="FREQ=WEEKLY;BYDAY=MO;COUNT=10",
-            )
-
-    message = _structured_error(exc_info.value)["error"]["message"]
-    assert "backend rejected rrule" in message
-    assert "socket already torn down" not in message
-    ws.disconnect.assert_awaited_once()
-
-
-@pytest.mark.asyncio
-async def test_disconnect_error_swallowed_on_success():
-    """A disconnect failure after a successful send_command must not fail the tool."""
-    client = _make_mock_client()
-    ws = AsyncMock()
-    ws.send_command = AsyncMock(return_value={"success": True, "result": None})
-    ws.disconnect = AsyncMock(side_effect=RuntimeError("socket already torn down"))
-
-    with patch(
-        "ha_mcp.tools.tools_calendar.get_connected_ws_client",
-        return_value=(ws, None),
-    ):
-        tools = CalendarTools(client)
-        result = await tools.ha_config_set_calendar_event(
+    tools = CalendarTools(client)
+    with pytest.raises(ToolError) as exc_info:
+        await tools.ha_config_set_calendar_event(
             entity_id="calendar.test",
             summary="Weekly sync",
             start="2026-06-15T10:00:00",
             end="2026-06-15T10:30:00",
             rrule="FREQ=WEEKLY;BYDAY=MO;COUNT=10",
         )
-
-    assert result["success"] is True
-    ws.disconnect.assert_awaited_once()
-
-
-@pytest.mark.asyncio
-async def test_rrule_failure_prepends_rrule_suggestion():
-    """A failed rrule create surfaces the RRULE-syntax hint as the first suggestion."""
-    client = _make_mock_client()
-    ws = AsyncMock()
-    ws.send_command = AsyncMock(
-        side_effect=HomeAssistantCommandError("Command failed: backend rejected rrule")
-    )
-
-    with patch(
-        "ha_mcp.tools.tools_calendar.get_connected_ws_client",
-        return_value=(ws, None),
-    ):
-        tools = CalendarTools(client)
-        with pytest.raises(ToolError) as exc_info:
-            await tools.ha_config_set_calendar_event(
-                entity_id="calendar.test",
-                summary="Weekly sync",
-                start="2026-06-15T10:00:00",
-                end="2026-06-15T10:30:00",
-                rrule="FREQ=WEEKLY;BYDAY=MO;COUNT=10",
-            )
 
     suggestions = _structured_error(exc_info.value)["error"]["suggestions"]
     assert suggestions[0].startswith("Check RRULE syntax")
@@ -356,16 +223,15 @@ async def test_non_rrule_failure_omits_rrule_suggestion():
         side_effect=HomeAssistantCommandError("Command failed: backend boom")
     )
 
-    with patch("ha_mcp.tools.tools_calendar.get_connected_ws_client") as ws_factory:
-        tools = CalendarTools(client)
-        with pytest.raises(ToolError) as exc_info:
-            await tools.ha_config_set_calendar_event(
-                entity_id="calendar.test",
-                summary="One-off",
-                start="2026-06-15T10:00:00",
-                end="2026-06-15T11:00:00",
-            )
+    tools = CalendarTools(client)
+    with pytest.raises(ToolError) as exc_info:
+        await tools.ha_config_set_calendar_event(
+            entity_id="calendar.test",
+            summary="One-off",
+            start="2026-06-15T10:00:00",
+            end="2026-06-15T11:00:00",
+        )
 
     suggestions = _structured_error(exc_info.value)["error"]["suggestions"]
     assert all(not s.startswith("Check RRULE syntax") for s in suggestions)
-    ws_factory.assert_not_called()
+    client.send_websocket_message.assert_not_awaited()

--- a/tests/src/unit/test_tools_config_scenes.py
+++ b/tests/src/unit/test_tools_config_scenes.py
@@ -954,6 +954,120 @@ class TestSceneResponseShape:
 
 
 @pytest.mark.asyncio
+class TestSceneResolutionDedup:
+    """Issue #1813 P5 item 3: each scene tool call resolves the storage key
+    exactly once. The tool pre-resolves for its own use (entity_id resolver,
+    response echo) and threads ``_resolved=True`` into the rest-client method
+    so it does not resolve a second time. The client stub here mirrors the real
+    rest-client (re-resolves unless ``_resolved=True``), so the total
+    ``resolve_scene_id`` count across a full tool call is observable — it would
+    be 2 (set/remove) or 3 (python_transform) without the dedup."""
+
+    @staticmethod
+    def _dedup_client():
+        client = MagicMock()
+        resolve = AsyncMock(side_effect=lambda sid: sid.removeprefix("scene."))
+        client.resolve_scene_id = resolve
+
+        async def _get(scene_id, *, _resolved=False):
+            rid = scene_id if _resolved else await resolve(scene_id)
+            return {
+                "success": True,
+                "scene_id": rid,
+                "config": {
+                    "name": "Test Scene",
+                    "entities": {"light.kitchen": {"state": "on"}},
+                },
+            }
+
+        async def _upsert(config, scene_id, *, _resolved=False):
+            rid = scene_id if _resolved else await resolve(scene_id)
+            return {"success": True, "scene_id": rid, "result": "ok"}
+
+        async def _delete(scene_id, *, _resolved=False):
+            rid = scene_id if _resolved else await resolve(scene_id)
+            return {"success": True, "scene_id": rid, "operation": "deleted"}
+
+        client.get_scene_config = AsyncMock(side_effect=_get)
+        client.upsert_scene_config = AsyncMock(side_effect=_upsert)
+        client.delete_scene_config = AsyncMock(side_effect=_delete)
+        client.get_services = AsyncMock(return_value=[])
+        client.get_states = AsyncMock(return_value=[])
+        # Registry list empty → _resolve_scene_entity_id falls back to the
+        # naive slug (does not touch resolve_scene_id).
+        client.send_websocket_message = AsyncMock(
+            return_value={"success": True, "result": []}
+        )
+        client.get_entity_state = AsyncMock(
+            return_value={
+                "state": "2026-05-08T07:00:00+00:00",
+                "entity_id": "scene.test_scene",
+            }
+        )
+        return client
+
+    @staticmethod
+    def _tools(client, monkeypatch):
+        monkeypatch.setattr(ConfigSceneTools, "_RESOLVE_RETRY_DELAY", 0)
+        return ConfigSceneTools(client)
+
+    async def test_set_scene_config_resolves_once(self, monkeypatch):
+        client = self._dedup_client()
+        tools = self._tools(client, monkeypatch)
+
+        result = await tools.ha_config_set_scene(
+            scene_id="test_scene",
+            config={
+                "name": "Test Scene",
+                "entities": {"light.kitchen": {"state": "on"}},
+            },
+            wait=False,
+        )
+
+        assert result["success"] is True
+        assert result["scene_id"] == "test_scene"
+        assert client.resolve_scene_id.await_count == 1
+        _, kwargs = client.upsert_scene_config.call_args
+        assert kwargs.get("_resolved") is True
+
+    async def test_remove_scene_resolves_once(self, monkeypatch):
+        client = self._dedup_client()
+        tools = self._tools(client, monkeypatch)
+
+        result = await tools.ha_config_remove_scene(scene_id="test_scene", wait=False)
+
+        assert result["success"] is True
+        assert result["scene_id"] == "test_scene"
+        assert client.resolve_scene_id.await_count == 1
+        _, kwargs = client.delete_scene_config.call_args
+        assert kwargs.get("_resolved") is True
+
+    async def test_python_transform_resolves_once(self, monkeypatch):
+        from ha_mcp.utils.config_hash import compute_config_hash
+
+        client = self._dedup_client()
+        tools = self._tools(client, monkeypatch)
+
+        # The transform-path hash-verify fetch returns the stub's inner config;
+        # the hash must match to clear the optimistic-locking gate.
+        seed_hash = compute_config_hash(
+            {"name": "Test Scene", "entities": {"light.kitchen": {"state": "on"}}}
+        )
+
+        result = await tools.ha_config_set_scene(
+            scene_id="test_scene",
+            python_transform="config['entities']['light.kitchen']['state'] = 'off'",
+            config_hash=seed_hash,
+            wait=False,
+        )
+
+        assert result["success"] is True
+        assert result["action"] == "python_transform"
+        # One resolution total despite hash-verify fetch + upsert + re-fetch.
+        assert client.resolve_scene_id.await_count == 1
+
+
+@pytest.mark.asyncio
 class TestPythonTransformOrphanMetadata:
     """Issue #1168 R3 blocker 5: a python_transform comprehension that
     filters ``entities`` leaves ``metadata`` orphan entries on disk

--- a/tests/src/unit/test_tools_entities.py
+++ b/tests/src/unit/test_tools_entities.py
@@ -1212,24 +1212,24 @@ class TestHaSetEntityBulkOperations:
 
     @pytest.mark.asyncio
     async def test_bulk_expose_to(self, mock_mcp, mock_client):
-        """Bulk operation should update expose_to on multiple entities."""
-        entity_entry = {
-            "entity_id": "light.test",
-            "name": None,
-            "original_name": "Test",
-            "icon": None,
-            "area_id": None,
-            "disabled_by": None,
-            "hidden_by": None,
-            "aliases": [],
-            "labels": [],
-        }
+        """Bulk expose sends ONE expose_entity call with the full id list, then a
+        single get_entries refetch — not one expose + one get per entity."""
         mock_client.send_websocket_message = AsyncMock(
             side_effect=[
-                {"success": True},  # expose call for light.a
-                {"success": True, "result": entity_entry},  # get entity for light.a
-                {"success": True},  # expose call for light.b
-                {"success": True, "result": entity_entry},  # get entity for light.b
+                {"success": True},  # single batched expose call for [a, b]
+                {  # single get_entries refetch for [a, b]
+                    "success": True,
+                    "result": {
+                        "light.a": {
+                            "entity_id": "light.a",
+                            "options": {"conversation": {"should_expose": True}},
+                        },
+                        "light.b": {
+                            "entity_id": "light.b",
+                            "options": {"conversation": {"should_expose": True}},
+                        },
+                    },
+                },
             ]
         )
         register_entity_tools(mock_mcp, mock_client)
@@ -1242,6 +1242,21 @@ class TestHaSetEntityBulkOperations:
 
         assert result["success"] is True
         assert result["succeeded_count"] == 2
+        # Exactly two WS calls: one batched expose + one batched refetch.
+        assert mock_client.send_websocket_message.call_count == 2
+        expose_call = mock_client.send_websocket_message.call_args_list[0][0][0]
+        assert expose_call["type"] == "homeassistant/expose_entity"
+        assert expose_call["entity_ids"] == ["light.a", "light.b"]
+        assert expose_call["should_expose"] is True
+        refetch_call = mock_client.send_websocket_message.call_args_list[1][0][0]
+        assert refetch_call["type"] == "config/entity_registry/get_entries"
+        assert refetch_call["entity_ids"] == ["light.a", "light.b"]
+        # entity_entry reflects the post-exposure refetch (options carry the
+        # new should_expose), formatted through the same shape as before.
+        entries = {e["entity_id"]: e for e in result["succeeded"]}
+        assert entries["light.a"]["entity_entry"]["options"] == {
+            "conversation": {"should_expose": True}
+        }
 
     @pytest.mark.asyncio
     async def test_bulk_rejects_single_entity_params(self, mock_mcp, mock_client):

--- a/tests/src/unit/test_tools_entities_p2.py
+++ b/tests/src/unit/test_tools_entities_p2.py
@@ -1,0 +1,591 @@
+"""Unit tests for P2 entity bulk/resolver work (issue #1813 phase 0).
+
+Covers:
+- ha_get_entity bulk backend via native config/entity_registry/get_entries
+- ha_set_entity bulk expose batched into one homeassistant/expose_entity call
+- ha_remove_entity bulk removal envelope
+- ha_get_entity unique_id -> entity_id resolver mode
+"""
+
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastmcp.exceptions import ToolError
+
+from ha_mcp.tools.tools_entities import register_entity_tools
+
+
+def _make_client():
+    client = MagicMock()
+    client.send_websocket_message = AsyncMock()
+    return client
+
+
+def _register(client):
+    """Register entity tools against a mock MCP, returning {name: method}."""
+    mcp = MagicMock()
+    registered: dict = {}
+
+    def capture_add_tool(method):
+        fmcp = getattr(method, "__fastmcp__", None)
+        name = (fmcp.name if fmcp else None) or method.__name__
+        registered[name] = method
+
+    mcp.add_tool = capture_add_tool
+    register_entity_tools(mcp, client)
+    return registered
+
+
+def _error_body(exc_info) -> dict:
+    return json.loads(str(exc_info.value))
+
+
+# --------------------------------------------------------------------------
+# Item 1 — ha_get_entity bulk via config/entity_registry/get_entries
+# --------------------------------------------------------------------------
+class TestBulkGetViaGetEntries:
+    def _entry(self, eid, **overrides):
+        entry = {
+            "entity_id": eid,
+            "name": None,
+            "original_name": "Orig",
+            "icon": None,
+            "area_id": None,
+            "disabled_by": None,
+            "hidden_by": None,
+            "aliases": [],
+            "labels": [],
+            "categories": {},
+            "device_class": None,
+            "original_device_class": None,
+            "options": {},
+            "platform": "hue",
+            "device_id": None,
+            "config_entry_id": None,
+            "unique_id": f"uid_{eid}",
+        }
+        entry.update(overrides)
+        return entry
+
+    @pytest.mark.asyncio
+    async def test_bulk_get_uses_single_get_entries_call(self):
+        """Two ids => ONE get_entries WS message (not one get per id)."""
+        client = _make_client()
+        client.send_websocket_message = AsyncMock(
+            return_value={
+                "success": True,
+                "result": {
+                    "light.a": self._entry("light.a"),
+                    "switch.b": self._entry("switch.b", disabled_by="user"),
+                },
+            }
+        )
+        tool = _register(client)["ha_get_entity"]
+
+        result = await tool(entity_id=["light.a", "switch.b"])
+
+        assert result["success"] is True
+        assert result["count"] == 2
+        # Exactly one WS call, and it is the native bulk command.
+        assert client.send_websocket_message.call_count == 1
+        msg = client.send_websocket_message.call_args[0][0]
+        assert msg["type"] == "config/entity_registry/get_entries"
+        assert msg["entity_ids"] == ["light.a", "switch.b"]
+        # Shape is projected through the same formatter as the single path.
+        by_id = {e["entity_id"]: e for e in result["entity_entries"]}
+        assert by_id["light.a"]["enabled"] is True
+        assert by_id["light.a"]["platform"] == "hue"
+        assert by_id["light.a"]["unique_id"] == "uid_light.a"
+        assert by_id["switch.b"]["enabled"] is False
+        assert by_id["switch.b"]["disabled_by"] == "user"
+
+    @pytest.mark.asyncio
+    async def test_bulk_get_missing_id_maps_to_error(self):
+        """A null in the entries map reproduces the per-id not-found contract."""
+        client = _make_client()
+        client.send_websocket_message = AsyncMock(
+            return_value={
+                "success": True,
+                "result": {
+                    "light.a": self._entry("light.a"),
+                    "light.missing": None,
+                },
+            }
+        )
+        tool = _register(client)["ha_get_entity"]
+
+        result = await tool(entity_id=["light.a", "light.missing"])
+
+        assert result["success"] is True
+        assert result["count"] == 1
+        assert result["entity_entries"][0]["entity_id"] == "light.a"
+        assert result["errors"] == [
+            {"entity_id": "light.missing", "error": "Entity not found"}
+        ]
+        assert "suggestions" in result
+
+    @pytest.mark.asyncio
+    async def test_bulk_get_preserves_request_order(self):
+        """Response order follows the requested id order, not the map order."""
+        client = _make_client()
+        client.send_websocket_message = AsyncMock(
+            return_value={
+                "success": True,
+                "result": {
+                    "light.b": self._entry("light.b"),
+                    "light.a": self._entry("light.a"),
+                },
+            }
+        )
+        tool = _register(client)["ha_get_entity"]
+
+        result = await tool(entity_id=["light.a", "light.b"])
+
+        assert [e["entity_id"] for e in result["entity_entries"]] == [
+            "light.a",
+            "light.b",
+        ]
+
+    @pytest.mark.asyncio
+    async def test_bulk_get_whole_call_failure_errors_every_id(self):
+        """A chunk-level WS failure maps every id in the chunk to an error."""
+        client = _make_client()
+        client.send_websocket_message = AsyncMock(
+            return_value={"success": False, "error": {"message": "registry offline"}}
+        )
+        tool = _register(client)["ha_get_entity"]
+
+        result = await tool(entity_id=["light.a", "light.b"])
+
+        assert result["count"] == 0
+        assert {e["entity_id"] for e in result["errors"]} == {"light.a", "light.b"}
+        assert all("registry offline" in e["error"] for e in result["errors"])
+
+    @pytest.mark.asyncio
+    async def test_single_get_still_uses_registry_get(self):
+        """Single-entity path is untouched: still config/entity_registry/get."""
+        client = _make_client()
+        client.send_websocket_message = AsyncMock(
+            return_value={"success": True, "result": self._entry("light.a")}
+        )
+        tool = _register(client)["ha_get_entity"]
+
+        result = await tool(entity_id="light.a")
+
+        assert result["success"] is True
+        assert result["entity_id"] == "light.a"
+        assert client.send_websocket_message.call_args[0][0]["type"] == (
+            "config/entity_registry/get"
+        )
+
+
+# --------------------------------------------------------------------------
+# Item 2 — batched homeassistant/expose_entity in bulk ha_set_entity
+# --------------------------------------------------------------------------
+class TestBulkExposeBatching:
+    @pytest.mark.asyncio
+    async def test_mixed_true_false_sends_one_call_per_set(self):
+        """expose_to with an on-set and off-set => two expose calls, each with
+        the full id list, plus one get_entries refetch."""
+        client = _make_client()
+        client.send_websocket_message = AsyncMock(
+            side_effect=[
+                {"success": True},  # expose True set for [a, b]
+                {"success": True},  # expose False set for [a, b]
+                {  # single get_entries refetch
+                    "success": True,
+                    "result": {
+                        "light.a": {"entity_id": "light.a", "options": {}},
+                        "light.b": {"entity_id": "light.b", "options": {}},
+                    },
+                },
+            ]
+        )
+        tool = _register(client)["ha_set_entity"]
+
+        result = await tool(
+            entity_id=["light.a", "light.b"],
+            expose_to={"conversation": True, "cloud.alexa": False},
+        )
+
+        assert result["success"] is True
+        assert result["succeeded_count"] == 2
+        calls = [c[0][0] for c in client.send_websocket_message.call_args_list]
+        assert client.send_websocket_message.call_count == 3
+        assert calls[0]["type"] == "homeassistant/expose_entity"
+        assert calls[0]["assistants"] == ["conversation"]
+        assert calls[0]["entity_ids"] == ["light.a", "light.b"]
+        assert calls[0]["should_expose"] is True
+        assert calls[1]["assistants"] == ["cloud.alexa"]
+        assert calls[1]["entity_ids"] == ["light.a", "light.b"]
+        assert calls[1]["should_expose"] is False
+        assert calls[2]["type"] == "config/entity_registry/get_entries"
+
+    @pytest.mark.asyncio
+    async def test_batch_expose_failure_fails_all_ids(self):
+        """A batch-level expose failure is reported against every id."""
+        client = _make_client()
+        client.send_websocket_message = AsyncMock(
+            return_value={"success": False, "error": {"message": "not supported"}}
+        )
+        tool = _register(client)["ha_set_entity"]
+
+        result = await tool(
+            entity_id=["light.a", "light.b"],
+            expose_to={"conversation": True},
+        )
+
+        assert result["success"] is False
+        assert result["failed_count"] == 2
+        assert result["succeeded_count"] == 0
+        assert {f["entity_id"] for f in result["failed"]} == {"light.a", "light.b"}
+        assert all("not supported" in f["error"] for f in result["failed"])
+        # One expose attempt; no refetch after a failure.
+        assert client.send_websocket_message.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_labels_and_expose_registry_per_entity_expose_batched(self):
+        """labels+expose: per-entity registry updates, then ONE batched expose,
+        then one get_entries refetch. updates carry both label + expose info."""
+        client = _make_client()
+
+        def _reg_entry(eid):
+            return {
+                "success": True,
+                "result": {
+                    "entity_entry": {
+                        "entity_id": eid,
+                        "name": None,
+                        "original_name": "O",
+                        "icon": None,
+                        "area_id": None,
+                        "disabled_by": None,
+                        "hidden_by": None,
+                        "aliases": [],
+                        "labels": ["outdoor"],
+                        "options": {},
+                    }
+                },
+            }
+
+        client.send_websocket_message = AsyncMock(
+            side_effect=[
+                _reg_entry("light.a"),  # registry update for a
+                _reg_entry("light.b"),  # registry update for b
+                {"success": True},  # single batched expose for [a, b]
+                {  # single get_entries refetch
+                    "success": True,
+                    "result": {
+                        "light.a": {
+                            "entity_id": "light.a",
+                            "labels": ["outdoor"],
+                            "options": {"conversation": {"should_expose": True}},
+                        },
+                        "light.b": {
+                            "entity_id": "light.b",
+                            "labels": ["outdoor"],
+                            "options": {"conversation": {"should_expose": True}},
+                        },
+                    },
+                },
+            ]
+        )
+        tool = _register(client)["ha_set_entity"]
+
+        result = await tool(
+            entity_id=["light.a", "light.b"],
+            labels=["outdoor"],
+            expose_to={"conversation": True},
+        )
+
+        assert result["success"] is True
+        assert result["succeeded_count"] == 2
+        calls = [c[0][0] for c in client.send_websocket_message.call_args_list]
+        # 2 registry updates + 1 expose + 1 refetch
+        assert [c["type"] for c in calls] == [
+            "config/entity_registry/update",
+            "config/entity_registry/update",
+            "homeassistant/expose_entity",
+            "config/entity_registry/get_entries",
+        ]
+        assert calls[2]["entity_ids"] == ["light.a", "light.b"]
+        entries = {e["entity_id"]: e for e in result["succeeded"]}
+        updates_a = str(entries["light.a"]["updates"])
+        assert "labels=['outdoor']" in updates_a
+        assert "expose_to=" in updates_a
+        # entity_entry reflects the post-exposure refetch.
+        assert entries["light.a"]["entity_entry"]["options"] == {
+            "conversation": {"should_expose": True}
+        }
+
+
+# --------------------------------------------------------------------------
+# Item 3 — bulk removal in ha_remove_entity
+# --------------------------------------------------------------------------
+class TestBulkRemove:
+    @pytest.mark.asyncio
+    async def test_bulk_mixed_outcome(self):
+        """removed / skipped (not-found idempotent) / errors are classified."""
+        client = _make_client()
+        client.send_websocket_message = AsyncMock(
+            side_effect=[
+                {"success": True, "result": None},  # sensor.a removed
+                {"success": False, "error": "Entity not found"},  # sensor.b skipped
+                {"success": False, "error": "Permission denied"},  # sensor.c error
+            ]
+        )
+        tool = _register(client)["ha_remove_entity"]
+
+        result = await tool(entity_id=["sensor.a", "sensor.b", "sensor.c"])
+
+        assert result["success"] is False
+        assert result["total"] == 3
+        assert result["removed"] == ["sensor.a"]
+        assert result["skipped"] == ["sensor.b"]
+        assert result["errors"] == [
+            {
+                "entity_id": "sensor.c",
+                "code": "SERVICE_CALL_FAILED",
+                "message": "Permission denied",
+            }
+        ]
+        # Sequential: exactly one remove WS call per id.
+        assert client.send_websocket_message.call_count == 3
+        for call in client.send_websocket_message.call_args_list:
+            assert call[0][0]["type"] == "config/entity_registry/remove"
+
+    @pytest.mark.asyncio
+    async def test_bulk_all_removed_is_success(self):
+        client = _make_client()
+        client.send_websocket_message = AsyncMock(
+            return_value={"success": True, "result": None}
+        )
+        tool = _register(client)["ha_remove_entity"]
+
+        result = await tool(entity_id=["sensor.a", "sensor.b"])
+
+        assert result["success"] is True
+        assert result["removed"] == ["sensor.a", "sensor.b"]
+        assert result["skipped"] == []
+        assert result["errors"] == []
+
+    @pytest.mark.asyncio
+    async def test_single_string_removal_byte_identical(self):
+        """A plain string still returns the original single-entity envelope."""
+        client = _make_client()
+        client.send_websocket_message = AsyncMock(
+            return_value={"success": True, "result": None}
+        )
+        tool = _register(client)["ha_remove_entity"]
+
+        result = await tool(entity_id="sensor.a")
+
+        assert result == {"success": True, "entity_id": "sensor.a"}
+        assert client.send_websocket_message.call_args[0][0] == {
+            "type": "config/entity_registry/remove",
+            "entity_id": "sensor.a",
+        }
+
+    @pytest.mark.asyncio
+    async def test_bulk_cap_enforced(self):
+        client = _make_client()
+        tool = _register(client)["ha_remove_entity"]
+
+        with pytest.raises(ToolError) as exc_info:
+            await tool(entity_id=[f"sensor.e{i}" for i in range(101)])
+
+        body = _error_body(exc_info)
+        assert body["error"]["code"] == "VALIDATION_INVALID_PARAMETER"
+        assert "exceeds maximum" in body["error"]["message"]
+        client.send_websocket_message.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_bulk_empty_list_rejected(self):
+        client = _make_client()
+        tool = _register(client)["ha_remove_entity"]
+
+        with pytest.raises(ToolError) as exc_info:
+            await tool(entity_id=[])
+
+        body = _error_body(exc_info)
+        assert body["error"]["code"] == "VALIDATION_INVALID_PARAMETER"
+        assert "empty" in body["error"]["message"].lower()
+
+    @pytest.mark.asyncio
+    async def test_bulk_whitespace_id_rejected(self):
+        client = _make_client()
+        tool = _register(client)["ha_remove_entity"]
+
+        with pytest.raises(ToolError) as exc_info:
+            await tool(entity_id=["sensor.a", "  "])
+
+        body = _error_body(exc_info)
+        assert body["error"]["code"] == "VALIDATION_INVALID_PARAMETER"
+
+
+# --------------------------------------------------------------------------
+# Item 4 — unique_id -> entity_id resolver in ha_get_entity
+# --------------------------------------------------------------------------
+class TestUniqueIdResolver:
+    def _list_entry(self, eid, unique_id, platform):
+        return {
+            "entity_id": eid,
+            "unique_id": unique_id,
+            "platform": platform,
+            "name": None,
+            "original_name": "O",
+            "icon": None,
+            "area_id": None,
+            "disabled_by": None,
+            "hidden_by": None,
+            "labels": [],
+            "categories": {},
+            "options": {},
+            "device_id": None,
+            "config_entry_id": "ce1",
+        }
+
+    @pytest.mark.asyncio
+    async def test_resolve_single_match(self):
+        client = _make_client()
+        client.send_websocket_message = AsyncMock(
+            return_value={
+                "success": True,
+                "result": [
+                    self._list_entry("sensor.temp", "abc123", "zwave_js"),
+                    self._list_entry("sensor.other", "zzz", "hue"),
+                ],
+            }
+        )
+        tool = _register(client)["ha_get_entity"]
+
+        result = await tool(unique_id="abc123")
+
+        assert result["success"] is True
+        assert result["matches"] == 1
+        assert result["unique_id"] == "abc123"
+        entry = result["entity_entries"][0]
+        assert entry["entity_id"] == "sensor.temp"
+        assert entry["unique_id"] == "abc123"
+        assert entry["platform"] == "zwave_js"
+        # Single list fetch only.
+        assert client.send_websocket_message.call_count == 1
+        assert client.send_websocket_message.call_args[0][0] == {
+            "type": "config/entity_registry/list"
+        }
+
+    @pytest.mark.asyncio
+    async def test_resolve_multi_platform_collision(self):
+        """Same unique_id under two platforms => both returned."""
+        client = _make_client()
+        client.send_websocket_message = AsyncMock(
+            return_value={
+                "success": True,
+                "result": [
+                    self._list_entry("sensor.a", "shared", "hue"),
+                    self._list_entry("light.a", "shared", "zwave_js"),
+                ],
+            }
+        )
+        tool = _register(client)["ha_get_entity"]
+
+        result = await tool(unique_id="shared")
+
+        assert result["matches"] == 2
+        assert {e["entity_id"] for e in result["entity_entries"]} == {
+            "sensor.a",
+            "light.a",
+        }
+
+    @pytest.mark.asyncio
+    async def test_resolve_narrowing_by_platform(self):
+        client = _make_client()
+        client.send_websocket_message = AsyncMock(
+            return_value={
+                "success": True,
+                "result": [
+                    self._list_entry("sensor.a", "shared", "hue"),
+                    self._list_entry("light.a", "shared", "zwave_js"),
+                ],
+            }
+        )
+        tool = _register(client)["ha_get_entity"]
+
+        result = await tool(unique_id="shared", platform="zwave_js")
+
+        assert result["matches"] == 1
+        assert result["platform"] == "zwave_js"
+        assert result["entity_entries"][0]["entity_id"] == "light.a"
+
+    @pytest.mark.asyncio
+    async def test_resolve_narrowing_by_domain(self):
+        client = _make_client()
+        client.send_websocket_message = AsyncMock(
+            return_value={
+                "success": True,
+                "result": [
+                    self._list_entry("sensor.a", "shared", "hue"),
+                    self._list_entry("light.a", "shared", "zwave_js"),
+                ],
+            }
+        )
+        tool = _register(client)["ha_get_entity"]
+
+        result = await tool(unique_id="shared", domain="sensor")
+
+        assert result["matches"] == 1
+        assert result["domain"] == "sensor"
+        assert result["entity_entries"][0]["entity_id"] == "sensor.a"
+
+    @pytest.mark.asyncio
+    async def test_resolve_not_found_raises(self):
+        client = _make_client()
+        client.send_websocket_message = AsyncMock(
+            return_value={"success": True, "result": []}
+        )
+        tool = _register(client)["ha_get_entity"]
+
+        with pytest.raises(ToolError) as exc_info:
+            await tool(unique_id="nope")
+
+        body = _error_body(exc_info)
+        assert body["error"]["code"] == "ENTITY_NOT_FOUND"
+        assert "nope" in body["error"]["message"]
+
+    @pytest.mark.asyncio
+    async def test_mutual_exclusion_both_provided(self):
+        client = _make_client()
+        tool = _register(client)["ha_get_entity"]
+
+        with pytest.raises(ToolError) as exc_info:
+            await tool(entity_id="sensor.temp", unique_id="abc123")
+
+        body = _error_body(exc_info)
+        assert body["error"]["code"] == "VALIDATION_INVALID_PARAMETER"
+        assert "exactly one" in body["error"]["message"].lower()
+        client.send_websocket_message.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_neither_entity_id_nor_unique_id(self):
+        client = _make_client()
+        tool = _register(client)["ha_get_entity"]
+
+        with pytest.raises(ToolError) as exc_info:
+            await tool()
+
+        body = _error_body(exc_info)
+        assert body["error"]["code"] == "VALIDATION_MISSING_PARAMETER"
+        client.send_websocket_message.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_domain_filter_without_unique_id_rejected(self):
+        client = _make_client()
+        tool = _register(client)["ha_get_entity"]
+
+        with pytest.raises(ToolError) as exc_info:
+            await tool(entity_id="sensor.temp", domain="sensor")
+
+        body = _error_body(exc_info)
+        assert body["error"]["code"] == "VALIDATION_INVALID_PARAMETER"
+        assert "resolver filter" in body["error"]["message"]

--- a/tests/src/unit/test_tools_filesystem.py
+++ b/tests/src/unit/test_tools_filesystem.py
@@ -42,6 +42,23 @@ def _reset_settings_singleton(tmp_path, monkeypatch):
     get_data_dir.cache_clear()
 
 
+@pytest.fixture(autouse=True)
+def _default_caps_none():
+    """Default the shared capability probe to None so the availability gate
+    takes its legacy ``get_services()`` path unless a test opts in.
+
+    ``_assert_mcp_tools_available`` now consults ``get_component_caps`` first;
+    with the mock clients these tests use, an unstubbed probe would attempt a
+    live WebSocket round-trip. Tests exercising the caps-first path patch
+    ``get_component_caps`` explicitly, overriding this default.
+    """
+    with patch(
+        "ha_mcp.tools.tools_filesystem.get_component_caps",
+        AsyncMock(return_value=None),
+    ):
+        yield
+
+
 class TestFeatureFlag:
     """Test feature flag functionality.
 
@@ -160,6 +177,94 @@ class TestIsMcpToolsAvailable:
 
         with pytest.raises(Exception, match="Connection failed"):
             await _is_mcp_tools_available(client)
+
+
+class TestAssertMcpToolsAvailableCapsFirst:
+    """``_assert_mcp_tools_available`` consults the shared caps probe first and
+    only falls back to the ``get_services()`` existence probe when caps is None
+    (issue #1813 P5 item 1c)."""
+
+    @staticmethod
+    def _caps(version: str = "1.2.0"):
+        from ha_mcp.tools.component_api import ComponentCaps
+
+        return ComponentCaps(
+            schema_version=1,
+            component_version=version,
+            capabilities=frozenset({"search"}),
+            limits={},
+        )
+
+    @pytest.mark.asyncio
+    async def test_caps_hit_skips_get_services(self):
+        """A caps-present component obviously exists — the get_services probe
+        is skipped entirely."""
+        from ha_mcp.tools.tools_filesystem import _assert_mcp_tools_available
+
+        client = AsyncMock()
+        with patch(
+            "ha_mcp.tools.tools_filesystem.get_component_caps",
+            AsyncMock(return_value=self._caps("1.2.0")),
+        ):
+            await _assert_mcp_tools_available(client)  # must not raise
+
+        client.get_services.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_caps_hit_enforces_min_version(self):
+        """The version gate still fires on the caps path: a caps-present
+        component below MIN_COMPONENT_VERSION raises the actionable error."""
+        from ha_mcp.tools.tools_filesystem import _assert_mcp_tools_available
+
+        client = AsyncMock()
+        with (
+            patch(
+                "ha_mcp.tools.tools_filesystem.get_component_caps",
+                AsyncMock(return_value=self._caps("0.10.0")),
+            ),
+            pytest.raises(ToolError) as exc,
+        ):
+            await _assert_mcp_tools_available(client)
+
+        data = json.loads(str(exc.value))
+        assert data["success"] is False
+        assert "too old" in data["error"]["message"].lower()
+        client.get_services.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_caps_miss_falls_back_to_get_services_present(self):
+        """caps None → the legacy get_services() probe runs; domain present → ok."""
+        from ha_mcp.tools.tools_filesystem import _assert_mcp_tools_available
+
+        client = AsyncMock()
+        client.get_services.return_value = [
+            {"domain": MCP_TOOLS_DOMAIN, "services": {"list_files": {}}}
+        ]
+        with patch(
+            "ha_mcp.tools.tools_filesystem.get_component_caps",
+            AsyncMock(return_value=None),
+        ):
+            await _assert_mcp_tools_available(client)  # must not raise
+
+        client.get_services.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_caps_miss_falls_back_to_get_services_absent(self):
+        """caps None + domain absent → COMPONENT_NOT_INSTALLED via the legacy path."""
+        from ha_mcp.tools.tools_filesystem import _assert_mcp_tools_available
+
+        client = AsyncMock()
+        client.get_services.return_value = [{"domain": "homeassistant", "services": {}}]
+        with (
+            patch(
+                "ha_mcp.tools.tools_filesystem.get_component_caps",
+                AsyncMock(return_value=None),
+            ),
+            pytest.raises(ToolError),
+        ):
+            await _assert_mcp_tools_available(client)
+
+        client.get_services.assert_awaited_once()
 
 
 class TestRegisterFilesystemTools:

--- a/tests/src/unit/test_tools_history.py
+++ b/tests/src/unit/test_tools_history.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from fastmcp.exceptions import ToolError
 
+from ha_mcp.tools import tools_history
 from ha_mcp.tools.tools_history import HistoryTools
 
 
@@ -27,15 +28,19 @@ class TestHaGetHistoryExceptionSuggestions:
         return tools.ha_get_history
 
     @pytest.mark.asyncio
-    async def test_statistics_exception_includes_state_class_hint(self, history_tool):
-        """Unexpected exception with source=statistics surfaces state_class suggestion."""
-        with (
-            patch(
-                "ha_mcp.tools.tools_history.get_connected_ws_client",
-                side_effect=RuntimeError("unexpected"),
-            ),
-            pytest.raises(ToolError) as exc_info,
-        ):
+    async def test_statistics_exception_includes_state_class_hint(
+        self, history_tool, mock_client
+    ):
+        """Unexpected exception with source=statistics surfaces state_class suggestion.
+
+        The pooled WS call now raises inside _fetch_statistics; the failure
+        propagates to ha_get_history's ``except Exception`` exactly as the old
+        dedicated-connection failure did.
+        """
+        mock_client.send_websocket_message = AsyncMock(
+            side_effect=RuntimeError("unexpected")
+        )
+        with pytest.raises(ToolError) as exc_info:
             await history_tool(entity_ids="sensor.test", source="statistics")
 
         suggestions = json.loads(str(exc_info.value))["error"]["suggestions"]
@@ -43,16 +48,13 @@ class TestHaGetHistoryExceptionSuggestions:
 
     @pytest.mark.asyncio
     async def test_history_exception_does_not_include_state_class_hint(
-        self, history_tool
+        self, history_tool, mock_client
     ):
         """Unexpected exception with source=history does not surface state_class suggestion."""
-        with (
-            patch(
-                "ha_mcp.tools.tools_history.get_connected_ws_client",
-                side_effect=RuntimeError("unexpected"),
-            ),
-            pytest.raises(ToolError) as exc_info,
-        ):
+        mock_client.send_websocket_message = AsyncMock(
+            side_effect=RuntimeError("unexpected")
+        )
+        with pytest.raises(ToolError) as exc_info:
             await history_tool(entity_ids="sensor.test", source="history")
 
         suggestions = json.loads(str(exc_info.value))["error"]["suggestions"]
@@ -97,19 +99,9 @@ class TestHaGetHistoryFieldsProjection:
     def history_tool(self, mock_client):
         return HistoryTools(mock_client).ha_get_history
 
-    def _ws_patch(self):
-        ws = AsyncMock()
-        ws.disconnect = AsyncMock()
-        return patch(
-            "ha_mcp.tools.tools_history.get_connected_ws_client",
-            new_callable=AsyncMock,
-            return_value=(ws, None),
-        )
-
     @pytest.mark.asyncio
     async def test_no_fields_returns_full_response(self, history_tool):
         with (
-            self._ws_patch(),
             patch(
                 "ha_mcp.tools.tools_history._fetch_history",
                 new_callable=AsyncMock,
@@ -130,7 +122,6 @@ class TestHaGetHistoryFieldsProjection:
     @pytest.mark.asyncio
     async def test_single_field_projects_to_that_key_plus_success(self, history_tool):
         with (
-            self._ws_patch(),
             patch(
                 "ha_mcp.tools.tools_history._fetch_history",
                 new_callable=AsyncMock,
@@ -145,7 +136,6 @@ class TestHaGetHistoryFieldsProjection:
     @pytest.mark.asyncio
     async def test_multiple_fields_projects_correctly(self, history_tool):
         with (
-            self._ws_patch(),
             patch(
                 "ha_mcp.tools.tools_history._fetch_history",
                 new_callable=AsyncMock,
@@ -161,7 +151,6 @@ class TestHaGetHistoryFieldsProjection:
     @pytest.mark.asyncio
     async def test_success_always_present_regardless_of_fields(self, history_tool):
         with (
-            self._ws_patch(),
             patch(
                 "ha_mcp.tools.tools_history._fetch_history",
                 new_callable=AsyncMock,
@@ -176,7 +165,6 @@ class TestHaGetHistoryFieldsProjection:
     async def test_unknown_field_emits_warning(self, history_tool):
         """Unknown fields key emits a diagnostic warning instead of being silently dropped."""
         with (
-            self._ws_patch(),
             patch(
                 "ha_mcp.tools.tools_history._fetch_history",
                 new_callable=AsyncMock,
@@ -249,19 +237,9 @@ class TestHaGetHistoryStatisticsFieldsProjection:
     def history_tool(self, mock_client):
         return HistoryTools(mock_client).ha_get_history
 
-    def _ws_patch(self):
-        ws = AsyncMock()
-        ws.disconnect = AsyncMock()
-        return patch(
-            "ha_mcp.tools.tools_history.get_connected_ws_client",
-            new_callable=AsyncMock,
-            return_value=(ws, None),
-        )
-
     @pytest.mark.asyncio
     async def test_no_fields_returns_full_response(self, history_tool):
         with (
-            self._ws_patch(),
             patch(
                 "ha_mcp.tools.tools_history._fetch_statistics",
                 new_callable=AsyncMock,
@@ -284,7 +262,6 @@ class TestHaGetHistoryStatisticsFieldsProjection:
     @pytest.mark.asyncio
     async def test_single_field_projection(self, history_tool):
         with (
-            self._ws_patch(),
             patch(
                 "ha_mcp.tools.tools_history._fetch_statistics",
                 new_callable=AsyncMock,
@@ -300,7 +277,6 @@ class TestHaGetHistoryStatisticsFieldsProjection:
     @pytest.mark.asyncio
     async def test_stats_specific_key_period_type(self, history_tool):
         with (
-            self._ws_patch(),
             patch(
                 "ha_mcp.tools.tools_history._fetch_statistics",
                 new_callable=AsyncMock,
@@ -316,7 +292,6 @@ class TestHaGetHistoryStatisticsFieldsProjection:
     @pytest.mark.asyncio
     async def test_success_always_present(self, history_tool):
         with (
-            self._ws_patch(),
             patch(
                 "ha_mcp.tools.tools_history._fetch_statistics",
                 new_callable=AsyncMock,
@@ -332,7 +307,6 @@ class TestHaGetHistoryStatisticsFieldsProjection:
     async def test_unknown_field_emits_warning(self, history_tool):
         """Unknown fields key emits a diagnostic warning instead of being silently dropped."""
         with (
-            self._ws_patch(),
             patch(
                 "ha_mcp.tools.tools_history._fetch_statistics",
                 new_callable=AsyncMock,
@@ -382,20 +356,10 @@ class TestHaGetHistoryOrder:
     def history_tool(self, mock_client):
         return HistoryTools(mock_client).ha_get_history
 
-    def _ws_patch(self):
-        ws = AsyncMock()
-        ws.disconnect = AsyncMock()
-        return patch(
-            "ha_mcp.tools.tools_history.get_connected_ws_client",
-            new_callable=AsyncMock,
-            return_value=(ws, None),
-        )
-
     @pytest.mark.asyncio
     async def test_order_desc_default_passed_to_fetch_history(self, history_tool):
         """Default order='desc' is threaded through to _fetch_history."""
         with (
-            self._ws_patch(),
             patch(
                 "ha_mcp.tools.tools_history._fetch_history",
                 new_callable=AsyncMock,
@@ -410,7 +374,6 @@ class TestHaGetHistoryOrder:
     async def test_order_asc_passed_to_fetch_history(self, history_tool):
         """order='asc' is passed through to _fetch_history unchanged."""
         with (
-            self._ws_patch(),
             patch(
                 "ha_mcp.tools.tools_history._fetch_history",
                 new_callable=AsyncMock,
@@ -437,7 +400,6 @@ class TestHaGetHistoryOrder:
             "query_params": {"limit": 100, "offset": 0},
         }
         with (
-            self._ws_patch(),
             patch(
                 "ha_mcp.tools.tools_history._fetch_statistics",
                 new_callable=AsyncMock,
@@ -449,3 +411,46 @@ class TestHaGetHistoryOrder:
             )
         # _fetch_statistics should be called, not _fetch_history
         mock_stats.assert_called_once()
+
+
+class TestHaGetHistoryPooledTransport:
+    """The single recorder query routes through the shared pooled client
+    (``client.send_websocket_message``) rather than a per-call dedicated
+    WebSocket connection (issue #1813)."""
+
+    @staticmethod
+    def _client(ws_return) -> MagicMock:
+        client = MagicMock()
+        client.base_url = "http://ha.local"
+        client.token = "tok"
+        client.get_config = AsyncMock(return_value={"time_zone": "UTC"})
+        client.send_websocket_message = AsyncMock(return_value=ws_return)
+        return client
+
+    @pytest.mark.asyncio
+    async def test_history_routes_through_pooled_client(self):
+        client = self._client({"success": True, "result": {"sensor.temp": []}})
+        tool = HistoryTools(client).ha_get_history
+        with patch(
+            "ha_mcp.tools.tools_history.add_timezone_metadata",
+            side_effect=lambda _c, d, **_kw: d,
+        ):
+            await tool(entity_ids="sensor.temp")
+
+        client.send_websocket_message.assert_awaited_once()
+        message = client.send_websocket_message.await_args.args[0]
+        assert message["type"] == "history/history_during_period"
+        # The dedicated-connection helper is gone from the module namespace,
+        # so the tool cannot fall back to a per-call connect/auth handshake.
+        assert not hasattr(tools_history, "get_connected_ws_client")
+
+    @pytest.mark.asyncio
+    async def test_pooled_failure_surfaces_structured_error(self):
+        # send_websocket_message collapses a failed WS command into
+        # ``{"success": False, ...}``; the fetch guard raises SERVICE_CALL_FAILED.
+        client = self._client({"success": False, "error": "recorder unavailable"})
+        tool = HistoryTools(client).ha_get_history
+        with pytest.raises(ToolError) as exc_info:
+            await tool(entity_ids="sensor.temp")
+        err = json.loads(str(exc_info.value))["error"]
+        assert err["code"] == "SERVICE_CALL_FAILED"

--- a/tests/src/unit/test_tools_mcp_component.py
+++ b/tests/src/unit/test_tools_mcp_component.py
@@ -725,3 +725,76 @@ class TestHacsDownloadRetry:
         # propagating, leaving the other two side_effect slots
         # untouched.
         assert ws_client.send_command.await_count == 3
+
+
+class TestAlreadyInstalledVersion:
+    """The 'already installed' path reports the running component version from
+    the shared caps probe when available, else HACS's installed_version
+    (issue #1813 P5 item 1b)."""
+
+    @staticmethod
+    def _ws_client_installed():
+        ws_client = MagicMock()
+        ws_client.send_command = AsyncMock(
+            side_effect=[
+                # _ensure_hacs_ready: hacs/info ok
+                {"success": True, "result": {}},
+                # repositories/list — repo present AND installed
+                {
+                    "success": True,
+                    "result": [
+                        {
+                            "full_name": MCP_TOOLS_REPO,
+                            "id": 99,
+                            "installed": True,
+                            "installed_version": "1.0.0",
+                        }
+                    ],
+                },
+            ]
+        )
+        return ws_client
+
+    async def _run(self, monkeypatch, ws_client, caps):
+        async def _ok():
+            return None
+
+        monkeypatch.setattr("ha_mcp.tools.tools_hacs._assert_hacs_available", _ok)
+        monkeypatch.setattr(
+            "ha_mcp.client.websocket_client.get_websocket_client",
+            AsyncMock(return_value=ws_client),
+        )
+        monkeypatch.setattr(
+            "ha_mcp.tools.tools_mcp_component.get_component_caps",
+            AsyncMock(return_value=caps),
+        )
+        client_mock = AsyncMock()
+        client_mock.get_config = AsyncMock(return_value={"time_zone": "UTC"})
+        tools = McpComponentTools(client_mock)
+        return await tools.ha_install_mcp_tools(restart=False)
+
+    @pytest.mark.asyncio
+    async def test_reports_caps_version_when_loaded(self, monkeypatch):
+        from ha_mcp.tools.component_api import ComponentCaps
+
+        caps = ComponentCaps(
+            schema_version=1,
+            component_version="1.2.0",
+            capabilities=frozenset({"search"}),
+            limits={},
+        )
+        result = await self._run(monkeypatch, self._ws_client_installed(), caps)
+
+        data = result.get("data", result)
+        assert data["already_installed"] is True
+        assert data["version"] == "1.2.0"
+        assert "1.2.0" in data["message"]
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_installed_version_when_caps_none(self, monkeypatch):
+        result = await self._run(monkeypatch, self._ws_client_installed(), None)
+
+        data = result.get("data", result)
+        assert data["already_installed"] is True
+        assert data["version"] == "1.0.0"
+        assert "1.0.0" in data["message"]

--- a/tests/src/unit/test_tools_system.py
+++ b/tests/src/unit/test_tools_system.py
@@ -2434,9 +2434,41 @@ class TestReloadCore:
             "success": True,
             "message": "Reloaded config entry abc123",
             "reloaded": True,
+            "require_restart": False,
             "entry_id": "abc123",
         }
         client.call_service.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_entry_id_require_restart_surfaced(self):
+        """Core's require_restart=True (entry cannot hot-reload) must not be
+        reported as a completed reload."""
+        client = MagicMock()
+        client._request = AsyncMock(return_value={"require_restart": True})
+
+        result = await SystemTools(client).ha_reload_core(entry_id="abc123")
+
+        assert result["success"] is True
+        assert result["reloaded"] is False
+        assert result["require_restart"] is True
+        assert "restart" in result["message"].lower()
+
+    @pytest.mark.asyncio
+    async def test_entry_id_forbidden_maps_to_cannot_reload_not_auth(self):
+        """Core returns 403 'Entry cannot be reloaded' for OperationNotAllowed;
+        that must surface as a cannot-reload error, not an auth failure."""
+        client = MagicMock()
+        client._request = AsyncMock(
+            side_effect=HomeAssistantAPIError(
+                "API error: 403 - Entry cannot be reloaded", status_code=403
+            )
+        )
+        with pytest.raises(ToolError) as excinfo:
+            await SystemTools(client).ha_reload_core(entry_id="abc123")
+        err = json.loads(str(excinfo.value))
+        assert err["error"]["code"] == "SERVICE_CALL_FAILED"
+        assert "cannot be reloaded" in err["error"]["message"]
+        assert "abc123" in err["error"]["message"]
 
     @pytest.mark.asyncio
     async def test_entry_id_not_found_maps_to_resource_not_found(self):

--- a/tests/src/unit/test_tools_system.py
+++ b/tests/src/unit/test_tools_system.py
@@ -873,6 +873,7 @@ class TestGetSystemHealthGather:
 
         mock_zha.assert_awaited_once()
         # Helper called with ws_client + full=True
+        assert mock_zha.await_args is not None
         assert mock_zha.await_args.kwargs == {"full": True}
 
     @pytest.mark.asyncio
@@ -1080,6 +1081,7 @@ class TestGetSystemHealthDiagnostics:
         ):
             result = await tools.ha_get_system_health(include="diagnostics")
         # Positional config_entry_id is None, not "".
+        assert mock_fetch.await_args is not None
         assert mock_fetch.await_args.args[1] is None
         assert result["diagnostics"]["config_entry_id"] is None
 
@@ -2294,3 +2296,196 @@ class TestHomeAssistantConnectionErrorPropagation:
         msg = str(excinfo.value)
         assert "CONNECTION_FAILED" in msg
         assert "ws gone" in msg
+
+
+class TestReloadCore:
+    """``ha_reload_core``: bounded-concurrency sweep (Item 2) and single
+    config-entry reload via ``entry_id`` (Item 3 — issue #1813 fold-in)."""
+
+    @staticmethod
+    def _reloadable_count() -> int:
+        from ha_mcp.tools.tools_system import RELOAD_TARGETS
+
+        return sum(1 for info in RELOAD_TARGETS.values() if info is not None)
+
+    @pytest.mark.asyncio
+    async def test_all_mode_respects_semaphore_bound(self):
+        """target='all' fires every reloadable subsystem concurrently but the
+        in-flight count never exceeds the Semaphore(4) bound — and, since the
+        target set is far larger than 4, actually saturates it (proving the
+        calls are not silently serial)."""
+        max_bound = 4
+
+        class _ConcurrencyClient:
+            def __init__(self) -> None:
+                self.in_flight = 0
+                self.max_in_flight = 0
+                self.calls: list[tuple[str, str]] = []
+
+            async def call_service(self, domain, service, data):
+                self.in_flight += 1
+                self.max_in_flight = max(self.max_in_flight, self.in_flight)
+                self.calls.append((domain, service))
+                # Hold the slot so overlap is forced and the counter can climb.
+                await asyncio.sleep(0.01)
+                self.in_flight -= 1
+                return []
+
+        client = _ConcurrencyClient()
+        result = await SystemTools(client).ha_reload_core(target="all")
+
+        expected = self._reloadable_count()
+        assert len(client.calls) == expected
+        assert client.max_in_flight <= max_bound
+        assert client.max_in_flight == min(max_bound, expected)
+        assert result["success"] is True
+        assert len(result["reloaded"]) == expected
+        assert "warnings" not in result
+
+    @pytest.mark.asyncio
+    async def test_all_mode_one_failing_target_reports_per_target(self):
+        """A single failing subsystem lands in ``warnings``; every sibling still
+        reloads and is attempted — the failure must not cancel the gather."""
+
+        class _OneFailClient:
+            def __init__(self, fail_domain: str) -> None:
+                self.fail_domain = fail_domain
+                self.calls: list[tuple[str, str]] = []
+
+            async def call_service(self, domain, service, data):
+                self.calls.append((domain, service))
+                if domain == self.fail_domain:
+                    raise RuntimeError("template reload blew up")
+                return []
+
+        client = _OneFailClient("template")
+        result = await SystemTools(client).ha_reload_core(target="all")
+
+        expected = self._reloadable_count()
+        # Every target attempted despite the failure — no sibling was cancelled.
+        assert len(client.calls) == expected
+        assert result["success"] is True
+        assert "templates" not in result["reloaded"]
+        assert len(result["reloaded"]) == expected - 1
+        warnings = result["warnings"]
+        assert any(
+            "templates" in w and "template reload blew up" in w for w in warnings
+        )
+
+    @pytest.mark.asyncio
+    async def test_all_mode_not_found_errors_suppressed(self):
+        """A target whose service is unavailable ('not found') is silently
+        skipped, not surfaced as a warning (some helpers aren't installed)."""
+
+        class _NotFoundClient:
+            async def call_service(self, domain, service, data):
+                if domain == "template":
+                    raise RuntimeError("Service template.reload not found")
+                return []
+
+        result = await SystemTools(_NotFoundClient()).ha_reload_core(target="all")
+
+        assert result["success"] is True
+        assert "templates" not in result["reloaded"]
+        assert "warnings" not in result
+
+    @pytest.mark.asyncio
+    async def test_single_target_unchanged(self):
+        """Single-target mode still issues exactly one service call and returns
+        the single-target envelope (unaffected by the concurrency rework)."""
+        client = AsyncMock()
+        client.call_service.return_value = []
+
+        result = await SystemTools(client).ha_reload_core(target="automations")
+
+        client.call_service.assert_awaited_once_with("automation", "reload", {})
+        assert result == {
+            "success": True,
+            "message": "Successfully reloaded automations",
+            "target": "automations",
+            "service": "automation.reload",
+        }
+
+    @pytest.mark.asyncio
+    async def test_invalid_target_rejected(self):
+        """An unknown target still raises VALIDATION_INVALID_PARAMETER before
+        any service call (unchanged guard)."""
+        client = AsyncMock()
+        with pytest.raises(ToolError) as excinfo:
+            await SystemTools(client).ha_reload_core(target="bogus")
+        err = json.loads(str(excinfo.value))
+        assert err["error"]["code"] == "VALIDATION_INVALID_PARAMETER"
+        client.call_service.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_entry_id_reload_happy_path_exact_url(self):
+        """entry_id reloads exactly one config entry via the REST endpoint,
+        hitting the exact path including the ``/entry/`` segment; the sweep path
+        (call_service) is never touched."""
+        client = MagicMock()
+        client._request = AsyncMock(return_value={})
+
+        result = await SystemTools(client).ha_reload_core(entry_id="abc123")
+
+        client._request.assert_awaited_once_with(
+            "POST", "/config/config_entries/entry/abc123/reload"
+        )
+        assert result == {
+            "success": True,
+            "message": "Reloaded config entry abc123",
+            "reloaded": True,
+            "entry_id": "abc123",
+        }
+        client.call_service.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_entry_id_not_found_maps_to_resource_not_found(self):
+        """A 404 from the reload endpoint becomes a RESOURCE_NOT_FOUND error
+        that names the entry_id."""
+        client = MagicMock()
+        client._request = AsyncMock(
+            side_effect=HomeAssistantAPIError(
+                "API error: 404 - Config entry not found", status_code=404
+            )
+        )
+        with pytest.raises(ToolError) as excinfo:
+            await SystemTools(client).ha_reload_core(entry_id="missing_entry")
+        err = json.loads(str(excinfo.value))
+        assert err["error"]["code"] == "RESOURCE_NOT_FOUND"
+        assert "missing_entry" in err["error"]["message"]
+
+    @pytest.mark.asyncio
+    async def test_entry_id_non_404_failure_raises_tool_error(self):
+        """A non-404 backend failure still surfaces as a ToolError (routed
+        through the shared exception classifier), not a silent success."""
+        client = MagicMock()
+        client._request = AsyncMock(
+            side_effect=HomeAssistantAPIError("API error: 500 - boom", status_code=500)
+        )
+        with pytest.raises(ToolError):
+            await SystemTools(client).ha_reload_core(entry_id="abc123")
+
+    @pytest.mark.asyncio
+    async def test_entry_id_with_explicit_target_conflict(self):
+        """entry_id combined with an explicit subsystem target is a validation
+        error — the reload endpoint is never hit."""
+        client = MagicMock()
+        client._request = AsyncMock()
+        with pytest.raises(ToolError) as excinfo:
+            await SystemTools(client).ha_reload_core(
+                target="scripts", entry_id="abc123"
+            )
+        err = json.loads(str(excinfo.value))
+        assert err["error"]["code"] == "VALIDATION_INVALID_PARAMETER"
+        client._request.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_entry_id_empty_rejected(self):
+        """An empty/whitespace entry_id is rejected before any REST call."""
+        client = MagicMock()
+        client._request = AsyncMock()
+        with pytest.raises(ToolError) as excinfo:
+            await SystemTools(client).ha_reload_core(entry_id="   ")
+        err = json.loads(str(excinfo.value))
+        assert err["error"]["code"] == "VALIDATION_INVALID_PARAMETER"
+        client._request.assert_not_awaited()


### PR DESCRIPTION
## What does this PR do?

Implements all ten Phase 0 items from the #1813 audit plus the three maintainer-acked fold-ins from the issue comments — all server-only (zero component/manifest changes), each with the legacy path preserved:

**New capability surfaced**
- `ha_get_zone` now routes through the component's `helpers_list` capability when available, so YAML-defined zones **including `home`** are finally visible (native `zone/list` structurally cannot return them); adds an additive `editable`/`source` discriminator, legacy fallback unchanged.
- `ha_get_entity` gains a `unique_id → entity_id` resolver mode (`unique_id=` + optional `domain`/`platform` narrowing) — one registry-list fetch, returns all matching records (fold-in from issue comments).
- `ha_remove_entity` accepts a list (cap 100) and returns a `removed` / `skipped` (not-found = idempotent) / `errors` envelope for orphan cleanup (fold-in); single-id behavior byte-identical.
- `ha_reload_core` gains `entry_id=` to reload exactly one config entry via `/api/config/config_entries/entry/{id}/reload` instead of sweeping all subsystems (fold-in).

**Robustness / flow**
- `ha_get_overview`: drops the unexercised visibility-gate bypass — component fast path now serves visibility-active installs with identical filtered output.
- `ha_get_entity` bulk reads use one chunked native `config/entity_registry/get_entries` call instead of up to 100 per-id round-trips.
- `ha_set_entity` batches `homeassistant/expose_entity` across bulk ids (schema already accepts a list).
- `ha_config_list_helpers` exposes the component's all-types listing (omitted `helper_types` = full storage + flow inventory in one call); structured error on component-less installs, mirroring the flow-helper precedent.
- Pooled-WS swap: plain request/response call sites in traces, backup, addons, calendar, and history use the shared client instead of a per-call connect/auth/disconnect. `tools_system.py`'s `system_health/info` site intentionally keeps its dedicated connection — it pipelines result+event frames across 6 concurrent sections on one socket, which the pooled path can't serve.
- `ha_reload_core(target="all")` runs its subsystem reloads concurrently under a semaphore(4) with per-target attribution preserved.
- Availability probes in `ha_report_issue`, `ha_install_mcp_tools`, and the file tools consult the cached `ha_mcp_tools/info` handshake first (legacy probe kept for pre-1.1.0 components).
- `ha_manage_radio._resolve_entity_device` uses targeted `config/entity_registry/get` instead of a full-registry pull.
- Scene update/delete/activate resolve the scene id exactly once (was twice per call).

Design note: all three fold-ins land as extensions of existing tools rather than new tools, keeping catalog cost flat.

Refs #1813.

## Type of change
- [x] ✨ New feature
- [x] 🔧 Maintenance/refactor

## Testing
- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

## Checklist
- [x] I have updated documentation if needed
