### PR TITLE
fix: Guide stale-schema clients past BestPracticeKey client-side rejection

### DIFF
--- a/src/ha_mcp/strict_bps.py
+++ b/src/ha_mcp/strict_bps.py
@@ -161,8 +161,12 @@ def strict_bps_ack_line() -> str:
 def _raise_bps_ack_required_error(name: str) -> NoReturn:
     """Raise the structured block error for a gated write missing the key.
 
-    The message and suggestion tell the model how to obtain the key but
-    never contain the key itself.
+    The suggestions tell the model how to obtain the key but never contain
+    the key itself. The second suggestion pre-arms the model for clients
+    that validate tool arguments against a stale cached tool schema and
+    reject the ``BestPracticeKey`` retry client-side (#1901) — that
+    rejection never reaches the server, so this error is the only server
+    surface that can carry the recovery path.
     """
     reference_file = STRICT_BPS_GATED_TOOLS[name]
     message = (
@@ -178,7 +182,14 @@ def _raise_bps_ack_required_error(name: str) -> NoReturn:
             suggestions=[
                 f"Call ha_get_skill_guide(skill={_HA_BEST_PRACTICES_SKILL_NAME!r}, "
                 f"file={reference_file!r}), read the content, then retry with "
-                f"{STRICT_BPS_KEY_PARAM} set."
+                f"{STRICT_BPS_KEY_PARAM} set.",
+                f"If your client then rejects the retry with a schema-validation "
+                f"error such as 'must NOT have additional properties', it is "
+                f"validating against a stale cached tool schema from an older "
+                f"server version that lacks {STRICT_BPS_KEY_PARAM}. Ask the user "
+                f"to fully reload the client application (VS Code: run "
+                f"'Developer: Reload Window' — restarting the MCP server or "
+                f"resetting cached tools is not enough), then retry.",
             ],
             context={"tool_name": name, "strict_mandatory_bps": True},
         )

--- a/src/ha_mcp/strict_bps.py
+++ b/src/ha_mcp/strict_bps.py
@@ -8,7 +8,10 @@ the call carries an acknowledgment key that is published ONLY inside the
 best-practices skill content served by ``ha_get_skill_guide``. The block
 error tells the model exactly how to obtain the key but never the key
 itself, forcing it to actually fetch/read the best practices before
-writing.
+writing. It also pre-arms the model with a recovery hint for clients that
+validate tool calls against a stale cached tool schema and reject the
+``BestPracticeKey`` retry client-side (#1901) — that rejection never
+reaches the server, so it cannot be handled anywhere else.
 
 Strict mode is *effective* only when BOTH ``enable_mandatory_bps`` (the
 parent, #1182) and ``enable_strict_mandatory_bps`` (the child, #1779) are
@@ -161,8 +164,8 @@ def strict_bps_ack_line() -> str:
 def _raise_bps_ack_required_error(name: str) -> NoReturn:
     """Raise the structured block error for a gated write missing the key.
 
-    The suggestions tell the model how to obtain the key but never contain
-    the key itself. The second suggestion pre-arms the model for clients
+    Neither suggestion ever contains the key itself. The first tells the
+    model how to obtain it; the second pre-arms the model for clients
     that validate tool arguments against a stale cached tool schema and
     reject the ``BestPracticeKey`` retry client-side (#1901) — that
     rejection never reaches the server, so this error is the only server

--- a/tests/src/unit/test_strict_bps.py
+++ b/tests/src/unit/test_strict_bps.py
@@ -196,6 +196,30 @@ class TestStrictBpsMiddleware:
         # scene maps to SKILL.md (its canonical first file).
         assert "SKILL.md" in body["error"]["suggestion"]
 
+    async def test_block_error_guides_stale_schema_clients(self, strict_on):
+        """The block error pre-arms the model for schema-validating clients
+        that reject the BestPracticeKey retry against a stale cached tool
+        schema (#1901). That rejection happens client-side — the call never
+        reaches the server — so this error is the only server surface that
+        can carry the recovery path."""
+        mw = StrictBpsMiddleware()
+        call_next = AsyncMock(return_value="ok")
+        ctx = make_context("ha_config_set_dashboard", {"url_path": "x"})
+        with pytest.raises(ToolError) as excinfo:
+            await mw.on_call_tool(ctx, call_next)
+        raw = excinfo.value.args[0]
+        body = json.loads(raw)
+        suggestions = body["error"]["suggestions"]
+        assert len(suggestions) == 2
+        # The primary suggestion stays the key-recovery call.
+        assert "ha_get_skill_guide" in suggestions[0]
+        stale_hint = suggestions[1]
+        # Names the client-side error verbatim so the model can match it.
+        assert "must NOT have additional properties" in stale_hint
+        assert "Developer: Reload Window" in stale_hint
+        # The key literal must still never appear anywhere in the error.
+        assert STRICT_BPS_ACK_KEY not in raw
+
     async def test_gated_with_correct_key_passes_and_strips_key(self, strict_on):
         mw = StrictBpsMiddleware()
         call_next = AsyncMock(return_value="ok")


### PR DESCRIPTION
## What does this PR do?

Adds a second suggestion to the strict-BPS `BPS_ACKNOWLEDGMENT_REQUIRED` block error covering clients that validate tool calls against a stale cached tool schema (#1901).

Root cause of #1901: VS Code Copilot Chat validates model-generated arguments with AJV against its own copy of the tool schema before sending `tools/call` (`extensions/copilot/src/extension/tools/common/toolsService.ts`). The compiled validator is cached per tool name for the lifetime of the window and is not invalidated by MCP server restarts, reconnects, or `MCP: Reset Cached Tools` (see microsoft/vscode#284221 — the maintainer confirms a reload is required). After upgrading the server in place, the client can therefore keep rejecting `BestPracticeKey` with `must NOT have additional properties` even though v7.13.0 publishes the parameter: raw `tools/list` dumps of both releases confirm v7.12.0 and v7.13.0 both serve `additionalProperties: false` and only v7.13.0 declares `BestPracticeKey`, so validating the retry against the older schema produces exactly the reported error. Disabling strict mode "fixes" it only because the model stops sending the argument — the schema is declared unconditionally either way.

The rejection happens entirely client-side — the retry never reaches the server — so the block error (which the model always sees first, and which is what teaches it the `BestPracticeKey` argument name) is the only server surface that can carry the recovery path. The new suggestion names the client-side error verbatim so the model can match it, and directs a full client reload (VS Code: `Developer: Reload Window`).

## Type of change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`) — `tests/src/unit/test_strict_bps.py` run locally (30 passed, including the new regression test); full suite runs in CI
- [x] Code follows style guidelines (`uv run ruff check`)

## Checklist
- [x] I have updated documentation if needed
