### PR TITLE
fix: keep embedded bring-up alive while the worker makes startup progress

### DIFF
--- a/custom_components/ha_mcp_tools/embedded_server.py
+++ b/custom_components/ha_mcp_tools/embedded_server.py
@@ -92,13 +92,19 @@ _LOGGER = logging.getLogger(__name__)
 # from the same refresh token on every start regardless.
 _ACCESS_TOKEN_TTL = timedelta(days=3650)
 
-# Readiness probe: how long to wait for the server thread to accept a loopback
-# TCP connection before declaring the start failed. Generous on purpose: a
-# cold import of the fastmcp tree takes 1-3s on real hardware but has been
-# observed to exceed 30s on QEMU-emulated HAOS (the e2e lane), and a single
-# readiness timeout fails the bring-up outright — there is no retry. Real
-# deployments only pay this budget on the failure path.
-_READY_TIMEOUT_SECONDS = 90.0
+# Readiness probe: fail the bring-up only when the worker shows no observable
+# startup progress (no new modules landing in sys.modules, no phase advance)
+# for this long. The previous flat 90s deadline assumed real hardware imports
+# the server tree in seconds — issue #1904 (HA Green) showed a cold import
+# alone can take minutes there, and killing the still-importing worker at the
+# deadline is what created the orphaned-thread/port-collision cascade: the
+# worker cannot be joined mid-import, lingered as a zombie, and later bound
+# the port out from under the retry. A genuinely wedged worker still fails
+# after one stall budget.
+_READY_STALL_TIMEOUT_SECONDS = 90.0
+# Absolute ceiling on one bring-up regardless of apparent progress, matching
+# the HAOS e2e lane's own 600s readiness deadline.
+_READY_TOTAL_CAP_SECONDS = 600.0
 _READY_POLL_INTERVAL_SECONDS = 0.5
 
 # How long to wait for the worker thread to exit on stop before giving up and
@@ -241,6 +247,9 @@ class EmbeddedServerManager:
         # Compared against the installed distribution after start to detect a
         # stale-code worker (see _purge_ha_mcp_modules).
         self._running_version: str | None = None
+        # Startup phase published by the worker (plain attribute write, read
+        # by the readiness poll for progress detection and error messages).
+        self._startup_phase: str = "not started"
 
     @property
     def port(self) -> int:
@@ -285,7 +294,7 @@ class EmbeddedServerManager:
                 kind="package",
             )
 
-        await self._async_ensure_package()
+        ready_version = await self._async_ensure_package()
         access_token = await self._async_provision_token()
         await self._hass.async_add_executor_job(self._prepare_config_dir)
 
@@ -304,19 +313,38 @@ class EmbeddedServerManager:
         # can outlive both the readiness timeout and the stop-join budget).
         # The post-start staleness check below surfaces the consequence
         # (old code possibly serving) instead.
+        #
+        # Also skipped when the cached modules already ARE the generation on
+        # disk (issue #1904): purging on every attempt made each retry pay
+        # the full cold import again, so slow hardware that missed the
+        # readiness window once could never recover. A reinstall that keeps
+        # the same version string (same-version tarball override) is the
+        # accepted blind spot; the post-start staleness check still reports
+        # the running/installed pair.
         orphan = self._orphaned_thread
         if orphan is not None and not orphan.is_alive():
             self._orphaned_thread = orphan = None
-        if orphan is None:
-            _purge_ha_mcp_modules()
-        else:
+        if orphan is not None:
             _LOGGER.warning(
                 "Skipping the ha_mcp module purge: a previous worker thread "
                 "is still shutting down. The new worker may serve the "
                 "previously imported code until Home Assistant restarts."
             )
+        elif (
+            ready_version is not None
+            and _CACHED_IMPORT_VERSION is not None
+            and ready_version == _CACHED_IMPORT_VERSION
+        ):
+            _LOGGER.debug(
+                "Cached ha_mcp modules already match installed version %s; "
+                "skipping the module purge (warm start)",
+                ready_version,
+            )
+        else:
+            _purge_ha_mcp_modules()
 
         self._thread_exc = None
