### PR TITLE
feat: add overwrite option to ha_import_blueprint for blueprint re-import

### DIFF
--- a/src/ha_mcp/tools/tools_blueprints.py
+++ b/src/ha_mcp/tools/tools_blueprints.py
@@ -234,16 +234,19 @@ class BlueprintTools:
 
         Returns the blueprint/save result payload (contains overrides_existing).
         """
-        save_response = await self._client.send_websocket_message(
-            {
-                "type": "blueprint/save",
-                "domain": domain,
-                "path": path,
-                "yaml": yaml_data,
-                "source_url": url,
-                "allow_override": overwrite,
-            }
-        )
+        save_message: dict[str, Any] = {
+            "type": "blueprint/save",
+            "domain": domain,
+            "path": path,
+            "yaml": yaml_data,
+            "source_url": url,
+        }
+        # allow_override only exists on HA >= 2023.12 and the WS schema
+        # rejects unknown keys - only send it when actually overwriting
+        if overwrite:
+            save_message["allow_override"] = True
+
+        save_response = await self._client.send_websocket_message(save_message)
 
         if not save_response.get("success"):
             error = save_response.get("error", {})
@@ -258,7 +261,11 @@ class BlueprintTools:
                 "Use ha_get_blueprint() to check if it already exists",
             ]
 
-            if "already exists" in save_error.lower():
+            # Reachable despite the early exists check: a race between
+            # import and save, or an installed file that failed to load
+            # (core reports exists=false for those)
+            already_exists = "already exists" in save_error.lower()
+            if already_exists:
                 suggestions.insert(
                     0,
                     "A blueprint with this path already exists - pass overwrite=true to re-import it",
@@ -266,7 +273,9 @@ class BlueprintTools:
 
             raise_tool_error(
                 create_error_response(
-                    ErrorCode.SERVICE_CALL_FAILED,
+                    ErrorCode.RESOURCE_ALREADY_EXISTS
+                    if already_exists
+                    else ErrorCode.SERVICE_CALL_FAILED,
                     save_error,
                     context={"url": url, "path": path},
                     suggestions=suggestions,
@@ -393,6 +402,24 @@ class BlueprintTools:
             # suggested_filename without the extension (e.g. "user/blueprint_name")
             if not suggested_filename.endswith((".yaml", ".yml")):
                 suggested_filename = suggested_filename + ".yaml"
+
+            # blueprint/save does not re-run these checks (currently the
+            # blueprint's min Home Assistant version) - without this gate an
+            # unsupported blueprint saves cleanly and reports success
+            validation_errors = result_data.get("validation_errors")
+            if validation_errors:
+                raise_tool_error(
+                    create_error_response(
+                        ErrorCode.VALIDATION_FAILED,
+                        "Blueprint failed validation: "
+                        + "; ".join(str(e) for e in validation_errors),
+                        context={"url": url, "validation_errors": validation_errors},
+                        suggestions=[
+                            "The blueprint is not compatible with this Home Assistant installation",
+                            "Update Home Assistant to satisfy the blueprint's minimum version requirement",
+                        ],
+                    )
+                )
 
             # blueprint/import reports whether the target path is already
             # installed - fail early with a re-import hint instead of letting

--- a/src/ha_mcp/tools/tools_blueprints.py
+++ b/src/ha_mcp/tools/tools_blueprints.py
@@ -222,6 +222,59 @@ class BlueprintTools:
             )
             return None  # unreachable: exception_to_structured_error always raises
 
+    async def _save_blueprint(
+        self,
+        url: str,
+        domain: str,
+        path: str,
+        yaml_data: str,
+        overwrite: bool,
+    ) -> dict[str, Any]:
+        """Persist a validated blueprint via blueprint/save, raising on failure.
+
+        Returns the blueprint/save result payload (contains overrides_existing).
+        """
+        save_response = await self._client.send_websocket_message(
+            {
+                "type": "blueprint/save",
+                "domain": domain,
+                "path": path,
+                "yaml": yaml_data,
+                "source_url": url,
+                "allow_override": overwrite,
+            }
+        )
+
+        if not save_response.get("success"):
+            error = save_response.get("error", {})
+            save_error = (
+                error.get("message", str(error))
+                if isinstance(error, dict)
+                else str(error)
+            )
+
+            suggestions = [
+                "The blueprint was validated but could not be saved to disk",
+                "Use ha_get_blueprint() to check if it already exists",
+            ]
+
+            if "already exists" in save_error.lower():
+                suggestions.insert(
+                    0,
+                    "A blueprint with this path already exists - pass overwrite=true to re-import it",
+                )
+
+            raise_tool_error(
+                create_error_response(
+                    ErrorCode.SERVICE_CALL_FAILED,
+                    save_error,
+                    context={"url": url, "path": path},
+                    suggestions=suggestions,
+                )
+            )
+
+        return save_response.get("result") or {}
+
     @tool(
         name="ha_import_blueprint",
         tags={"Blueprints"},
@@ -240,17 +293,29 @@ class BlueprintTools:
                 description="URL to import blueprint from (GitHub, Home Assistant Community, or direct YAML URL)"
             ),
         ],
+        overwrite: Annotated[
+            bool,
+            Field(
+                description="Overwrite the blueprint if it is already installed (re-import). "
+                "Home Assistant reloads all automations/scripts using the blueprint.",
+                default=False,
+            ),
+        ] = False,
     ) -> dict[str, Any]:
         """
         Import a blueprint from a URL.
 
         Imports a blueprint from GitHub, Home Assistant Community forums,
