### PR TITLE
feat: read-only YAML fragment lookup for configuration and package keys

### DIFF
--- a/custom_components/ha_mcp_tools/__init__.py
+++ b/custom_components/ha_mcp_tools/__init__.py
@@ -699,10 +699,19 @@ def _follow_include(loader: yaml.Loader, node: yaml.nodes.Node) -> Any:
     if depth >= 8 or not isinstance(name, str) or not name or name.startswith("<"):
         return None
     path = os.path.join(os.path.dirname(name), str(node.value))
+    # Recorded BEFORE the open, and even when it fails: the caching layer keys
+    # on these files' mtimes, so an include target that does not exist yet must
+    # still be tracked (with a -1 stamp) or creating it later would not
+    # invalidate.
+    opened = getattr(loader, "_pkg_opened", None)
+    if opened is not None:
+        opened.append(path)
     try:
         with open(path, encoding="utf-8") as handle:
             sub = _PackagesDirLoader(handle)
             sub._pkg_include_depth = depth + 1
+            # Same list object, so a nested include lands in one signature.
+            sub._pkg_opened = opened
             try:
                 return sub.get_single_data()
             finally:
@@ -752,6 +761,27 @@ def _extract_package_dir_markers(data: object) -> set[str]:
     return {str(m) for m in markers}
 
 
+def _load_package_dir_markers_tracked(config_path: str) -> tuple[set[str], list[str]]:
+    """``_load_package_dir_markers`` that also reports every file it read.
+
+    The file list (configuration.yaml plus any ``!include`` followed from it) is
+    what ``_package_dir_markers_cached`` keys its mtime signature on, so the
+    cache invalidates no matter which of them the packages directive lives in.
+    """
+    opened: list[str] = [config_path]
+    try:
+        with open(config_path, encoding="utf-8") as handle:
+            loader = _PackagesDirLoader(handle)
+            loader._pkg_opened = opened
+            try:
+                data = loader.get_single_data()
+            finally:
+                loader.dispose()
+    except (OSError, yaml.YAMLError):
+        return set(), opened
+    return _extract_package_dir_markers(data), opened
+
+
 def _load_package_dir_markers(config_path: str) -> set[str]:
     """Parse configuration.yaml (following ``!include``) and return the raw
     folder argument(s) of every packages ``!include_dir_*named`` directive.
@@ -759,16 +789,52 @@ def _load_package_dir_markers(config_path: str) -> set[str]:
     Blocking (opens files) — call via an executor. Returns raw strings, possibly
     absolute; the caller relativizes and filters them against the config dir.
     """
-    try:
-        with open(config_path, encoding="utf-8") as handle:
-            loader = _PackagesDirLoader(handle)
-            try:
-                data = loader.get_single_data()
-            finally:
-                loader.dispose()
-    except (OSError, yaml.YAMLError):
-        return set()
-    return _extract_package_dir_markers(data)
+    markers, _opened = _load_package_dir_markers_tracked(config_path)
+    return markers
+
+
+def _mtime_sig(paths: list[str]) -> tuple[tuple[str, int], ...]:
+    """Stamp each path with its mtime, or -1 when it does not exist.
+
+    The -1 is load-bearing: an ``!include`` target that is missing today and
+    created tomorrow changes the signature, so the cache invalidates instead of
+    serving folder-detection that predates the file.
+    """
+    sig: list[tuple[str, int]] = []
+    for path in paths:
+        try:
+            sig.append((path, os.stat(path).st_mtime_ns))
+        except OSError:
+            sig.append((path, -1))
+    return tuple(sig)
+
+
+# config_path -> (signature of the files last read, markers found in them).
+# Module-level: the folder binding is per config dir, and HA runs one per
+# process. Concurrent first-callers may each miss and parse once before the
+# entry lands — bounded, self-healing, and cheaper than holding a lock across
+# executor threads.
+_PACKAGE_DIR_CACHE: dict[str, tuple[tuple[tuple[str, int], ...], set[str]]] = {}
+
+
+def _package_dir_markers_cached(config_path: str) -> set[str]:
+    """``_load_package_dir_markers``, skipping the parse when nothing changed.
+
+    Blocking (stats files) — call via an executor. Every file operation resolves
+    the packages folder, and a ``ha_config_get_yaml`` glob fires one detection
+    per matched file, so this would otherwise re-parse configuration.yaml (and
+    whatever it includes) N times per search. Stat-per-file is cheap; the YAML
+    parse is not.
+    """
+    cached = _PACKAGE_DIR_CACHE.get(config_path)
+    if cached is not None:
+        signature, markers = cached
+        if _mtime_sig([path for path, _ in signature]) == signature:
+            return set(markers)
+    markers, opened = _load_package_dir_markers_tracked(config_path)
+    # Copy in and out: the cached set must not be mutable through a caller.
+    _PACKAGE_DIR_CACHE[config_path] = (_mtime_sig(opened), set(markers))
+    return markers
 
 
 def _package_folder_relative_to_config(raw: str, config_dir: str) -> str | None:
@@ -810,7 +876,9 @@ async def _detect_package_dirs(hass: HomeAssistant) -> set[str]:
     config_path = hass.config.path(ALLOWED_YAML_CONFIG_FILES[0])
     # normpath is a pure string transform (no I/O), so ASYNC240 doesn't apply.
     config_dir = os.path.normpath(hass.config.config_dir)  # noqa: ASYNC240
-    markers = await hass.async_add_executor_job(_load_package_dir_markers, config_path)
+    markers = await hass.async_add_executor_job(
+        _package_dir_markers_cached, config_path
+    )
     for raw in markers:
         folder = _package_folder_relative_to_config(raw, config_dir)
         if folder:

