### PR TITLE
ci: skip Codex reviews for dependency bots

### DIFF
--- a/.github/workflows/pr-codex-review-request.yml
+++ b/.github/workflows/pr-codex-review-request.yml
@@ -20,7 +20,26 @@ jobs:
   request-codex-review:
     name: Validate and dispatch review
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'pull_request_target' || (github.event_name == 'issue_comment' && github.event.issue.pull_request && (github.event.comment.body == '/review' || github.event.comment.body == '@ghhamcp review') && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)) }}
+    if: >-
+      ${{
+        (github.event_name == 'pull_request_target' &&
+          !contains(
+            fromJSON('["dependabot[bot]", "ha-mcp-renovate[bot]"]'),
+            github.event.pull_request.user.login
+          )) ||
+        (github.event_name == 'issue_comment' &&
+          github.event.issue.pull_request &&
+          !contains(
+            fromJSON('["dependabot[bot]", "ha-mcp-renovate[bot]"]'),
+            github.event.issue.user.login
+          ) &&
+          (github.event.comment.body == '/review' ||
+            github.event.comment.body == '@ghhamcp review') &&
+          contains(
+            fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'),
+            github.event.comment.author_association
+          ))
+      }}
     concurrency:
       group: codex-review-global-admission
       cancel-in-progress: false


### PR DESCRIPTION
## What does this PR do?

Excludes pull requests authored by Dependabot (`dependabot[bot]`) or the repository's Renovate app (`ha-mcp-renovate[bot]`) from the Codex review admission job.

The author guard applies to both automatic `pull_request_target` admission and maintainer-triggered review comments, so these dependency-bot PRs cannot dispatch a Codex review.

## Why

The admission condition currently accepts every opened or ready-for-review pull request. Automated dependency PRs therefore consume Codex review capacity even though they do not need an AI code review.

Keeping the exclusion at the job-level condition makes these runs skip cleanly before runner allocation or dispatch.

## Type of change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [x] 🔧 Maintenance/refactor
- [ ] 💥 Breaking change

## Testing

- [x] Workflow YAML parses successfully with `ruamel.yaml`
- [x] `git diff --check`
- [ ] Full project test suite (not run; workflow-only change)

## Checklist

- [x] Documentation is not needed for this internal workflow change
