### PR TITLE
feat: add ws_command escape hatch to ha_call_service for WebSocket-only commands

### DIFF
--- a/src/ha_mcp/policy/evaluator.py
+++ b/src/ha_mcp/policy/evaluator.py
@@ -145,4 +145,17 @@ def find_matching_rule(
 def evaluate(tool_name: str, args: dict[str, Any], policy: Policy) -> Verdict:
     if find_matching_rule(tool_name, args, policy) is not None:
         return Verdict.REQUIRE_APPROVAL
+    # ha_call_service exposes a raw WebSocket escape hatch (``ws_command``) that
+    # carries no ``domain``/``service`` argument, so a rule keyed on
+    # ``args.domain``/``args.service`` cannot match it and it would otherwise slip
+    # through the fail-open default. If the operator has scoped ANY rule to
+    # ha_call_service, treat an unmatched ws_command call as require-approval
+    # (fail safe) so the escape hatch cannot sneak past that oversight. Operators
+    # who want finer control can still add a rule keyed on ``args.ws_command``.
+    if (
+        tool_name == "ha_call_service"
+        and args.get("ws_command")
+        and any(rule.tool_name == "ha_call_service" for rule in policy.rules)
+    ):
+        return Verdict.REQUIRE_APPROVAL
     return Verdict.ALLOW

--- a/src/ha_mcp/policy/evaluator.py
+++ b/src/ha_mcp/policy/evaluator.py
@@ -148,14 +148,19 @@ def evaluate(tool_name: str, args: dict[str, Any], policy: Policy) -> Verdict:
     # ha_call_service exposes a raw WebSocket escape hatch (``ws_command``) that
     # carries no ``domain``/``service`` argument, so a rule keyed on
     # ``args.domain``/``args.service`` cannot match it and it would otherwise slip
-    # through the fail-open default. If the operator has scoped ANY rule to
-    # ha_call_service, treat an unmatched ws_command call as require-approval
-    # (fail safe) so the escape hatch cannot sneak past that oversight. Operators
-    # who want finer control can still add a rule keyed on ``args.ws_command``.
+    # through the fail-open default. If the operator has ANY rule that applies to
+    # ha_call_service -- one scoped to it by name, or a wildcard ``*`` rule, which
+    # ``match_rule`` treats as applying to every tool -- treat an unmatched
+    # ws_command call as require-approval (fail safe) so the escape hatch cannot
+    # sneak past that oversight. Blocking the call (require-approval) rather than
+    # silently allowing it is the safe error direction for a raw WS escape hatch,
+    # especially since the write-command blocklist is a deliberately
+    # non-exhaustive wrapper-bypass list that leans on this gate.
+    # Operators who want finer control can add a rule keyed on ``args.ws_command``.
     if (
         tool_name == "ha_call_service"
         and args.get("ws_command")
-        and any(rule.tool_name == "ha_call_service" for rule in policy.rules)
+        and any(rule.tool_name in ("ha_call_service", "*") for rule in policy.rules)
     ):
         return Verdict.REQUIRE_APPROVAL
     return Verdict.ALLOW

--- a/src/ha_mcp/tools/tools_code.py
+++ b/src/ha_mcp/tools/tools_code.py
@@ -36,6 +36,7 @@ from fastmcp.server.context import Context
 from ..config import get_global_settings
 from ..errors import ErrorCode, create_error_response
 from .helpers import log_tool_usage, raise_tool_error
+from .util_helpers import BLOCKED_WS_WRITE_COMMANDS
 
 logger = logging.getLogger(__name__)
 
@@ -153,53 +154,6 @@ _BLOCKED_HA_INTERNAL_EVENTS: frozenset[str] = frozenset(
         "component_loaded",
         "recorder_5min_statistics_generated",
         "recorder_hourly_statistics_generated",
-    }
-)
-
-# WebSocket commands the sandbox must not send. Each one either changes
-# persistent state in a way that bypasses a wrapping tool's validation
-# (lovelace, registry mutations) or has no sandbox-appropriate use case
-# at all (``config/core/update`` rewrites the HA installation's location/
-# timezone/currency/lat-long).
-_BLOCKED_WS_COMMANDS: frozenset[str] = frozenset(
-    {
-        "config/core/update",
-        "lovelace/config/save",
-        "lovelace/dashboards/create",
-        "lovelace/dashboards/delete",
-        "lovelace/dashboards/update",
-        "config/area_registry/delete",
-        "config/area_registry/disable",
-        "config/area_registry/update",
-        "config/device_registry/delete",
-        "config/device_registry/disable",
-        "config/device_registry/update",
-        # Device registry deletion is registered as ``remove_config_entry`` on
-        # HA Core, not ``delete`` — see ``tools_registry.py:753`` for the
-        # actually-emitted command. ``ha_remove_device`` wraps it; raw
-        # ``ws_send`` would skip those checks.
-        "config/device_registry/remove_config_entry",
-        "config/entity_registry/delete",
-        "config/entity_registry/disable",
-        "config/entity_registry/update",
-        # Entity registry deletion is registered as ``remove`` on HA Core,
-        # not ``delete`` — see ``tools_entities.py:1130`` for the
-        # actually-emitted command. ``ha_remove_entity`` wraps it.
-        "config/entity_registry/remove",
-        # Floor / label / category registries follow the same rationale as
-        # area / device / entity above: each has a wrapping MCP tool
-        # (``ha_set_area_or_floor``, ``ha_config_set_label``,
-        # ``ha_config_set_category``) that performs invariant checks the
-        # raw WS command skips.
-        "config/floor_registry/create",
-        "config/floor_registry/delete",
-        "config/floor_registry/update",
-        "config/label_registry/create",
-        "config/label_registry/delete",
-        "config/label_registry/update",
-        "config/category_registry/create",
-        "config/category_registry/delete",
-        "config/category_registry/update",
     }
 )
 
@@ -859,7 +813,7 @@ class _SandboxBridge:
         code is dynamic and may pass non-dict values; the runtime guard
         below converts that into an error dict.
 
-        Commands listed in ``_BLOCKED_WS_COMMANDS`` are rejected with an
+        Commands listed in ``BLOCKED_WS_WRITE_COMMANDS`` are rejected with an
         explanatory error: those either rewrite persistent state in ways
         that have no sandbox-appropriate use case (``config/core/update``)
         or bypass the validation in their wrapping MCP tool
@@ -876,7 +830,7 @@ class _SandboxBridge:
         msg_type = message.get("type")
         if not isinstance(msg_type, str):
             return {"error": "ws_send(message) requires a 'type' field"}
-        if msg_type in _BLOCKED_WS_COMMANDS:
+        if msg_type in BLOCKED_WS_WRITE_COMMANDS:
             logger.info("sandbox.ws_send.blocked type=%r", msg_type)
             return {
                 "error": (

--- a/src/ha_mcp/tools/tools_search.py
+++ b/src/ha_mcp/tools/tools_search.py
@@ -2689,7 +2689,10 @@ class SearchTools:
                 default=False,
                 description=(
                     "Include user-dismissed/ignored repairs (default: False). "
-                    "Matches the HA Repairs UI which hides dismissed items by default."
+                    "Matches the HA Repairs UI which hides dismissed items by default. "
+                    "To dismiss/ignore a repair, call ha_call_service with "
+                    'ws_command="repairs/ignore_issue" and data={"domain": ..., '
+                    '"issue_id": ..., "ignore": true}.'
                 ),
             ),
         ] = False,

