### PR TITLE
feat: set openWorldHint explicitly on every MCP tool

### DIFF
--- a/.gemini/styleguide.md
+++ b/.gemini/styleguide.md
@@ -70,6 +70,7 @@ Verify that safety annotations match actual tool behavior:
 - Tool with `readOnlyHint: True` must NOT modify state (no writes, no service calls)
 - Tool with `destructiveHint: True` must actually delete data
 - State-changing operations should have `idempotentHint: True` only if safe to retry
+- Tool with `openWorldHint: True` must reach an external, third-party-authored world (HACS store, add-on repositories, GitHub release feeds, arbitrary import URLs); a tool whose domain is the local Home Assistant instance should use `False`. It is open-world if its output carries externally-authored content back to the client, even when a local integration (HACS, Supervisor, HA Core) makes the actual network call on its behalf
 
 Flag HIGH severity if annotation contradicts actual behavior in the implementation.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -553,7 +553,7 @@ Every tool needs `tags={"Category Name"}` (native FastMCP parameter). Drives the
 | `readOnlyHint: True` | `False` | Tool does not modify its environment |
 | `destructiveHint: True` | `True` | Tool may perform destructive updates (only meaningful when `readOnlyHint` is false). Set to `False` for non-destructive writes (e.g., creating a record) |
 | `idempotentHint: True` | `False` | Repeated calls with same args have no additional effect (only meaningful when `readOnlyHint` is false) |
-| `openWorldHint: True` | `True` | Tool reaches an external, third-party-authored world (HACS store, add-on repositories, GitHub release feeds, arbitrary import URLs). Set to `False` when the tool's domain is the local Home Assistant instance. Required on every tool — the default is `true`, so an omitted value silently marks a local tool as open-world |
+| `openWorldHint: True` | `True` | Tool reaches an external, third-party-authored world (HACS store, add-on repositories, GitHub release feeds, arbitrary import URLs). Set to `False` when the tool's domain is the local Home Assistant instance. A tool is also open-world if its output carries externally-authored content back to the client, even when a local integration (HACS, Supervisor, HA Core) makes the actual network call on its behalf — `ha_get_overview` and `ha_get_system_health` embed the update-check field that reaches PyPI / the Supervisor store, while `ha_get_blueprint` and `ha_config_list_dashboard_resources` return externally-authored content from purely local reads. Required on every tool — the default is `true`, so an omitted value silently marks a local tool as open-world |
 
 ### Error Handling
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -553,6 +553,7 @@ Every tool needs `tags={"Category Name"}` (native FastMCP parameter). Drives the
 | `readOnlyHint: True` | `False` | Tool does not modify its environment |
 | `destructiveHint: True` | `True` | Tool may perform destructive updates (only meaningful when `readOnlyHint` is false). Set to `False` for non-destructive writes (e.g., creating a record) |
 | `idempotentHint: True` | `False` | Repeated calls with same args have no additional effect (only meaningful when `readOnlyHint` is false) |
+| `openWorldHint: True` | `True` | Tool reaches an external, third-party-authored world (HACS store, add-on repositories, GitHub release feeds, arbitrary import URLs). Set to `False` when the tool's domain is the local Home Assistant instance. Required on every tool — the default is `true`, so an omitted value silently marks a local tool as open-world |
 
 ### Error Handling
 

