### PR TITLE
feat: add snapshot delete + fix backup progress heartbeats (#1861)

### DIFF
--- a/homeassistant-addon-dev/config.yaml
+++ b/homeassistant-addon-dev/config.yaml
@@ -58,6 +58,12 @@ options:
   enable_auto_backup: true
   auto_backup_throttle_minutes: 0
   auto_backup_retain_per_entity: 100
+  # Off by default (#1861) — an agent deleting a full HA snapshot is
+  # categorically riskier than the lightweight edits-scope auto-backups
+  # above (a snapshot may be the last recovery point after the agent
+  # itself broke something). A human opts in here, not the agent.
+  enable_snapshot_delete: false
+  snapshot_delete_min_age_days: 7
   tool_search_max_results: 5
   disabled_tools: ""
   pinned_tools: ""
@@ -84,6 +90,8 @@ schema:
   enable_auto_backup: bool?
   auto_backup_throttle_minutes: int(0,1440)?
   auto_backup_retain_per_entity: int(1,10000)?
+  enable_snapshot_delete: bool?
+  snapshot_delete_min_age_days: int(0,365)?
   tool_search_max_results: int(2,10)?
   disabled_tools: str?
   pinned_tools: str?

--- a/homeassistant-addon-dev/translations/en.yaml
+++ b/homeassistant-addon-dev/translations/en.yaml
@@ -156,6 +156,21 @@ configuration:
       Maximum number of snapshots kept per entity. Older snapshots beyond
       this cap are rotated out on each successful capture. Default 100,
       range 1–10000.
+  enable_snapshot_delete:
+    name: Allow snapshot deletion
+    description: >-
+      Lets ha_manage_backup delete full HA snapshot tarballs
+      (scope='snapshot', action='delete'). Off by default — a snapshot may
+      be the last recovery point after a mistaken change, so a human must
+      opt in here. Even when on, scheduled backups, the newest remaining
+      snapshot, and anything younger than the age floor below stay
+      protected.
+  snapshot_delete_min_age_days:
+    name: Minimum snapshot age to delete (days)
+    description: >-
+      A snapshot must be at least this old before it can be deleted. Range
+      0–365; 0 disables the floor (the newest-snapshot and
+      scheduled-backup protections still apply). Default 7.
   enable_lite_docstrings:
     name: Enable lite tool docstrings (beta)
     description: >-

--- a/homeassistant-addon/config.yaml
+++ b/homeassistant-addon/config.yaml
@@ -56,6 +56,12 @@ options:
   enable_auto_backup: true
   auto_backup_throttle_minutes: 0
   auto_backup_retain_per_entity: 100
+  # Off by default (#1861) — an agent deleting a full HA snapshot is
+  # categorically riskier than the lightweight edits-scope auto-backups
+  # above (a snapshot may be the last recovery point after the agent
+  # itself broke something). A human opts in here, not the agent.
+  enable_snapshot_delete: false
+  snapshot_delete_min_age_days: 7
   verify_ssl: true
 schema:
   backup_hint: list(strong|normal|weak|auto)
@@ -71,6 +77,8 @@ schema:
   enable_auto_backup: bool?
   auto_backup_throttle_minutes: int(0,1440)?
   auto_backup_retain_per_entity: int(1,10000)?
+  enable_snapshot_delete: bool?
+  snapshot_delete_min_age_days: int(0,365)?
   verify_ssl: bool?
 # Add-on exposes HTTP port for MCP communication (fixed internal port)
 ports:

--- a/homeassistant-addon/start.py
+++ b/homeassistant-addon/start.py
@@ -386,6 +386,11 @@ def main() -> int:
     )
     auto_backup_throttle_minutes = 0  # default — every write
     auto_backup_retain_per_entity = 100  # default
+    # Off by default (#1861 — a snapshot may be the last recovery point
+    # after the agent itself broke something; a human opts in, not the
+    # agent).
+    enable_snapshot_delete = False  # default
+    snapshot_delete_min_age_days = 7  # default
     tool_search_max_results = 5  # default
     disabled_tools_raw = ""  # default
     pinned_tools_raw = ""  # default
@@ -529,6 +534,14 @@ def main() -> int:
             raw_retain = config.get("auto_backup_retain_per_entity", 100)
             auto_backup_retain_per_entity = (
                 raw_retain if isinstance(raw_retain, int) else 100
+            )
+            raw_snapshot_delete = config.get("enable_snapshot_delete", False)
+            enable_snapshot_delete = (
+                raw_snapshot_delete if isinstance(raw_snapshot_delete, bool) else False
+            )
+            raw_min_age = config.get("snapshot_delete_min_age_days", 7)
+            snapshot_delete_min_age_days = (
+                raw_min_age if isinstance(raw_min_age, int) else 7
             )
             raw_max_results = config.get("tool_search_max_results", 5)
             tool_search_max_results = (
@@ -696,6 +709,8 @@ def main() -> int:
     os.environ["ENABLE_AUTO_BACKUP"] = str(enable_auto_backup).lower()
     os.environ["AUTO_BACKUP_THROTTLE_MINUTES"] = str(auto_backup_throttle_minutes)
     os.environ["AUTO_BACKUP_RETAIN_PER_ENTITY"] = str(auto_backup_retain_per_entity)
+    os.environ["ENABLE_SNAPSHOT_DELETE"] = str(enable_snapshot_delete).lower()
+    os.environ["SNAPSHOT_DELETE_MIN_AGE_DAYS"] = str(snapshot_delete_min_age_days)
     # Persist saved custom tools across addon restarts. /data is the
     # per-addon writable directory mapped by Supervisor and survives
     # add-on updates (but not uninstall/reinstall — users should copy

--- a/homeassistant-addon/translations/en.yaml
+++ b/homeassistant-addon/translations/en.yaml
@@ -100,6 +100,21 @@ configuration:
       Maximum number of snapshots kept per entity. Older snapshots beyond
       this cap are rotated out on each successful capture. Default 100,
       range 1–10000.
+  enable_snapshot_delete:
+    name: Allow snapshot deletion
+    description: >-
+      Lets ha_manage_backup delete full HA snapshot tarballs
+      (scope='snapshot', action='delete'). Off by default — a snapshot may
+      be the last recovery point after a mistaken change, so a human must
+      opt in here. Even when on, scheduled backups, the newest remaining
+      snapshot, and anything younger than the age floor below stay
+      protected.
+  snapshot_delete_min_age_days:
+    name: Minimum snapshot age to delete (days)
+    description: >-
+      A snapshot must be at least this old before it can be deleted. Range
+      0–365; 0 disables the floor (the newest-snapshot and
+      scheduled-backup protections still apply). Default 7.
   verify_ssl:
     name: Verify TLS certificate
     description: >-

--- a/src/ha_mcp/config.py
+++ b/src/ha_mcp/config.py
@@ -355,6 +355,26 @@ class Settings(BaseSettings):
         7, ge=1, le=365, alias="HAMCP_AUTO_BACKUP_CALENDAR_LOOKAHEAD_DAYS"
     )
 
+    # Snapshot-tarball deletion gate (#1861). Off by default: an agent
+    # deleting a full HA snapshot is categorically riskier than the
+    # lightweight `edits`-scope auto-backups (which already delete freely),
+    # since a snapshot may be the last recovery point after the agent
+    # itself broke something. A human must opt in via env var, the web
+    # settings UI override file, or (in the add-on) the Supervisor options
+    # — never something the agent can flip on itself.
+    enable_snapshot_delete: bool = Field(False, alias="ENABLE_SNAPSHOT_DELETE")
+
+    # Minimum age (days) a snapshot must have before it's deletable. This is
+    # the load-bearing guard, not `enable_snapshot_delete`: a count-based
+    # "keep the last N" rule is defeatable by an agent flooding new
+    # snapshots before deleting old ones, but it cannot forge a backup's
+    # HA-stamped creation date. 0 disables the age floor (still gated by
+    # enable_snapshot_delete + the newest-snapshot / automatic-backup
+    # guards enforced in tools/backup.py).
+    snapshot_delete_min_age_days: int = Field(
+        7, ge=0, le=365, alias="SNAPSHOT_DELETE_MIN_AGE_DAYS"
+    )
+
     # Mirror the legacy ``os.getenv("FLAG", "").lower() in ("true", ...)``
     # semantics for the two ex-direct-getenv flags: an empty env var
     # value MUST be treated as False rather than raising
@@ -1500,6 +1520,10 @@ BACKUP_OVERRIDE_FIELDS: tuple[BackupOverrideField, ...] = (
         "HAMCP_AUTO_BACKUP_CALENDAR_LOOKAHEAD_DAYS",
         int,
     ),
+    BackupOverrideField("enable_snapshot_delete", "ENABLE_SNAPSHOT_DELETE", bool),
+    BackupOverrideField(
+        "snapshot_delete_min_age_days", "SNAPSHOT_DELETE_MIN_AGE_DAYS", int
+    ),
 )
 
 # Override-file location is the same data dir that holds tool_config.json
@@ -1651,6 +1675,13 @@ def _coerce_backup_int_value(field_name: str, raw: object) -> tuple[bool, Any]:
         logger.warning(
             "backup_settings.json: auto_backup_calendar_lookahead_days=%d out of "
             "range 1..365; ignoring",
+            coerced,
+        )
+        return False, None
+    if field_name == "snapshot_delete_min_age_days" and not 0 <= coerced <= 365:
+        logger.warning(
+            "backup_settings.json: snapshot_delete_min_age_days=%d out of "
+            "range 0..365; ignoring",
             coerced,
         )
         return False, None

--- a/src/ha_mcp/settings_ui/_handlers_backups.py
+++ b/src/ha_mcp/settings_ui/_handlers_backups.py
@@ -278,6 +278,7 @@ _BACKUP_INT_BOUNDS: dict[str, tuple[int, int]] = {
     "auto_backup_throttle_minutes": (0, 1440),
     "auto_backup_retain_per_entity": (1, 10_000),
     "auto_backup_calendar_lookahead_days": (1, 365),
+    "snapshot_delete_min_age_days": (0, 365),
 }
 
 

--- a/src/ha_mcp/settings_ui/settings.js
+++ b/src/ha_mcp/settings_ui/settings.js
@@ -1053,6 +1053,14 @@ const BACKUP_FIELD_LABELS = {
     label: 'Calendar lookahead (days)',
     help: 'How far ahead to query for calendar events when capturing pre-edit snapshots. Range 1–365.',
   },