--- a/custom_components/ha_mcp_tools/__init__.py
+++ b/custom_components/ha_mcp_tools/__init__.py
@@ -1064,11 +1064,16 @@ def _mask_secrets_content(content: str) -> str:
     """Return secrets.yaml content with every secret value masked.
 
     Parses the document structurally (ruamel — the same YAML stack used
-    elsewhere in this component) and emits ``key: [MASKED]`` for each top-level
-    key. This closes the gap in the previous line-by-line regex, which masked
-    only single-line ``key: value`` pairs and leaked multi-line block scalars
-    (``|``, ``>``) whose continuation lines have no colon — SSH keys, TLS
-    material, and service-account JSON are commonly stored that way.
+    elsewhere in this component) and emits ``key: "[MASKED]"`` for each
+    top-level key. This closes the gap in the previous line-by-line regex, which
+    masked only single-line ``key: value`` pairs and leaked multi-line block
+    scalars (``|``, ``>``) whose continuation lines have no colon — SSH keys,
+    TLS material, and service-account JSON are commonly stored that way.
+
+    The marker is quoted because the masked text is itself valid YAML that gets
+    re-parsed: read_file's ``yaml_path``/``include_parsed`` views load it, and
+    an unquoted ``[MASKED]`` is flow-sequence syntax, so the parsed view would
+    render the mask as the list ``["MASKED"]`` instead of a scalar.
 
     Fails closed: any content that cannot be parsed and masked as a key-value
     mapping is withheld rather than returned raw, so a failure on this path never
@@ -1085,7 +1090,7 @@ def _mask_secrets_content(content: str) -> str:
             return (
                 "# secrets.yaml is empty or not a key-value mapping — content withheld"
             )
-        return "\n".join(f"{key}: [MASKED]" for key in parsed)
+        return "\n".join(f'{key}: "[MASKED]"' for key in parsed)
     except YAMLError:
         return "# secrets.yaml could not be parsed — content withheld to avoid leaking secrets"
     except Exception:

--- a/custom_components/ha_mcp_tools/__init__.py
+++ b/custom_components/ha_mcp_tools/__init__.py
@@ -57,7 +57,13 @@ from .const import (
     YAML_KEY_POST_ACTIONS,
 )
 from .websocket_api import async_register_commands
-from .yaml_rt import apply_seq_indent, detect_seq_indent, make_yaml, yaml_dumps
+from .yaml_rt import (
+    apply_seq_indent,
+    detect_seq_indent,
+    make_yaml,
+    yaml_dumps,
+    yaml_jsonify,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -145,6 +151,10 @@ SERVICE_READ_FILE_SCHEMA = vol.Schema(
         # dotted path under ``subtree`` (used by ha-mcp's per-edit auto-backup
         # to snapshot the prior value before ha_config_set_yaml edits it, #1579).
         vol.Optional("yaml_path"): cv.string,
+        # With ``yaml_path``, also return that subtree as JSON-safe parsed data
+        # under ``parsed`` (ha_config_get_yaml's include_parsed, #1788). HA tags
+        # are rendered to source form, never resolved.
+        vol.Optional("include_parsed", default=False): cv.boolean,
         vol.Optional(CALLER_TOKEN_FIELD): cv.string,
     }
 )
@@ -823,11 +833,34 @@ def _path_in_package_dir(normalized: str, package_dirs: set[str] | None) -> bool
     )
 
 
+def _dir_in_package_dir(normalized: str, package_dirs: set[str] | None) -> bool:
+    """True if ``normalized`` IS a configured package folder, or a folder under one.
+
+    The file-level twin is ``_path_in_package_dir``; this one matches the
+    FOLDER itself (and nested folders) so ``list_files`` can enumerate a
+    packages directory the way ``read_file`` can already read the ``*.yaml``
+    inside it (issue #1854).
+
+    Unlike ``_path_in_package_dir``, this does NOT default to ``{"packages"}``
+    when ``package_dirs`` is None: ``_is_path_allowed_for_dir`` is shared with
+    write_file and delete_file, which must never gain package access
+    (``edit_yaml_config`` is the only write path to config YAML). Only the
+    read-side lister passes ``package_dirs``.
+    """
+    if not package_dirs:
+        return False
+    return any(
+        normalized == folder or normalized.startswith(folder + "/")
+        for folder in package_dirs
+    )
+
+
 def _is_path_allowed_for_dir(
     config_dir: Path,
     rel_path: str,
     allowed_dirs: list[str],
     extra_dirs: list[str] | None = None,
+    package_dirs: set[str] | None = None,
 ) -> bool:
     """Check if a path is within allowed directories.
 
@@ -835,6 +868,11 @@ def _is_path_allowed_for_dir(
     granted in addition to ``allowed_dirs``. The non-overridable deny floor is
     checked first, so a custom directory can never grant access to ``.storage``
     or other floored paths.
+
+    ``package_dirs`` (issue #1854) widens ONLY the allow decision — every
+    containment, deny-floor and symlink check below still runs — and is passed
+    by the read-side lister alone; write and delete leave it None so a
+    packages folder stays non-writable through this helper.
     """
     # Absolute HAOS sibling-volume path (issue #1586) — enforced against its
     # volume root rather than the config dir. Detected by a POSIX-absolute
@@ -856,10 +894,16 @@ def _is_path_allowed_for_dir(
         return False
 
     # Built-in allowlist matches on the first segment; user-configured extra
-    # dirs match on a path-boundary prefix (so nested entries work).
+    # dirs match on a path-boundary prefix (so nested entries work). A
+    # configured packages folder matches literally (it may itself be nested,
+    # e.g. "conf/packages", so a first-segment test would miss it).
     parts = normalized.split(os.sep)
     builtin_ok = bool(parts) and parts[0] in allowed_dirs
-    if not builtin_ok and not _matches_extra_dir(normalized, extra_dirs):
+    if (
+        not builtin_ok
+        and not _dir_in_package_dir(normalized, package_dirs)
+        and not _matches_extra_dir(normalized, extra_dirs)
+    ):
         return False
 
     # Symlink-safe containment on the REAL path the handler will open (issue
@@ -1752,32 +1796,52 @@ def _build_edit_yaml_config_handler(
     return handle_edit_yaml_config
 
 
-def _extract_yaml_subtree(content: str, yaml_path: str) -> str | None:
-    """Return the YAML subtree at the dotted ``yaml_path`` as round-trip text.
+def _extract_yaml_views(
+    content: str, yaml_path: str, include_parsed: bool = False
+) -> dict[str, Any]:
+    """Return the subtree at ``yaml_path`` as round-trip text and, optionally,
+    as JSON-safe parsed data — from a SINGLE parse of ``content``.
 
-    Used by ``read_file``'s optional ``yaml_path`` to let ha-mcp's per-edit
-    auto-backup snapshot the prior value of a key before ``edit_yaml_config``
-    changes it (#1579). Runs here, in the component, because the round-trip
-    parse needs ``ruamel`` (a component requirement) which the MCP server's
-    runtime does not carry. Comments and HA tags (``!secret`` / ``!include``)
-    are preserved. Returns ``None`` when the root is not a mapping or the key
-    is absent (new-key write — nothing to snapshot); malformed YAML also
-    yields ``None`` (the edit itself would then fail and report the error).
+    Runs here, in the component, because the round-trip parse needs ``ruamel``
+    (a component requirement) which the MCP server's runtime does not carry.
+    Comments and HA tags (``!secret`` / ``!include``) are preserved in the text
+    view and rendered to their source form in the parsed view — never resolved,
+    so neither view can surface a secret's plaintext.
+
+    ``subtree`` is None when the root is not a mapping or the key is absent
+    (new-key write — nothing to snapshot); malformed YAML also yields None (the
+    edit itself would then fail and report the error). ``parsed`` is present
+    only when ``include_parsed`` and the key resolved.
     """
+    views: dict[str, Any] = {"subtree": None}
     try:
         ry = make_yaml()
         # The per-thread cached instance may carry a sequence style applied
         # by a prior edit's dump on this executor thread — reset it so the
         # snapshot never inherits another file's indentation.
         apply_seq_indent(ry, None)
-        node = ry.load(StringIO(content))
+        node: Any = ry.load(StringIO(content))
         for seg in yaml_path.split("."):
             if not isinstance(node, dict) or seg not in node:
-                return None
+                return views
             node = node[seg]
-        return yaml_dumps(ry, node)
+        views["subtree"] = yaml_dumps(ry, node)
+        if include_parsed:
+            views["parsed"] = yaml_jsonify(node)
     except YAMLError:
-        return None
+        return {"subtree": None}
+    return views
+
+
+def _extract_yaml_subtree(content: str, yaml_path: str) -> str | None:
+    """Return the YAML subtree at the dotted ``yaml_path`` as round-trip text.
+
+    Used by ``read_file``'s optional ``yaml_path`` to let ha-mcp's per-edit
+    auto-backup snapshot the prior value of a key before ``edit_yaml_config``
+    changes it (#1579).
+    """
+    subtree: str | None = _extract_yaml_views(content, yaml_path)["subtree"]
+    return subtree
 
 
 def _parse_and_validate_yaml_path(
@@ -2093,15 +2157,21 @@ async def _async_setup_tools_entry(hass: HomeAssistant, entry: ConfigEntry) -> b
         rel_path = call.data["path"]
         pattern = call.data.get("pattern")
 
-        # Security check
+        # Security check. Package files may live under a non-default folder
+        # (issue #1854); read_file already resolves and honours the configured
+        # folder(s), so the lister does too — otherwise a packages folder is
+        # readable file-by-file but cannot be enumerated, which is what
+        # ha_config_get_yaml's cross-file key discovery needs (issue #1788).
         extra_dirs = _current_extra_dirs()
+        package_dirs = await _detect_package_dirs(hass)
         if not _is_path_allowed_for_dir(
-            config_dir, rel_path, ALLOWED_READ_DIRS, extra_dirs
+            config_dir, rel_path, ALLOWED_READ_DIRS, extra_dirs, package_dirs
         ):
             _LOGGER.warning("Attempted to list files in disallowed path: %s", rel_path)
+            allowed_display = ALLOWED_READ_DIRS + sorted(package_dirs) + extra_dirs
             return {
                 "success": False,
-                "error": f"Path not allowed. Must be in: {', '.join(ALLOWED_READ_DIRS + extra_dirs)}",
+                "error": f"Path not allowed. Must be in: {', '.join(allowed_display)}",
                 "files": [],
             }
 
@@ -2156,6 +2226,7 @@ async def _async_setup_tools_entry(hass: HomeAssistant, entry: ConfigEntry) -> b
         rel_path = call.data["path"]
         tail_lines = call.data.get("tail_lines")
         yaml_path = call.data.get("yaml_path")
+        include_parsed = bool(call.data.get("include_parsed", False))
 
         # Security check. Package files may live under a non-default folder
         # (issue #1854), so resolve the configured folder(s) — the same way the
@@ -2260,8 +2331,10 @@ async def _async_setup_tools_entry(hass: HomeAssistant, entry: ConfigEntry) -> b
             "modified": modified_dt.isoformat(),
         }
         if yaml_path:
-            response["subtree"] = await hass.async_add_executor_job(
-                _extract_yaml_subtree, content, yaml_path
+            response.update(
+                await hass.async_add_executor_job(
+                    _extract_yaml_views, content, yaml_path, include_parsed
+                )
             )
         return response
 

--- a/custom_components/ha_mcp_tools/__init__.py
+++ b/custom_components/ha_mcp_tools/__init__.py
@@ -1877,9 +1877,11 @@ def _extract_yaml_views(
     so neither view can surface a secret's plaintext.
 
     ``subtree`` is None when the root is not a mapping or the key is absent
-    (new-key write — nothing to snapshot); malformed YAML also yields None (the
-    edit itself would then fail and report the error). ``parsed`` is present
-    only when ``include_parsed`` and the key resolved.
+    (new-key write — nothing to snapshot). Malformed YAML also yields None, but
+    additionally sets ``parse_error``, so a caller can tell "this file does not
+    define the key" apart from "this file could not be read at all" — without
+    it, one broken package silently reads as a key that is simply absent.
+    ``parsed`` is present only when ``include_parsed`` and the key resolved.
     """
     views: dict[str, Any] = {"subtree": None}
     try:
@@ -1896,8 +1898,18 @@ def _extract_yaml_views(
         views["subtree"] = yaml_dumps(ry, node)
         if include_parsed:
             views["parsed"] = yaml_jsonify(node)
-    except YAMLError:
-        return {"subtree": None}
+    except YAMLError as err:
+        # Position only, never the error text: ruamel embeds the offending
+        # source line in its message, which would put file content — possibly
+        # an inline credential — into a response this path otherwise keeps
+        # free of resolved values.
+        mark = getattr(err, "problem_mark", None)
+        where = (
+            f" at line {mark.line + 1}, column {mark.column + 1}"
+            if mark is not None
+            else ""
+        )
+        return {"subtree": None, "parse_error": f"not valid YAML{where}"}
     return views
 
 
@@ -2386,6 +2398,7 @@ async def _async_setup_tools_entry(hass: HomeAssistant, entry: ConfigEntry) -> b
             }
 
         # Apply tail for other files if requested
+        full_content = content
         if tail_lines:
             lines = content.split("\n")
             if len(lines) > tail_lines:
@@ -2399,9 +2412,12 @@ async def _async_setup_tools_entry(hass: HomeAssistant, entry: ConfigEntry) -> b
             "modified": modified_dt.isoformat(),
         }
         if yaml_path:
+            # Extract from the UNTAILED text: tailing is a display concern, and
+            # the retained tail is both likely to exclude the key and likely to
+            # be invalid YAML on its own, which would report the key as absent.
             response.update(
                 await hass.async_add_executor_job(
-                    _extract_yaml_views, content, yaml_path, include_parsed
+                    _extract_yaml_views, full_content, yaml_path, include_parsed
                 )
             )
         return response

--- a/custom_components/ha_mcp_tools/services.yaml
+++ b/custom_components/ha_mcp_tools/services.yaml
@@ -96,6 +96,26 @@ read_file:
           min: 1
           max: 10000
           mode: box
+    yaml_path:
+      name: YAML Path
+      description: >-
+        Dotted key path. When set, the response also carries the round-trip
+        text of that YAML subtree under "subtree". Comments and HA tags
+        (!secret, !include) are preserved as written.
+      required: false
+      example: "alert2"
+      selector:
+        text:
+    include_parsed:
+      name: Include Parsed
+      description: >-
+        With yaml_path, also return the subtree as structured data under
+        "parsed". HA tags are rendered to their source form (!secret api_key)
+        and never resolved, so no secret value is exposed.
+      required: false
+      default: false
+      selector:
+        boolean:
 
 write_file:
   name: Write File

--- a/custom_components/ha_mcp_tools/yaml_rt.py
+++ b/custom_components/ha_mcp_tools/yaml_rt.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 import re
 import threading
 from collections.abc import Callable
@@ -10,6 +11,7 @@ from io import StringIO
 from typing import Any
 
 from ruamel.yaml import YAML
+from ruamel.yaml.scalarbool import ScalarBoolean
 
 
 class _TaggedScalar:
@@ -174,6 +176,19 @@ def yaml_dumps(ry: YAML, data: Any) -> str:
     return buf.getvalue()
 
 
+def _jsonify_float(node: float) -> float | str:
+    """Narrow a float to something json can encode.
+
+    ``.inf``/``.nan`` are valid YAML with no JSON encoding, so they render back
+    to their YAML source form — the same treatment a tag gets.
+    """
+    if math.isnan(node):
+        return ".nan"
+    if math.isinf(node):
+        return ".inf" if node > 0 else "-.inf"
+    return float(node)
+
+
 def yaml_jsonify(node: Any) -> Any:
     """Convert a round-trip node into JSON-serializable plain Python.
 
@@ -186,7 +201,9 @@ def yaml_jsonify(node: Any) -> Any:
     ruamel's scalar types subclass the builtins (``ScalarInt``/``ScalarFloat``/
     ``ScalarString``), so they are narrowed to the plain type; timestamps
     (``!!timestamp``) come back as ``date``/``datetime``, which json cannot
-    encode, and become ISO strings.
+    encode, and become ISO strings. Non-finite floats (``.inf``/``.nan``) have
+    no JSON encoding either, so they render back to their YAML source form —
+    the same treatment a tag gets.
     """
     if isinstance(node, _TaggedScalar):
         return f"{node.tag} {node.value}".strip()
@@ -194,13 +211,18 @@ def yaml_jsonify(node: Any) -> Any:
         return {str(key): yaml_jsonify(value) for key, value in node.items()}
     if isinstance(node, (list, tuple)):
         return [yaml_jsonify(item) for item in node]
-    # bool before int: bool subclasses int.
+    # Both branches must precede int: plain bool subclasses int, and a bool
+    # carrying an anchor loads as ruamel's ScalarBoolean, which subclasses int
+    # WITHOUT subclassing bool — so an `enabled: &flag true` would otherwise
+    # serialize as 1.
     if node is None or isinstance(node, bool):
         return node
+    if isinstance(node, ScalarBoolean):
+        return bool(node)
     if isinstance(node, int):
         return int(node)
     if isinstance(node, float):
-        return float(node)
+        return _jsonify_float(node)
     if isinstance(node, str):
         return str(node)
     if isinstance(node, (datetime, date)):

--- a/custom_components/ha_mcp_tools/yaml_rt.py
+++ b/custom_components/ha_mcp_tools/yaml_rt.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import re
 import threading
 from collections.abc import Callable
+from datetime import date, datetime
 from io import StringIO
 from typing import Any
 
@@ -171,3 +172,37 @@ def yaml_dumps(ry: YAML, data: Any) -> str:
     buf = StringIO()
     ry.dump(data, buf)
     return buf.getvalue()
+
+
+def yaml_jsonify(node: Any) -> Any:
+    """Convert a round-trip node into JSON-serializable plain Python.
+
+    An HA tag is rendered back to its SOURCE form (``!secret api_key``), never
+    resolved: the value behind a ``!secret`` lives in secrets.yaml and is not
+    looked up here, so a parsed view carries no plaintext-secret surface — the
+    same property the round-trip text view has. Lives here because this module
+    owns ``_TaggedScalar`` and the tag registry.
+
+    ruamel's scalar types subclass the builtins (``ScalarInt``/``ScalarFloat``/
+    ``ScalarString``), so they are narrowed to the plain type; timestamps
+    (``!!timestamp``) come back as ``date``/``datetime``, which json cannot
+    encode, and become ISO strings.
+    """
+    if isinstance(node, _TaggedScalar):
+        return f"{node.tag} {node.value}".strip()
+    if isinstance(node, dict):
+        return {str(key): yaml_jsonify(value) for key, value in node.items()}
+    if isinstance(node, (list, tuple)):
+        return [yaml_jsonify(item) for item in node]
+    # bool before int: bool subclasses int.
+    if node is None or isinstance(node, bool):
+        return node
+    if isinstance(node, int):
+        return int(node)
+    if isinstance(node, float):
+        return float(node)
+    if isinstance(node, str):
+        return str(node)
+    if isinstance(node, (datetime, date)):
+        return node.isoformat()
+    return str(node)

--- a/src/ha_mcp/settings_ui/_tools_meta.py
+++ b/src/ha_mcp/settings_ui/_tools_meta.py
@@ -89,8 +89,9 @@ TRANSFORM_GENERATED_TOOLS: dict[str, ToolStub] = {}
 # won't appear in local_provider._list_tools(), so we inject stub entries
 # into the settings UI so users discover the tool exists and how to enable
 # it. Keep this dict in sync with the ``"beta"`` tag added to each tool's
-# source file (tools_yaml_config.py, tools_filesystem.py, tools_mcp_component.py,
-# tools_code.py) — a future rename or removal needs to land in both places.
+# source file (tools_yaml_config.py, tools_yaml_read.py, tools_filesystem.py,
+# tools_mcp_component.py, tools_code.py) — a future rename or removal needs to
+# land in both places.
 FEATURE_GATED_TOOLS: dict[str, ToolStub] = {
     "ha_config_set_yaml": {
         "title": "Set YAML Config",
@@ -98,6 +99,13 @@ FEATURE_GATED_TOOLS: dict[str, ToolStub] = {
         "description": "Add, replace, or remove top-level keys in configuration.yaml or package files.",
         "disabled_by": "enable_yaml_config_editing",
         "destructiveHint": True,
+    },
+    "ha_config_get_yaml": {
+        "title": "Read YAML Config Fragment",
+        "primary_tag": "System",
+        "description": "Read the YAML fragment under a key in a config file, or find which file defines it.",
+        "disabled_by": "enable_filesystem_tools",
+        "readOnlyHint": True,
     },
     "ha_manage_custom_tool": {
         "title": "Custom Tool",

--- a/src/ha_mcp/tools/tools_filesystem.py
+++ b/src/ha_mcp/tools/tools_filesystem.py
@@ -74,7 +74,14 @@ CALLER_TOKEN_BOOTSTRAP_SERVICE = "get_caller_token"
 # ENABLE_YAML_EDIT_CONFIRM, default on); a <0.11.0 component's strict
 # (PREVENT_EXTRA) schema rejects the unknown arg with a raw voluptuous
 # error — the gate surfaces an actionable "update" prompt instead.
-MIN_COMPONENT_VERSION = "0.11.0"
+# 1.1.0: the YAML fragment read (#1788) needs two component behaviours that a
+# <1.1.0 component reports no differently from a missing key. ``list_files``
+# only now honours the configured packages folder, so ha_config_get_yaml's
+# glob/discovery would otherwise come back "Path not allowed" instead of
+# enumerating packages; and ``include_parsed`` on ``read_file`` is a new arg
+# that an older strict (PREVENT_EXTRA) schema rejects with a raw voluptuous
+# error. The gate turns both into the actionable "update" prompt.
+MIN_COMPONENT_VERSION = "1.1.0"
 
 
 def _version_tuple(version: str) -> tuple[int, ...]:
@@ -509,6 +516,19 @@ class FilesystemTools:
                 ),
             ),
         ] = None,
+        yaml_path: Annotated[
+            str | None,
+            Field(
+                default=None,
+                description=(
+                    "Dotted YAML key path (e.g. 'alert2', 'mqtt.sensor'). When "
+                    "set, the response also carries 'subtree': the round-trip "
+                    "text of just that key's value. To look a key up across "
+                    "packages/*.yaml, or to get it as structured data, use "
+                    "ha_config_get_yaml instead."
+                ),
+            ),
+        ] = None,
     ) -> dict[str, Any]:
         """Read a file from the Home Assistant config directory.
 
@@ -539,6 +559,9 @@ class FilesystemTools:
         - size: File size in bytes
         - modified: Last modification timestamp
         - path: The file path that was read
+        - subtree: Round-trip text of the `yaml_path` key, when that arg is set
+          (null when the key is absent). Comments and HA tags (`!secret`,
+          `!include`) survive as written — a `!secret` is never resolved.
 
         **Example:**
         ```python
@@ -547,6 +570,9 @@ class FilesystemTools:
 
         # Read last 100 lines of log
         result = ha_read_file(path="home-assistant.log", tail_lines=100)
+
+        # Read just the alert2 block out of a package file
+        result = ha_read_file(path="packages/alert2.yaml", yaml_path="alert2")
         ```
         """
         try:
@@ -557,6 +583,8 @@ class FilesystemTools:
             service_data: dict[str, Any] = {"path": path}
             if tail_lines is not None:
                 service_data["tail_lines"] = tail_lines
+            if yaml_path is not None:
+                service_data["yaml_path"] = yaml_path
 
             # Call the custom component service
             result = await call_mcp_tools_service(

--- a/src/ha_mcp/tools/tools_yaml_read.py
+++ b/src/ha_mcp/tools/tools_yaml_read.py
@@ -224,11 +224,6 @@ class YamlReadTools:
         except ToolError:
             raise
         except Exception as e:
-            # Typed NoReturn (raise_error defaults True), so this is the last
-            # statement: the sibling tools' trailing `return None` guards a
-            # shape whose try block ends in a raise_tool_error() call CodeQL
-            # cannot see through. This try ends in a real return, so the same
-            # trailer would be provably unreachable (py/unreachable-statement).
             exception_to_structured_error(
                 e,
                 context={
@@ -237,6 +232,15 @@ class YamlReadTools:
                     "yaml_path": yaml_path,
                 },
             )
+            # Unreachable (the call is typed NoReturn) but explicit, because
+            # CodeQL cannot see the NoReturn and would otherwise read this
+            # handler as falling through to an implicit None (py/mixed-returns).
+            # The sibling tools additionally carry a `return None` AFTER the
+            # try/except; that shape only works because their try ends in a
+            # raise_tool_error() call CodeQL treats as returning. This try ends
+            # in a real return, so the same trailer is provably dead there
+            # (py/unreachable-statement).
+            return None
 
 
 def register_yaml_read_tools(mcp: Any, client: Any, **kwargs: Any) -> None:

--- a/src/ha_mcp/tools/tools_yaml_read.py
+++ b/src/ha_mcp/tools/tools_yaml_read.py
@@ -179,6 +179,7 @@ class YamlReadTools:
         tags={"System", "beta"},
         annotations={
             "readOnlyHint": True,
+            "openWorldHint": False,
             "title": "Read YAML Config Fragment",
         },
     )

--- a/src/ha_mcp/tools/tools_yaml_read.py
+++ b/src/ha_mcp/tools/tools_yaml_read.py
@@ -6,9 +6,13 @@ addressing, so a fragment found here can be handed straight back to the editor.
 **Dependency:** Requires the ha_mcp_tools custom component (the round-trip parse
 needs ``ruamel``, which the component carries and the MCP server does not).
 
-Unlike ``ha_config_set_yaml`` this is NOT behind ENABLE_YAML_CONFIG_EDITING:
-reading a config fragment is not an edit, and an agent needs to inspect config
-whether or not YAML editing is turned on.
+Gating: behind ``enable_filesystem_tools``, NOT ENABLE_YAML_CONFIG_EDITING. The
+editing flag gates *edits*, and reading a fragment is not one — but this returns
+config-file contents through the same ``read_file``/``list_files`` component
+services as ``ha_read_file``/``ha_list_files``, so it belongs behind the same
+flag those are behind. Registering it unconditionally would hand an install that
+deliberately turned filesystem tools off a config-file read surface through the
+back door.
 """
 
 import asyncio
@@ -29,6 +33,7 @@ from .helpers import (
 from .tools_filesystem import (
     _assert_mcp_tools_available,
     call_mcp_tools_service,
+    is_filesystem_tools_enabled,
 )
 from .util_helpers import unwrap_service_response
 
@@ -63,6 +68,74 @@ def _unwrap_or_raise(result: Any, service: str, context: dict[str, Any]) -> Any:
     if not unwrapped.get("success", True):
         raise_tool_error(unwrapped)
     return unwrapped
+
+
+def _failure_text(payload: dict[str, Any]) -> str:
+    """Readable reason out of a failure payload, for a per-file warning.
+
+    The component answers with ``error`` as a plain string; the shared
+    ``create_error_response`` shape nests a ``message`` under it instead.
+    """
+    error = payload.get("error")
+    if isinstance(error, dict):
+        return str(error.get("message") or error)
+    return str(error or "read failed")
+
+
+def _evaluate_read(
+    response: Any,
+    target: str,
+    yaml_path: str,
+    *,
+    is_glob: bool,
+    include_content: bool,
+    include_parsed: bool,
+) -> tuple[dict[str, Any] | None, str | None]:
+    """Turn one ``read_file`` response into a match, a warning, or neither.
+
+    Three outcomes, in the order they are decided:
+
+    * **warning** — the file could not be searched at all. Under a glob that
+      must not sink the whole search and discard the matches already found:
+      the glob is not restricted to ``*.yaml``, so ``packages/*`` can turn up
+      a README the component refuses to read, and a permission-denied or
+      non-UTF-8 ``.yaml`` lands here too. A syntactically broken file is the
+      same class — reporting it as "key absent" would claim a file was
+      inspected when it never was. A single explicit target has no siblings
+      to salvage, so it raises instead.
+    * **neither** — the file parsed and simply has no such key. The real
+      non-match, and the whole point of a glob search.
+    * **match** — the key is there.
+    """
+    # Only reachable under a glob: with a single target return_exceptions is
+    # False, so gather itself raised.
+    if isinstance(response, BaseException):
+        return None, f"{target} was not searched: {response}."
+
+    if not isinstance(response, dict):
+        if is_glob:
+            return None, f"{target} was not searched: unexpected read_file response."
+        _call_failed("read_file", {"file": target, "yaml_path": yaml_path})
+    unwrapped = unwrap_service_response(response)
+
+    if not unwrapped.get("success", True):
+        if not is_glob:
+            raise_tool_error(unwrapped)
+        return None, f"{target} was not searched: {_failure_text(unwrapped)}."
+
+    parse_error = unwrapped.get("parse_error")
+    if parse_error:
+        return None, f"{target} was not searched: {parse_error}."
+
+    if unwrapped.get("subtree") is None:
+        return None, None
+
+    match: dict[str, Any] = {"file": target, "yaml_path": yaml_path}
+    if include_content:
+        match["content"] = unwrapped["subtree"]
+    if include_parsed:
+        match["parsed"] = unwrapped.get("parsed")
+    return match, None
 
 
 async def _resolve_target_files(client: Any, file: str) -> list[str]:
@@ -103,7 +176,7 @@ class YamlReadTools:
 
     @tool(
         name="ha_config_get_yaml",
-        tags={"System"},
+        tags={"System", "beta"},
         annotations={
             "readOnlyHint": True,
             "title": "Read YAML Config Fragment",
@@ -171,17 +244,21 @@ class YamlReadTools:
         differs from the running config. Comments and HA tags survive as written
         and a ``!secret`` is never resolved to its value, so ``content`` can be
         handed back to ha_config_set_yaml unchanged. Files outside the read
-        allowlist and secrets.yaml itself stay unreadable.
+        allowlist stay unreadable, and secrets.yaml reads back with its values
+        masked.
         """
         try:
             await _assert_mcp_tools_available(self._client)
 
+            is_glob = _has_glob(file)
             targets = await _resolve_target_files(self._client, file)
 
             extra: dict[str, Any] = {"include_parsed": True} if include_parsed else {}
             # The reads are independent, so fan them out rather than paying N
             # sequential round-trips to HA — a packages glob is routinely 10+
             # files. gather preserves order, so matches stay sorted by file.
+            # Under a glob a single read blowing up must not sink its siblings,
+            # so exceptions come back as values to be warned about below.
             responses = await asyncio.gather(
                 *(
                     call_mcp_tools_service(
@@ -190,36 +267,25 @@ class YamlReadTools:
                         {"path": target, "yaml_path": yaml_path, **extra},
                     )
                     for target in targets
-                )
+                ),
+                return_exceptions=is_glob,
             )
 
             matches: list[dict[str, Any]] = []
             warnings: list[str] = []
             for target, response in zip(targets, responses, strict=True):
-                unwrapped = _unwrap_or_raise(
-                    response, "read_file", {"file": target, "yaml_path": yaml_path}
+                match, warning = _evaluate_read(
+                    response,
+                    target,
+                    yaml_path,
+                    is_glob=is_glob,
+                    include_content=include_content,
+                    include_parsed=include_parsed,
                 )
-
-                # A file that could not be parsed is NOT a non-match: reporting
-                # it as one would tell the caller the key is absent when the
-                # file was never inspected. One broken package in a glob must
-                # not read as a clean "not defined anywhere".
-                parse_error = unwrapped.get("parse_error")
-                if parse_error:
-                    warnings.append(f"{target} was not searched: {parse_error}.")
-                    continue
-
-                # None here means the file parsed but has no such key: a real
-                # non-match, which is the whole point of a glob search.
-                if unwrapped.get("subtree") is None:
-                    continue
-
-                match: dict[str, Any] = {"file": target, "yaml_path": yaml_path}
-                if include_content:
-                    match["content"] = unwrapped["subtree"]
-                if include_parsed:
-                    match["parsed"] = unwrapped.get("parsed")
-                matches.append(match)
+                if warning:
+                    warnings.append(warning)
+                elif match:
+                    matches.append(match)
 
             result: dict[str, Any] = {
                 "success": True,
@@ -259,7 +325,11 @@ class YamlReadTools:
 def register_yaml_read_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
     """Register the read-only YAML lookup tool.
 
-    Intentionally unconditional: ENABLE_YAML_CONFIG_EDITING gates *editing*, and
-    reading a fragment is useful (and safe) with editing switched off.
+    Behind ``enable_filesystem_tools`` (see module docstring): this returns
+    config-file contents, so it registers with the same flag as the other
+    file-read tools rather than with the YAML *editing* flag.
     """
+    if not is_filesystem_tools_enabled():
+        logger.debug("YAML read tool disabled (set HAMCP_ENABLE_FILESYSTEM_TOOLS=true)")
+        return
     register_tool_methods(mcp, YamlReadTools(client))

--- a/src/ha_mcp/tools/tools_yaml_read.py
+++ b/src/ha_mcp/tools/tools_yaml_read.py
@@ -224,6 +224,11 @@ class YamlReadTools:
         except ToolError:
             raise
         except Exception as e:
+            # Typed NoReturn (raise_error defaults True), so this is the last
+            # statement: the sibling tools' trailing `return None` guards a
+            # shape whose try block ends in a raise_tool_error() call CodeQL
+            # cannot see through. This try ends in a real return, so the same
+            # trailer would be provably unreachable (py/unreachable-statement).
             exception_to_structured_error(
                 e,
                 context={
@@ -232,8 +237,6 @@ class YamlReadTools:
                     "yaml_path": yaml_path,
                 },
             )
-            return None  # raise_tool_error always raises; explicit for CodeQL
-        return None  # py/mixed-returns: explicit terminal; handlers above always raise
 
 
 def register_yaml_read_tools(mcp: Any, client: Any, **kwargs: Any) -> None:

--- a/src/ha_mcp/tools/tools_yaml_read.py
+++ b/src/ha_mcp/tools/tools_yaml_read.py
@@ -1,0 +1,240 @@
+"""Read-only YAML fragment lookup for Home Assistant config files.
+
+The read companion to ``ha_config_set_yaml``: same ``file`` + ``yaml_path``
+addressing, so a fragment found here can be handed straight back to the editor.
+
+**Dependency:** Requires the ha_mcp_tools custom component (the round-trip parse
+needs ``ruamel``, which the component carries and the MCP server does not).
+
+Unlike ``ha_config_set_yaml`` this is NOT behind ENABLE_YAML_CONFIG_EDITING:
+reading a config fragment is not an edit, and an agent needs to inspect config
+whether or not YAML editing is turned on.
+"""
+
+import logging
+from typing import Annotated, Any
+
+from fastmcp.exceptions import ToolError
+from fastmcp.tools import tool
+from pydantic import Field
+
+from ..errors import ErrorCode, create_error_response
+from .helpers import (
+    exception_to_structured_error,
+    log_tool_usage,
+    raise_tool_error,
+    register_tool_methods,
+)
+from .tools_filesystem import (
+    _assert_mcp_tools_available,
+    call_mcp_tools_service,
+)
+from .util_helpers import unwrap_service_response
+
+logger = logging.getLogger(__name__)
+
+# fnmatch metacharacters. Matching itself happens component-side (list_files
+# fnmatches on the file name); this only decides single-file vs. glob.
+_GLOB_METACHARS = ("*", "?", "[")
+
+
+def _has_glob(file: str) -> bool:
+    """True if ``file`` carries an fnmatch wildcard and must be expanded."""
+    return any(char in file for char in _GLOB_METACHARS)
+
+
+def _call_failed(service: str, context: dict[str, Any]) -> None:
+    """Raise the shared 'unexpected response' error for a component service."""
+    raise_tool_error(
+        create_error_response(
+            ErrorCode.SERVICE_CALL_FAILED,
+            f"Unexpected response format from {service} service",
+            context=context,
+        )
+    )
+
+
+async def _unwrap_or_raise(result: Any, service: str, context: dict[str, Any]) -> Any:
+    """Unwrap a component service response, raising on a failure payload."""
+    if not isinstance(result, dict):
+        _call_failed(service, context)
+    unwrapped = unwrap_service_response(result)
+    if not unwrapped.get("success", True):
+        raise_tool_error(unwrapped)
+    return unwrapped
+
+
+async def _resolve_target_files(client: Any, file: str) -> list[str]:
+    """Expand ``file`` into the concrete config-relative paths to read.
+
+    A plain path is returned as-is (the read itself reports a missing file). A
+    glob is expanded through the component's ``list_files``, which matches the
+    file name only — so ``packages/*.yaml`` covers one directory level, not a
+    nested tree.
+    """
+    if not _has_glob(file):
+        return [file]
+
+    directory, _, pattern = file.rpartition("/")
+    unwrapped = await _unwrap_or_raise(
+        await call_mcp_tools_service(
+            client,
+            "list_files",
+            {"path": directory or ".", "pattern": pattern},
+        ),
+        "list_files",
+        {"file": file},
+    )
+    entries = unwrapped.get("files")
+    if not isinstance(entries, list):
+        _call_failed("list_files", {"file": file})
+    # Sorted so a multi-file result is deterministic across calls.
+    return sorted(
+        str(entry["path"])
+        for entry in entries
+        if isinstance(entry, dict) and entry.get("path") and not entry.get("is_dir")
+    )
+
+
+class YamlReadTools:
+    def __init__(self, client: Any) -> None:
+        self._client = client
+
+    @tool(
+        name="ha_config_get_yaml",
+        tags={"System"},
+        annotations={
+            "readOnlyHint": True,
+            "title": "Read YAML Config Fragment",
+        },
+    )
+    @log_tool_usage
+    async def ha_config_get_yaml(
+        self,
+        yaml_path: Annotated[
+            str,
+            Field(
+                description=(
+                    "Dotted YAML key path to look up, e.g. 'alert2', 'mqtt', "
+                    "'template'. Any key is readable — unlike ha_config_set_yaml, "
+                    "which only writes an allowlisted set."
+                ),
+            ),
+        ],
+        file: Annotated[
+            str,
+            Field(
+                default="configuration.yaml",
+                description=(
+                    "Config-relative file to read. Accepts an fnmatch glob to "
+                    "search several files at once — 'packages/*.yaml' matches one "
+                    "directory level, not a nested tree. Use the glob to find "
+                    "which file defines a key."
+                ),
+            ),
+        ] = "configuration.yaml",
+        include_content: Annotated[
+            bool,
+            Field(
+                default=True,
+                description=(
+                    "Return the round-trip YAML text of each match. Set False to "
+                    "discover only which files define the key."
+                ),
+            ),
+        ] = True,
+        include_parsed: Annotated[
+            bool,
+            Field(
+                default=False,
+                description=(
+                    "Additionally return each match as structured data. HA tags "
+                    "stay in source form ('!secret api_key'), never resolved."
+                ),
+            ),
+        ] = False,
+    ) -> dict[str, Any]:
+        """Get the current YAML fragment under a key, from one config file or across a glob.
+
+        Use before ha_config_set_yaml to inspect what a key currently holds, and
+        to find which file defines it — the returned ``file`` + ``yaml_path`` are
+        exactly the arguments that address the same fragment for an edit.
+
+        Not for storage-mode items: automations, scripts and scenes created
+        through the UI live outside YAML — read those with ha_config_get_automation,
+        ha_config_get_script and ha_config_get_scene. This tool sees only what is
+        written in the config files themselves.
+
+        Reads the file, so it reflects what is on disk rather than what Home
+        Assistant currently has loaded; a fragment edited but not yet reloaded
+        differs from the running config. Comments and HA tags survive as written
+        and a ``!secret`` is never resolved to its value, so ``content`` can be
+        handed back to ha_config_set_yaml unchanged. Files outside the read
+        allowlist and secrets.yaml itself stay unreadable.
+        """
+        try:
+            await _assert_mcp_tools_available(self._client)
+
+            targets = await _resolve_target_files(self._client, file)
+
+            matches: list[dict[str, Any]] = []
+            for target in targets:
+                service_data: dict[str, Any] = {
+                    "path": target,
+                    "yaml_path": yaml_path,
+                }
+                if include_parsed:
+                    service_data["include_parsed"] = True
+
+                unwrapped = await _unwrap_or_raise(
+                    await call_mcp_tools_service(
+                        self._client, "read_file", service_data
+                    ),
+                    "read_file",
+                    {"file": target, "yaml_path": yaml_path},
+                )
+
+                # None = the file parsed but has no such key: not an error, just
+                # a non-match, which is the whole point of a glob search.
+                if unwrapped.get("subtree") is None:
+                    continue
+
+                match: dict[str, Any] = {"file": target, "yaml_path": yaml_path}
+                if include_content:
+                    match["content"] = unwrapped["subtree"]
+                if include_parsed:
+                    match["parsed"] = unwrapped.get("parsed")
+                matches.append(match)
+
+            return {
+                "success": True,
+                "yaml_path": yaml_path,
+                "matches": matches,
+                "count": len(matches),
+                # Separates "the glob matched no files" from "no file defines
+                # the key" — same empty matches[], different fix.
+                "files_searched": len(targets),
+            }
+
+        except ToolError:
+            raise
+        except Exception as e:
+            exception_to_structured_error(
+                e,
+                context={
+                    "tool": "ha_config_get_yaml",
+                    "file": file,
+                    "yaml_path": yaml_path,
+                },
+            )
+            return None  # raise_tool_error always raises; explicit for CodeQL
+        return None  # py/mixed-returns: explicit terminal; handlers above always raise
+
+
+def register_yaml_read_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
+    """Register the read-only YAML lookup tool.
+
+    Intentionally unconditional: ENABLE_YAML_CONFIG_EDITING gates *editing*, and
+    reading a fragment is useful (and safe) with editing switched off.
+    """
+    register_tool_methods(mcp, YamlReadTools(client))

--- a/src/ha_mcp/tools/tools_yaml_read.py
+++ b/src/ha_mcp/tools/tools_yaml_read.py
@@ -11,6 +11,7 @@ reading a config fragment is not an edit, and an agent needs to inspect config
 whether or not YAML editing is turned on.
 """
 
+import asyncio
 import logging
 from typing import Annotated, Any
 
@@ -54,7 +55,7 @@ def _call_failed(service: str, context: dict[str, Any]) -> None:
     )
 
 
-async def _unwrap_or_raise(result: Any, service: str, context: dict[str, Any]) -> Any:
+def _unwrap_or_raise(result: Any, service: str, context: dict[str, Any]) -> Any:
     """Unwrap a component service response, raising on a failure payload."""
     if not isinstance(result, dict):
         _call_failed(service, context)
@@ -76,7 +77,7 @@ async def _resolve_target_files(client: Any, file: str) -> list[str]:
         return [file]
 
     directory, _, pattern = file.rpartition("/")
-    unwrapped = await _unwrap_or_raise(
+    unwrapped = _unwrap_or_raise(
         await call_mcp_tools_service(
             client,
             "list_files",
@@ -177,21 +178,25 @@ class YamlReadTools:
 
             targets = await _resolve_target_files(self._client, file)
 
-            matches: list[dict[str, Any]] = []
-            for target in targets:
-                service_data: dict[str, Any] = {
-                    "path": target,
-                    "yaml_path": yaml_path,
-                }
-                if include_parsed:
-                    service_data["include_parsed"] = True
+            extra: dict[str, Any] = {"include_parsed": True} if include_parsed else {}
+            # The reads are independent, so fan them out rather than paying N
+            # sequential round-trips to HA — a packages glob is routinely 10+
+            # files. gather preserves order, so matches stay sorted by file.
+            responses = await asyncio.gather(
+                *(
+                    call_mcp_tools_service(
+                        self._client,
+                        "read_file",
+                        {"path": target, "yaml_path": yaml_path, **extra},
+                    )
+                    for target in targets
+                )
+            )
 
-                unwrapped = await _unwrap_or_raise(
-                    await call_mcp_tools_service(
-                        self._client, "read_file", service_data
-                    ),
-                    "read_file",
-                    {"file": target, "yaml_path": yaml_path},
+            matches: list[dict[str, Any]] = []
+            for target, response in zip(targets, responses, strict=True):
+                unwrapped = _unwrap_or_raise(
+                    response, "read_file", {"file": target, "yaml_path": yaml_path}
                 )
 
                 # None = the file parsed but has no such key: not an error, just

--- a/src/ha_mcp/tools/tools_yaml_read.py
+++ b/src/ha_mcp/tools/tools_yaml_read.py
@@ -194,13 +194,23 @@ class YamlReadTools:
             )
 
             matches: list[dict[str, Any]] = []
+            warnings: list[str] = []
             for target, response in zip(targets, responses, strict=True):
                 unwrapped = _unwrap_or_raise(
                     response, "read_file", {"file": target, "yaml_path": yaml_path}
                 )
 
-                # None = the file parsed but has no such key: not an error, just
-                # a non-match, which is the whole point of a glob search.
+                # A file that could not be parsed is NOT a non-match: reporting
+                # it as one would tell the caller the key is absent when the
+                # file was never inspected. One broken package in a glob must
+                # not read as a clean "not defined anywhere".
+                parse_error = unwrapped.get("parse_error")
+                if parse_error:
+                    warnings.append(f"{target} was not searched: {parse_error}.")
+                    continue
+
+                # None here means the file parsed but has no such key: a real
+                # non-match, which is the whole point of a glob search.
                 if unwrapped.get("subtree") is None:
                     continue
 
@@ -211,7 +221,7 @@ class YamlReadTools:
                     match["parsed"] = unwrapped.get("parsed")
                 matches.append(match)
 
-            return {
+            result: dict[str, Any] = {
                 "success": True,
                 "yaml_path": yaml_path,
                 "matches": matches,
@@ -220,6 +230,9 @@ class YamlReadTools:
                 # the key" — same empty matches[], different fix.
                 "files_searched": len(targets),
             }
+            if warnings:
+                result["warnings"] = warnings
+            return result
 
         except ToolError:
             raise

--- a/tests/src/e2e/conftest.py
+++ b/tests/src/e2e/conftest.py
@@ -950,6 +950,28 @@ def _seed_legacy_yaml_backups(config_path: Path) -> None:
     )
 
 
+def _seed_non_yaml_package_file(config_path: Path) -> None:
+    """Stage a non-YAML file inside the bound packages folder pre-boot (#1788).
+
+    ``ha_config_get_yaml``'s glob is not restricted to ``*.yaml``, so
+    ``custom_packages/*`` legitimately turns up a file the component refuses to
+    read (its package-dir read rule requires ``.yaml``). The warn-and-continue
+    path that keeps one such file from sinking the whole search needs the real
+    component to produce that refusal, and no tool can create the file:
+    ``write_file`` is never granted package access, so it is staged here, like
+    the legacy backups above (a post-boot host write doesn't propagate in CI).
+
+    Inert at boot: HA loads a ``!include_dir_named`` folder through
+    ``_find_files(loc, "*.yaml")`` (annotatedyaml), so a ``.md`` is ignored.
+    The folder name matches the one initial_test_state/configuration.yaml binds.
+    """
+    packages_dir = config_path / "custom_packages"
+    packages_dir.mkdir(parents=True, exist_ok=True)
+    (packages_dir / "_e2e_not_yaml.md").write_text(
+        "Not YAML. Staged so a packages glob has a file the component skips.\n"
+    )
+
+
 def _collect_manifest_requirements(config_path: Path) -> list[str]:
     """Aggregate ``requirements`` from every installed custom-component manifest.
 
@@ -1933,6 +1955,10 @@ def ha_container_with_fresh_config(request):
     # the bind-mounted .ha_mcp_tools_backups/ is populated when the component
     # reads it (a post-boot host write doesn't propagate in CI).
     _seed_legacy_yaml_backups(config_path)
+
+    # A non-YAML file in the bound packages folder for the glob warn-and-continue
+    # e2e (#1788): same pre-boot reason, and no tool can write it there.
+    _seed_non_yaml_package_file(config_path)
 
     # Shift the pre-baked recorder timestamps forward so the seeded rows
     # look "recent" to history queries with a 24h window. The recorder DB in

--- a/tests/src/e2e/workflows/filesystem/test_yaml_read.py
+++ b/tests/src/e2e/workflows/filesystem/test_yaml_read.py
@@ -1,0 +1,214 @@
+"""
+End-to-End tests for the read-only YAML fragment lookup (ha_config_get_yaml).
+
+This test suite validates:
+- Registration without the YAML-editing feature flag (the tool is ungated)
+- Single-file fragment reads addressed by file + yaml_path
+- Cross-file key discovery through a glob, against the NON-default packages
+  folder the e2e config binds (``custom_packages``, see initial_test_state/
+  configuration.yaml) — which is exactly the runtime-detection path
+- HA tags surviving unresolved into both the text and the parsed view
+
+These tests require the ha_mcp_tools custom component to be installed in Home
+Assistant. Unlike ha_config_set_yaml, ha_config_get_yaml needs no feature flag;
+the flag is only enabled here to SEED a package file to then discover.
+
+Tests are designed for the Docker Home Assistant test environment.
+"""
+
+import logging
+import os
+from typing import Any
+
+import pytest
+
+from ...utilities.assertions import MCPAssertions
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+TOOL_NAME = "ha_config_get_yaml"
+SET_TOOL = "ha_config_set_yaml"
+FEATURE_FLAG = "ENABLE_YAML_CONFIG_EDITING"
+
+# initial_test_state/configuration.yaml binds packages under this NON-default
+# folder on purpose (#1854), so a glob over it only resolves if the component
+# detects the configured folder at runtime rather than assuming "packages".
+PACKAGES_DIR = "custom_packages"
+
+
+@pytest.fixture(scope="module")
+def yaml_editing_enabled(ha_container_with_fresh_config):
+    """Enable YAML editing for the module — only needed to seed a package."""
+    os.environ[FEATURE_FLAG] = "true"
+    yield
+    os.environ.pop(FEATURE_FLAG, None)
+
+
+async def _set_yaml_confirmed(mcp: Any, args: dict[str, Any]) -> dict[str, Any]:
+    """Drive ha_config_set_yaml's default-on two-step confirm flow to a write.
+
+    Local to this module: a sibling test file's module-level helper is not
+    importable as a fixture, and this only needs the write half.
+    """
+    data = await mcp.call_tool_success(SET_TOOL, args)
+    if data.get("preview"):
+        data = await mcp.call_tool_success(
+            SET_TOOL, {**args, "confirm_token": data["confirm_token"]}
+        )
+    return data
+
+
+@pytest.mark.filesystem
+class TestYamlReadAvailability:
+    """ha_config_get_yaml is registered regardless of the editing flag."""
+
+    async def test_registered_without_editing_flag(self, mcp_client):
+        """The read tool must be present even with YAML editing off.
+
+        That independence is the reason it lives in its own module — reading a
+        fragment is not an edit.
+        """
+        original = os.environ.pop(FEATURE_FLAG, None)
+        try:
+            tools = await mcp_client.list_tools()
+            assert TOOL_NAME in {t.name for t in tools}, (
+                f"{TOOL_NAME} must register without {FEATURE_FLAG}"
+            )
+        finally:
+            if original:
+                os.environ[FEATURE_FLAG] = original
+
+
+@pytest.mark.filesystem
+class TestYamlReadSingleFile:
+    """Fragment reads addressed exactly like ha_config_set_yaml."""
+
+    async def test_reads_key_from_configuration_yaml(self, mcp_client):
+        async with MCPAssertions(mcp_client) as mcp:
+            data = await mcp.call_tool_success(
+                TOOL_NAME, {"yaml_path": "http", "file": "configuration.yaml"}
+            )
+
+        assert data["count"] == 1
+        assert data["files_searched"] == 1
+        match = data["matches"][0]
+        assert match["file"] == "configuration.yaml"
+        assert match["yaml_path"] == "http"
+        # The http block of initial_test_state/configuration.yaml.
+        assert "use_x_forwarded_for" in match["content"]
+
+    async def test_absent_key_is_an_empty_result_not_an_error(self, mcp_client):
+        async with MCPAssertions(mcp_client) as mcp:
+            data = await mcp.call_tool_success(
+                TOOL_NAME,
+                {"yaml_path": "no_such_key_here", "file": "configuration.yaml"},
+            )
+
+        assert data["success"] is True
+        assert data["matches"] == []
+        assert data["count"] == 0
+        # The file WAS searched — distinguishes this from a glob that matched
+        # no files at all.
+        assert data["files_searched"] == 1
+
+    async def test_include_content_false_omits_bodies(self, mcp_client):
+        async with MCPAssertions(mcp_client) as mcp:
+            data = await mcp.call_tool_success(
+                TOOL_NAME,
+                {
+                    "yaml_path": "http",
+                    "file": "configuration.yaml",
+                    "include_content": False,
+                },
+            )
+
+        assert data["count"] == 1
+        assert "content" not in data["matches"][0]
+
+    async def test_include_parsed_returns_structured_data(self, mcp_client):
+        async with MCPAssertions(mcp_client) as mcp:
+            data = await mcp.call_tool_success(
+                TOOL_NAME,
+                {
+                    "yaml_path": "http",
+                    "file": "configuration.yaml",
+                    "include_parsed": True,
+                },
+            )
+
+        parsed = data["matches"][0]["parsed"]
+        assert isinstance(parsed, dict)
+        assert parsed["use_x_forwarded_for"] is True
+
+
+@pytest.mark.filesystem
+class TestYamlReadTagPreservation:
+    """HA tags reach the caller unresolved — the property that keeps a
+    ``!secret`` from ever being dereferenced by this read path."""
+
+    async def test_include_tag_not_resolved(self, mcp_client):
+        """configuration.yaml has ``automation: !include automations.yaml``.
+
+        Both views must show the tag as written. If either ever resolved the
+        include, the same machinery would resolve ``!secret`` to plaintext.
+        """
+        async with MCPAssertions(mcp_client) as mcp:
+            data = await mcp.call_tool_success(
+                TOOL_NAME,
+                {
+                    "yaml_path": "automation",
+                    "file": "configuration.yaml",
+                    "include_parsed": True,
+                },
+            )
+
+        match = data["matches"][0]
+        assert "!include automations.yaml" in match["content"]
+        assert match["parsed"] == "!include automations.yaml"
+
+
+@pytest.mark.filesystem
+class TestYamlReadGlobDiscovery:
+    """The issue's core ask: find which file defines a key."""
+
+    async def test_glob_discovers_defining_file(self, mcp_client, yaml_editing_enabled):
+        """Seed two package files, then discover the one defining the key.
+
+        Globs ``custom_packages/*.yaml`` — the folder is bound via
+        ``!include_dir_named custom_packages``, so listing it works only
+        because the component resolves the configured packages folder.
+        """
+        async with MCPAssertions(mcp_client) as mcp:
+            await _set_yaml_confirmed(
+                mcp,
+                {
+                    "yaml_path": "command_line",
+                    "action": "add",
+                    "file": f"{PACKAGES_DIR}/_e2e_read_hit.yaml",
+                    "content": "- sensor:\n    name: e2e_read_probe\n    command: echo 1\n",
+                },
+            )
+            await _set_yaml_confirmed(
+                mcp,
+                {
+                    "yaml_path": "shell_command",
+                    "action": "add",
+                    "file": f"{PACKAGES_DIR}/_e2e_read_miss.yaml",
+                    "content": "e2e_read_noop: echo 2\n",
+                },
+            )
+
+            data = await mcp.call_tool_success(
+                TOOL_NAME,
+                {"yaml_path": "command_line", "file": f"{PACKAGES_DIR}/*.yaml"},
+            )
+
+        # Only the file that defines command_line matches, but both were read.
+        assert data["count"] == 1
+        assert data["files_searched"] >= 2
+        match = data["matches"][0]
+        assert match["file"] == f"{PACKAGES_DIR}/_e2e_read_hit.yaml"
+        assert "e2e_read_probe" in match["content"]
+        # file + yaml_path address the same fragment for ha_config_set_yaml.
+        assert match["yaml_path"] == "command_line"

--- a/tests/src/e2e/workflows/filesystem/test_yaml_read.py
+++ b/tests/src/e2e/workflows/filesystem/test_yaml_read.py
@@ -2,16 +2,19 @@
 End-to-End tests for the read-only YAML fragment lookup (ha_config_get_yaml).
 
 This test suite validates:
-- Registration without the YAML-editing feature flag (the tool is ungated)
+- Registration without the YAML-*editing* feature flag (reading is not editing)
 - Single-file fragment reads addressed by file + yaml_path
 - Cross-file key discovery through a glob, against the NON-default packages
   folder the e2e config binds (``custom_packages``, see initial_test_state/
   configuration.yaml) — which is exactly the runtime-detection path
 - HA tags surviving unresolved into both the text and the parsed view
+- secrets.yaml reading back masked through those views
+- The get → set round-trip that is the point of the feature
 
 These tests require the ha_mcp_tools custom component to be installed in Home
-Assistant. Unlike ha_config_set_yaml, ha_config_get_yaml needs no feature flag;
-the flag is only enabled here to SEED a package file to then discover.
+Assistant. ha_config_get_yaml hangs on ``enable_filesystem_tools`` (it returns
+config-file contents) but NOT on ENABLE_YAML_CONFIG_EDITING; that flag is
+enabled here only to SEED a package file to then discover.
 
 Tests are designed for the Docker Home Assistant test environment.
 """
@@ -62,13 +65,15 @@ async def _set_yaml_confirmed(mcp: Any, args: dict[str, Any]) -> dict[str, Any]:
 
 @pytest.mark.filesystem
 class TestYamlReadAvailability:
-    """ha_config_get_yaml is registered regardless of the editing flag."""
+    """ha_config_get_yaml is registered regardless of the *editing* flag."""
 
     async def test_registered_without_editing_flag(self, mcp_client):
         """The read tool must be present even with YAML editing off.
 
         That independence is the reason it lives in its own module — reading a
-        fragment is not an edit.
+        fragment is not an edit. (It does hang on enable_filesystem_tools; the
+        unit suite pins that gate, which env changes here cannot exercise
+        against an already-running server.)
         """
         original = os.environ.pop(FEATURE_FLAG, None)
         try:
@@ -201,6 +206,88 @@ class TestReadFileYamlPath:
         assert "use_x_forwarded_for" in data["subtree"]
         # content stays truncated: tailing is a display concern only.
         assert len(data["content"].split("\n")) <= 3
+
+
+@pytest.mark.filesystem
+class TestSecretsMasking:
+    """secrets.yaml reads back masked through the yaml_path views too.
+
+    The unit half (test_custom_component_filesystem.py::
+    TestReadFileSecretsMaskingOrder) pins the ordering that makes this hold;
+    this is the behavioural half against the real component.
+    """
+
+    async def test_subtree_and_parsed_are_masked(self, mcp_client):
+        """initial_test_state/secrets.yaml holds ``some_password: welcome``."""
+        async with MCPAssertions(mcp_client) as mcp:
+            data = await mcp.call_tool_success(
+                TOOL_NAME,
+                {
+                    "yaml_path": "some_password",
+                    "file": "secrets.yaml",
+                    "include_parsed": True,
+                },
+            )
+
+        match = data["matches"][0]
+        assert "welcome" not in match["content"]
+        assert "[MASKED]" in match["content"]
+        assert match["parsed"] == "[MASKED]"
+
+
+@pytest.mark.filesystem
+class TestYamlReadRoundTrip:
+    """#1788's core promise: a match feeds straight back into set_yaml."""
+
+    async def test_read_content_is_accepted_by_set_yaml(
+        self, mcp_client, yaml_editing_enabled
+    ):
+        """Seed a tag-bearing key, read it, hand the content back to set_yaml.
+
+        The read `content` carries an unresolved ``!secret``. If set_yaml
+        rejected or mangled tag-bearing subtree text, the feature would be
+        broken end-to-end with nothing else failing — the two tools would
+        simply not compose.
+        """
+        target = f"{PACKAGES_DIR}/_e2e_roundtrip.yaml"
+        async with MCPAssertions(mcp_client) as mcp:
+            await _set_yaml_confirmed(
+                mcp,
+                {
+                    "yaml_path": "shell_command",
+                    "action": "add",
+                    "file": target,
+                    "content": "e2e_roundtrip_probe: !secret some_password\n",
+                },
+            )
+
+            read = await mcp.call_tool_success(
+                TOOL_NAME, {"yaml_path": "shell_command", "file": target}
+            )
+            match = read["matches"][0]
+            assert "!secret some_password" in match["content"], (
+                "the tag must survive the read for the round-trip to mean anything"
+            )
+
+            # The whole point: file + yaml_path + content address the same
+            # fragment for the editor, unchanged.
+            await _set_yaml_confirmed(
+                mcp,
+                {
+                    "yaml_path": match["yaml_path"],
+                    "action": "replace",
+                    "file": match["file"],
+                    "content": match["content"],
+                },
+            )
+
+            after = await mcp.call_tool_success(
+                TOOL_NAME, {"yaml_path": "shell_command", "file": target}
+            )
+
+        # Round-tripped through the editor without mangling the tag.
+        assert after["matches"][0]["content"] == match["content"]
+        assert "!secret some_password" in after["matches"][0]["content"]
 
 
 @pytest.mark.filesystem

--- a/tests/src/e2e/workflows/filesystem/test_yaml_read.py
+++ b/tests/src/e2e/workflows/filesystem/test_yaml_read.py
@@ -7,6 +7,8 @@ This test suite validates:
 - Cross-file key discovery through a glob, against the NON-default packages
   folder the e2e config binds (``custom_packages``, see initial_test_state/
   configuration.yaml) — which is exactly the runtime-detection path
+- A glob that matches several defining files, and one that matches a file the
+  component refuses to read (warned about, search continues)
 - HA tags surviving unresolved into both the text and the parsed view
 - secrets.yaml reading back masked through those views
 - The get → set round-trip that is the point of the feature
@@ -39,6 +41,26 @@ FEATURE_FLAG = "ENABLE_YAML_CONFIG_EDITING"
 # folder on purpose (#1854), so a glob over it only resolves if the component
 # detects the configured folder at runtime rather than assuming "packages".
 PACKAGES_DIR = "custom_packages"
+
+# Staged pre-boot by conftest._seed_non_yaml_package_file — the file a
+# `custom_packages/*` glob must skip rather than fail on.
+NON_YAML_FILE = f"{PACKAGES_DIR}/_e2e_not_yaml.md"
+
+
+def _require_seeded_backend(container_info: dict) -> None:
+    """Skip unless the non-YAML package file was staged into the config_path.
+
+    ``_seed_non_yaml_package_file`` runs on the shared testcontainer setup path,
+    used by the ``container`` and ``embedded`` backends; the HAOS backends boot a
+    pre-baked qcow2 that carries no such seed. Nothing else can create the file —
+    package folders are readable but never writable through the file tools — so
+    the test skips rather than seeding at runtime.
+    """
+    if container_info.get("backend") not in ("container", "embedded"):
+        pytest.skip(
+            "the non-YAML package file is staged pre-boot into the container "
+            "config_path (testcontainer / embedded backends only)"
+        )
 
 
 @pytest.fixture(scope="module")
@@ -334,3 +356,83 @@ class TestYamlReadGlobDiscovery:
         assert "e2e_read_probe" in match["content"]
         # file + yaml_path address the same fragment for ha_config_set_yaml.
         assert match["yaml_path"] == "command_line"
+
+    async def test_glob_returns_every_defining_file(
+        self, mcp_client, yaml_editing_enabled
+    ):
+        """Two files defining the same key both come back — #1788's core shape.
+
+        "Which file defines this key?" has more than one answer whenever a key is
+        split across packages, and the caller needs each ``file`` to address the
+        right fragment for an edit.
+        """
+        first = f"{PACKAGES_DIR}/_e2e_multi_a.yaml"
+        second = f"{PACKAGES_DIR}/_e2e_multi_b.yaml"
+        async with MCPAssertions(mcp_client) as mcp:
+            for target, marker in ((first, "a"), (second, "b")):
+                await _set_yaml_confirmed(
+                    mcp,
+                    {
+                        "yaml_path": "notify",
+                        "action": "add",
+                        "file": target,
+                        "content": (
+                            f"- name: e2e_multi_{marker}\n"
+                            "  platform: command_line\n"
+                            f"  command: echo {marker}\n"
+                        ),
+                    },
+                )
+
+            data = await mcp.call_tool_success(
+                TOOL_NAME, {"yaml_path": "notify", "file": f"{PACKAGES_DIR}/*.yaml"}
+            )
+
+        assert data["count"] == 2
+        # Sorted by file, so each match's content pairs with its own file.
+        assert [m["file"] for m in data["matches"]] == [first, second]
+        assert "e2e_multi_a" in data["matches"][0]["content"]
+        assert "e2e_multi_b" in data["matches"][1]["content"]
+
+    async def test_unreadable_file_warns_without_sinking_the_search(
+        self, mcp_client, ha_container_with_fresh_config, yaml_editing_enabled
+    ):
+        """``custom_packages/*`` matches a non-YAML file; the search survives it.
+
+        The behavioural half of the warn-and-continue path the unit suite pins
+        against mocks: the refusal has to come from the real component, whose
+        package-dir read rule requires ``.yaml``. The skipped file is named in
+        ``warnings`` rather than silently dropped — a skip reported as "key not
+        here" would be a wrong answer to "which file defines it?".
+        """
+        _require_seeded_backend(ha_container_with_fresh_config)
+        hit = f"{PACKAGES_DIR}/_e2e_read_warn.yaml"
+        async with MCPAssertions(mcp_client) as mcp:
+            await _set_yaml_confirmed(
+                mcp,
+                {
+                    "yaml_path": "group",
+                    "action": "add",
+                    "file": hit,
+                    "content": "e2e_warn_probe:\n  entities:\n    - sun.sun\n",
+                },
+            )
+
+            data = await mcp.call_tool_success(
+                TOOL_NAME, {"yaml_path": "group", "file": f"{PACKAGES_DIR}/*"}
+            )
+
+        # The sibling match survives the unreadable file.
+        assert data["count"] == 1
+        assert data["matches"][0]["file"] == hit
+        assert "e2e_warn_probe" in data["matches"][0]["content"]
+
+        # Named once, as a skip carrying the component's refusal — not as a
+        # stray mention inside some other warning.
+        skipped = [w for w in data.get("warnings", []) if NON_YAML_FILE in w]
+        assert len(skipped) == 1, data.get("warnings")
+        assert skipped[0].startswith(
+            f"{NON_YAML_FILE} was not searched: Path not allowed."
+        ), skipped
+        # Both the skipped file and the match were targets of the search.
+        assert data["files_searched"] >= 2

--- a/tests/src/e2e/workflows/filesystem/test_yaml_read.py
+++ b/tests/src/e2e/workflows/filesystem/test_yaml_read.py
@@ -29,6 +29,7 @@ logger = logging.getLogger(__name__)
 
 TOOL_NAME = "ha_config_get_yaml"
 SET_TOOL = "ha_config_set_yaml"
+READ_TOOL = "ha_read_file"
 FEATURE_FLAG = "ENABLE_YAML_CONFIG_EDITING"
 
 # initial_test_state/configuration.yaml binds packages under this NON-default
@@ -166,6 +167,40 @@ class TestYamlReadTagPreservation:
         match = data["matches"][0]
         assert "!include automations.yaml" in match["content"]
         assert match["parsed"] == "!include automations.yaml"
+
+
+@pytest.mark.filesystem
+class TestReadFileYamlPath:
+    """`ha_read_file` forwards yaml_path for the single-file case."""
+
+    async def test_yaml_path_returns_subtree(self, mcp_client):
+        async with MCPAssertions(mcp_client) as mcp:
+            data = await mcp.call_tool_success(
+                READ_TOOL, {"path": "configuration.yaml", "yaml_path": "http"}
+            )
+
+        assert "use_x_forwarded_for" in data["subtree"]
+
+    async def test_yaml_path_extracts_from_the_untailed_file(self, mcp_client):
+        """tail_lines must not truncate the text the key is extracted from.
+
+        `http:` sits near the top of configuration.yaml, so a tail of a few
+        lines excludes it entirely, and the retained tail is not valid YAML on
+        its own. Extracting from the tailed text would report the key as
+        absent; the subtree must still come back, while `content` stays tailed.
+        """
+        async with MCPAssertions(mcp_client) as mcp:
+            data = await mcp.call_tool_success(
+                READ_TOOL,
+                {"path": "configuration.yaml", "tail_lines": 3, "yaml_path": "http"},
+            )
+
+        assert data["subtree"] is not None, (
+            "yaml_path must extract from the full file, not the tailed text"
+        )
+        assert "use_x_forwarded_for" in data["subtree"]
+        # content stays truncated: tailing is a display concern only.
+        assert len(data["content"].split("\n")) <= 3
 
 
 @pytest.mark.filesystem

--- a/tests/src/unit/test_caller_token_auth.py
+++ b/tests/src/unit/test_caller_token_auth.py
@@ -571,13 +571,17 @@ class TestCallMcpToolsServiceInjectsToken:
                 "services": {CALLER_TOKEN_BOOTSTRAP_SERVICE: {}, "list_files": {}},
             }
         ]
-        # Hardcoded "0.99.0" so a future MIN bump still sorts BELOW it.
+        # DERIVED from the current minimum (major + 1) rather than hardcoded:
+        # the previous literal "0.99.0" was picked so "a future MIN bump still
+        # sorts BELOW it", but the 0.11.0 → 1.1.0 bump (#1788) overtook it and
+        # broke the test. Deriving keeps that intent true for every bump.
+        above_minimum = f"{_version_tuple(MIN_COMPONENT_VERSION)[0] + 1}.0.0"
         client.call_service = AsyncMock(
             return_value={
                 "service_response": {
                     "success": True,
                     "token": "tok-future",
-                    "version": "0.99.0",
+                    "version": above_minimum,
                 }
             }
         )

--- a/tests/src/unit/test_custom_component_filesystem.py
+++ b/tests/src/unit/test_custom_component_filesystem.py
@@ -1625,6 +1625,32 @@ class TestExtractYamlViews:
         assert views["subtree"] is None
         assert "parsed" not in views
 
+    def test_malformed_yaml_reports_parse_error(self):
+        """A broken file must be distinguishable from one lacking the key.
+
+        Without this, one syntactically broken package in a glob reads as a
+        clean "the key is not defined anywhere".
+        """
+        views = _extract_yaml_views("key: [1, 2\n", "key")
+        assert views["subtree"] is None
+        assert "not valid YAML" in views["parse_error"]
+
+    def test_absent_key_reports_no_parse_error(self):
+        views = _extract_yaml_views("a: 1\n", "nope")
+        assert views["subtree"] is None
+        assert "parse_error" not in views
+
+    def test_parse_error_carries_position_but_no_file_content(self):
+        """ruamel embeds the offending source line in its message; that line
+        can hold an inline credential, so only the position is reported."""
+        secret = "hunter2-should-never-surface"
+        views = _extract_yaml_views(
+            f"rest:\n  api_key: {secret}\n  bad: [1, 2\n", "rest"
+        )
+        assert views["subtree"] is None
+        assert secret not in views["parse_error"]
+        assert "line" in views["parse_error"]
+
 
 class TestRecorderYamlKey:
     """#1852: recorder is editable via edit_yaml_config / ha_config_set_yaml.

--- a/tests/src/unit/test_custom_component_filesystem.py
+++ b/tests/src/unit/test_custom_component_filesystem.py
@@ -889,6 +889,47 @@ class TestLegacyBackupServiceWiring:
         assert "SERVICE_READ_LEGACY_BACKUP" in unload_src
 
 
+class TestReadFileSecretsMaskingOrder:
+    """secrets.yaml masking must survive the yaml_path/include_parsed views.
+
+    The masking holds only because ``handle_read_file`` captures
+    ``full_content`` AFTER ``_mask_secrets_content`` and extracts the views
+    from that. Nothing else pins the ordering, so a future reorder that
+    captured ``full_content`` from the raw text would leak plaintext secrets
+    through ``subtree``/``parsed`` — the two views that did not exist when the
+    masking was written. Source-level guard, per the file's existing wiring
+    guards: the handler is a closure inside the setup entry, so it cannot be
+    called directly from a unit test. The behavioural half runs e2e
+    (test_yaml_read.py::TestSecretsMasking).
+    """
+
+    def _handler_source(self) -> str:
+        import inspect
+
+        from custom_components.ha_mcp_tools import _async_setup_tools_entry
+
+        src = inspect.getsource(_async_setup_tools_entry)
+        start = src.index("async def handle_read_file")
+        return src[start : src.index("async def handle_", start + 1)]
+
+    def test_full_content_is_captured_after_masking(self):
+        src = self._handler_source()
+        mask = src.index("_mask_secrets_content(content)")
+        capture = src.index("full_content = content")
+        assert mask < capture, (
+            "full_content must be captured AFTER _mask_secrets_content, or "
+            "yaml_path/include_parsed would extract from unmasked text"
+        )
+
+    def test_views_are_extracted_from_full_content(self):
+        """And the extraction must read that captured text, not raw content.
+
+        Handed to the executor as bare args, so the anchor carries no "(".
+        """
+        src = self._handler_source()
+        assert "_extract_yaml_views, full_content, yaml_path" in src
+
+
 class TestEditYamlConfigBackCompat:
     """Source guard: the strict (PREVENT_EXTRA) edit_yaml_config schema must
     keep accepting the legacy ``backup`` key. A pre-7.9.0 server still sends
@@ -1614,6 +1655,40 @@ class TestExtractYamlViews:
             "z": None,
             "l": [1, 2],
         }
+
+    def test_parsed_anchored_bool_stays_a_bool(self):
+        """A bool carrying an anchor loads as ruamel's ScalarBoolean, which
+        subclasses int but NOT bool — so an isinstance(x, bool) check alone
+        lets it fall through to the int branch and serialize as 1/0."""
+        views = _extract_yaml_views("a:\n  on: &flag true\n  off: *flag\n", "a", True)
+        assert views["parsed"] == {"on": True, "off": True}
+
+    def test_parsed_non_finite_floats_render_to_source_form(self):
+        """.inf/.nan are valid YAML but have no JSON encoding, so they come
+        back as their source form rather than breaking the response."""
+        views = _extract_yaml_views(
+            "a:\n  hi: .inf\n  lo: -.inf\n  n: .nan\n", "a", True
+        )
+        assert views["parsed"] == {"hi": ".inf", "lo": "-.inf", "n": ".nan"}
+        assert json.dumps(views["parsed"], allow_nan=False)
+
+    def test_parsed_timestamps_render_as_iso_strings(self):
+        """!!timestamp comes back as date/datetime, which json cannot encode."""
+        views = _extract_yaml_views(
+            "a:\n  d: 2024-01-02\n  dt: 2024-01-02 03:04:05\n", "a", True
+        )
+        assert views["parsed"] == {"d": "2024-01-02", "dt": "2024-01-02T03:04:05"}
+        assert json.dumps(views["parsed"])
+
+    def test_present_but_null_key_is_a_match_not_an_absence(self):
+        """`default_config:` is a real key with no value — the text view must
+        come back so it does not read as "not defined"."""
+        views = _extract_yaml_views(
+            "default_config:\nhttp:\n  x: 1\n", "default_config", True
+        )
+        assert views["subtree"] is not None
+        assert views["parsed"] is None
+        assert "parse_error" not in views
 
     def test_missing_key_yields_no_parsed(self):
         views = _extract_yaml_views("a: 1\n", "nope", True)

--- a/tests/src/unit/test_custom_component_filesystem.py
+++ b/tests/src/unit/test_custom_component_filesystem.py
@@ -297,8 +297,21 @@ password: 'mypassword'
         assert "mypassword" not in result
         assert "[MASKED]" in result
 
+    def test_mask_marker_reparses_as_a_scalar(self):
+        """The masked text is itself re-parsed by read_file's yaml_path views,
+        so the marker must be quoted: an unquoted ``[MASKED]`` is flow-sequence
+        syntax and would come back as the list ``["MASKED"]``."""
+        import io
+
+        from custom_components.ha_mcp_tools.yaml_rt import make_yaml, yaml_jsonify
+
+        result = _mask_secrets_content("api_key: secret123\n")
+
+        reparsed = make_yaml().load(io.StringIO(result))
+        assert yaml_jsonify(reparsed) == {"api_key": "[MASKED]"}
+
     def test_drops_comments_and_blank_lines(self):
-        """The structural mask emits only ``key: [MASKED]`` lines. Comments and
+        """The structural mask emits only ``key: "[MASKED]"`` lines. Comments and
         blank lines are intentionally not reproduced — they are not needed to
         show which keys exist, and dropping them avoids leaking a secret that a
         user pasted into a comment."""
@@ -309,7 +322,7 @@ password: 'mypassword'
 
         assert "secret123" not in result
         assert "pass456" not in result
-        assert result == "api_key: [MASKED]\npassword: [MASKED]"
+        assert result == 'api_key: "[MASKED]"\npassword: "[MASKED]"'
 
     def test_preserves_key_names(self):
         """Should preserve key names but mask values."""
@@ -333,7 +346,7 @@ token: tok789
         result = _mask_secrets_content("outer:\n  inner_secret: value\n")
 
         assert "value" not in result
-        assert result == "outer: [MASKED]"
+        assert result == 'outer: "[MASKED]"'
 
     def test_block_scalar_leaves_no_secret_bytes(self):
         """Core advisory PoC (GHSA-mc92-ww4q-6fg4): a block scalar's continuation
@@ -350,7 +363,7 @@ token: tok789
         assert "BEGIN OPENSSH" not in result
         assert "b3BlbnNzaC1rZXktdjEAAAAA" not in result
         assert "hunter2" not in result
-        assert result == "backup_ssh_key: [MASKED]\napi_password: [MASKED]"
+        assert result == 'backup_ssh_key: "[MASKED]"\napi_password: "[MASKED]"'
 
     def test_empty_or_non_mapping_withheld(self):
         """Empty file (None) or a top-level list/scalar: nothing to mask
@@ -367,7 +380,7 @@ token: tok789
     def test_custom_tag_does_not_crash(self):
         """The round-trip loader resolves HA-style custom tags instead of
         raising, so masking still produces a redacted key line."""
-        assert _mask_secrets_content("foo: !secret bar\n") == "foo: [MASKED]"
+        assert _mask_secrets_content("foo: !secret bar\n") == 'foo: "[MASKED]"'
 
     def test_yaml_anchors_do_not_leak_dereferenced_secrets(self):
         """A secret defined once via an anchor and reused via aliases is
@@ -376,7 +389,7 @@ token: tok789
         content = "base_token: &tok 'secret123'\nprod: *tok\ndev: *tok\n"
         result = _mask_secrets_content(content)
         assert "secret123" not in result
-        assert result == "base_token: [MASKED]\nprod: [MASKED]\ndev: [MASKED]"
+        assert result == 'base_token: "[MASKED]"\nprod: "[MASKED]"\ndev: "[MASKED]"'
 
 
 class TestFileOperationsIntegration:

--- a/tests/src/unit/test_custom_component_filesystem.py
+++ b/tests/src/unit/test_custom_component_filesystem.py
@@ -4,6 +4,7 @@ These tests focus on the pure Python utility functions that don't require
 Home Assistant dependencies.
 """
 
+import json
 import os
 import shutil
 import sys
@@ -36,7 +37,9 @@ from custom_components.ha_mcp_tools import (  # noqa: E402
     _decode_legacy_backup_name,
     _delete_file_sync,
     _detect_package_dirs,
+    _dir_in_package_dir,
     _extract_yaml_subtree,
+    _extract_yaml_views,
     _is_path_allowed_for_dir,
     _is_path_allowed_for_read,
     _is_within_config_dir,
@@ -1558,6 +1561,69 @@ class TestExtractYamlSubtree:
         assert _extract_yaml_subtree("key: [1, 2\n", "key") is None
 
 
+class TestExtractYamlViews:
+    """#1788: ``_extract_yaml_views`` backs read_file's yaml_path/include_parsed.
+    ``_extract_yaml_subtree`` is now a thin wrapper over it, so the text-view
+    contract above still pins that half.
+    """
+
+    def test_parsed_omitted_unless_requested(self):
+        views = _extract_yaml_views("rest:\n  method: GET\n", "rest")
+        assert views["subtree"] is not None
+        assert "parsed" not in views
+
+    def test_parsed_returns_structured_data(self):
+        views = _extract_yaml_views(
+            "rest:\n  method: GET\n  timeout: 5\n", "rest", True
+        )
+        assert views["parsed"] == {"method": "GET", "timeout": 5}
+
+    def test_parsed_keeps_secret_unresolved(self):
+        """The security property: a parsed view renders !secret in SOURCE form.
+
+        Resolving would require reading secrets.yaml, which this path never
+        does — so no plaintext secret can reach the response.
+        """
+        views = _extract_yaml_views(
+            "rest:\n  api_key: !secret alert2_api_key\n", "rest", True
+        )
+        assert views["parsed"] == {"api_key": "!secret alert2_api_key"}
+        # And the text view keeps the tag too.
+        assert "!secret alert2_api_key" in views["subtree"]
+
+    def test_parsed_keeps_include_unresolved(self):
+        views = _extract_yaml_views("group: !include groups.yaml\n", "group", True)
+        assert views["parsed"] == "!include groups.yaml"
+
+    def test_parsed_is_json_serializable(self):
+        # ruamel hands back CommentedMap/ScalarInt subclasses; the response is
+        # JSON-encoded on the way out, so plain types are the contract.
+        views = _extract_yaml_views(
+            "a:\n  n: 1\n  f: 1.5\n  b: true\n  s: x\n  z:\n  l: [1, 2]\n",
+            "a",
+            True,
+        )
+        assert json.dumps(views["parsed"])
+        assert views["parsed"] == {
+            "n": 1,
+            "f": 1.5,
+            "b": True,
+            "s": "x",
+            "z": None,
+            "l": [1, 2],
+        }
+
+    def test_missing_key_yields_no_parsed(self):
+        views = _extract_yaml_views("a: 1\n", "nope", True)
+        assert views["subtree"] is None
+        assert views.get("parsed") is None
+
+    def test_malformed_yaml_yields_no_parsed(self):
+        views = _extract_yaml_views("key: [1, 2\n", "key", True)
+        assert views["subtree"] is None
+        assert "parsed" not in views
+
+
 class TestRecorderYamlKey:
     """#1852: recorder is editable via edit_yaml_config / ha_config_set_yaml.
 
@@ -1768,3 +1834,73 @@ class TestReadAllowlistPackageFolder:
 
     def test_default_packages_folder_still_allowed(self, tmp_path):
         assert _is_path_allowed_for_read(tmp_path, "packages/foo.yaml")
+
+
+class TestDirInPackageDir:
+    """#1788: folder-level twin of _path_in_package_dir, used by the lister."""
+
+    def test_matches_folder_itself_and_nested(self):
+        dirs = {"packages", "custom_packages"}
+        assert _dir_in_package_dir("packages", dirs)
+        assert _dir_in_package_dir("custom_packages/sub", dirs)
+
+    def test_sibling_prefix_not_matched(self):
+        assert not _dir_in_package_dir("packagesX", {"packages"})
+
+    def test_glob_metachar_folder_literal(self):
+        # Mirrors _path_in_package_dir: a folder named 'pkg[1]' matches itself,
+        # not the fnmatch expansion 'pkg1'.
+        assert _dir_in_package_dir("pkg[1]", {"pkg[1]"})
+        assert not _dir_in_package_dir("pkg1", {"pkg[1]"})
+
+    def test_no_default_packages_when_none(self):
+        # Deliberately UNLIKE _path_in_package_dir, which defaults to
+        # {"packages"}: this helper backs a check shared with write/delete, so
+        # omitting package_dirs must grant nothing.
+        assert not _dir_in_package_dir("packages", None)
+        assert not _dir_in_package_dir("packages", set())
+
+
+class TestListAllowlistPackageFolder:
+    """#1788: the lister honours the configured packages folder the way the
+    read allowlist already does (#1854) — a packages folder that can be read
+    file-by-file must also be enumerable, which is what cross-file key
+    discovery needs.
+    """
+
+    def test_packages_folder_listable_when_passed(self, tmp_path):
+        assert _is_path_allowed_for_dir(
+            tmp_path, "packages", ALLOWED_READ_DIRS, None, {"packages"}
+        )
+
+    def test_custom_folder_listable_when_detected(self, tmp_path):
+        assert _is_path_allowed_for_dir(
+            tmp_path,
+            "integrations",
+            ALLOWED_READ_DIRS,
+            None,
+            {"packages", "integrations"},
+        )
+
+    def test_packages_not_listable_without_package_dirs(self, tmp_path):
+        # Back-compat: callers that don't resolve the packages folder keep the
+        # historical (deny) behaviour.
+        assert not _is_path_allowed_for_dir(tmp_path, "packages", ALLOWED_READ_DIRS)
+
+    def test_write_dirs_never_gain_package_access(self, tmp_path):
+        """Security invariant: _is_path_allowed_for_dir is shared with
+        write_file and delete_file, which pass no package_dirs. A packages
+        folder must stay unwritable there — edit_yaml_config is the only write
+        path that may reach config YAML.
+        """
+        assert not _is_path_allowed_for_dir(tmp_path, "packages", ALLOWED_WRITE_DIRS)
+        assert not _is_path_allowed_for_dir(
+            tmp_path, "packages/lights.yaml", ALLOWED_WRITE_DIRS
+        )
+
+    def test_deny_floor_still_applies_to_package_dirs(self, tmp_path):
+        # The widened allow decision must not outrank the deny floor: a
+        # maliciously configured '.storage' packages folder stays blocked.
+        assert not _is_path_allowed_for_dir(
+            tmp_path, ".storage", ALLOWED_READ_DIRS, None, {".storage"}
+        )

--- a/tests/src/unit/test_custom_component_filesystem.py
+++ b/tests/src/unit/test_custom_component_filesystem.py
@@ -34,6 +34,7 @@ sys.modules["homeassistant.loader"] = MagicMock()
 
 # Now we can import the functions
 from custom_components.ha_mcp_tools import (  # noqa: E402
+    _PACKAGE_DIR_CACHE,
     _decode_legacy_backup_name,
     _delete_file_sync,
     _detect_package_dirs,
@@ -49,6 +50,7 @@ from custom_components.ha_mcp_tools import (  # noqa: E402
     _mask_secrets_content,
     _migrate_legacy_backup_dir,
     _normalize_extra_dir,
+    _package_dir_markers_cached,
     _package_folder_relative_to_config,
     _parse_and_validate_yaml_path,
     _path_in_package_dir,
@@ -1782,6 +1784,77 @@ class TestPathInPackageDir:
 
     def test_default_packages_when_none(self):
         assert _path_in_package_dir("packages/foo.yaml", None)
+
+
+class TestPackageDirMarkersCached:
+    """#1788: folder detection runs on every file op, and a glob fires one per
+    matched file, so the parse is cached behind an mtime signature covering
+    every file the loader read.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _clear_cache(self):
+        _PACKAGE_DIR_CACHE.clear()
+        yield
+        _PACKAGE_DIR_CACHE.clear()
+
+    def test_second_call_does_not_reparse(self, tmp_path, monkeypatch):
+        p = _write_config(
+            tmp_path, "homeassistant:\n  packages: !include_dir_named pkgs\n"
+        )
+        assert _package_dir_markers_cached(p) == {"pkgs"}
+
+        def _boom(*_a, **_k):
+            raise AssertionError("cache miss: re-parsed an unchanged config")
+
+        monkeypatch.setattr(
+            "custom_components.ha_mcp_tools._load_package_dir_markers_tracked", _boom
+        )
+        assert _package_dir_markers_cached(p) == {"pkgs"}
+
+    def test_edit_invalidates(self, tmp_path):
+        p = _write_config(
+            tmp_path, "homeassistant:\n  packages: !include_dir_named pkgs\n"
+        )
+        assert _package_dir_markers_cached(p) == {"pkgs"}
+        _write_config(
+            tmp_path, "homeassistant:\n  packages: !include_dir_named other\n"
+        )
+        os.utime(p, ns=(0, 0))  # force a distinct mtime, not clock granularity
+        assert _package_dir_markers_cached(p) == {"other"}
+
+    def test_edit_to_included_file_invalidates(self, tmp_path):
+        """The reason the signature spans every file read, not just the root.
+
+        With the homeassistant: section split into an !include, keying on
+        configuration.yaml alone would serve a stale allowlist forever.
+        """
+        _write_config(tmp_path, "packages: !include_dir_named pkgs\n", name="ha.yaml")
+        p = _write_config(tmp_path, "homeassistant: !include ha.yaml\n")
+        assert _package_dir_markers_cached(p) == {"pkgs"}
+
+        (tmp_path / "ha.yaml").write_text(
+            "packages: !include_dir_named moved\n", encoding="utf-8"
+        )
+        os.utime(tmp_path / "ha.yaml", ns=(0, 0))
+        assert _package_dir_markers_cached(p) == {"moved"}
+
+    def test_creating_a_missing_include_invalidates(self, tmp_path):
+        """A missing include is stamped -1, so creating it later invalidates."""
+        p = _write_config(tmp_path, "homeassistant: !include later.yaml\n")
+        assert _package_dir_markers_cached(p) == set()
+
+        (tmp_path / "later.yaml").write_text(
+            "packages: !include_dir_named pkgs\n", encoding="utf-8"
+        )
+        assert _package_dir_markers_cached(p) == {"pkgs"}
+
+    def test_cached_set_is_not_mutable_through_caller(self, tmp_path):
+        p = _write_config(
+            tmp_path, "homeassistant:\n  packages: !include_dir_named pkgs\n"
+        )
+        _package_dir_markers_cached(p).add("injected")
+        assert _package_dir_markers_cached(p) == {"pkgs"}
 
 
 class TestDetectPackageDirs:

--- a/tests/src/unit/test_settings_ui.py
+++ b/tests/src/unit/test_settings_ui.py
@@ -395,6 +395,9 @@ class TestFeatureGatedTools:
             "ha_read_file",
             "ha_write_file",
             "ha_delete_file",
+            # Returns config-file contents through the same component
+            # services, so it rides the same flag (#1788).
+            "ha_config_get_yaml",
         ):
             assert FEATURE_GATED_TOOLS[name]["disabled_by"] == "enable_filesystem_tools"
 

--- a/tests/src/unit/test_yaml_read_tool.py
+++ b/tests/src/unit/test_yaml_read_tool.py
@@ -246,6 +246,55 @@ async def test_list_failure_raises_tool_error():
         await fn(yaml_path="alert2", file="packages/*.yaml")
 
 
+async def test_parse_error_warns_instead_of_reading_as_a_non_match():
+    """A file that could not be parsed must not read as "key not defined".
+
+    The glob case is the dangerous one: one broken package would otherwise make
+    the whole search report a clean absence.
+    """
+
+    def read(payload):
+        if payload["path"] == "packages/broken.yaml":
+            return {
+                "success": True,
+                "path": payload["path"],
+                "content": "...",
+                "subtree": None,
+                "parse_error": "not valid YAML at line 3, column 5",
+            }
+        return _read_ok("- name: ok\n")
+
+    fn, _ = await _make_tool(
+        {
+            "list_files": {
+                "success": True,
+                "files": [
+                    {"path": "packages/broken.yaml", "is_dir": False},
+                    {"path": "packages/good.yaml", "is_dir": False},
+                ],
+            },
+            "read_file": read,
+        }
+    )
+
+    out = await fn(yaml_path="alert2", file="packages/*.yaml")
+
+    assert out["count"] == 1
+    assert out["matches"][0]["file"] == "packages/good.yaml"
+    assert out["warnings"] == [
+        "packages/broken.yaml was not searched: not valid YAML at line 3, column 5."
+    ]
+
+
+async def test_no_warnings_key_when_nothing_degraded():
+    """`warnings` is omitted when empty, per the tool return contract."""
+    fn, _ = await _make_tool({"read_file": _read_ok("method: GET\n")})
+
+    out = await fn(yaml_path="rest", file="configuration.yaml")
+
+    assert "warnings" not in out
+
+
 async def test_root_level_glob_lists_config_root():
     """A glob with no directory part asks the lister for the config root.
 

--- a/tests/src/unit/test_yaml_read_tool.py
+++ b/tests/src/unit/test_yaml_read_tool.py
@@ -1,0 +1,246 @@
+"""Unit tests for the ha_config_get_yaml MCP tool wrapper (#1788)."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastmcp.exceptions import ToolError
+
+
+@pytest.fixture(autouse=True)
+def _reset_caller_token_cache():
+    """The filesystem wrapper caches the bootstrap token per-client; each test
+    builds a fresh client, so drop stale entries from a recycled id()."""
+    from ha_mcp.tools.tools_filesystem import _reset_caller_token_cache
+
+    _reset_caller_token_cache()
+    yield
+    _reset_caller_token_cache()
+
+
+def _service_mock(responses: dict):
+    """call_service mock answering the bootstrap plus per-service responses.
+
+    ``responses`` maps a service name to either a single response dict or a
+    callable taking the payload (so read_file can answer per-file).
+    """
+
+    async def fake_call_service(domain, service, payload, **kwargs):
+        if service == "get_caller_token":
+            from ha_mcp.tools.tools_filesystem import MIN_COMPONENT_VERSION
+
+            return {
+                "service_response": {
+                    "success": True,
+                    "token": "test-token",
+                    "version": MIN_COMPONENT_VERSION,
+                }
+            }
+        handler = responses[service]
+        result = handler(payload) if callable(handler) else handler
+        return {"service_response": result}
+
+    return AsyncMock(side_effect=fake_call_service)
+
+
+async def _make_tool(responses: dict):
+    """Build a minimal mcp + client harness around register_yaml_read_tools."""
+    from ha_mcp.tools.tools_yaml_read import register_yaml_read_tools
+
+    captured: dict = {}
+
+    class FakeMCP:
+        def add_tool(self, method):
+            captured.setdefault("fns", []).append(method)
+
+    client = MagicMock()
+    client.get_services = AsyncMock(
+        return_value=[
+            {
+                "domain": "ha_mcp_tools",
+                "services": {
+                    "get_caller_token": {},
+                    "read_file": {},
+                    "list_files": {},
+                },
+            }
+        ]
+    )
+    client.call_service = _service_mock(responses)
+
+    mcp = FakeMCP()
+    register_yaml_read_tools(mcp, client)
+    return captured["fns"][0], client
+
+
+def _read_ok(subtree, parsed=None):
+    body = {"success": True, "path": "x", "content": "...", "subtree": subtree}
+    if parsed is not None:
+        body["parsed"] = parsed
+    return body
+
+
+async def test_registers_without_yaml_editing_flag(monkeypatch):
+    """The read tool is ungated: it must register even with YAML editing off.
+
+    This is the whole reason it is a separate module from tools_yaml_config —
+    that module's register function returns early when the flag is off.
+    """
+    from ha_mcp import config as ha_mcp_config
+
+    monkeypatch.setenv("ENABLE_YAML_CONFIG_EDITING", "false")
+    monkeypatch.setenv("ENABLE_BETA_FEATURES", "false")
+    monkeypatch.setattr(ha_mcp_config, "_settings", None)
+    try:
+        fn, _ = await _make_tool({"read_file": _read_ok("rest:\n")})
+        assert fn is not None
+    finally:
+        ha_mcp_config._settings = None
+
+
+async def test_single_file_returns_match():
+    fn, client = await _make_tool({"read_file": _read_ok("method: GET\n")})
+
+    out = await fn(yaml_path="rest", file="configuration.yaml")
+
+    assert out["success"] is True
+    assert out["count"] == 1
+    assert out["files_searched"] == 1
+    assert out["matches"] == [
+        {
+            "file": "configuration.yaml",
+            "yaml_path": "rest",
+            "content": "method: GET\n",
+        }
+    ]
+
+
+async def test_absent_key_is_a_non_match_not_an_error():
+    """subtree=None means the file parsed but has no such key."""
+    fn, _ = await _make_tool({"read_file": _read_ok(None)})
+
+    out = await fn(yaml_path="nope", file="configuration.yaml")
+
+    assert out["success"] is True
+    assert out["matches"] == []
+    assert out["count"] == 0
+    assert out["files_searched"] == 1
+
+
+async def test_glob_expands_and_filters_to_defining_files():
+    """The discovery case: only files that actually define the key match."""
+
+    def read(payload):
+        if payload["path"] == "packages/alert2.yaml":
+            return _read_ok("- name: my_alert\n")
+        return _read_ok(None)
+
+    fn, client = await _make_tool(
+        {
+            "list_files": {
+                "success": True,
+                "files": [
+                    {"path": "packages/lights.yaml", "is_dir": False},
+                    {"path": "packages/alert2.yaml", "is_dir": False},
+                ],
+            },
+            "read_file": read,
+        }
+    )
+
+    out = await fn(yaml_path="alert2", file="packages/*.yaml")
+
+    assert out["count"] == 1
+    assert out["files_searched"] == 2
+    assert out["matches"][0]["file"] == "packages/alert2.yaml"
+    # list_files is asked for the directory, with the file-name pattern.
+    list_call = next(
+        c for c in client.call_service.await_args_list if c.args[1] == "list_files"
+    )
+    assert list_call.args[2]["path"] == "packages"
+    assert list_call.args[2]["pattern"] == "*.yaml"
+
+
+async def test_glob_skips_directories_and_sorts():
+    def read(payload):
+        return _read_ok(f"from: {payload['path']}\n")
+
+    fn, _ = await _make_tool(
+        {
+            "list_files": {
+                "success": True,
+                "files": [
+                    {"path": "packages/b.yaml", "is_dir": False},
+                    {"path": "packages/nested", "is_dir": True},
+                    {"path": "packages/a.yaml", "is_dir": False},
+                ],
+            },
+            "read_file": read,
+        }
+    )
+
+    out = await fn(yaml_path="k", file="packages/*.yaml")
+
+    assert [m["file"] for m in out["matches"]] == [
+        "packages/a.yaml",
+        "packages/b.yaml",
+    ]
+
+
+async def test_include_content_false_discovers_without_bodies():
+    fn, _ = await _make_tool({"read_file": _read_ok("- name: my_alert\n")})
+
+    out = await fn(
+        yaml_path="alert2", file="packages/alert2.yaml", include_content=False
+    )
+
+    assert out["count"] == 1
+    assert "content" not in out["matches"][0]
+    assert out["matches"][0]["file"] == "packages/alert2.yaml"
+
+
+async def test_include_parsed_requests_and_returns_parsed():
+    fn, client = await _make_tool(
+        {"read_file": _read_ok("api_key: !secret k\n", {"api_key": "!secret k"})}
+    )
+
+    out = await fn(yaml_path="rest", file="configuration.yaml", include_parsed=True)
+
+    assert out["matches"][0]["parsed"] == {"api_key": "!secret k"}
+    read_call = next(
+        c for c in client.call_service.await_args_list if c.args[1] == "read_file"
+    )
+    assert read_call.args[2]["include_parsed"] is True
+
+
+async def test_include_parsed_not_sent_by_default():
+    """Default calls must not send include_parsed at all — the component's
+    schema is strict, and the flag costs a parse the caller didn't ask for."""
+    fn, client = await _make_tool({"read_file": _read_ok("method: GET\n")})
+
+    await fn(yaml_path="rest", file="configuration.yaml")
+
+    read_call = next(
+        c for c in client.call_service.await_args_list if c.args[1] == "read_file"
+    )
+    assert "include_parsed" not in read_call.args[2]
+
+
+async def test_read_failure_raises_tool_error():
+    fn, _ = await _make_tool(
+        {"read_file": {"success": False, "error": "File does not exist: nope.yaml"}}
+    )
+
+    with pytest.raises(ToolError):
+        await fn(yaml_path="rest", file="nope.yaml")
+
+
+async def test_list_failure_raises_tool_error():
+    fn, _ = await _make_tool(
+        {
+            "list_files": {"success": False, "error": "Path not allowed.", "files": []},
+            "read_file": _read_ok("x\n"),
+        }
+    )
+
+    with pytest.raises(ToolError):
+        await fn(yaml_path="alert2", file="packages/*.yaml")

--- a/tests/src/unit/test_yaml_read_tool.py
+++ b/tests/src/unit/test_yaml_read_tool.py
@@ -244,3 +244,24 @@ async def test_list_failure_raises_tool_error():
 
     with pytest.raises(ToolError):
         await fn(yaml_path="alert2", file="packages/*.yaml")
+
+
+async def test_root_level_glob_lists_config_root():
+    """A glob with no directory part asks the lister for the config root.
+
+    The component denies that (the root is not in ALLOWED_READ_DIRS), which is
+    the pre-existing lister boundary — root files stay readable one-by-one via
+    an explicit `file`. This pins the '.' the tool sends, so the request is a
+    deliberate deny rather than a malformed path.
+    """
+    seen: dict = {}
+
+    def list_files(payload):
+        seen["path"] = payload["path"]
+        return {"success": False, "error": "Path not allowed.", "files": []}
+
+    fn, _ = await _make_tool({"list_files": list_files, "read_file": _read_ok("x\n")})
+
+    with pytest.raises(ToolError):
+        await fn(yaml_path="rest", file="*.yaml")
+    assert seen["path"] == "."

--- a/tests/src/unit/test_yaml_read_tool.py
+++ b/tests/src/unit/test_yaml_read_tool.py
@@ -17,11 +17,43 @@ def _reset_caller_token_cache():
     _reset_caller_token_cache()
 
 
+@pytest.fixture(autouse=True)
+def _filesystem_tools_enabled(monkeypatch):
+    """The tool registers only with filesystem tools on — it returns
+    config-file contents, so it sits behind the same flag as ha_read_file.
+
+    Autouse because every test below needs a registered tool; the gate itself
+    is asserted by TestGating.
+    """
+    from ha_mcp import config as ha_mcp_config
+
+    # enable_filesystem_tools is a beta sub-flag, so the master toggle has to
+    # be on too or the master gate forces it back off (BETA_FEATURE_FIELDS).
+    monkeypatch.setenv("ENABLE_BETA_FEATURES", "true")
+    monkeypatch.setenv("HAMCP_ENABLE_FILESYSTEM_TOOLS", "true")
+    monkeypatch.setattr(ha_mcp_config, "_settings", None)
+    yield
+    ha_mcp_config._settings = None
+
+
+class _Raw:
+    """Marks a value that call_service returns verbatim.
+
+    Everything else is wrapped in HA's ``{"service_response": ...}`` envelope,
+    which is always a dict — so this is the only way to exercise a caller's
+    handling of a non-dict service result.
+    """
+
+    def __init__(self, value):
+        self.value = value
+
+
 def _service_mock(responses: dict):
     """call_service mock answering the bootstrap plus per-service responses.
 
     ``responses`` maps a service name to either a single response dict or a
-    callable taking the payload (so read_file can answer per-file).
+    callable taking the payload (so read_file can answer per-file). Wrap a
+    value in ``_Raw`` to skip the service_response envelope.
     """
 
     async def fake_call_service(domain, service, payload, **kwargs):
@@ -37,6 +69,8 @@ def _service_mock(responses: dict):
             }
         handler = responses[service]
         result = handler(payload) if callable(handler) else handler
+        if isinstance(result, _Raw):
+            return result.value
         return {"service_response": result}
 
     return AsyncMock(side_effect=fake_call_service)
@@ -69,7 +103,8 @@ async def _make_tool(responses: dict):
 
     mcp = FakeMCP()
     register_yaml_read_tools(mcp, client)
-    return captured["fns"][0], client
+    # None when the feature gate refused to register (see TestGating).
+    return (captured["fns"][0] if captured.get("fns") else None), client
 
 
 def _read_ok(subtree, parsed=None):
@@ -79,22 +114,42 @@ def _read_ok(subtree, parsed=None):
     return body
 
 
-async def test_registers_without_yaml_editing_flag(monkeypatch):
-    """The read tool is ungated: it must register even with YAML editing off.
+class TestGating:
+    """Which flag the tool hangs on — reading is not editing, but it IS a
+    config-file read."""
 
-    This is the whole reason it is a separate module from tools_yaml_config —
-    that module's register function returns early when the flag is off.
-    """
-    from ha_mcp import config as ha_mcp_config
+    async def test_registers_without_yaml_editing_flag(self, monkeypatch):
+        """Registers with YAML *editing* off.
 
-    monkeypatch.setenv("ENABLE_YAML_CONFIG_EDITING", "false")
-    monkeypatch.setenv("ENABLE_BETA_FEATURES", "false")
-    monkeypatch.setattr(ha_mcp_config, "_settings", None)
-    try:
+        This is the whole reason it is a separate module from
+        tools_yaml_config — that module's register function returns early when
+        the editing flag is off, and reading a fragment is not an edit.
+        """
+        from ha_mcp import config as ha_mcp_config
+
+        monkeypatch.setenv("ENABLE_YAML_CONFIG_EDITING", "false")
+        monkeypatch.setattr(ha_mcp_config, "_settings", None)
+
         fn, _ = await _make_tool({"read_file": _read_ok("rest:\n")})
+
         assert fn is not None
-    finally:
-        ha_mcp_config._settings = None
+
+    async def test_not_registered_without_filesystem_tools_flag(self, monkeypatch):
+        """Does NOT register with filesystem tools off.
+
+        It returns config-file contents through the same read_file/list_files
+        component services as ha_read_file/ha_list_files. An install that
+        turned those off must not get a config-read surface back through this
+        tool.
+        """
+        from ha_mcp import config as ha_mcp_config
+
+        monkeypatch.setenv("HAMCP_ENABLE_FILESYSTEM_TOOLS", "false")
+        monkeypatch.setattr(ha_mcp_config, "_settings", None)
+
+        fn, _ = await _make_tool({"read_file": _read_ok("rest:\n")})
+
+        assert fn is None
 
 
 async def test_single_file_returns_match():
@@ -226,12 +281,141 @@ async def test_include_parsed_not_sent_by_default():
 
 
 async def test_read_failure_raises_tool_error():
+    """A single explicit target has no siblings to salvage, so it still raises."""
     fn, _ = await _make_tool(
         {"read_file": {"success": False, "error": "File does not exist: nope.yaml"}}
     )
 
     with pytest.raises(ToolError):
         await fn(yaml_path="rest", file="nope.yaml")
+
+
+async def test_glob_read_failure_warns_instead_of_aborting():
+    """One unreadable file must not discard the matches already found.
+
+    Reachable without contrivance: the glob is not restricted to *.yaml, so
+    `packages/*` turns up a README the component refuses to read.
+    """
+
+    def read(payload):
+        if payload["path"] == "packages/README.md":
+            return {"success": False, "error": "Path not allowed: packages/README.md"}
+        return _read_ok("- name: my_alert\n")
+
+    fn, _ = await _make_tool(
+        {
+            "list_files": {
+                "success": True,
+                "files": [
+                    {"path": "packages/README.md", "is_dir": False},
+                    {"path": "packages/alert2.yaml", "is_dir": False},
+                ],
+            },
+            "read_file": read,
+        }
+    )
+
+    out = await fn(yaml_path="alert2", file="packages/*")
+
+    assert out["count"] == 1
+    assert out["matches"][0]["file"] == "packages/alert2.yaml"
+    assert out["files_searched"] == 2
+    assert out["warnings"] == [
+        "packages/README.md was not searched: Path not allowed: packages/README.md."
+    ]
+
+
+async def test_glob_read_exception_warns_instead_of_aborting():
+    """A read that blows up is the same failure class as one that says no."""
+
+    def read(payload):
+        if payload["path"] == "packages/broken.yaml":
+            raise RuntimeError("connection reset")
+        return _read_ok("- name: my_alert\n")
+
+    fn, _ = await _make_tool(
+        {
+            "list_files": {
+                "success": True,
+                "files": [
+                    {"path": "packages/broken.yaml", "is_dir": False},
+                    {"path": "packages/alert2.yaml", "is_dir": False},
+                ],
+            },
+            "read_file": read,
+        }
+    )
+
+    out = await fn(yaml_path="alert2", file="packages/*.yaml")
+
+    assert out["count"] == 1
+    assert out["matches"][0]["file"] == "packages/alert2.yaml"
+    assert out["warnings"] == [
+        "packages/broken.yaml was not searched: connection reset."
+    ]
+
+
+async def test_glob_malformed_response_warns_instead_of_aborting():
+    """A response that is not a dict at all is the same failure class.
+
+    Every way "this one file could not be searched" can present must degrade
+    the same way under a glob, or the inconsistency just moves.
+    """
+
+    def read(payload):
+        if payload["path"] == "packages/weird.yaml":
+            return _Raw("not a dict at all")
+        return _read_ok("- name: my_alert\n")
+
+    fn, _ = await _make_tool(
+        {
+            "list_files": {
+                "success": True,
+                "files": [
+                    {"path": "packages/weird.yaml", "is_dir": False},
+                    {"path": "packages/alert2.yaml", "is_dir": False},
+                ],
+            },
+            "read_file": read,
+        }
+    )
+
+    out = await fn(yaml_path="alert2", file="packages/*.yaml")
+
+    assert out["count"] == 1
+    assert out["matches"][0]["file"] == "packages/alert2.yaml"
+    assert out["warnings"] == [
+        "packages/weird.yaml was not searched: unexpected read_file response."
+    ]
+
+
+async def test_single_file_malformed_response_still_raises():
+    """With one target there is nothing to salvage, so it stays an error."""
+    fn, _ = await _make_tool({"read_file": _Raw("not a dict at all")})
+
+    with pytest.raises(ToolError):
+        await fn(yaml_path="rest", file="configuration.yaml")
+
+
+async def test_empty_glob_matches_nothing_without_raising():
+    """A glob matching no files is an empty result, not an error.
+
+    files_searched=0 is what separates it from "no file defines the key".
+    """
+    fn, _ = await _make_tool(
+        {
+            "list_files": {"success": True, "files": []},
+            "read_file": _read_ok("x\n"),
+        }
+    )
+
+    out = await fn(yaml_path="alert2", file="packages/*.yaml")
+
+    assert out["success"] is True
+    assert out["matches"] == []
+    assert out["count"] == 0
+    assert out["files_searched"] == 0
+    assert "warnings" not in out
 
 
 async def test_list_failure_raises_tool_error():


### PR DESCRIPTION
Closes #1788

## What does this PR do?

Adds `ha_config_get_yaml`, the read counterpart to `ha_config_set_yaml`: it returns the YAML fragment under a key, addressed by the same `file` + `yaml_path` pair, so what you read is what you hand back to the editor.

`file` accepts an fnmatch glob, so `packages/*.yaml` searches a directory in one call and reports only the files that actually define the key. That covers the "which file defines alert2?" case from the issue. `include_content=False` reduces the result to pure discovery. The per-file reads are gathered concurrently rather than serialised, and under a glob a file that cannot be searched is reported in `warnings` rather than sinking the whole search.

The tool lives in its own module, behind `enable_filesystem_tools` rather than `ENABLE_YAML_CONFIG_EDITING`: reading a fragment is not an edit, so the editing flag is the wrong gate for it, but it returns config-file contents through the same `read_file`/`list_files` component services that `ha_read_file`/`ha_list_files` sit behind. `ha_read_file` now forwards `yaml_path` too, for the single-file case inside the filesystem toolset.

Three supporting changes:

- **`list_files` now honours the configured packages folder.** `read_file` resolves the folder bound via `homeassistant: packages:` and reads `*.yaml` under it (#1854), but the lister never got the same treatment, so a packages folder was readable file-by-file yet could not be enumerated, and the glob needs enumeration. The widening happens after the deny floor and containment checks, and `package_dirs` defaults to None so `write_file` and `delete_file`, which share the helper, cannot gain package access.
- **The component's `read_file` service gained `include_parsed`** (default off), returning the same subtree as structured data from a single parse. `ha_config_get_yaml` is what surfaces it; the `ha_read_file` tool forwards only `yaml_path`.
- **`MIN_COMPONENT_VERSION` moves to the pending 1.1.0**, since the glob and `include_parsed` both depend on component behaviour that a pre-1.1.0 component reports no differently from a missing key. `COMPONENT_VERSION` is untouched – it already reads 1.1.0 on master, so this rides the open pending version rather than opening a new one.

### Secrets

Both views keep HA tags as written, and the parsed view renders them to source form (`!secret api_key`) instead of resolving them. Resolving a `!secret` would mean reading secrets.yaml, which this path never does, so there is no plaintext-secret surface to filter here. The canonical `secrets.yaml` reads back with every value masked by `_mask_secrets_content`, which runs before the subtree is extracted, so both views see masked text; every other path that resolves to a secrets.yaml – nested, symlink-renamed, mixed-case – stays denied outright by the deny floor, since only the literal config-root file is masked. The mask marker is quoted so the masked text re-parses as a scalar in the parsed view. An e2e test pins tag preservation against `automation: !include automations.yaml`, and a component test pins that extraction over secrets.yaml stays masked under both views.

### Two deviations from the shape proposed in the issue

- **No `config_hash`.** `ha_config_set_yaml` takes no such argument. It locks with `confirm_token`, derived from the path plus the new content being written, which a read cannot produce.
- **`include_parsed` defaults off** rather than on. `content` is the round-trippable view, and returning both by default doubles the payload for one fragment.

## Type of change
- [x] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [ ] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

63 new tests: 19 unit for the tool, 31 unit for the component helpers, 13 e2e. The e2e globs `custom_packages/*.yaml`, the non-default folder the test config binds deliberately, so it exercises the runtime packages-folder detection rather than the hardcoded default. It also covers the get → set round-trip on a tag-bearing fragment, a glob matching two defining files, and a glob matching a file the component refuses to read.

On the two unchecked boxes: I ran the affected unit files locally (475 passed) plus ruff and mypy, but not the full suite, since the e2e lane needs a Docker daemon I do not have on this machine, so I am relying on CI for it. I have not driven the tool from an LLM agent yet.

## Checklist
- [x] I have updated documentation if needed
