### PR TITLE
fix: reject malformed feature-flags payload instead of silent no-op

### DIFF
--- a/src/ha_mcp/settings_ui/__init__.py
+++ b/src/ha_mcp/settings_ui/__init__.py
@@ -1982,12 +1982,31 @@ def build_settings_handlers(
                 ),
                 status_code=400,
             )
-        raw_flags = body.get("flags", {})
+        # Require the nested ``{"flags": {...}}`` shape. A flat body
+        # (e.g. ``{"enable_lite_docstrings": true}``) has no ``flags``
+        # key, so a lenient ``body.get("flags", {})`` default silently
+        # dropped every field and still returned
+        # ``success=True``/``restart_required=True`` — worse than a
+        # visible no-op, because the caller believed the flag changed
+        # and a restart was pending when nothing happened (#1840).
+        raw_flags = body.get("flags")
         if not isinstance(raw_flags, dict):
             return JSONResponse(
                 create_error_response(
                     ErrorCode.VALIDATION_INVALID_PARAMETER,
-                    "'flags' must be an object mapping field names to values",
+                    "Request body must contain a 'flags' object mapping "
+                    'field names to values, e.g. {"flags": '
+                    '{"enable_lite_docstrings": true}}. A flat body such '
+                    'as {"enable_lite_docstrings": true} is not accepted.',
+                ),
+                status_code=400,
+            )
+        if not raw_flags:
+            return JSONResponse(
+                create_error_response(
+                    ErrorCode.VALIDATION_INVALID_PARAMETER,
+                    "'flags' object is empty; include at least one "
+                    "feature-flag field to update.",
                 ),
                 status_code=400,
             )

--- a/src/ha_mcp/settings_ui/__init__.py
+++ b/src/ha_mcp/settings_ui/__init__.py
@@ -1998,6 +1998,10 @@ def build_settings_handlers(
                     'field names to values, e.g. {"flags": '
                     '{"enable_lite_docstrings": true}}. A flat body such '
                     'as {"enable_lite_docstrings": true} is not accepted.',
+                    suggestions=[
+                        'Wrap the flags in a "flags" object, e.g. '
+                        '{"flags": {"enable_lite_docstrings": true}}.',
+                    ],
                 ),
                 status_code=400,
             )
@@ -2007,6 +2011,10 @@ def build_settings_handlers(
                     ErrorCode.VALIDATION_INVALID_PARAMETER,
                     "'flags' object is empty; include at least one "
                     "feature-flag field to update.",
+                    suggestions=[
+                        'Include at least one field inside "flags", e.g. '
+                        '{"flags": {"enable_lite_docstrings": true}}.',
+                    ],
                 ),
                 status_code=400,
             )

--- a/tests/src/unit/test_settings_ui.py
+++ b/tests/src/unit/test_settings_ui.py
@@ -2174,6 +2174,57 @@ class TestSaveFeatureFlagsStandaloneMode:
         get_data_dir.cache_clear()
         _reset_global_settings()
 
+    @pytest.mark.asyncio
+    async def test_flat_body_rejected_not_silent_noop(self, monkeypatch, tmp_path):
+        """A flat body (missing the ``flags`` wrapper) must 400, not
+        silently no-op with ``success``/``restart_required`` (#1840).
+
+        Before the fix, ``POST {"enable_lite_docstrings": true}``
+        returned ``{"success": true, "applied": {}, "mode": "file",
+        "restart_required": true}`` — worse than a plain no-op, since a
+        caller believed the flag changed and a restart was pending when
+        nothing happened. No override file should be written either.
+        """
+        post_handler = self._capture_post_handler(monkeypatch, tmp_path)
+
+        resp = await post_handler(self._make_request({"enable_lite_docstrings": True}))
+
+        assert resp.status_code == 400
+        body = json.loads(resp.body)
+        assert body["success"] is False
+        assert body["error"]["code"] == "VALIDATION_INVALID_PARAMETER"
+        # A rejected save must not persist anything.
+        assert not (tmp_path / "feature_flags.json").exists()
+
+    @pytest.mark.asyncio
+    async def test_empty_flags_object_rejected(self, monkeypatch, tmp_path):
+        """An explicitly empty ``flags`` object applies nothing and must
+        400 rather than falsely reporting ``restart_required`` (#1840)."""
+        post_handler = self._capture_post_handler(monkeypatch, tmp_path)
+
+        resp = await post_handler(self._make_request({"flags": {}}))
+
+        assert resp.status_code == 400
+        body = json.loads(resp.body)
+        assert body["success"] is False
+        assert body["error"]["code"] == "VALIDATION_INVALID_PARAMETER"
+        assert not (tmp_path / "feature_flags.json").exists()
+
+    @pytest.mark.asyncio
+    async def test_non_dict_flags_rejected(self, monkeypatch, tmp_path):
+        """``flags`` present but not an object (e.g. a list) must 400."""
+        post_handler = self._capture_post_handler(monkeypatch, tmp_path)
+
+        resp = await post_handler(
+            self._make_request({"flags": ["enable_lite_docstrings"]})
+        )
+
+        assert resp.status_code == 400
+        body = json.loads(resp.body)
+        assert body["success"] is False
+        assert body["error"]["code"] == "VALIDATION_INVALID_PARAMETER"
+        assert not (tmp_path / "feature_flags.json").exists()
+
 
 class TestSaveToolsResponseShape:
     """Pins the unified ``{success, applied, mode, restart_required}``

--- a/tests/src/unit/test_settings_ui.py
+++ b/tests/src/unit/test_settings_ui.py
@@ -2193,6 +2193,8 @@ class TestSaveFeatureFlagsStandaloneMode:
         body = json.loads(resp.body)
         assert body["success"] is False
         assert body["error"]["code"] == "VALIDATION_INVALID_PARAMETER"
+        # Progressive disclosure: the error guides the caller to the shape.
+        assert body["error"]["suggestion"]
         # A rejected save must not persist anything.
         assert not (tmp_path / "feature_flags.json").exists()
 
@@ -2208,6 +2210,7 @@ class TestSaveFeatureFlagsStandaloneMode:
         body = json.loads(resp.body)
         assert body["success"] is False
         assert body["error"]["code"] == "VALIDATION_INVALID_PARAMETER"
+        assert body["error"]["suggestion"]
         assert not (tmp_path / "feature_flags.json").exists()
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## What does this PR do?

Closes #1840. `POST /api/settings/features` defaulted a missing `flags` key
to `{}` (`raw_flags = body.get("flags", {})`), so a flat body such as
`{"enable_lite_docstrings": true}` silently applied nothing yet returned
`{"success": true, "applied": {}, "mode": "file", "restart_required": true}`.
This is worse than a visible no-op: the caller believes the flag changed and
a restart is pending when nothing happened.

The handler now requires the nested `{"flags": {...}}` shape and returns a 400
with a clear message for malformed payloads:

- Body without a `flags` object → 400, with the correct shape shown in the message.
- Empty `flags` object → 400 (nothing to apply).
- Non-dict `flags` (e.g. a list) → 400.

The web settings page always POSTs `{"flags": {[field]: value}}`, so only
malformed external/scripted callers are affected — no behavior change for the UI.

## Type of change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

Added 3 regression tests to `TestSaveFeatureFlagsStandaloneMode`
(`test_flat_body_rejected_not_silent_noop`, `test_empty_flags_object_rejected`,
`test_non_dict_flags_rejected`). The full settings-UI unit suite (209 tests)
passes; `ruff` and `mypy` are clean.

## Checklist
- [x] I have updated documentation if needed
