### PR TITLE
fix: exclude inactive repair issues

### DIFF
--- a/custom_components/ha_mcp_tools/websocket_api.py
+++ b/custom_components/ha_mcp_tools/websocket_api.py
@@ -2067,15 +2067,17 @@ def _notification_values(data: Any) -> list[Any]:
 
 
 def _overview_repairs(hass: HomeAssistant) -> list[dict[str, Any]]:
-    """Raw issue-registry entries (the server filters/projects them itself).
+    """Return active issue-registry entries for server-side projection.
 
     ``ignored`` is derived from ``dismissed_version`` so the server's
-    ``filter_active_repairs`` (which keys off ``ignored``) works unchanged.
+    ``filter_active_repairs`` can apply the requested dismissed-repair filter.
     """
     registry = _safe(ir.async_get, hass)
     issues = getattr(registry, "issues", None) if registry is not None else None
     out: list[dict[str, Any]] = []
     for issue in _mapping_values(issues):
+        if getattr(issue, "active", True) is False:
+            continue
         dismissed = getattr(issue, "dismissed_version", None)
         out.append(
             {

--- a/src/ha_mcp/tools/tools_search.py
+++ b/src/ha_mcp/tools/tools_search.py
@@ -3353,7 +3353,11 @@ class SearchTools:
                 )
                 result["repair_count"] = len(visible_issues)
                 if not include_dismissed_repairs_bool:
-                    dismissed_count = len(all_issues) - len(visible_issues)
+                    dismissed_count = sum(
+                        issue.get("ignored")
+                        and issue.get("active") is not False
+                        for issue in all_issues
+                    )
                     if dismissed_count:
                         result["dismissed_repair_count"] = dismissed_count
                 result["repairs"] = [project_repair_fields(r) for r in visible_issues]

--- a/src/ha_mcp/tools/tools_system.py
+++ b/src/ha_mcp/tools/tools_system.py
@@ -1019,7 +1019,11 @@ class SystemTools:
                     "count": len(visible_issues),
                 }
                 if not include_dismissed:
-                    dismissed_count = len(all_issues) - len(visible_issues)
+                    dismissed_count = sum(
+                        issue.get("ignored")
+                        and issue.get("active") is not False
+                        for issue in all_issues
+                    )
                     if dismissed_count:
                         repairs["dismissed_count"] = dismissed_count
             else:

--- a/src/ha_mcp/tools/util_helpers.py
+++ b/src/ha_mcp/tools/util_helpers.py
@@ -540,16 +540,18 @@ _REPAIR_PROJECTION_FIELDS = (
 def filter_active_repairs(
     issues: list[dict[str, Any]], *, include_dismissed: bool = False
 ) -> list[dict[str, Any]]:
-    """Drop user-dismissed repairs unless ``include_dismissed`` is set.
+    """Drop inactive and, by default, user-dismissed repairs.
 
     HA's `repairs/list_issues` returns both active and ignored repairs (the
     Repairs UI hides ignored ones by default). Mirror that UI default so
-    overview / system-health responses don't surface repairs the user has
-    already dismissed.
+    overview / system-health responses don't surface inactive repairs or ones
+    the user has already dismissed. Entries without ``active`` are live
+    WebSocket responses and are treated as active.
     """
+    active_issues = [r for r in issues if r.get("active") is not False]
     if include_dismissed:
-        return list(issues)
-    return [r for r in issues if not r.get("ignored")]
+        return active_issues
+    return [r for r in active_issues if not r.get("ignored")]
 
 
 def project_repair_fields(issue: dict[str, Any]) -> dict[str, Any]:

--- a/tests/src/unit/test_component_ws_search.py
+++ b/tests/src/unit/test_component_ws_search.py
@@ -2352,6 +2352,20 @@ class TestOverview:
         assert by_id["old_issue"]["ignored"] is True
         assert by_id["old_issue"]["dismissed_version"] == "2026.1.0"
 
+    def test_repairs_exclude_inactive_issue_registry_entries(self, monkeypatch):
+        monkeypatch.setattr(wsapi, "_resolve_registries", lambda hass: self._view())
+        registry = FakeIssueRegistry(
+            [
+                FakeIssue("active_issue", "mqtt"),
+                FakeIssue("inactive_issue", "zwave", active=False),
+            ]
+        )
+        monkeypatch.setattr(wsapi, "ir", FakeIssueRegModule(registry))
+
+        res = wsapi._do_overview(self._hass(), {})
+
+        assert [repair["issue_id"] for repair in res["repairs"]] == ["active_issue"]
+
     def test_include_flags_skip_sections(self, monkeypatch):
         monkeypatch.setattr(wsapi, "_resolve_registries", lambda hass: self._view())
         monkeypatch.setattr(

--- a/tests/src/unit/test_overview_repairs.py
+++ b/tests/src/unit/test_overview_repairs.py
@@ -47,6 +47,12 @@ def _ignored_issue(issue_id: str, dismissed_version: str = "2026.4.0") -> dict:
     }
 
 
+def _inactive_issue(issue_id: str, *, ignored: bool = False) -> dict:
+    issue = _ignored_issue(issue_id) if ignored else _active_issue(issue_id)
+    issue["active"] = False
+    return issue
+
+
 class TestHaGetOverviewRepairs:
     """ha_get_overview repairs filtering, count, and field projection."""
 
@@ -114,13 +120,35 @@ class TestHaGetOverviewRepairs:
         assert result["dismissed_repair_count"] == 2
 
     @pytest.mark.asyncio