--- a/src/ha_mcp/server.py
+++ b/src/ha_mcp/server.py
@@ -1349,6 +1349,7 @@ class HomeAssistantSmartMCPServer(EnhancedToolsMixin):
             name=SKILL_TOOL_NAME,
             description=tool_description,
             annotations={
+                "openWorldHint": False,
                 "readOnlyHint": True,
                 "idempotentHint": True,
                 "title": "Get Home Assistant Best Practices Skill Guide",

--- a/src/ha_mcp/tools/backup.py
+++ b/src/ha_mcp/tools/backup.py
@@ -1054,7 +1054,11 @@ def register_backup_tools(
     @mcp.tool(
         description=manage_backup_description,
         tags={"System"},
-        annotations={"destructiveHint": True, "title": "Manage Backups"},
+        annotations={
+            "openWorldHint": False,
+            "destructiveHint": True,
+            "title": "Manage Backups",
+        },
     )
     @log_tool_usage
     async def ha_manage_backup(

--- a/src/ha_mcp/tools/tools_addons.py
+++ b/src/ha_mcp/tools/tools_addons.py
@@ -2572,6 +2572,7 @@ def register_addon_tools(mcp: Any, client: HomeAssistantClient, **kwargs: Any) -
     @mcp.tool(
         tags={"Add-ons"},
         annotations={
+            "openWorldHint": True,
             "idempotentHint": True,
             "readOnlyHint": True,
             "title": "Get Add-ons",
@@ -2660,6 +2661,7 @@ def register_addon_tools(mcp: Any, client: HomeAssistantClient, **kwargs: Any) -
     @mcp.tool(
         tags={"Add-ons"},
         annotations={
+            "openWorldHint": True,
             "destructiveHint": True,
             "idempotentHint": False,
             "readOnlyHint": False,

--- a/src/ha_mcp/tools/tools_areas.py
+++ b/src/ha_mcp/tools/tools_areas.py
@@ -139,6 +139,7 @@ class AreaTools:
         name="ha_list_floors_areas",
         tags={"Areas & Floors"},
         annotations={
+            "openWorldHint": False,
             "idempotentHint": True,
             "readOnlyHint": True,
             "title": "List Floors and Areas",
@@ -390,6 +391,7 @@ class AreaTools:
         name="ha_set_area_or_floor",
         tags={"Areas & Floors"},
         annotations={
+            "openWorldHint": False,
             "destructiveHint": True,
             "title": "Create or Update Area or Floor",
         },
@@ -640,6 +642,7 @@ class AreaTools:
         name="ha_remove_area_or_floor",
         tags={"Areas & Floors"},
         annotations={
+            "openWorldHint": False,
             "destructiveHint": True,
             "idempotentHint": True,
             "title": "Remove Area or Floor",

--- a/src/ha_mcp/tools/tools_blueprints.py
+++ b/src/ha_mcp/tools/tools_blueprints.py
@@ -76,6 +76,7 @@ class BlueprintTools:
         name="ha_get_blueprint",
         tags={"Blueprints"},
         annotations={
+            "openWorldHint": False,
             "idempotentHint": True,
             "readOnlyHint": True,
             "title": "Get Blueprint",
@@ -224,7 +225,11 @@ class BlueprintTools:
     @tool(
         name="ha_import_blueprint",
         tags={"Blueprints"},
-        annotations={"destructiveHint": True, "title": "Import Blueprint"},
+        annotations={
+            "openWorldHint": True,
+            "destructiveHint": True,
+            "title": "Import Blueprint",
+        },
     )
     @log_tool_usage
     async def ha_import_blueprint(

--- a/src/ha_mcp/tools/tools_blueprints.py
+++ b/src/ha_mcp/tools/tools_blueprints.py
@@ -76,7 +76,7 @@ class BlueprintTools:
         name="ha_get_blueprint",
         tags={"Blueprints"},
         annotations={
-            "openWorldHint": False,
+            "openWorldHint": True,
             "idempotentHint": True,
             "readOnlyHint": True,
             "title": "Get Blueprint",

--- a/src/ha_mcp/tools/tools_bug_report.py
+++ b/src/ha_mcp/tools/tools_bug_report.py
@@ -646,6 +646,7 @@ class BugReportTools:
         name="ha_report_issue",
         tags={"Utilities"},
         annotations={
+            "openWorldHint": False,
             "idempotentHint": True,
             "readOnlyHint": True,
             "title": "Report Issue or Feedback",

--- a/src/ha_mcp/tools/tools_calendar.py
+++ b/src/ha_mcp/tools/tools_calendar.py
@@ -43,6 +43,7 @@ class CalendarTools:
         name="ha_config_get_calendar_events",
         tags={"Calendar"},
         annotations={
+            "openWorldHint": False,
             "idempotentHint": True,
             "readOnlyHint": True,
             "title": "Get Calendar Events",
@@ -282,6 +283,7 @@ class CalendarTools:
         name="ha_config_set_calendar_event",
         tags={"Calendar"},
         annotations={
+            "openWorldHint": False,
             "destructiveHint": True,
             "title": "Create or Update Calendar Event",
         },
@@ -426,6 +428,7 @@ class CalendarTools:
         name="ha_config_remove_calendar_event",
         tags={"Calendar"},
         annotations={
+            "openWorldHint": False,
             "destructiveHint": True,
             "idempotentHint": True,
             "title": "Remove Calendar Event",

--- a/src/ha_mcp/tools/tools_camera.py
+++ b/src/ha_mcp/tools/tools_camera.py
@@ -62,6 +62,7 @@ class CameraTools:
         name="ha_get_camera_image",
         tags={"Camera"},
         annotations={
+            "openWorldHint": False,
             "idempotentHint": True,
             "readOnlyHint": True,
             "title": "Get Camera Image",

--- a/src/ha_mcp/tools/tools_categories.py
+++ b/src/ha_mcp/tools/tools_categories.py
@@ -38,6 +38,7 @@ class CategoryTools:
         name="ha_config_get_category",
         tags={"Labels & Categories"},
         annotations={
+            "openWorldHint": False,
             "idempotentHint": True,
             "readOnlyHint": True,
             "title": "Get Category",
@@ -170,7 +171,11 @@ class CategoryTools:
     @tool(
         name="ha_config_set_category",
         tags={"Labels & Categories"},
-        annotations={"destructiveHint": True, "title": "Create or Update Category"},
+        annotations={
+            "openWorldHint": False,
+            "destructiveHint": True,
+            "title": "Create or Update Category",
+        },
     )
     @with_auto_backup(
         domain="category",
@@ -313,6 +318,7 @@ class CategoryTools:
         name="ha_config_remove_category",
         tags={"Labels & Categories"},
         annotations={
+            "openWorldHint": False,
             "destructiveHint": True,
             "idempotentHint": True,
             "title": "Remove Category",

--- a/src/ha_mcp/tools/tools_code.py
+++ b/src/ha_mcp/tools/tools_code.py
@@ -1335,6 +1335,7 @@ def register_code_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
     @mcp.tool(
         tags={"System", "beta"},
         annotations={
+            "openWorldHint": False,
             "title": "Custom Tool",
             "destructiveHint": True,
             "idempotentHint": False,

--- a/src/ha_mcp/tools/tools_config_automations.py
+++ b/src/ha_mcp/tools/tools_config_automations.py
@@ -340,6 +340,7 @@ class AutomationConfigTools:
         name="ha_config_get_automation",
         tags={"Automations"},
         annotations={
+            "openWorldHint": False,
             "idempotentHint": True,
             "readOnlyHint": True,
             "title": "Get Automation Config",
@@ -450,6 +451,7 @@ class AutomationConfigTools:
         name="ha_config_set_automation",
         tags={"Automations"},
         annotations={
+            "openWorldHint": False,
             "destructiveHint": True,
             "title": "Create or Update Automation",
         },
@@ -1291,6 +1293,7 @@ class AutomationConfigTools:
         name="ha_config_remove_automation",
         tags={"Automations"},
         annotations={
+            "openWorldHint": False,
             "destructiveHint": True,
             "idempotentHint": True,
             "title": "Remove Automation",

--- a/src/ha_mcp/tools/tools_config_dashboards.py
+++ b/src/ha_mcp/tools/tools_config_dashboards.py
@@ -1259,6 +1259,7 @@ class DashboardConfigTools:
         name="ha_config_get_dashboard",
         tags={"Dashboards"},
         annotations={
+            "openWorldHint": False,
             "destructiveHint": False,
             "idempotentHint": True,
             "title": "Get Dashboard",
@@ -1815,7 +1816,11 @@ class DashboardConfigTools:
     @tool(
         name="ha_config_set_dashboard",
         tags={"Dashboards"},
-        annotations={"destructiveHint": True, "title": "Create or Update Dashboard"},
+        annotations={
+            "openWorldHint": False,
+            "destructiveHint": True,
+            "title": "Create or Update Dashboard",
+        },
     )
     @with_auto_backup(domain="dashboard", id_param="url_path")
     @log_tool_usage
@@ -2743,7 +2748,11 @@ class DashboardConfigTools:
     @tool(
         name="ha_config_delete_dashboard",
         tags={"Dashboards"},
-        annotations={"destructiveHint": True, "title": "Delete Dashboard"},
+        annotations={
+            "openWorldHint": False,
+            "destructiveHint": True,
+            "title": "Delete Dashboard",
+        },
     )
     @with_auto_backup(domain="dashboard", id_param="url_path")
     @log_tool_usage

--- a/src/ha_mcp/tools/tools_config_helpers.py
+++ b/src/ha_mcp/tools/tools_config_helpers.py
@@ -3608,6 +3608,7 @@ class HelperConfigTools:
         name="ha_config_list_helpers",
         tags={"Helper Entities"},
         annotations={
+            "openWorldHint": False,
             "idempotentHint": True,
             "readOnlyHint": True,
             "title": "List Helpers",
@@ -4021,7 +4022,11 @@ class HelperConfigTools:
     @tool(
         name="ha_config_set_helper",
         tags={"Helper Entities"},
-        annotations={"destructiveHint": True, "title": "Create or Update Helper"},
+        annotations={
+            "openWorldHint": False,
+            "destructiveHint": True,
+            "title": "Create or Update Helper",
+        },
     )
     @with_auto_backup(
         domain_fn=lambda kw: f"helper_{kw.get('helper_type', 'unknown')}",

--- a/src/ha_mcp/tools/tools_config_scenes.py
+++ b/src/ha_mcp/tools/tools_config_scenes.py
@@ -204,6 +204,7 @@ class ConfigSceneTools:
         name="ha_config_get_scene",
         tags={"Scenes"},
         annotations={
+            "openWorldHint": False,
             "idempotentHint": True,
             "readOnlyHint": True,
             "title": "Get Scene Config",
@@ -453,6 +454,7 @@ class ConfigSceneTools:
         name="ha_config_set_scene",
         tags={"Scenes"},
         annotations={
+            "openWorldHint": False,
             "destructiveHint": True,
             "title": "Create or Update Scene",
         },
@@ -976,6 +978,7 @@ class ConfigSceneTools:
         name="ha_config_remove_scene",
         tags={"Scenes"},
         annotations={
+            "openWorldHint": False,
             "destructiveHint": True,
             "idempotentHint": True,
             "title": "Remove Scene",

--- a/src/ha_mcp/tools/tools_config_scripts.py
+++ b/src/ha_mcp/tools/tools_config_scripts.py
@@ -99,6 +99,7 @@ class ConfigScriptTools:
         name="ha_config_get_script",
         tags={"Scripts"},
         annotations={
+            "openWorldHint": False,
             "idempotentHint": True,
             "readOnlyHint": True,
             "title": "Get Script Config",
@@ -409,6 +410,7 @@ class ConfigScriptTools:
         name="ha_config_set_script",
         tags={"Scripts"},
         annotations={
+            "openWorldHint": False,
             "destructiveHint": True,
             "title": "Create or Update Script",
         },
@@ -860,6 +862,7 @@ class ConfigScriptTools:
         name="ha_config_remove_script",
         tags={"Scripts"},
         annotations={
+            "openWorldHint": False,
             "destructiveHint": True,
             "idempotentHint": True,
             "title": "Remove Script",

--- a/src/ha_mcp/tools/tools_dashboard_screenshot.py
+++ b/src/ha_mcp/tools/tools_dashboard_screenshot.py
@@ -100,6 +100,7 @@ class DashboardScreenshotTools:
         name="ha_get_dashboard_screenshot",
         tags={"Dashboard", "beta"},
         annotations={
+            "openWorldHint": False,
             "destructiveHint": False,
             "title": "Get Dashboard Screenshot",
         },

--- a/src/ha_mcp/tools/tools_dev.py
+++ b/src/ha_mcp/tools/tools_dev.py
@@ -456,7 +456,11 @@ class DevTools:
     @tool(
         name="ha_dev_manage_settings",
         tags={"Developer"},
-        annotations={"title": "Manage Server Settings (dev)", "destructiveHint": True},
+        annotations={
+            "openWorldHint": False,
+            "title": "Manage Server Settings (dev)",
+            "destructiveHint": True,
+        },
     )
     @log_tool_usage
     async def ha_dev_manage_settings(
@@ -698,7 +702,11 @@ class DevTools:
     @tool(
         name="ha_dev_manage_server",
         tags={"Developer"},
-        annotations={"title": "Manage MCP Server (dev)", "destructiveHint": True},
+        annotations={
+            "openWorldHint": True,
+            "title": "Manage MCP Server (dev)",
+            "destructiveHint": True,
+        },
     )
     @log_tool_usage
     async def ha_dev_manage_server(

--- a/src/ha_mcp/tools/tools_energy.py
+++ b/src/ha_mcp/tools/tools_energy.py
@@ -370,6 +370,7 @@ class EnergyTools:
         name="ha_manage_energy_prefs",
         tags={"Energy"},
         annotations={
+            "openWorldHint": False,
             "destructiveHint": True,
             "idempotentHint": False,
             "title": "Manage Energy Dashboard Preferences",

--- a/src/ha_mcp/tools/tools_entities.py
+++ b/src/ha_mcp/tools/tools_entities.py
@@ -1388,6 +1388,7 @@ class EntityTools:
         name="ha_set_entity",
         tags={"Entity Registry"},
         annotations={
+            "openWorldHint": False,
             "destructiveHint": True,
             "idempotentHint": True,
             "title": "Set Entity",
@@ -1723,6 +1724,7 @@ class EntityTools:
         name="ha_get_entity",
         tags={"Entity Registry"},
         annotations={
+            "openWorldHint": False,
             "readOnlyHint": True,
             "idempotentHint": True,
             "title": "Get Entity",
@@ -2014,6 +2016,7 @@ class EntityTools:
         name="ha_remove_entity",
         tags={"Entity Registry"},
         annotations={
+            "openWorldHint": False,
             "destructiveHint": True,
             "idempotentHint": True,
             "title": "Remove Entity",

--- a/src/ha_mcp/tools/tools_filesystem.py
+++ b/src/ha_mcp/tools/tools_filesystem.py
@@ -371,6 +371,7 @@ class FilesystemTools:
         name="ha_list_files",
         tags={"Files", "beta"},
         annotations={
+            "openWorldHint": False,
             "readOnlyHint": True,
             "title": "List Files",
         },
@@ -478,6 +479,7 @@ class FilesystemTools:
         name="ha_read_file",
         tags={"Files", "beta"},
         annotations={
+            "openWorldHint": False,
             "readOnlyHint": True,
             "title": "Read File",
         },
@@ -593,6 +595,7 @@ class FilesystemTools:
         name="ha_write_file",
         tags={"Files", "beta"},
         annotations={
+            "openWorldHint": False,
             "destructiveHint": True,
             "title": "Write File",
         },
@@ -735,6 +738,7 @@ class FilesystemTools:
         name="ha_delete_file",
         tags={"Files", "beta"},
         annotations={
+            "openWorldHint": False,
             "destructiveHint": True,
             "title": "Delete File",
         },

--- a/src/ha_mcp/tools/tools_groups.py
+++ b/src/ha_mcp/tools/tools_groups.py
@@ -136,6 +136,7 @@ class GroupTools:
         name="ha_config_list_groups",
         tags={"Groups"},
         annotations={
+            "openWorldHint": False,
             "idempotentHint": True,
             "readOnlyHint": True,
             "title": "List Groups",
@@ -210,7 +211,11 @@ class GroupTools:
     @tool(
         name="ha_config_set_group",
         tags={"Groups"},
-        annotations={"destructiveHint": True, "title": "Create or Update Group"},
+        annotations={
+            "openWorldHint": False,
+            "destructiveHint": True,
+            "title": "Create or Update Group",
+        },
     )
     @with_auto_backup(domain="group", id_param="object_id")
     @log_tool_usage
@@ -390,6 +395,7 @@ class GroupTools:
         name="ha_config_remove_group",
         tags={"Groups"},
         annotations={
+            "openWorldHint": False,
             "destructiveHint": True,
             "idempotentHint": True,
             "title": "Remove Group",

--- a/src/ha_mcp/tools/tools_hacs.py
+++ b/src/ha_mcp/tools/tools_hacs.py
@@ -111,6 +111,7 @@ class HacsTools:
         name="ha_get_hacs_info",
         tags={"HACS"},
         annotations={
+            "openWorldHint": True,
             "idempotentHint": True,
             "readOnlyHint": True,
             "title": "Get HACS Info",
@@ -214,6 +215,7 @@ class HacsTools:
         name="ha_manage_hacs",
         tags={"HACS"},
         annotations={
+            "openWorldHint": True,
             "destructiveHint": True,
             "title": "Manage HACS",
         },

--- a/src/ha_mcp/tools/tools_history.py
+++ b/src/ha_mcp/tools/tools_history.py
@@ -127,6 +127,7 @@ class HistoryTools:
         name="ha_get_history",
         tags={"History & Statistics"},
         annotations={
+            "openWorldHint": False,
             "idempotentHint": True,
             "readOnlyHint": True,
             "title": "Get Entity History or Statistics",

--- a/src/ha_mcp/tools/tools_integrations.py
+++ b/src/ha_mcp/tools/tools_integrations.py
@@ -292,6 +292,7 @@ class IntegrationTools:
         name="ha_get_integration",
         tags={"Integrations"},
         annotations={
+            "openWorldHint": False,
             "idempotentHint": True,
             "readOnlyHint": True,
             "title": "Get Integration",
@@ -1188,7 +1189,11 @@ class IntegrationTools:
     @tool(
         name="ha_set_integration",
         tags={"Integrations"},
-        annotations={"destructiveHint": True, "title": "Set Integration"},
+        annotations={
+            "openWorldHint": False,
+            "destructiveHint": True,
+            "title": "Set Integration",
+        },
     )
     @with_auto_backup(domain="integration", id_param="entry_id")
     @log_tool_usage
@@ -1412,6 +1417,7 @@ class IntegrationTools:
         name="ha_remove_helpers_integrations",
         tags={"Helper Entities", "Integrations"},
         annotations={
+            "openWorldHint": False,
             "destructiveHint": True,
             "idempotentHint": True,
             "title": "Remove Helper or Integration",

--- a/src/ha_mcp/tools/tools_labels.py
+++ b/src/ha_mcp/tools/tools_labels.py
@@ -35,6 +35,7 @@ class LabelTools:
         name="ha_config_get_label",
         tags={"Labels & Categories"},
         annotations={
+            "openWorldHint": False,
             "idempotentHint": True,
             "readOnlyHint": True,
             "title": "Get Label",
@@ -151,7 +152,11 @@ class LabelTools:
     @tool(
         name="ha_config_set_label",
         tags={"Labels & Categories"},
-        annotations={"destructiveHint": True, "title": "Create or Update Label"},
+        annotations={
+            "openWorldHint": False,
+            "destructiveHint": True,
+            "title": "Create or Update Label",
+        },
     )
     @with_auto_backup(domain="label", id_param="label_id")
     @log_tool_usage
@@ -289,6 +294,7 @@ class LabelTools:
         name="ha_config_remove_label",
         tags={"Labels & Categories"},
         annotations={
+            "openWorldHint": False,
             "destructiveHint": True,
             "idempotentHint": True,
             "title": "Remove Label",

--- a/src/ha_mcp/tools/tools_mcp_component.py
+++ b/src/ha_mcp/tools/tools_mcp_component.py
@@ -253,7 +253,11 @@ class McpComponentTools:
     @tool(
         name="ha_install_mcp_tools",
         tags={"Utilities", "beta"},
-        annotations={"destructiveHint": True, "title": "Install MCP Tools Component"},
+        annotations={
+            "openWorldHint": True,
+            "destructiveHint": True,
+            "title": "Install MCP Tools Component",
+        },
     )
     @log_tool_usage
     async def ha_install_mcp_tools(

--- a/src/ha_mcp/tools/tools_radio.py
+++ b/src/ha_mcp/tools/tools_radio.py
@@ -90,6 +90,7 @@ class RadioTools:
         name="ha_manage_radio",
         tags={"Radio Management", "Z-Wave", "Zigbee", "Matter", "Thread"},
         annotations={
+            "openWorldHint": False,
             "destructiveHint": True,
             "idempotentHint": False,
             "title": "Manage Radios (Z-Wave / Zigbee / Matter / Thread)",

--- a/src/ha_mcp/tools/tools_registry.py
+++ b/src/ha_mcp/tools/tools_registry.py
@@ -616,6 +616,7 @@ class RegistryTools:
         name="ha_get_device",
         tags={"Device Registry", "Zigbee", "Z-Wave", "Matter"},
         annotations={
+            "openWorldHint": False,
             "idempotentHint": True,
             "readOnlyHint": True,
             "title": "Get Device (incl. Zigbee/ZHA/Z2M, Z-Wave and Matter)",
@@ -755,7 +756,11 @@ class RegistryTools:
     @tool(
         name="ha_set_device",
         tags={"Device Registry"},
-        annotations={"destructiveHint": True, "title": "Set Device"},
+        annotations={
+            "openWorldHint": False,
+            "destructiveHint": True,
+            "title": "Set Device",
+        },
     )
     @with_auto_backup(domain="device", id_param="device_id")
     @log_tool_usage
@@ -852,6 +857,7 @@ class RegistryTools:
         name="ha_remove_device",
         tags={"Device Registry"},
         annotations={
+            "openWorldHint": False,
             "destructiveHint": True,
             "idempotentHint": True,
             "title": "Remove Device",

--- a/src/ha_mcp/tools/tools_resources.py
+++ b/src/ha_mcp/tools/tools_resources.py
@@ -146,6 +146,7 @@ class ResourceTools:
         name="ha_config_list_dashboard_resources",
         tags={"Dashboards"},
         annotations={
+            "openWorldHint": False,
             "idempotentHint": True,
             "readOnlyHint": True,
             "title": "List Dashboard Resources",
@@ -246,6 +247,7 @@ class ResourceTools:
         name="ha_config_set_dashboard_resource",
         tags={"Dashboards"},
         annotations={
+            "openWorldHint": False,
             "destructiveHint": True,
             "title": "Set Dashboard Resource",
         },
@@ -651,6 +653,7 @@ class ResourceTools:
         name="ha_config_delete_dashboard_resource",
         tags={"Dashboards"},
         annotations={
+            "openWorldHint": False,
             "destructiveHint": True,
             "title": "Delete Dashboard Resource",
         },

--- a/src/ha_mcp/tools/tools_resources.py
+++ b/src/ha_mcp/tools/tools_resources.py
@@ -146,7 +146,7 @@ class ResourceTools:
         name="ha_config_list_dashboard_resources",
         tags={"Dashboards"},
         annotations={
-            "openWorldHint": False,
+            "openWorldHint": True,
             "idempotentHint": True,
             "readOnlyHint": True,
             "title": "List Dashboard Resources",

--- a/src/ha_mcp/tools/tools_search.py
+++ b/src/ha_mcp/tools/tools_search.py
@@ -1370,6 +1370,7 @@ class SearchTools:
         name="ha_search",
         tags={"Search & Discovery"},
         annotations={
+            "openWorldHint": False,
             "idempotentHint": True,
             "readOnlyHint": True,
             "title": "Search",
@@ -2604,6 +2605,7 @@ class SearchTools:
         name="ha_get_overview",
         tags={"Search & Discovery"},
         annotations={
+            "openWorldHint": False,
             "idempotentHint": True,
             "readOnlyHint": True,
             "title": "Get System Overview",
@@ -3295,6 +3297,7 @@ class SearchTools:
         name="ha_get_state",
         tags={"Search & Discovery"},
         annotations={
+            "openWorldHint": False,
             "idempotentHint": True,
             "readOnlyHint": True,
             "title": "Get Entity State",

--- a/src/ha_mcp/tools/tools_search.py
+++ b/src/ha_mcp/tools/tools_search.py
@@ -2605,7 +2605,7 @@ class SearchTools:
         name="ha_get_overview",
         tags={"Search & Discovery"},
         annotations={
-            "openWorldHint": False,
+            "openWorldHint": True,
             "idempotentHint": True,
             "readOnlyHint": True,
             "title": "Get System Overview",

--- a/src/ha_mcp/tools/tools_service.py
+++ b/src/ha_mcp/tools/tools_service.py
@@ -375,7 +375,11 @@ class ServiceTools:
     @tool(
         name="ha_call_service",
         tags={"Service & Device Control"},
-        annotations={"destructiveHint": True, "title": "Call Service"},
+        annotations={
+            "openWorldHint": False,
+            "destructiveHint": True,
+            "title": "Call Service",
+        },
     )
     @log_tool_usage
     async def ha_call_service(
@@ -569,7 +573,11 @@ class ServiceTools:
     @tool(
         name="ha_get_operation_status",
         tags={"Service & Device Control"},
-        annotations={"readOnlyHint": True, "title": "Get Operation Status"},
+        annotations={
+            "openWorldHint": False,
+            "readOnlyHint": True,
+            "title": "Get Operation Status",
+        },
     )
     @log_tool_usage
     async def ha_get_operation_status(
@@ -627,7 +635,11 @@ class ServiceTools:
     @tool(
         name="ha_bulk_control",
         tags={"Service & Device Control"},
-        annotations={"destructiveHint": True, "title": "Bulk Control"},
+        annotations={
+            "openWorldHint": False,
+            "destructiveHint": True,
+            "title": "Bulk Control",
+        },
     )
     @log_tool_usage
     async def ha_bulk_control(
@@ -671,6 +683,7 @@ class ServiceTools:
         name="ha_call_event",
         tags={"Service & Device Control"},
         annotations={
+            "openWorldHint": False,
             "destructiveHint": True,
             "idempotentHint": False,
             "title": "Call Event",

--- a/src/ha_mcp/tools/tools_services.py
+++ b/src/ha_mcp/tools/tools_services.py
@@ -40,6 +40,7 @@ class ServiceDiscoveryTools:
         name="ha_list_services",
         tags={"Service & Device Control"},
         annotations={
+            "openWorldHint": False,
             "idempotentHint": True,
             "readOnlyHint": True,
             "title": "List Available Services",

--- a/src/ha_mcp/tools/tools_system.py
+++ b/src/ha_mcp/tools/tools_system.py
@@ -103,7 +103,11 @@ class SystemTools:
     @tool(
         name="ha_restart",
         tags={"System"},
-        annotations={"destructiveHint": True, "title": "Restart Home Assistant"},
+        annotations={
+            "openWorldHint": False,
+            "destructiveHint": True,
+            "title": "Restart Home Assistant",
+        },
     )
     @log_tool_usage
     async def ha_restart(
@@ -224,7 +228,11 @@ class SystemTools:
     @tool(
         name="ha_reload_core",
         tags={"System"},
-        annotations={"destructiveHint": True, "title": "Reload Core Components"},
+        annotations={
+            "openWorldHint": False,
+            "destructiveHint": True,
+            "title": "Reload Core Components",
+        },
     )
     @log_tool_usage
     async def ha_reload_core(
@@ -504,6 +512,7 @@ class SystemTools:
         name="ha_get_system_health",
         tags={"System", "Zigbee", "Z-Wave", "Thread", "Matter", "Integrations"},
         annotations={
+            "openWorldHint": False,
             "idempotentHint": True,
             "readOnlyHint": True,
             "title": "Get System Health (incl. ZHA/Z-Wave/integration diagnostics)",

--- a/src/ha_mcp/tools/tools_system.py
+++ b/src/ha_mcp/tools/tools_system.py
@@ -512,7 +512,7 @@ class SystemTools:
         name="ha_get_system_health",
         tags={"System", "Zigbee", "Z-Wave", "Thread", "Matter", "Integrations"},
         annotations={
-            "openWorldHint": False,
+            "openWorldHint": True,
             "idempotentHint": True,
             "readOnlyHint": True,
             "title": "Get System Health (incl. ZHA/Z-Wave/integration diagnostics)",

--- a/src/ha_mcp/tools/tools_themes.py
+++ b/src/ha_mcp/tools/tools_themes.py
@@ -55,6 +55,7 @@ class ThemesTools:
         name="ha_manage_theme",
         tags={"System"},
         annotations={
+            "openWorldHint": False,
             "destructiveHint": True,
             "idempotentHint": True,
             "readOnlyHint": False,

--- a/src/ha_mcp/tools/tools_todo.py
+++ b/src/ha_mcp/tools/tools_todo.py
@@ -37,7 +37,12 @@ class TodoTools:
     @tool(
         name="ha_get_todo",
         tags={"Todo Lists"},
-        annotations={"idempotentHint": True, "readOnlyHint": True, "title": "Get Todo"},
+        annotations={
+            "openWorldHint": False,
+            "idempotentHint": True,
+            "readOnlyHint": True,
+            "title": "Get Todo",
+        },
     )
     @log_tool_usage
     async def ha_get_todo(
@@ -209,7 +214,11 @@ class TodoTools:
     @tool(
         name="ha_set_todo_item",
         tags={"Todo Lists"},
-        annotations={"destructiveHint": True, "title": "Set Todo Item"},
+        annotations={
+            "openWorldHint": False,
+            "destructiveHint": True,
+            "title": "Set Todo Item",
+        },
     )
     @with_auto_backup(
         domain="todo_item",
@@ -526,6 +535,7 @@ class TodoTools:
         name="ha_remove_todo_item",
         tags={"Todo Lists"},
         annotations={
+            "openWorldHint": False,
             "destructiveHint": True,
             "idempotentHint": True,
             "title": "Remove Todo Item",

--- a/src/ha_mcp/tools/tools_traces.py
+++ b/src/ha_mcp/tools/tools_traces.py
@@ -39,6 +39,7 @@ class TraceTools:
         name="ha_get_automation_traces",
         tags={"History & Statistics"},
         annotations={
+            "openWorldHint": False,
             "idempotentHint": True,
             "readOnlyHint": True,
             "title": "Get Automation Traces",

--- a/src/ha_mcp/tools/tools_utility.py
+++ b/src/ha_mcp/tools/tools_utility.py
@@ -1166,6 +1166,7 @@ def register_utility_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
     @mcp.tool(
         tags={"History & Statistics"},
         annotations={
+            "openWorldHint": False,
             "idempotentHint": True,
             "readOnlyHint": True,
             "title": "Get Logs",
@@ -1245,6 +1246,7 @@ def register_utility_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
     @mcp.tool(
         tags={"Utilities"},
         annotations={
+            "openWorldHint": False,
             "idempotentHint": True,
             "readOnlyHint": True,
             "title": "Evaluate Template",

--- a/src/ha_mcp/tools/tools_voice_assistant.py
+++ b/src/ha_mcp/tools/tools_voice_assistant.py
@@ -368,6 +368,7 @@ class VoiceAssistantTools:
         name="ha_manage_pipeline",
         tags={"Assist"},
         annotations={
+            "openWorldHint": False,
             "destructiveHint": True,
             "idempotentHint": False,
             "readOnlyHint": False,
@@ -638,6 +639,7 @@ class VoiceAssistantTools:
         name="ha_get_entity_exposure",
         tags={"Entity Registry"},
         annotations={
+            "openWorldHint": False,
             "idempotentHint": True,
             "readOnlyHint": True,
             "title": "Get Entity Exposure",

--- a/src/ha_mcp/tools/tools_yaml_config.py
+++ b/src/ha_mcp/tools/tools_yaml_config.py
@@ -297,6 +297,7 @@ class YamlConfigTools:
         name="ha_config_set_yaml",
         tags={"System", "beta"},
         annotations={
+            "openWorldHint": False,
             "destructiveHint": True,
             "idempotentHint": False,
             "title": "Raw YAML Config Edit",

--- a/src/ha_mcp/tools/tools_zones.py
+++ b/src/ha_mcp/tools/tools_zones.py
@@ -127,7 +127,12 @@ class ZoneTools:
     @tool(
         name="ha_get_zone",
         tags={"Zones"},
-        annotations={"idempotentHint": True, "readOnlyHint": True, "title": "Get Zone"},
+        annotations={
+            "openWorldHint": False,
+            "idempotentHint": True,
+            "readOnlyHint": True,
+            "title": "Get Zone",
+        },
     )
     @log_tool_usage
     async def ha_get_zone(
@@ -312,7 +317,11 @@ class ZoneTools:
     @tool(
         name="ha_set_zone",
         tags={"Zones"},
-        annotations={"destructiveHint": True, "title": "Set Zone"},
+        annotations={
+            "openWorldHint": False,
+            "destructiveHint": True,
+            "title": "Set Zone",
+        },
     )
     @with_auto_backup(
         domain="zone",
@@ -512,6 +521,7 @@ class ZoneTools:
         name="ha_remove_zone",
         tags={"Zones"},
         annotations={
+            "openWorldHint": False,
             "destructiveHint": True,
             "idempotentHint": True,
             "title": "Remove Zone",

--- a/src/ha_mcp/transforms/categorized_search.py
+++ b/src/ha_mcp/transforms/categorized_search.py
@@ -466,28 +466,28 @@ class CategorizedSearchTransform(BM25SearchTransform):
         search_tool = search_tool.model_copy(
             update={
                 "description": self._search_tool_description or search_tool.description,
-                "annotations": ToolAnnotations(readOnlyHint=True),
+                "annotations": ToolAnnotations(openWorldHint=False, readOnlyHint=True),
             }
         )
 
         call_read = self._make_categorized_proxy(
             proxy_name=self._call_read_name,
             category="read",
-            annotations=ToolAnnotations(readOnlyHint=True),
+            annotations=ToolAnnotations(openWorldHint=True, readOnlyHint=True),
             description=self._proxy_descs["read"],
         )
 
         call_write = self._make_categorized_proxy(
             proxy_name=self._call_write_name,
             category="write",
-            annotations=ToolAnnotations(destructiveHint=True),
+            annotations=ToolAnnotations(openWorldHint=True, destructiveHint=True),
             description=self._proxy_descs["write"],
         )
 
         call_delete = self._make_categorized_proxy(
             proxy_name=self._call_delete_name,
             category="delete",
-            annotations=ToolAnnotations(destructiveHint=True),
+            annotations=ToolAnnotations(openWorldHint=False, destructiveHint=True),
             description=self._proxy_descs["delete"],
         )
 
@@ -506,21 +506,21 @@ class CategorizedSearchTransform(BM25SearchTransform):
             return self._make_categorized_proxy(
                 self._call_read_name,
                 "read",
-                ToolAnnotations(readOnlyHint=True),
+                ToolAnnotations(openWorldHint=True, readOnlyHint=True),
                 self._proxy_descs["read"],
             )
         if name == self._call_write_name:
             return self._make_categorized_proxy(
                 self._call_write_name,
                 "write",
-                ToolAnnotations(destructiveHint=True),
+                ToolAnnotations(openWorldHint=True, destructiveHint=True),
                 self._proxy_descs["write"],
             )
         if name == self._call_delete_name:
             return self._make_categorized_proxy(
                 self._call_delete_name,
                 "delete",
-                ToolAnnotations(destructiveHint=True),
+                ToolAnnotations(openWorldHint=False, destructiveHint=True),
                 self._proxy_descs["delete"],
             )
         return await super().get_tool(name, call_next, version=version)

--- a/tests/src/unit/test_tool_annotations.py
+++ b/tests/src/unit/test_tool_annotations.py
@@ -9,6 +9,7 @@ Every tool MUST declare its safety behavior with one of:
 Additionally, every tool SHOULD have a title for UI display.
 """
 
+import ast
 import re
 from pathlib import Path
 
@@ -35,7 +36,8 @@ def _parse_decorator_args(decorator_args: str, func_name: str, file_name: str) -
     has_title = "title" in decorator_args
     has_tags = "tags=" in decorator_args or "tags =" in decorator_args
     has_open_world = (
-        re.search(r'"openWorldHint"\s*:\s*(True|False)', decorator_args) is not None
+        re.search(r'["\']openWorldHint["\']\s*:\s*(True|False)', decorator_args)
+        is not None
     )
 
     return {
@@ -187,6 +189,57 @@ class TestToolAnnotations:
             + "\n\nAdd openWorldHint (true if the tool reaches external systems, "
             "false if it only touches local Home Assistant state) to each "
             "@tool() decorator; the MCP default is true."
+        )
+
+    def test_server_registered_tools_have_open_world_hint(self):
+        """Tools registered directly on the server must also set openWorldHint.
+
+        get_all_tools() only scans src/ha_mcp/tools, so ha_get_skill_guide --
+        registered in server.py via self.mcp.tool(...) -- would otherwise keep
+        the implicit open-world default. Parse server.py's AST and assert every
+        self.mcp.tool(...) registration carries openWorldHint.
+        """
+        server_py = get_tools_dir().parent / "server.py"
+        tree = ast.parse(server_py.read_text(encoding="utf-8"), filename=str(server_py))
+
+        registrations = [
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "tool"
+            and isinstance(node.func.value, ast.Attribute)
+            and node.func.value.attr == "mcp"
+        ]
+        assert registrations, (
+            "no self.mcp.tool(...) registrations found in server.py -- "
+            "the scanner's shape assumption drifted"
+        )
+
+        missing = []
+        for call in registrations:
+            name = next(
+                (
+                    kw.value.value
+                    for kw in call.keywords
+                    if kw.arg == "name" and isinstance(kw.value, ast.Constant)
+                ),
+                "<unknown>",
+            )
+            annotations = next(
+                (kw.value for kw in call.keywords if kw.arg == "annotations"), None
+            )
+            keys = (
+                {k.value for k in annotations.keys if isinstance(k, ast.Constant)}
+                if isinstance(annotations, ast.Dict)
+                else set()
+            )
+            if "openWorldHint" not in keys:
+                missing.append(name)
+
+        assert not missing, (
+            f"server-registered tools missing openWorldHint: {missing}. Add it to "
+            "the annotations dict in the self.mcp.tool(...) call in server.py."
         )
 
     def test_all_tools_have_tags(self):

--- a/tests/src/unit/test_tool_annotations.py
+++ b/tests/src/unit/test_tool_annotations.py
@@ -34,6 +34,9 @@ def _parse_decorator_args(decorator_args: str, func_name: str, file_name: str) -
     )
     has_title = "title" in decorator_args
     has_tags = "tags=" in decorator_args or "tags =" in decorator_args
+    has_open_world = (
+        re.search(r'"openWorldHint"\s*:\s*(True|False)', decorator_args) is not None
+    )
 
     return {
         "file": file_name,
@@ -43,6 +46,7 @@ def _parse_decorator_args(decorator_args: str, func_name: str, file_name: str) -
         "has_explicit_non_destructive_hint": has_explicit_non_destructive,
         "has_title": has_title,
         "has_tags": has_tags,
+        "has_open_world_hint": has_open_world,
         "decorator_args": decorator_args.strip(),
     }
 
@@ -91,6 +95,7 @@ def extract_tool_decorators(file_path: Path) -> list[dict]:
                 "has_destructive_hint": False,
                 "has_explicit_non_destructive_hint": False,
                 "has_title": False,
+                "has_open_world_hint": False,
                 "decorator_args": "",
             }
         )
@@ -159,6 +164,29 @@ class TestToolAnnotations:
         assert not missing_titles, (
             f"Tools missing title annotation ({len(missing_titles)}):\n  "
             + "\n  ".join(missing_titles)
+        )
+
+    def test_all_tools_have_open_world_hint(self):
+        """Every tool must set openWorldHint explicitly (true or false).
+
+        The MCP default is true, so an omitted value silently marks a local
+        tool as open-world. This guards the explicit value; the true/false
+        choice itself is a behaviour judgement left to review.
+        """
+        tools = get_all_tools()
+
+        missing_open_world = [
+            f"{tool['file']}:{tool['function']}"
+            for tool in tools
+            if not tool["has_open_world_hint"]
+        ]
+
+        assert not missing_open_world, (
+            f"Tools missing openWorldHint annotation ({len(missing_open_world)}):\n  "
+            + "\n  ".join(missing_open_world)
+            + "\n\nAdd openWorldHint (true if the tool reaches external systems, "
+            "false if it only touches local Home Assistant state) to each "
+            "@tool() decorator; the MCP default is true."
         )
 
     def test_all_tools_have_tags(self):

--- a/tests/src/unit/test_tool_annotations.py
+++ b/tests/src/unit/test_tool_annotations.py
@@ -62,11 +62,12 @@ def extract_tool_decorators(file_path: Path) -> list[dict]:
     # such as ``@with_auto_backup(domain="entity", id_param="entity_id",
     # client=client)`` between ``@mcp.tool`` and ``async def``; the old
     # bare-only ``(?:@\w+\s*)*`` dropped those backed-up tools from the count.
-    # ``\([^()]*\)`` does NOT span nested parens, so a decorator whose args
-    # contain them (e.g. ``ha_set_entity``'s ``id_fn=lambda``) stays unmatched
-    # — pre-existing, not introduced here. Requiring decorators-then-
-    # ``async def`` (not arbitrary text) keeps docstring ``@mcp.tool(...)``
-    # mentions from matching.
+    # ``\([^()]*\)`` does NOT span nested parens, so a closure-form tool whose
+    # decorator args contain them would stay unmatched; no tool does today
+    # (``ha_set_entity``'s ``id_fn=lambda`` is class-form, so Pattern 2 takes
+    # it), and test_tool_scan_finds_every_annotated_tool fails loudly if one
+    # ever falls out. Requiring decorators-then-``async def`` (not arbitrary
+    # text) keeps docstring ``@mcp.tool(...)`` mentions from matching.
     pattern = r"@mcp\.tool\(([^)]*)\)\s*(?:@\w+(?:\([^()]*\))?\s*)*async def (\w+)"
     tools = [
         _parse_decorator_args(m.group(1), m.group(2), file_path.name)
@@ -191,6 +192,32 @@ class TestToolAnnotations:
             "@tool() decorator; the MCP default is true."
         )
 
+    def test_tool_scan_finds_every_annotated_tool(self):
+        """The scan must not silently drop a tool from the checks above.
+
+        The closure-form pattern ``@mcp.tool\\(([^)]*)\\)`` cannot span a ``)``,
+        so a future decorator whose args contain one (e.g. a title like
+        "Get Logs (verbose)") would fall out of get_all_tools() and escape every
+        annotation assertion -- inheriting the MCP default openWorldHint=true
+        unnoticed. Every tool sets openWorldHint exactly once, so the scanned
+        count must equal the occurrences across the tool files; a drop breaks
+        parity and fails here instead of passing silently.
+        """
+        tools = get_all_tools()
+        occurrences = sum(
+            py_file.read_text(encoding="utf-8").count("openWorldHint")
+            for py_file in sorted(get_tools_dir().glob("*.py"))
+            if not py_file.name.startswith("_")
+        )
+
+        assert len(tools) == occurrences, (
+            f"Tool scan found {len(tools)} tools but {occurrences} openWorldHint "
+            f"occurrences across the tool files. A tool the regex cannot parse is "
+            f"dropped from get_all_tools() and skips every annotation check. Fix "
+            f"the pattern in extract_tool_decorators() (a ')' inside the decorator "
+            f"args is the usual cause) rather than adjusting this count."
+        )
+
     def test_server_registered_tools_have_open_world_hint(self):
         """Tools registered directly on the server must also set openWorldHint.
 
@@ -216,16 +243,30 @@ class TestToolAnnotations:
             "the scanner's shape assumption drifted"
         )
 
+        # ha_get_skill_guide registers as name=SKILL_TOOL_NAME, not a literal, so
+        # resolve module-level string constants to keep failures naming the tool
+        # rather than "<unknown>".
+        constants = {
+            target.id: node.value.value
+            for node in tree.body
+            if isinstance(node, ast.Assign)
+            and isinstance(node.value, ast.Constant)
+            and isinstance(node.value.value, str)
+            for target in node.targets
+            if isinstance(target, ast.Name)
+        }
+
+        def tool_name(call: ast.Call) -> str:
+            value = next((kw.value for kw in call.keywords if kw.arg == "name"), None)
+            if isinstance(value, ast.Constant):
+                return str(value.value)
+            if isinstance(value, ast.Name):
+                return constants.get(value.id, value.id)
+            return "<unknown>" if value is None else ast.unparse(value)
+
         missing = []
         for call in registrations:
-            name = next(
-                (
-                    kw.value.value
-                    for kw in call.keywords
-                    if kw.arg == "name" and isinstance(kw.value, ast.Constant)
-                ),
-                "<unknown>",
-            )
+            name = tool_name(call)
             annotations = next(
                 (kw.value for kw in call.keywords if kw.arg == "annotations"), None
             )
@@ -297,9 +338,7 @@ class TestToolAnnotations:
     def test_ha_check_config_removed_and_folded(self):
         """ha_check_config was removed and folded into ha_get_system_health
         (include='config_check'). Lock the removal at the source registration so
-        a bad merge that re-adds the @tool block fails CI. (Checks the source
-        string directly rather than get_all_tools(), whose regex can't parse
-        ha_get_system_health's paren-containing title.)"""
+        a bad merge that re-adds the @tool block fails CI."""
         system_src = (get_tools_dir() / "tools_system.py").read_text(encoding="utf-8")
         assert 'name="ha_check_config"' not in system_src, (
             "ha_check_config was removed in favor of "

--- a/tests/src/unit/test_tool_annotations.py
+++ b/tests/src/unit/test_tool_annotations.py
@@ -242,6 +242,42 @@ class TestToolAnnotations:
             "the annotations dict in the self.mcp.tool(...) call in server.py."
         )
 
+    def test_search_proxy_tools_have_open_world_hint(self):
+        """Runtime tool-search proxies must also set openWorldHint.
+
+        When ENABLE_TOOL_SEARCH=true, CategorizedSearchTransform builds
+        ha_search_tools and the ha_call_* proxies at runtime via
+        ToolAnnotations(...), which the src/ha_mcp/tools scan never sees. Assert
+        every ToolAnnotations construction in categorized_search.py sets
+        openWorldHint so those proxies don't inherit the implicit default.
+        """
+        transform_py = get_tools_dir().parent / "transforms" / "categorized_search.py"
+        tree = ast.parse(
+            transform_py.read_text(encoding="utf-8"), filename=str(transform_py)
+        )
+        constructions = [
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "ToolAnnotations"
+        ]
+        assert constructions, (
+            "no ToolAnnotations(...) constructions found in categorized_search.py "
+            "-- the scanner's shape assumption drifted"
+        )
+
+        missing = sum(
+            1
+            for c in constructions
+            if not any(kw.arg == "openWorldHint" for kw in c.keywords)
+        )
+        assert missing == 0, (
+            f"{missing} of {len(constructions)} ToolAnnotations(...) in "
+            "categorized_search.py omit openWorldHint; the runtime search proxies "
+            "would inherit the MCP default. Set it explicitly on each proxy."
+        )
+
     def test_all_tools_have_tags(self):
         """Every tool must have a tags= parameter for categorization."""
         tools = get_all_tools()


### PR DESCRIPTION
Closes #1871

## What does this PR do?

Sets `openWorldHint` explicitly on all 88 MCP tools. `openWorldHint` defaults to `true` in the MCP spec, so any tool that omits it is silently treated as open-world by clients. Before this change only `ha_manage_updates` set it; the other 87 tools relied on the implicit default.

The annotation is now explicit everywhere:

- **`true` (12 tools)** – output crosses a trust boundary into an externally-authored world:
  - `ha_get_hacs_info`, `ha_manage_hacs` (HACS/GitHub catalog)
  - `ha_get_addon`, `ha_manage_addon` (add-on store repositories)
  - `ha_import_blueprint` (arbitrary import URL)
  - `ha_manage_updates` (GitHub release feeds)
  - `ha_dev_manage_server` (server self-update from GitHub/PyPI)
  - `ha_install_mcp_tools` (component install via HACS)
  - `ha_get_overview`, `ha_get_system_health` (both embed the update-check field, which reaches PyPI / the Supervisor store at call time)
  - `ha_get_blueprint`, `ha_config_list_dashboard_resources` (local `blueprint/list` / `lovelace/resources` reads that return externally-authored content – no external call at call time)
- **`false` (76 tools)** – domain is the local Home Assistant instance.

A tool is open-world when its output carries externally-authored content back to the client, even when a local integration (HACS, Supervisor, HA Core) makes the actual network call on its behalf – matching the MCP spec's "open world of external entities" and the guidance that clients scrutinize open-world output for untrusted content. Clients that honor the hint can then skip that scrutiny on local reads and keep flagging the genuinely external tools.

The runtime tool-search proxies (`ENABLE_TOOL_SEARCH=true`) are annotated separately, since `CategorizedSearchTransform` builds them at runtime rather than via a decorator: `ha_call_read_tool` and `ha_call_write_tool` are `true` (a conservative superset – those buckets contain open-world tools), while `ha_call_delete_tool` and `ha_search_tools` are `false`.

Also:
- Adds annotation guards to `tests/src/unit/test_tool_annotations.py` so a new tool that forgets the annotation fails CI rather than silently inheriting the default: one over the `tools/` scan, one over `server.py`'s AST, one over `categorized_search.py`'s AST, plus a count-parity assertion that fails if the scanner's regex ever drops a tool.
- Documents the annotation in `AGENTS.md` and `.gemini/styleguide.md` alongside the other safety hints.

`site/src/data/tools.json` is intentionally not touched here – it is auto-generated and synced by the `sync-tool-docs` workflow after merge.

No runtime behavior changes – this is tool metadata surfaced in `tools/list`.

## Type of change
- [x] ✨ New feature

## Testing
- [ ] I have tested these changes with a LLM agent
- [ ] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

Verified locally: `ruff check` + `ruff format --check` clean, `mypy` clean over the changed `src/` sources (mypy does not cover `tests/`), and the annotation unit tests plus adjacent annotation suites pass (`test_tool_annotations`, `test_read_only`, `test_categorized_search`, `test_skills_instructions`). The split is 12 `true` / 76 `false` across the 88 tools. The full pytest suite (incl. HAOS e2e) runs in CI. No LLM-agent test box: the change is serialization metadata with no agent-observable runtime path.

## Checklist
- [x] I have updated documentation if needed
