### PR TITLE
fix: correct Tools-tab group master + LLM API toggle rendering

### DIFF
--- a/src/ha_mcp/settings_ui/__init__.py
+++ b/src/ha_mcp/settings_ui/__init__.py
@@ -1446,6 +1446,12 @@ def build_settings_handlers(
                 "read_only_exempt": sorted(READ_ONLY_EXEMPT_TOOLS),
                 "llm_api": llm_effective,
                 "llm_api_overrides": llm_overrides,
+                # LLM API exposure is registered by the ha_mcp_tools custom
+                # component (in-process/embedded server). On the add-on,
+                # Docker, or standalone server nothing consumes it, so the UI
+                # hides the per-tool "LLM API" toggle rather than showing a
+                # no-op control.
+                "llm_api_available": is_embedded(),
             }
         )
 

--- a/src/ha_mcp/settings_ui/settings.js
+++ b/src/ha_mcp/settings_ui/settings.js
@@ -33,6 +33,12 @@ let toolEnvPinned = {};
 // never flipped keep tracking their defaults across releases.
 let toolLlm = {};
 let toolLlmOverrides = {};
+// True only when this settings page is served by the in-process custom
+// component (embedded server). The LLM API exposure surface is registered by
+// the ha_mcp_tools custom component; on the add-on / Docker / standalone
+// server nothing consumes it, so the per-tool "LLM API" toggle is hidden
+// there rather than shown as a no-op. Server sends ``llm_api_available``.
+let llmApiAvailable = false;
 let saveTimer = null;
 let openGroups = new Set();
 