+        self._startup_phase = "waiting for the worker thread"
         self._thread = threading.Thread(
             target=self._thread_main,
             args=(access_token,),
@@ -454,8 +482,11 @@ class EmbeddedServerManager:
             return None
         return DIST_NAME_STABLE if self._channel == CHANNEL_DEV else DIST_NAME_DEV
 
-    async def _async_ensure_package(self) -> None:
+    async def _async_ensure_package(self) -> str | None:
         """Ensure ``ha-mcp`` is importable, installing the pip spec if needed.
+
+        Returns the installed version that the worker is about to run, for the
+        caller's warm-cache purge decision.
 
         With auto-update on (the default) both channels install their
         distribution UNPINNED, so every entry reload / HA restart must pick up
@@ -581,6 +612,7 @@ class EmbeddedServerManager:
         _LOGGER.info("HA-MCP in-process server package ready (version %s)", version)
         if stored_spec != self._pip_spec:
             self._store_installed_spec()
+        return version
 
     async def _async_remove_legacy_target(
         self, target_dist: str, installed_version: str | None
@@ -776,6 +808,15 @@ class EmbeddedServerManager:
 
     # -- worker thread -----------------------------------------------------
 
+    def _note_startup_phase(self, phase: str) -> None:
+        """Publish the worker's startup phase (a plain attribute write).
+
+        Read by the readiness poll: a phase advance counts as progress, and the
+        failure message names the phase the worker was last seen in.
+        """
+        self._startup_phase = phase
+        _LOGGER.debug("HA-MCP in-process server startup: %s", phase)
+
     def _thread_main(self, access_token: str) -> None:
         """Thread entry point: stage non-secret env, then run the server.
 
@@ -798,6 +839,18 @@ class EmbeddedServerManager:
         self._stop_event = stop_event
         try:
             loop.run_until_complete(self._serve(access_token, stop_event))
+        except SystemExit as err:
+            # uvicorn signals a startup failure (e.g. the port is already in
+            # use) with SystemExit(STARTUP_FAILURE), which ``except Exception``
+            # misses — live issue #1904 saw the real bind error surface only
+            # in HA's generic task-exception log while the component reported
+            # a bare readiness timeout. Unwrap the original error so the
+            # repair issue names the actual cause.
+            cause: BaseException = err.__context__ or err.__cause__ or err
+            self._thread_exc = EmbeddedServerError(
+                f"the server's HTTP listener exited during startup: {cause}"
+            )
+            _LOGGER.error("HA-MCP in-process server exited during startup: %s", cause)
         except Exception as err:
             self._thread_exc = err
             _LOGGER.exception("HA-MCP in-process server thread crashed")
@@ -831,6 +884,7 @@ class EmbeddedServerManager:
         # Hand ha-mcp the loopback URL + provisioned admin token in memory, before
         # the server (and its settings singleton) is built. Keeping the token out
         # of os.environ is the whole point of the in-process channel.
+        self._note_startup_phase("importing the server package")
         import ha_mcp.config as _hamcp_config
 
         # Record which code generation this worker imported. Prefer the
@@ -838,6 +892,11 @@ class EmbeddedServerManager:
         # ha_mcp.__version__ itself checks stable first and stale stable
         # metadata can otherwise make a fresh dev worker look outdated.
         self._running_version = _running_ha_mcp_version(self._channel)
+        # The cache in sys.modules now holds this generation — remembered
+        # process-wide so the next start can skip the purge when the install
+        # has not changed (issue #1904).
+        global _CACHED_IMPORT_VERSION
+        _CACHED_IMPORT_VERSION = self._running_version
 
         # Drop any settings singleton cached by a PREVIOUS start in this same
         # Python process: an entry reload must re-read the override files
@@ -883,6 +942,7 @@ class EmbeddedServerManager:
         from ha_mcp.server import HomeAssistantSmartMCPServer
         from ha_mcp.settings_ui import register_settings_routes
 
+        self._note_startup_phase("building the server")
         server = HomeAssistantSmartMCPServer()
 
         # Startup observability (no secrets): confirm the in-memory connection
@@ -921,6 +981,7 @@ class EmbeddedServerManager:
 
         # Parity with the CLI HTTP runner: serve the web settings UI under the
         # same secret path as the MCP endpoint.
+        self._note_startup_phase("registering web routes")
         register_settings_routes(server.mcp, server, secret_path=self._secret_path)
 
         # Parity with the CLI HTTP runner: answer a browser GET on the MCP path
@@ -977,6 +1038,7 @@ class EmbeddedServerManager:
         )
         uv_server = uvicorn.Server(config)
 
+        self._note_startup_phase("starting the HTTP listener")
         stop_task = asyncio.create_task(stop_event.wait())
         async with server.mcp._lifespan_manager():
             serve_task = asyncio.create_task(uv_server.serve())
@@ -996,15 +1058,31 @@ class EmbeddedServerManager:
                 # Surface a server that exited on its own (bind failure, etc.).
                 serve_task.result()
 
+    def _progress_signature(self) -> tuple[int, str]:
+        """Snapshot the observable startup progress of the worker thread.
+
+        ``len(sys.modules)`` moves continuously while the worker grinds
+        through a cold import (the single longest startup step — minutes on
+        slow hardware, issue #1904), and the published phase moves between
+        steps. Any change in the pair counts as progress.
+        """
+        return (len(sys.modules), self._startup_phase)
+
     async def _async_wait_until_ready(self) -> None:
         """Poll a loopback TCP connect until the server accepts, or fail.
 
-        On failure (timeout or an early thread crash) stops the thread and raises
+        Patience is progress-based: the wait only gives up when the worker
+        shows no observable progress for ``_READY_STALL_TIMEOUT_SECONDS`` (or
+        blows the absolute ``_READY_TOTAL_CAP_SECONDS`` ceiling). A slow cold
+        import keeps the wait alive; a wedged worker still fails after one
+        stall budget. On failure stops the thread and raises
         :class:`EmbeddedServerError` so the caller leaves the webhook
         unregistered and files a repair issue.
         """
-        deadline = self._hass.loop.time() + _READY_TIMEOUT_SECONDS
-        while self._hass.loop.time() < deadline:
+        start = self._hass.loop.time()
+        last_progress = start
+        last_signature = self._progress_signature()
+        while True:
             if self._thread_exc is not None:
                 raise EmbeddedServerError(
                     f"HA-MCP in-process server failed to start: {self._thread_exc}"
@@ -1020,15 +1098,32 @@ class EmbeddedServerManager:
                     self._port,
                 )
                 return