--- a/src/ha_mcp/tools/tools_service.py
+++ b/src/ha_mcp/tools/tools_service.py
@@ -15,6 +15,8 @@ from pydantic import Field
 
 from ..client.rest_client import HomeAssistantConnectionError
 from ..errors import (
+    ErrorCode,
+    create_error_response,
     create_validation_error,
 )
 from .helpers import (
@@ -126,6 +128,20 @@ _SERVICE_TO_STATE: dict[str, str] = {
 }
 
 
+# WebSocket commands that stream events (or otherwise never resolve to a single
+# terminal result) rather than replying once. ha_call_service's ws_command escape
+# hatch only supports one-shot request/response commands, so these are rejected.
+# Subscription commands are matched by the "subscribe" substring; render_template
+# is event-based (use ha_eval_template instead).
+_WS_COMMAND_EVENT_BLOCKLIST = frozenset({"render_template"})
+
+
+def _is_streaming_ws_command(command_type: str) -> bool:
+    """Return True for subscription / event-streaming WS commands not supported here."""
+    lowered = command_type.lower()
+    return "subscribe" in lowered or lowered in _WS_COMMAND_EVENT_BLOCKLIST
+
+
 def _build_service_suggestions(
     domain: str, service: str, entity_id: str | None
 ) -> list[str]:
@@ -161,6 +177,46 @@ class ServiceTools:
         if entity_id:
             service_data["entity_id"] = entity_id
         return service_data
+
+    @staticmethod
+    def _validate_service_call_params(
+        domain: str | None, service: str | None
+    ) -> tuple[str, str]:
+        """Validate service-mode params and return the (domain, service) pair.
+
+        Raises a structured ToolError when domain/service are missing (the caller
+        likely wants the ws_command escape hatch) or when the domain targets the
+        reserved ha_mcp_tools namespace.
+        """
+        if not domain or not service:
+            raise_tool_error(
+                create_validation_error(
+                    "domain and service are required for a service call. To send "
+                    "a raw WebSocket command instead, pass ws_command.",
+                    parameter="domain" if not domain else "service",
+                )
+            )
+        # ha_mcp_tools.* services are restricted to the ha-mcp server's dedicated
+        # wrappers (which inject the required caller token). Block ha_call_service
+        # from forwarding to that domain — it would otherwise be a bypass path
+        # around the dedicated tools. HA core's service registry lowercases the
+        # domain on fallback lookup (homeassistant/core.py
+        # ServiceRegistry.async_call), so normalise here to make sure a mixed-case
+        # `HA_MCP_TOOLS` can't slip past this exact-string check and still resolve
+        # downstream.
+        if domain.strip().lower() == "ha_mcp_tools":
+            raise_tool_error(
+                create_validation_error(
+                    (
+                        "ha_call_service cannot invoke services in the "
+                        "'ha_mcp_tools' domain. Use the dedicated MCP tool "
+                        "instead: ha_list_files, ha_read_file, ha_write_file, "
+                        "ha_delete_file, or ha_config_set_yaml."
+                    ),
+                    parameter="domain",
+                )
+            )
+        return domain, service
 
     @staticmethod
     def _parse_result_projection_params(
@@ -372,6 +428,105 @@ class ServiceTools:
             suggestions=suggestions,
         )
 
+    async def _call_ws_command(
+        self,
+        ws_command: str,
+        data: str | dict[str, Any] | None,
+        *,
+        domain: str | None,
+        service: str | None,
+    ) -> dict[str, Any]:
+        """Send a one-shot WebSocket command via ha_call_service's escape hatch.
+
+        Reaches Home Assistant WebSocket commands that are not registered
+        services (e.g. ``repairs/ignore_issue``). Only one-shot
+        request/response commands are supported — streaming / subscription
+        commands are rejected up front.
+        """
+        command_type = ws_command.strip()
+        if domain is not None or service is not None:
+            raise_tool_error(
+                create_validation_error(
+                    "Provide either domain + service (a registered service call) "
+                    "OR ws_command (a raw WebSocket command), not both.",
+                    parameter="ws_command",
+                )
+            )
+        if not command_type:
+            raise_tool_error(
+                create_validation_error(
+                    "ws_command must be a non-empty WebSocket command type, "
+                    "e.g. 'repairs/ignore_issue'.",
+                    parameter="ws_command",
+                )
+            )
+        if _is_streaming_ws_command(command_type):
+            raise_tool_error(
+                create_validation_error(
+                    f"ws_command '{command_type}' is a streaming/subscription "
+                    "command; ha_call_service only sends one-shot "
+                    "request/response commands. For template rendering use "
+                    "ha_eval_template.",
+                    parameter="ws_command",
+                )
+            )
+        if command_type.lower().startswith("ha_mcp_tools/"):
+            raise_tool_error(
+                create_validation_error(
+                    "ha_call_service cannot invoke 'ha_mcp_tools/*' WebSocket "
+                    "commands. Use the dedicated ha-mcp tools instead.",
+                    parameter="ws_command",
+                )
+            )
+        command_params = (
+            _parse_json_dict_param(
+                data, type_error_message="ws_command data must be a JSON object"
+            )
+            or {}
+        )
+        try:
+            result = await self._client.send_websocket_message(
+                {"type": command_type, **command_params}
+            )
+        except ToolError:
+            raise
+        except Exception as error:
+            exception_to_structured_error(
+                error,
+                context={"ws_command": command_type},
+                suggestions=[
+                    "Verify the WebSocket command type and its parameters",
+                    "Check Home Assistant connectivity",
+                ],
+            )
+            return None  # unreachable: exception_to_structured_error always raises
+
+        if not isinstance(result, dict) or not result.get("success", False):
+            error_msg = (
+                result.get("error") if isinstance(result, dict) else None
+            ) or "WebSocket command failed"
+            raise_tool_error(
+                create_error_response(
+                    ErrorCode.SERVICE_CALL_FAILED,
+                    str(error_msg),
+                    context={"ws_command": command_type},
+                    suggestions=[
+                        "Verify the command type and its parameters (e.g. "
+                        + "repairs/ignore_issue needs domain, issue_id, ignore)",
+                        "Confirm the target still exists (a repair must be "
+                        + "present to ignore it)",
+                    ],
+                )
+            )
+
+        return {
+            "success": True,
+            "ws_command": command_type,
+            "parameters": command_params or None,
+            "result": result.get("result"),
+            "message": f"Successfully executed WebSocket command '{command_type}'",
+        }
+
     @tool(
         name="ha_call_service",
         tags={"Service & Device Control"},
@@ -380,8 +535,8 @@ class ServiceTools:
     @log_tool_usage
     async def ha_call_service(
         self,
-        domain: str,
-        service: str,
+        domain: str | None = None,
+        service: str | None = None,
         entity_id: str | None = None,
         data: Annotated[dict[str, Any] | None, JSON_STRING_COERCION] = None,
         return_response: bool = False,
@@ -425,6 +580,19 @@ class ServiceTools:
                 ),
             ),
         ] = None,
+        ws_command: Annotated[
+            str | None,
+            Field(
+                default=None,
+                description=(
+                    "Advanced escape hatch: send a raw one-shot Home Assistant "
+                    "WebSocket command that is NOT a registered service (e.g. "
+                    "'repairs/ignore_issue' to dismiss a Repairs issue). When set, "
+                    "omit domain/service and put the command's parameters in data. "
+                    "Streaming/subscription commands are not supported."
+                ),
+            ),
+        ] = None,
     ) -> dict[str, Any]:
         """
         Execute Home Assistant services to control entities and trigger automations.
@@ -462,27 +630,32 @@ class ServiceTools:
 
         Common patterns: Use ha_get_state() to check current values before making changes.
         Use ha_search() to find correct entity IDs.
+
+        **WebSocket command escape hatch (advanced):**
+        A few Home Assistant operations are WebSocket-only commands, not
+        registered services — most notably dismissing a Repairs issue. Pass
+        ``ws_command`` (instead of domain/service) to send one, with its
+        parameters in ``data``:
+        ```python
+        # Dismiss a repair (get domain/issue_id from ha_get_overview repairs
+        # or ha_get_system_health include="repairs")
+        ha_call_service(ws_command="repairs/ignore_issue",
+                        data={"domain": "sun", "issue_id": "abc", "ignore": True})
+        ```
+        Only one-shot request/response commands are supported;
+        streaming/subscription commands are rejected.
         """