+  enable_snapshot_delete: {
+    label: 'Allow snapshot deletion',
+    help: 'Lets ha_manage_backup delete full HA snapshot tarballs. Off by default: a snapshot may be the last recovery point after a mistaken change. Even when on, scheduled backups, the newest remaining snapshot, and anything younger than the age floor below stay protected.',
+  },
+  snapshot_delete_min_age_days: {
+    label: 'Minimum snapshot age to delete (days)',
+    help: 'A snapshot must be at least this old before it can be deleted. Range 0–365; 0 disables the floor (the newest-snapshot and scheduled-backup protections still apply).',
+  },
 };
 
 const BACKUP_ORIGIN_LABELS = {
@@ -1104,6 +1112,7 @@ function renderBackupConfig() {
       let max = 10000;
       if (f.field === 'auto_backup_throttle_minutes') { min = 0; max = 1440; }
       else if (f.field === 'auto_backup_calendar_lookahead_days') { min = 1; max = 365; }
+      else if (f.field === 'snapshot_delete_min_age_days') { min = 0; max = 365; }
       controlHtml = `<input type="number" name="backup:${escapeHtml(f.field)}" data-field="${escapeHtml(f.field)}" aria-labelledby="label-backup-${escapeHtml(f.field)}" value="${Number(f.value)}" min="${min}" max="${max}" ${f.editable ? '' : 'disabled'}>`;
     }
     let originMsg;

--- a/src/ha_mcp/tools/backup.py
+++ b/src/ha_mcp/tools/backup.py
@@ -75,6 +75,13 @@ _BACKUP_DATE_FILTER_TOLERANCE_S = 5
 # progress for 300s"). Independent of poll_interval so a tight poll loop
 # doesn't flood the client with redundant notifications.
 _BACKUP_PROGRESS_INTERVAL_S = 10
+# backup/delete fans out to every configured agent (including cloud/remote
+# ones — S3, Google Drive, WebDAV, etc.) via asyncio.gather server-side, and
+# the WS response doesn't arrive until all of them finish. The client's
+# default 30s wait (HomeAssistantWebSocketClient.send_command's
+# _wait_timeout) can be too tight for a slow or rate-limited remote agent —
+# same class of false-timeout problem this file already fixes for creation.
+_BACKUP_DELETE_WAIT_S = 60.0
 
 
 def _get_backup_hint_text() -> str:
@@ -1045,7 +1052,10 @@ async def delete_backup(
     1. ``confirm=True`` is required.
     2. The backup must exist (verified against ``backup/info``, mirroring
        ``restore_backup`` — HA's own ``backup/delete`` silently no-ops on
-       an unknown ID rather than erroring).
+       an unknown ID rather than erroring). If ``backup/info`` itself
+       reports ``agent_errors`` (an agent failed to enumerate its backups),
+       the returned list may be incomplete — refuse deletion rather than
+       evaluate the guards below against a possibly-partial view.
     3. Scheduled backups (``with_automatic_settings=True``) are never
        deletable.
     4. The single newest remaining snapshot, of any type, is never
@@ -1055,8 +1065,13 @@ async def delete_backup(
        a "too young" message whose suggested remedy (lower the floor)
        would not actually unblock it.
     5. The target must be older than ``snapshot_delete_min_age_days`` (0
-       disables this floor). A missing/unparseable date fails closed
-       (treated as too new to delete).
+       unconditionally disables this floor, even across clock skew between
+       this host and the HA instance that stamped the backup's date). A
+       missing/unparseable date fails closed (treated as too new to delete).
+
+    The actual ``backup/delete`` call uses an elevated WS wait timeout
+    (``_BACKUP_DELETE_WAIT_S``) since it fans out to every configured agent
+    — including slow/rate-limited remote ones — server-side.
 
     Raises ToolError if disabled, unconfirmed, not found, blocked by a
     guard, or if HA reports a per-agent deletion failure.
@@ -1099,7 +1114,20 @@ async def delete_backup(
                     info_result.get("error", "Failed to retrieve backup information"),
                 )
             )
-        backups = (info_result.get("result") or {}).get("backups") or []
+        info_result_block = info_result.get("result") or {}
+        info_agent_errors = info_result_block.get("agent_errors") or {}
+        if info_agent_errors:
+            raise_tool_error(
+                create_error_response(
+                    ErrorCode.SERVICE_CALL_FAILED,
+                    "Cannot verify the backup inventory is complete: one or "
+                    "more backup agents failed to respond, so the newest-"
+                    "snapshot and scheduled-backup guards can't be trusted "
+                    "against a possibly-partial list.",
+                    context={"backup_id": backup_id, "agent_errors": info_agent_errors},
+                )
+            )
+        backups = info_result_block.get("backups") or []
         matched = next((b for b in backups if b.get("backup_id") == backup_id), None)
         if matched is None:
             raise_tool_error(
@@ -1145,7 +1173,11 @@ async def delete_backup(
                 backup_id=backup_id,
             )
         cutoff = datetime.now(UTC) - timedelta(days=min_age_days)
-        if target_date > cutoff:
+        # min_age_days=0 must unconditionally disable the floor, even if
+        # target_date is slightly ahead of this host's clock (clock skew
+        # vs the HA instance that stamped it) — guard explicitly rather
+        # than relying on the arithmetic reduction, which clock skew breaks.
+        if min_age_days > 0 and target_date > cutoff:
             _refuse_snapshot_delete(
                 f"Refusing to delete a backup younger than "
                 f"snapshot_delete_min_age_days={min_age_days} days — at "
@@ -1156,7 +1188,9 @@ async def delete_backup(
             )
 
         delete_result = await ws_client.send_command(
-            "backup/delete", backup_id=backup_id
+            "backup/delete",
+            backup_id=backup_id,
+            _wait_timeout=_BACKUP_DELETE_WAIT_S,
         )
         if not delete_result.get("success"):
             raise_tool_error(

--- a/src/ha_mcp/tools/backup.py
+++ b/src/ha_mcp/tools/backup.py
@@ -19,8 +19,9 @@ HA restore path. Each call must explicitly pick its scope.
 import asyncio
 import logging
 from datetime import UTC, datetime, timedelta
-from typing import TYPE_CHECKING, Annotated, Any, Literal, cast
+from typing import TYPE_CHECKING, Annotated, Any, Literal, NoReturn, cast
 
+from fastmcp import Context
 from fastmcp.exceptions import ToolError
 from pydantic import Field
 
@@ -38,6 +39,7 @@ from .helpers import (
     get_connected_ws_client,
     log_tool_usage,
     raise_tool_error,
+    safe_progress,
 )
 
 if TYPE_CHECKING:
@@ -45,12 +47,19 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-# Default poll window for full HA backups. The 120s prior default underfit
-# slow HA instances (#1433: poll loop exited while HA was still in
-# state="create_backup", the wrapper treated that as failure, retried, and
-# produced duplicate backups). 300s covers the long tail without making the
-# happy-path wait noticeable.
-_BACKUP_MAX_WAIT_S = 300
+# Poll window for full HA backups. HA's own frontend imposes no timeout at
+# all on backup creation — it subscribes to `backup/subscribe_events` and
+# waits however long the job takes. Our poll-based design still needs a
+# finite bound per tool call, so this mirrors _SAFETY_BACKUP_MAX_WAIT_S (the
+# codebase's existing "generous but bounded" ceiling) rather than inventing a
+# third number. The prior 300s was tighter than the reported case (#1861: a
+# client that received no MCP progress notifications for 300s concluded the
+# connection was dead and aborted, even though the snapshot can legitimately
+# take >5 minutes and continues running server-side after the client gives
+# up). 120s before that underfit slow HA instances too (#1433: poll loop
+# exited while HA was still in state="create_backup", the wrapper treated
+# that as failure, retried, and produced duplicate backups).
+_BACKUP_MAX_WAIT_S = 1800
 _BACKUP_POLL_INTERVAL_S = 2
 # The pre-restore safety backup is a *full* backup (include_database=True, plus
 # all add-ons on Supervised), unlike the fast create_backup path. A multi-GB
@@ -60,6 +69,12 @@ _BACKUP_POLL_INTERVAL_S = 2
 _SAFETY_BACKUP_MAX_WAIT_S = 1800
 # Clock-skew tolerance when filtering backup entries by date vs job-start.
 _BACKUP_DATE_FILTER_TOLERANCE_S = 5
+# Minimum spacing between in-loop MCP progress heartbeats during a backup
+# poll (#1861: with no progress notifications at all, a client can decide
+# the connection is dead and abort mid-backup — "sent no response or
+# progress for 300s"). Independent of poll_interval so a tight poll loop
+# doesn't flood the client with redundant notifications.
+_BACKUP_PROGRESS_INTERVAL_S = 10
 
 
 def _get_backup_hint_text() -> str:
@@ -288,6 +303,7 @@ async def _poll_backup_completion(
     max_wait_seconds: int,
     poll_interval: int,
     agent_id: str,
+    ctx: Context | None = None,
 ) -> dict[str, Any]:
     """Poll backup/info until the named backup completes, fails, or times out.
 
@@ -304,14 +320,34 @@ async def _poll_backup_completion(
     creation in progress, surfaces ``likely_in_progress=true`` in the error
     context so callers can back off retries instead of compounding duplicates.
 
+    ``ctx``, when supplied, receives a ``report_progress`` heartbeat before
+    the first poll and at least every ``_BACKUP_PROGRESS_INTERVAL_S`` while
+    waiting, so an MCP client watching for "no response or progress" doesn't
+    abort the connection mid-backup (#1861).
+
     Raises ToolError on backup failure or final timeout with no completion.
     """
     job_start_ts = datetime.now(UTC)
     waited = 0
+    next_progress_at = _BACKUP_PROGRESS_INTERVAL_S
+    await safe_progress(
+        ctx,
+        progress=0,
+        total=max_wait_seconds,
+        message="waiting for backup to complete",
+    )
 
     while waited < max_wait_seconds:
         await asyncio.sleep(poll_interval)
         waited += poll_interval
+        if waited >= next_progress_at:
+            await safe_progress(
+                ctx,
+                progress=waited,
+                total=max_wait_seconds,
+                message=f"waiting for backup to complete ({waited}s elapsed)",
+            )
+            next_progress_at = waited + _BACKUP_PROGRESS_INTERVAL_S
 
         info_result = await ws_client.send_command("backup/info")
         if not info_result.get("success"):
@@ -448,7 +484,9 @@ async def _poll_backup_completion(
 
 
 async def create_backup(
-    client: HomeAssistantClient, name: str | None = None
+    client: HomeAssistantClient,
+    name: str | None = None,
+    ctx: Context | None = None,
 ) -> dict[str, Any]:
     """
     Create a fast Home Assistant backup (local only, excludes database).
@@ -456,6 +494,7 @@ async def create_backup(
     Args:
         client: Home Assistant REST client
         name: Optional backup name (auto-generated if not provided)
+        ctx: Optional FastMCP context for progress heartbeats during the wait
 
     Returns:
         Dictionary with backup result including backup_id, status, duration, etc.
@@ -528,6 +567,7 @@ async def create_backup(
             max_wait_seconds=_BACKUP_MAX_WAIT_S,
             poll_interval=_BACKUP_POLL_INTERVAL_S,
             agent_id=local_agent,
+            ctx=ctx,
         )
 
     except ToolError:
@@ -558,6 +598,7 @@ async def _create_safety_backup(
     ws_client: HomeAssistantWebSocketClient,
     password: str | None,
     agent_id: str,
+    ctx: Context | None = None,
 ) -> tuple[str | None, list[str]]:
     """Create a pre-restore safety backup and wait for it to complete.
 
@@ -620,6 +661,7 @@ async def _create_safety_backup(
         max_wait_seconds=_SAFETY_BACKUP_MAX_WAIT_S,
         poll_interval=_BACKUP_POLL_INTERVAL_S,
         agent_id=agent_id,
+        ctx=ctx,
     )
     logger.info(f"Safety backup completed: {safety_backup_id}")
     return cast(str, safety_backup_id), poll_result.get("warnings", [])
@@ -645,7 +687,10 @@ def _backup_protected(entry: dict[str, Any]) -> bool | None:
 
 
 async def restore_backup(
-    client: HomeAssistantClient, backup_id: str, restore_database: bool = False
+    client: HomeAssistantClient,
+    backup_id: str,
+    restore_database: bool = False,
+    ctx: Context | None = None,
 ) -> dict[str, Any]:
     """
     Restore Home Assistant from a backup (DESTRUCTIVE - use with caution).
@@ -661,6 +706,8 @@ async def restore_backup(
             match when restoring Home Assistant; a warning is returned if the
             value is overridden. On Core installs the caller's value is honoured
             as-is (Core enforces no such match).
+        ctx: Optional FastMCP context for progress heartbeats during the
+            pre-restore safety-backup wait
 
     Returns:
         Dictionary with restore result including safety_backup_id, status, etc.
@@ -722,7 +769,7 @@ async def restore_backup(
             password = None
 
         safety_backup_id, safety_warnings = await _create_safety_backup(
-            ws_client, password, local_agent
+            ws_client, password, local_agent, ctx=ctx
         )
 
         # `backup/info` returns ManagerBackup entries: `database_included` is a
@@ -950,12 +997,221 @@ async def list_backups(client: HomeAssistantClient, limit: int = 200) -> dict[st
         return None  # unreachable: exception_to_structured_error always raises
 
 
+def _refuse_snapshot_delete(message: str, **context: Any) -> NoReturn:
+    """Raise the shared VALIDATION_INVALID_PARAMETER shape for every
+    snapshot-delete guard rejection (gate, confirm, automatic-settings, age
+    floor, newest-snapshot protection)."""
+    raise_tool_error(
+        create_error_response(
+            ErrorCode.VALIDATION_INVALID_PARAMETER,
+            message,
+            context=context,
+        )
+    )
+
+
+def _newest_backup_id(backups: list[dict[str, Any]]) -> str | None:
+    """Return the ``backup_id`` of the single most-recent entry by date, or
+    None if no entry has a parseable date.
+
+    Entries with a missing/malformed date are excluded from consideration —
+    they can never be "the newest" — but that does not make them safe to
+    delete; ``delete_backup`` fails closed on an unparseable *target* date
+    separately, before this function is ever consulted for the target.
+    """
+    dated = [
+        (b.get("backup_id"), parsed)
+        for b in backups
+        if (parsed := _parse_backup_date(b.get("date"))) is not None
+    ]
+    if not dated:
+        return None
+    return max(dated, key=lambda pair: pair[1])[0]
+
+
+async def delete_backup(
+    client: HomeAssistantClient,
+    backup_id: str,
+    confirm: bool = False,
+    ctx: Context | None = None,
+) -> dict[str, Any]:
+    """Delete one full HA snapshot tarball (#1861).
+
+    Off by default (``enable_snapshot_delete``) — a human must opt in via
+    env var, the web settings UI override file, or (in the add-on) the
+    Supervisor options; an agent cannot enable this itself. Layered guards
+    beyond the gate, applied in order:
+
+    1. ``confirm=True`` is required.
+    2. The backup must exist (verified against ``backup/info``, mirroring
+       ``restore_backup`` — HA's own ``backup/delete`` silently no-ops on
+       an unknown ID rather than erroring).
+    3. Scheduled backups (``with_automatic_settings=True``) are never
+       deletable.
+    4. The single newest remaining snapshot, of any type, is never
+       deletable — guarantees at least one recovery point always survives.
+       Checked before the age floor below so a backup that is both the
+       newest AND too young reports "newest" (with its own remedy), not
+       a "too young" message whose suggested remedy (lower the floor)
+       would not actually unblock it.
+    5. The target must be older than ``snapshot_delete_min_age_days`` (0
+       disables this floor). A missing/unparseable date fails closed
+       (treated as too new to delete).
+
+    Raises ToolError if disabled, unconfirmed, not found, blocked by a
+    guard, or if HA reports a per-agent deletion failure.
+    """
+    settings = get_global_settings()
+    if not settings.enable_snapshot_delete:
+        _refuse_snapshot_delete(
+            "Snapshot deletion is disabled on this server "
+            "(enable_snapshot_delete=false). A human must enable it via the "
+            "ENABLE_SNAPSHOT_DELETE env var, the web settings UI, or (in "
+            "the add-on) the Supervisor options — this cannot be turned on "
+            "from a tool call.",
+        )
+    if not confirm:
+        _refuse_snapshot_delete(
+            "Deletion not confirmed. Set confirm=True to delete a snapshot.",
+            backup_id=backup_id,
+        )
+
+    ws_client = None
+    try:
+        ws_client, error = await get_connected_ws_client(
+            client.base_url, client.token, verify_ssl=client.verify_ssl
+        )
+        if error:
+            raise_tool_error(
+                error
+                or create_error_response(
+                    ErrorCode.CONNECTION_FAILED,
+                    "Failed to connect to Home Assistant WebSocket for backup deletion",
+                )
+            )
+        ws_client = cast(HomeAssistantWebSocketClient, ws_client)
+
+        info_result = await ws_client.send_command("backup/info")
+        if not info_result.get("success"):
+            raise_tool_error(
+                create_error_response(
+                    ErrorCode.SERVICE_CALL_FAILED,
+                    info_result.get("error", "Failed to retrieve backup information"),
+                )
+            )
+        backups = info_result.get("result", {}).get("backups", [])
+        matched = next((b for b in backups if b.get("backup_id") == backup_id), None)
+        if matched is None:
+            raise_tool_error(
+                create_error_response(
+                    ErrorCode.RESOURCE_NOT_FOUND,
+                    f"Backup '{backup_id}' not found",
+                    suggestions=[
+                        "Use ha_manage_backup(scope='snapshot', action='list') "
+                        "to see available backup IDs",
+                    ],
+                )
+            )
+
+        if matched.get("with_automatic_settings"):
+            _refuse_snapshot_delete(
+                "Refusing to delete a scheduled (automatic) backup — those "
+                "are managed by Home Assistant's own retention settings, "
+                "not this tool.",
+                backup_id=backup_id,
+            )
+
+        # Checked before the age floor below: a backup that is BOTH the
+        # newest AND too young must report "newest" (create a new one
+        # first), not "too young" — the age-floor message's remedy
+        # ("lower snapshot_delete_min_age_days") would be actively
+        # misleading advice for the newest snapshot, which stays
+        # protected at any age floor including 0.
+        newest_id = _newest_backup_id(backups)
+        if newest_id == backup_id:
+            _refuse_snapshot_delete(
+                "Refusing to delete the newest snapshot — at least one "
+                "recovery point must remain. Create a new snapshot first "
+                "if you specifically need to free this one's space.",
+                backup_id=backup_id,
+            )
+
+        min_age_days = settings.snapshot_delete_min_age_days
+        target_date = _parse_backup_date(matched.get("date"))
+        if target_date is None:
+            _refuse_snapshot_delete(
+                "Refusing to delete a backup with a missing or unparseable "
+                "date — cannot verify it clears the minimum-age floor.",
+                backup_id=backup_id,
+            )
+        cutoff = datetime.now(UTC) - timedelta(days=min_age_days)
+        if target_date > cutoff:
+            _refuse_snapshot_delete(
+                f"Refusing to delete a backup younger than "
+                f"snapshot_delete_min_age_days={min_age_days} days — at "
+                "least one recent recovery point must remain. Delete an "
+                "older backup, or lower snapshot_delete_min_age_days if "
+                "this recurs.",
+                backup_id=backup_id,
+            )
+
+        delete_result = await ws_client.send_command(
+            "backup/delete", backup_id=backup_id
+        )
+        if not delete_result.get("success"):
+            raise_tool_error(
+                create_error_response(
+                    ErrorCode.SERVICE_CALL_FAILED,
+                    delete_result.get("error", "Backup deletion failed"),
+                    context={"backup_id": backup_id},
+                )
+            )
+        agent_errors = delete_result.get("result", {}).get("agent_errors") or {}
+        if agent_errors:
+            raise_tool_error(
+                create_error_response(
+                    ErrorCode.SERVICE_CALL_FAILED,
+                    "Backup deletion failed on one or more agents",
+                    context={"backup_id": backup_id, "agent_errors": agent_errors},
+                )
+            )
+
+        return {
+            "success": True,
+            "backup_id": backup_id,
+            "name": matched.get("name"),
+            "status": "Backup deleted successfully",
+        }
+
+    except ToolError:
+        raise
+    except Exception as e:
+        logger.error(f"Error deleting backup: {e}")
+        exception_to_structured_error(
+            e,
+            context={"tool": "delete_backup", "backup_id": backup_id},
+            suggestions=["Check Home Assistant connection and backup availability"],
+        )
+        return None  # unreachable: exception_to_structured_error always raises
+    finally:
+        if ws_client:
+            try:
+                await ws_client.disconnect()
+            except (TimeoutError, OSError, ConnectionError) as err:
+                logger.debug(
+                    "ws disconnect (cleanup) transport error: %s: %s",
+                    type(err).__name__,
+                    err,
+                )
+
+
 # Valid (scope, action) combinations. Anything outside this set is
 # rejected with a structured VALIDATION_INVALID_PARAMETER error.
 _VALID_COMBOS: set[tuple[str, str]] = {
     ("snapshot", "create"),
     ("snapshot", "list"),
     ("snapshot", "restore"),
+    ("snapshot", "delete"),
     ("edits", "create"),
     ("edits", "list"),
     ("edits", "view"),
@@ -1019,9 +1275,10 @@ def register_backup_tools(
 
 | scope | action | What it does |
 |---|---|---|
-| `snapshot` | `create` | Create a full HA tarball (config + addons, no DB by default). Heavy, seconds-long. |
+| `snapshot` | `create` | Create a full HA tarball (config + addons, no DB by default). Can take a while on a large instance; progress heartbeats are sent while waiting. |
 | `snapshot` | `list` | List full HA tarball snapshots (id, name, date, size). Read-only — use to discover a `backup_id` or confirm a backup landed. |
 | `snapshot` | `restore` | Restore a full HA tarball. **Restarts HA.** Last-resort recovery. |
+| `snapshot` | `delete` | Delete one full HA tarball by `backup_id` (`confirm=True` required). **Disabled by default** (`enable_snapshot_delete` setting) and layered with guards even when enabled — see below. |
 | `edits` | `create` | On-demand snapshot of one entity (`domain` + `entity_id` required). Use before the user manually edits in the HA UI. Same handler path the decorator takes on writes; bypasses the `enable_auto_backup` toggle. |
 | `edits` | `list` | List per-entity auto-backups (lightweight). Filter by `domain` and/or `entity_id`. |
 | `edits` | `view` | Read one auto-backup file by name; returns YAML and parsed `config`. |
@@ -1036,12 +1293,21 @@ def register_backup_tools(
 **`scope="snapshot"` backup-hint:**
 {backup_hint_text}
 
+**`(snapshot, delete)` is off by default and layered even when enabled:** a human must
+set `enable_snapshot_delete=true` (env var, web settings UI, or add-on Supervisor
+options) — an agent cannot turn this on itself. When enabled, a delete call is still
+refused if: the target is a scheduled/automatic backup; it's younger than
+`snapshot_delete_min_age_days` (default 7, 0 disables the floor); or it's the single
+newest snapshot remaining. These guarantee at least one recovery point always
+survives an agent's own mistakes.
+
 **`enable_auto_backup` and `scope="edits"`:** the automatic-on-write capture (every wrapped tool call) is gated by `enable_auto_backup=true` — if the listing is empty, check the toggle (web settings UI or `ENABLE_AUTO_BACKUP=true` env var). The explicit `(edits, create)` action bypasses the toggle since the request is explicit; `list` / `view` / `restore` / `delete` operate on whatever's already on disk regardless of the toggle's current state.
 
 **Examples:**
 - Snapshot before risky op: `ha_manage_backup(scope="snapshot", action="create", name="Before_Big_Change")`
 - List snapshots (to discover a backup_id or confirm one landed): `ha_manage_backup(scope="snapshot", action="list")`
 - Restore full snapshot: `ha_manage_backup(scope="snapshot", action="restore", backup_id="dd7550ed")`
+- Delete an old snapshot (requires `enable_snapshot_delete=true`): `ha_manage_backup(scope="snapshot", action="delete", backup_id="dd7550ed", confirm=True)`
 - On-demand entity snapshot before a manual UI edit: `ha_manage_backup(scope="edits", action="create", domain="helper_input_boolean", entity_id="kitchen_lights_active")`
 - List recent auto-backups for one automation: `ha_manage_backup(scope="edits", action="list", domain="automation", entity_id="kitchen_lights")`
 - View an auto-backup: `ha_manage_backup(scope="edits", action="view", backup_name="automation.kitchen_lights.20260521_153000.yaml")`
@@ -1082,7 +1348,7 @@ def register_backup_tools(
             str | None,
             Field(
                 default=None,
-                description="(snapshot.restore) Tarball ID to restore (e.g. 'dd7550ed').",
+                description="(snapshot.restore / snapshot.delete) Tarball ID (e.g. 'dd7550ed').",
             ),
         ] = None,
         restore_database: Annotated[
@@ -1090,6 +1356,16 @@ def register_backup_tools(
             Field(
                 default=False,
                 description="(snapshot.restore) Include database in the restore. Default false (config-only).",
+            ),
+        ] = False,
+        confirm: Annotated[
+            bool,
+            Field(
+                default=False,
+                description=(
+                    "(snapshot.delete) Must be True to confirm deletion — a "
+                    "safety measure against accidental calls."
+                ),
             ),
         ] = False,
         # edits scope params
@@ -1134,18 +1410,22 @@ def register_backup_tools(
                 description="(edits.list / snapshot.list) Maximum number of entries to return.",
             ),
         ] = 200,
+        ctx: Context | None = None,
     ) -> dict[str, Any]:
         """Polymorphic backup tool. See the tool description for the routing matrix."""
         _gate_combo(scope, action)
 
         if scope == "snapshot":
             if action == "create":
-                return await create_backup(client, name)
+                return await create_backup(client, name, ctx=ctx)
             if action == "list":
                 return await list_backups(client, limit)
+            if action == "delete":
+                bid = _require("backup_id", backup_id, scope, action)
+                return await delete_backup(client, bid, confirm, ctx=ctx)
             # action == "restore"
             bid = _require("backup_id", backup_id, scope, action)
-            return await restore_backup(client, bid, restore_database)
+            return await restore_backup(client, bid, restore_database, ctx=ctx)
 
         # scope == "edits"
         settings = get_global_settings()

--- a/src/ha_mcp/tools/backup.py
+++ b/src/ha_mcp/tools/backup.py
@@ -52,13 +52,20 @@ logger = logging.getLogger(__name__)
 # waits however long the job takes. Our poll-based design still needs a
 # finite bound per tool call, so this mirrors _SAFETY_BACKUP_MAX_WAIT_S (the
 # codebase's existing "generous but bounded" ceiling) rather than inventing a
-# third number. The prior 300s was tighter than the reported case (#1861: a
-# client that received no MCP progress notifications for 300s concluded the
-# connection was dead and aborted, even though the snapshot can legitimately
-# take >5 minutes and continues running server-side after the client gives
-# up). 120s before that underfit slow HA instances too (#1433: poll loop
-# exited while HA was still in state="create_backup", the wrapper treated
-# that as failure, retried, and produced duplicate backups).
+# third number.
+#
+# Two distinct problems, both fixed in the same PR, by different mechanisms:
+# the client-side abort reported in #1861 (an MCP client that received no
+# progress notifications for 300s concluded the connection was dead) is
+# fixed by the ctx.report_progress heartbeats in _poll_backup_completion,
+# not by this constant. Raising it from 300 to 1800 instead fixes *our own*
+# poll loop giving up on a legitimately >5-minute backup — the job keeps
+# running server-side after our loop times out, so a too-tight ceiling here
+# means _poll_backup_completion raises TIMEOUT_OPERATION on a backup that
+# would otherwise have succeeded. 120s before that underfit slow HA
+# instances too (#1433: poll loop exited while HA was still in
+# state="create_backup", the wrapper treated that as failure, retried, and
+# produced duplicate backups).
 _BACKUP_MAX_WAIT_S = 1800
 _BACKUP_POLL_INTERVAL_S = 2
 # The pre-restore safety backup is a *full* backup (include_database=True, plus
@@ -1023,8 +1030,9 @@ def _newest_backup_id(backups: list[dict[str, Any]]) -> str | None:
 
     Entries with a missing/malformed date are excluded from consideration —
     they can never be "the newest" — but that does not make them safe to
-    delete; ``delete_backup`` fails closed on an unparseable *target* date
-    separately, before this function is ever consulted for the target.
+    delete; ``delete_backup`` fails closed on an unparseable target date
+    separately, so an undated target can never be deleted regardless of
+    this function's result.
     """
     dated = [
         (b.get("backup_id"), parsed)
@@ -1050,14 +1058,18 @@ async def delete_backup(
     beyond the gate, applied in order:
 
     1. ``confirm=True`` is required.
-    2. The backup must exist (verified against ``backup/info``, mirroring
-       ``restore_backup`` — HA's own ``backup/delete`` silently no-ops on
-       an unknown ID rather than erroring). If ``backup/info`` itself
-       reports ``agent_errors`` (an agent failed to enumerate its backups),
-       the returned list may be incomplete — refuse deletion rather than
-       evaluate the guards below against a possibly-partial view.
+    2. ``backup/info`` must not report ``agent_errors`` — evaluated before
+       the "does it exist" check right below, since an agent that failed
+       to enumerate its backups could make that list (and every guard
+       below) incomplete. The backup must then exist (verified against
+       ``backup/info``, mirroring ``restore_backup`` — HA's own
+       ``backup/delete`` silently no-ops on an unknown ID rather than
+       erroring).
     3. Scheduled backups (``with_automatic_settings=True``) are never
-       deletable.
+       deletable. Fails closed the same way when HA can't confirm the
+       backup is manual (``with_automatic_settings=None`` — not created
+       by this HA instance, or predates this metadata field): only an
+       explicit ``False`` is treated as deletable.
     4. The single newest remaining snapshot, of any type, is never
        deletable — guarantees at least one recovery point always survives.
        Checked before the age floor below so a backup that is both the
@@ -1071,7 +1083,9 @@ async def delete_backup(
 
     The actual ``backup/delete`` call uses an elevated WS wait timeout
     (``_BACKUP_DELETE_WAIT_S``) since it fans out to every configured agent
-    — including slow/rate-limited remote ones — server-side.
+    — including slow/rate-limited remote ones — server-side. ``ctx``, when
+    supplied, receives one ``report_progress`` heartbeat immediately before
+    that call.
 
     Raises ToolError if disabled, unconfirmed, not found, blocked by a
     guard, or if HA reports a per-agent deletion failure.
@@ -1141,11 +1155,13 @@ async def delete_backup(
                 )
             )
 
-        if matched.get("with_automatic_settings"):
+        if matched.get("with_automatic_settings") is not False:
             _refuse_snapshot_delete(
-                "Refusing to delete a scheduled (automatic) backup — those "
-                "are managed by Home Assistant's own retention settings, "
-                "not this tool.",
+                "Refusing to delete a scheduled (automatic) backup, or one "
+                "whose automatic/manual origin Home Assistant cannot "
+                "confirm (with_automatic_settings=None — not created by "
+                "this HA instance, or predates this metadata) — treated "
+                "as not provably manual, and therefore not deletable.",
                 backup_id=backup_id,
             )
 
@@ -1187,6 +1203,12 @@ async def delete_backup(
                 backup_id=backup_id,
             )
 
+        await safe_progress(
+            ctx,
+            progress=0,
+            total=_BACKUP_DELETE_WAIT_S,
+            message="deleting backup",
+        )
         delete_result = await ws_client.send_command(
             "backup/delete",
             backup_id=backup_id,

--- a/src/ha_mcp/tools/backup.py
+++ b/src/ha_mcp/tools/backup.py
@@ -1099,7 +1099,7 @@ async def delete_backup(
                     info_result.get("error", "Failed to retrieve backup information"),
                 )
             )
-        backups = info_result.get("result", {}).get("backups", [])
+        backups = (info_result.get("result") or {}).get("backups") or []
         matched = next((b for b in backups if b.get("backup_id") == backup_id), None)
         if matched is None:
             raise_tool_error(
@@ -1166,7 +1166,7 @@ async def delete_backup(
                     context={"backup_id": backup_id},
                 )
             )
-        agent_errors = delete_result.get("result", {}).get("agent_errors") or {}
+        agent_errors = (delete_result.get("result") or {}).get("agent_errors") or {}
         if agent_errors:
             raise_tool_error(
                 create_error_response(

--- a/tests/src/e2e/conftest.py
+++ b/tests/src/e2e/conftest.py
@@ -151,6 +151,16 @@ _EMBEDDED_FEATURE_FLAGS: dict[str, bool] = {
     # keyless writes aren't hard-blocked.
     "enable_strict_mandatory_bps": False,
 }
+# BACKUP_OVERRIDE_FIELDS (not FEATURE_FLAG_FIELDS) values for the embedded
+# server — a separate override file (backup_settings.json) from
+# _EMBEDDED_FEATURE_FLAGS's feature_flags.json, since ha_mcp.config reads the
+# two registries from different files. Mirrors the ENABLE_SNAPSHOT_DELETE env
+# var the container backend sets directly (#1861); the embedded server can't
+# read that env, so it goes through this file instead, same rationale as
+# _EMBEDDED_FEATURE_FLAGS above.
+_EMBEDDED_BACKUP_OVERRIDES: dict[str, bool] = {
+    "enable_snapshot_delete": True,
+}
 # Boot budgets for the embedded path. The wheel + its dependency tree is
 # preinstalled in the container entrypoint BEFORE HA's /init (so bring-up is
 # fast + deterministic), which delays /api/ liveness by the pip window — hence a
@@ -807,9 +817,9 @@ def _install_embedded_server(config_path: Path, wheel_name: str) -> None:
     The ha_mcp_tools component itself is already copied by
     ``_install_custom_component`` (which also seeds the "tools" services entry);
     the in-process server is a SECOND config entry of that same component,
-    discriminated by ``data.entry_type == "server"``. Two pieces here, laid down
-    before the container boots (so a post-boot host write to the bind mount
-    doesn't have to propagate, matching the other pre-boot seeders):
+    discriminated by ``data.entry_type == "server"``. Three pieces here, laid
+    down before the container boots (so a post-boot host write to the bind
+    mount doesn't have to propagate, matching the other pre-boot seeders):
 
     1. Seed the server config entry with the stable webhook id/secret (so the
        mcp_client fixture knows the connect URL) and a ``file://`` ``pip_spec``
@@ -824,6 +834,10 @@ def _install_embedded_server(config_path: Path, wheel_name: str) -> None:
        ``ha_mcp.config`` reads in a standalone deployment (the embedded server is
        standalone: ``is_running_in_addon()`` is False in embedded mode, so the
        file is honored rather than short-circuited by Supervisor).
+    3. Write the backup-settings override file (``backup_settings.json``,
+       ``_EMBEDDED_BACKUP_OVERRIDES``) the same way, for ``BACKUP_OVERRIDE_FIELDS``
+       values (e.g. ``enable_snapshot_delete``) — a separate registry from
+       ``FEATURE_FLAG_FIELDS``, read from a separate override file.
     """
     storage_file = config_path / ".storage" / "core.config_entries"
     data = json.loads(storage_file.read_text())
@@ -871,8 +885,12 @@ def _install_embedded_server(config_path: Path, wheel_name: str) -> None:
     (server_data_dir / "feature_flags.json").write_text(
         json.dumps(_EMBEDDED_FEATURE_FLAGS, indent=2)
     )
+    (server_data_dir / "backup_settings.json").write_text(
+        json.dumps(_EMBEDDED_BACKUP_OVERRIDES, indent=2)
+    )
     logger.info(
-        "Seeded ha_mcp_tools in-process server config entry + feature-flag overrides"
+        "Seeded ha_mcp_tools in-process server config entry + feature-flag "
+        "+ backup-setting overrides"
     )
 
 
@@ -1542,16 +1560,25 @@ def ha_container_with_fresh_config(request):
         # Must run before boot (offline qcow2 edit), like the refreshers above.
         stage_embedded_server_wheel_in_qcow2(image_path)
         # haos_embedded lane only: the WHOLE suite runs through the in-process
-        # server, so deliver the same feature-flag overrides the container
-        # ``embedded`` backend injects (yaml editing, filesystem tools, custom
-        # component integration, …) into <config>/.ha_mcp/feature_flags.json.
+        # server, so deliver the same settings overrides the container
+        # ``embedded`` backend injects — feature flags (yaml editing, filesystem
+        # tools, custom component integration, …) into
+        # <config>/.ha_mcp/feature_flags.json, and separately the
+        # BACKUP_OVERRIDE_FIELDS values (enable_snapshot_delete, #1861) into
+        # <config>/.ha_mcp/backup_settings.json — two different override files
+        # since ha_mcp.config reads the two registries separately.
         # Gated to this lane so the external / inaddon lanes (green) are untouched —
-        # their only embedded consumer is the smoke test, which needs no flags.
+        # their only embedded consumer is the smoke test, which needs no overrides.
         # Hard-raises on failure (unlike the best-effort wheel staging): the suite
-        # depends on these flags, so a delivery failure should fail setup loudly.
+        # depends on these overrides, so a delivery failure should fail setup loudly.
         if haos_embedded:
             stage_embedded_server_feature_flags_in_qcow2(
                 image_path, _EMBEDDED_FEATURE_FLAGS
+            )
+            stage_embedded_server_feature_flags_in_qcow2(
+                image_path,
+                _EMBEDDED_BACKUP_OVERRIDES,
+                filename="backup_settings.json",
             )
         # Inaddon mode: overwrite the baked addon source with PR's current
         # source + bump config.yaml version so Supervisor detects an

--- a/tests/src/e2e/conftest.py
+++ b/tests/src/e2e/conftest.py
@@ -1581,6 +1581,10 @@ def ha_container_with_fresh_config(request):
             # pin it OFF so the suite's keyless writes aren't hard-blocked. The
             # strict-gate e2e test builds its own server with the flag enabled.
             os.environ["ENABLE_STRICT_MANDATORY_BPS"] = "false"
+            # Snapshot deletion (#1861) defaults OFF in production; enabled
+            # here so the e2e suite can cover the (snapshot, delete) guard
+            # chain against a disposable test HAOS instance.
+            os.environ["ENABLE_SNAPSHOT_DELETE"] = "true"
             _reset_ha_in_process_caches()
             # Mirrors the sun.sun + entity wait loop in the testcontainer
             # branch of ha_container_with_fresh_config: the first tests reach
@@ -2108,6 +2112,10 @@ def ha_container_with_fresh_config(request):
         # OFF so the suite's keyless writes aren't hard-blocked. The strict-gate
         # e2e test builds its own server with the flag enabled.
         os.environ["ENABLE_STRICT_MANDATORY_BPS"] = "false"
+        # Snapshot deletion (#1861) defaults OFF in production; enabled here so
+        # the e2e suite can cover the (snapshot, delete) guard chain against a
+        # disposable test container.
+        os.environ["ENABLE_SNAPSHOT_DELETE"] = "true"
 
         # Reset cached settings + WebSocket pool so subsequent client
         # lookups pick up the new container's URL.

--- a/tests/src/e2e/workflows/convenience/test_backup.py
+++ b/tests/src/e2e/workflows/convenience/test_backup.py
@@ -332,7 +332,25 @@ class TestSnapshotDelete:
     disk, since most guards run before or independent of state; the success
     path lowers ``snapshot_delete_min_age_days`` to 0 for the duration of
     the test so a just-created backup clears the age floor.
+
+    Skipped entirely on the HAOS inaddon tier: that tier runs the real dev
+    add-on against its own Supervisor-managed ``options.json`` (i.e.
+    ``config.yaml``'s shipped ``enable_snapshot_delete=false`` default),
+    which this suite has no per-run override mechanism for — unlike the
+    container-embedded / HAOS-embedded tiers, which get the setting via a
+    seeded ``backup_settings.json`` override file (there is no in-process
+    server to seed a file for; overriding would mean POSTing to the real
+    Supervisor options API).
     """
+
+    @pytest.fixture(autouse=True)
+    def _skip_on_haos_inaddon(self):
+        if os.environ.get("HAOS_TEST_MODE", "external") == "inaddon":
+            pytest.skip(
+                "HAOS inaddon tier has no mechanism to override the real "
+                "add-on's Supervisor-managed enable_snapshot_delete option "
+                "(shipped default is false)"
+            )
 
     async def test_delete_requires_confirm(self, mcp_client):
         logger.info("🗑️ Testing snapshot delete without confirm...")

--- a/tests/src/e2e/workflows/convenience/test_backup.py
+++ b/tests/src/e2e/workflows/convenience/test_backup.py
@@ -16,6 +16,7 @@ These tools are critical for configuration safety and disaster recovery.
 
 import asyncio
 import logging
+import os
 import time
 
 import pytest
@@ -28,6 +29,18 @@ logger = logging.getLogger(__name__)
 def _error_message(data: dict) -> str:
     error = data.get("error", {})
     return error.get("message", str(error)) if isinstance(error, dict) else str(error)
+
+
+def _server_is_out_of_process() -> bool:
+    """True when the MCP server under test runs in a separate process from
+    pytest: the container-embedded backend (E2E_BACKEND=embedded) or the
+    HAOS embedded/inaddon tiers all run ha-mcp inside the HA instance
+    itself. `monkeypatch.setenv` + `_reset_global_settings()` only affect
+    the pytest process's own Settings singleton, so they cannot reach a
+    server running in one of these modes."""
+    if os.environ.get("E2E_BACKEND", "").strip().lower() == "embedded":
+        return True
+    return os.environ.get("HAOS_TEST_MODE", "external") in ("embedded", "inaddon")
 
 
 @pytest.mark.convenience
@@ -417,6 +430,13 @@ class TestSnapshotDelete:
     ):
         """Full happy path: with the age floor disabled, an old-enough
         (non-newest) ad-hoc backup can actually be deleted end-to-end."""
+        if _server_is_out_of_process():
+            pytest.skip(
+                "monkeypatch.setenv cannot reach an out-of-process server "
+                "(container-embedded / HAOS embedded / HAOS inaddon); the "
+                "guard-rejection tests above already exercise the real "
+                "delete path end-to-end under those backends"
+            )
         logger.info("🗑️ Testing snapshot delete success path...")
 
         from ha_mcp.config import _reset_global_settings

--- a/tests/src/e2e/workflows/convenience/test_backup.py
+++ b/tests/src/e2e/workflows/convenience/test_backup.py
@@ -14,6 +14,7 @@ Tests for backup MCP tools that provide safety mechanisms:
 These tools are critical for configuration safety and disaster recovery.
 """
 
+import asyncio
 import logging
 import time
 
@@ -22,6 +23,11 @@ import pytest
 from ...utilities.assertions import safe_call_tool
 
 logger = logging.getLogger(__name__)
+
+
+def _error_message(data: dict) -> str:
+    error = data.get("error", {})
+    return error.get("message", str(error)) if isinstance(error, dict) else str(error)
 
 
 @pytest.mark.convenience
@@ -301,3 +307,181 @@ class TestBackupTools:
         except Exception as e:
             logger.error(f"❌ Password retrieval test failed: {e}")
             raise
+
+
+@pytest.mark.convenience
+class TestSnapshotDelete:
+    """E2E coverage for scope='snapshot', action='delete' (#1861).
+
+    ``ENABLE_SNAPSHOT_DELETE=true`` is set for the whole e2e suite (see
+    conftest.py) so these guard paths are reachable; production defaults
+    the feature off. Guard-rejection tests don't need an actual backup on
+    disk, since most guards run before or independent of state; the success
+    path lowers ``snapshot_delete_min_age_days`` to 0 for the duration of
+    the test so a just-created backup clears the age floor.
+    """
+
+    async def test_delete_requires_confirm(self, mcp_client):
+        logger.info("🗑️ Testing snapshot delete without confirm...")
+
+        data = await safe_call_tool(
+            mcp_client,
+            "ha_manage_backup",
+            {"scope": "snapshot", "action": "delete", "backup_id": "does-not-matter"},
+        )
+
+        assert data.get("success") is False, "Expected delete without confirm to fail"
+        assert "confirm" in _error_message(data).lower()
+
+    async def test_delete_nonexistent_backup_id(self, mcp_client):
+        logger.info("🗑️ Testing snapshot delete of a nonexistent backup id...")
+
+        data = await safe_call_tool(
+            mcp_client,
+            "ha_manage_backup",
+            {
+                "scope": "snapshot",
+                "action": "delete",
+                "backup_id": "nonexistent_backup_id_12345",
+                "confirm": True,
+            },
+        )
+
+        assert data.get("success") is False, (
+            "Expected delete to fail for a nonexistent backup"
+        )
+        assert "not found" in _error_message(data).lower()
+
+    async def test_delete_refuses_freshly_created_backup(self, mcp_client):
+        """The default 7-day age floor blocks deleting a backup created
+        moments ago — proves the guard is live end-to-end, not just at the
+        unit level.
+
+        A second, newer backup is created after the target so the target
+        is NOT also the single newest snapshot — otherwise the newest-
+        snapshot guard (checked first; see backup.py) would fire instead
+        of the age-floor guard this test is meant to isolate, since a
+        freshly created backup with nothing after it is trivially "newest"
+        in a shared test container.
+        """
+        logger.info("🗑️ Testing snapshot delete refuses a too-young backup...")
+
+        created = await safe_call_tool(
+            mcp_client,
+            "ha_manage_backup",
+            {
+                "scope": "snapshot",
+                "action": "create",
+                "name": f"E2E_Delete_TooYoung_{int(time.time())}",
+            },
+        )
+        if not created.get("success"):
+            if "password" in _error_message(created).lower():
+                pytest.skip("Test environment missing default backup password")
+            raise AssertionError(f"Backup creation failed: {_error_message(created)}")
+        backup_id = created["backup_id"]
+
+        await asyncio.sleep(1.1)
+
+        newer = await safe_call_tool(
+            mcp_client,
+            "ha_manage_backup",
+            {
+                "scope": "snapshot",
+                "action": "create",
+                "name": f"E2E_Delete_TooYoung_Newer_{int(time.time())}",
+            },
+        )
+        assert newer.get("success") is True, (
+            f"Second backup creation failed: {_error_message(newer)}"
+        )
+
+        data = await safe_call_tool(
+            mcp_client,
+            "ha_manage_backup",
+            {
+                "scope": "snapshot",
+                "action": "delete",
+                "backup_id": backup_id,
+                "confirm": True,
+            },
+        )
+
+        assert data.get("success") is False, (
+            "Expected delete to be refused for a freshly created backup"
+        )
+        assert "days" in _error_message(data).lower()
+
+    async def test_delete_succeeds_with_age_floor_disabled(
+        self, mcp_client, monkeypatch
+    ):
+        """Full happy path: with the age floor disabled, an old-enough
+        (non-newest) ad-hoc backup can actually be deleted end-to-end."""
+        logger.info("🗑️ Testing snapshot delete success path...")
+
+        from ha_mcp.config import _reset_global_settings
+
+        monkeypatch.setenv("SNAPSHOT_DELETE_MIN_AGE_DAYS", "0")
+        _reset_global_settings()
+
+        # Two backups so the target is never the single newest snapshot.
+        target = await safe_call_tool(
+            mcp_client,
+            "ha_manage_backup",
+            {
+                "scope": "snapshot",
+                "action": "create",
+                "name": f"E2E_Delete_Target_{int(time.time())}",
+            },
+        )
+        if not target.get("success"):
+            if "password" in _error_message(target).lower():
+                pytest.skip("Test environment missing default backup password")
+            raise AssertionError(f"Backup creation failed: {_error_message(target)}")
+
+        # Guarantee a distinct, strictly-later `date` for the second backup —
+        # `_newest_backup_id` picks the newest by date, and two creates close
+        # enough together could otherwise tie under coarse timestamp
+        # precision, making `target` spuriously look like the newest.
+        await asyncio.sleep(1.1)
+
+        newer = await safe_call_tool(
+            mcp_client,
+            "ha_manage_backup",
+            {
+                "scope": "snapshot",
+                "action": "create",
+                "name": f"E2E_Delete_Newer_{int(time.time())}",
+            },
+        )
+        assert newer.get("success") is True, (
+            f"Second backup creation failed: {_error_message(newer)}"
+        )
+
+        backup_id = target["backup_id"]
+        data = await safe_call_tool(
+            mcp_client,
+            "ha_manage_backup",
+            {
+                "scope": "snapshot",
+                "action": "delete",
+                "backup_id": backup_id,
+                "confirm": True,
+            },
+        )
+
+        assert data.get("success") is True, f"Snapshot delete failed: {data}"
+        assert data["backup_id"] == backup_id
+
+        # Verify it's actually gone via the list action.
+        listing = await safe_call_tool(
+            mcp_client,
+            "ha_manage_backup",
+            {"scope": "snapshot", "action": "list"},
+        )
+        remaining_ids = {b["backup_id"] for b in listing["backups"]}
+        assert backup_id not in remaining_ids, (
+            "Deleted backup_id still present in snapshot list"
+        )
+
+        logger.info("✅ Snapshot delete success path completed")

--- a/tests/src/haos_runtime.py
+++ b/tests/src/haos_runtime.py
@@ -870,19 +870,27 @@ _HAOS_EMBEDDED_SERVER_DATA_DIR = f"{_HAOS_CONFIG_DIR}/.ha_mcp"
 
 
 def stage_embedded_server_feature_flags_in_qcow2(
-    image_path: Path, feature_flags: dict[str, bool]
+    image_path: Path,
+    feature_flags: dict[str, bool],
+    *,
+    filename: str = "feature_flags.json",
 ) -> None:
-    """Write the in-process server's feature-flag override into the qcow2 (#1527).
+    """Write an in-process server settings-override file into the qcow2 (#1527).
 
     Only the ``haos_embedded`` lane calls this. On that lane the WHOLE E2E suite
-    runs through the in-process MCP server, so it needs the same feature flags
-    the container ``embedded`` backend injects (yaml-config editing, filesystem
-    tools, custom-component integration, …). The container backend delivers those
-    as pytest-process env vars for its in-process server; the HAOS embedded server
-    runs inside the core container and can't read that env, so the equivalent
-    values go to ``<config>/.ha_mcp/feature_flags.json`` — the override
-    layer ``ha_mcp.config`` reads in a standalone deployment. The server is
-    standalone here (``is_running_in_addon()`` is False in embedded mode despite
+    runs through the in-process MCP server, so it needs the same settings
+    overrides the container ``embedded`` backend injects — feature flags
+    (yaml-config editing, filesystem tools, custom-component integration, …) via
+    ``feature_flags.json``, and separately ``BACKUP_OVERRIDE_FIELDS`` values
+    (e.g. ``enable_snapshot_delete``, #1861) via ``backup_settings.json`` —
+    ``ha_mcp.config`` reads the two registries from two different override
+    files, so ``filename`` picks which one this call seeds. The container
+    backend delivers those as pytest-process env vars for its in-process
+    server; the HAOS embedded server runs inside the core container and can't
+    read that env, so the equivalent values go to
+    ``<config>/.ha_mcp/<filename>`` — the override layer ``ha_mcp.config``
+    reads in a standalone deployment. The server is standalone here
+    (``is_running_in_addon()`` is False in embedded mode despite
     ``SUPERVISOR_TOKEN`` in the core env), so the file is honored rather than
     short-circuited by Supervisor.
 
@@ -894,19 +902,19 @@ def stage_embedded_server_feature_flags_in_qcow2(
     ``ha_mcp_tools`` write_file service after boot. The integration's
     ``_prepare_config_dir`` does ``os.makedirs(..., exist_ok=True)``, so a
     pre-created dir + file is picked up rather than clobbered (proven on the
-    container embedded lane, which pre-seeds the identical file).
+    container embedded lane, which pre-seeds the identical files).
 
     Unlike the best-effort wheel staging, a failure here RAISES: the whole
-    haos_embedded suite depends on these flags, so failing session setup loudly
-    with a clear message beats letting dozens of feature-gated tests fail
-    confusingly downstream.
+    haos_embedded suite depends on these overrides, so failing session setup
+    loudly with a clear message beats letting dozens of feature-gated tests
+    fail confusingly downstream.
     """
     import shutil as _shutil
     import tempfile
 
     workdir = Path(tempfile.mkdtemp(prefix="haos-embedded-flags-"))
     try:
-        local = workdir / "feature_flags.json"
+        local = workdir / filename
         local.write_text(json.dumps(feature_flags, indent=2), encoding="utf-8")
         try:
             subprocess.run(
@@ -936,14 +944,15 @@ def stage_embedded_server_feature_flags_in_qcow2(
         except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as exc:
             stderr = (getattr(exc, "stderr", "") or "").strip()
             raise RuntimeError(
-                f"Failed to stage the embedded-server feature_flags.json into "
+                f"Failed to stage the embedded-server {filename} into "
                 f"{image_path} ({type(exc).__name__}"
                 + (f": {stderr[-300:]}" if stderr else "")
-                + "). The haos_embedded suite needs these flags; aborting session "
-                "setup rather than running the whole suite with default flags."
+                + f"). The haos_embedded suite needs {filename}; aborting session "
+                "setup rather than running the whole suite with default overrides."
             ) from exc
         LOG.info(
-            "Staged embedded-server feature_flags.json (%d flags) into %s in %s",
+            "Staged embedded-server %s (%d entries) into %s in %s",
+            filename,
             len(feature_flags),
             _HAOS_EMBEDDED_SERVER_DATA_DIR,
             image_path,

--- a/tests/src/unit/test_advanced_settings_coverage.py
+++ b/tests/src/unit/test_advanced_settings_coverage.py
@@ -388,6 +388,29 @@ def test_every_advanced_field_has_a_settings_js_label() -> None:
     )
 
 
+def test_every_backup_override_field_has_a_settings_js_label() -> None:
+    """The Backups-tab GET handler is data-driven over BACKUP_OVERRIDE_FIELDS,
+    but settings.js looks up each row's label/help in ``BACKUP_FIELD_LABELS``
+    (falling back to the raw snake_case field name). A row added to config.py
+    without a matching JS entry silently degrades the UI — same drift class
+    as ADVANCED_FIELD_META (issue #1538); caught here for #1861's
+    enable_snapshot_delete / snapshot_delete_min_age_days after they
+    initially shipped without entries."""
+    import re
+
+    js = (_package_dir() / "settings_ui" / "settings.js").read_text(encoding="utf-8")
+    m = re.search(r"const BACKUP_FIELD_LABELS = \{(.*?)\n\};", js, re.S)
+    assert m, "BACKUP_FIELD_LABELS object not found in settings.js"
+    label_keys = set(
+        re.findall(r"^\s*([A-Za-z_][A-Za-z0-9_]*)\s*:\s*\{", m.group(1), re.M)
+    )
+    missing = sorted({f.field for f in BACKUP_OVERRIDE_FIELDS} - label_keys)
+    assert not missing, (
+        "BACKUP_OVERRIDE_FIELDS rows missing a BACKUP_FIELD_LABELS entry in "
+        f"settings.js (they would render with a raw field-name label): {missing}."
+    )
+
+
 def test_screenshot_engine_url_is_surfaced_as_editable_advanced_field() -> None:
     """#1538: the screenshot engine URL is env-settable (docker/.env) but was
     invisible to add-on users. It must now be an editable Advanced row, no

--- a/tests/src/unit/test_backup_delete.py
+++ b/tests/src/unit/test_backup_delete.py
@@ -20,6 +20,10 @@ L2. An age floor (`snapshot_delete_min_age_days`, default 7) — count-based
 L3. The single newest remaining snapshot is never deletable, regardless of
     type — guarantees at least one recovery point always survives.
 Plus a `confirm=True` requirement as a cheap backstop.
+
+The L-numbers above are a taxonomy label, not the runtime evaluation
+sequence: `delete_backup` checks L3 (newest) before L2 (age floor) — see
+its docstring for why.
 """
 
 from datetime import UTC, datetime, timedelta
@@ -49,7 +53,7 @@ def _entry(
     backup_id: str,
     *,
     date: str,
-    with_automatic_settings: bool = False,
+    with_automatic_settings: bool | None = False,
     name: str = "Some_Backup",
 ) -> dict[str, Any]:
     return {
@@ -167,6 +171,29 @@ class TestSnapshotDeleteGuards:
         )
 
     @pytest.mark.asyncio
+    async def test_refuses_automatic_settings_backup_when_flag_is_none(self) -> None:
+        """L1 fails closed on `with_automatic_settings=None` (HA reports this
+        when a backup wasn't created by this instance, or predates the
+        metadata field) — an unknown origin must not be treated as
+        "confirmed manual"."""
+        old = _iso(_now() - timedelta(days=100))
+        newer = _iso(_now() - timedelta(days=1))
+        ws = _ws_client(
+            [
+                _entry("target", date=old, with_automatic_settings=None),
+                _entry("other", date=newer),
+            ]
+        )
+        settings = _settings(enabled=True)
+        p1, p2 = _patched(ws, settings)
+        with p1, p2, pytest.raises(ToolError) as exc_info:
+            await delete_backup(_client(), "target", confirm=True)
+        assert ErrorCode.VALIDATION_INVALID_PARAMETER.value in str(exc_info.value)
+        assert not any(
+            c.args[0] == "backup/delete" for c in ws.send_command.call_args_list
+        )
+
+    @pytest.mark.asyncio
     async def test_refuses_too_young_backup(self) -> None:
         """L2: a backup newer than the age floor cannot be deleted, even
         when it is not the single newest one."""
@@ -206,6 +233,31 @@ class TestSnapshotDeleteGuards:
         assert not any(
             c.args[0] == "backup/delete" for c in ws.send_command.call_args_list
         )
+
+    @pytest.mark.asyncio
+    async def test_newest_beats_age_floor_message_when_target_is_also_too_young(
+        self,
+    ) -> None:
+        """Pins the newest-before-age-floor evaluation order: a target that
+        is BOTH the newest snapshot AND younger than the age floor must
+        report "newest" (with its own remedy), not "too young" — swapping
+        the two guards in `delete_backup` would still pass every other
+        existing test but would flip this message."""
+        older = _iso(_now() - timedelta(days=200))
+        target_date = _iso(_now())
+        ws = _ws_client(
+            [
+                _entry("other", date=older),
+                _entry("target", date=target_date),
+            ]
+        )
+        settings = _settings(enabled=True, min_age_days=7)
+        p1, p2 = _patched(ws, settings)
+        with p1, p2, pytest.raises(ToolError) as exc_info:
+            await delete_backup(_client(), "target", confirm=True)
+        message = str(exc_info.value).lower()
+        assert "newest" in message
+        assert "days" not in message
 
     @pytest.mark.asyncio
     async def test_malformed_date_fails_closed(self) -> None:
@@ -385,6 +437,47 @@ class TestSnapshotDeleteWaitTimeout:
             c for c in ws.send_command.call_args_list if c.args[0] == "backup/delete"
         )
         assert delete_call.kwargs.get("_wait_timeout", 30.0) > 30.0
+
+
+class TestSnapshotDeleteProgress:
+    """kingpanther13 review: `delete_backup` accepted `ctx` but never used
+    it, unlike `create_backup`/`restore_backup`. The 60s delete wait should
+    still emit one heartbeat, consistent with those other paths."""
+
+    @pytest.mark.asyncio
+    async def test_emits_one_heartbeat_before_the_delete_call(self) -> None:
+        old = _iso(_now() - timedelta(days=100))
+        newer = _iso(_now() - timedelta(days=1))
+        ws = _ws_client(
+            [
+                _entry("target", date=old),
+                _entry("other", date=newer),
+            ]
+        )
+        settings = _settings(enabled=True, min_age_days=7)
+        p1, p2 = _patched(ws, settings)
+        ctx = MagicMock()
+        ctx.report_progress = AsyncMock()
+        with p1, p2:
+            await delete_backup(_client(), "target", confirm=True, ctx=ctx)
+        ctx.report_progress.assert_awaited_once()
+        assert "delet" in ctx.report_progress.await_args.kwargs["message"].lower()
+
+    @pytest.mark.asyncio
+    async def test_no_ctx_does_not_raise(self) -> None:
+        old = _iso(_now() - timedelta(days=100))
+        newer = _iso(_now() - timedelta(days=1))
+        ws = _ws_client(
+            [
+                _entry("target", date=old),
+                _entry("other", date=newer),
+            ]
+        )
+        settings = _settings(enabled=True, min_age_days=7)
+        p1, p2 = _patched(ws, settings)
+        with p1, p2:
+            result = await delete_backup(_client(), "target", confirm=True)
+        assert result["success"] is True
 
 
 class TestSnapshotDeleteMalformedResult:

--- a/tests/src/unit/test_backup_delete.py
+++ b/tests/src/unit/test_backup_delete.py
@@ -1,0 +1,300 @@
+"""Unit tests for the snapshot-delete path in `backup.py` (#1861).
+
+`ha_manage_backup(scope="snapshot", action="delete")` did not exist before
+this change — snapshots could be created but never removed, so an agent
+that filled the disk with accumulated snapshots had no way to free space.
+
+Adding delete widens the tool's blast radius (a full HA snapshot may be the
+last recovery point after the agent itself broke something), so the
+implementation is layered:
+
+L0. `enable_snapshot_delete` (default False) — a human-only opt-in via env
+    var / web-settings override file / add-on Supervisor options. An agent
+    cannot flip this on itself.
+L1. Scheduled backups (`with_automatic_settings=True`) are never deletable —
+    they are the user's real safety net and HA's own retention already
+    manages them.
+L2. An age floor (`snapshot_delete_min_age_days`, default 7) — count-based
+    "keep the last N" is defeatable by an agent flooding new backups before
+    deleting old ones, but the HA-stamped creation date cannot be forged.
+L3. The single newest remaining snapshot is never deletable, regardless of
+    type — guarantees at least one recovery point always survives.
+Plus a `confirm=True` requirement as a cheap backstop.
+"""
+
+from datetime import UTC, datetime, timedelta
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastmcp.exceptions import ToolError
+
+from ha_mcp.errors import ErrorCode
+from ha_mcp.tools.backup import delete_backup
+
+
+def _now() -> datetime:
+    """Real wall-clock time, computed fresh per call rather than frozen —
+    the guard logic under test compares against `datetime.now(UTC)`
+    directly, so offsets relative to a live clock are simpler and more
+    robust than mocking the `datetime` module."""
+    return datetime.now(UTC)
+
+
+def _iso(dt: datetime) -> str:
+    return dt.isoformat().replace("+00:00", "Z")
+
+
+def _entry(
+    backup_id: str,
+    *,
+    date: str,
+    with_automatic_settings: bool = False,
+    name: str = "Some_Backup",
+) -> dict[str, Any]:
+    return {
+        "backup_id": backup_id,
+        "name": name,
+        "date": date,
+        "with_automatic_settings": with_automatic_settings,
+    }
+
+
+def _ws_client(
+    backups: list[dict[str, Any]],
+    *,
+    delete_agent_errors: dict[str, str] | None = None,
+) -> AsyncMock:
+    ws = AsyncMock()
+
+    async def _send(command: str, **kwargs: Any) -> Any:
+        if command == "backup/info":
+            return {"success": True, "result": {"backups": backups}}
+        if command == "backup/delete":
+            return {
+                "success": True,
+                "result": {"agent_errors": delete_agent_errors or {}},
+            }
+        raise AssertionError(f"unexpected WS command: {command!r}")
+
+    ws.send_command.side_effect = _send
+    return ws
+
+
+def _settings(*, enabled: bool, min_age_days: int = 7) -> MagicMock:
+    settings = MagicMock()
+    settings.enable_snapshot_delete = enabled
+    settings.snapshot_delete_min_age_days = min_age_days
+    return settings
+
+
+def _client() -> MagicMock:
+    return MagicMock(base_url="http://ha", token="tok", verify_ssl=True)
+
+
+def _patched(ws: AsyncMock, settings: MagicMock):
+    return (
+        patch(
+            "ha_mcp.tools.backup.get_connected_ws_client",
+            new=AsyncMock(return_value=(ws, None)),
+        ),
+        patch("ha_mcp.tools.backup.get_global_settings", return_value=settings),
+    )
+
+
+class TestSnapshotDeleteGate:
+    @pytest.mark.asyncio
+    async def test_disabled_by_default_raises_without_any_ws_call(self) -> None:
+        ws = _ws_client([_entry("target", date=_iso(_now() - timedelta(days=30)))])
+        settings = _settings(enabled=False)
+        p1, p2 = _patched(ws, settings)
+        with p1, p2, pytest.raises(ToolError) as exc_info:
+            await delete_backup(_client(), "target", confirm=True)
+        assert ErrorCode.VALIDATION_INVALID_PARAMETER.value in str(exc_info.value)
+        ws.send_command.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_requires_confirm_true(self) -> None:
+        ws = _ws_client([_entry("target", date=_iso(_now() - timedelta(days=30)))])
+        settings = _settings(enabled=True)
+        p1, p2 = _patched(ws, settings)
+        with p1, p2, pytest.raises(ToolError) as exc_info:
+            await delete_backup(_client(), "target", confirm=False)
+        assert ErrorCode.VALIDATION_INVALID_PARAMETER.value in str(exc_info.value)
+        assert "confirm" in str(exc_info.value).lower()
+        ws.send_command.assert_not_awaited()
+
+
+class TestSnapshotDeleteLookup:
+    @pytest.mark.asyncio
+    async def test_backup_not_found_raises(self) -> None:
+        ws = _ws_client([_entry("other", date=_iso(_now() - timedelta(days=30)))])
+        settings = _settings(enabled=True)
+        p1, p2 = _patched(ws, settings)
+        with p1, p2, pytest.raises(ToolError) as exc_info:
+            await delete_backup(_client(), "missing-id", confirm=True)
+        assert ErrorCode.RESOURCE_NOT_FOUND.value in str(exc_info.value)
+
+
+class TestSnapshotDeleteGuards:
+    @pytest.mark.asyncio
+    async def test_refuses_automatic_settings_backup(self) -> None:
+        """L1: scheduled backups are never deletable, even if old and not
+        the newest."""
+        old = _iso(_now() - timedelta(days=100))
+        newer = _iso(_now() - timedelta(days=1))
+        ws = _ws_client(
+            [
+                _entry("target", date=old, with_automatic_settings=True),
+                _entry("other", date=newer),
+            ]
+        )
+        settings = _settings(enabled=True)
+        p1, p2 = _patched(ws, settings)
+        with p1, p2, pytest.raises(ToolError) as exc_info:
+            await delete_backup(_client(), "target", confirm=True)
+        assert ErrorCode.VALIDATION_INVALID_PARAMETER.value in str(exc_info.value)
+        assert "automatic" in str(exc_info.value).lower()
+        assert not any(
+            c.args[0] == "backup/delete" for c in ws.send_command.call_args_list
+        )
+
+    @pytest.mark.asyncio
+    async def test_refuses_too_young_backup(self) -> None:
+        """L2: a backup newer than the age floor cannot be deleted, even
+        when it is not the single newest one."""
+        young = _iso(_now() - timedelta(days=1))
+        newest = _iso(_now())
+        ws = _ws_client(
+            [
+                _entry("target", date=young),
+                _entry("other", date=newest),
+            ]
+        )
+        settings = _settings(enabled=True, min_age_days=7)
+        p1, p2 = _patched(ws, settings)
+        with p1, p2, pytest.raises(ToolError) as exc_info:
+            await delete_backup(_client(), "target", confirm=True)
+        assert ErrorCode.VALIDATION_INVALID_PARAMETER.value in str(exc_info.value)
+        assert "days" in str(exc_info.value).lower()
+
+    @pytest.mark.asyncio
+    async def test_refuses_deleting_newest_snapshot(self) -> None:
+        """L3: the single newest snapshot overall is protected, even though
+        it individually clears the age floor."""
+        older = _iso(_now() - timedelta(days=200))
+        target_date = _iso(_now() - timedelta(days=100))
+        ws = _ws_client(
+            [
+                _entry("other", date=older),
+                _entry("target", date=target_date),
+            ]
+        )
+        settings = _settings(enabled=True, min_age_days=7)
+        p1, p2 = _patched(ws, settings)
+        with p1, p2, pytest.raises(ToolError) as exc_info:
+            await delete_backup(_client(), "target", confirm=True)
+        assert ErrorCode.VALIDATION_INVALID_PARAMETER.value in str(exc_info.value)
+        assert "newest" in str(exc_info.value).lower()
+        assert not any(
+            c.args[0] == "backup/delete" for c in ws.send_command.call_args_list
+        )
+
+    @pytest.mark.asyncio
+    async def test_malformed_date_fails_closed(self) -> None:
+        """A missing/unparseable `date` on the target must refuse deletion
+        rather than silently treat it as old-enough."""
+        entry = _entry("target", date=_iso(_now() - timedelta(days=100)))
+        entry["date"] = None
+        ws = _ws_client([entry])
+        settings = _settings(enabled=True, min_age_days=7)
+        p1, p2 = _patched(ws, settings)
+        with p1, p2, pytest.raises(ToolError) as exc_info:
+            await delete_backup(_client(), "target", confirm=True)
+        assert ErrorCode.VALIDATION_INVALID_PARAMETER.value in str(exc_info.value)
+        assert not any(
+            c.args[0] == "backup/delete" for c in ws.send_command.call_args_list
+        )
+
+    @pytest.mark.asyncio
+    async def test_min_age_days_zero_disables_age_floor(self) -> None:
+        """min_age_days=0 (opt-out) allows a recent backup through, as long
+        as it is not the newest and not automatic."""
+        recent = _iso(_now() - timedelta(hours=1))
+        newest = _iso(_now())
+        ws = _ws_client(
+            [
+                _entry("target", date=recent),
+                _entry("other", date=newest),
+            ]
+        )
+        settings = _settings(enabled=True, min_age_days=0)
+        p1, p2 = _patched(ws, settings)
+        with p1, p2:
+            result = await delete_backup(_client(), "target", confirm=True)
+        assert result["success"] is True
+
+    @pytest.mark.asyncio
+    async def test_newest_guard_survives_with_age_floor_disabled(self) -> None:
+        """L3 (newest-snapshot protection) must fire independently of L2 (the
+        age floor) — an admin disabling the age floor must not also,
+        accidentally, disable the newest-snapshot guard. Regression coverage
+        for a refactor that nests the newest-check inside the age-check
+        block, which would pass every other existing test."""
+        older = _iso(_now() - timedelta(days=200))
+        newest = _iso(_now())
+        ws = _ws_client(
+            [
+                _entry("other", date=older),
+                _entry("target", date=newest),
+            ]
+        )
+        settings = _settings(enabled=True, min_age_days=0)
+        p1, p2 = _patched(ws, settings)
+        with p1, p2, pytest.raises(ToolError) as exc_info:
+            await delete_backup(_client(), "target", confirm=True)
+        assert ErrorCode.VALIDATION_INVALID_PARAMETER.value in str(exc_info.value)
+        assert "newest" in str(exc_info.value).lower()
+        assert not any(
+            c.args[0] == "backup/delete" for c in ws.send_command.call_args_list
+        )
+
+
+class TestSnapshotDeleteSuccess:
+    @pytest.mark.asyncio
+    async def test_deletes_old_non_newest_ad_hoc_backup(self) -> None:
+        old = _iso(_now() - timedelta(days=100))
+        newer = _iso(_now() - timedelta(days=1))
+        ws = _ws_client(
+            [
+                _entry("target", date=old, name="Pre_Change"),
+                _entry("other", date=newer),
+            ]
+        )
+        settings = _settings(enabled=True, min_age_days=7)
+        p1, p2 = _patched(ws, settings)
+        with p1, p2:
+            result = await delete_backup(_client(), "target", confirm=True)
+        assert result["success"] is True
+        assert result["backup_id"] == "target"
+        delete_call = next(
+            c for c in ws.send_command.call_args_list if c.args[0] == "backup/delete"
+        )
+        assert delete_call.kwargs["backup_id"] == "target"
+
+    @pytest.mark.asyncio
+    async def test_agent_errors_raises_service_call_failed(self) -> None:
+        old = _iso(_now() - timedelta(days=100))
+        newer = _iso(_now() - timedelta(days=1))
+        ws = _ws_client(
+            [
+                _entry("target", date=old),
+                _entry("other", date=newer),
+            ],
+            delete_agent_errors={"hassio.local": "boom"},
+        )
+        settings = _settings(enabled=True, min_age_days=7)
+        p1, p2 = _patched(ws, settings)
+        with p1, p2, pytest.raises(ToolError) as exc_info:
+            await delete_backup(_client(), "target", confirm=True)
+        assert ErrorCode.SERVICE_CALL_FAILED.value in str(exc_info.value)

--- a/tests/src/unit/test_backup_delete.py
+++ b/tests/src/unit/test_backup_delete.py
@@ -64,12 +64,19 @@ def _ws_client(
     backups: list[dict[str, Any]],
     *,
     delete_agent_errors: dict[str, str] | None = None,
+    info_agent_errors: dict[str, str] | None = None,
 ) -> AsyncMock:
     ws = AsyncMock()
 
     async def _send(command: str, **kwargs: Any) -> Any:
         if command == "backup/info":
-            return {"success": True, "result": {"backups": backups}}
+            return {
+                "success": True,
+                "result": {
+                    "backups": backups,
+                    "agent_errors": info_agent_errors or {},
+                },
+            }
         if command == "backup/delete":
             return {
                 "success": True,
@@ -298,6 +305,86 @@ class TestSnapshotDeleteSuccess:
         with p1, p2, pytest.raises(ToolError) as exc_info:
             await delete_backup(_client(), "target", confirm=True)
         assert ErrorCode.SERVICE_CALL_FAILED.value in str(exc_info.value)
+
+
+class TestSnapshotDeleteAgentErrorsOnInfo:
+    """codex review: if `backup/info` reports `agent_errors` (one or more
+    agents failed to enumerate their backups), the returned `backups` list
+    may be an incomplete view — the newest-snapshot and automatic-backup
+    guards would then be evaluated against partial data. Refuse deletion
+    rather than risk deleting a backup that a currently-unreachable agent
+    would have revealed as protected."""
+
+    @pytest.mark.asyncio
+    async def test_refuses_when_backup_info_reports_agent_errors(self) -> None:
+        old = _iso(_now() - timedelta(days=100))
+        newer = _iso(_now() - timedelta(days=1))
+        ws = _ws_client(
+            [
+                _entry("target", date=old),
+                _entry("other", date=newer),
+            ],
+            info_agent_errors={"cloud_agent": "timeout"},
+        )
+        settings = _settings(enabled=True, min_age_days=7)
+        p1, p2 = _patched(ws, settings)
+        with p1, p2, pytest.raises(ToolError) as exc_info:
+            await delete_backup(_client(), "target", confirm=True)
+        assert ErrorCode.SERVICE_CALL_FAILED.value in str(exc_info.value)
+        assert not any(
+            c.args[0] == "backup/delete" for c in ws.send_command.call_args_list
+        )
+
+
+class TestSnapshotDeleteAgeFloorClockSkew:
+    """codex review: min_age_days=0 must unconditionally disable the age
+    floor, including when the target's HA-stamped date is slightly ahead of
+    the ha-mcp host's own clock (clock skew between the two systems) —
+    `target_date > cutoff` would otherwise still reject it even though the
+    UI/docs promise 0 means "no floor"."""
+
+    @pytest.mark.asyncio
+    async def test_min_age_days_zero_ignores_future_dated_backup(self) -> None:
+        future = _iso(_now() + timedelta(hours=1))
+        newer = _iso(_now() + timedelta(hours=2))
+        ws = _ws_client(
+            [
+                _entry("target", date=future),
+                _entry("other", date=newer),
+            ]
+        )
+        settings = _settings(enabled=True, min_age_days=0)
+        p1, p2 = _patched(ws, settings)
+        with p1, p2:
+            result = await delete_backup(_client(), "target", confirm=True)
+        assert result["success"] is True
+
+
+class TestSnapshotDeleteWaitTimeout:
+    """codex review: `backup/delete` fans out to every configured agent
+    (including cloud/remote ones) and the tool call doesn't return until
+    all finish — the WS client's default 30s wait can be too tight for a
+    slow/rate-limited remote agent, same class of problem this PR already
+    fixes for snapshot creation."""
+
+    @pytest.mark.asyncio
+    async def test_delete_uses_an_elevated_wait_timeout(self) -> None:
+        old = _iso(_now() - timedelta(days=100))
+        newer = _iso(_now() - timedelta(days=1))
+        ws = _ws_client(
+            [
+                _entry("target", date=old),
+                _entry("other", date=newer),
+            ]
+        )
+        settings = _settings(enabled=True, min_age_days=7)
+        p1, p2 = _patched(ws, settings)
+        with p1, p2:
+            await delete_backup(_client(), "target", confirm=True)
+        delete_call = next(
+            c for c in ws.send_command.call_args_list if c.args[0] == "backup/delete"
+        )
+        assert delete_call.kwargs.get("_wait_timeout", 30.0) > 30.0
 
 
 class TestSnapshotDeleteMalformedResult:

--- a/tests/src/unit/test_backup_delete.py
+++ b/tests/src/unit/test_backup_delete.py
@@ -298,3 +298,45 @@ class TestSnapshotDeleteSuccess:
         with p1, p2, pytest.raises(ToolError) as exc_info:
             await delete_backup(_client(), "target", confirm=True)
         assert ErrorCode.SERVICE_CALL_FAILED.value in str(exc_info.value)
+
+
+class TestSnapshotDeleteMalformedResult:
+    """A `success: true` response with a null `result` key (present but
+    None, not absent) must not crash with AttributeError — `.get(key, {})`
+    only substitutes the default when the key is ABSENT, not when its
+    value is None."""
+
+    @pytest.mark.asyncio
+    async def test_backup_info_null_result_raises_not_found_not_attributeerror(
+        self,
+    ) -> None:
+        ws = AsyncMock()
+        ws.send_command.side_effect = [{"success": True, "result": None}]
+        settings = _settings(enabled=True)
+        p1, p2 = _patched(ws, settings)
+        with p1, p2, pytest.raises(ToolError) as exc_info:
+            await delete_backup(_client(), "target", confirm=True)
+        assert ErrorCode.RESOURCE_NOT_FOUND.value in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_delete_result_null_result_treated_as_no_agent_errors(self) -> None:
+        old = _iso(_now() - timedelta(days=100))
+        newer = _iso(_now() - timedelta(days=1))
+        ws = AsyncMock()
+        ws.send_command.side_effect = [
+            {
+                "success": True,
+                "result": {
+                    "backups": [
+                        _entry("target", date=old),
+                        _entry("other", date=newer),
+                    ]
+                },
+            },
+            {"success": True, "result": None},
+        ]
+        settings = _settings(enabled=True, min_age_days=7)
+        p1, p2 = _patched(ws, settings)
+        with p1, p2:
+            result = await delete_backup(_client(), "target", confirm=True)
+        assert result["success"] is True

--- a/tests/src/unit/test_backup_poll_timeout.py
+++ b/tests/src/unit/test_backup_poll_timeout.py
@@ -582,6 +582,32 @@ class TestPollBackupCompletionProgress:
             assert call.kwargs["total"] == 60
 
     @pytest.mark.asyncio
+    async def test_heartbeat_is_throttled_not_emitted_every_poll(self):
+        """kingpanther13 review: `test_emits_periodic_heartbeat_during_long_wait`
+        sets `poll_interval == _BACKUP_PROGRESS_INTERVAL_S`, so every tick
+        clears the `next_progress_at` throttle and the test can't tell a
+        working throttle from no throttle at all. With `poll_interval=2`
+        over a 30s wait (15 ticks), only the ~10s-spaced throttle should
+        fire: initial + ticks at 10/20/30 = 4, not 15."""
+        ctx = self._make_ctx()
+        ws = _ws_client(
+            *[_backup_info("create_backup", "in_progress", []) for _ in range(14)],
+            _backup_info("idle", "completed", [_backup_entry("Slow")]),
+        )
+        with patch("ha_mcp.tools.backup.asyncio.sleep", new=AsyncMock()):
+            result = await _poll_backup_completion(
+                ws,
+                name="Slow",
+                backup_job_id="job-1",
+                max_wait_seconds=30,
+                poll_interval=2,
+                agent_id="backup.local",
+                ctx=ctx,
+            )
+        assert result["success"] is True
+        assert ctx.report_progress.await_count == 4
+
+    @pytest.mark.asyncio
     async def test_no_ctx_does_not_raise(self):
         """Legacy callers passing no ctx must keep working unchanged."""
         ws = _ws_client(_backup_info("idle", "completed", [_backup_entry("Fast")]))

--- a/tests/src/unit/test_backup_poll_timeout.py
+++ b/tests/src/unit/test_backup_poll_timeout.py
@@ -516,6 +516,87 @@ class TestPollBackupCompletionPostTimeout:
         assert result["backup_id"] == "FRESH"
 
 
+class TestPollBackupCompletionProgress:
+    """Coverage for #1861: a client with no notifications for the whole poll
+    window aborts the connection ("sent no response or progress for 300s").
+    ``_poll_backup_completion`` must emit ``ctx.report_progress`` heartbeats
+    while it waits, not just at the very end."""
+
+    def _make_ctx(self) -> MagicMock:
+        ctx = MagicMock()
+        ctx.report_progress = AsyncMock()
+        return ctx
+
+    @pytest.mark.asyncio
+    async def test_emits_initial_progress_before_first_poll(self):
+        ctx = self._make_ctx()
+        ws = _ws_client(_backup_info("idle", "completed", [_backup_entry("Fast")]))
+        with patch("ha_mcp.tools.backup.asyncio.sleep", new=AsyncMock()):
+            await _poll_backup_completion(
+                ws,
+                name="Fast",
+                backup_job_id="job-1",
+                max_wait_seconds=10,
+                poll_interval=2,
+                agent_id="backup.local",
+                ctx=ctx,
+            )
+        first_call = ctx.report_progress.await_args_list[0]
+        assert first_call.kwargs["progress"] == 0
+        assert first_call.kwargs["total"] == 10
+        assert "waiting for backup" in first_call.kwargs["message"]
+
+    @pytest.mark.asyncio
+    async def test_emits_periodic_heartbeat_during_long_wait(self):
+        """A backup that takes several poll ticks to complete must produce
+        more than one progress event (the initial one), each with a growing
+        `progress` value, proving the client is being kept alive throughout
+        the wait rather than only notified once."""
+        ctx = self._make_ctx()
+        # 5 ticks of "still creating" before the 6th observes completion.
+        ws = _ws_client(
+            _backup_info("create_backup", "in_progress", []),
+            _backup_info("create_backup", "in_progress", []),
+            _backup_info("create_backup", "in_progress", []),
+            _backup_info("create_backup", "in_progress", []),
+            _backup_info("create_backup", "in_progress", []),
+            _backup_info("idle", "completed", [_backup_entry("Slow")]),
+        )
+        with patch("ha_mcp.tools.backup.asyncio.sleep", new=AsyncMock()):
+            result = await _poll_backup_completion(
+                ws,
+                name="Slow",
+                backup_job_id="job-1",
+                max_wait_seconds=60,
+                poll_interval=10,
+                agent_id="backup.local",
+                ctx=ctx,
+            )
+        assert result["success"] is True
+        # Initial (progress=0) + at least one in-loop heartbeat.
+        assert ctx.report_progress.await_count >= 2
+        progresses = [c.kwargs["progress"] for c in ctx.report_progress.await_args_list]
+        assert progresses == sorted(progresses)
+        assert progresses[-1] > progresses[0]
+        for call in ctx.report_progress.await_args_list:
+            assert call.kwargs["total"] == 60
+
+    @pytest.mark.asyncio
+    async def test_no_ctx_does_not_raise(self):
+        """Legacy callers passing no ctx must keep working unchanged."""
+        ws = _ws_client(_backup_info("idle", "completed", [_backup_entry("Fast")]))
+        with patch("ha_mcp.tools.backup.asyncio.sleep", new=AsyncMock()):
+            result = await _poll_backup_completion(
+                ws,
+                name="Fast",
+                backup_job_id="job-1",
+                max_wait_seconds=10,
+                poll_interval=2,
+                agent_id="backup.local",
+            )
+        assert result["success"] is True
+
+
 class TestPollBackupCompletionInLoop:
     @pytest.mark.asyncio
     async def test_in_loop_success_path_still_works_after_refactor(self):
@@ -587,6 +668,44 @@ class TestCreateBackupWrapperSeam:
     post-timeout `warnings`-bearing dict survives through the wrapper's
     outer try/except Exception — that's the surface the fix actually
     protects against the duplicate-retry pattern in #1433."""
+
+    @pytest.mark.asyncio
+    async def test_create_backup_forwards_ctx_to_poll(self):
+        """#1861: a `ctx` passed to `create_backup` must reach
+        `_poll_backup_completion` so the poll loop can emit progress
+        heartbeats — otherwise a caller supplying `ctx` still gets no
+        notifications during the wait."""
+        from ha_mcp.tools import backup as backup_module
+
+        ws_mock = AsyncMock()
+        ws_mock.send_command.side_effect = [
+            {
+                "success": True,
+                "result": {"config": {"create_backup": {"password": "pw"}}},
+            },
+            {
+                "success": True,
+                "result": {"agents": [{"agent_id": "backup.local", "name": "local"}]},
+            },
+            {"success": True, "result": {"backup_job_id": "j-1"}},
+        ]
+        ws_mock.disconnect = AsyncMock()
+        client_mock = MagicMock(base_url="http://ha", token="tok", verify_ssl=True)
+        fake_ctx = MagicMock()
+        poll_mock = AsyncMock(return_value={"success": True})
+
+        with (
+            patch(
+                "ha_mcp.tools.backup.get_connected_ws_client",
+                new=AsyncMock(return_value=(ws_mock, None)),
+            ),
+            patch("ha_mcp.tools.backup._poll_backup_completion", new=poll_mock),
+        ):
+            await backup_module.create_backup(
+                client_mock, name="Ctx_Test", ctx=fake_ctx
+            )
+
+        assert poll_mock.await_args.kwargs["ctx"] is fake_ctx
 
     @pytest.mark.asyncio
     async def test_create_backup_returns_warnings_dict_unchanged(self):

--- a/tests/src/unit/test_backup_restore.py
+++ b/tests/src/unit/test_backup_restore.py
@@ -182,6 +182,30 @@ class TestRestoreAwaitsSafetyBackup:
         assert "backup/restore" not in call_log
 
 
+class TestRestoreForwardsCtx:
+    @pytest.mark.asyncio
+    async def test_ctx_forwarded_to_safety_backup_poll(self) -> None:
+        """#1861: `restore_backup`'s pre-restore safety backup is a *full*
+        backup (up to 1800s) — a `ctx` passed in must reach that poll too,
+        not just the fast create_backup path."""
+        call_log: list[str] = []
+        ws = _scripted_ws(_restore_responses(), call_log)
+        client = MagicMock(base_url="http://ha", token="tok", verify_ssl=True)
+        fake_ctx = MagicMock()
+        poll_mock = AsyncMock(return_value={"success": True})
+
+        with (
+            patch(
+                "ha_mcp.tools.backup.get_connected_ws_client",
+                new=AsyncMock(return_value=(ws, None)),
+            ),
+            patch("ha_mcp.tools.backup._poll_backup_completion", new=poll_mock),
+        ):
+            await restore_backup(client, "target-slug", ctx=fake_ctx)
+
+        assert poll_mock.await_args.kwargs["ctx"] is fake_ctx
+
+
 class TestRestoreForwardsPassword:
     @pytest.mark.asyncio
     async def test_password_forwarded_for_protected_target(self) -> None:

--- a/tests/src/unit/test_config.py
+++ b/tests/src/unit/test_config.py
@@ -727,3 +727,104 @@ def test_backup_override_lookahead_accepts_in_range(
 
     _reset_global_settings()
     assert get_global_settings().auto_backup_calendar_lookahead_days == 30
+
+
+# snapshot-delete gating (#1861) — default-off, env/override-file/bounds coverage.
+
+
+def test_enable_snapshot_delete_default_false() -> None:
+    from ha_mcp.config import Settings
+
+    assert Settings().enable_snapshot_delete is False
+
+
+def test_snapshot_delete_min_age_days_default_seven() -> None:
+    from ha_mcp.config import Settings
+
+    assert Settings().snapshot_delete_min_age_days == 7
+
+
+def test_enable_snapshot_delete_env_var_true() -> None:
+    from ha_mcp.config import Settings
+
+    settings = Settings(
+        _env_file=None,  # type: ignore[call-arg]
+        ENABLE_SNAPSHOT_DELETE="true",
+    )
+    assert settings.enable_snapshot_delete is True
+
+
+def test_snapshot_delete_min_age_days_env_var() -> None:
+    from ha_mcp.config import Settings
+
+    settings = Settings(
+        _env_file=None,  # type: ignore[call-arg]
+        SNAPSHOT_DELETE_MIN_AGE_DAYS="14",
+    )
+    assert settings.snapshot_delete_min_age_days == 14
+
+
+def test_snapshot_delete_min_age_days_zero_disables_floor() -> None:
+    """0 is a valid, in-range value (the age floor is opt-out per #1861
+    design: min_age_days=0 disables the age guard)."""
+    from ha_mcp.config import Settings
+
+    settings = Settings(
+        _env_file=None,  # type: ignore[call-arg]
+        SNAPSHOT_DELETE_MIN_AGE_DAYS="0",
+    )
+    assert settings.snapshot_delete_min_age_days == 0
+
+
+def test_snapshot_delete_min_age_days_rejects_out_of_range() -> None:
+    import pydantic
+
+    from ha_mcp.config import Settings
+
+    with pytest.raises(pydantic.ValidationError):
+        Settings(
+            _env_file=None,  # type: ignore[call-arg]
+            SNAPSHOT_DELETE_MIN_AGE_DAYS="9999",
+        )
+
+
+def test_backup_override_enable_snapshot_delete_accepts_bool(
+    isolated_data_dir, monkeypatch
+) -> None:
+    _clear_all_feature_envs(monkeypatch)
+    monkeypatch.delenv("ENABLE_SNAPSHOT_DELETE", raising=False)
+    (isolated_data_dir / "backup_settings.json").write_text(
+        json.dumps({"enable_snapshot_delete": True})
+    )
+    from ha_mcp.config import _reset_global_settings, get_global_settings
+
+    _reset_global_settings()
+    assert get_global_settings().enable_snapshot_delete is True
+
+
+def test_backup_override_min_age_days_rejects_out_of_range(
+    isolated_data_dir, monkeypatch
+) -> None:
+    _clear_all_feature_envs(monkeypatch)
+    monkeypatch.delenv("SNAPSHOT_DELETE_MIN_AGE_DAYS", raising=False)
+    (isolated_data_dir / "backup_settings.json").write_text(
+        json.dumps({"snapshot_delete_min_age_days": 9999})
+    )
+    from ha_mcp.config import _reset_global_settings, get_global_settings
+
+    _reset_global_settings()
+    assert get_global_settings().snapshot_delete_min_age_days == 7  # field default
+
+
+def test_backup_override_min_age_days_accepts_in_range(
+    isolated_data_dir, monkeypatch
+) -> None:
+    _clear_all_feature_envs(monkeypatch)
+    monkeypatch.delenv("SNAPSHOT_DELETE_MIN_AGE_DAYS", raising=False)
+    (isolated_data_dir / "backup_settings.json").write_text(
+        json.dumps({"snapshot_delete_min_age_days": 30})
+    )
+    from ha_mcp.config import _reset_global_settings, get_global_settings
+
+    _reset_global_settings()
+    assert get_global_settings().snapshot_delete_min_age_days == 30

--- a/tests/src/unit/test_context_injection.py
+++ b/tests/src/unit/test_context_injection.py
@@ -605,6 +605,43 @@ async def test_ha_get_automation_traces_empty_diagnostics_emits_progress() -> No
 
 
 # ---------------------------------------------------------------------------
+# tools_backup.ha_manage_backup (#1861) — the tool is a nested-function
+# @mcp.tool closure inside register_backup_tools, not a class method like
+# every other tool above. Its unit tests (test_backup_delete.py,
+# test_backup_poll_timeout.py) call the module-level create_backup /
+# restore_backup / delete_backup functions directly with an explicit
+# ctx= kwarg, which proves the plumbing but NOT that FastMCP actually
+# injects a live Context into ha_manage_backup's own signature when a
+# real client calls it. If injection silently failed, ctx would stay
+# None at the dispatcher and every progress heartbeat would be a no-op
+# while every other test still passed. FastMCP's signal that it claimed
+# a parameter for injection is excluding it from the tool's exposed
+# JSON schema — assert that here instead.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ha_manage_backup_ctx_is_injected_not_exposed() -> None:
+    from fastmcp import FastMCP
+
+    from ha_mcp.tools.backup import register_backup_tools
+
+    mcp = FastMCP("test")
+    register_backup_tools(mcp, _mock_ha_client())
+    tool = await mcp.get_tool("ha_manage_backup")
+    props = tool.parameters.get("properties", {})
+
+    assert "ctx" not in props, (
+        "ctx leaked into the exposed schema — FastMCP is not claiming it for "
+        "injection, so ha_manage_backup's progress heartbeats would silently "
+        "never fire for a real client"
+    )
+    # Sanity: real dispatch params ARE exposed, so the absence of "ctx" above
+    # isn't just an empty-schema false positive.
+    assert {"scope", "action", "confirm", "backup_id"} <= props.keys()
+
+
+# ---------------------------------------------------------------------------
 # safe_progress / safe_info: transport errors must not mask successful tool results
 # ---------------------------------------------------------------------------
 

--- a/tests/src/unit/test_read_only.py
+++ b/tests/src/unit/test_read_only.py
@@ -124,6 +124,11 @@ class TestExemptionRules:
             ({"scope": "snapshot", "action": "create"}, False),
             ({"scope": "snapshot", "action": "list"}, True),
             ({"scope": "snapshot", "action": "restore"}, False),
+            # #1861: snapshot deletion must stay blocked in read-only mode
+            # even with confirm=True — confirm has no bearing on the
+            # scope/action gate.
+            ({"scope": "snapshot", "action": "delete"}, False),
+            ({"scope": "snapshot", "action": "delete", "confirm": True}, False),
             ({}, False),
         ],
     )
@@ -649,6 +654,11 @@ _EXEMPT_GATED_OR_READ_ARGS = {
         "name",
         "backup_id",
         "restore_database",
+        # snapshot delete confirmation flag — the (scope, action) dispatch
+        # already blocks (snapshot, delete) outright; confirm has no
+        # mutation capability of its own, it only gates whether that
+        # already-blocked action proceeds.
+        "confirm",
         # ...edits create payload / list filters (list is an allowed read),
         "domain",
         "entity_id",


### PR DESCRIPTION
## What does this PR do?

Fixes #1861 — two problems with `ha_manage_backup`'s `scope="snapshot"` operations:

1. **No progress heartbeat on long `snapshot,create`.** The internal poll loop never touched the MCP `Context`, so a client watching for "no response or progress" could abort mid-backup even though the backup was still succeeding server-side. `ctx: Context | None` now threads through `create_backup` -> `_poll_backup_completion` and `restore_backup` -> `_create_safety_backup` -> `_poll_backup_completion`, emitting a `report_progress` heartbeat before the first poll and every ~10s during the wait. The internal poll ceiling also moved from 300s to 1800s — HA's own frontend (`backup/subscribe_events`) imposes no timeout at all on backup creation, so 300s was stricter than upstream and directly caused the reported false-timeout.

2. **No way to delete a snapshot.** Added `(scope="snapshot", action="delete")`. Because a full HA snapshot may be an agent's last recovery point after it broke something, deletion is layered with guards:
   - `enable_snapshot_delete` setting, **off by default** — a human opts in via env var, the web settings UI, or (add-on) Supervisor options; an agent cannot enable this itself
   - `confirm=True` required
   - the backup must exist (`RESOURCE_NOT_FOUND` otherwise)
   - scheduled/automatic backups are never deletable
   - the target must clear `snapshot_delete_min_age_days` (default 7, `0` disables the floor) — an HA-stamped date an agent can't forge, unlike a count-based "keep N" rule that's defeatable by flooding new backups
   - the single newest remaining snapshot, of any type, is never deletable — guaranteeing at least one recovery point always survives, checked before the age floor so the error message never suggests a remedy that wouldn't actually work

Both new settings are wired through both HA add-on flavors (`config.yaml` + `start.py`) and the web settings UI (labels, help text, and correct input bounds — including making `0` reachable for the age-floor opt-out).

## Type of change
- [x] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [x] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

Unit: 6777 passed (full suite). E2E: full `tests/src/e2e/workflows/convenience/test_backup.py` suite passes against a live HA test container, including a real create → delete → verify-gone round trip for the new delete action, plus the adjacent auto-backup and read-only-mode e2e suites (no regressions).

## Checklist
- [x] I have updated documentation if needed