-        or any direct URL to a blueprint YAML file.
+        or any direct URL to a blueprint YAML file. Set overwrite=true to
+        re-import a blueprint that is already installed (equivalent to the
+        UI's "Re-import blueprint" action) - Home Assistant then reloads all
+        automations/scripts that use it.
 
         EXAMPLES:
         - Import from GitHub: ha_import_blueprint("https://github.com/user/repo/blob/main/blueprint.yaml")
         - Import from HA Community: ha_import_blueprint("https://community.home-assistant.io/t/motion-light/123456")
         - Import direct YAML: ha_import_blueprint("https://example.com/my-blueprint.yaml")
+        - Re-import an installed blueprint: ha_import_blueprint("https://example.com/my-blueprint.yaml", overwrite=True)
 
         SUPPORTED SOURCES:
         - GitHub repository URLs (will be converted to raw URLs)
@@ -260,6 +325,7 @@ class BlueprintTools:
         RETURNS:
         - Import result with the blueprint path where it was saved
         - Blueprint metadata (name, domain, description)
+        - overrides_existing: true when an installed blueprint was overwritten
         - Error details if import fails
         """
         try:
@@ -328,43 +394,32 @@ class BlueprintTools:
             if not suggested_filename.endswith((".yaml", ".yml")):
                 suggested_filename = suggested_filename + ".yaml"
 
-            # Save the blueprint to disk (blueprint/import only validates)
-            save_response = await self._client.send_websocket_message(
-                {
-                    "type": "blueprint/save",
-                    "domain": domain,
-                    "path": suggested_filename,
-                    "yaml": raw_data,
-                    "source_url": url,
-                }
-            )
-
-            if not save_response.get("success"):
-                error = save_response.get("error", {})
-                save_error = (
-                    error.get("message", str(error))
-                    if isinstance(error, dict)
-                    else str(error)
-                )
-
-                suggestions = [
-                    "The blueprint was validated but could not be saved to disk",
-                    "Use ha_get_blueprint() to check if it already exists",
-                ]
-
-                if "already exists" in save_error.lower():
-                    suggestions.insert(0, "A blueprint with this path already exists")
-
+            # blueprint/import reports whether the target path is already
+            # installed - fail early with a re-import hint instead of letting
+            # blueprint/save reject the write
+            if result_data.get("exists") and not overwrite:
                 raise_tool_error(
                     create_error_response(
-                        ErrorCode.SERVICE_CALL_FAILED,
-                        save_error,
-                        context={"url": url, "path": suggested_filename},
-                        suggestions=suggestions,
+                        ErrorCode.RESOURCE_ALREADY_EXISTS,
+                        f"Blueprint already exists at '{suggested_filename}'. "
+                        "Pass overwrite=true to re-import it.",
+                        context={
+                            "url": url,
+                            "path": suggested_filename,
+                            "domain": domain,
+                        },
+                        suggestions=[
+                            "Call ha_import_blueprint with overwrite=true to update the installed blueprint",
+                            "Use ha_get_blueprint() to inspect the currently installed version",
+                        ],
                     )
                 )
 
-            save_result = save_response.get("result") or {}
+            # Save the blueprint to disk (blueprint/import only validates)
+            save_result = await self._save_blueprint(
+                url, domain, suggested_filename, raw_data, overwrite
+            )
+            overrides_existing = save_result.get("overrides_existing", False)
 
             return {
                 "success": True,
@@ -375,8 +430,12 @@ class BlueprintTools:
                     "name": blueprint_meta.get("name"),
                     "description": blueprint_meta.get("description"),
                 },
-                "overrides_existing": save_result.get("overrides_existing", False),
-                "message": "Blueprint imported successfully. Use ha_get_blueprint() to see all installed blueprints.",
+                "overrides_existing": overrides_existing,
+                "message": (
+                    "Blueprint re-imported successfully. Automations/scripts using it were reloaded."
+                    if overrides_existing
+                    else "Blueprint imported successfully. Use ha_get_blueprint() to see all installed blueprints."
+                ),
             }
 
         except ToolError:

--- a/tests/src/e2e/conftest.py
+++ b/tests/src/e2e/conftest.py
@@ -1450,7 +1450,12 @@ def _blueprint_http_server():
     logger.info(f"🌐 Blueprint HTTP server on :{port}, container URL: {base_url}")
 
     try:
-        yield {"base_url": base_url, "port": port, "extra_hosts": env["extra_hosts"]}
+        yield {
+            "base_url": base_url,
+            "port": port,
+            "extra_hosts": env["extra_hosts"],
+            "local_dir": str(assets_dir),
+        }
     finally:
         srv.shutdown()
 
@@ -1471,6 +1476,7 @@ def _copy_local_blueprint_to_www(config_path: Path) -> dict[str, str]:
     return {
         "base_url": "http://localhost:8123/local",
         "filename": blueprint_name,
+        "local_dir": str(www_dir),
     }
 
 

--- a/tests/src/e2e/workflows/blueprints/test_blueprints.py
+++ b/tests/src/e2e/workflows/blueprints/test_blueprints.py
@@ -10,6 +10,8 @@ and production environments. Blueprint availability may vary.
 """
 
 import logging
+import uuid
+from pathlib import Path
 
 import pytest
 
@@ -21,6 +23,33 @@ from ...utilities.assertions import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+def _blueprint_yaml(name: str, description: str, min_version: str | None = None) -> str:
+    """Render a minimal automation blueprint for import tests."""
+    homeassistant_block = (
+        f'  homeassistant:\n    min_version: "{min_version}"\n' if min_version else ""
+    )
+    return f"""blueprint:
+  name: {name}
+  description: {description}
+  domain: automation
+{homeassistant_block}  input:
+    target_entity:
+      name: Target Entity
+      description: The entity to control
+      selector:
+        entity: {{}}
+
+trigger:
+  - platform: time
+    at: "00:00:00"
+
+action:
+  - service: homeassistant.turn_on
+    target:
+      entity_id: !input target_entity
+"""
 
 
 @pytest.mark.blueprint
@@ -389,6 +418,124 @@ class TestBlueprintManagement:
                 f"Blueprint path should end with .yaml, got: {imported.get('path')}"
             )
             logger.info("Blueprint re-imported with overwrite=true")