-        # ha_mcp_tools.* services are restricted to the ha-mcp server's
-        # dedicated wrappers (which inject the required caller token). Block
-        # ha_call_service from forwarding to that domain — it would otherwise
-        # be a bypass path around the dedicated tools.
-        # HA core's service registry lowercases the domain on fallback lookup
-        # (homeassistant/core.py ServiceRegistry.async_call), so normalise
-        # here to make sure a mixed-case `HA_MCP_TOOLS` can't slip past this
-        # exact-string check and still resolve downstream.
-        if isinstance(domain, str) and domain.strip().lower() == "ha_mcp_tools":
-            raise_tool_error(
-                create_validation_error(
-                    (
-                        "ha_call_service cannot invoke services in the "
-                        "'ha_mcp_tools' domain. Use the dedicated MCP tool "
-                        "instead: ha_list_files, ha_read_file, ha_write_file, "
-                        "ha_delete_file, or ha_config_set_yaml."
-                    ),
-                    parameter="domain",
-                )
+        # WebSocket-command escape hatch (issue #1839): reach one-shot WS
+        # commands that aren't registered services (e.g. repairs/ignore_issue).
+        if ws_command is not None:
+            return await self._call_ws_command(
+                ws_command, data, domain=domain, service=service
             )
+
+        # Service mode requires domain + service (optional at the signature level
+        # only to make room for the ws_command escape hatch) and rejects the
+        # reserved ha_mcp_tools domain.
+        domain, service = self._validate_service_call_params(domain, service)
         try:
             service_data = self._parse_service_data(data, entity_id)
 

--- a/src/ha_mcp/tools/tools_service.py
+++ b/src/ha_mcp/tools/tools_service.py
@@ -128,16 +128,37 @@ _SERVICE_TO_STATE: dict[str, str] = {
 }
 
 
-# WebSocket commands that stream events (or otherwise never resolve to a single
-# terminal result) rather than replying once. ha_call_service's ws_command escape
-# hatch only supports one-shot request/response commands, so these are rejected.
-# Subscription commands are matched by the "subscribe" substring; render_template
-# is event-based (use ha_eval_template instead).
-_WS_COMMAND_EVENT_BLOCKLIST = frozenset({"render_template"})
+# WebSocket commands that stream events or reply in two phases (an initial ack
+# then the real payload as a follow-up event) rather than resolving to a single
+# terminal result. ha_call_service's ws_command escape hatch only supports
+# one-shot request/response commands, so these are rejected: the "subscribe"
+# substring catches subscription commands, and the set names known two-phase /
+# streaming commands whose names don't contain "subscribe". The set is a floor,
+# not an exhaustive list -- HA's WS command naming isn't consistent enough for a
+# name check alone to be fully reliable.
+_WS_COMMAND_EVENT_BLOCKLIST = frozenset(
+    {
+        "render_template",  # event-based; use ha_eval_template instead
+        "system_health/info",  # two-phase (see tools_system._fetch_health_info)
+        "logbook/event_stream",  # streams logbook events indefinitely
+        "assist_pipeline/run",  # streams pipeline events
+    }
+)
+
+# One-shot WS commands that re-enter Home Assistant's service invocation. Routing
+# them through the escape hatch would bypass the service-mode guards (notably the
+# reserved ha_mcp_tools domain block), so they are rejected -- use the
+# domain/service parameters for service calls instead.
+_WS_COMMAND_SERVICE_INVOKERS = frozenset({"call_service", "execute_script"})
+
+# Reserved WebSocket envelope keys the transport owns. Allowing them inside data
+# would let a caller override the validated command type (defeating every check
+# below) or collide with the transport's message id, so they are rejected.
+_WS_RESERVED_ENVELOPE_KEYS = frozenset({"type", "id"})
 
 
 def _is_streaming_ws_command(command_type: str) -> bool:
-    """Return True for subscription / event-streaming WS commands not supported here."""
+    """Return True for subscription / two-phase WS commands not supported here."""
     lowered = command_type.lower()
     return "subscribe" in lowered or lowered in _WS_COMMAND_EVENT_BLOCKLIST
 
@@ -217,6 +238,40 @@ class ServiceTools:
                 )
             )
         return domain, service
+
+    @staticmethod
+    def _reject_incompatible_ws_params(
+        entity_id: str | None,
+        return_response: bool,
+        verbose: bool,
+        result_fields: str | list[str] | None,
+        result_attribute_keys: str | list[str] | None,
+    ) -> None:
+        """Reject service-mode-only params when the ws_command escape hatch is used.
+
+        These shape a registered-service call and have no meaning for a raw
+        WebSocket command; silently ignoring them would be a confusing no-op, so
+        (mirroring the domain/service "not both" guard) they must be omitted.
+        """
+        offenders = [
+            name
+            for name, is_set in (
+                ("entity_id", entity_id is not None),
+                ("return_response", return_response),
+                ("verbose", verbose),
+                ("result_fields", result_fields is not None),
+                ("result_attribute_keys", result_attribute_keys is not None),
+            )
+            if is_set
+        ]
+        if offenders:
+            raise_tool_error(
+                create_validation_error(
+                    "These parameters apply only to service calls and must be "
+                    f"omitted when ws_command is set: {', '.join(offenders)}.",
+                    parameter="ws_command",
+                )
+            )
 
     @staticmethod
     def _parse_result_projection_params(
@@ -463,10 +518,19 @@ class ServiceTools:
         if _is_streaming_ws_command(command_type):
             raise_tool_error(
                 create_validation_error(
-                    f"ws_command '{command_type}' is a streaming/subscription "
+                    f"ws_command '{command_type}' is a streaming or two-phase "
                     "command; ha_call_service only sends one-shot "
                     "request/response commands. For template rendering use "
                     "ha_eval_template.",
+                    parameter="ws_command",
+                )
+            )
+        if command_type.lower() in _WS_COMMAND_SERVICE_INVOKERS:
+            raise_tool_error(
+                create_validation_error(
+                    f"ws_command '{command_type}' invokes Home Assistant services "
+                    "and would bypass ha_call_service's safeguards. Use the "
+                    "domain/service parameters for service calls instead.",
                     parameter="ws_command",
                 )
             )
@@ -484,22 +548,23 @@ class ServiceTools:
             )
             or {}
         )
-        try:
-            result = await self._client.send_websocket_message(
-                {"type": command_type, **command_params}
+        reserved = _WS_RESERVED_ENVELOPE_KEYS & command_params.keys()
+        if reserved:
+            raise_tool_error(
+                create_validation_error(
+                    "data must not contain the reserved WebSocket envelope key(s) "
+                    f"{', '.join(sorted(reserved))}; the command type is set by "
+                    "ws_command, and the message id is managed by the transport.",
+                    parameter="data",
+                )
             )
-        except ToolError:
-            raise
-        except Exception as error:
-            exception_to_structured_error(
-                error,
-                context={"ws_command": command_type},
-                suggestions=[
-                    "Verify the WebSocket command type and its parameters",
-                    "Check Home Assistant connectivity",
-                ],
-            )
-            return None  # unreachable: exception_to_structured_error always raises
+        # send_websocket_message catches its own transport errors and always
+        # returns a {"success": ...} dict (never raises), so the failure is
+        # handled by the result-shape check below -- matching the other
+        # send_websocket_message call sites in the codebase.
+        result = await self._client.send_websocket_message(
+            {"type": command_type, **command_params}
+        )
 
         if not isinstance(result, dict) or not result.get("success", False):
             error_msg = (
@@ -588,8 +653,10 @@ class ServiceTools:
                     "Advanced escape hatch: send a raw one-shot Home Assistant "
                     "WebSocket command that is NOT a registered service (e.g. "
                     "'repairs/ignore_issue' to dismiss a Repairs issue). When set, "
-                    "omit domain/service and put the command's parameters in data. "
-                    "Streaming/subscription commands are not supported."
+                    "omit domain/service and the other service params; put the "
+                    "command's parameters in data. Streaming/two-phase and "
+                    "service-invoking commands (call_service, execute_script) are "
+                    "rejected."
                 ),
             ),
         ] = None,
