### PR TITLE
fix: track importing workers process-wide so a reload cannot purge under them

### DIFF
--- a/custom_components/ha_mcp_tools/embedded_server.py
+++ b/custom_components/ha_mcp_tools/embedded_server.py
@@ -334,10 +334,12 @@ class EmbeddedServerManager:
         # crashed mid-import with KeyError: 'ha_mcp.config' when its modules
         # were ripped out from under it (issue #1904, live on 1.1.1-dev.107).
         # The process-global registry survives manager turnover.
-        _IMPORTING_WORKERS.difference_update(
-            [t for t in list(_IMPORTING_WORKERS) if not t.is_alive()]
-        )
-        if orphan is not None or _IMPORTING_WORKERS:
+        with _IMPORTING_WORKERS_LOCK:
+            _IMPORTING_WORKERS.difference_update(
+                [t for t in list(_IMPORTING_WORKERS) if not t.is_alive()]
+            )
+            importing_busy = bool(_IMPORTING_WORKERS)
+        if orphan is not None or importing_busy:
             _LOGGER.warning(
                 "Skipping the ha_mcp module purge: a previous worker thread "
                 "is still shutting down. The new worker may serve the "
@@ -857,7 +859,8 @@ class EmbeddedServerManager:
         # per-manager orphan guard cannot cover this (managers are recreated
         # per bring-up). Deregistered in _serve once the import section
         # completes, and here on exit as the backstop.
-        _IMPORTING_WORKERS.add(threading.current_thread())
+        with _IMPORTING_WORKERS_LOCK:
+            _IMPORTING_WORKERS.add(threading.current_thread())
         try:
             loop.run_until_complete(self._serve(access_token, stop_event))
         except SystemExit as err:
@@ -884,7 +887,8 @@ class EmbeddedServerManager:
             self._thread_exc = err
             _LOGGER.exception("HA-MCP in-process server thread crashed")
         finally:
-            _IMPORTING_WORKERS.discard(threading.current_thread())
+            with _IMPORTING_WORKERS_LOCK:
+                _IMPORTING_WORKERS.discard(threading.current_thread())
             # Teardown is best-effort but never SILENT (review finding): a
             # raise here must not mask the primary outcome, yet a recurring
             # cleanup failure (leaking executor threads across reloads) has
@@ -1058,7 +1062,8 @@ class EmbeddedServerManager:
         # registry so a later bring-up's purge is no longer a hazard to this
         # thread (removal from sys.modules cannot unload already-bound
         # modules; only in-flight imports are corruptible).
-        _IMPORTING_WORKERS.discard(threading.current_thread())
+        with _IMPORTING_WORKERS_LOCK:
+            _IMPORTING_WORKERS.discard(threading.current_thread())
 
         app = server.mcp.http_app(path=self._secret_path, stateless_http=True)
         config = uvicorn.Config(
@@ -1192,7 +1197,11 @@ class EmbeddedServerManager:
 # manager is recreated on every bring-up, so per-manager orphan tracking
 # cannot see a previous manager's abandoned worker. Workers register in
 # _thread_main before their first import and deregister once their import
-# section completes (or on thread exit, whichever comes first).
+# section completes (or on thread exit, whichever comes first). All access
+# goes through the lock: CPython's GIL would make the individual set ops
+# atomic, but the purge gate's prune-then-check is a composite read and the
+# lock keeps its correctness independent of GIL scheduling arguments.
+_IMPORTING_WORKERS_LOCK = threading.Lock()
 _IMPORTING_WORKERS: set[threading.Thread] = set()
 
 # Version of the ha_mcp generation currently cached in sys.modules — set by

--- a/custom_components/ha_mcp_tools/embedded_server.py
+++ b/custom_components/ha_mcp_tools/embedded_server.py
@@ -336,14 +336,23 @@ class EmbeddedServerManager:
         # The process-global registry survives manager turnover.
         with _IMPORTING_WORKERS_LOCK:
             _IMPORTING_WORKERS.difference_update(
-                [t for t in list(_IMPORTING_WORKERS) if not t.is_alive()]
+                [t for t in _IMPORTING_WORKERS if not t.is_alive()]
             )
             importing_busy = bool(_IMPORTING_WORKERS)
-        if orphan is not None or importing_busy:
+        if orphan is not None:
             _LOGGER.warning(
                 "Skipping the ha_mcp module purge: a previous worker thread "
                 "is still shutting down. The new worker may serve the "
                 "previously imported code until Home Assistant restarts."
+            )
+        elif importing_busy:
+            # Distinct from the orphan message: this worker is still STARTING
+            # (mid cold-import, the #1904 incident shape), not shutting down —
+            # naming the actual state matters when reading logs during one.
+            _LOGGER.warning(
+                "Skipping the ha_mcp module purge: a previous bring-up's "
+                "worker thread is still importing. The new worker may serve "
+                "the previously imported code until Home Assistant restarts."
             )
         elif (
             not self._pip_spec_override
@@ -1058,10 +1067,13 @@ class EmbeddedServerManager:
         else:
             ensure_host_origin_guard_default_off()
 
-        # All ha_mcp/uvicorn imports are done — leave the importing-workers
-        # registry so a later bring-up's purge is no longer a hazard to this
-        # thread (removal from sys.modules cannot unload already-bound
-        # modules; only in-flight imports are corruptible).
+        # The cold import — the multi-minute window that crashed in #1904 —
+        # is complete: every explicit ha_mcp import in _serve precedes this
+        # line. Leave the registry so a long-running healthy server never
+        # blocks later bring-ups' purges (removal from sys.modules cannot
+        # unload already-bound modules; only in-flight imports are
+        # corruptible, and any later lazy import is outside the window this
+        # registry protects).
         with _IMPORTING_WORKERS_LOCK:
             _IMPORTING_WORKERS.discard(threading.current_thread())
 
@@ -1201,6 +1213,11 @@ class EmbeddedServerManager:
 # goes through the lock: CPython's GIL would make the individual set ops
 # atomic, but the purge gate's prune-then-check is a composite read and the
 # lock keeps its correctness independent of GIL scheduling arguments.
+# Deliberate tradeoff: a worker wedged forever inside its import stays
+# registered and blocks every later purge until an HA core restart — evicting
+# a live importer on a timer would reintroduce the very corruption this
+# registry prevents, and the skip warning plus the post-start staleness check
+# surface the condition.
 _IMPORTING_WORKERS_LOCK = threading.Lock()
 _IMPORTING_WORKERS: set[threading.Thread] = set()
 
@@ -1219,10 +1236,12 @@ def _purge_ha_mcp_modules() -> None:
     Python resolves imports from the process-wide ``sys.modules`` cache — so
     after a pip install the next worker would silently reuse the OLD code
     unless the cache is purged first. Safe here because ``ha_mcp`` is pure
-    Python and is only ever imported inside the (currently stopped) worker
-    thread; third-party dependencies are deliberately NOT purged (they are
-    shared with the rest of Home Assistant), so a dependency-version change
-    still needs an HA core restart.
+    Python and is only ever imported inside worker threads, and the caller's
+    gate guarantees no registered worker is mid-import when this runs (a
+    worker past its imports keeps its already-bound modules regardless);
+    third-party dependencies are deliberately NOT purged (they are shared
+    with the rest of Home Assistant), so a dependency-version change still
+    needs an HA core restart.
     """
     global _CACHED_IMPORT_VERSION
     _CACHED_IMPORT_VERSION = None

--- a/custom_components/ha_mcp_tools/embedded_server.py
+++ b/custom_components/ha_mcp_tools/embedded_server.py
@@ -327,7 +327,17 @@ class EmbeddedServerManager:
         orphan = self._orphaned_thread
         if orphan is not None and not orphan.is_alive():
             self._orphaned_thread = orphan = None
-        if orphan is not None:
+        # The per-manager orphan above cannot be the only guard: every
+        # bring-up constructs a FRESH manager (async_bring_up_server), so an
+        # entry reload during a slow cold import hands the purge to a manager
+        # that has never heard of the still-importing worker — which then
+        # crashed mid-import with KeyError: 'ha_mcp.config' when its modules
+        # were ripped out from under it (issue #1904, live on 1.1.1-dev.107).
+        # The process-global registry survives manager turnover.
+        _IMPORTING_WORKERS.difference_update(
+            [t for t in list(_IMPORTING_WORKERS) if not t.is_alive()]
+        )
+        if orphan is not None or _IMPORTING_WORKERS:
             _LOGGER.warning(
                 "Skipping the ha_mcp module purge: a previous worker thread "
                 "is still shutting down. The new worker may serve the "
@@ -842,6 +852,12 @@ class EmbeddedServerManager:
         stop_event = asyncio.Event()
         self._loop = loop
         self._stop_event = stop_event
+        # Registered BEFORE the first ha_mcp import so no later bring-up can
+        # purge sys.modules while this worker's imports are in flight — the
+        # per-manager orphan guard cannot cover this (managers are recreated
+        # per bring-up). Deregistered in _serve once the import section
+        # completes, and here on exit as the backstop.
+        _IMPORTING_WORKERS.add(threading.current_thread())
         try:
             loop.run_until_complete(self._serve(access_token, stop_event))
         except SystemExit as err:
@@ -868,6 +884,7 @@ class EmbeddedServerManager:
             self._thread_exc = err
             _LOGGER.exception("HA-MCP in-process server thread crashed")
         finally:
+            _IMPORTING_WORKERS.discard(threading.current_thread())
             # Teardown is best-effort but never SILENT (review finding): a
             # raise here must not mask the primary outcome, yet a recurring
             # cleanup failure (leaking executor threads across reloads) has
@@ -1037,6 +1054,12 @@ class EmbeddedServerManager:
         else:
             ensure_host_origin_guard_default_off()
 
+        # All ha_mcp/uvicorn imports are done — leave the importing-workers
+        # registry so a later bring-up's purge is no longer a hazard to this
+        # thread (removal from sys.modules cannot unload already-bound
+        # modules; only in-flight imports are corruptible).
+        _IMPORTING_WORKERS.discard(threading.current_thread())
+
         app = server.mcp.http_app(path=self._secret_path, stateless_http=True)
         config = uvicorn.Config(
             app,
@@ -1162,6 +1185,15 @@ class EmbeddedServerManager:
             await asyncio.wait_for(writer.wait_closed(), timeout=1.0)
         return True
 
+
+# Worker threads that may still be executing their ha_mcp imports. Purging
+# sys.modules while any of them is alive corrupts the in-flight import
+# (KeyError from frozen importlib — issue #1904). Process-global because a
+# manager is recreated on every bring-up, so per-manager orphan tracking
+# cannot see a previous manager's abandoned worker. Workers register in
+# _thread_main before their first import and deregister once their import
+# section completes (or on thread exit, whichever comes first).
+_IMPORTING_WORKERS: set[threading.Thread] = set()
 
 # Version of the ha_mcp generation currently cached in sys.modules — set by
 # the worker right after its first import lands, cleared by the purge. Process-wide

--- a/custom_components/ha_mcp_tools/embedded_server.py
+++ b/custom_components/ha_mcp_tools/embedded_server.py
@@ -296,77 +296,17 @@ class EmbeddedServerManager:
                 kind="package",
             )
 
-        ready_version = await self._async_ensure_package()
+        # Read the importer registry BEFORE the package step too: replacing
+        # the distribution's files on disk under a live importer corrupts it
+        # exactly like the sys.modules purge does (review finding), so a
+        # mutating install is deferred while any registered worker is alive.
+        ready_version = await self._async_ensure_package(
+            defer_mutations=_prune_and_check_importing_workers()
+        )
         access_token = await self._async_provision_token()
         await self._hass.async_add_executor_job(self._prepare_config_dir)
 
-        # Drop cached ha_mcp modules so the worker imports the code that is on
-        # disk NOW. Without this, a reload after a pip install keeps serving
-        # the OLD code forever: all workers are threads of the one HA core
-        # process, and Python resolves ``import ha_mcp`` from sys.modules —
-        # installs only took effect after a full HA core restart (issue
-        # observed live: options saves reinstalled the package, the web UI
-        # footer showed the new on-disk version, yet the serving worker kept
-        # reporting the version it was first imported with).
-        #
-        # SKIPPED while an orphaned worker may still be importing: ripping
-        # entries out of sys.modules under a live importer corrupts its
-        # import in progress (seen on QEMU-slow HAOS, where a cold import
-        # can outlive both the readiness timeout and the stop-join budget).
-        # The post-start staleness check below surfaces the consequence
-        # (old code possibly serving) instead.
-        #
-        # Also skipped when the cached modules already ARE the generation on
-        # disk (issue #1904): purging on every attempt made each retry pay
-        # the full cold import again, so slow hardware that missed the
-        # readiness window once could never recover. Never skipped under a
-        # pip-spec override — that is the one workflow where a reinstall can
-        # change the code without changing the version string (re-pointed
-        # tarball/pin), which a version-keyed skip would serve stale; channel
-        # installs mint a distinct version per build.
-        orphan = self._orphaned_thread
-        if orphan is not None and not orphan.is_alive():
-            self._orphaned_thread = orphan = None
-        # The per-manager orphan above cannot be the only guard: every
-        # bring-up constructs a FRESH manager (async_bring_up_server), so an
-        # entry reload during a slow cold import hands the purge to a manager
-        # that has never heard of the still-importing worker — which then
-        # crashed mid-import with KeyError: 'ha_mcp.config' when its modules
-        # were ripped out from under it (issue #1904, live on 1.1.1-dev.107).
-        # The process-global registry survives manager turnover.
-        with _IMPORTING_WORKERS_LOCK:
-            _IMPORTING_WORKERS.difference_update(
-                [t for t in _IMPORTING_WORKERS if not t.is_alive()]
-            )
-            importing_busy = bool(_IMPORTING_WORKERS)
-        if orphan is not None:
-            _LOGGER.warning(
-                "Skipping the ha_mcp module purge: a previous worker thread "
-                "is still shutting down. The new worker may serve the "
-                "previously imported code until Home Assistant restarts."
-            )
-        elif importing_busy:
-            # Distinct from the orphan message: this worker is still STARTING
-            # (mid cold-import, the #1904 incident shape), not shutting down —
-            # naming the actual state matters when reading logs during one.
-            _LOGGER.warning(
-                "Skipping the ha_mcp module purge: a previous bring-up's "
-                "worker thread is still importing. The new worker may serve "
-                "the previously imported code until Home Assistant restarts."
-            )
-        elif (
-            not self._pip_spec_override
-            and ready_version is not None
-            and _CACHED_IMPORT_VERSION is not None
-            and ready_version == _CACHED_IMPORT_VERSION
-        ):
-            _LOGGER.debug(
-                "Cached ha_mcp modules already match installed version %s; "
-                "skipping the module purge (warm start)",
-                ready_version,
-            )
-        else:
-            _purge_ha_mcp_modules()
+        self._maybe_purge_stale_modules(ready_version)
 
         self._thread_exc = None
         self._startup_phase = "waiting for the worker thread"
@@ -376,7 +316,19 @@ class EmbeddedServerManager:
             name="ha-mcp-server",
             daemon=True,
         )
-        self._thread.start()
+        # Registered by THIS (main) thread before start(): every bring-up
+        # runs its gate → register → start section synchronously on the one
+        # event loop, so another bring-up's purge gate can never interleave
+        # with a worker that exists but has not yet registered itself
+        # (review finding). The worker itself only ever deregisters.
+        with _IMPORTING_WORKERS_LOCK:
+            _IMPORTING_WORKERS.add(self._thread)
+        try:
+            self._thread.start()
+        except BaseException:
+            with _IMPORTING_WORKERS_LOCK:
+                _IMPORTING_WORKERS.discard(self._thread)
+            raise
 
         await self._async_wait_until_ready()
 
@@ -507,11 +459,85 @@ class EmbeddedServerManager:
             return None
         return DIST_NAME_STABLE if self._channel == CHANNEL_DEV else DIST_NAME_DEV
 
-    async def _async_ensure_package(self) -> str | None:
+    def _maybe_purge_stale_modules(self, ready_version: str | None) -> None:
+        """Purge cached ha_mcp modules unless doing so is unsafe or pointless.
+
+        The purge makes the next worker import the code that is on disk NOW.
+        Without it, a reload after a pip install keeps serving the OLD code
+        forever: all workers are threads of the one HA core process, and
+        Python resolves ``import ha_mcp`` from sys.modules — installs only
+        took effect after a full HA core restart (observed live: options
+        saves reinstalled the package, the web UI footer showed the new
+        on-disk version, yet the serving worker kept reporting the version
+        it was first imported with).
+
+        SKIPPED while any previous worker may still be importing — ripping
+        entries out of sys.modules under a live importer corrupts its import
+        in progress. Two guards cover that: the per-manager orphan (a worker
+        this manager's stop could not join), and the process-global
+        ``_IMPORTING_WORKERS`` registry, because every bring-up constructs a
+        FRESH manager (async_bring_up_server) and an entry reload during a
+        slow cold import otherwise hands the purge to a manager that has
+        never heard of the still-importing worker — which then crashed
+        mid-import with KeyError: 'ha_mcp.config' (issue #1904, live on
+        1.1.1-dev.107). The post-start staleness check surfaces the
+        consequence (old code possibly serving) instead.
+
+        Also skipped when the cached modules already ARE the generation on
+        disk: purging on every attempt made each retry pay the full cold
+        import again, so slow hardware that missed the readiness window once
+        could never recover (#1904). Never skipped under a pip-spec override
+        — the one workflow where a reinstall can change the code without
+        changing the version string (re-pointed tarball/pin), which a
+        version-keyed skip would serve stale; channel installs mint a
+        distinct version per build.
+        """
+        orphan = self._orphaned_thread
+        if orphan is not None and not orphan.is_alive():
+            self._orphaned_thread = orphan = None
+        importing_busy = _prune_and_check_importing_workers()
+        if orphan is not None:
+            _LOGGER.warning(
+                "Skipping the ha_mcp module purge: a previous worker thread "
+                "is still shutting down. The new worker may serve the "
+                "previously imported code until Home Assistant restarts."
+            )
+        elif importing_busy:
+            # Distinct from the orphan message: that worker is still STARTING
+            # (mid cold-import, the #1904 incident shape), not shutting down —
+            # naming the actual state matters when reading logs during one.
+            _LOGGER.warning(
+                "Skipping the ha_mcp module purge: a previous bring-up's "
+                "worker thread is still importing. The new worker may serve "
+                "the previously imported code until Home Assistant restarts."
+            )
+        elif (
+            not self._pip_spec_override
+            and ready_version is not None
+            and _CACHED_IMPORT_VERSION is not None
+            and ready_version == _CACHED_IMPORT_VERSION
+        ):
+            _LOGGER.debug(
+                "Cached ha_mcp modules already match installed version %s; "
+                "skipping the module purge (warm start)",
+                ready_version,
+            )
+        else:
+            _purge_ha_mcp_modules()
+
+    async def _async_ensure_package(
+        self, *, defer_mutations: bool = False
+    ) -> str | None:
         """Ensure ``ha-mcp`` is importable, installing the pip spec if needed.
 
         Returns the installed version that the worker is about to run, for the
         caller's warm-cache purge decision.
+
+        ``defer_mutations=True`` (a previous bring-up's worker is still
+        importing) downgrades any would-be uninstall/force-install to the
+        non-mutating fast path: replacing the distribution's files on disk
+        under a live importer corrupts it the same way a sys.modules purge
+        does. The deferred update applies on the next reload or HA restart.
 
         With auto-update on (the default) both channels install their
         distribution UNPINNED, so every entry reload / HA restart must pick up
@@ -607,6 +633,15 @@ class EmbeddedServerManager:
             and _is_compatible_embedded_version(installed_version)
         )
         if fast_path_ok:
+            await self._async_process_requirements_fast()
+        elif defer_mutations:
+            _LOGGER.warning(
+                "Deferring the ha-mcp install/upgrade: a previous bring-up's "
+                "worker thread is still importing, and replacing the package "
+                "files under it could corrupt that import. The currently "
+                "installed build will be used; reload the integration (or "
+                "restart Home Assistant) to apply the update."
+            )
             await self._async_process_requirements_fast()
         else:
             await self._async_remove_conflicting_dist()
@@ -863,13 +898,10 @@ class EmbeddedServerManager:
         stop_event = asyncio.Event()
         self._loop = loop
         self._stop_event = stop_event
-        # Registered BEFORE the first ha_mcp import so no later bring-up can
-        # purge sys.modules while this worker's imports are in flight — the
-        # per-manager orphan guard cannot cover this (managers are recreated
-        # per bring-up). Deregistered in _serve once the import section
-        # completes, and here on exit as the backstop.
-        with _IMPORTING_WORKERS_LOCK:
-            _IMPORTING_WORKERS.add(threading.current_thread())
+        # Registration in _IMPORTING_WORKERS happened on the MAIN thread,
+        # before start() — see async_start. This thread only deregisters:
+        # in _serve once the import section completes, and in the finally
+        # below on exit as the backstop.
         try:
             loop.run_until_complete(self._serve(access_token, stop_event))
         except SystemExit as err:
@@ -1207,9 +1239,10 @@ class EmbeddedServerManager:
 # sys.modules while any of them is alive corrupts the in-flight import
 # (KeyError from frozen importlib — issue #1904). Process-global because a
 # manager is recreated on every bring-up, so per-manager orphan tracking
-# cannot see a previous manager's abandoned worker. Workers register in
-# _thread_main before their first import and deregister once their import
-# section completes (or on thread exit, whichever comes first). All access
+# cannot see a previous manager's abandoned worker. The spawning (main)
+# thread registers the worker BEFORE start() — see async_start — and the
+# worker deregisters once its import section completes (or on thread exit,
+# whichever comes first). All access
 # goes through the lock: CPython's GIL would make the individual set ops
 # atomic, but the purge gate's prune-then-check is a composite read and the
 # lock keeps its correctness independent of GIL scheduling arguments.
@@ -1220,6 +1253,16 @@ class EmbeddedServerManager:
 # surface the condition.
 _IMPORTING_WORKERS_LOCK = threading.Lock()
 _IMPORTING_WORKERS: set[threading.Thread] = set()
+
+
+def _prune_and_check_importing_workers() -> bool:
+    """Drop dead workers from the registry; return True if any live one remains."""
+    with _IMPORTING_WORKERS_LOCK:
+        _IMPORTING_WORKERS.difference_update(
+            [t for t in _IMPORTING_WORKERS if not t.is_alive()]
+        )
+        return bool(_IMPORTING_WORKERS)
+
 
 # Version of the ha_mcp generation currently cached in sys.modules — set by
 # the worker right after its first import lands, cleared by the purge. Process-wide

--- a/tests/src/unit/test_embedded_server.py
+++ b/tests/src/unit/test_embedded_server.py
@@ -11,10 +11,12 @@ these tests never actually run.
 
 from __future__ import annotations
 
+import asyncio
 import importlib.metadata
 import os
 import sys
 import threading
+import time
 from types import ModuleType, SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
@@ -2288,6 +2290,34 @@ class TestPurgeSkippedWhileOrphanAlive:
         assert purges == [True]
         assert not es._IMPORTING_WORKERS  # dead entry pruned
 
+    async def test_prune_keeps_live_worker_while_dropping_dead_one(
+        self, tmp_path, monkeypatch
+    ):
+        # The composite prune-then-check must drop only the dead entry and
+        # still block the purge on the surviving live one.
+        mgr, _hass, _entry = _manager(tmp_path)
+        purges: list[bool] = []
+        self._start_kwargs(mgr, monkeypatch, purges)
+
+        class _AliveWorker:
+            def is_alive(self):
+                return True
+
+        class _DeadWorker:
+            def is_alive(self):
+                return False
+
+        alive = _AliveWorker()
+        dead = _DeadWorker()
+        monkeypatch.setattr(es, "_IMPORTING_WORKERS", {alive, dead})
+
+        await mgr.async_start()
+        if mgr._thread is not None:
+            mgr._thread.join(timeout=2)
+
+        assert purges == []
+        assert {alive} == es._IMPORTING_WORKERS
+
 
 class TestImportingWorkerRegistry:
     """The worker must be registered for exactly its import window."""
@@ -2325,6 +2355,86 @@ class TestImportingWorkerRegistry:
         assert seen == [True]
         assert not es._IMPORTING_WORKERS
 
+    def test_thread_main_deregisters_on_plain_exception_crash(
+        self, tmp_path, monkeypatch
+    ):
+        # A worker that dies of an ordinary Exception mid-import (the
+        # abandoned-worker case the registry exists for) must also leave the
+        # registry via the shared finally.
+        mgr, _hass, _entry = _manager(tmp_path)
+        monkeypatch.setattr(es, "_IMPORTING_WORKERS", set())
+
+        async def _boom(access_token, stop_event):
+            raise RuntimeError("boom mid-import")
+
+        monkeypatch.setattr(mgr, "_serve", _boom)
+        mgr._thread_main("tok")
+
+        assert isinstance(mgr._thread_exc, RuntimeError)
+        assert not es._IMPORTING_WORKERS
+
+    async def test_live_worker_blocks_a_fresh_managers_purge(
+        self, tmp_path, monkeypatch, caplog
+    ):
+        # The literal #1904 race, end to end: worker A registers itself via
+        # the REAL _thread_main path, and a freshly constructed manager B
+        # (a reload builds a new manager every time) must see A in the
+        # process-global registry and skip its purge.
+        monkeypatch.setattr(es, "_IMPORTING_WORKERS", set())
+        release = threading.Event()
+
+        mgr_a, _hass_a, _entry_a = _manager(tmp_path)
+
+        async def _hold(access_token, stop_event):
+            # threading.Event so the MAIN thread can release a coroutine
+            # running on worker A's own loop; run_in_executor keeps the
+            # worker loop unblocked while waiting.
+            await asyncio.get_running_loop().run_in_executor(None, release.wait)
+
+        monkeypatch.setattr(mgr_a, "_serve", _hold)
+        worker_a = threading.Thread(target=mgr_a._thread_main, args=("tok",))
+        worker_a.start()
+        try:
+
+            def _wait_registered() -> bool:
+                deadline = time.monotonic() + 5
+                while not es._IMPORTING_WORKERS and time.monotonic() < deadline:
+                    time.sleep(0.02)
+                return bool(es._IMPORTING_WORKERS)
+
+            registered = await asyncio.get_running_loop().run_in_executor(
+                None, _wait_registered
+            )
+            assert registered, "worker A never registered"
+
+            mgr_b, _hass_b, _entry_b = _manager(tmp_path)
+            purges: list[bool] = []
+            monkeypatch.setattr(
+                mgr_b, "_async_ensure_package", AsyncMock(return_value="1.2.3")
+            )
+            monkeypatch.setattr(
+                mgr_b, "_async_provision_token", AsyncMock(return_value="tok")
+            )
+            monkeypatch.setattr(mgr_b, "_prepare_config_dir", lambda: None)
+            monkeypatch.setattr(mgr_b, "_async_wait_until_ready", AsyncMock())
+            monkeypatch.setattr(mgr_b, "_thread_main", lambda token: None)
+            monkeypatch.setattr(
+                es, "_purge_ha_mcp_modules", lambda: purges.append(True)
+            )
+
+            with caplog.at_level("WARNING"):
+                await mgr_b.async_start()
+            if mgr_b._thread is not None:
+                mgr_b._thread.join(timeout=2)
+
+            assert purges == []
+            assert "Skipping the ha_mcp module purge" in caplog.text
+        finally:
+            release.set()
+            worker_a.join(timeout=5)
+        assert not worker_a.is_alive()
+        assert not es._IMPORTING_WORKERS
+
     def test_serve_deregisters_before_building_the_app(self, tmp_path, monkeypatch):
         # Once the import section completes, a concurrent purge is harmless -
         # the worker must leave the registry BEFORE the listener build so a
@@ -2341,15 +2451,29 @@ class TestImportingWorkerRegistry:
 
         class _FakeMcp:
             def http_app(self, path, stateless_http):
-                membership.append(threading.current_thread() in es._IMPORTING_WORKERS)
+                membership.append(
+                    ("http_app", threading.current_thread() in es._IMPORTING_WORKERS)
+                )
                 raise _StopServe
 
         _stub_ha_mcp_surface(monkeypatch, mcp=_FakeMcp())
         monkeypatch.setattr(es, "_installed_dist_version", lambda dist: None)
 
+        # Recorder on the stubbed settings-routes hook: registration must
+        # still be in effect there (imports not yet complete), making this
+        # test self-contained rather than relying on the sibling test to
+        # prove the add() happened at all.
+        def _routes_probe(*args, **kwargs):
+            membership.append(
+                ("routes", threading.current_thread() in es._IMPORTING_WORKERS)
+            )
+
+        sys.modules["ha_mcp.settings_ui"].register_settings_routes = _routes_probe
+
         mgr._thread_main("tok")
 
-        assert membership == [False]
+        assert membership == [("routes", True), ("http_app", False)]
+        assert not es._IMPORTING_WORKERS
         assert isinstance(mgr._thread_exc, _StopServe)
 
 

--- a/tests/src/unit/test_embedded_server.py
+++ b/tests/src/unit/test_embedded_server.py
@@ -1913,7 +1913,7 @@ class TestLifecycle:
         monkeypatch.setattr(
             mgr,
             "_async_ensure_package",
-            AsyncMock(side_effect=lambda: calls.append("ensure")),
+            AsyncMock(side_effect=lambda **kwargs: calls.append("ensure")),
         )
         monkeypatch.setattr(
             mgr,
@@ -2288,7 +2288,7 @@ class TestPurgeSkippedWhileOrphanAlive:
             mgr._thread.join(timeout=2)
 
         assert purges == [True]
-        assert not es._IMPORTING_WORKERS  # dead entry pruned
+        assert dead not in es._IMPORTING_WORKERS  # dead entry pruned
 
     async def test_prune_keeps_live_worker_while_dropping_dead_one(
         self, tmp_path, monkeypatch
@@ -2316,7 +2316,8 @@ class TestPurgeSkippedWhileOrphanAlive:
             mgr._thread.join(timeout=2)
 
         assert purges == []
-        assert {alive} == es._IMPORTING_WORKERS
+        assert alive in es._IMPORTING_WORKERS
+        assert dead not in es._IMPORTING_WORKERS
 
 
 class TestImportingWorkerRegistry:
@@ -2338,9 +2339,13 @@ class TestImportingWorkerRegistry:
             else:
                 os.environ[key] = value
 
-    def test_thread_main_registers_and_always_deregisters(self, tmp_path, monkeypatch):
+    def test_thread_main_always_deregisters_on_exit(self, tmp_path, monkeypatch):
+        # Registration happens in async_start (main thread) before start();
+        # this drives _thread_main with the current thread pre-registered the
+        # same way and proves the finally backstop clears it on exit even
+        # though _serve never reached its own early deregistration point.
         mgr, _hass, _entry = _manager(tmp_path)
-        monkeypatch.setattr(es, "_IMPORTING_WORKERS", set())
+        monkeypatch.setattr(es, "_IMPORTING_WORKERS", {threading.current_thread()})
         seen: list[bool] = []
 
         async def _probe(access_token, stop_event):
@@ -2350,8 +2355,6 @@ class TestImportingWorkerRegistry:
         monkeypatch.setattr(mgr, "_serve", _probe)
         mgr._thread_main("tok")
 
-        # Registered while _serve (the import site) ran; gone after exit even
-        # though _serve never reached its own early deregistration point.
         assert seen == [True]
         assert not es._IMPORTING_WORKERS
 
@@ -2362,7 +2365,7 @@ class TestImportingWorkerRegistry:
         # abandoned-worker case the registry exists for) must also leave the
         # registry via the shared finally.
         mgr, _hass, _entry = _manager(tmp_path)
-        monkeypatch.setattr(es, "_IMPORTING_WORKERS", set())
+        monkeypatch.setattr(es, "_IMPORTING_WORKERS", {threading.current_thread()})
 
         async def _boom(access_token, stop_event):
             raise RuntimeError("boom mid-import")
@@ -2393,6 +2396,10 @@ class TestImportingWorkerRegistry:
 
         monkeypatch.setattr(mgr_a, "_serve", _hold)
         worker_a = threading.Thread(target=mgr_a._thread_main, args=("tok",))
+        # Mirror async_start: the SPAWNING thread registers the worker
+        # before start(), the worker only deregisters.
+        with es._IMPORTING_WORKERS_LOCK:
+            es._IMPORTING_WORKERS.add(worker_a)
         worker_a.start()
         try:
 
@@ -2433,7 +2440,9 @@ class TestImportingWorkerRegistry:
             release.set()
             worker_a.join(timeout=5)
         assert not worker_a.is_alive()
-        assert not es._IMPORTING_WORKERS
+        # Worker A deregistered itself on exit; manager B's stubbed worker
+        # (no real _thread_main, so no self-discard) may linger dead.
+        assert worker_a not in es._IMPORTING_WORKERS
 
     def test_serve_deregisters_before_building_the_app(self, tmp_path, monkeypatch):
         # Once the import section completes, a concurrent purge is harmless -
@@ -2470,11 +2479,121 @@ class TestImportingWorkerRegistry:
 
         sys.modules["ha_mcp.settings_ui"].register_settings_routes = _routes_probe
 
+        # Pre-register the current thread the way async_start does before
+        # start(); _serve's early discard must clear it before http_app.
+        with es._IMPORTING_WORKERS_LOCK:
+            es._IMPORTING_WORKERS.add(threading.current_thread())
         mgr._thread_main("tok")
 
         assert membership == [("routes", True), ("http_app", False)]
         assert not es._IMPORTING_WORKERS
         assert isinstance(mgr._thread_exc, _StopServe)
+
+
+class TestImporterAwareBringUp:
+    """async_start must register its worker itself and defer package
+    mutations while a previous worker is still importing (review findings:
+    the worker-side add left a pre-registration window, and ensure-package
+    could replace files on disk under a live importer)."""
+
+    def _stub_bring_up(self, mgr, monkeypatch, ensure: AsyncMock) -> None:
+        monkeypatch.setattr(mgr, "_async_ensure_package", ensure)
+        monkeypatch.setattr(
+            mgr, "_async_provision_token", AsyncMock(return_value="tok")
+        )
+        monkeypatch.setattr(mgr, "_prepare_config_dir", lambda: None)
+        monkeypatch.setattr(mgr, "_async_wait_until_ready", AsyncMock())
+        monkeypatch.setattr(es, "_purge_ha_mcp_modules", lambda: None)
+
+    async def test_async_start_registers_worker_before_it_runs(
+        self, tmp_path, monkeypatch
+    ):
+        mgr, _hass, _entry = _manager(tmp_path)
+        monkeypatch.setattr(es, "_IMPORTING_WORKERS", set())
+        ensure = AsyncMock(return_value="1.2.3")
+        self._stub_bring_up(mgr, monkeypatch, ensure)
+        recorded: list[bool] = []
+
+        def _stub_main(token: str) -> None:
+            recorded.append(threading.current_thread() in es._IMPORTING_WORKERS)
+
+        monkeypatch.setattr(mgr, "_thread_main", _stub_main)
+
+        await mgr.async_start()
+        if mgr._thread is not None:
+            mgr._thread.join(timeout=2)
+
+        assert recorded == [True]
+
+    async def test_async_start_defers_install_while_importer_busy(
+        self, tmp_path, monkeypatch
+    ):
+        mgr, _hass, _entry = _manager(tmp_path)
+
+        class _AliveWorker:
+            def is_alive(self):
+                return True
+
+        monkeypatch.setattr(es, "_IMPORTING_WORKERS", {_AliveWorker()})
+        ensure = AsyncMock(return_value="1.2.3")
+        self._stub_bring_up(mgr, monkeypatch, ensure)
+        monkeypatch.setattr(mgr, "_thread_main", lambda token: None)
+
+        await mgr.async_start()
+        if mgr._thread is not None:
+            mgr._thread.join(timeout=2)
+
+        assert ensure.await_args.kwargs == {"defer_mutations": True}
+
+    async def test_async_start_allows_install_when_no_importer(
+        self, tmp_path, monkeypatch
+    ):
+        mgr, _hass, _entry = _manager(tmp_path)
+        monkeypatch.setattr(es, "_IMPORTING_WORKERS", set())
+        ensure = AsyncMock(return_value="1.2.3")
+        self._stub_bring_up(mgr, monkeypatch, ensure)
+        monkeypatch.setattr(mgr, "_thread_main", lambda token: None)
+
+        await mgr.async_start()
+        if mgr._thread is not None:
+            mgr._thread.join(timeout=2)
+
+        assert ensure.await_args.kwargs == {"defer_mutations": False}
+
+    async def test_ensure_package_defers_force_install(
+        self, tmp_path, monkeypatch, caplog
+    ):
+        # An unpinned dev channel would normally take the uninstall +
+        # force-install path; with defer_mutations it must fall back to the
+        # non-mutating fast path and say so.
+        mgr, _hass, _entry = _manager(
+            tmp_path,
+            options={OPT_CHANNEL: CHANNEL_DEV},
+            data={DATA_SECRET_PATH: "/p", DATA_LAST_PIP_SPEC: DEV_PIP_SPEC},
+        )
+
+        def installed_version(preferred_dist: str | None = None) -> str | None:
+            return "7.12.1.dev5"
+
+        monkeypatch.setattr(es, "_installed_ha_mcp_version", installed_version)
+        fast = AsyncMock()
+        force = AsyncMock()
+        remove_conflicting = AsyncMock()
+        remove_legacy = AsyncMock()
+        monkeypatch.setattr(mgr, "_async_process_requirements_fast", fast)
+        monkeypatch.setattr(mgr, "_async_force_install", force)
+        monkeypatch.setattr(mgr, "_async_remove_conflicting_dist", remove_conflicting)
+        monkeypatch.setattr(mgr, "_async_remove_legacy_target", remove_legacy)
+
+        with caplog.at_level("WARNING"):
+            ready = await mgr._async_ensure_package(defer_mutations=True)
+
+        assert ready == "7.12.1.dev5"
+        fast.assert_awaited_once()
+        force.assert_not_awaited()
+        remove_conflicting.assert_not_awaited()
+        remove_legacy.assert_not_awaited()
+        assert "Deferring the ha-mcp install/upgrade" in caplog.text
 
 
 class TestPurgeSkippedOnWarmCache:

--- a/tests/src/unit/test_embedded_server.py
+++ b/tests/src/unit/test_embedded_server.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import importlib.metadata
 import os
 import sys
+import threading
 from types import ModuleType, SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
@@ -2240,6 +2241,116 @@ class TestPurgeSkippedWhileOrphanAlive:
 
         assert purges == [True]
         assert mgr._orphaned_thread is None  # bookkeeping cleared
+
+    async def test_purge_skipped_while_foreign_worker_importing(
+        self, tmp_path, monkeypatch, caplog
+    ):
+        # The orphan guard is per-manager, but every bring-up constructs a
+        # FRESH manager - a still-importing worker abandoned by a PREVIOUS
+        # manager must also block the purge (issue #1904: the reload-era
+        # purge crashed the old worker mid-import with KeyError).
+        mgr, _hass, _entry = _manager(tmp_path)
+        purges: list[bool] = []
+        self._start_kwargs(mgr, monkeypatch, purges)
+
+        class _AliveWorker:
+            def is_alive(self):
+                return True
+
+        foreign = _AliveWorker()
+        monkeypatch.setattr(es, "_IMPORTING_WORKERS", {foreign})
+
+        with caplog.at_level("WARNING"):
+            await mgr.async_start()
+        if mgr._thread is not None:
+            mgr._thread.join(timeout=2)
+
+        assert purges == []
+        assert "Skipping the ha_mcp module purge" in caplog.text
+        assert foreign in es._IMPORTING_WORKERS  # live entry retained
+
+    async def test_purge_resumes_once_foreign_worker_died(self, tmp_path, monkeypatch):
+        mgr, _hass, _entry = _manager(tmp_path)
+        purges: list[bool] = []
+        self._start_kwargs(mgr, monkeypatch, purges)
+
+        class _DeadWorker:
+            def is_alive(self):
+                return False
+
+        dead = _DeadWorker()
+        monkeypatch.setattr(es, "_IMPORTING_WORKERS", {dead})
+
+        await mgr.async_start()
+        if mgr._thread is not None:
+            mgr._thread.join(timeout=2)
+
+        assert purges == [True]
+        assert not es._IMPORTING_WORKERS  # dead entry pruned
+
+
+class TestImportingWorkerRegistry:
+    """The worker must be registered for exactly its import window."""
+
+    @pytest.fixture(autouse=True)
+    def _isolate_env(self):
+        # _thread_main stages HA_MCP_CONFIG_DIR/HA_MCP_EMBEDDED into
+        # os.environ; snapshot + restore so the flags never leak into
+        # unrelated suites on this worker.
+        keys = ("HA_MCP_CONFIG_DIR", "HA_MCP_EMBEDDED")
+        saved = {k: os.environ.get(k) for k in keys}
+        for key in keys:
+            os.environ.pop(key, None)
+        yield
+        for key, value in saved.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+
+    def test_thread_main_registers_and_always_deregisters(self, tmp_path, monkeypatch):
+        mgr, _hass, _entry = _manager(tmp_path)
+        monkeypatch.setattr(es, "_IMPORTING_WORKERS", set())
+        seen: list[bool] = []
+
+        async def _probe(access_token, stop_event):
+            seen.append(threading.current_thread() in es._IMPORTING_WORKERS)
+            raise SystemExit(3)
+
+        monkeypatch.setattr(mgr, "_serve", _probe)
+        mgr._thread_main("tok")
+
+        # Registered while _serve (the import site) ran; gone after exit even
+        # though _serve never reached its own early deregistration point.
+        assert seen == [True]
+        assert not es._IMPORTING_WORKERS
+
+    def test_serve_deregisters_before_building_the_app(self, tmp_path, monkeypatch):
+        # Once the import section completes, a concurrent purge is harmless -
+        # the worker must leave the registry BEFORE the listener build so a
+        # long-running healthy server never blocks later bring-ups' purges.
+        mgr, _hass, _entry = _manager(
+            tmp_path, options={OPT_SERVER_URL: "http://ha.local:8123"}
+        )
+        monkeypatch.setattr(es, "_IMPORTING_WORKERS", set())
+
+        class _StopServe(Exception):
+            pass
+
+        membership: list[bool] = []
+
+        class _FakeMcp:
+            def http_app(self, path, stateless_http):
+                membership.append(threading.current_thread() in es._IMPORTING_WORKERS)
+                raise _StopServe
+
+        _stub_ha_mcp_surface(monkeypatch, mcp=_FakeMcp())
+        monkeypatch.setattr(es, "_installed_dist_version", lambda dist: None)
+
+        mgr._thread_main("tok")
+
+        assert membership == [False]
+        assert isinstance(mgr._thread_exc, _StopServe)
 
 
 class TestPurgeSkippedOnWarmCache:


### PR DESCRIPTION
## What does this PR do?

Fixes the `KeyError: 'ha_mcp.config'` worker crash reported on 1.1.1-dev.107 in #1904.

Every bring-up constructs a fresh `EmbeddedServerManager`, so the per-manager orphan guard from #1780 cannot see a worker abandoned by a *previous* manager. An entry reload during a slow cold import handed the module purge to a manager that had never heard of the still-importing worker — ripping `sys.modules` out from under its in-flight import and crashing it inside frozen importlib.

Workers now register in a process-global registry before their first `ha_mcp` import and deregister once their import section completes (thread exit as backstop); `async_start` skips the purge while any registered worker is alive, exactly like the orphan case.

Fixes #1904

## Type of change
- [x] 🐛 Bug fix

## Testing
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

## Checklist
- [x] I have updated documentation if needed

