### PR TITLE
feat: edit recorder config and packages under any configured folder

### DIFF
--- a/custom_components/ha_mcp_tools/__init__.py
+++ b/custom_components/ha_mcp_tools/__init__.py
@@ -23,6 +23,7 @@ from pathlib import Path, PurePosixPath
 from typing import Any
 
 import voluptuous as vol
+import yaml  # type: ignore[import-untyped]
 from homeassistant.components import persistent_notification
 from homeassistant.config import async_check_ha_config_file
 from homeassistant.config_entries import ConfigEntry
@@ -665,6 +666,163 @@ def _matches_extra_dir(normalized: str, extra_dirs: list[str] | None) -> bool:
     return any(normalized == d or normalized.startswith(d + os.sep) for d in extra_dirs)
 
 
+class _PackagesDir(str):
+    """Marker for the folder argument of a packages ``!include_dir_*named``."""
+
+
+def _capture_packages_dir(loader: yaml.Loader, node: yaml.nodes.Node) -> _PackagesDir:
+    """Construct a packages include-dir tag as its folder-name argument."""
+    return _PackagesDir(str(node.value))
+
+
+def _follow_include(loader: yaml.Loader, node: yaml.nodes.Node) -> Any:
+    """Follow ``!include`` so a split ``homeassistant:`` / ``packages:`` block in
+    another file is still seen during folder discovery (#1854 review).
+
+    Depth-guarded and best-effort: an unreadable/unparseable target (or a
+    string-stream loader with no base path) yields ``None``, like any other tag.
+    Only the referenced file's structure is read; every other HA tag inside it
+    is still dropped by the ignore constructor.
+    """
+    depth = getattr(loader, "_pkg_include_depth", 0)
+    name = getattr(loader, "name", "")
+    if depth >= 8 or not isinstance(name, str) or not name or name.startswith("<"):
+        return None
+    path = os.path.join(os.path.dirname(name), str(node.value))
+    try:
+        with open(path, encoding="utf-8") as handle:
+            sub = _PackagesDirLoader(handle)
+            sub._pkg_include_depth = depth + 1
+            try:
+                return sub.get_single_data()
+            finally:
+                sub.dispose()
+    except (OSError, yaml.YAMLError):
+        return None
+
+
+def _ignore_unknown_tag(
+    loader: yaml.Loader, tag_suffix: str, node: yaml.nodes.Node
+) -> None:
+    """Drop any other HA custom tag (``!secret`` / ``!env_var`` / ...).
+
+    Folder discovery only needs the ``homeassistant: packages:`` structure, so
+    unresolved tags are irrelevant — turning them into ``None`` lets
+    configuration.yaml parse structurally without resolving secrets, which is
+    what keeps this from being fragile hand-parsing.
+    """
+    return None
+
+
+class _PackagesDirLoader(yaml.SafeLoader):
+    """SafeLoader that captures packages include-dir folder names, follows
+    ``!include``, and ignores every other HA custom tag."""
+
+
+_PackagesDirLoader.add_constructor("!include_dir_named", _capture_packages_dir)
+_PackagesDirLoader.add_constructor("!include_dir_merge_named", _capture_packages_dir)
+_PackagesDirLoader.add_constructor("!include", _follow_include)
+_PackagesDirLoader.add_multi_constructor("!", _ignore_unknown_tag)
+
+
+def _extract_package_dir_markers(data: object) -> set[str]:
+    """Return the raw folder argument(s) of the packages include directive(s) in
+    a parsed configuration mapping. Inline packages declare no folder."""
+    if not isinstance(data, dict):
+        return set()
+    core = data.get("homeassistant")
+    if not isinstance(core, dict):
+        return set()
+    packages = core.get("packages")
+    markers: list[_PackagesDir] = []
+    if isinstance(packages, _PackagesDir):
+        markers.append(packages)
+    elif isinstance(packages, dict):
+        markers.extend(v for v in packages.values() if isinstance(v, _PackagesDir))
+    return {str(m) for m in markers}
+
+
+def _load_package_dir_markers(config_path: str) -> set[str]:
+    """Parse configuration.yaml (following ``!include``) and return the raw
+    folder argument(s) of every packages ``!include_dir_*named`` directive.
+
+    Blocking (opens files) — call via an executor. Returns raw strings, possibly
+    absolute; the caller relativizes and filters them against the config dir.
+    """
+    try:
+        with open(config_path, encoding="utf-8") as handle:
+            loader = _PackagesDirLoader(handle)
+            try:
+                data = loader.get_single_data()
+            finally:
+                loader.dispose()
+    except (OSError, yaml.YAMLError):
+        return set()
+    return _extract_package_dir_markers(data)
+
+
+def _package_folder_relative_to_config(raw: str, config_dir: str) -> str | None:
+    """Normalize a captured packages-folder argument to a config-relative folder
+    name, or ``None`` if it escapes the config dir.
+
+    An absolute include under the config dir (``!include_dir_named
+    /config/integrations``) is expressed relative to it; an absolute path
+    elsewhere, a parent escape, or the config root itself is dropped.
+    """
+    if raw.startswith("/"):
+        norm = os.path.normpath(raw)
+        if norm == config_dir or norm.startswith(config_dir + os.sep):
+            rel = os.path.relpath(norm, config_dir)
+            return rel if rel != "." else None
+        return None
+    folder = os.path.normpath(raw)
+    if folder and folder != "." and not folder.startswith(".."):
+        return folder
+    return None
+
+
+async def _detect_package_dirs(hass: HomeAssistant) -> set[str]:
+    """Return the config-relative folder name(s) HA loads packages from.
+
+    Home Assistant binds packages via ``homeassistant: packages:
+    !include_dir_named <folder>`` (or ``!include_dir_merge_named``), where
+    ``<folder>`` is any user-chosen directory — not necessarily ``packages``
+    (issue #1854). The folder is read straight from that directive in
+    configuration.yaml (following ``!include`` for a split ``homeassistant:``
+    section), so it is found even when the folder is still empty (the first
+    package is about to be created), a nested layout resolves to the configured
+    include root, and an in-config absolute include is relativized.
+
+    Always includes the built-in ``"packages"`` default, and degrades to just
+    that if configuration.yaml can't be read.
+    """
+    dirs = {"packages"}
+    config_path = hass.config.path(ALLOWED_YAML_CONFIG_FILES[0])
+    # normpath is a pure string transform (no I/O), so ASYNC240 doesn't apply.
+    config_dir = os.path.normpath(hass.config.config_dir)  # noqa: ASYNC240
+    markers = await hass.async_add_executor_job(_load_package_dir_markers, config_path)
+    for raw in markers:
+        folder = _package_folder_relative_to_config(raw, config_dir)
+        if folder:
+            dirs.add(folder)
+    return dirs
+
+
+def _path_in_package_dir(normalized: str, package_dirs: set[str] | None) -> bool:
+    """True if ``normalized`` is a ``*.yaml`` file at any depth under one of the
+    configured package folders.
+
+    Literal folder match (not ``fnmatch``), so a folder name containing glob
+    metacharacters — valid on HA's Linux filesystem — is matched as the literal
+    include root rather than a wildcard (#1854 review).
+    """
+    if not normalized.endswith(".yaml"):
+        return False
+    return any(
+        normalized.startswith(folder + "/") for folder in (package_dirs or {"packages"})
+    )
+
+
 def _is_path_allowed_for_dir(
     config_dir: Path,
     rel_path: str,
@@ -717,16 +875,23 @@ def _is_path_allowed_for_dir(
 
 
 def _is_path_allowed_for_read(
-    config_dir: Path, rel_path: str, extra_dirs: list[str] | None = None
+    config_dir: Path,
+    rel_path: str,
+    extra_dirs: list[str] | None = None,
+    package_dirs: set[str] | None = None,
 ) -> bool:
     """Check if a path is allowed for reading.
 
     Allowed:
     - Files directly in config dir: configuration.yaml, automations.yaml, etc.
     - Files in allowed directories: www/, themes/, custom_templates/
-    - Files matching patterns: packages/*.yaml, custom_components/**/*.py
+    - Files matching patterns: <packages-folder>/*.yaml, custom_components/**/*.py
     - User-configured extra directories (``extra_dirs``), granted read+write
       (issue #1567)
+
+    ``package_dirs`` is the set of configured packages folder name(s) (issue
+    #1854); it defaults to ``{"packages"}`` when not supplied so callers that
+    don't resolve the live config keep the historical behaviour.
 
     The non-overridable deny floor is checked first, so a custom directory can
     never reach ``.storage`` or an unmasked ``secrets.yaml``.
@@ -768,11 +933,10 @@ def _is_path_allowed_for_read(
     if parts and parts[0] in ALLOWED_READ_DIRS:
         return True
 
-    # Check for packages/*.yaml pattern. ``fnmatch``'s ``*`` matches
-    # ``/`` too, so this pattern alone covers nested paths
-    # (``packages/sub/foo.yaml``) — no explicit recursive variant
-    # needed.
-    if fnmatch.fnmatch(normalized, "packages/*.yaml"):
+    # Check for <packages-folder>/*.yaml at any depth. The configured folder(s)
+    # default to {"packages"} (issue #1854); literal match so a folder name with
+    # glob metacharacters is treated as the include root, not a wildcard.
+    if _path_in_package_dir(normalized, package_dirs):
         return True
 
     # Check for custom_components/**/*.py pattern
@@ -1103,19 +1267,44 @@ def _build_edit_yaml_config_handler(
             }
 
         is_config_yaml = normalized in ALLOWED_YAML_CONFIG_FILES
-        # ``fnmatch``'s ``*`` matches ``/`` too, so this single
-        # pattern covers both flat ``packages/foo.yaml`` and nested
-        # ``packages/sub/foo.yaml``. The recursive variant
-        # ``packages/**/*.yaml`` is mathematically a subset of this
-        # one (``**`` reduces to ``*`` in fnmatch), so it's omitted.
-        is_package = fnmatch.fnmatch(normalized, "packages/*.yaml")
         is_theme = fnmatch.fnmatch(normalized, "themes/*.yaml")
+        # Package files may live under any folder the user binds via
+        # ``homeassistant: packages: !include_dir_named <folder>`` — not just the
+        # default ``packages`` (issue #1854). The configured folder(s) are
+        # detected at runtime (parsing configuration.yaml), so only do that work
+        # when the target isn't already a config-root or theme file. The set
+        # always includes ``"packages"`` as a fallback.
+        package_dirs: set[str] = set()
+        is_package = False
+        if not is_config_yaml and not is_theme:
+            package_dirs = await _detect_package_dirs(hass)
+            is_package = _path_in_package_dir(normalized, package_dirs)
         if not is_config_yaml and not is_package and not is_theme:
+            allowed_pkg = ", ".join(
+                f"{folder}/*.yaml" for folder in sorted(package_dirs)
+            )
             return {
                 "success": False,
                 "error": (
                     f"File '{rel_path}' is not allowed. "
-                    f"Only {', '.join(ALLOWED_YAML_CONFIG_FILES)}, packages/*.yaml, and themes/*.yaml are supported."
+                    f"Only {', '.join(ALLOWED_YAML_CONFIG_FILES)}, {allowed_pkg}, and themes/*.yaml are supported."
+                ),
+            }
+
+        # Symlink-safe containment (parity with the read path, issue #1586): the
+        # write target is ``config_dir / normalized``, so a package/theme folder
+        # that is (or contains) a symlink escaping the config dir — or a path
+        # resolving into the deny floor (.storage / secrets.yaml) — must be
+        # rejected before writing, exactly as read_file already does.
+        if _violates_deny_floor(config_dir, normalized) or not _resolves_within(
+            config_dir, rel_path
+        ):
+            _LOGGER.warning("Rejected YAML edit escaping the config dir: %s", rel_path)
+            return {
+                "success": False,
+                "error": (
+                    f"Path '{rel_path}' resolves outside the config directory or "
+                    "into a protected location and cannot be edited."
                 ),
             }
 
@@ -1968,14 +2157,21 @@ async def _async_setup_tools_entry(hass: HomeAssistant, entry: ConfigEntry) -> b
         tail_lines = call.data.get("tail_lines")
         yaml_path = call.data.get("yaml_path")
 
-        # Security check
+        # Security check. Package files may live under a non-default folder
+        # (issue #1854), so resolve the configured folder(s) — the same way the
+        # YAML editor does — and honour them here too, otherwise the pre-write
+        # backup snapshot (a read of the target) blocks edits to those files.
         extra_dirs = _current_extra_dirs()
-        if not _is_path_allowed_for_read(config_dir, rel_path, extra_dirs):
+        package_dirs = await _detect_package_dirs(hass)
+        if not _is_path_allowed_for_read(
+            config_dir, rel_path, extra_dirs, package_dirs
+        ):
             _LOGGER.warning("Attempted to read disallowed path: %s", rel_path)
             allowed_patterns = (
                 ALLOWED_READ_FILES
                 + [f"{d}/**" for d in ALLOWED_READ_DIRS]
-                + ["packages/*.yaml", "custom_components/**/*.py"]
+                + [f"{d}/*.yaml" for d in sorted(package_dirs)]
+                + ["custom_components/**/*.py"]
                 + [f"{d}/**" for d in extra_dirs]
             )
             return {

--- a/custom_components/ha_mcp_tools/const.py
+++ b/custom_components/ha_mcp_tools/const.py
@@ -75,7 +75,9 @@ ALLOWED_VOLUME_ROOTS = ("/share", "/media", "/ssl", "/backup")
 
 # Files allowed for managed YAML editing
 ALLOWED_YAML_CONFIG_FILES = ["configuration.yaml"]
-# Also allows packages/*.yaml via pattern matching
+# Also allows <packages-folder>/*.yaml via pattern matching, where the folder is
+# the one the user binds under ``homeassistant: packages:`` (default "packages",
+# detected at runtime — see _detect_package_dirs), plus themes/*.yaml.
 
 # Top-level YAML keys allowed for editing in any allowed file
 # (configuration.yaml or packages/*.yaml).
@@ -103,6 +105,11 @@ ALLOWED_YAML_KEYS = frozenset(
         "notify",
         "group",
         "utility_meter",
+        # recorder is YAML-only (no UI or storage-mode helper): purge_keep_days,
+        # include/exclude, commit_interval. Its surface is smaller than keys
+        # already here — it only controls what HA records and for how long, with
+        # no code-execution path like command_line/shell_command/rest (#1852).
+        "recorder",
     }
 )
 

--- a/tests/initial_test_state/configuration.yaml
+++ b/tests/initial_test_state/configuration.yaml
@@ -2,6 +2,14 @@
 # Loads default set of integrations. Do not remove.
 default_config:
 
+homeassistant:
+  # Bind YAML packages under a NON-default folder name ("custom_packages",
+  # not "packages") so the e2e suite exercises ha_config_set_yaml's runtime
+  # packages-folder detection (#1854) instead of the hardcoded default. The
+  # tool keeps "packages" as a fallback, so tests writing to packages/*.yaml
+  # still pass.
+  packages: !include_dir_named custom_packages
+
 # Load frontend themes from the themes folder
 frontend:
   themes: !include_dir_merge_named themes

--- a/tests/src/e2e/workflows/filesystem/test_yaml_config.py
+++ b/tests/src/e2e/workflows/filesystem/test_yaml_config.py
@@ -748,6 +748,106 @@ class TestYamlConfigSafeguards:
             )
             logger.info(f"post_action={inner.get('post_action')}")
 
+    async def test_recorder_key_is_editable(self, mcp_client_with_yaml_config):
+        """recorder is editable via ha_config_set_yaml (#1852).
+
+        recorder is YAML-only (no UI/storage-mode helper) and has no reload
+        service in HA core, so it defaults to post_action=restart_required.
+        """
+
+        async with MCPAssertions(mcp_client_with_yaml_config) as mcp:
+            data = await call_set_yaml_confirmed(
+                mcp,
+                {
+                    "yaml_path": "recorder",
+                    "action": "add",
+                    "content": "purge_keep_days: 5",
+                    "file": "packages/_e2e_test_recorder.yaml",
+                },
+            )
+            assert data.get("success") is True, f"recorder add should succeed: {data}"
+            assert data.get("post_action") == "restart_required", (
+                f"recorder should default to post_action=restart_required: {data}"
+            )
+            assert "reload_service" not in data, (
+                f"reload_service should NOT be present for recorder: {data}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Configured (non-default) packages folder — issue #1854
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.filesystem
+class TestYamlConfigCustomPackagesFolder:
+    """#1854: package files under the *configured* packages folder are editable.
+
+    The e2e container binds packages under a non-default folder via
+    ``homeassistant: packages: !include_dir_named custom_packages`` (see
+    tests/initial_test_state/configuration.yaml). The folder ships empty, so
+    these also cover first-package creation under a configured folder: detection
+    reads the directive, not the folder contents. If the folder were still
+    hardcoded to ``packages``, a ``custom_packages/*.yaml`` target would be
+    rejected as "not allowed"; these prove it is detected at runtime.
+    """
+
+    async def test_edit_under_configured_packages_folder(
+        self, mcp_client_with_yaml_config
+    ):
+        """A plain allowed key writes successfully under custom_packages/.
+
+        Reaching a success here means the path itself was accepted: a
+        non-config, non-theme path is only allowed when detected as a package
+        folder, so this exercises the detection, not just the key allowlist.
+        """
+        async with MCPAssertions(mcp_client_with_yaml_config) as mcp:
+            data = await call_set_yaml_confirmed(
+                mcp,
+                {
+                    "yaml_path": "template",
+                    "action": "add",
+                    "content": (
+                        "- sensor:\n"
+                        "    - name: E2E Alt Folder Sensor\n"
+                        '      state: "{{ 1 }}"\n'
+                    ),
+                    "file": "custom_packages/_e2e_alt_folder.yaml",
+                },
+            )
+            assert data.get("success") is True, (
+                f"editing under the configured packages folder should "
+                f"succeed (#1854): {data}"
+            )
+
+    async def test_packages_only_key_allowed_in_configured_folder(
+        self, mcp_client_with_yaml_config
+    ):
+        """A PACKAGES_ONLY key (automation) is accepted under custom_packages/.
+
+        automation/script/scene are rejected in configuration.yaml but allowed
+        in a package file. Accepting automation here proves the folder is
+        classified as a package folder (is_package), not merely path-allowed.
+        """
+        async with MCPAssertions(mcp_client_with_yaml_config) as mcp:
+            data = await call_set_yaml_confirmed(
+                mcp,
+                {
+                    "yaml_path": "automation",
+                    "action": "add",
+                    "content": (
+                        "- alias: E2E Alt Folder Automation\n"
+                        "  triggers: []\n"
+                        "  actions: []\n"
+                    ),
+                    "file": "custom_packages/_e2e_alt_automation.yaml",
+                },
+            )
+            assert data.get("success") is True, (
+                f"PACKAGES_ONLY key 'automation' should be accepted under the "
+                f"configured packages folder (#1854): {data}"
+            )
+
 
 # ---------------------------------------------------------------------------
 # Comment and HA tag preservation

--- a/tests/src/unit/test_custom_component_filesystem.py
+++ b/tests/src/unit/test_custom_component_filesystem.py
@@ -35,15 +35,20 @@ sys.modules["homeassistant.loader"] = MagicMock()
 from custom_components.ha_mcp_tools import (  # noqa: E402
     _decode_legacy_backup_name,
     _delete_file_sync,
+    _detect_package_dirs,
     _extract_yaml_subtree,
     _is_path_allowed_for_dir,
     _is_path_allowed_for_read,
     _is_within_config_dir,
     _list_files_sync,
     _list_legacy_backups_sync,
+    _load_package_dir_markers,
     _mask_secrets_content,
     _migrate_legacy_backup_dir,
     _normalize_extra_dir,
+    _package_folder_relative_to_config,
+    _parse_and_validate_yaml_path,
+    _path_in_package_dir,
     _read_file_sync,
     _read_legacy_backup_sync,
     _resolves_within,
@@ -55,6 +60,7 @@ from custom_components.ha_mcp_tools.const import (  # noqa: E402
     ALLOWED_READ_DIRS,
     ALLOWED_VOLUME_ROOTS,
     ALLOWED_WRITE_DIRS,
+    ALLOWED_YAML_KEYS,
 )
 
 from ._symlink_support import symlink_or_skip  # noqa: E402
@@ -1550,3 +1556,215 @@ class TestExtractYamlSubtree:
         # Malformed YAML yields None (the edit itself would then fail and
         # report the parse error); capture just skips.
         assert _extract_yaml_subtree("key: [1, 2\n", "key") is None
+
+
+class TestRecorderYamlKey:
+    """#1852: recorder is editable via edit_yaml_config / ha_config_set_yaml.
+
+    recorder is YAML-only (no UI or storage-mode helper) and has no
+    code-execution surface, so it belongs in the plain ALLOWED_YAML_KEYS set
+    (editable in configuration.yaml and package files alike).
+    """
+
+    def test_recorder_in_allowed_keys(self):
+        assert "recorder" in ALLOWED_YAML_KEYS
+
+    def test_recorder_parses_as_single_key(self):
+        kind, parts, err = _parse_and_validate_yaml_path("recorder")
+        assert err is None
+        assert kind == "single"
+        assert parts == ("recorder",)
+
+    def test_recorder_accepted_in_configuration_yaml(self):
+        # Not a packages-only key, so it validates even outside a package file.
+        _, _, err = _parse_and_validate_yaml_path("recorder", is_package=False)
+        assert err is None
+
+
+def _fake_hass_fs(config_dir):
+    """A hass whose executor offload actually runs the given function."""
+    hass = MagicMock()
+    hass.config.config_dir = str(config_dir)
+    hass.config.path = lambda name, cd=str(config_dir): os.path.join(cd, name)
+
+    async def _run(func, *args):
+        return func(*args)
+
+    hass.async_add_executor_job = _run
+    return hass
+
+
+def _write_config(tmp_path, text, name="configuration.yaml"):
+    p = tmp_path / name
+    p.write_text(text, encoding="utf-8")
+    return str(p)
+
+
+class TestLoadPackageDirMarkers:
+    """#1854: the packages folder argument is read from the include directive."""
+
+    def test_no_packages(self, tmp_path):
+        p = _write_config(tmp_path, "default_config:\n")
+        assert _load_package_dir_markers(p) == set()
+
+    def test_single_include_dir_named(self, tmp_path):
+        p = _write_config(
+            tmp_path, "homeassistant:\n  packages: !include_dir_named custom_packages\n"
+        )
+        assert _load_package_dir_markers(p) == {"custom_packages"}
+
+    def test_include_dir_merge_named(self, tmp_path):
+        p = _write_config(
+            tmp_path,
+            "homeassistant:\n  packages: !include_dir_merge_named integrations\n",
+        )
+        assert _load_package_dir_markers(p) == {"integrations"}
+
+    def test_named_group_mapping(self, tmp_path):
+        p = _write_config(
+            tmp_path, "homeassistant:\n  packages:\n    grp: !include_dir_named pkgs\n"
+        )
+        assert _load_package_dir_markers(p) == {"pkgs"}
+
+    def test_inline_packages_declare_no_folder(self, tmp_path):
+        p = _write_config(
+            tmp_path,
+            "homeassistant:\n  packages:\n    inline_pkg:\n      light: []\n",
+        )
+        assert _load_package_dir_markers(p) == set()
+
+    def test_other_ha_tags_ignored(self, tmp_path):
+        p = _write_config(
+            tmp_path,
+            "homeassistant:\n  packages: !include_dir_named custom_packages\n"
+            "recorder:\n  db_url: !secret db_url\n",
+        )
+        assert _load_package_dir_markers(p) == {"custom_packages"}
+
+    def test_absolute_include_returned_raw(self, tmp_path):
+        # Absolute args are returned as-is here; relativization happens in
+        # _package_folder_relative_to_config.
+        p = _write_config(
+            tmp_path,
+            "homeassistant:\n  packages: !include_dir_named /config/integrations\n",
+        )
+        assert _load_package_dir_markers(p) == {"/config/integrations"}
+
+    def test_follows_split_homeassistant_include(self, tmp_path):
+        # #1854 review: the homeassistant section split into another file. The
+        # included file holds the body of the section (no homeassistant: wrapper).
+        _write_config(
+            tmp_path, "packages: !include_dir_named integrations\n", name="ha.yaml"
+        )
+        p = _write_config(
+            tmp_path, "default_config:\nhomeassistant: !include ha.yaml\n"
+        )
+        assert _load_package_dir_markers(p) == {"integrations"}
+
+    def test_missing_file_returns_empty(self, tmp_path):
+        assert _load_package_dir_markers(str(tmp_path / "nope.yaml")) == set()
+
+    def test_malformed_yaml_returns_empty(self, tmp_path):
+        assert (
+            _load_package_dir_markers(_write_config(tmp_path, "key: [1, 2\n")) == set()
+        )
+
+
+class TestPackageFolderRelativeToConfig:
+    """#1854 review: normalize/relativize captured folder arguments."""
+
+    def test_plain_relative(self):
+        assert (
+            _package_folder_relative_to_config("integrations", "/config")
+            == "integrations"
+        )
+
+    def test_absolute_under_config_relativized(self):
+        assert (
+            _package_folder_relative_to_config("/config/integrations", "/config")
+            == "integrations"
+        )
+
+    def test_absolute_outside_config_dropped(self):
+        assert _package_folder_relative_to_config("/etc/pkgs", "/config") is None
+
+    def test_parent_escape_dropped(self):
+        assert _package_folder_relative_to_config("../evil", "/config") is None
+
+    def test_config_root_dropped(self):
+        assert _package_folder_relative_to_config("/config", "/config") is None
+
+
+class TestPathInPackageDir:
+    """#1854 review: literal folder matching (glob-metachar safe)."""
+
+    def test_flat_and_nested(self):
+        dirs = {"packages", "custom_packages"}
+        assert _path_in_package_dir("packages/foo.yaml", dirs)
+        assert _path_in_package_dir("custom_packages/sub/foo.yaml", dirs)
+
+    def test_non_yaml_rejected(self):
+        assert not _path_in_package_dir("packages/foo.txt", {"packages"})
+
+    def test_sibling_prefix_not_matched(self):
+        assert not _path_in_package_dir("packagesX/foo.yaml", {"packages"})
+
+    def test_glob_metachar_folder_literal(self):
+        # A folder named 'pkg[1]' must match its own path literally, not 'pkg1'.
+        assert _path_in_package_dir("pkg[1]/foo.yaml", {"pkg[1]"})
+        assert not _path_in_package_dir("pkg1/foo.yaml", {"pkg[1]"})
+
+    def test_default_packages_when_none(self):
+        assert _path_in_package_dir("packages/foo.yaml", None)
+
+
+class TestDetectPackageDirs:
+    """#1854: detection reads configuration.yaml and adds the packages fallback."""
+
+    async def test_default_when_no_packages(self, tmp_path):
+        _write_config(tmp_path, "default_config:\n")
+        assert await _detect_package_dirs(_fake_hass_fs(tmp_path)) == {"packages"}
+
+    async def test_detects_custom_folder(self, tmp_path):
+        _write_config(
+            tmp_path, "homeassistant:\n  packages: !include_dir_named integrations\n"
+        )
+        assert await _detect_package_dirs(_fake_hass_fs(tmp_path)) == {
+            "packages",
+            "integrations",
+        }
+
+    async def test_relativizes_absolute_include(self, tmp_path):
+        cfg = str(tmp_path)
+        _write_config(
+            tmp_path,
+            f"homeassistant:\n  packages: !include_dir_named {cfg}/integrations\n",
+        )
+        assert await _detect_package_dirs(_fake_hass_fs(tmp_path)) == {
+            "packages",
+            "integrations",
+        }
+
+    async def test_missing_config_falls_back(self, tmp_path):
+        # No configuration.yaml written -> unreadable -> default only.
+        assert await _detect_package_dirs(_fake_hass_fs(tmp_path)) == {"packages"}
+
+
+class TestReadAllowlistPackageFolder:
+    """#1854: the read allowlist honours the configured packages folder.
+
+    The pre-write backup snapshots a file by reading it, so the read path must
+    accept the same non-default packages folder the YAML editor writes to.
+    """
+
+    def test_custom_folder_allowed_when_detected(self, tmp_path):
+        assert _is_path_allowed_for_read(
+            tmp_path, "integrations/lights.yaml", None, {"packages", "integrations"}
+        )
+
+    def test_custom_folder_rejected_when_not_detected(self, tmp_path):
+        # Default set is {"packages"} only — an unconfigured folder is not read.
+        assert not _is_path_allowed_for_read(tmp_path, "integrations/lights.yaml")
+
+    def test_default_packages_folder_still_allowed(self, tmp_path):
+        assert _is_path_allowed_for_read(tmp_path, "packages/foo.yaml")


### PR DESCRIPTION
## What does this PR do?

Two YAML-config editing improvements (`ha_config_set_yaml` / the component's `edit_yaml_config` service), closing two feature requests.

**#1852 — `recorder` is now editable.** Adds `recorder` to `ALLOWED_YAML_KEYS`. Recorder tuning (`purge_keep_days`, `include`/`exclude`, `commit_interval`) is YAML-only — no UI or storage-mode helper exists for it — so it fits the allowlist rule ("keys with no UI/API alternative"). Its surface is smaller than keys already allowed: `command_line`/`shell_command`/`rest` carry code-execution / arbitrary-HTTP surface, whereas recorder only controls what HA records and for how long. It has no reload service, so it defaults to `post_action=restart_required`.

**#1854 — packages folder is detected, not hardcoded.** The check was `fnmatch(path, "packages/*.yaml")`, so instances binding packages under a different folder (`homeassistant: packages: !include_dir_named integrations`) could never edit those files. The folder is now detected at runtime: `configuration.yaml` is loaded with HA's own loader (which resolves `!include*` / `!secret` and split configs exactly as startup does), and each package value's `__config_file__` annotation reveals its source folder. `"packages"` stays in the set as a fallback (so first-time package creation still works), and an unparseable config degrades to that default rather than blocking edits. Only computed for non-config / non-theme targets.

No server (`src/`) code changed — both are component-side. The component version rides the already-open pending `1.1.0` (stable is `1.0.4`), so no bump; no `MIN_COMPONENT_VERSION` change (additive, no new server dependency).

Closes #1852
Closes #1854

## Type of change
- [x] ✨ New feature
- [x] 🐛 Bug fix (#1854)

## Testing
- [x] Code follows style guidelines (`ruff check` / `ruff format --check` pass)

Unit coverage for `_detect_package_dirs` (default / custom / nested / multiple folders, inline packages, missing annotation, non-dict config, parse-failure fallback) and the `recorder` allowlist + parse path. E2E: a `recorder` round-trip, plus an alt-folder case — the e2e container now binds packages under a **non-default** folder (`homeassistant: packages: !include_dir_named custom_packages` in `initial_test_state/configuration.yaml`), and new tests edit a `custom_packages/*.yaml` file (a plain key and a PACKAGES_ONLY key), which only succeed if the folder is detected. Existing `packages/*.yaml` tests still pass via the fallback. Ran the touched unit files locally; full e2e (Docker) runs in CI.

## Checklist
- [x] I have updated documentation if needed