@@ -642,12 +709,20 @@ class ServiceTools:
         ha_call_service(ws_command="repairs/ignore_issue",
                         data={"domain": "sun", "issue_id": "abc", "ignore": True})
         ```
-        Only one-shot request/response commands are supported;
-        streaming/subscription commands are rejected.
+        Only one-shot request/response commands are supported; streaming/two-phase
+        and service-invoking commands are rejected, and the other service
+        parameters (entity_id, return_response, etc.) don't apply.
         """
         # WebSocket-command escape hatch (issue #1839): reach one-shot WS
         # commands that aren't registered services (e.g. repairs/ignore_issue).
         if ws_command is not None:
+            self._reject_incompatible_ws_params(
+                entity_id,
+                return_response,
+                verbose,
+                result_fields,
+                result_attribute_keys,
+            )
             return await self._call_ws_command(
                 ws_command, data, domain=domain, service=service
             )

--- a/src/ha_mcp/tools/tools_service.py
+++ b/src/ha_mcp/tools/tools_service.py
@@ -26,6 +26,7 @@ from .helpers import (
     register_tool_methods,
 )
 from .util_helpers import (
+    BLOCKED_WS_WRITE_COMMANDS,
     JSON_STRING_COERCION,
     compact_service_result,
     parse_json_param,
@@ -140,10 +141,17 @@ _WS_COMMAND_EVENT_BLOCKLIST = frozenset(
     {
         "render_template",  # event-based; use ha_eval_template instead
         "system_health/info",  # two-phase (see tools_system._fetch_health_info)
-        "logbook/event_stream",  # streams logbook events indefinitely
         "assist_pipeline/run",  # streams pipeline events
     }
 )
+
+# Substrings that mark a WS command as streaming / subscription-based even when
+# its name isn't in the blocklist above. Such commands ack once and then push
+# follow-up events on the same id; the one-shot send_command path returns the
+# ack and leaks the subscription. "subscribe" covers subscribe_* and */subscribe;
+# "stream" covers history/stream, logbook/event_stream, camera/stream, ...;
+# "start_preview" covers template/start_preview and the config-flow preview family.
+_WS_STREAMING_SUBSTRINGS = ("subscribe", "stream", "start_preview")
 
 # One-shot WS commands that re-enter Home Assistant's service invocation. Routing
 # them through the escape hatch would bypass the service-mode guards (notably the
@@ -158,9 +166,11 @@ _WS_RESERVED_ENVELOPE_KEYS = frozenset({"type", "id"})
 
 
 def _is_streaming_ws_command(command_type: str) -> bool:
-    """Return True for subscription / two-phase WS commands not supported here."""
+    """Return True for subscription / streaming / two-phase WS commands."""
     lowered = command_type.lower()
-    return "subscribe" in lowered or lowered in _WS_COMMAND_EVENT_BLOCKLIST
+    if lowered in _WS_COMMAND_EVENT_BLOCKLIST:
+        return True
+    return any(sub in lowered for sub in _WS_STREAMING_SUBSTRINGS)
 
 
 def _build_service_suggestions(
@@ -539,6 +549,16 @@ class ServiceTools:
                 create_validation_error(
                     "ha_call_service cannot invoke 'ha_mcp_tools/*' WebSocket "
                     "commands. Use the dedicated ha-mcp tools instead.",
+                    parameter="ws_command",
+                )
+            )
+        if command_type.lower() in BLOCKED_WS_WRITE_COMMANDS:
+            raise_tool_error(
+                create_validation_error(
+                    f"ws_command '{command_type}' mutates persistent state that a "
+                    "dedicated tool guards with backups and conflict checks. Use "
+                    "the corresponding ha-mcp tool (e.g. ha_config_set_dashboard, "
+                    "ha_set_area_or_floor, ha_remove_entity) instead.",
                     parameter="ws_command",
                 )
             )

--- a/src/ha_mcp/tools/tools_system.py
+++ b/src/ha_mcp/tools/tools_system.py
@@ -541,7 +541,7 @@ class SystemTools:
 
         **Parameters:**
         - include: Optional comma-separated list of additional data to include.
-          - "repairs": Repair items from Settings > System > Repairs (active only by default; pass `include_dismissed_repairs=True` for all)
+          - "repairs": Repair items from Settings > System > Repairs (active only by default; pass `include_dismissed_repairs=True` for all). To dismiss/ignore a repair, call `ha_call_service(ws_command="repairs/ignore_issue", data={"domain": <domain>, "issue_id": <issue_id>, "ignore": true})`.
           - "zha_network": ZHA Zigbee devices with radio signal summary (name, LQI, RSSI)
           - "zha_network_full": ZHA Zigbee devices with all device details (can be large on 100+ device networks; prefer "zha_network" for summary)
           - "zwave_network": Z-Wave JS network status and node summary (status, security, routing)

--- a/src/ha_mcp/tools/util_helpers.py
+++ b/src/ha_mcp/tools/util_helpers.py
@@ -480,6 +480,46 @@ def unwrap_service_response(result: dict[str, Any]) -> dict[str, Any]:
     return sr if isinstance(sr, dict) else result
 
 
+# WebSocket commands that mutate persistent state in a way that bypasses a
+# wrapping MCP tool's validation (auto-backup, config-hash optimistic locking,
+# registry invariant checks), or that have no escape-hatch-appropriate use case
+# (`config/core/update` rewrites the installation's location/timezone/currency/
+# lat-long). Shared by the code sandbox's `ws_send` bridge (tools_code.py) and
+# ha_call_service's `ws_command` escape hatch (tools_service.py) so the two raw
+# WebSocket surfaces stay in lockstep. Registry deletion command names differ on
+# HA Core: device deletion is `remove_config_entry` and entity deletion is
+# `remove` (not `delete`) -- ha_remove_device / ha_remove_entity emit those.
+BLOCKED_WS_WRITE_COMMANDS: frozenset[str] = frozenset(
+    {
+        "config/core/update",
+        "lovelace/config/save",
+        "lovelace/dashboards/create",
+        "lovelace/dashboards/delete",
+        "lovelace/dashboards/update",
+        "config/area_registry/delete",
+        "config/area_registry/disable",
+        "config/area_registry/update",
+        "config/device_registry/delete",
+        "config/device_registry/disable",
+        "config/device_registry/update",
+        "config/device_registry/remove_config_entry",
+        "config/entity_registry/delete",
+        "config/entity_registry/disable",
+        "config/entity_registry/update",
+        "config/entity_registry/remove",
+        "config/floor_registry/create",
+        "config/floor_registry/delete",
+        "config/floor_registry/update",
+        "config/label_registry/create",
+        "config/label_registry/delete",
+        "config/label_registry/update",
+        "config/category_registry/create",
+        "config/category_registry/delete",
+        "config/category_registry/update",
+    }
+)
+
+
 # Fields surfaced from each repair issue. Includes `ignored` / `dismissed_version`
 # so callers can distinguish active vs. user-dismissed repairs when both are
 # returned (e.g., `include_dismissed_repairs=True`).

--- a/tests/src/e2e/policy/test_approval_flow.py
+++ b/tests/src/e2e/policy/test_approval_flow.py
@@ -261,6 +261,30 @@ async def test_case_insensitive_match_gates_regardless_of_caller_casing(
 
 
 @pytest.mark.asyncio
+async def test_ws_command_gated_when_policy_scopes_call_service(policy_enabled_mcp):
+    """ws_command escape hatch fail-safe: a domain-keyed rule can't match a
+    ws_command call (no ``domain``/``service`` args), but scoping ANY rule to
+    ``ha_call_service`` still forces approval on it rather than letting it
+    slip through the fail-open default (see ``evaluate()`` in
+    ``ha_mcp/policy/evaluator.py``)."""
+    client, server, handlers = policy_enabled_mcp
+    await _install_rule(
+        handlers,
+        {
+            "tool_name": "ha_call_service",
+            "when": [{"path": "args.domain", "op": "eq", "value": "light"}],
+            "remember_minutes": 0,
+        },
+    )
+    # No domain/service — the rule's predicate can't match this call — but
+    # the fail-safe clause must still gate it because a ha_call_service rule
+    # exists in the policy.
+    await _expect_blocked(client, {"ws_command": "repairs/ignore_issue"})
+    pending = server.approval_queue.list_pending()
+    assert len(pending) == 1
+
+
+@pytest.mark.asyncio
 async def test_deny_raises_user_denied(policy_enabled_mcp):
     """POST /deny → middleware raises USER_DENIED, never calls the tool."""
     client, server, handlers = policy_enabled_mcp

--- a/tests/src/e2e/workflows/services/test_call_service_ws_command.py
+++ b/tests/src/e2e/workflows/services/test_call_service_ws_command.py
@@ -1,0 +1,128 @@
+"""E2E coverage for ha_call_service's ws_command escape hatch (issue #1839).
+
+``ws_command`` lets ha_call_service send a raw one-shot Home Assistant
+WebSocket command that is NOT a registered service (motivating case:
+``repairs/ignore_issue`` to dismiss a Repairs issue). See
+``ServiceTools._call_ws_command`` in ``src/ha_mcp/tools/tools_service.py``.
+
+This module proves the escape hatch reaches a real Home Assistant instance
+end-to-end (round-trip against ``repairs/list_issues``, a safe one-shot read)
+and that the validation refusals fire against the live server, not just in
+unit tests.
+
+NOTE on full-cycle coverage: a "create a repair issue -> ignore it via
+ws_command -> verify it's dismissed" test is intentionally NOT included here.
+Repairs are created server-side by integrations calling
+``homeassistant.helpers.issue_registry.async_create_issue`` — there is no
+WebSocket command or MCP tool that creates one, and the e2e test container
+config (``tests/initial_test_state/configuration.yaml``) does not load any
+integration that files a repair by default (confirmed against
+``test_get_system_health_with_repairs`` in
+``workflows/system/test_system_tools.py``, which only asserts the repairs
+list shape, not a non-zero count, for the same reason). Fabricating a repair
+purely for this test (e.g. importing ``issue_registry`` and calling
+``async_create_issue`` directly against the test container) would be testing
+a hand-rolled fixture, not the feature — and ``repairs/ignore_issue`` shares
+the exact ``send_websocket_message`` dispatch path already exercised by the
+``repairs/list_issues`` round-trip below and covered param-wise (mutual
+exclusion, empty command, streaming/subscription refusal, ha_mcp_tools
+refusal, backend-failure propagation) by
+``tests/src/unit/test_call_service_ws_command.py``.
+"""
+
+import logging
+
+import pytest
+
+from ...utilities.assertions import (
+    MCPAssertions,
+    extract_error_message,
+    safe_call_tool,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.mark.asyncio
+@pytest.mark.services
+class TestWsCommandRoundTrip:
+    """Positive path: a real one-shot WS command reaches Home Assistant."""
+
+    async def test_repairs_list_issues_round_trips(self, mcp_client):
+        """repairs/list_issues is a safe, read-only one-shot WS command.
+
+        Proves the ws_command escape hatch actually dispatches to Home
+        Assistant and returns its result, not just that validation passes.
+        """
+        logger.info("Testing ha_call_service ws_command=repairs/list_issues")
+
+        async with MCPAssertions(mcp_client) as mcp:
+            data = await mcp.call_tool_success(
+                "ha_call_service",
+                {"ws_command": "repairs/list_issues"},
+            )
+
+        assert data.get("ws_command") == "repairs/list_issues"
+        result = data.get("result")
+        assert isinstance(result, dict), f"Expected a dict result, got: {result!r}"
+        assert "issues" in result, f"Expected 'issues' key in result: {result!r}"
+        assert isinstance(result["issues"], list), (
+            f"'issues' should be a list (possibly empty): {result!r}"
+        )
+
+        logger.info(
+            f"repairs/list_issues round-trip succeeded: "
+            f"{len(result['issues'])} issue(s) found"
+        )
+
+
+@pytest.mark.asyncio
+@pytest.mark.services
+class TestWsCommandRefusals:
+    """Validation refusals fire against the live server."""
+
+    async def test_subscribe_events_refused_as_streaming(self, mcp_client):
+        """Subscription commands are rejected — ha_call_service only supports
+        one-shot request/response WS commands."""
+        result = await safe_call_tool(
+            mcp_client,
+            "ha_call_service",
+            {"ws_command": "subscribe_events"},
+        )
+
+        error_msg = extract_error_message(result)
+        assert "streaming/subscription" in error_msg, (
+            f"Expected streaming/subscription refusal; got: {error_msg!r}"
+        )
+
+    async def test_ha_mcp_tools_prefix_refused(self, mcp_client):
+        """The reserved ha_mcp_tools/* WebSocket namespace is refused,
+        mirroring the domain refusal for the service-call path."""
+        result = await safe_call_tool(
+            mcp_client,
+            "ha_call_service",
+            {"ws_command": "ha_mcp_tools/overview"},
+        )
+
+        error_msg = extract_error_message(result)
+        assert "ha_mcp_tools" in error_msg, (
+            f"Expected ha_mcp_tools refusal; got: {error_msg!r}"
+        )
+
+    async def test_ws_command_with_domain_refused_as_not_both(self, mcp_client):
+        """Passing ws_command together with domain/service is rejected —
+        the two modes are mutually exclusive."""
+        result = await safe_call_tool(
+            mcp_client,
+            "ha_call_service",
+            {
+                "ws_command": "repairs/ignore_issue",
+                "domain": "light",
+                "data": {"domain": "sun", "issue_id": "nonexistent", "ignore": True},
+            },
+        )
+
+        error_msg = extract_error_message(result)
+        assert "not both" in error_msg, (
+            f"Expected mutual-exclusion refusal; got: {error_msg!r}"
+        )

--- a/tests/src/e2e/workflows/services/test_call_service_ws_command.py
+++ b/tests/src/e2e/workflows/services/test_call_service_ws_command.py
@@ -14,8 +14,11 @@ NOTE on full-cycle coverage: a "create a repair issue -> ignore it via
 ws_command -> verify it's dismissed" test is intentionally NOT included here.
 Repairs are created server-side by integrations calling
 ``homeassistant.helpers.issue_registry.async_create_issue`` — there is no
-WebSocket command or MCP tool that creates one, and the e2e test container
-config (``tests/initial_test_state/configuration.yaml``) does not load any
+simple, on-demand way to create one without coupling to unrelated internal
+state (the ha_mcp_tools component itself calls ``async_create_issue``
+internally under specific conditions, but that's not a general-purpose
+lever), and the e2e test container config
+(``tests/initial_test_state/configuration.yaml``) does not load any
 integration that files a repair by default (confirmed against
 ``test_get_system_health_with_repairs`` in
 ``workflows/system/test_system_tools.py``, which only asserts the repairs
@@ -25,7 +28,7 @@ purely for this test (e.g. importing ``issue_registry`` and calling
 a hand-rolled fixture, not the feature — and ``repairs/ignore_issue`` shares
 the exact ``send_websocket_message`` dispatch path already exercised by the
 ``repairs/list_issues`` round-trip below and covered param-wise (mutual
-exclusion, empty command, streaming/subscription refusal, ha_mcp_tools
+exclusion, empty command, streaming/two-phase refusal, ha_mcp_tools
 refusal, backend-failure propagation) by
 ``tests/src/unit/test_call_service_ws_command.py``.
 """
@@ -91,8 +94,8 @@ class TestWsCommandRefusals:
         )
 
         error_msg = extract_error_message(result)
-        assert "streaming/subscription" in error_msg, (
-            f"Expected streaming/subscription refusal; got: {error_msg!r}"
+        assert "streaming or two-phase" in error_msg, (
+            f"Expected streaming/two-phase refusal; got: {error_msg!r}"
         )
 
     async def test_ha_mcp_tools_prefix_refused(self, mcp_client):
@@ -125,4 +128,44 @@ class TestWsCommandRefusals:
         error_msg = extract_error_message(result)
         assert "not both" in error_msg, (
             f"Expected mutual-exclusion refusal; got: {error_msg!r}"
+        )
+
+    async def test_call_service_invoker_refused(self, mcp_client):
+        """ws_command='call_service' is refused rather than forwarded —
+        proves the service-invocation bypass (which would skip the
+        ha_mcp_tools domain guard) is closed against a real server, not
+        just in the unit-level mock."""
+        result = await safe_call_tool(
+            mcp_client,
+            "ha_call_service",
+            {
+                "ws_command": "call_service",
+                "data": {"domain": "ha_mcp_tools", "service": "get_caller_token"},
+            },
+        )
+
+        error_msg = extract_error_message(result)
+        assert "invokes Home Assistant services" in error_msg, (
+            f"Expected a services/safeguards refusal; got: {error_msg!r}"
+        )
+        assert "safeguards" in error_msg, (
+            f"Expected the refusal to mention safeguards; got: {error_msg!r}"
+        )
+
+    async def test_reserved_envelope_key_in_data_refused(self, mcp_client):
+        """data={"type": ...} is refused rather than silently overriding the
+        validated ws_command — proves the type-override bypass is closed
+        against a real server, not just in the unit-level mock."""
+        result = await safe_call_tool(
+            mcp_client,
+            "ha_call_service",
+            {
+                "ws_command": "repairs/list_issues",
+                "data": {"type": "subscribe_events"},
+            },
+        )
+
+        error_msg = extract_error_message(result)
+        assert "reserved" in error_msg, (
+            f"Expected a reserved-envelope-key refusal; got: {error_msg!r}"
         )

--- a/tests/src/e2e/workflows/services/test_call_service_ws_command.py
+++ b/tests/src/e2e/workflows/services/test_call_service_ws_command.py
@@ -152,6 +152,24 @@ class TestWsCommandRefusals:
             f"Expected the refusal to mention safeguards; got: {error_msg!r}"
         )
 
+    async def test_blocked_write_command_refused(self, mcp_client):
+        """Config-write WS commands (e.g. lovelace/config/save) are refused —
+        they bypass a dedicated tool's backups and conflict checks, so
+        ha_call_service rejects them before dispatch against a real server."""
+        result = await safe_call_tool(
+            mcp_client,
+            "ha_call_service",
+            {
+                "ws_command": "lovelace/config/save",
+                "data": {"config": {"views": []}},
+            },
+        )
+
+        error_msg = extract_error_message(result)
+        assert "dedicated tool guards with backups and conflict checks" in error_msg, (
+            f"Expected a blocked-write refusal; got: {error_msg!r}"
+        )
+
     async def test_reserved_envelope_key_in_data_refused(self, mcp_client):
         """data={"type": ...} is refused rather than silently overriding the
         validated ws_command — proves the type-override bypass is closed

--- a/tests/src/unit/policy/test_evaluator.py
+++ b/tests/src/unit/policy/test_evaluator.py
@@ -257,10 +257,11 @@ class TestWildcardPredicate:
 class TestWsCommandEscapeHatch:
     """``ha_call_service`` exposes a raw WebSocket ``ws_command`` escape hatch
     with no ``domain``/``service`` args, so domain/service-keyed rules can't
-    match it. ``evaluate`` closes that gap: if the policy scopes ANY rule to
-    ``ha_call_service`` but none matched normally, an unmatched ws_command
-    call still requires approval (fail-safe) rather than sneaking through
-    the fail-open default."""
+    match it. ``evaluate`` closes that gap: if the policy has ANY rule that
+    applies to ``ha_call_service`` -- scoped to it by name OR a wildcard ``*``
+    rule -- but none matched normally, an unmatched ws_command call still
+    requires approval (fail-safe) rather than sneaking through the fail-open
+    default."""
 
     def test_bypass_closed_by_non_matching_domain_rule(self):
         p = Policy(
@@ -347,10 +348,14 @@ class TestWsCommandEscapeHatch:
             == Verdict.REQUIRE_APPROVAL
         )
 
-    def test_wildcard_tool_rule_does_not_force_gate_ws_command(self):
-        # The fail-safe clause keys on tool_name == "ha_call_service"
-        # specifically — a "*" rule scoped to an unrelated predicate must
-        # not count as "policy has an ha_call_service rule".
+    def test_wildcard_tool_rule_force_gates_ws_command(self):
+        # A "*" rule applies to ha_call_service (match_rule treats "*" as any
+        # tool), so an operator gating broadly signals MORE caution than a
+        # service-scoped one. A domain/entity predicate a domain-less ws_command
+        # can't satisfy would otherwise fall through find_matching_rule AND the
+        # fail-safe, landing on ALLOW — the escape hatch dodging a broad gate.
+        # The fail-safe therefore counts "*" rules too, erring toward blocking
+        # (require-approval) rather than silently allowing.
         p = Policy(
             rules=[
                 Rule(
@@ -363,5 +368,5 @@ class TestWsCommandEscapeHatch:
         )
         assert (
             evaluate("ha_call_service", {"ws_command": "repairs/ignore_issue"}, p)
-            == Verdict.ALLOW
+            == Verdict.REQUIRE_APPROVAL
         )

--- a/tests/src/unit/policy/test_evaluator.py
+++ b/tests/src/unit/policy/test_evaluator.py
@@ -251,3 +251,117 @@ class TestWildcardPredicate:
             == Verdict.REQUIRE_APPROVAL
         )
         assert evaluate("ha_call_service", {"domain": "light"}, pol) == Verdict.ALLOW
+
+
+# --- ws_command escape hatch fail-safe ---
+class TestWsCommandEscapeHatch:
+    """``ha_call_service`` exposes a raw WebSocket ``ws_command`` escape hatch
+    with no ``domain``/``service`` args, so domain/service-keyed rules can't
+    match it. ``evaluate`` closes that gap: if the policy scopes ANY rule to
+    ``ha_call_service`` but none matched normally, an unmatched ws_command
+    call still requires approval (fail-safe) rather than sneaking through
+    the fail-open default."""
+
+    def test_bypass_closed_by_non_matching_domain_rule(self):
+        p = Policy(
+            rules=[
+                Rule(
+                    tool_name="ha_call_service",
+                    when=[Predicate(path="args.domain", op="eq", value="light")],
+                )
+            ],
+        )
+        assert (
+            evaluate("ha_call_service", {"ws_command": "repairs/ignore_issue"}, p)
+            == Verdict.REQUIRE_APPROVAL
+        )
+
+    def test_fail_open_preserved_with_no_rules(self):
+        p = Policy()
+        assert (
+            evaluate("ha_call_service", {"ws_command": "repairs/ignore_issue"}, p)
+            == Verdict.ALLOW
+        )
+
+    def test_only_other_tool_rule_does_not_force_gate(self):
+        p = Policy(
+            rules=[Rule(tool_name="ha_config_set_dashboard")],
+        )
+        assert (
+            evaluate("ha_call_service", {"ws_command": "repairs/ignore_issue"}, p)
+            == Verdict.ALLOW
+        )
+
+    def test_empty_when_ha_call_service_rule_gates_ws_command(self):
+        p = Policy(
+            rules=[Rule(tool_name="ha_call_service", when=[])],
+        )
+        assert (
+            evaluate("ha_call_service", {"ws_command": "repairs/ignore_issue"}, p)
+            == Verdict.REQUIRE_APPROVAL
+        )
+
+    def test_explicit_ws_command_rule_matches_normally(self):
+        p = Policy(
+            rules=[
+                Rule(
+                    tool_name="ha_call_service",
+                    when=[Predicate(path="args.ws_command", op="exists")],
+                )
+            ],
+        )
+        assert (
+            evaluate("ha_call_service", {"ws_command": "repairs/ignore_issue"}, p)
+            == Verdict.REQUIRE_APPROVAL
+        )
+
+    def test_normal_service_call_unaffected_non_matching(self):
+        p = Policy(
+            rules=[
+                Rule(
+                    tool_name="ha_call_service",
+                    when=[Predicate(path="args.domain", op="eq", value="light")],
+                )
+            ],
+        )
+        assert (
+            evaluate(
+                "ha_call_service",
+                {"domain": "cover", "service": "open_cover", "entity_id": "cover.x"},
+                p,
+            )
+            == Verdict.ALLOW
+        )
+
+    def test_normal_service_call_unaffected_matching(self):
+        p = Policy(
+            rules=[
+                Rule(
+                    tool_name="ha_call_service",
+                    when=[Predicate(path="args.domain", op="eq", value="light")],
+                )
+            ],
+        )
+        assert (
+            evaluate("ha_call_service", {"domain": "light", "service": "turn_on"}, p)
+            == Verdict.REQUIRE_APPROVAL
+        )
+
+    def test_wildcard_tool_rule_does_not_force_gate_ws_command(self):
+        # The fail-safe clause keys on tool_name == "ha_call_service"
+        # specifically — a "*" rule scoped to an unrelated predicate must
+        # not count as "policy has an ha_call_service rule".
+        p = Policy(
+            rules=[
+                Rule(
+                    tool_name="*",
+                    when=[
+                        Predicate(path="args.entity_id", op="eq", value="lock.front")
+                    ],
+                )
+            ],
+        )
+        assert (
+            evaluate("ha_call_service", {"ws_command": "repairs/ignore_issue"}, p)
+            == Verdict.ALLOW
+        )

--- a/tests/src/unit/test_call_service_ws_command.py
+++ b/tests/src/unit/test_call_service_ws_command.py
@@ -1,0 +1,164 @@
+"""Unit tests for ha_call_service's ws_command escape hatch (issue #1839).
+
+Covers the raw one-shot WebSocket-command path (``ServiceTools._call_ws_command``)
+reached via ``ws_command=...`` on ``ha_call_service``, plus a couple of
+service-mode regression checks to confirm the unchanged path still works when
+``ws_command`` is omitted.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastmcp.exceptions import ToolError
+
+from ha_mcp.tools.tools_service import ServiceTools
+
+
+def _make_tools(send_websocket_message_return: dict | None = None) -> ServiceTools:
+    client = MagicMock()
+    client.send_websocket_message = AsyncMock(
+        return_value=send_websocket_message_return
+    )
+    device_tools = MagicMock()
+    return ServiceTools(client, device_tools)
+
+
+class TestWsCommandSuccess:
+    async def test_success_dispatches_type_plus_data_and_echoes_parameters(self):
+        tools = _make_tools({"success": True, "result": None})
+        data = {"domain": "sun", "issue_id": "x", "ignore": True}
+
+        result = await tools.ha_call_service(
+            ws_command="repairs/ignore_issue", data=data
+        )
+
+        tools._client.send_websocket_message.assert_awaited_once_with(
+            {
+                "type": "repairs/ignore_issue",
+                "domain": "sun",
+                "issue_id": "x",
+                "ignore": True,
+            }
+        )
+        assert result["success"] is True
+        assert result["ws_command"] == "repairs/ignore_issue"
+        assert result["parameters"] == data
+        assert result["result"] is None
+        assert "repairs/ignore_issue" in result["message"]
+
+    async def test_success_with_no_data_sends_type_only_and_treats_data_as_empty(self):
+        tools = _make_tools({"success": True, "result": {"issues": []}})
+
+        result = await tools.ha_call_service(ws_command="repairs/list_issues")
+
+        tools._client.send_websocket_message.assert_awaited_once_with(
+            {"type": "repairs/list_issues"}
+        )
+        assert result["success"] is True
+        assert result["ws_command"] == "repairs/list_issues"
+        # No data was passed in -> parameters echoes back None, not {}.
+        assert result["parameters"] is None
+        assert result["result"] == {"issues": []}
+
+
+class TestWsCommandValidation:
+    async def test_ws_command_with_domain_raises_not_both(self):
+        tools = _make_tools({"success": True, "result": None})
+
+        with pytest.raises(ToolError) as excinfo:
+            await tools.ha_call_service(
+                ws_command="repairs/ignore_issue", domain="light"
+            )
+
+        assert "not both" in str(excinfo.value)
+        tools._client.send_websocket_message.assert_not_awaited()
+
+    async def test_ws_command_with_service_raises_not_both(self):
+        tools = _make_tools({"success": True, "result": None})
+
+        with pytest.raises(ToolError) as excinfo:
+            await tools.ha_call_service(
+                ws_command="repairs/ignore_issue", service="turn_on"
+            )
+
+        assert "not both" in str(excinfo.value)
+        tools._client.send_websocket_message.assert_not_awaited()
+
+    async def test_empty_ws_command_raises_non_empty(self):
+        tools = _make_tools({"success": True, "result": None})
+
+        with pytest.raises(ToolError) as excinfo:
+            await tools.ha_call_service(ws_command="  ")
+
+        assert "non-empty" in str(excinfo.value)
+        tools._client.send_websocket_message.assert_not_awaited()
+
+    async def test_subscribe_events_raises_streaming_error(self):
+        tools = _make_tools({"success": True, "result": None})
+
+        with pytest.raises(ToolError) as excinfo:
+            await tools.ha_call_service(ws_command="subscribe_events")
+
+        message = str(excinfo.value)
+        assert "streaming/subscription" in message
+        assert "ha_eval_template" in message
+        tools._client.send_websocket_message.assert_not_awaited()
+
+    async def test_render_template_raises_streaming_error(self):
+        tools = _make_tools({"success": True, "result": None})
+
+        with pytest.raises(ToolError) as excinfo:
+            await tools.ha_call_service(ws_command="render_template")
+
+        message = str(excinfo.value)
+        assert "streaming/subscription" in message
+        assert "ha_eval_template" in message
+        tools._client.send_websocket_message.assert_not_awaited()
+
+    async def test_ha_mcp_tools_prefix_raises_reserved_namespace_error(self):
+        tools = _make_tools({"success": True, "result": None})
+
+        with pytest.raises(ToolError) as excinfo:
+            await tools.ha_call_service(ws_command="ha_mcp_tools/overview")
+
+        assert "ha_mcp_tools" in str(excinfo.value)
+        tools._client.send_websocket_message.assert_not_awaited()
+
+
+class TestWsCommandBackendFailure:
+    async def test_backend_failure_raises_service_call_failed_with_error_text(self):
+        tools = _make_tools({"success": False, "error": "boom"})
+
+        with pytest.raises(ToolError) as excinfo:
+            await tools.ha_call_service(
+                ws_command="repairs/ignore_issue",
+                data={"domain": "sun", "issue_id": "x", "ignore": True},
+            )
+
+        assert "boom" in str(excinfo.value)
+
+
+class TestServiceModeRegression:
+    async def test_missing_service_raises_domain_and_service_required(self):
+        tools = _make_tools()
+
+        with pytest.raises(ToolError) as excinfo:
+            await tools.ha_call_service(domain="light")
+
+        assert "domain and service are required" in str(excinfo.value)
+        tools._client.send_websocket_message.assert_not_awaited()
+
+    async def test_happy_service_call_still_works_without_ws_command(self):
+        client = MagicMock()
+        client.call_service = AsyncMock(return_value=[])
+        client.send_websocket_message = AsyncMock()
+        device_tools = MagicMock()
+        tools = ServiceTools(client, device_tools)
+
+        result = await tools.ha_call_service(domain="light", service="turn_on")
+
+        assert result["success"] is True
+        assert result["domain"] == "light"
+        assert result["service"] == "turn_on"
+        client.call_service.assert_awaited_once()
+        client.send_websocket_message.assert_not_awaited()

--- a/tests/src/unit/test_call_service_ws_command.py
+++ b/tests/src/unit/test_call_service_ws_command.py
@@ -6,6 +6,7 @@ service-mode regression checks to confirm the unchanged path still works when
 ``ws_command`` is omitted.
 """
 
+import json
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -60,6 +61,32 @@ class TestWsCommandSuccess:
         assert result["parameters"] is None
         assert result["result"] == {"issues": []}
 
+    async def test_empty_dict_data_is_equivalent_to_no_data(self):
+        """data={} must behave exactly like data omitted: no envelope
+        pollution and parameters echoed back as None, not {}."""
+        tools = _make_tools({"success": True, "result": {"issues": []}})
+
+        result = await tools.ha_call_service(ws_command="repairs/list_issues", data={})
+
+        tools._client.send_websocket_message.assert_awaited_once_with(
+            {"type": "repairs/list_issues"}
+        )
+        assert result["success"] is True
+        assert result["parameters"] is None
+
+    async def test_whitespace_stripped_ws_command_succeeds(self):
+        """Leading/trailing whitespace around ws_command is stripped before
+        both validation and the dispatched envelope's ``type``."""
+        tools = _make_tools({"success": True, "result": None})
+
+        result = await tools.ha_call_service(ws_command="  repairs/list_issues  ")
+
+        tools._client.send_websocket_message.assert_awaited_once_with(
+            {"type": "repairs/list_issues"}
+        )
+        assert result["success"] is True
+        assert result["ws_command"] == "repairs/list_issues"
+
 
 class TestWsCommandValidation:
     async def test_ws_command_with_domain_raises_not_both(self):
@@ -100,7 +127,7 @@ class TestWsCommandValidation:
             await tools.ha_call_service(ws_command="subscribe_events")
 
         message = str(excinfo.value)
-        assert "streaming/subscription" in message
+        assert "streaming or two-phase" in message
         assert "ha_eval_template" in message
         tools._client.send_websocket_message.assert_not_awaited()
 
@@ -111,7 +138,7 @@ class TestWsCommandValidation:
             await tools.ha_call_service(ws_command="render_template")
 
         message = str(excinfo.value)
-        assert "streaming/subscription" in message
+        assert "streaming or two-phase" in message
         assert "ha_eval_template" in message
         tools._client.send_websocket_message.assert_not_awaited()
 
@@ -120,6 +147,162 @@ class TestWsCommandValidation:
 
         with pytest.raises(ToolError) as excinfo:
             await tools.ha_call_service(ws_command="ha_mcp_tools/overview")
+
+        assert "ha_mcp_tools" in str(excinfo.value)
+        tools._client.send_websocket_message.assert_not_awaited()
+
+
+class TestWsCommandExpandedStreamingBlocklist:
+    """Streaming / two-phase commands beyond subscribe_events + render_template.
+
+    ``system_health/info``, ``logbook/event_stream``, and ``assist_pipeline/run``
+    are two-phase or indefinitely-streaming WS commands that don't contain the
+    "subscribe" substring, so they're rejected via the explicit
+    ``_WS_COMMAND_EVENT_BLOCKLIST`` set rather than the substring check. Also
+    covers a case-variant of the substring-matched ``subscribe_events``.
+    """
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "system_health/info",
+            "logbook/event_stream",
+            "assist_pipeline/run",
+            "SUBSCRIBE_EVENTS",
+        ],
+        ids=[
+            "system_health_info",
+            "logbook_event_stream",
+            "assist_pipeline_run",
+            "case_variant",
+        ],
+    )
+    async def test_expanded_blocklist_command_raises_streaming_error(self, command):
+        tools = _make_tools({"success": True, "result": None})
+
+        with pytest.raises(ToolError) as excinfo:
+            await tools.ha_call_service(ws_command=command)
+
+        message = str(excinfo.value)
+        assert "streaming or two-phase" in message
+        tools._client.send_websocket_message.assert_not_awaited()
+
+
+class TestWsCommandServiceInvokerReject:
+    """ws_command values that would re-enter HA's service invocation.
+
+    Routing ``call_service`` / ``execute_script`` through the escape hatch
+    would bypass ha_call_service's service-mode guards (notably the reserved
+    ha_mcp_tools domain block), so they're rejected outright.
+    """
+
+    @pytest.mark.parametrize(
+        "command",
+        ["call_service", "execute_script", "Call_Service"],
+        ids=["call_service", "execute_script", "case_variant"],
+    )
+    async def test_service_invoker_command_rejected(self, command):
+        tools = _make_tools({"success": True, "result": None})
+
+        with pytest.raises(ToolError) as excinfo:
+            await tools.ha_call_service(ws_command=command)
+
+        message = str(excinfo.value)
+        assert "invokes Home Assistant services" in message
+        tools._client.send_websocket_message.assert_not_awaited()
+
+
+class TestWsCommandReservedEnvelopeKeys:
+    """data must not smuggle the WS envelope's own ``type``/``id`` keys.
+
+    Allowing them would let a caller override the validated command type
+    (defeating every guard above it) or collide with the transport's message
+    id.
+    """
+
+    @pytest.mark.parametrize("reserved_key", ["type", "id"])
+    async def test_reserved_key_in_data_rejected(self, reserved_key):
+        tools = _make_tools({"success": True, "result": None})
+
+        with pytest.raises(ToolError) as excinfo:
+            await tools.ha_call_service(
+                ws_command="repairs/ignore_issue",
+                data={reserved_key: "subscribe_events"},
+            )
+
+        message = str(excinfo.value)
+        assert "reserved WebSocket envelope key" in message
+        assert json.loads(message)["parameter"] == "data"
+        tools._client.send_websocket_message.assert_not_awaited()
+
+
+class TestWsCommandIncompatibleServiceParams:
+    """Service-call-only params must be omitted when ws_command is set."""
+
+    @pytest.mark.parametrize(
+        "kwargs, offender",
+        [
+            ({"entity_id": "light.x"}, "entity_id"),
+            ({"return_response": True}, "return_response"),
+            ({"verbose": True}, "verbose"),
+            ({"result_fields": ["a"]}, "result_fields"),
+            ({"result_attribute_keys": ["b"]}, "result_attribute_keys"),
+        ],
+        ids=[
+            "entity_id",
+            "return_response",
+            "verbose",
+            "result_fields",
+            "result_attribute_keys",
+        ],
+    )
+    async def test_incompatible_param_rejected(self, kwargs, offender):
+        tools = _make_tools({"success": True, "result": None})
+
+        with pytest.raises(ToolError) as excinfo:
+            await tools.ha_call_service(ws_command="repairs/ignore_issue", **kwargs)
+
+        message = str(excinfo.value)
+        assert "apply only to service calls" in message
+        assert offender in message
+        tools._client.send_websocket_message.assert_not_awaited()
+
+
+class TestWsCommandNonDictData:
+    async def test_list_data_rejected_as_non_object(self):
+        tools = _make_tools({"success": True, "result": None})
+
+        with pytest.raises(ToolError) as excinfo:
+            await tools.ha_call_service(
+                ws_command="repairs/ignore_issue", data=[1, 2, 3]
+            )
+
+        assert "ws_command data must be a JSON object" in str(excinfo.value)
+        tools._client.send_websocket_message.assert_not_awaited()
+
+
+class TestWsCommandHaMcpToolsPrefixVariants:
+    """Case and whitespace variants of the reserved ha_mcp_tools/* prefix.
+
+    Mirrors the sibling domain-refusal coverage in
+    tests/src/e2e/workflows/services/test_ha_mcp_tools_refusal.py for the
+    domain/service path.
+    """
+
+    @pytest.mark.parametrize(
+        "variant",
+        [
+            "HA_MCP_TOOLS/overview",
+            "Ha_Mcp_Tools/overview",
+            "  ha_mcp_tools/overview  ",
+        ],
+        ids=["upper", "mixed", "padded_lower"],
+    )
+    async def test_prefix_case_and_whitespace_variants_rejected(self, variant):
+        tools = _make_tools({"success": True, "result": None})
+
+        with pytest.raises(ToolError) as excinfo:
+            await tools.ha_call_service(ws_command=variant)
 
         assert "ha_mcp_tools" in str(excinfo.value)
         tools._client.send_websocket_message.assert_not_awaited()
@@ -137,6 +320,29 @@ class TestWsCommandBackendFailure:
 
         assert "boom" in str(excinfo.value)
 
+    async def test_none_backend_return_raises_websocket_command_failed(self):
+        """send_websocket_message never raises (it always returns a dict),
+        but defend the non-dict-return shape anyway: None must still surface
+        as a structured failure, not an AttributeError from a bare .get()."""
+        tools = _make_tools(None)
+
+        with pytest.raises(ToolError) as excinfo:
+            await tools.ha_call_service(ws_command="repairs/list_issues")
+
+        assert "WebSocket command failed" in str(excinfo.value)
+
+    async def test_success_false_without_error_key_raises_websocket_command_failed(
+        self,
+    ):
+        """success: False with no 'error' key must still fail with a
+        readable message, not surface None or crash formatting str(None)."""
+        tools = _make_tools({"success": False})
+
+        with pytest.raises(ToolError) as excinfo:
+            await tools.ha_call_service(ws_command="repairs/list_issues")
+
+        assert "WebSocket command failed" in str(excinfo.value)
+
 
 class TestServiceModeRegression:
     async def test_missing_service_raises_domain_and_service_required(self):
@@ -144,6 +350,24 @@ class TestServiceModeRegression:
 
         with pytest.raises(ToolError) as excinfo:
             await tools.ha_call_service(domain="light")
+
+        assert "domain and service are required" in str(excinfo.value)
+        tools._client.send_websocket_message.assert_not_awaited()
+
+    async def test_no_params_set_raises_domain_and_service_required(self):
+        tools = _make_tools()
+
+        with pytest.raises(ToolError) as excinfo:
+            await tools.ha_call_service()
+
+        assert "domain and service are required" in str(excinfo.value)
+        tools._client.send_websocket_message.assert_not_awaited()
+
+    async def test_service_only_raises_domain_and_service_required(self):
+        tools = _make_tools()
+
+        with pytest.raises(ToolError) as excinfo:
+            await tools.ha_call_service(service="turn_on")
 
         assert "domain and service are required" in str(excinfo.value)
         tools._client.send_websocket_message.assert_not_awaited()

--- a/tests/src/unit/test_call_service_ws_command.py
+++ b/tests/src/unit/test_call_service_ws_command.py
@@ -159,7 +159,10 @@ class TestWsCommandExpandedStreamingBlocklist:
     are two-phase or indefinitely-streaming WS commands that don't contain the
     "subscribe" substring, so they're rejected via the explicit
     ``_WS_COMMAND_EVENT_BLOCKLIST`` set rather than the substring check. Also
-    covers a case-variant of the substring-matched ``subscribe_events``.
+    covers a case-variant of the substring-matched ``subscribe_events``, plus
+    the "stream" / "start_preview" substrings (``history/stream``,
+    ``template/start_preview``, ``camera/stream``) added to
+    ``_WS_STREAMING_SUBSTRINGS``.
     """
 
     @pytest.mark.parametrize(
@@ -169,12 +172,18 @@ class TestWsCommandExpandedStreamingBlocklist:
             "logbook/event_stream",
             "assist_pipeline/run",
             "SUBSCRIBE_EVENTS",
+            "history/stream",
+            "template/start_preview",
+            "camera/stream",
         ],
         ids=[
             "system_health_info",
             "logbook_event_stream",
             "assist_pipeline_run",
             "case_variant",
+            "history_stream",
+            "template_start_preview",
+            "camera_stream",
         ],
     )
     async def test_expanded_blocklist_command_raises_streaming_error(self, command):
@@ -209,6 +218,44 @@ class TestWsCommandServiceInvokerReject:
 
         message = str(excinfo.value)
         assert "invokes Home Assistant services" in message
+        tools._client.send_websocket_message.assert_not_awaited()
+
+
+class TestWsCommandBlockedWriteCommands:
+    """WS commands in BLOCKED_WS_WRITE_COMMANDS are rejected outright.
+
+    These mutate persistent state (dashboards, area/device/entity/floor/label/
+    category registries, core config) in ways a dedicated ha-mcp tool guards
+    with backups and conflict checks; routing them through the raw ws_command
+    escape hatch would bypass those guards, so they're rejected before
+    dispatch regardless of case.
+    """
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "lovelace/config/save",
+            "lovelace/dashboards/delete",
+            "config/entity_registry/remove",
+            "config/core/update",
+            "LOVELACE/CONFIG/SAVE",
+        ],
+        ids=[
+            "lovelace_config_save",
+            "lovelace_dashboards_delete",
+            "config_entity_registry_remove",
+            "config_core_update",
+            "case_variant",
+        ],
+    )
+    async def test_blocked_write_command_rejected(self, command):
+        tools = _make_tools({"success": True, "result": None})
+
+        with pytest.raises(ToolError) as excinfo:
+            await tools.ha_call_service(ws_command=command)
+
+        message = str(excinfo.value)
+        assert "dedicated tool guards with backups and conflict checks" in message
         tools._client.send_websocket_message.assert_not_awaited()
 
 


### PR DESCRIPTION
## What does this PR do?

Adds a `ws_command` escape hatch to `ha_call_service` so agents can send raw
one-shot Home Assistant WebSocket commands that aren't registered services —
most importantly `repairs/ignore_issue`, to dismiss/resolve a Repairs issue
programmatically. Closes #1839.

HA's Repairs "Ignore" action is a WebSocket-only command (`repairs/ignore_issue`),
not a registered service, so `ha_call_service` (REST service registry only) had no
way to reach it. This adds that path without a new tool.

**Behavior**
- New optional `ws_command`: sends `{"type": ws_command, **data}` over the existing
  per-client WebSocket transport. `domain`/`service` become optional and are
  mutually exclusive with `ws_command`.
- Read-side hints on `ha_get_overview` and `ha_get_system_health` point at
  `repairs/ignore_issue`.

**Guards (the escape hatch can't be used to bypass existing protections)**
- One-shot only: streaming/two-phase commands rejected (`subscribe`, `stream`,
  `start_preview` substrings + a named blocklist floor).
- No service re-entry: `call_service`/`execute_script` rejected (would bypass the
  `ha_mcp_tools` domain guard).
- Reserved envelope keys (`type`/`id`) in `data` rejected (can't override the
  validated command type).
- `ha_mcp_tools/*` rejected.
- Config-write commands with safer dedicated tools rejected via a shared
  `BLOCKED_WS_WRITE_COMMANDS` set (lovelace/config, all registry mutations) —
  extracted so the code sandbox's `ws_send` bridge and this path stay in lockstep.
- Service-only params (`entity_id`, `return_response`, `verbose`,
  `result_fields`, `result_attribute_keys`) rejected rather than silently ignored.
- **Security policy**: the approval evaluator fail-safes ws_command — a
  `ha_call_service` call carrying `ws_command` that doesn't otherwise match a rule
  still requires approval whenever any `ha_call_service`-scoped rule exists.
  (@Patch76 — one decision worth a look: this keys on `ha_call_service`-scoped
  rules, not `*`, to avoid false-positive-gating unrelated ws_commands.)

## Type of change
- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

Unit coverage for `_call_ws_command` (all guards), the policy evaluator
(bypass-closed / fail-open / normal-call-unaffected / wildcard boundary), plus
e2e refusals and an approval-flow e2e. CI green.

## Checklist
- [x] I have updated documentation if needed