+            now = self._hass.loop.time()
+            signature = self._progress_signature()
+            if signature != last_signature:
+                last_signature = signature
+                last_progress = now
+            if now - start >= _READY_TOTAL_CAP_SECONDS:
+                failure = (
+                    f"HA-MCP in-process server did not become reachable on "
+                    f"port {self._port} within {_READY_TOTAL_CAP_SECONDS:.0f}s "
+                    f"(last startup phase: {self._startup_phase})."
+                )
+                break
+            if now - last_progress >= _READY_STALL_TIMEOUT_SECONDS:
+                failure = (
+                    f"HA-MCP in-process server did not become reachable on "
+                    f"port {self._port}: no startup progress for "
+                    f"{_READY_STALL_TIMEOUT_SECONDS:.0f}s (stalled at: "
+                    f"{self._startup_phase}; {now - start:.0f}s since start)."
+                )
+                break
             await asyncio.sleep(_READY_POLL_INTERVAL_SECONDS)
 
-        # Timed out — tear the thread down so we never leave a half-started
+        # Gave up — tear the thread down so we never leave a half-started
         # server behind an unregistered webhook.
         await self.async_stop()
-        raise EmbeddedServerError(
-            f"HA-MCP in-process server did not become reachable on port "
-            f"{self._port} within {_READY_TIMEOUT_SECONDS:.0f}s."
-        )
+        raise EmbeddedServerError(failure)
 
     async def _async_probe_port(self) -> bool:
         """Return True if a loopback TCP connection to the server port succeeds.
@@ -1049,6 +1144,14 @@ class EmbeddedServerManager:
         return True
 
 
+# Version of the ha_mcp generation currently cached in sys.modules — set by
+# the worker right after its imports land, cleared by the purge. Process-wide
+# (the module cache it describes is process-wide too). Lets a retry with an
+# unchanged install keep the warm cache instead of paying the full cold import
+# again (issue #1904).
+_CACHED_IMPORT_VERSION: str | None = None
+
+
 def _purge_ha_mcp_modules() -> None:
     """Drop every cached ``ha_mcp`` module so the next import loads fresh code.
 
@@ -1061,6 +1164,8 @@ def _purge_ha_mcp_modules() -> None:
     shared with the rest of Home Assistant), so a dependency-version change
     still needs an HA core restart.
     """
+    global _CACHED_IMPORT_VERSION
+    _CACHED_IMPORT_VERSION = None
     # Snapshot the keys: sys.modules can be mutated by concurrent imports on
     # other threads mid-iteration (HA core is heavily threaded).
     purged = [

--- a/custom_components/ha_mcp_tools/embedded_server.py
+++ b/custom_components/ha_mcp_tools/embedded_server.py
@@ -92,15 +92,16 @@ _LOGGER = logging.getLogger(__name__)
 # from the same refresh token on every start regardless.
 _ACCESS_TOKEN_TTL = timedelta(days=3650)
 
-# Readiness probe: fail the bring-up only when the worker shows no observable
-# startup progress (no new modules landing in sys.modules, no phase advance)
-# for this long. The previous flat 90s deadline assumed real hardware imports
-# the server tree in seconds — issue #1904 (HA Green) showed a cold import
-# alone can take minutes there, and killing the still-importing worker at the
+# Readiness probe: fail the bring-up only when there is no observable startup
+# progress (no new modules landing in sys.modules, no phase advance) for this
+# long. The previous flat 90s deadline assumed real hardware imports the
+# server tree in seconds — issue #1904 (HA Green) showed a cold import alone
+# can take minutes there, and killing the still-importing worker at the
 # deadline is what created the orphaned-thread/port-collision cascade: the
 # worker cannot be joined mid-import, lingered as a zombie, and later bound
-# the port out from under the retry. A genuinely wedged worker still fails
-# after one stall budget.
+# the port out from under the retry. The module count is process-wide (see
+# _progress_signature), so a wedged worker trips the stall budget on a quiet
+# instance and the absolute cap below at the latest.
 _READY_STALL_TIMEOUT_SECONDS = 90.0
 # Absolute ceiling on one bring-up regardless of apparent progress, matching
 # the HAOS e2e lane's own 600s readiness deadline.
@@ -247,8 +248,9 @@ class EmbeddedServerManager:
         # Compared against the installed distribution after start to detect a
         # stale-code worker (see _purge_ha_mcp_modules).
         self._running_version: str | None = None
-        # Startup phase published by the worker (plain attribute write, read
-        # by the readiness poll for progress detection and error messages).
+        # Startup phase marker (plain attribute writes: init markers from the
+        # main thread, _note_startup_phase transitions from the worker). Read
+        # by the readiness poll for progress detection and error messages.
         self._startup_phase: str = "not started"
 
     @property
@@ -317,10 +319,11 @@ class EmbeddedServerManager:
         # Also skipped when the cached modules already ARE the generation on
         # disk (issue #1904): purging on every attempt made each retry pay
         # the full cold import again, so slow hardware that missed the
-        # readiness window once could never recover. A reinstall that keeps
-        # the same version string (same-version tarball override) is the
-        # accepted blind spot; the post-start staleness check still reports
-        # the running/installed pair.
+        # readiness window once could never recover. Never skipped under a
+        # pip-spec override — that is the one workflow where a reinstall can
+        # change the code without changing the version string (re-pointed
+        # tarball/pin), which a version-keyed skip would serve stale; channel
+        # installs mint a distinct version per build.
         orphan = self._orphaned_thread
         if orphan is not None and not orphan.is_alive():
             self._orphaned_thread = orphan = None
@@ -331,7 +334,8 @@ class EmbeddedServerManager:
                 "previously imported code until Home Assistant restarts."
             )
         elif (
-            ready_version is not None
+            not self._pip_spec_override
+            and ready_version is not None
             and _CACHED_IMPORT_VERSION is not None
             and ready_version == _CACHED_IMPORT_VERSION
         ):
@@ -588,6 +592,7 @@ class EmbeddedServerManager:
             await self._async_remove_legacy_target(target_dist, installed_version)
             await self._async_force_install()
 
+        version: str | None
         if not self._pip_spec_override and self._channel == CHANNEL_DEV:
             version = await self._hass.async_add_executor_job(
                 _installed_ha_mcp_version, target_dist
@@ -845,12 +850,20 @@ class EmbeddedServerManager:
             # misses — live issue #1904 saw the real bind error surface only
             # in HA's generic task-exception log while the component reported
             # a bare readiness timeout. Unwrap the original error so the
-            # repair issue names the actual cause.
-            cause: BaseException = err.__context__ or err.__cause__ or err
+            # repair issue names the actual cause; a bare SystemExit (no
+            # chained exception) is reported by repr so an empty/zero exit
+            # code still reads as what it is. The phase names where in
+            # _serve the exit happened instead of hardcoding a bind failure.
+            cause = err.__context__ or err.__cause__
+            detail = str(cause) if cause is not None else repr(err)
             self._thread_exc = EmbeddedServerError(
-                f"the server's HTTP listener exited during startup: {cause}"
+                f"the server exited during startup ({self._startup_phase}): {detail}"
             )
-            _LOGGER.error("HA-MCP in-process server exited during startup: %s", cause)
+            _LOGGER.error(
+                "HA-MCP in-process server exited during startup (%s): %s",
+                self._startup_phase,
+                detail,
+            )
         except Exception as err:
             self._thread_exc = err
             _LOGGER.exception("HA-MCP in-process server thread crashed")
@@ -1064,18 +1077,24 @@ class EmbeddedServerManager:
         ``len(sys.modules)`` moves continuously while the worker grinds
         through a cold import (the single longest startup step — minutes on
         slow hardware, issue #1904), and the published phase moves between
-        steps. Any change in the pair counts as progress.
+        steps. Any change in the pair counts as progress. The module count is
+        PROCESS-wide — an approximation: nothing finer-grained is observable
+        from outside a thread stuck inside one ``import`` statement, and any
+        other HA thread importing concurrently also refreshes the stall
+        budget. Erring toward patience is the point; the absolute cap bounds
+        the wait regardless.
         """
         return (len(sys.modules), self._startup_phase)
 
     async def _async_wait_until_ready(self) -> None:
         """Poll a loopback TCP connect until the server accepts, or fail.
 
-        Patience is progress-based: the wait only gives up when the worker
-        shows no observable progress for ``_READY_STALL_TIMEOUT_SECONDS`` (or
-        blows the absolute ``_READY_TOTAL_CAP_SECONDS`` ceiling). A slow cold
-        import keeps the wait alive; a wedged worker still fails after one
-        stall budget. On failure stops the thread and raises
+        Patience is progress-based: the wait only gives up when there is no
+        observable progress for ``_READY_STALL_TIMEOUT_SECONDS`` (or the
+        absolute ``_READY_TOTAL_CAP_SECONDS`` ceiling is hit). A slow cold
+        import keeps the wait alive; a wedged worker is caught by the stall
+        budget on a quiet instance, by the cap at the latest (the progress
+        signal is process-wide). On failure stops the thread and raises
         :class:`EmbeddedServerError` so the caller leaves the webhook
         unregistered and files a repair issue.
         """