+
+    @pytest.mark.slow
+    async def test_reimport_updates_blueprint_content(
+        self, mcp_client, local_blueprint_server
+    ):
+        """
+        Test: Re-import actually replaces the installed blueprint content (issue #1894)
+
+        The issue-#1894 user story: a blueprint's source changed upstream and the
+        user re-imports to pick up the new version. Serves v1 of a uniquely-named
+        blueprint, imports it (overwrite=true on a fresh import must succeed with
+        overrides_existing=False), then serves changed content and re-imports,
+        verifying via ha_get_blueprint that the NEW content landed.
+        """
+        local_dir = local_blueprint_server.get("local_dir")
+        assert local_dir, (
+            "local_blueprint_server must expose local_dir (writable served directory)"
+        )
+
+        run_id = uuid.uuid4().hex[:8]
+        filename = f"e2e_reimport_{run_id}.yaml"
+        served_file = Path(local_dir) / filename
+        test_url = f"{local_blueprint_server['base_url']}/{filename}"
+        marker_v1 = f"reimport-v1-{run_id}"
+        marker_v2 = f"reimport-v2-{run_id}"
+
+        try:
+            served_file.write_text(
+                _blueprint_yaml(f"Reimport E2E {run_id}", marker_v1), encoding="utf-8"
+            )
+
+            async with MCPAssertions(mcp_client) as mcp:
+                # overwrite=true on a not-yet-installed blueprint: plain install
+                first = await mcp.call_tool_success(
+                    "ha_import_blueprint",
+                    {"url": test_url, "overwrite": True},
+                )
+                assert first.get("overrides_existing") is False, (
+                    f"Fresh import must not report an override, got: {first}"
+                )
+                blueprint_path = first["imported_blueprint"]["path"]
+
+                # Serve changed content and re-import
+                served_file.write_text(
+                    _blueprint_yaml(f"Reimport E2E {run_id}", marker_v2),
+                    encoding="utf-8",
+                )
+                second = await mcp.call_tool_success(
+                    "ha_import_blueprint",
+                    {"url": test_url, "overwrite": True},
+                )
+                assert second.get("overrides_existing") is True, (
+                    f"Re-import must report the override, got: {second}"
+                )
+                assert "reload" in second.get("message", "").lower(), (
+                    f"Override response should mention the consumer reload, got: {second}"
+                )
+
+                # The installed blueprint must now carry the v2 content
+                detail = await mcp.call_tool_success(
+                    "ha_get_blueprint",
+                    {"path": blueprint_path, "domain": "automation"},
+                )
+                description = (detail.get("metadata") or {}).get("description") or ""
+                assert marker_v2 in description, (
+                    f"Re-imported blueprint should carry '{marker_v2}', got: {description}"
+                )
+                assert marker_v1 not in description, (
+                    f"Old content '{marker_v1}' should be gone, got: {description}"
+                )
+                logger.info("Re-import replaced blueprint content on disk")
+        finally:
+            served_file.unlink(missing_ok=True)
+
+    @pytest.mark.slow
+    async def test_import_blueprint_min_version_rejected(
+        self, mcp_client, local_blueprint_server
+    ):
+        """
+        Test: import surfaces blueprint/import validation_errors
+
+        blueprint/save does not re-run the min-version check, so the tool must
+        fail the import itself instead of silently saving an unsupported
+        blueprint (found while reviewing #1894's overwrite path, where it would
+        clobber a working installed blueprint).
+        """
+        local_dir = local_blueprint_server.get("local_dir")
+        assert local_dir, (
+            "local_blueprint_server must expose local_dir (writable served directory)"
+        )
+
+        run_id = uuid.uuid4().hex[:8]
+        filename = f"e2e_minversion_{run_id}.yaml"
+        served_file = Path(local_dir) / filename
+        test_url = f"{local_blueprint_server['base_url']}/{filename}"
+
+        try:
+            served_file.write_text(
+                _blueprint_yaml(
+                    f"MinVersion E2E {run_id}",
+                    "requires an impossible HA version",
+                    min_version="9999.1.0",
+                ),
+                encoding="utf-8",
+            )
+
+            async with MCPAssertions(mcp_client) as mcp:
+                result = await mcp.call_tool_failure(
+                    "ha_import_blueprint",
+                    {"url": test_url, "overwrite": True},
+                    expected_error="Requires at least Home Assistant",
+                )
+                assert result["error"]["code"] == "VALIDATION_FAILED", (
+                    f"Expected VALIDATION_FAILED, got: {result['error']}"
+                )
+                logger.info("Unsupported blueprint properly rejected at import")
+        finally:
+            served_file.unlink(missing_ok=True)
 
 
 @pytest.mark.blueprint