@@ -169,6 +175,7 @@ async function loadTools() {
   toolEnvPinned = data.env_pinned || {};
   toolLlm = data.llm_api || {};
   toolLlmOverrides = data.llm_api_overrides || {};
+  llmApiAvailable = !!data.llm_api_available;
   READ_ONLY_EXEMPT = new Set(data.read_only_exempt || []);
   // Load policy state before the first render so the "security gated"
   // toggle reflects current policy.rules. loadPolicyState() never throws
@@ -760,14 +767,19 @@ function render() {
               `<span class="slider"></span></label>` +
             `<span>security gated</span>` +
           `</div>` +
-          `<div class="toggle-group ${isEnabled ? '' : 'disabled-toggle'}" ` +
-               `title="Offer this tool to Home Assistant conversation agents through the LLM API. Applies on the agent's next message - no restart. A tool disabled above is unavailable to agents regardless.">` +
-            `<label class="switch"><input type="checkbox" name="tool:${escapeHtml(t.name)}:llm" data-tool="${escapeHtml(t.name)}" data-field="llm" ` +
-              `aria-label="${escapeHtml(title)} exposed to the conversation-agent LLM API" ` +
-              `${(toolLlm[t.name] !== false) ? 'checked' : ''} ${isEnabled ? '' : 'disabled'}>` +
-              `<span class="slider"></span></label>` +
-            `<span>LLM API</span>` +
-          `</div>` +
+          // LLM API exposure only exists on the in-process custom-component
+          // (embedded) server; hide the column entirely on other install
+          // methods where the toggle would be a no-op.
+          (llmApiAvailable
+            ? `<div class="toggle-group ${isEnabled ? '' : 'disabled-toggle'}" ` +
+                 `title="Offer this tool to Home Assistant conversation agents through the LLM API. Applies on the agent's next message - no restart. A tool disabled above is unavailable to agents regardless.">` +
+              `<label class="switch"><input type="checkbox" name="tool:${escapeHtml(t.name)}:llm" data-tool="${escapeHtml(t.name)}" data-field="llm" ` +
+                `aria-label="${escapeHtml(title)} exposed to the conversation-agent LLM API" ` +
+                `${(toolLlm[t.name] !== false) ? 'checked' : ''} ${isEnabled ? '' : 'disabled'}>` +
+                `<span class="slider"></span></label>` +
+              `<span>LLM API</span>` +
+            `</div>`
+            : '') +
         `</div>`;
 
       const inputs = div.querySelectorAll('input[type="checkbox"]');

--- a/src/ha_mcp/settings_ui/settings.js
+++ b/src/ha_mcp/settings_ui/settings.js
@@ -33,11 +33,11 @@ let toolEnvPinned = {};
 // never flipped keep tracking their defaults across releases.
 let toolLlm = {};
 let toolLlmOverrides = {};
-// True only when this settings page is served by the in-process custom
-// component (embedded server). The LLM API exposure surface is registered by
-// the ha_mcp_tools custom component; on the add-on / Docker / standalone
+// True only on the in-process custom-component (embedded) server, which
+// registers the LLM API exposure surface. On the add-on / Docker / standalone
 // server nothing consumes it, so the per-tool "LLM API" toggle is hidden
-// there rather than shown as a no-op. Server sends ``llm_api_available``.
+// rather than shown as a no-op. Set from data.llm_api_available (see
+// settings_ui/__init__.py).
 let llmApiAvailable = false;
 let saveTimer = null;
 let openGroups = new Set();
@@ -609,11 +609,14 @@ function render() {
     // enabled" — it is a bulk control over the tools the user can actually
     // flip. But when a group has NO toggleable tools (all mandatory /
     // env-pinned / feature-gated), the switch is disabled and purely reflects
-    // status, so it must show the group's real enabled state (groupEnabled)
-    // instead of anyEnabled — which is always false over an empty toggleable
-    // set. An all-mandatory group (e.g. Search & Discovery) is fully enabled
-    // and must read as ON, matching its "N/N enabled" count.
-    const masterChecked = toggleable.length === 0 ? groupEnabled > 0 : anyEnabled;
+    // status: show it ON only when the group is FULLY enabled (every tool on),
+    // matching the "N/N enabled" count. anyEnabled can't be reused here — it is
+    // always false over an empty toggleable set. So an all-mandatory group
+    // (e.g. Search & Discovery) reads as ON, while a partially-enabled locked
+    // group (e.g. a mandatory tool beside an env-pinned-off one) reads as OFF
+    // rather than contradicting its own "1/N enabled" count.
+    const masterChecked =
+      toggleable.length === 0 ? groupEnabled === tools.length : anyEnabled;
 
     const header = document.createElement('div');
     header.className = 'group-header';
@@ -734,6 +737,19 @@ function render() {
         : (roExemptActive
           ? '<div class="feature-locked-note">Read Only Mode: write operations of this tool are blocked; read operations stay available.</div>'
           : '');
+      // LLM API exposure column — rendered only on the embedded custom-component
+      // server (see llmApiAvailable); dropped elsewhere rather than shown as a
+      // no-op. Built here as a fragment, matching the *Note consts above.
+      const llmToggleHtml = llmApiAvailable
+        ? `<div class="toggle-group ${isEnabled ? '' : 'disabled-toggle'}" ` +
+             `title="Offer this tool to Home Assistant conversation agents through the LLM API. Applies on the agent's next message - no restart. A tool disabled above is unavailable to agents regardless.">` +
+          `<label class="switch"><input type="checkbox" name="tool:${escapeHtml(t.name)}:llm" data-tool="${escapeHtml(t.name)}" data-field="llm" ` +
+            `aria-label="${escapeHtml(title)} exposed to the conversation-agent LLM API" ` +
+            `${(toolLlm[t.name] !== false) ? 'checked' : ''} ${isEnabled ? '' : 'disabled'}>` +
+            `<span class="slider"></span></label>` +
+          `<span>LLM API</span>` +
+        `</div>`
+        : '';
 
       div.innerHTML = `<div class="tool-info">` +
         `<div class="tool-name">${escapeHtml(title)}${badges}</div>` +
@@ -767,19 +783,7 @@ function render() {
               `<span class="slider"></span></label>` +
             `<span>security gated</span>` +
           `</div>` +
-          // LLM API exposure only exists on the in-process custom-component
-          // (embedded) server; hide the column entirely on other install
-          // methods where the toggle would be a no-op.
-          (llmApiAvailable
-            ? `<div class="toggle-group ${isEnabled ? '' : 'disabled-toggle'}" ` +
-                 `title="Offer this tool to Home Assistant conversation agents through the LLM API. Applies on the agent's next message - no restart. A tool disabled above is unavailable to agents regardless.">` +
-              `<label class="switch"><input type="checkbox" name="tool:${escapeHtml(t.name)}:llm" data-tool="${escapeHtml(t.name)}" data-field="llm" ` +
-                `aria-label="${escapeHtml(title)} exposed to the conversation-agent LLM API" ` +
-                `${(toolLlm[t.name] !== false) ? 'checked' : ''} ${isEnabled ? '' : 'disabled'}>` +
-                `<span class="slider"></span></label>` +
-              `<span>LLM API</span>` +
-            `</div>`
-            : '') +
+          llmToggleHtml +
         `</div>`;
 
       const inputs = div.querySelectorAll('input[type="checkbox"]');

--- a/src/ha_mcp/settings_ui/settings.js
+++ b/src/ha_mcp/settings_ui/settings.js
@@ -598,6 +598,16 @@ function render() {
       return MANDATORY.includes(t.name) || (!t.disabled_by && s !== 'disabled');
     }).length;
 
+    // Master-switch checked state. Normally it mirrors "any toggleable tool
+    // enabled" — it is a bulk control over the tools the user can actually
+    // flip. But when a group has NO toggleable tools (all mandatory /
+    // env-pinned / feature-gated), the switch is disabled and purely reflects
+    // status, so it must show the group's real enabled state (groupEnabled)
+    // instead of anyEnabled — which is always false over an empty toggleable
+    // set. An all-mandatory group (e.g. Search & Discovery) is fully enabled
+    // and must read as ON, matching its "N/N enabled" count.
+    const masterChecked = toggleable.length === 0 ? groupEnabled > 0 : anyEnabled;
+
     const header = document.createElement('div');
     header.className = 'group-header';
     header.innerHTML = `<div class="group-header-left">` +
@@ -606,7 +616,7 @@ function render() {
       `<span class="group-count">${groupEnabled}/${tools.length} enabled</span>` +
       `</div>` +
       `<label class="switch group-master" title="Enable/disable all tools in this group">` +
-        `<input type="checkbox" name="tool-group:${escapeHtml(tag)}" ${anyEnabled ? 'checked' : ''} ${toggleable.length === 0 ? 'disabled' : ''}>` +
+        `<input type="checkbox" name="tool-group:${escapeHtml(tag)}" ${masterChecked ? 'checked' : ''} ${toggleable.length === 0 ? 'disabled' : ''}>` +
         `<span class="slider"></span>` +
       `</label>`;
 

--- a/tests/src/unit/test_settings_ui.py
+++ b/tests/src/unit/test_settings_ui.py
@@ -2577,6 +2577,47 @@ class TestEnvPinnedTools:
         assert body["llm_api"]["ha_get_state"] is False
         # The stub renders hidden-by-default (feature-gated == beta).
         assert body["llm_api"]["ha_config_set_yaml"] is False
+        # Not the in-process custom-component server: the UI hides the LLM API
+        # toggle (nothing consumes the exposure on this install method).
+        assert body["llm_api_available"] is False
+        get_data_dir.cache_clear()
+        _reset_global_settings()
+
+    @pytest.mark.asyncio
+    async def test_get_tools_llm_api_available_true_when_embedded(
+        self, monkeypatch, tmp_path
+    ):
+        """On the in-process custom-component (embedded) server the tools
+        payload advertises ``llm_api_available: True`` so the UI renders the
+        per-tool LLM API toggle."""
+        monkeypatch.setenv("HA_MCP_CONFIG_DIR", str(tmp_path))
+        monkeypatch.setenv("HA_MCP_EMBEDDED", "1")
+        from ha_mcp.utils.data_paths import get_data_dir
+
+        get_data_dir.cache_clear()
+        from ha_mcp import settings_ui as sui
+        from ha_mcp.config import _reset_global_settings
+
+        _reset_global_settings()
+        monkeypatch.setattr(
+            sui,
+            "load_tool_metadata_cache",
+            lambda: [
+                {
+                    "name": "ha_get_state",
+                    "title": "Get State",
+                    "primary_tag": "Entity",
+                    "tags": ["Entity"],
+                    "description": "x",
+                    "category": "read",
+                },
+            ],
+        )
+        handlers = sui.build_settings_handlers(server=None)
+        resp = await handlers["get_tools"](MagicMock())
+        body = json.loads(resp.body)
+
+        assert body["llm_api_available"] is True
         get_data_dir.cache_clear()
         _reset_global_settings()
 

--- a/tests/src/unit/test_settings_ui_js_behavior.py
+++ b/tests/src/unit/test_settings_ui_js_behavior.py
@@ -1055,13 +1055,17 @@ class TestGroupMasterToggle:
     """
 
     @staticmethod
-    def _tools_fetch(tools: list[dict], states: dict[str, str]) -> dict:
+    def _tools_fetch(
+        tools: list[dict],
+        states: dict[str, str],
+        env_pinned: dict[str, str] | None = None,
+    ) -> dict:
+        payload = {"tools": tools, "states": states}
+        if env_pinned is not None:
+            payload["env_pinned"] = env_pinned
         return {
             **DEFAULT_FETCHES,
-            "/api/settings/tools": {
-                "status": 200,
-                "json": {"tools": tools, "states": states},
-            },
+            "/api/settings/tools": {"status": 200, "json": payload},
         }
 
     @staticmethod
@@ -1106,6 +1110,87 @@ class TestGroupMasterToggle:
         assert " disabled" in tag_html, (
             f"all-mandatory group master must be disabled (nothing to flip); "
             f"got: {tag_html}"
+        )
+
+    def test_all_env_pinned_enabled_group_master_is_checked_and_disabled(
+        self, settings_script: str
+    ) -> None:
+        """The fix generalizes past mandatory tools: env-pinned tools are also
+        excluded from ``toggleable`` and still counted as enabled. A group whose
+        only tool is env-pinned to ``pinned`` (locked on) is fully enabled and
+        non-toggleable, so its master must render checked+disabled — the same
+        bug class as the all-mandatory case, via the env-pin branch.
+        """
+        tools = [
+            {
+                "name": "ha_foo",
+                "title": "Foo",
+                "primary_tag": "Utilities",
+                "tags": ["Utilities"],
+                "description": "d",
+                "annotations": {"readOnlyHint": True},
+            }
+        ]
+        result = run_script(
+            settings_script,
+            initial_html=MIN_DOM,
+            fetch_map=self._tools_fetch(tools, {}, {"ha_foo": "pinned"}),
+            invoke="await new Promise(r => setTimeout(r, 200));",
+        )
+        _assert_clean_init(result)
+        tag_html = self._master_input(result.dom, "Utilities")
+        assert "checked" in tag_html, (
+            f"all-env-pinned-on group master must be checked; got: {tag_html}"
+        )
+        assert " disabled" in tag_html, (
+            f"all-env-pinned group master must be disabled; got: {tag_html}"
+        )
+
+    def test_partially_enabled_locked_group_master_is_unchecked(
+        self, settings_script: str
+    ) -> None:
+        """A fully-locked group that is only PARTIALLY enabled must render the
+        master unchecked — checked means "fully enabled" (N/N), so a mixed
+        locked group must not read as ON and contradict its "1/2 enabled" count.
+
+        Group: a mandatory tool (always on) beside an env-pinned-disabled tool
+        (off). Both are excluded from ``toggleable`` (empty set → disabled
+        master), but only one is enabled, so ``groupEnabled`` (1) != tools (2).
+        This is the case where ``groupEnabled > 0`` and ``groupEnabled ===
+        tools.length`` diverge; the former would wrongly render it checked.
+        """
+        tools = [
+            {
+                "name": "ha_search",  # mandatory, always on
+                "title": "Search",
+                "primary_tag": "Mixed",
+                "tags": ["Mixed"],
+                "description": "d",
+                "annotations": {"readOnlyHint": True},
+            },
+            {
+                "name": "ha_foo",  # env-pinned OFF
+                "title": "Foo",
+                "primary_tag": "Mixed",
+                "tags": ["Mixed"],
+                "description": "d",
+                "annotations": {"readOnlyHint": True},
+            },
+        ]
+        result = run_script(
+            settings_script,
+            initial_html=MIN_DOM,
+            fetch_map=self._tools_fetch(tools, {}, {"ha_foo": "disabled"}),
+            invoke="await new Promise(r => setTimeout(r, 200));",
+        )
+        _assert_clean_init(result)
+        tag_html = self._master_input(result.dom, "Mixed")
+        assert "checked" not in tag_html, (
+            f"partially-enabled locked group master must be unchecked "
+            f"(1/2 enabled); got: {tag_html}"
+        )
+        assert " disabled" in tag_html, (
+            f"fully-locked group master must be disabled; got: {tag_html}"
         )
 
     def test_toggleable_group_all_disabled_master_is_unchecked(
@@ -4484,14 +4569,28 @@ class TestLlmApiToggle:
             "llm_api_available": True,
         }
 
-    def test_toggle_hidden_when_llm_api_unavailable(self, settings_script: str) -> None:
-        """On a non-embedded server (add-on / Docker / standalone) the tools
-        payload carries no ``llm_api_available`` flag, so the LLM API toggle
-        column must not render — it would be a no-op there. The other toggles
+    @pytest.mark.parametrize(
+        "shape",
+        ["explicit_false", "absent"],
+        ids=["explicit_false", "absent_default"],
+    )
+    def test_toggle_hidden_when_llm_api_unavailable(
+        self, settings_script: str, shape: str
+    ) -> None:
+        """On a non-embedded server (add-on / Docker / standalone) the LLM API
+        toggle column must not render — it would be a no-op there. Other toggles
         still render.
+
+        Covers both the shape the server actually sends —
+        ``llm_api_available: False`` (``is_embedded()`` on a non-embedded
+        server) — and, defensively, an older payload that omits the key
+        entirely (the JS ``!!data.llm_api_available`` default hides it too).
         """
         payload = self._tools_json(True)
-        del payload["llm_api_available"]  # non-embedded server omits the flag
+        if shape == "explicit_false":
+            payload["llm_api_available"] = False
+        else:
+            del payload["llm_api_available"]
         fetches = {
             **DEFAULT_FETCHES,
             "/api/settings/tools": {"status": 200, "json": payload},

--- a/tests/src/unit/test_settings_ui_js_behavior.py
+++ b/tests/src/unit/test_settings_ui_js_behavior.py
@@ -4480,7 +4480,42 @@ class TestLlmApiToggle:
             "read_only_exempt": [],
             "llm_api": {"ha_get_state": llm_effective},
             "llm_api_overrides": {},
+            # Embedded (custom-component) server: the LLM API toggle renders.
+            "llm_api_available": True,
         }
+
+    def test_toggle_hidden_when_llm_api_unavailable(self, settings_script: str) -> None:
+        """On a non-embedded server (add-on / Docker / standalone) the tools
+        payload carries no ``llm_api_available`` flag, so the LLM API toggle
+        column must not render — it would be a no-op there. The other toggles
+        still render.
+        """
+        payload = self._tools_json(True)
+        del payload["llm_api_available"]  # non-embedded server omits the flag
+        fetches = {
+            **DEFAULT_FETCHES,
+            "/api/settings/tools": {"status": 200, "json": payload},
+        }
+        result = run_script(
+            settings_script,
+            initial_html=MIN_DOM,
+            fetch_map=fetches,
+            settle_ms=300,
+            invoke="""
+              await new Promise(r => setTimeout(r, 200));
+              document.body.setAttribute('data-llm-present',
+                document.querySelector('input[data-field="llm"]') ? 'yes' : 'no');
+              document.body.setAttribute('data-enabled-present',
+                document.querySelector('input[data-field="enabled"]') ? 'yes' : 'no');
+            """,
+        )
+        _assert_clean_init(result)
+        assert _probe(result, "llm-present") == "no", (
+            "LLM API toggle must be hidden when the server is not embedded"
+        )
+        assert _probe(result, "enabled-present") == "yes", (
+            "other tool toggles must still render"
+        )
 
     def test_toggle_renders_effective_value(self, settings_script: str) -> None:
         fetches = {

--- a/tests/src/unit/test_settings_ui_js_behavior.py
+++ b/tests/src/unit/test_settings_ui_js_behavior.py
@@ -1042,6 +1042,147 @@ class TestEnvPinnedToolRows:
         )
 
 
+class TestGroupMasterToggle:
+    """The per-group master switch must reflect the group's real enabled
+    state.
+
+    A group whose tools are all mandatory (always-on, non-toggleable) has an
+    empty ``toggleable`` set, so the pre-fix ``anyEnabled`` computation was
+    always false and the switch rendered unchecked+disabled — reading as "the
+    whole group is off" while the count next to it said "N/N enabled". The
+    Search & Discovery group (ha_search / ha_get_overview / ha_get_state, all
+    mandatory) hit this. The master switch now shows the group's real state.
+    """
+
+    @staticmethod
+    def _tools_fetch(tools: list[dict], states: dict[str, str]) -> dict:
+        return {
+            **DEFAULT_FETCHES,
+            "/api/settings/tools": {
+                "status": 200,
+                "json": {"tools": tools, "states": states},
+            },
+        }
+
+    @staticmethod
+    def _master_input(dom: str, tag: str) -> str:
+        m = re.search(rf'<input[^>]*name="tool-group:{re.escape(tag)}"[^>]*>', dom)
+        assert m is not None, (
+            f"group-master input for {tag!r} not rendered; dom tail: {dom[-2000:]}"
+        )
+        return m.group(0)
+
+    def test_all_mandatory_group_master_is_checked_and_disabled(
+        self, settings_script: str
+    ) -> None:
+        """The reported bug: an all-mandatory group showed the master switch
+        OFF (unchecked) even though every tool is enabled and cannot be
+        disabled. It must render checked (on) AND disabled (unchangeable).
+        """
+        tools = [
+            {
+                "name": name,
+                "title": name,
+                "primary_tag": "Search",
+                "tags": ["Search"],
+                "description": "d",
+                "annotations": {"readOnlyHint": True},
+            }
+            # All three are members of MANDATORY_TOOLS.
+            for name in ("ha_search", "ha_get_overview", "ha_get_state")
+        ]
+        result = run_script(
+            settings_script,
+            initial_html=MIN_DOM,
+            fetch_map=self._tools_fetch(tools, {}),
+            invoke="await new Promise(r => setTimeout(r, 200));",
+        )
+        _assert_clean_init(result)
+        tag_html = self._master_input(result.dom, "Search")
+        assert "checked" in tag_html, (
+            f"all-mandatory group master must be checked (group is fully "
+            f"enabled); got: {tag_html}"
+        )
+        assert " disabled" in tag_html, (
+            f"all-mandatory group master must be disabled (nothing to flip); "
+            f"got: {tag_html}"
+        )
+
+    def test_toggleable_group_all_disabled_master_is_unchecked(
+        self, settings_script: str
+    ) -> None:
+        """Guard the fix's boundary: a group of ordinary (toggleable) tools
+        that are all disabled must still render the master switch unchecked
+        and interactive (not disabled), so the user can bulk-enable them.
+        """
+        tools = [
+            {
+                "name": "ha_foo",
+                "title": "Foo",
+                "primary_tag": "Utilities",
+                "tags": ["Utilities"],
+                "description": "d",
+                "annotations": {"readOnlyHint": True},
+            }
+        ]
+        result = run_script(
+            settings_script,
+            initial_html=MIN_DOM,
+            fetch_map=self._tools_fetch(tools, {"ha_foo": "disabled"}),
+            invoke="await new Promise(r => setTimeout(r, 200));",
+        )
+        _assert_clean_init(result)
+        tag_html = self._master_input(result.dom, "Utilities")
+        assert "checked" not in tag_html, (
+            f"all-disabled toggleable group master must be unchecked; got: {tag_html}"
+        )
+        assert " disabled" not in tag_html, (
+            f"toggleable group master must stay interactive; got: {tag_html}"
+        )
+
+    def test_mixed_group_keeps_bulk_semantics(self, settings_script: str) -> None:
+        """A group mixing a mandatory tool with a disabled toggleable tool
+        keeps the interactive bulk semantics: the switch stays enabled and
+        reflects ``anyEnabled`` (false here — the one toggleable tool is off),
+        so flipping it bulk-enables the toggleable tool. The fix only changes
+        the no-toggleable case.
+        """
+        tools = [
+            {
+                "name": "ha_search",  # mandatory, always on
+                "title": "Search",
+                "primary_tag": "Mixed",
+                "tags": ["Mixed"],
+                "description": "d",
+                "annotations": {"readOnlyHint": True},
+            },
+            {
+                "name": "ha_foo",  # toggleable, disabled
+                "title": "Foo",
+                "primary_tag": "Mixed",
+                "tags": ["Mixed"],
+                "description": "d",
+                "annotations": {"readOnlyHint": True},
+            },
+        ]
+        result = run_script(
+            settings_script,
+            initial_html=MIN_DOM,
+            fetch_map=self._tools_fetch(tools, {"ha_foo": "disabled"}),
+            invoke="await new Promise(r => setTimeout(r, 200));",
+        )
+        _assert_clean_init(result)
+        tag_html = self._master_input(result.dom, "Mixed")
+        assert " disabled" not in tag_html, (
+            f"mixed group has a toggleable tool, master must stay interactive; "
+            f"got: {tag_html}"
+        )
+        assert "checked" not in tag_html, (
+            f"mixed group's only toggleable tool is disabled, so the bulk "
+            f"master must be unchecked; got: {tag_html}"
+        )
+
+
 class TestAdvancedSectionRender:
     """JSDOM coverage for the Advanced Settings sections."""
 


### PR DESCRIPTION
## What does this PR do?

Two Tools-tab (settings UI) toggle-rendering fixes:

**1. Group master toggle for all-mandatory groups.** The per-group master switch derived its checked state from `anyEnabled`, computed only over *toggleable* tools. For a group whose tools are all mandatory — e.g. Search & Discovery (`ha_search`, `ha_get_overview`, `ha_get_state`) — that set is empty, so the switch rendered unchecked+disabled: it read as "the group is off" while the count beside it said "3/3 enabled" and the tools can't be disabled at all. It now takes the checked state from the group's real enabled status when nothing is toggleable, so an all-mandatory group shows on+disabled. Interactive/mixed groups are unchanged.

**2. LLM API toggle only on the custom-component (embedded) server.** The per-tool "LLM API" toggle offers a tool to Home Assistant conversation agents via the LLM API surface the `ha_mcp_tools` custom component registers. That surface only exists on the in-process (embedded) server; on the add-on / Docker / standalone server nothing consumes it, so the toggle was a no-op yet still rendered for every tool. `/api/settings/tools` now reports `llm_api_available` (= `is_embedded()`), and the Tools tab renders the LLM API column only when it is true.

## Type of change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [ ] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

Added JSDOM regression tests for both fixes (group master: all-mandatory / all-disabled / mixed; LLM API column hidden when the flag is absent) plus a server-side test that `llm_api_available` is true under `HA_MCP_EMBEDDED`. Verified against the jsdom harness that the all-mandatory master is unchecked before the change and checked+disabled after, and that the LLM API column renders only when embedded. Full unit + E2E suites run in CI.

## Checklist
- [x] I have updated documentation if needed