@@ -1113,8 +1132,8 @@ class EmbeddedServerManager:
             if now - last_progress >= _READY_STALL_TIMEOUT_SECONDS:
                 failure = (
                     f"HA-MCP in-process server did not become reachable on "
-                    f"port {self._port}: no startup progress for "
-                    f"{_READY_STALL_TIMEOUT_SECONDS:.0f}s (stalled at: "
+                    f"port {self._port}: no startup progress observed for "
+                    f"{_READY_STALL_TIMEOUT_SECONDS:.0f}s (last phase: "
                     f"{self._startup_phase}; {now - start:.0f}s since start)."
                 )
                 break
@@ -1145,7 +1164,7 @@ class EmbeddedServerManager:
 
 
 # Version of the ha_mcp generation currently cached in sys.modules — set by
-# the worker right after its imports land, cleared by the purge. Process-wide
+# the worker right after its first import lands, cleared by the purge. Process-wide
 # (the module cache it describes is process-wide too). Lets a retry with an
 # unchanged install keep the warm cache instead of paying the full cold import
 # again (issue #1904).

--- a/tests/src/unit/test_embedded_server.py
+++ b/tests/src/unit/test_embedded_server.py
@@ -1575,19 +1575,159 @@ class TestReadinessProbe:
         assert isinstance(mgr._thread_exc, OSError)
         assert "address already in use" in str(mgr._thread_exc)
 