--- a/tests/src/e2e/workflows/blueprints/test_blueprints.py
+++ b/tests/src/e2e/workflows/blueprints/test_blueprints.py
@@ -333,6 +333,63 @@ class TestBlueprintManagement:
 
             logger.info("ha_import_blueprint save-to-disk test completed")
 
+    @pytest.mark.slow
+    async def test_reimport_blueprint_with_overwrite(
+        self, mcp_client, local_blueprint_server
+    ):
+        """
+        Test: Re-import an installed blueprint with overwrite=true (issue #1894)
+
+        Validates the "Re-import Blueprint" equivalent: importing an already
+        installed blueprint fails with RESOURCE_ALREADY_EXISTS unless
+        overwrite=true is passed, in which case the save succeeds and reports
+        overrides_existing=True.
+        """
+        test_url = f"{local_blueprint_server['base_url']}/e2e_test_blueprint.yaml"
+        logger.info(f"Testing blueprint re-import with URL: {test_url}")
+
+        async with MCPAssertions(mcp_client) as mcp:
+            # Ensure the blueprint is installed (tolerate a prior import)
+            first = await safe_call_tool(
+                mcp_client,
+                "ha_import_blueprint",
+                {"url": test_url},
+            )
+            if not first.get("success"):
+                error_msg = extract_error_message(first)
+                assert "already exists" in error_msg.lower(), (
+                    f"Expected 'already exists' error, got: {first}"
+                )
+                logger.info("Blueprint already installed from a prior run")
+
+            # Re-import without overwrite must fail with a structured error
+            failure = await mcp.call_tool_failure(
+                "ha_import_blueprint",
+                {"url": test_url},
+                expected_error="already exists",
+            )
+            assert failure["error"]["code"] == "RESOURCE_ALREADY_EXISTS", (
+                f"Expected RESOURCE_ALREADY_EXISTS, got: {failure['error']}"
+            )
+            assert "overwrite" in str(failure["error"]).lower(), (
+                "Error should point the caller at overwrite=true"
+            )
+            logger.info("Re-import without overwrite properly rejected")
+
+            # Re-import with overwrite succeeds and reports the override
+            result = await mcp.call_tool_success(
+                "ha_import_blueprint",
+                {"url": test_url, "overwrite": True},
+            )
+            assert result.get("overrides_existing") is True, (
+                f"Expected overrides_existing=True, got: {result}"
+            )
+            imported = result.get("imported_blueprint", {})
+            assert imported.get("path", "").endswith(".yaml"), (
+                f"Blueprint path should end with .yaml, got: {imported.get('path')}"
+            )
+            logger.info("Blueprint re-imported with overwrite=true")
+
 
 @pytest.mark.blueprint
 async def test_blueprint_discovery_workflow(mcp_client):


### PR DESCRIPTION
Closes #1894

## What does this PR do?

Adds an `overwrite` parameter (default `false`) to `ha_import_blueprint`, giving parity with the UI's "Re-import blueprint" action.

Previously, re-importing an installed blueprint failed at the save step with "File already exists" because `blueprint/save` was called without `allow_override`. Now:

- `overwrite=true` passes `allow_override` to `blueprint/save`; Home Assistant overwrites the blueprint and automatically reloads all automations/scripts that use it.
- Without `overwrite`, an already-installed blueprint fails early with a structured `RESOURCE_ALREADY_EXISTS` error pointing at `overwrite=true` (using the `exists` flag `blueprint/import` already returns), instead of the raw save failure.
- The `overrides_existing` field in the response (previously always `false`) is now meaningful.

The save step was extracted into a `_save_blueprint` helper to keep `ha_import_blueprint` under the complexity limit.

## Type of change
- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

New e2e test `test_reimport_blueprint_with_overwrite` covers: re-import without `overwrite` → structured `RESOURCE_ALREADY_EXISTS`; re-import with `overwrite=true` → success with `overrides_existing=true`.

## Checklist
- [ ] I have updated documentation if needed