+    async def test_inactive_repairs_are_not_counted_or_returned(
+        self, mock_mcp, mock_smart_tools
+    ):
+        """Inactive issue-registry entries stay hidden in every repair view."""
+        issues = [
+            _active_issue("active_one"),
+            _ignored_issue("dismissed_one"),
+            _inactive_issue("inactive_one"),
+            _inactive_issue("inactive_dismissed", ignored=True),
+        ]
+        client = self._make_client(issues)
+        tool = self._build_tool(mock_mcp, client, mock_smart_tools)
+
+        result = await tool(detail_level="minimal")
+
+        assert result["repair_count"] == 1
+        assert [r["issue_id"] for r in result["repairs"]] == ["active_one"]
+        assert result["dismissed_repair_count"] == 1
+
+    @pytest.mark.asyncio
     async def test_include_dismissed_returns_all_repairs(
         self, mock_mcp, mock_smart_tools
     ):
-        """With `include_dismissed_repairs=True`, all repairs surface and
-        the standalone dismissed counter is omitted.
-        """
-        issues = [_active_issue("active_one"), _ignored_issue("dismissed_one")]
+        """Opting into dismissed repairs still excludes inactive entries."""
+        issues = [
+            _active_issue("active_one"),
+            _ignored_issue("dismissed_one"),
+            _inactive_issue("inactive_one"),
+        ]
         client = self._make_client(issues)
         tool = self._build_tool(mock_mcp, client, mock_smart_tools)
 

--- a/tests/src/unit/test_tools_system.py
+++ b/tests/src/unit/test_tools_system.py
@@ -269,6 +269,27 @@ class TestFetchRepairs:
         assert result["dismissed_count"] == 1
 
     @pytest.mark.asyncio
+    async def test_inactive_repairs_are_not_counted_or_dismissed(self):
+        ws = _ws_client_with_issues(
+            [
+                {"issue_id": "active", "ignored": False, "active": True},
+                {"issue_id": "dismissed", "ignored": True, "active": True},
+                {"issue_id": "inactive", "ignored": False, "active": False},
+                {
+                    "issue_id": "inactive_dismissed",
+                    "ignored": True,
+                    "active": False,
+                },
+            ]
+        )
+
+        result = await SystemTools._fetch_repairs(ws)
+
+        assert result["count"] == 1
+        assert [i["issue_id"] for i in result["issues"]] == ["active"]
+        assert result["dismissed_count"] == 1
+
+    @pytest.mark.asyncio
     async def test_include_dismissed_returns_all(self):
         ws = _ws_client_with_issues(
             [

--- a/tests/src/unit/test_util_helpers.py
+++ b/tests/src/unit/test_util_helpers.py
@@ -377,10 +377,21 @@ class TestFilterActiveRepairs:
         ]
         assert [r["issue_id"] for r in filter_active_repairs(issues)] == ["a", "c"]
 
-    def test_include_dismissed_returns_all(self):
+    def test_filters_inactive_repairs(self):
         issues = [
-            {"issue_id": "a", "ignored": False},
-            {"issue_id": "b", "ignored": True},
+            {"issue_id": "a", "ignored": False, "active": True},
+            {"issue_id": "b", "ignored": False, "active": False},
+            {"issue_id": "c", "ignored": True, "active": False},
+            {"issue_id": "d", "ignored": False},
+        ]
+        assert [r["issue_id"] for r in filter_active_repairs(issues)] == ["a", "d"]
+
+    def test_include_dismissed_still_filters_inactive(self):
+        issues = [
+            {"issue_id": "a", "ignored": False, "active": True},
+            {"issue_id": "b", "ignored": True, "active": True},
+            {"issue_id": "c", "ignored": False, "active": False},
+            {"issue_id": "d", "ignored": True, "active": False},
         ]
         out = filter_active_repairs(issues, include_dismissed=True)
         assert [r["issue_id"] for r in out] == ["a", "b"]


### PR DESCRIPTION
# fix: exclude inactive repair issues

## Summary

`ha_get_overview` treated inactive issue-registry entries as active repairs and could include them in the dismissed-repair count. This change consistently excludes entries whose `active` field is explicitly `False`, while preserving the existing behavior that WebSocket entries without that field are active. It also ensures the custom-component overview slice omits inactive entries.

Fixes #1905

## Changes

- Filter inactive repairs in the shared server-side repair helper and custom-component overview slice.
- Count only active dismissed repairs in overview and system-health responses.
- Add regression coverage for component, overview, system, and helper paths.

## Testing

- Passed: `sandbox-run "pip install ruff pytest && ruff check custom_components/ha_mcp_tools/websocket_api.py src/ha_mcp/tools/util_helpers.py src/ha_mcp/tools/tools_search.py src/ha_mcp/tools/tools_system.py tests/src/unit/test_component_ws_search.py tests/src/unit/test_overview_repairs.py tests/src/unit/test_tools_system.py tests/src/unit/test_util_helpers.py && python -m py_compile custom_components/ha_mcp_tools/websocket_api.py src/ha_mcp/tools/util_helpers.py src/ha_mcp/tools/tools_search.py src/ha_mcp/tools/tools_system.py tests/src/unit/test_component_ws_search.py tests/src/unit/test_overview_repairs.py tests/src/unit/test_tools_system.py tests/src/unit/test_util_helpers.py"`
- Unit-test execution was blocked in the sandbox because its Python is 3.12.13 while this project requires Python 3.13 or newer. Installing the project therefore failed before pytest could run.

---
### AI assistance disclosure

This contribution was produced by an autonomous AI coding agent (Claude Code) that @Dodothereal operates and monitors. @Dodothereal is accountable for it, will address review feedback promptly, and will close this PR immediately if this kind of contribution is unwelcome in this project. Commits carry an `Assisted-by: Claude Code` trailer.