-    async def test_wait_ready_timeout_stops_thread_and_raises(
+    def test_thread_main_unwraps_uvicorn_systemexit(self, tmp_path, monkeypatch):
+        # Real uvicorn does NOT let a bind failure escape as OSError: startup()
+        # catches it and calls sys.exit(STARTUP_FAILURE). SystemExit is a
+        # BaseException, so the worker's `except Exception` missed it and the
+        # component reported a bare readiness timeout while the actual cause
+        # (port in use) only surfaced in HA's generic task-exception log
+        # (issue #1904). The handler must unwrap the original error.
+        _saved = {
+            k: os.environ.get(k) for k in ("HA_MCP_CONFIG_DIR", "HA_MCP_EMBEDDED")
+        }
+
+        def _restore_env():
+            for k, v in _saved.items():
+                if v is None:
+                    os.environ.pop(k, None)
+                else:
+                    os.environ[k] = v
+
+        mgr, _hass, _entry = _manager(
+            tmp_path, options={OPT_SERVER_URL: "http://ha.local:8123"}
+        )
+        from contextlib import asynccontextmanager
+
+        settings = SimpleNamespace(
+            homeassistant_url="http://127.0.0.1:8123", homeassistant_token="jwt"
+        )
+        ha_mcp_mod = ModuleType("ha_mcp")
+        ha_mcp_mod.__path__ = []
+        cfg = ModuleType("ha_mcp.config")
+        cfg.reset_global_settings = lambda: None
+        cfg.set_embedded_connection = lambda u, t: None
+        cfg.OAUTH_MODE_URL = "__sentinel_url__"
+        cfg.OAUTH_MODE_TOKEN = "__sentinel_token__"
+        cfg.get_global_settings = lambda: settings
+
+        @asynccontextmanager
+        async def _lifespan():
+            yield
+
+        class _FakeMcp:
+            def http_app(self, path, stateless_http):
+                return object()
+
+            _lifespan_manager = staticmethod(_lifespan)
+
+        server_mod = ModuleType("ha_mcp.server")
+        server_mod.HomeAssistantSmartMCPServer = lambda: SimpleNamespace(mcp=_FakeMcp())
+        ui_mod = ModuleType("ha_mcp.settings_ui")
+        ui_mod.register_settings_routes = lambda *a, **k: None
+
+        class _FakeUvServer:
+            def __init__(self, config):
+                self.should_exit = False
+
+            async def serve(self):
+                # Mirror uvicorn.Server.startup(): the bind error is caught
+                # and converted to sys.exit(STARTUP_FAILURE), leaving the
+                # OSError only as SystemExit.__context__.
+                try:
+                    raise OSError(98, "address already in use")
+                except OSError:
+                    # uvicorn calls bare sys.exit(STARTUP_FAILURE), leaving
+                    # the OSError only in __context__ — no `from` chaining.
+                    raise SystemExit(3)  # noqa: B904
+
+        uvicorn_mod = ModuleType("uvicorn")
+        uvicorn_mod.Config = lambda *a, **k: SimpleNamespace()
+        uvicorn_mod.Server = _FakeUvServer
+
+        for name, mod in (
+            ("ha_mcp", ha_mcp_mod),
+            ("ha_mcp.config", cfg),
+            ("ha_mcp.server", server_mod),
+            ("ha_mcp.settings_ui", ui_mod),
+            ("uvicorn", uvicorn_mod),
+        ):
+            monkeypatch.setitem(sys.modules, name, mod)
+        ha_mcp_mod.config = cfg
+        ha_mcp_mod.server = server_mod
+        ha_mcp_mod.settings_ui = ui_mod
+        monkeypatch.setitem(
+            sys.modules,
+            "ha_mcp.browser_landing",
+            ModuleType("ha_mcp.browser_landing"),
+        )
+
+        try:
+            mgr._thread_main("tok")
+        finally:
+            _restore_env()
+
+        assert isinstance(mgr._thread_exc, es.EmbeddedServerError)
+        assert "exited during startup" in str(mgr._thread_exc)
+        assert "address already in use" in str(mgr._thread_exc)
+
+    async def test_wait_ready_stall_stops_thread_and_raises(
         self, tmp_path, monkeypatch
     ):
+        # No observable progress (pinned signature) past the stall budget.
         mgr, hass, _entry = _manager(tmp_path)
-        # loop.time advances past the deadline on the second read.
-        hass.loop.time = MagicMock(side_effect=[0.0, 0.0, 9999.0, 9999.0])
+        hass.loop.time = MagicMock(side_effect=[0.0, 100.0])
         mgr._thread = SimpleNamespace(is_alive=lambda: True)
+        mgr._startup_phase = "pinned"
+        monkeypatch.setattr(mgr, "_progress_signature", lambda: (0, "pinned"))
         monkeypatch.setattr(mgr, "_async_probe_port", AsyncMock(return_value=False))
         stop = AsyncMock()
         monkeypatch.setattr(mgr, "async_stop", stop)
         monkeypatch.setattr(es.asyncio, "sleep", AsyncMock())
 
-        with pytest.raises(es.EmbeddedServerError, match="did not become reachable"):
+        with pytest.raises(
+            es.EmbeddedServerError, match="no startup progress"
+        ) as excinfo:
+            await mgr._async_wait_until_ready()
+        stop.assert_awaited_once()
+        # The failure names the phase the worker was last seen in.
+        assert "pinned" in str(excinfo.value)
+
+    async def test_wait_ready_progress_extends_past_stall_budget(
+        self, tmp_path, monkeypatch
+    ):
+        # 150s elapsed (past the 90s stall budget) but the worker kept
+        # importing (signature moves) - the wait must NOT give up (#1904).
+        mgr, hass, _entry = _manager(tmp_path)
+        hass.loop.time = MagicMock(side_effect=[0.0, 150.0])
+        mgr._thread = SimpleNamespace(is_alive=lambda: True)
+        ticks = iter(range(100))
+        monkeypatch.setattr(
+            mgr, "_progress_signature", lambda: (next(ticks), "importing")
+        )
+        monkeypatch.setattr(
+            mgr, "_async_probe_port", AsyncMock(side_effect=[False, True])
+        )
+        monkeypatch.setattr(es.asyncio, "sleep", AsyncMock())
+
+        await mgr._async_wait_until_ready()  # must not raise
+
+    async def test_wait_ready_total_cap_fires_despite_progress(
+        self, tmp_path, monkeypatch
+    ):
+        # Endless "progress" cannot extend the wait past the absolute cap.
+        mgr, hass, _entry = _manager(tmp_path)
+        hass.loop.time = MagicMock(side_effect=[0.0, 700.0])
+        mgr._thread = SimpleNamespace(is_alive=lambda: True)
+        ticks = iter(range(100))
+        monkeypatch.setattr(
+            mgr, "_progress_signature", lambda: (next(ticks), "importing")
+        )
+        monkeypatch.setattr(mgr, "_async_probe_port", AsyncMock(return_value=False))
+        stop = AsyncMock()
+        monkeypatch.setattr(mgr, "async_stop", stop)
+        monkeypatch.setattr(es.asyncio, "sleep", AsyncMock())
+
+        with pytest.raises(es.EmbeddedServerError, match="within 600s"):
             await mgr._async_wait_until_ready()
         stop.assert_awaited_once()
 
@@ -1888,6 +2028,12 @@ class TestPurgeHaMcpModules:
             sys.modules.pop(name)
         es._purge_ha_mcp_modules()  # must not raise
 
+    def test_purge_clears_cached_import_version(self, monkeypatch):
+        monkeypatch.setattr(es, "_CACHED_IMPORT_VERSION", "9.9.9")
+        monkeypatch.setitem(sys.modules, "ha_mcp", ModuleType("ha_mcp"))
+        es._purge_ha_mcp_modules()
+        assert es._CACHED_IMPORT_VERSION is None
+
 
 class TestRunningVersionStalenessWarning:
     async def test_start_prefers_configured_dev_distribution(
@@ -2047,6 +2193,65 @@ class TestPurgeSkippedWhileOrphanAlive:
         assert mgr._orphaned_thread is None  # bookkeeping cleared
 
 
+class TestPurgeSkippedOnWarmCache:
+    """A retry with an unchanged install must reuse the warm module cache.
+
+    Issue #1904: purging on every attempt made each retry pay the full cold
+    import again, so slow hardware that missed the readiness window once
+    could never recover.
+    """
+
+    def _start_kwargs(self, mgr, monkeypatch, purges, ready_version):
+        monkeypatch.setattr(
+            mgr, "_async_ensure_package", AsyncMock(return_value=ready_version)
+        )
+        monkeypatch.setattr(
+            mgr, "_async_provision_token", AsyncMock(return_value="tok")
+        )
+        monkeypatch.setattr(mgr, "_prepare_config_dir", lambda: None)
+        monkeypatch.setattr(mgr, "_async_wait_until_ready", AsyncMock())
+        monkeypatch.setattr(mgr, "_thread_main", lambda token: None)
+        monkeypatch.setattr(es, "_purge_ha_mcp_modules", lambda: purges.append(True))
+
+    async def test_purge_skipped_when_cache_matches_installed(
+        self, tmp_path, monkeypatch
+    ):
+        mgr, _hass, _entry = _manager(tmp_path)
+        purges: list[bool] = []
+        self._start_kwargs(mgr, monkeypatch, purges, "1.2.3")
+        monkeypatch.setattr(es, "_CACHED_IMPORT_VERSION", "1.2.3")
+
+        await mgr.async_start()
+        if mgr._thread is not None:
+            mgr._thread.join(timeout=2)
+
+        assert purges == []
+
+    async def test_purge_runs_when_cache_differs(self, tmp_path, monkeypatch):
+        mgr, _hass, _entry = _manager(tmp_path)
+        purges: list[bool] = []
+        self._start_kwargs(mgr, monkeypatch, purges, "1.2.3")
+        monkeypatch.setattr(es, "_CACHED_IMPORT_VERSION", "1.2.2")
+
+        await mgr.async_start()
+        if mgr._thread is not None:
+            mgr._thread.join(timeout=2)
+
+        assert purges == [True]
+
+    async def test_purge_runs_when_cache_unknown(self, tmp_path, monkeypatch):
+        mgr, _hass, _entry = _manager(tmp_path)
+        purges: list[bool] = []
+        self._start_kwargs(mgr, monkeypatch, purges, "1.2.3")
+        monkeypatch.setattr(es, "_CACHED_IMPORT_VERSION", None)
+
+        await mgr.async_start()
+        if mgr._thread is not None:
+            mgr._thread.join(timeout=2)
+
+        assert purges == [True]
+
+
 class TestServeRunningVersionCapture:
     @pytest.fixture(autouse=True)
     def _isolate_env(self):
@@ -2082,9 +2287,12 @@ class TestServeRunningVersionCapture:
         sys.modules["ha_mcp"].__version__ = "9.8.7"
         monkeypatch.setattr(es, "_installed_dist_version", lambda dist: None)
 
+        monkeypatch.setattr(es, "_CACHED_IMPORT_VERSION", None)
         mgr._thread_main("tok")
 
         assert mgr._running_version == "9.8.7"
+        # The warm-cache purge skip keys on this recording (issue #1904).
+        assert es._CACHED_IMPORT_VERSION == "9.8.7"
         assert isinstance(mgr._thread_exc, _StopServe)
 
     def test_serve_prefers_configured_dev_metadata(self, tmp_path, monkeypatch):

--- a/tests/src/unit/test_embedded_server.py
+++ b/tests/src/unit/test_embedded_server.py
@@ -1670,6 +1670,36 @@ class TestReadinessProbe:
         assert "exited during startup" in str(mgr._thread_exc)
         assert "address already in use" in str(mgr._thread_exc)
 
+    def test_thread_main_wraps_bare_systemexit(self, tmp_path, monkeypatch):
+        # A SystemExit with no chained exception (bare sys.exit) must still
+        # land in _thread_exc as an EmbeddedServerError naming the exit -
+        # not escape the worker, and not read as an empty failure message.
+        _saved = {
+            k: os.environ.get(k) for k in ("HA_MCP_CONFIG_DIR", "HA_MCP_EMBEDDED")
+        }
+
+        def _restore_env() -> None:
+            for k, v in _saved.items():
+                if v is None:
+                    os.environ.pop(k, None)
+                else:
+                    os.environ[k] = v
+
+        mgr, _hass, _entry = _manager(tmp_path)
+
+        async def _exit_now(access_token, stop_event):
+            raise SystemExit(3)
+
+        monkeypatch.setattr(mgr, "_serve", _exit_now)
+        try:
+            mgr._thread_main("tok")
+        finally:
+            _restore_env()
+
+        assert isinstance(mgr._thread_exc, es.EmbeddedServerError)
+        assert "exited during startup" in str(mgr._thread_exc)
+        assert "SystemExit(3)" in str(mgr._thread_exc)
+
     async def test_wait_ready_stall_stops_thread_and_raises(
         self, tmp_path, monkeypatch
     ):
@@ -1730,6 +1760,20 @@ class TestReadinessProbe:
         with pytest.raises(es.EmbeddedServerError, match="within 600s"):
             await mgr._async_wait_until_ready()
         stop.assert_awaited_once()
+
+    def test_progress_signature_tracks_modules_and_phase(self, tmp_path, monkeypatch):
+        # The production progress source itself (review gap): module-count
+        # growth and phase advances must each change the signature - this is
+        # the mechanism that keeps a slow cold import alive (#1904).
+        mgr, _hass, _entry = _manager(tmp_path)
+        base = mgr._progress_signature()
+        monkeypatch.setitem(
+            sys.modules, "_pr1908_progress_probe", ModuleType("_pr1908_progress_probe")
+        )
+        after_import = mgr._progress_signature()
+        assert after_import != base
+        mgr._startup_phase = "further along"
+        assert mgr._progress_signature() != after_import
 
 
 # ---------------------------------------------------------------------------
@@ -2250,6 +2294,22 @@ class TestPurgeSkippedOnWarmCache:
 
         assert purges == [True]
 
+    async def test_purge_runs_under_pip_spec_override_despite_match(
+        self, tmp_path, monkeypatch
+    ):
+        # A pip-spec override can re-point to different code under the SAME
+        # version string, so the warm-cache skip must never fire for it.
+        mgr, _hass, _entry = _manager(tmp_path, options={OPT_PIP_SPEC: "ha-mcp==1.2.3"})
+        purges: list[bool] = []
+        self._start_kwargs(mgr, monkeypatch, purges, "1.2.3")
+        monkeypatch.setattr(es, "_CACHED_IMPORT_VERSION", "1.2.3")
+
+        await mgr.async_start()
+        if mgr._thread is not None:
+            mgr._thread.join(timeout=2)
+
+        assert purges == [True]
+
     async def test_purge_runs_when_cache_unknown(self, tmp_path, monkeypatch):
         mgr, _hass, _entry = _manager(tmp_path)
         purges: list[bool] = []
@@ -2261,6 +2321,65 @@ class TestPurgeSkippedOnWarmCache:
             mgr._thread.join(timeout=2)
 
         assert purges == [True]
+
+
+class TestWarmCacheVersionAgreement:
+    """The two sides of the warm-cache comparison must agree for a plain
+    install, or the purge skip could never fire in production: async_start
+    keys on _async_ensure_package's return while the worker records
+    _running_ha_mcp_version into _CACHED_IMPORT_VERSION (review gap)."""
+
+    def _stub_install_surface(
+        self, monkeypatch: pytest.MonkeyPatch, versions: dict[str, str]
+    ) -> None:
+        def installed_version(preferred_dist: str | None = None) -> str | None:
+            if preferred_dist is not None:
+                return versions.get(preferred_dist)
+            return versions.get(DIST_NAME_STABLE) or versions.get(DIST_NAME_DEV)
+
+        monkeypatch.setattr(es, "install_package", MagicMock(return_value=True))
+        monkeypatch.setattr(es, "pip_kwargs", lambda cfg: {})
+        monkeypatch.setattr(es, "_installed_ha_mcp_version", installed_version)
+        monkeypatch.setattr(es, "_installed_dist_version", versions.get)
+        monkeypatch.setattr(es, "_dist_installed", lambda name: False)
+        monkeypatch.setattr(
+            es, "_uninstall_distribution", MagicMock(return_value=False)
+        )
+
+    async def test_dev_channel_sides_agree_despite_stale_stable_metadata(
+        self, tmp_path, monkeypatch
+    ):
+        mgr, _hass, _entry = _manager(
+            tmp_path,
+            options={OPT_CHANNEL: CHANNEL_DEV},
+            data={DATA_SECRET_PATH: "/p", DATA_LAST_PIP_SPEC: DEV_PIP_SPEC},
+        )
+        versions = {DIST_NAME_STABLE: "6.2.0", DIST_NAME_DEV: "7.12.1.dev5"}
+        self._stub_install_surface(monkeypatch, versions)
+        fake = ModuleType("ha_mcp")
+        fake.__version__ = versions[DIST_NAME_STABLE]  # stale stable metadata
+        monkeypatch.setitem(sys.modules, "ha_mcp", fake)
+
+        ready_version = await mgr._async_ensure_package()
+
+        assert ready_version == versions[DIST_NAME_DEV]
+        assert es._running_ha_mcp_version(CHANNEL_DEV) == ready_version
+
+    async def test_stable_channel_sides_agree(self, tmp_path, monkeypatch):
+        mgr, _hass, _entry = _manager(
+            tmp_path,
+            data={DATA_SECRET_PATH: "/p", DATA_LAST_PIP_SPEC: DEFAULT_PIP_SPEC},
+        )
+        versions = {DIST_NAME_STABLE: "7.13.0"}
+        self._stub_install_surface(monkeypatch, versions)
+        fake = ModuleType("ha_mcp")
+        fake.__version__ = versions[DIST_NAME_STABLE]
+        monkeypatch.setitem(sys.modules, "ha_mcp", fake)
+
+        ready_version = await mgr._async_ensure_package()
+
+        assert ready_version == versions[DIST_NAME_STABLE]
+        assert es._running_ha_mcp_version(CHANNEL_STABLE) == ready_version
 
 
 class TestServeRunningVersionCapture:
@@ -2304,6 +2423,9 @@ class TestServeRunningVersionCapture:
         assert mgr._running_version == "9.8.7"
         # The warm-cache purge skip keys on this recording (issue #1904).
         assert es._CACHED_IMPORT_VERSION == "9.8.7"
+        # _serve advanced through its phase markers before http_app raised -
+        # a dropped or mislabeled _note_startup_phase call surfaces here.
+        assert mgr._startup_phase == "registering web routes"
         assert isinstance(mgr._thread_exc, _StopServe)
 
     def test_serve_prefers_configured_dev_metadata(self, tmp_path, monkeypatch):

--- a/tests/src/unit/test_embedded_server.py
+++ b/tests/src/unit/test_embedded_server.py
@@ -1494,7 +1494,7 @@ class TestReadinessProbe:
             k: os.environ.get(k) for k in ("HA_MCP_CONFIG_DIR", "HA_MCP_EMBEDDED")
         }
 
-        def _restore_env():
+        def _restore_env() -> None:
             for k, v in _saved.items():
                 if v is None:
                     os.environ.pop(k, None)
@@ -1586,7 +1586,7 @@ class TestReadinessProbe:
             k: os.environ.get(k) for k in ("HA_MCP_CONFIG_DIR", "HA_MCP_EMBEDDED")
         }
 
-        def _restore_env():
+        def _restore_env() -> None:
             for k, v in _saved.items():
                 if v is None:
                     os.environ.pop(k, None)
@@ -2144,7 +2144,12 @@ class TestPurgeSkippedWhileOrphanAlive:
     bring-up never came up.
     """
 
-    def _start_kwargs(self, mgr, monkeypatch, purges):
+    def _start_kwargs(
+        self,
+        mgr: es.EmbeddedServerManager,
+        monkeypatch: pytest.MonkeyPatch,
+        purges: list[bool],
+    ) -> None:
         monkeypatch.setattr(mgr, "_async_ensure_package", AsyncMock())
         monkeypatch.setattr(
             mgr, "_async_provision_token", AsyncMock(return_value="tok")
@@ -2201,7 +2206,13 @@ class TestPurgeSkippedOnWarmCache:
     could never recover.
     """
 
-    def _start_kwargs(self, mgr, monkeypatch, purges, ready_version):
+    def _start_kwargs(
+        self,
+        mgr: es.EmbeddedServerManager,
+        monkeypatch: pytest.MonkeyPatch,
+        purges: list[bool],
+        ready_version: str | None,
+    ) -> None:
         monkeypatch.setattr(
             mgr, "_async_ensure_package", AsyncMock(return_value=ready_version)
         )


### PR DESCRIPTION
## What does this PR do?

Fixes the embedded (custom component) server bring-up failing permanently on slow hardware (#1904).

The flat 90s readiness deadline killed workers still making real progress — on an HA Green a cold import of the server tree alone takes minutes (live logs in #1904 show the worker logging its first line 2m17s *after* being declared dead). The killed worker can't be joined mid-import, lingered as a zombie, and later bound the port out from under the retry (`[Errno 98]` in the issue) — and every retry re-purged the module cache and paid the full cold import again, so one missed window was unrecoverable.

- **Progress-aware readiness wait**: gives up only after 90s with no observable progress (`sys.modules` growth / startup-phase advance), with an absolute 600s ceiling matching the HAOS e2e lane's own deadline. A genuinely wedged worker still fails after one stall budget.
- **Warm retries**: the module purge is skipped when the cached `ha_mcp` generation already matches the installed version.
- **Startup phases**: the worker publishes DEBUG-logged phases, so a stall failure names the phase it died in instead of a bare timeout.
- **Real bind errors**: uvicorn signals startup failure with `SystemExit`, which `except Exception` missed — the actual cause (e.g. "address in use") now lands in the component's error message instead of only HA's generic task-exception log.

No component version bump — the manifest stays 1.1.1; the mirror cuts the next `v1.1.1-dev.N` automatically on merge.

Fixes #1904

## Type of change
- [x] 🐛 Bug fix

## Testing
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

## Checklist
- [x] I have updated documentation if needed
