### PR TITLE
fix: Restore the engine user's saved theme after dashboard screenshots

### DIFF
--- a/docs/beta.md
+++ b/docs/beta.md
@@ -175,11 +175,19 @@ page and (by its design) restarts; ha-mcp surfaces this as a clear "set the
 engine's access token" error rather than a silent failure.
 
 Puppet's theme and dark-mode renderer controls dispatch Home Assistant's
-`settheme` event and can persist preferences on the frontend profile used by
-that token; even a fresh Puppet browser's first default render may save the
-default theme/dark selection. Use a dedicated Puppet account so screenshot QA
-does not alter a person's normal frontend preferences. Language selection is
-local to Puppet's browser session.
+`settheme` event, which Home Assistant persists on the frontend profile of
+the user whose token the engine runs with — and syncs to that user's real
+web and mobile sessions. Even a fresh Puppet browser's first default render
+saves a "light" selection, which used to flip a dark-mode user's whole UI to
+light on every screenshot. ha-mcp now brackets every capture: it reads that
+user's saved theme before rendering and writes it back afterwards if the
+render changed it (in add-on mode it authenticates with the Puppet add-on's
+own configured token; in sidecar/standalone mode with ha-mcp's own HA
+credentials, which protects the user whenever both tokens belong to the same
+account). The restore is best-effort — a failed restore surfaces as a
+`warnings` entry on the tool response. A dedicated Puppet account remains a
+sound belt-and-suspenders setup. Language selection is local to Puppet's
+browser session.
 
 To change the Puppet engine add-on's own options (such as `keep_browser_open`)
 or to restart it, use `ha_manage_addon`; the screenshot tools only render and
@@ -254,8 +262,9 @@ render failure to a warning so it never breaks a write that already committed.
 screenshot *is* the requested payload, so a total render failure surfaces as
 an error (matching the standalone `ha_get_dashboard_screenshot` tool) rather
 than a warning a caller might miss. Because Puppet can persist theme/dark
-preferences, screenshot operations are blocked in server Read Only Mode;
-ordinary dashboard get/list/search calls remain available.
+preferences (and the theme-restore bracket writes frontend user data to undo
+that), screenshot operations are blocked in server Read Only Mode; ordinary
+dashboard get/list/search calls remain available.
 
 **Raw rendered paths remain constrained.** `ha_get_dashboard_screenshot`
 validates legacy `dashboard_path` values (rejects URLs, query strings,

--- a/docs/beta.md
+++ b/docs/beta.md
@@ -182,9 +182,9 @@ saves a "light" selection, which used to flip a dark-mode user's whole UI to
 light on every screenshot. ha-mcp now brackets every capture: it reads that
 user's saved theme before rendering and writes it back afterwards if the
 render changed it (in add-on mode it authenticates with the Puppet add-on's
-own configured token; in sidecar/standalone mode with ha-mcp's own HA
-credentials, which protects the user whenever both tokens belong to the same
-account). The restore is best-effort — a failed restore surfaces as a
+own configured token; in sidecar / self-hosted non-add-on mode with ha-mcp's
+own HA credentials, which protects the user whenever both tokens belong to the
+same account). The restore is best-effort — a failed restore surfaces as a
 `warnings` entry on the tool response. A dedicated Puppet account remains a
 sound belt-and-suspenders setup. Language selection is local to Puppet's
 browser session.

--- a/src/ha_mcp/config.py
+++ b/src/ha_mcp/config.py
@@ -836,7 +836,7 @@ ADVANCED_SETTINGS_FIELDS: tuple[AdvancedField, ...] = (
     AdvancedField("enable_websocket", "ENABLE_WEBSOCKET", bool, "operations", True),
     # Dashboard-screenshot engine URL (#1538): docker/.env users could set
     # HAMCP_DASHBOARD_SCREENSHOT_ENGINE_URL, but add-on users had no path to
-    # it. It is resolved live per capture (resolve_engine_url), so unlike the
+    # it. It is resolved live per capture (resolve_engine), so unlike the
     # time budgets it takes effect without a restart. Blank = auto-discover
     # the Puppet add-on via the Supervisor.
     AdvancedField(

--- a/src/ha_mcp/dashboard_screenshot/__init__.py
+++ b/src/ha_mcp/dashboard_screenshot/__init__.py
@@ -19,7 +19,8 @@ from .capture import (
     DashboardImageCapture,
     capture_dashboard_images,
 )
-from .provision import resolve_engine_url
+from .provision import EngineTarget, resolve_engine, resolve_engine_url
+from .theme_guard import ThemeGuard
 
 __all__ = [
     "DEFAULT_HEIGHT",
@@ -27,6 +28,9 @@ __all__ = [
     "DEFAULT_WAIT_MS",
     "DEFAULT_WIDTH",
     "DashboardImageCapture",
+    "EngineTarget",
+    "ThemeGuard",
     "capture_dashboard_images",
+    "resolve_engine",
     "resolve_engine_url",
 ]

--- a/src/ha_mcp/dashboard_screenshot/__init__.py
+++ b/src/ha_mcp/dashboard_screenshot/__init__.py
@@ -19,8 +19,8 @@ from .capture import (
     DashboardImageCapture,
     capture_dashboard_images,
 )
-from .provision import EngineTarget, resolve_engine, resolve_engine_url
-from .theme_guard import ThemeGuard
+from .provision import EngineTarget, resolve_engine
+from .theme_guard import EngineCredential, ThemeGuard
 
 __all__ = [
     "DEFAULT_HEIGHT",
@@ -28,9 +28,9 @@ __all__ = [
     "DEFAULT_WAIT_MS",
     "DEFAULT_WIDTH",
     "DashboardImageCapture",
+    "EngineCredential",
     "EngineTarget",
     "ThemeGuard",
     "capture_dashboard_images",
     "resolve_engine",
-    "resolve_engine_url",
 ]

--- a/src/ha_mcp/dashboard_screenshot/capture.py
+++ b/src/ha_mcp/dashboard_screenshot/capture.py
@@ -2,8 +2,11 @@
 
 The engine (balloob's Puppet add-on, or a docker-compose sidecar)
 authenticates to Home Assistant with its OWN configured long-lived token, so
-this client passes only the dashboard path + render parameters — no HA token
-ever flows through ha-mcp or the LLM for screenshots.
+this client passes only the dashboard path + render parameters to the engine
+— no HA token is ever sent to the engine or exposed to the LLM. The
+:mod:`theme_guard` bracket around each capture batch may hold the engine's
+token in server memory to restore the engine user's saved theme (issue
+#1909); see that module's docstring for the containment rules.
 """
 
 from __future__ import annotations
@@ -20,7 +23,8 @@ from fastmcp.exceptions import ToolError
 
 from ..errors import ErrorCode, create_error_response
 from ..tools.helpers import raise_tool_error
-from .provision import TOKEN_HINT, resolve_engine_url
+from .provision import TOKEN_HINT, resolve_engine
+from .theme_guard import ThemeGuard
 
 logger = logging.getLogger(__name__)
 
@@ -789,6 +793,8 @@ async def capture_dashboard_images(
     image_format: ScreenshotFormat = "png",
     render_timeout_seconds: float = DEFAULT_RENDER_TIMEOUT_SECONDS,
     partial_failures: list[dict[str, Any]] | None = None,
+    client: Any | None = None,
+    capture_warnings: list[str] | None = None,
 ) -> list[DashboardImageCapture]:
     """Render one or more ordered dashboard images via the screenshot engine.
 
@@ -796,6 +802,12 @@ async def capture_dashboard_images(
     preset or custom dimensions when needed; omitting it preserves each
     preset's native orientation. ``full_page`` is a compatibility alias for
     requesting the engine's native ``WIDTHxauto`` viewport.
+
+    The batch is bracketed by a :class:`ThemeGuard` that restores the engine
+    user's saved frontend theme if rendering changed it (issue #1909).
+    ``client`` supplies the guard's non-add-on credential fallback and
+    ``capture_warnings`` collects the guard's non-fatal warnings; both are
+    optional and never affect the captures themselves.
     """
     path = _validate_dashboard_path(dashboard_path)
     options = validate_capture_parameters(
@@ -814,94 +826,107 @@ async def capture_dashboard_images(
     )
     viewports = _capture_viewports(options)
 
-    engine = await resolve_engine_url()
+    engine_target = await resolve_engine()
+    engine = engine_target.url
     url = f"{engine}/{path}"
     mime_type = _MIME_TYPES[options.image_format]
     captures: list[DashboardImageCapture] = []
 
-    async with httpx.AsyncClient(
-        timeout=httpx.Timeout(options.render_timeout_seconds)
-    ) as http_client:
-        for capture_index, viewport in enumerate(viewports):
-            params: dict[str, str] = {
-                "viewport": f"{viewport.width}x{viewport.height}",
-                "zoom": str(options.zoom),
-                "wait": str(options.wait_ms),
-                "format": options.image_format,
-            }
-            if options.theme is not None:
-                params["theme"] = options.theme
-            if options.dark_mode:
-                # Puppet checks only for query-key presence.
-                params["dark"] = ""
-            if options.language is not None:
-                params["lang"] = options.language
+    # The engine dispatches a theme write into the authenticated frontend on
+    # cold renders, which Home Assistant persists to the engine user's real
+    # profile (issue #1909). Snapshot before, restore after — including when
+    # the batch fails, since the engine may already have rendered (and
+    # written) before the failure.
+    guard = ThemeGuard.for_capture(engine_target.addon_options, client)
+    await guard.take_snapshot()
+    try:
+        async with httpx.AsyncClient(
+            timeout=httpx.Timeout(options.render_timeout_seconds)
+        ) as http_client:
+            for capture_index, viewport in enumerate(viewports):
+                params: dict[str, str] = {
+                    "viewport": f"{viewport.width}x{viewport.height}",
+                    "zoom": str(options.zoom),
+                    "wait": str(options.wait_ms),
+                    "format": options.image_format,
+                }
+                if options.theme is not None:
+                    params["theme"] = options.theme
+                if options.dark_mode:
+                    # Puppet checks only for query-key presence.
+                    params["dark"] = ""
+                if options.language is not None:
+                    params["lang"] = options.language
 
-            request_context = {
-                "path": path,
-                "preset": viewport.preset,
-                "width": viewport.width,
-                "height": viewport.height,
-                "requested_format": options.image_format,
-                "capture_index": capture_index,
-                "capture_count": len(viewports),
-                "completed_count": len(captures),
-            }
-            aggregate_bytes = sum(capture.size_bytes for capture in captures)
-            remaining_batch_bytes = MAX_BATCH_PAYLOAD_BYTES - aggregate_bytes
-            if remaining_batch_bytes <= 0:
-                assert partial_failures is not None
-                partial_failures.append(
-                    create_error_response(
-                        ErrorCode.IMAGE_PAYLOAD_TOO_LARGE,
-                        "Screenshot image batch reached the server's safe "
-                        "inline-image limit.",
-                        context={
-                            **request_context,
-                            "aggregate_bytes_before_capture": aggregate_bytes,
-                            "limit_kind": "batch",
-                            "limit_bytes": MAX_BATCH_PAYLOAD_BYTES,
-                        },
+                request_context = {
+                    "path": path,
+                    "preset": viewport.preset,
+                    "width": viewport.width,
+                    "height": viewport.height,
+                    "requested_format": options.image_format,
+                    "capture_index": capture_index,
+                    "capture_count": len(viewports),
+                    "completed_count": len(captures),
+                }
+                aggregate_bytes = sum(capture.size_bytes for capture in captures)
+                remaining_batch_bytes = MAX_BATCH_PAYLOAD_BYTES - aggregate_bytes
+                if remaining_batch_bytes <= 0:
+                    assert partial_failures is not None
+                    partial_failures.append(
+                        create_error_response(
+                            ErrorCode.IMAGE_PAYLOAD_TOO_LARGE,
+                            "Screenshot image batch reached the server's safe "
+                            "inline-image limit.",
+                            context={
+                                **request_context,
+                                "aggregate_bytes_before_capture": aggregate_bytes,
+                                "limit_kind": "batch",
+                                "limit_bytes": MAX_BATCH_PAYLOAD_BYTES,
+                            },
+                        )
+                    )
+                    break
+
+                outcome = await _request_or_collect_failure(
+                    http_client,
+                    url=url,
+                    path=path,
+                    engine=engine,
+                    params=params,
+                    options=options,
+                    viewport=viewport,
+                    mime_type=mime_type,
+                    request_context=request_context,
+                    aggregate_bytes=aggregate_bytes,
+                    remaining_batch_bytes=remaining_batch_bytes,
+                    partial_failures=partial_failures,
+                )
+                if outcome is None:
+                    if (
+                        partial_failures
+                        and partial_failures[-1].get("limit_kind") == "batch"
+                    ):
+                        break
+                    continue
+                image_data, capture_height, fallback_used = outcome
+
+                captures.append(
+                    DashboardImageCapture(
+                        data=image_data,
+                        width=viewport.width,
+                        height=capture_height,
+                        preset=viewport.preset,
+                        orientation=viewport.orientation,
+                        image_format=options.image_format,
+                        mime_type=mime_type,
+                        size_bytes=len(image_data),
+                        options=options,
+                        legacy_full_page_fallback=fallback_used,
                     )
                 )
-                break
-
-            outcome = await _request_or_collect_failure(
-                http_client,
-                url=url,
-                path=path,
-                engine=engine,
-                params=params,
-                options=options,
-                viewport=viewport,
-                mime_type=mime_type,
-                request_context=request_context,
-                aggregate_bytes=aggregate_bytes,
-                remaining_batch_bytes=remaining_batch_bytes,
-                partial_failures=partial_failures,
-            )
-            if outcome is None:
-                if (
-                    partial_failures
-                    and partial_failures[-1].get("limit_kind") == "batch"
-                ):
-                    break
-                continue
-            image_data, capture_height, fallback_used = outcome
-
-            captures.append(
-                DashboardImageCapture(
-                    data=image_data,
-                    width=viewport.width,
-                    height=capture_height,
-                    preset=viewport.preset,
-                    orientation=viewport.orientation,
-                    image_format=options.image_format,
-                    mime_type=mime_type,
-                    size_bytes=len(image_data),
-                    options=options,
-                    legacy_full_page_fallback=fallback_used,
-                )
-            )
+    finally:
+        await guard.restore()
+        if capture_warnings is not None:
+            capture_warnings.extend(guard.warnings)
 
     return _complete_capture_batch(captures, partial_failures)

--- a/src/ha_mcp/dashboard_screenshot/capture.py
+++ b/src/ha_mcp/dashboard_screenshot/capture.py
@@ -761,9 +761,30 @@ async def _request_or_collect_failure(
         return None
 
 
+def _viewport_params(
+    options: _CaptureOptions, viewport: _ViewportRequest
+) -> dict[str, str]:
+    """Build one viewport's engine query parameters."""
+    params: dict[str, str] = {
+        "viewport": f"{viewport.width}x{viewport.height}",
+        "zoom": str(options.zoom),
+        "wait": str(options.wait_ms),
+        "format": options.image_format,
+    }
+    if options.theme is not None:
+        params["theme"] = options.theme
+    if options.dark_mode:
+        # Puppet checks only for query-key presence.
+        params["dark"] = ""
+    if options.language is not None:
+        params["lang"] = options.language
+    return params
+
+
 def _complete_capture_batch(
     captures: list[DashboardImageCapture],
     partial_failures: list[dict[str, Any]] | None,
+    guard_warnings: list[str],
 ) -> list[DashboardImageCapture]:
     """Return partial successes, but raise when every requested capture failed."""
     if not captures and partial_failures:
@@ -773,8 +794,39 @@ def _complete_capture_batch(
             "failure_count": len(partial_failures),
             "screenshot_failures": partial_failures,
         }
+        if guard_warnings:
+            aggregate_failure["warnings"] = [
+                *aggregate_failure.get("warnings", []),
+                *guard_warnings,
+            ]
         raise_tool_error(aggregate_failure)
     return captures
+
+
+def _reraise_with_guard_warnings(error: ToolError, warnings: list[str]) -> NoReturn:
+    """Re-raise a capture ToolError with the theme guard's warnings attached.
+
+    A batch that raises may already have rendered (and clobbered the engine
+    user's theme) before failing, so a failed restore must stay visible on
+    the error path too — otherwise the tool contract ("an attempted but
+    failed restore surfaces as a warning") silently breaks exactly when the
+    theme is most likely left flipped.
+    """
+    if not warnings:
+        raise error
+    try:
+        payload = json.loads(str(error))
+    except (json.JSONDecodeError, TypeError):
+        payload = None
+    if not isinstance(payload, dict):
+        raise error
+    existing = payload.get("warnings")
+    payload["warnings"] = [
+        *(existing if isinstance(existing, list) else []),
+        *warnings,
+    ]
+    raise_tool_error(payload)
+    raise AssertionError("unreachable: raise_tool_error always raises")
 
 
 async def capture_dashboard_images(
@@ -837,26 +889,15 @@ async def capture_dashboard_images(
     # profile (issue #1909). Snapshot before, restore after — including when
     # the batch fails, since the engine may already have rendered (and
     # written) before the failure.
-    guard = ThemeGuard.for_capture(engine_target.addon_options, client)
+    guard = ThemeGuard.for_capture(engine_target.addon_credential, client)
     await guard.take_snapshot()
+    batch_error: ToolError | None = None
     try:
         async with httpx.AsyncClient(
             timeout=httpx.Timeout(options.render_timeout_seconds)
         ) as http_client:
             for capture_index, viewport in enumerate(viewports):
-                params: dict[str, str] = {
-                    "viewport": f"{viewport.width}x{viewport.height}",
-                    "zoom": str(options.zoom),
-                    "wait": str(options.wait_ms),
-                    "format": options.image_format,
-                }
-                if options.theme is not None:
-                    params["theme"] = options.theme
-                if options.dark_mode:
-                    # Puppet checks only for query-key presence.
-                    params["dark"] = ""
-                if options.language is not None:
-                    params["lang"] = options.language
+                params = _viewport_params(options, viewport)
 
                 request_context = {
                     "path": path,
@@ -924,9 +965,15 @@ async def capture_dashboard_images(
                         legacy_full_page_fallback=fallback_used,
                     )
                 )
+    except ToolError as exc:
+        # Held (not re-raised here) so the restore in ``finally`` runs first
+        # and its outcome can be attached to the error payload below.
+        batch_error = exc
     finally:
         await guard.restore()
         if capture_warnings is not None:
             capture_warnings.extend(guard.warnings)
 
-    return _complete_capture_batch(captures, partial_failures)
+    if batch_error is not None:
+        _reraise_with_guard_warnings(batch_error, guard.warnings)
+    return _complete_capture_batch(captures, partial_failures, guard.warnings)

--- a/src/ha_mcp/dashboard_screenshot/provision.py
+++ b/src/ha_mcp/dashboard_screenshot/provision.py
@@ -31,6 +31,7 @@ from fastmcp.exceptions import ToolError
 
 from ..errors import ErrorCode, create_error_response
 from ..tools.helpers import raise_tool_error
+from .theme_guard import EngineCredential, addon_credential_from_options
 
 logger = logging.getLogger(__name__)
 
@@ -39,16 +40,16 @@ logger = logging.getLogger(__name__)
 class EngineTarget:
     """A resolved screenshot engine endpoint.
 
-    ``addon_options`` carries the Puppet add-on's Supervisor options
-    (``access_token``, ``home_assistant_url``, ...) when the engine was
-    discovered via the Supervisor, so the theme guard can authenticate as
-    the engine's user without a second discovery round-trip. It is ``None``
-    for an explicitly configured engine URL. The token inside never leaves
-    the server process — it must not be logged or surfaced in responses.
+    ``addon_credential`` authenticates as the engine's user (extracted from
+    the Puppet add-on's Supervisor options during discovery, so the theme
+    guard needs no second round-trip and the raw secret-bearing options
+    dict never leaves this module). It is ``None`` for an explicitly
+    configured engine URL. The token inside never leaves the server process
+    — it must not be logged or surfaced in responses.
     """
 
     url: str
-    addon_options: dict[str, Any] | None = None
+    addon_credential: EngineCredential | None = None
 
 
 ENGINE_PORT = 10000
@@ -164,11 +165,6 @@ def _supervisor_addon_listing(payload: Any) -> list[dict[str, Any]]:
     return addons
 
 
-async def resolve_engine_url() -> str:
-    """Return the base URL of the screenshot engine, or raise ToolError."""
-    return (await resolve_engine()).url
-
-
 async def resolve_engine() -> EngineTarget:
     """Resolve the screenshot engine endpoint, or raise ToolError.
 
@@ -255,7 +251,9 @@ async def _discover_engine_via_supervisor() -> EngineTarget:
             options = data.get("options")
             return EngineTarget(
                 url=f"http://{hostname}:{ENGINE_PORT}",
-                addon_options=options if isinstance(options, dict) else None,
+                addon_credential=addon_credential_from_options(
+                    options if isinstance(options, dict) else None
+                ),
             )
     except ToolError:
         raise

--- a/src/ha_mcp/dashboard_screenshot/provision.py
+++ b/src/ha_mcp/dashboard_screenshot/provision.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 import logging
 import os
+from dataclasses import dataclass
 from typing import Any
 
 import httpx
@@ -32,6 +33,23 @@ from ..errors import ErrorCode, create_error_response
 from ..tools.helpers import raise_tool_error
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True, slots=True)
+class EngineTarget:
+    """A resolved screenshot engine endpoint.
+
+    ``addon_options`` carries the Puppet add-on's Supervisor options
+    (``access_token``, ``home_assistant_url``, ...) when the engine was
+    discovered via the Supervisor, so the theme guard can authenticate as
+    the engine's user without a second discovery round-trip. It is ``None``
+    for an explicitly configured engine URL. The token inside never leaves
+    the server process — it must not be logged or surfaced in responses.
+    """
+
+    url: str
+    addon_options: dict[str, Any] | None = None
+
 
 ENGINE_PORT = 10000
 # The Supervisor slug is ``<repo-hash>_puppet`` for balloob's Puppet add-on.
@@ -147,7 +165,12 @@ def _supervisor_addon_listing(payload: Any) -> list[dict[str, Any]]:
 
 
 async def resolve_engine_url() -> str:
-    """Return the base URL of the screenshot engine, or raise ToolError.
+    """Return the base URL of the screenshot engine, or raise ToolError."""
+    return (await resolve_engine()).url
+
+
+async def resolve_engine() -> EngineTarget:
+    """Resolve the screenshot engine endpoint, or raise ToolError.
 
     See module docstring for the three-mode resolution order.
     """
@@ -155,10 +178,10 @@ async def resolve_engine_url() -> str:
 
     explicit = (get_global_settings().dashboard_screenshot_engine_url or "").strip()
     if explicit:
-        return explicit.rstrip("/")
+        return EngineTarget(url=explicit.rstrip("/"))
 
     if os.environ.get("SUPERVISOR_TOKEN"):
-        return await _discover_engine_url_via_supervisor()
+        return await _discover_engine_via_supervisor()
 
     raise_tool_error(
         create_error_response(
@@ -178,8 +201,8 @@ async def resolve_engine_url() -> str:
     raise AssertionError("unreachable: raise_tool_error always raises")
 
 
-async def _discover_engine_url_via_supervisor() -> str:
-    """Find the Puppet add-on via the Supervisor and return its internal URL.
+async def _discover_engine_via_supervisor() -> EngineTarget:
+    """Find the Puppet add-on via the Supervisor and return its endpoint.
 
     Requires the ha-mcp add-on's ``manager`` role (already declared) for the
     read-only ``/addons`` + ``/addons/<slug>/info`` endpoints. Raises a
@@ -229,7 +252,11 @@ async def _discover_engine_url_via_supervisor() -> str:
                         context={"slug": slug},
                     )
                 )
-            return f"http://{hostname}:{ENGINE_PORT}"
+            options = data.get("options")
+            return EngineTarget(
+                url=f"http://{hostname}:{ENGINE_PORT}",
+                addon_options=options if isinstance(options, dict) else None,
+            )
     except ToolError:
         raise
     except (httpx.HTTPError, KeyError, ValueError) as e:

--- a/src/ha_mcp/dashboard_screenshot/provision.py
+++ b/src/ha_mcp/dashboard_screenshot/provision.py
@@ -174,7 +174,10 @@ async def resolve_engine() -> EngineTarget:
 
     explicit = (get_global_settings().dashboard_screenshot_engine_url or "").strip()
     if explicit:
-        return EngineTarget(url=explicit.rstrip("/"))
+        return EngineTarget(
+            url=explicit.rstrip("/"),
+            addon_credential=await _addon_credential_best_effort(),
+        )
 
     if os.environ.get("SUPERVISOR_TOKEN"):
         return await _discover_engine_via_supervisor()
@@ -195,6 +198,33 @@ async def resolve_engine() -> EngineTarget:
     # reports py/mixed-returns for the implicit None fall-through past it. Keep
     # this terminal statement to suppress that false positive (repo convention).
     raise AssertionError("unreachable: raise_tool_error always raises")
+
+
+async def _addon_credential_best_effort() -> EngineCredential | None:
+    """Best-effort theme-guard credential for an explicitly configured URL.
+
+    HA OS / Supervised users may set ``HAMCP_DASHBOARD_SCREENSHOT_ENGINE_URL``
+    to override auto-discovery while still running the Puppet add-on; without
+    its token the theme guard would go inactive exactly where the add-on
+    credential exists (``_client_credential`` refuses Supervisor-proxy auth).
+    Any failure — no Supervisor, no verified add-on, not started — simply
+    means "no credential": the explicit URL may point at a non-add-on
+    engine, so this must never raise. If the explicit URL targets a
+    different engine than the discovered add-on, the guard still only ever
+    writes back a value that the discovered add-on's own user changed
+    mid-capture, which only that add-on's renders would do — a safe no-op.
+    """
+    if not os.environ.get("SUPERVISOR_TOKEN"):
+        return None
+    try:
+        return (await _discover_engine_via_supervisor()).addon_credential
+    except Exception:
+        logger.debug(
+            "No Supervisor-discoverable engine credential for the explicit "
+            "engine URL; the theme guard stays inactive.",
+            exc_info=True,
+        )
+        return None
 
 
 async def _discover_engine_via_supervisor() -> EngineTarget:

--- a/src/ha_mcp/dashboard_screenshot/theme_guard.py
+++ b/src/ha_mcp/dashboard_screenshot/theme_guard.py
@@ -19,9 +19,9 @@ Credential resolution mirrors engine discovery:
   ``home_assistant_url`` options, taken from the Supervisor add-on info that
   engine discovery already fetches. The token lives only in process memory
   for the duration of one capture batch and is never logged or returned.
-- **Docker / standalone / OAuth** — ha-mcp's direct Home Assistant
-  credentials. These protect the user whenever the sidecar engine runs with
-  a token for the same user (the common single-user setup).
+- **Docker / standalone / OAuth / embedded** — ha-mcp's direct Home
+  Assistant credentials. These protect the user whenever the sidecar engine
+  runs with a token for the same user (the common single-user setup).
 - Anything else (e.g. Supervisor-proxy auth with no discoverable engine
   token) — the guard stays inactive and captures behave as before.
 
@@ -37,11 +37,15 @@ cannot tell the engine's write apart from a concurrent human one.
 from __future__ import annotations
 
 import logging
-import os
 from collections.abc import AsyncIterator, Mapping
 from contextlib import asynccontextmanager
 from dataclasses import dataclass, field
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+from .._version import is_running_in_addon
+
+if TYPE_CHECKING:
+    from ..client.websocket_client import HomeAssistantWebSocketClient
 
 logger = logging.getLogger(__name__)
 
@@ -58,59 +62,73 @@ _RESTORE_HINT = (
 
 
 @dataclass(frozen=True, slots=True)
-class _EngineCredential:
-    """Home Assistant URL + token that authenticate as the engine's user."""
+class EngineCredential:
+    """Home Assistant URL + token that authenticate as the engine's user.
+
+    Deliberately carries only the two values the theme guard needs, so the
+    engine add-on's raw Supervisor options (a secret-bearing dict) never
+    cross module boundaries. The token must never be logged or surfaced in
+    responses.
+    """
 
     url: str
     token: str
 
 
-def _addon_credential(
+def addon_credential_from_options(
     addon_options: Mapping[str, Any] | None,
-) -> _EngineCredential | None:
-    """Build a credential from the discovered Puppet add-on's options."""
+) -> EngineCredential | None:
+    """Extract the engine user's credential from Puppet add-on options."""
     if not addon_options:
         return None
     token = str(addon_options.get("access_token") or "").strip()
     if not token:
         return None
     url = str(addon_options.get("home_assistant_url") or "").strip()
-    return _EngineCredential(url=url or DEFAULT_ENGINE_HA_URL, token=token)
+    return EngineCredential(url=url or DEFAULT_ENGINE_HA_URL, token=token)
 
 
-def _client_credential(client: Any) -> _EngineCredential | None:
+def _client_credential(client: Any) -> EngineCredential | None:
     """Fall back to ha-mcp's own direct Home Assistant credential.
 
     Only meaningful outside add-on mode: the Supervisor proxy authenticates
     as the Supervisor system user, whose frontend profile is unrelated to
     the engine token's user, so protecting it would be a silent no-op.
+    Embedded mode is deliberately NOT excluded — there the HA core container
+    carries ``SUPERVISOR_TOKEN`` but the server is a plain admin client with
+    a real user token, exactly what this fallback needs.
     """
-    if os.environ.get("SUPERVISOR_TOKEN"):
+    if is_running_in_addon():
         return None
     base_url = str(getattr(client, "base_url", "") or "").strip()
     token = str(getattr(client, "token", "") or "").strip()
     if not base_url.startswith(("http://", "https://")) or not token:
         return None
-    return _EngineCredential(url=base_url, token=token)
+    return EngineCredential(url=base_url, token=token)
 
 
 @dataclass
 class ThemeGuard:
-    """Per-capture-batch snapshot/restore of the engine user's saved theme."""
+    """Per-capture-batch snapshot/restore of the engine user's saved theme.
 
-    credential: _EngineCredential | None
-    snapshot: Any = None
-    snapshot_taken: bool = False
+    ``credential`` and ``warnings`` are the public contract; the snapshot
+    pair is internal lifecycle state driven only by :meth:`take_snapshot`
+    and :meth:`restore`.
+    """
+
+    credential: EngineCredential | None
     warnings: list[str] = field(default_factory=list)
+    _snapshot: Any = None
+    _snapshot_taken: bool = False
 
     @classmethod
     def for_capture(
         cls,
-        addon_options: Mapping[str, Any] | None,
+        addon_credential: EngineCredential | None,
         client: Any,
     ) -> ThemeGuard:
         """Resolve the engine user's credential for one capture batch."""
-        credential = _addon_credential(addon_options) or _client_credential(client)
+        credential = addon_credential or _client_credential(client)
         if credential is None:
             logger.debug(
                 "Dashboard theme guard inactive: no engine credential is "
@@ -119,7 +137,7 @@ class ThemeGuard:
         return cls(credential=credential)
 
     @asynccontextmanager
-    async def _session(self) -> AsyncIterator[Any]:
+    async def _session(self) -> AsyncIterator[HomeAssistantWebSocketClient]:
         """Yield a short-lived authenticated WebSocket as the engine user."""
         from ..client.websocket_client import HomeAssistantWebSocketClient
 
@@ -137,12 +155,12 @@ class ThemeGuard:
             await ws.disconnect()
 
     @staticmethod
-    async def _fetch_theme(ws: Any) -> Any:
+    async def _fetch_theme(ws: HomeAssistantWebSocketClient) -> Any:
         """Read the persisted ``theme`` frontend user-data value (may be None)."""
         response = await ws.send_command(
             "frontend/get_user_data", key=THEME_USER_DATA_KEY
         )
-        payload = response.get("result")
+        payload = response.get("result") if isinstance(response, dict) else None
         return payload.get("value") if isinstance(payload, dict) else None
 
     async def take_snapshot(self) -> None:
@@ -151,8 +169,8 @@ class ThemeGuard:
             return
         try:
             async with self._session() as ws:
-                self.snapshot = await self._fetch_theme(ws)
-            self.snapshot_taken = True
+                self._snapshot = await self._fetch_theme(ws)
+            self._snapshot_taken = True
         except Exception as exc:
             logger.warning(
                 "Could not read the screenshot engine user's saved theme "
@@ -166,16 +184,27 @@ class ThemeGuard:
 
     async def restore(self) -> None:
         """Write the snapshot back if the render changed it. Never raises."""
-        if not self.snapshot_taken or self.credential is None:
+        if not self._snapshot_taken or self.credential is None:
             return
         try:
             async with self._session() as ws:
+                # Ordering assumption: Puppet's settheme dispatch (and the
+                # frontend's resulting user-data write) happens during page
+                # navigation, before the engine returns the image — so a
+                # post-capture read observes the clobbered value.
                 current = await self._fetch_theme(ws)
-                if current != self.snapshot:
+                if current != self._snapshot:
+                    # A never-configured baseline must restore as {} rather
+                    # than null: live frontend sessions ignore a null
+                    # subscription push (they would stay flipped until
+                    # reload), while an empty settings object re-applies
+                    # default/auto behavior immediately and means the same
+                    # thing on the next frontend boot.
+                    restore_value = self._snapshot if self._snapshot is not None else {}
                     await ws.send_command(
                         "frontend/set_user_data",
                         key=THEME_USER_DATA_KEY,
-                        value=self.snapshot,
+                        value=restore_value,
                     )
         except Exception as exc:
             logger.warning(

--- a/src/ha_mcp/dashboard_screenshot/theme_guard.py
+++ b/src/ha_mcp/dashboard_screenshot/theme_guard.py
@@ -1,0 +1,190 @@
+"""Snapshot and restore the engine user's saved frontend theme (issue #1909).
+
+Stock Puppet dispatches Home Assistant's ``settheme`` event on every
+cold-browser render — its ``dark`` query flag is presence-based, so "not
+requested" reaches the frontend as an explicit "light". Home Assistant
+persists that selection server-side per user (``frontend/set_user_data``,
+key ``"theme"``) and syncs it to every session of the user whose long-lived
+token the engine runs with. A plain screenshot call therefore flips a
+dark-mode user's real web and mobile UI to light.
+
+ha-mcp cannot suppress the engine's write, so every capture batch is
+bracketed instead: read the engine user's saved theme before rendering and
+write it back afterwards when the render changed it (an unchanged value is
+never rewritten).
+
+Credential resolution mirrors engine discovery:
+
+- **HA OS / Supervised** — the Puppet add-on's own ``access_token`` and
+  ``home_assistant_url`` options, taken from the Supervisor add-on info that
+  engine discovery already fetches. The token lives only in process memory
+  for the duration of one capture batch and is never logged or returned.
+- **Docker / standalone / OAuth** — ha-mcp's direct Home Assistant
+  credentials. These protect the user whenever the sidecar engine runs with
+  a token for the same user (the common single-user setup).
+- Anything else (e.g. Supervisor-proxy auth with no discoverable engine
+  token) — the guard stays inactive and captures behave as before.
+
+Guard failures are always non-fatal: screenshots must keep working even
+when the theme cannot be protected. A snapshot or restore that was
+*attempted* but failed surfaces as a tool-response warning.
+
+Known limit: if a real session changes the user's theme during the few
+seconds of a capture batch, the restore reverts that change too — the guard
+cannot tell the engine's write apart from a concurrent human one.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from collections.abc import AsyncIterator, Mapping
+from contextlib import asynccontextmanager
+from dataclasses import dataclass, field
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+THEME_USER_DATA_KEY = "theme"
+
+# Where Puppet reaches Home Assistant when its ``home_assistant_url`` option
+# is unset — the Supervisor-internal alias, mirrored from the add-on default.
+DEFAULT_ENGINE_HA_URL = "http://homeassistant:8123"
+
+_RESTORE_HINT = (
+    "the engine token's user can re-select their theme under Profile > "
+    "General in the Home Assistant UI"
+)
+
+
+@dataclass(frozen=True, slots=True)
+class _EngineCredential:
+    """Home Assistant URL + token that authenticate as the engine's user."""
+
+    url: str
+    token: str
+
+
+def _addon_credential(
+    addon_options: Mapping[str, Any] | None,
+) -> _EngineCredential | None:
+    """Build a credential from the discovered Puppet add-on's options."""
+    if not addon_options:
+        return None
+    token = str(addon_options.get("access_token") or "").strip()
+    if not token:
+        return None
+    url = str(addon_options.get("home_assistant_url") or "").strip()
+    return _EngineCredential(url=url or DEFAULT_ENGINE_HA_URL, token=token)
+
+
+def _client_credential(client: Any) -> _EngineCredential | None:
+    """Fall back to ha-mcp's own direct Home Assistant credential.
+
+    Only meaningful outside add-on mode: the Supervisor proxy authenticates
+    as the Supervisor system user, whose frontend profile is unrelated to
+    the engine token's user, so protecting it would be a silent no-op.
+    """
+    if os.environ.get("SUPERVISOR_TOKEN"):
+        return None
+    base_url = str(getattr(client, "base_url", "") or "").strip()
+    token = str(getattr(client, "token", "") or "").strip()
+    if not base_url.startswith(("http://", "https://")) or not token:
+        return None
+    return _EngineCredential(url=base_url, token=token)
+
+
+@dataclass
+class ThemeGuard:
+    """Per-capture-batch snapshot/restore of the engine user's saved theme."""
+
+    credential: _EngineCredential | None
+    snapshot: Any = None
+    snapshot_taken: bool = False
+    warnings: list[str] = field(default_factory=list)
+
+    @classmethod
+    def for_capture(
+        cls,
+        addon_options: Mapping[str, Any] | None,
+        client: Any,
+    ) -> ThemeGuard:
+        """Resolve the engine user's credential for one capture batch."""
+        credential = _addon_credential(addon_options) or _client_credential(client)
+        if credential is None:
+            logger.debug(
+                "Dashboard theme guard inactive: no engine credential is "
+                "discoverable in this deployment"
+            )
+        return cls(credential=credential)
+
+    @asynccontextmanager
+    async def _session(self) -> AsyncIterator[Any]:
+        """Yield a short-lived authenticated WebSocket as the engine user."""
+        from ..client.websocket_client import HomeAssistantWebSocketClient
+
+        assert self.credential is not None
+        ws = HomeAssistantWebSocketClient(self.credential.url, self.credential.token)
+        if not await ws.connect():
+            reason = ws.last_connect_error
+            detail = f": {reason}" if isinstance(reason, str) else ""
+            raise ConnectionError(
+                f"could not authenticate to {self.credential.url}{detail}"
+            )
+        try:
+            yield ws
+        finally:
+            await ws.disconnect()
+
+    @staticmethod
+    async def _fetch_theme(ws: Any) -> Any:
+        """Read the persisted ``theme`` frontend user-data value (may be None)."""
+        response = await ws.send_command(
+            "frontend/get_user_data", key=THEME_USER_DATA_KEY
+        )
+        payload = response.get("result")
+        return payload.get("value") if isinstance(payload, dict) else None
+
+    async def take_snapshot(self) -> None:
+        """Record the saved theme before the engine renders. Never raises."""
+        if self.credential is None:
+            return
+        try:
+            async with self._session() as ws:
+                self.snapshot = await self._fetch_theme(ws)
+            self.snapshot_taken = True
+        except Exception as exc:
+            logger.warning(
+                "Could not read the screenshot engine user's saved theme "
+                "before rendering: %s",
+                exc,
+            )
+            self.warnings.append(
+                "Could not read the screenshot engine user's saved frontend "
+                f"theme before rendering; if the render changed it, {_RESTORE_HINT}."
+            )
+
+    async def restore(self) -> None:
+        """Write the snapshot back if the render changed it. Never raises."""
+        if not self.snapshot_taken or self.credential is None:
+            return
+        try:
+            async with self._session() as ws:
+                current = await self._fetch_theme(ws)
+                if current != self.snapshot:
+                    await ws.send_command(
+                        "frontend/set_user_data",
+                        key=THEME_USER_DATA_KEY,
+                        value=self.snapshot,
+                    )
+        except Exception as exc:
+            logger.warning(
+                "Could not restore the screenshot engine user's saved theme "
+                "after rendering: %s",
+                exc,
+            )
+            self.warnings.append(
+                "The screenshot render may have changed the saved frontend "
+                "theme of the engine token's user and restoring it failed; "
+                f"{_RESTORE_HINT}."
+            )

--- a/src/ha_mcp/dashboard_screenshot/theme_guard.py
+++ b/src/ha_mcp/dashboard_screenshot/theme_guard.py
@@ -36,6 +36,7 @@ cannot tell the engine's write apart from a concurrent human one.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from collections.abc import AsyncIterator, Mapping
 from contextlib import asynccontextmanager
@@ -59,6 +60,14 @@ _RESTORE_HINT = (
     "the engine token's user can re-select their theme under Profile > "
     "General in the Home Assistant UI"
 )
+
+# The engine returns the image as soon as the render settles, but the
+# frontend's settheme handler saves the user data asynchronously — with a
+# very low wait_ms the write can land after the HTTP response. Wait this
+# long before the post-capture read so it observes the engine's write
+# instead of racing it (a stale read would compare equal, skip the
+# restore, and let the late write survive).
+RESTORE_SETTLE_SECONDS = 1.0
 
 
 @dataclass(frozen=True, slots=True)
@@ -187,11 +196,11 @@ class ThemeGuard:
         if not self._snapshot_taken or self.credential is None:
             return
         try:
+            # Puppet's settheme dispatch happens during page navigation, but
+            # the frontend's resulting user-data write is asynchronous — let
+            # it land before reading (see RESTORE_SETTLE_SECONDS).
+            await asyncio.sleep(RESTORE_SETTLE_SECONDS)
             async with self._session() as ws:
-                # Ordering assumption: Puppet's settheme dispatch (and the
-                # frontend's resulting user-data write) happens during page
-                # navigation, before the engine returns the image — so a
-                # post-capture read observes the clobbered value.
                 current = await self._fetch_theme(ws)
                 if current != self._snapshot:
                     # A never-configured baseline must restore as {} rather

--- a/src/ha_mcp/tools/tools_config_dashboards.py
+++ b/src/ha_mcp/tools/tools_config_dashboards.py
@@ -1129,14 +1129,17 @@ async def _capture_dashboard_screenshot_result(
     except ToolError:
         raise
     except Exception as exc:
-        raise_tool_error(
-            create_error_response(
-                ErrorCode.IMAGE_SERIALIZATION_FAILED,
-                "Rendered dashboard images could not be packaged into the MCP response.",
-                details=str(exc),
-                context={"capture_count": len(captures), "render_path": render_path},
-            )
+        error_payload = create_error_response(
+            ErrorCode.IMAGE_SERIALIZATION_FAILED,
+            "Rendered dashboard images could not be packaged into the MCP response.",
+            details=str(exc),
+            context={"capture_count": len(captures), "render_path": render_path},
         )
+        if guard_warnings:
+            # The render already happened, so a theme-guard warning (e.g. a
+            # failed restore) must stay visible even when packaging fails.
+            error_payload["warnings"] = list(guard_warnings)
+        raise_tool_error(error_payload)
     # raise_tool_error is typed -> NoReturn, but CodeQL cannot see that, so it
     # reports py/mixed-returns for the implicit None fall-through past the
     # except block. Keep this terminal statement to suppress the false positive.

--- a/src/ha_mcp/tools/tools_config_dashboards.py
+++ b/src/ha_mcp/tools/tools_config_dashboards.py
@@ -1080,6 +1080,7 @@ async def _capture_dashboard_screenshot_result(
             result.setdefault("warnings", []).extend(target.warnings)
 
     capture_failures: list[dict[str, Any]] = []
+    guard_warnings: list[str] = []
     captures = await screenshot_capture.capture_dashboard_images(
         render_path,
         width=options.width,
@@ -1095,6 +1096,8 @@ async def _capture_dashboard_screenshot_result(
         image_format=options.image_format,
         render_timeout_seconds=options.render_timeout_seconds,
         partial_failures=capture_failures,
+        client=client,
+        capture_warnings=guard_warnings,
     )
     # Build every fallible image/metadata object before publishing screenshot
     # fields. The write path can then degrade serialization failures to a
@@ -1110,7 +1113,10 @@ async def _capture_dashboard_screenshot_result(
         if capture_failures:
             structured_result["screenshot_partial"] = True
             structured_result["screenshot_failures"] = capture_failures
-        capture_warnings = dashboard_screenshot_warnings(captures)
+        capture_warnings = [
+            *dashboard_screenshot_warnings(captures),
+            *guard_warnings,
+        ]
         if capture_warnings:
             structured_result["warnings"] = [
                 *structured_result.get("warnings", []),

--- a/src/ha_mcp/tools/tools_config_dashboards.py
+++ b/src/ha_mcp/tools/tools_config_dashboards.py
@@ -1245,13 +1245,20 @@ def _attach_screenshot_tool_error(
         {
             key: value
             for key, value in error_payload.items()
-            if key not in {"success", "error"}
+            if key not in {"success", "error", "warnings"}
         }
     )
     result["screenshot_error"] = screenshot_error
     result.setdefault("warnings", []).append(
         f"Screenshot unavailable: {extract_tool_error_message(error)}"
     )
+    # Theme-guard warnings ride on the error payload (a failing batch may
+    # already have rendered and clobbered the engine user's theme); keep them
+    # visible on the degraded-to-warning path instead of burying them in
+    # screenshot_error.
+    payload_warnings = error_payload.get("warnings")
+    if isinstance(payload_warnings, list):
+        result["warnings"].extend(str(warning) for warning in payload_warnings)
     return result
 
 

--- a/src/ha_mcp/tools/tools_dashboard_screenshot.py
+++ b/src/ha_mcp/tools/tools_dashboard_screenshot.py
@@ -82,17 +82,20 @@ def _package_screenshot_result(
     except ToolError:
         raise
     except Exception as exc:
-        raise_tool_error(
-            create_error_response(
-                ErrorCode.IMAGE_SERIALIZATION_FAILED,
-                "Rendered dashboard images could not be packaged into the MCP response.",
-                details=str(exc),
-                context={
-                    "capture_count": len(captures),
-                    "render_path": target.render_path,
-                },
-            )
+        error_payload = create_error_response(
+            ErrorCode.IMAGE_SERIALIZATION_FAILED,
+            "Rendered dashboard images could not be packaged into the MCP response.",
+            details=str(exc),
+            context={
+                "capture_count": len(captures),
+                "render_path": target.render_path,
+            },
         )
+        if capture_warnings:
+            # The render already happened, so a theme-guard warning (e.g. a
+            # failed restore) must stay visible even when packaging fails.
+            error_payload["warnings"] = list(capture_warnings)
+        raise_tool_error(error_payload)
 
 
 class DashboardScreenshotTools:

--- a/src/ha_mcp/tools/tools_dashboard_screenshot.py
+++ b/src/ha_mcp/tools/tools_dashboard_screenshot.py
@@ -51,6 +51,7 @@ def _package_screenshot_result(
     captures: list[Any],
     target: Any,
     capture_failures: list[dict[str, Any]],
+    capture_warnings: list[str],
 ) -> ToolResult:
     """Build the standalone native-image result with structured failures."""
     try:
@@ -67,7 +68,11 @@ def _package_screenshot_result(
         if capture_failures:
             structured_content["partial"] = True
             structured_content["screenshot_failures"] = capture_failures
-        warnings = [*target.warnings, *dashboard_screenshot_warnings(captures)]
+        warnings = [
+            *target.warnings,
+            *dashboard_screenshot_warnings(captures),
+            *capture_warnings,
+        ]
         if warnings:
             structured_content["warnings"] = warnings
         return ToolResult(
@@ -186,15 +191,17 @@ class DashboardScreenshotTools:
         theme: Annotated[
             str | None,
             Field(
-                description="Installed Home Assistant frontend theme name. Puppet "
-                "persists this selection on the frontend profile used by its token."
+                description="Installed Home Assistant frontend theme name, "
+                "applied to this render. The engine user's saved theme "
+                "preference is restored after the capture (best effort)."
             ),
         ] = None,
         dark_mode: Annotated[
             bool,
             Field(
-                description="Render the requested theme in dark mode. Puppet may "
-                "persist the theme/dark preference on the profile used by its token."
+                description="Render the requested theme in dark mode, applied "
+                "to this render. The engine user's saved theme preference is "
+                "restored after the capture (best effort)."
             ),
         ] = False,
         language: Annotated[
@@ -250,6 +257,7 @@ class DashboardScreenshotTools:
         )
         try:
             capture_failures: list[dict[str, Any]] = []
+            capture_warnings: list[str] = []
             captures = await capture_dashboard_images(
                 target.render_path,
                 width=width,
@@ -265,6 +273,8 @@ class DashboardScreenshotTools:
                 image_format=image_format,
                 render_timeout_seconds=render_timeout_seconds,
                 partial_failures=capture_failures,
+                client=self._client,
+                capture_warnings=capture_warnings,
             )
         except ToolError:
             raise
@@ -281,6 +291,7 @@ class DashboardScreenshotTools:
             captures=captures,
             target=target,
             capture_failures=capture_failures,
+            capture_warnings=capture_warnings,
         )
 
 

--- a/tests/src/e2e/tools/test_dashboard_screenshot_sidecar.py
+++ b/tests/src/e2e/tools/test_dashboard_screenshot_sidecar.py
@@ -1,10 +1,10 @@
 """Container/Docker-lane E2E for the dashboard screenshot sidecar path.
 
 The inaddon lane (``haos_only/test_dashboard_screenshot_addon.py``) exercises
-the Supervisor auto-discovery branch (``resolve_engine_url`` mode 2) + addon
+the Supervisor auto-discovery branch (``resolve_engine`` mode 2) + addon
 lifecycle against a lightweight mock engine. This module covers the **Docker /
 Container deployment** instead — the explicit
-``HAMCP_DASHBOARD_SCREENSHOT_ENGINE_URL`` sidecar path (``resolve_engine_url``
+``HAMCP_DASHBOARD_SCREENSHOT_ENGINE_URL`` sidecar path (``resolve_engine``
 mode 1), a different resolution branch that is otherwise untested. Neither lane
 runs real Chromium: that exercises balloob's add-on, not ha-mcp.
 

--- a/tests/src/unit/test_dashboard_screenshot.py
+++ b/tests/src/unit/test_dashboard_screenshot.py
@@ -240,6 +240,42 @@ class TestStandaloneScreenshotTool:
 
         assert "theme restore failed (unit)" in result.structured_content["warnings"]
 
+    async def test_packaging_failure_keeps_theme_guard_warning(
+        self, monkeypatch: Any
+    ) -> None:
+        """A restore warning survives even when image packaging fails."""
+        from ha_mcp.dashboard_screenshot.paths import DashboardRenderTarget
+        from ha_mcp.tools import tools_dashboard_screenshot as mod
+
+        async def resolve(*_a: Any, **_kw: Any) -> DashboardRenderTarget:
+            return DashboardRenderTarget(
+                dashboard_url_path="wall-panel",
+                view_path="home",
+                render_path="wall-panel/home",
+                view_index=0,
+                stable=True,
+            )
+
+        async def capture(*_a: Any, **kwargs: Any) -> list[Any]:
+            kwargs["capture_warnings"].append("theme restore failed (unit)")
+            return [_fake_dashboard_capture()]
+
+        def broken_content(*_a: Any, **_kw: Any) -> list[Any]:
+            raise RuntimeError("serialization boom")
+
+        monkeypatch.setattr(mod, "resolve_dashboard_render_target", resolve)
+        monkeypatch.setattr(mod, "capture_dashboard_images", capture)
+        monkeypatch.setattr(mod, "dashboard_image_content", broken_content)
+
+        with pytest.raises(ToolError) as exc_info:
+            await mod.DashboardScreenshotTools(object()).ha_get_dashboard_screenshot(
+                dashboard_url_path="wall-panel", view_path="home"
+            )
+
+        payload = json.loads(str(exc_info.value))
+        assert payload["error"]["code"] == "IMAGE_SERIALIZATION_FAILED"
+        assert "theme restore failed (unit)" in payload["warnings"]
+
     async def test_legacy_full_page_fallback_surfaces_warning(
         self, monkeypatch: Any
     ) -> None:
@@ -386,6 +422,57 @@ class TestResolveEngine:
         )
         with pytest.raises(ToolError):
             await provision.resolve_engine()
+
+    async def test_explicit_url_picks_up_addon_credential_in_addon_mode(
+        self, monkeypatch: Any
+    ) -> None:
+        # An explicit engine URL on HA OS must not disable the theme guard:
+        # the Puppet add-on's credential is still discovered best-effort.
+        from ha_mcp.dashboard_screenshot import provision
+        from ha_mcp.dashboard_screenshot.theme_guard import EngineCredential
+
+        monkeypatch.setenv("SUPERVISOR_TOKEN", "sup")
+        monkeypatch.setattr(
+            config,
+            "get_global_settings",
+            lambda: SimpleNamespace(
+                dashboard_screenshot_engine_url="http://engine:10000"
+            ),
+        )
+        _patch_supervisor(
+            monkeypatch,
+            {
+                "/addons": {"data": {"addons": [{"slug": "def_puppet"}]}},
+                "/addons/def_puppet/info": {
+                    "data": _puppet_info(state="started", hostname="def-puppet")
+                },
+            },
+        )
+        target = await provision.resolve_engine()
+        assert target.url == "http://engine:10000"
+        assert target.addon_credential == EngineCredential(
+            url="http://homeassistant:8123", token="secret"
+        )
+
+    async def test_explicit_url_credential_discovery_failure_is_silent(
+        self, monkeypatch: Any
+    ) -> None:
+        import httpx
+
+        from ha_mcp.dashboard_screenshot import provision
+
+        monkeypatch.setenv("SUPERVISOR_TOKEN", "sup")
+        monkeypatch.setattr(
+            config,
+            "get_global_settings",
+            lambda: SimpleNamespace(
+                dashboard_screenshot_engine_url="http://engine:10000"
+            ),
+        )
+        _patch_supervisor(monkeypatch, {"/addons": httpx.ConnectError("boom")})
+        target = await provision.resolve_engine()
+        assert target.url == "http://engine:10000"
+        assert target.addon_credential is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/src/unit/test_dashboard_screenshot.py
+++ b/tests/src/unit/test_dashboard_screenshot.py
@@ -26,6 +26,7 @@ from fastmcp.exceptions import ToolError
 from pydantic import ValidationError
 
 import ha_mcp.config as config
+from ha_mcp.dashboard_screenshot.provision import EngineTarget
 
 _PNG = b"\x89PNG\r\n\x1a\nunit"
 _JPEG = b"\xff\xd8\xffunit"
@@ -411,7 +412,7 @@ class TestDiscoverEngineViaSupervisor:
             {"/addons": {"data": {"addons": [{"slug": "core_ssh"}, {"slug": "a_db"}]}}},
         )
         with pytest.raises(ToolError) as exc:
-            await provision._discover_engine_url_via_supervisor()
+            await provision._discover_engine_via_supervisor()
         assert "not installed" in str(exc.value).lower()
 
     async def test_prefers_started_match(self, monkeypatch: Any) -> None:
@@ -434,8 +435,11 @@ class TestDiscoverEngineViaSupervisor:
                 },
             },
         )
-        url = await provision._discover_engine_url_via_supervisor()
-        assert url == "http://def-puppet:10000"
+        target = await provision._discover_engine_via_supervisor()
+        assert target.url == "http://def-puppet:10000"
+        # The discovered add-on's options ride along so the theme guard can
+        # authenticate as the engine's user without a second discovery.
+        assert target.addon_options == _puppet_options(keep_browser_open=False)
 
     async def test_multiple_verified_started_matches_fail_closed(
         self, monkeypatch: Any
@@ -463,7 +467,7 @@ class TestDiscoverEngineViaSupervisor:
         )
 
         with pytest.raises(ToolError) as exc_info:
-            await provision._discover_engine_url_via_supervisor()
+            await provision._discover_engine_via_supervisor()
 
         assert "ambiguous" in str(exc_info.value)
 
@@ -478,7 +482,7 @@ class TestDiscoverEngineViaSupervisor:
             },
         )
         with pytest.raises(ToolError) as exc:
-            await provision._discover_engine_url_via_supervisor()
+            await provision._discover_engine_via_supervisor()
         assert "hostname" in str(exc.value).lower()
 
     async def test_installed_but_not_started_raises(self, monkeypatch: Any) -> None:
@@ -492,7 +496,7 @@ class TestDiscoverEngineViaSupervisor:
             },
         )
         with pytest.raises(ToolError) as exc:
-            await provision._discover_engine_url_via_supervisor()
+            await provision._discover_engine_via_supervisor()
         assert "not started" in str(exc.value).lower()
 
     async def test_supervisor_http_error_raises_connection_failed(
@@ -504,7 +508,7 @@ class TestDiscoverEngineViaSupervisor:
 
         _patch_supervisor(monkeypatch, {"/addons": httpx.ConnectError("boom")})
         with pytest.raises(ToolError) as exc:
-            await provision._discover_engine_url_via_supervisor()
+            await provision._discover_engine_via_supervisor()
         assert "supervisor" in str(exc.value).lower()
 
     @pytest.mark.parametrize(
@@ -524,7 +528,7 @@ class TestDiscoverEngineViaSupervisor:
         _patch_supervisor(monkeypatch, {"/addons": payload})
 
         with pytest.raises(ToolError) as exc_info:
-            await provision._discover_engine_url_via_supervisor()
+            await provision._discover_engine_via_supervisor()
 
         error = json.loads(str(exc_info.value))
         assert error["error"]["code"] == "CONNECTION_FAILED"
@@ -544,7 +548,7 @@ class TestDiscoverEngineViaSupervisor:
         )
 
         with pytest.raises(ToolError) as exc_info:
-            await provision._discover_engine_url_via_supervisor()
+            await provision._discover_engine_via_supervisor()
 
         error = json.loads(str(exc_info.value))
         assert error["error"]["code"] == "CONNECTION_FAILED"
@@ -629,10 +633,10 @@ class TestCapture:
     async def test_builds_url_and_returns_png(self, monkeypatch: Any) -> None:
         from ha_mcp.dashboard_screenshot import capture
 
-        async def fake_resolve() -> str:
-            return "http://engine:10000"
+        async def fake_resolve() -> EngineTarget:
+            return EngineTarget(url="http://engine:10000")
 
-        monkeypatch.setattr(capture, "resolve_engine_url", fake_resolve)
+        monkeypatch.setattr(capture, "resolve_engine", fake_resolve)
         png = b"\x89PNG\r\n\x1a\nfake"
         _FakeAsyncClient._next = _FakeResponse(200, png)
         monkeypatch.setattr(capture.httpx, "AsyncClient", _FakeAsyncClient)
@@ -652,10 +656,10 @@ class TestCapture:
         """full_page=True uses Puppet's content-sized viewport request."""
         from ha_mcp.dashboard_screenshot import capture
 
-        async def fake_resolve() -> str:
-            return "http://engine:10000"
+        async def fake_resolve() -> EngineTarget:
+            return EngineTarget(url="http://engine:10000")
 
-        monkeypatch.setattr(capture, "resolve_engine_url", fake_resolve)
+        monkeypatch.setattr(capture, "resolve_engine", fake_resolve)
         _FakeAsyncClient._next = _FakeResponse(200, b"\x89PNG\r\n\x1a\nfake")
         monkeypatch.setattr(capture.httpx, "AsyncClient", _FakeAsyncClient)
 
@@ -670,10 +674,10 @@ class TestCapture:
     ) -> None:
         from ha_mcp.dashboard_screenshot import capture
 
-        async def fake_resolve() -> str:
-            return "http://engine:10000"
+        async def fake_resolve() -> EngineTarget:
+            return EngineTarget(url="http://engine:10000")
 
-        monkeypatch.setattr(capture, "resolve_engine_url", fake_resolve)
+        monkeypatch.setattr(capture, "resolve_engine", fake_resolve)
         _FakeAsyncClient.gets = []
         _FakeAsyncClient._next = _FakeResponse(200, _PNG)
         monkeypatch.setattr(capture.httpx, "AsyncClient", _FakeAsyncClient)
@@ -718,10 +722,10 @@ class TestCapture:
     ) -> None:
         from ha_mcp.dashboard_screenshot import capture
 
-        async def fake_resolve() -> str:
-            return "http://engine:10000"
+        async def fake_resolve() -> EngineTarget:
+            return EngineTarget(url="http://engine:10000")
 
-        monkeypatch.setattr(capture, "resolve_engine_url", fake_resolve)
+        monkeypatch.setattr(capture, "resolve_engine", fake_resolve)
         _FakeAsyncClient._next = _FakeResponse(200, _PNG)
         monkeypatch.setattr(capture.httpx, "AsyncClient", _FakeAsyncClient)
 
@@ -744,10 +748,10 @@ class TestCapture:
     ) -> None:
         from ha_mcp.dashboard_screenshot import capture
 
-        async def fake_resolve() -> str:
-            return "http://engine:10000"
+        async def fake_resolve() -> EngineTarget:
+            return EngineTarget(url="http://engine:10000")
 
-        monkeypatch.setattr(capture, "resolve_engine_url", fake_resolve)
+        monkeypatch.setattr(capture, "resolve_engine", fake_resolve)
         _FakeAsyncClient.gets = []
         _FakeAsyncClient._next = [
             _FakeResponse(400, b"", content_type="text/plain"),
@@ -771,10 +775,10 @@ class TestCapture:
     ) -> None:
         from ha_mcp.dashboard_screenshot import capture
 
-        async def fake_resolve() -> str:
-            return "http://engine:10000"
+        async def fake_resolve() -> EngineTarget:
+            return EngineTarget(url="http://engine:10000")
 
-        monkeypatch.setattr(capture, "resolve_engine_url", fake_resolve)
+        monkeypatch.setattr(capture, "resolve_engine", fake_resolve)
         _FakeAsyncClient.gets = []
         _FakeAsyncClient._next = _FakeResponse(400, b"", content_type="text/plain")
         monkeypatch.setattr(capture.httpx, "AsyncClient", _FakeAsyncClient)
@@ -789,11 +793,11 @@ class TestCapture:
     ) -> None:
         from ha_mcp.dashboard_screenshot import capture
 
-        async def fake_resolve() -> str:
-            return "http://engine:10000"
+        async def fake_resolve() -> EngineTarget:
+            return EngineTarget(url="http://engine:10000")
 
         response = _FakeResponse(200, b"12345", content_length=5)
-        monkeypatch.setattr(capture, "resolve_engine_url", fake_resolve)
+        monkeypatch.setattr(capture, "resolve_engine", fake_resolve)
         monkeypatch.setattr(capture, "MAX_IMAGE_PAYLOAD_BYTES", 4)
         monkeypatch.setattr(capture, "MAX_BATCH_PAYLOAD_BYTES", 8)
         _FakeAsyncClient._next = response
@@ -810,10 +814,10 @@ class TestCapture:
     async def test_chunked_oversize_stops_at_limit(self, monkeypatch: Any) -> None:
         from ha_mcp.dashboard_screenshot import capture
 
-        async def fake_resolve() -> str:
-            return "http://engine:10000"
+        async def fake_resolve() -> EngineTarget:
+            return EngineTarget(url="http://engine:10000")
 
-        monkeypatch.setattr(capture, "resolve_engine_url", fake_resolve)
+        monkeypatch.setattr(capture, "resolve_engine", fake_resolve)
         monkeypatch.setattr(capture, "MAX_IMAGE_PAYLOAD_BYTES", 4)
         monkeypatch.setattr(capture, "MAX_BATCH_PAYLOAD_BYTES", 8)
         _FakeAsyncClient._next = _FakeResponse(200, b"", chunks=[b"123", b"45"])
@@ -829,10 +833,10 @@ class TestCapture:
     async def test_exact_payload_boundary_succeeds(self, monkeypatch: Any) -> None:
         from ha_mcp.dashboard_screenshot import capture
 
-        async def fake_resolve() -> str:
-            return "http://engine:10000"
+        async def fake_resolve() -> EngineTarget:
+            return EngineTarget(url="http://engine:10000")
 
-        monkeypatch.setattr(capture, "resolve_engine_url", fake_resolve)
+        monkeypatch.setattr(capture, "resolve_engine", fake_resolve)
         monkeypatch.setattr(capture, "MAX_IMAGE_PAYLOAD_BYTES", 4)
         monkeypatch.setattr(capture, "MAX_BATCH_PAYLOAD_BYTES", 8)
         _FakeAsyncClient._next = _FakeResponse(
@@ -851,10 +855,10 @@ class TestCapture:
     ) -> None:
         from ha_mcp.dashboard_screenshot import capture
 
-        async def fake_resolve() -> str:
-            return "http://engine:10000"
+        async def fake_resolve() -> EngineTarget:
+            return EngineTarget(url="http://engine:10000")
 
-        monkeypatch.setattr(capture, "resolve_engine_url", fake_resolve)
+        monkeypatch.setattr(capture, "resolve_engine", fake_resolve)
         monkeypatch.setattr(capture, "MAX_IMAGE_PAYLOAD_BYTES", 4)
         monkeypatch.setattr(capture, "MAX_BATCH_PAYLOAD_BYTES", 6)
         _FakeAsyncClient._next = _FakeResponse(
@@ -883,10 +887,10 @@ class TestCapture:
 
         from ha_mcp.dashboard_screenshot import capture
 
-        async def fake_resolve() -> str:
-            return "http://engine:10000"
+        async def fake_resolve() -> EngineTarget:
+            return EngineTarget(url="http://engine:10000")
 
-        monkeypatch.setattr(capture, "resolve_engine_url", fake_resolve)
+        monkeypatch.setattr(capture, "resolve_engine", fake_resolve)
         _FakeAsyncClient._next = [
             _FakeResponse(200, _PNG),
             httpx.ReadTimeout("desktop timed out"),
@@ -913,10 +917,10 @@ class TestCapture:
 
         from ha_mcp.dashboard_screenshot import capture
 
-        async def fake_resolve() -> str:
-            return "http://engine:10000"
+        async def fake_resolve() -> EngineTarget:
+            return EngineTarget(url="http://engine:10000")
 
-        monkeypatch.setattr(capture, "resolve_engine_url", fake_resolve)
+        monkeypatch.setattr(capture, "resolve_engine", fake_resolve)
         _FakeAsyncClient._next = [
             httpx.ReadTimeout("mobile timed out"),
             _FakeResponse(200, _PNG),
@@ -942,10 +946,10 @@ class TestCapture:
 
         from ha_mcp.dashboard_screenshot import capture
 
-        async def fake_resolve() -> str:
-            return "http://engine:10000"
+        async def fake_resolve() -> EngineTarget:
+            return EngineTarget(url="http://engine:10000")
 
-        monkeypatch.setattr(capture, "resolve_engine_url", fake_resolve)
+        monkeypatch.setattr(capture, "resolve_engine", fake_resolve)
         _FakeAsyncClient._next = [
             httpx.ReadTimeout("mobile timed out"),
             httpx.ReadTimeout("desktop timed out"),
@@ -977,10 +981,10 @@ class TestCapture:
     ) -> None:
         from ha_mcp.dashboard_screenshot import capture
 
-        async def fake_resolve() -> str:
-            return "http://engine:10000"
+        async def fake_resolve() -> EngineTarget:
+            return EngineTarget(url="http://engine:10000")
 
-        monkeypatch.setattr(capture, "resolve_engine_url", fake_resolve)
+        monkeypatch.setattr(capture, "resolve_engine", fake_resolve)
         monkeypatch.setattr(capture, "MAX_IMAGE_PAYLOAD_BYTES", 4)
         monkeypatch.setattr(capture, "MAX_BATCH_PAYLOAD_BYTES", 6)
         _FakeAsyncClient._next = _FakeResponse(
@@ -1006,10 +1010,10 @@ class TestCapture:
     ) -> None:
         from ha_mcp.dashboard_screenshot import capture
 
-        async def fake_resolve() -> str:
-            return "http://engine:10000"
+        async def fake_resolve() -> EngineTarget:
+            return EngineTarget(url="http://engine:10000")
 
-        monkeypatch.setattr(capture, "resolve_engine_url", fake_resolve)
+        monkeypatch.setattr(capture, "resolve_engine", fake_resolve)
         _FakeAsyncClient.gets = []
         _FakeAsyncClient._next = _FakeResponse(200, _JPEG, content_type="image/jpeg")
         monkeypatch.setattr(capture.httpx, "AsyncClient", _FakeAsyncClient)
@@ -1052,10 +1056,10 @@ class TestCapture:
     async def test_rejects_unexpected_content_type(self, monkeypatch: Any) -> None:
         from ha_mcp.dashboard_screenshot import capture
 
-        async def fake_resolve() -> str:
-            return "http://engine:10000"
+        async def fake_resolve() -> EngineTarget:
+            return EngineTarget(url="http://engine:10000")
 
-        monkeypatch.setattr(capture, "resolve_engine_url", fake_resolve)
+        monkeypatch.setattr(capture, "resolve_engine", fake_resolve)
         _FakeAsyncClient._next = _FakeResponse(
             200, b"not a jpeg", content_type="image/png"
         )
@@ -1083,10 +1087,10 @@ class TestCapture:
     ) -> None:
         from ha_mcp.dashboard_screenshot import capture
 
-        async def fake_resolve() -> str:
-            return "http://engine:10000"
+        async def fake_resolve() -> EngineTarget:
+            return EngineTarget(url="http://engine:10000")
 
-        monkeypatch.setattr(capture, "resolve_engine_url", fake_resolve)
+        monkeypatch.setattr(capture, "resolve_engine", fake_resolve)
         _FakeAsyncClient._next = _FakeResponse(200, body, content_type=mime_type)
         monkeypatch.setattr(capture.httpx, "AsyncClient", _FakeAsyncClient)
 
@@ -1113,10 +1117,10 @@ class TestCapture:
     ) -> None:
         from ha_mcp.dashboard_screenshot import capture
 
-        async def fake_resolve() -> str:
-            return "http://engine:10000"
+        async def fake_resolve() -> EngineTarget:
+            return EngineTarget(url="http://engine:10000")
 
-        monkeypatch.setattr(capture, "resolve_engine_url", fake_resolve)
+        monkeypatch.setattr(capture, "resolve_engine", fake_resolve)
         _FakeAsyncClient._next = _FakeResponse(
             200, b"<html>login</html>", content_type=mime_type
         )
@@ -1139,10 +1143,10 @@ class TestCapture:
 
         from ha_mcp.dashboard_screenshot import capture
 
-        async def fake_resolve() -> str:
-            return "http://engine:10000"
+        async def fake_resolve() -> EngineTarget:
+            return EngineTarget(url="http://engine:10000")
 
-        monkeypatch.setattr(capture, "resolve_engine_url", fake_resolve)
+        monkeypatch.setattr(capture, "resolve_engine", fake_resolve)
         _FakeAsyncClient._next = httpx.ReadTimeout("render too slow")
         monkeypatch.setattr(capture.httpx, "AsyncClient", _FakeAsyncClient)
 
@@ -1164,10 +1168,10 @@ class TestCapture:
     async def test_http_error_raises_toolerror(self, monkeypatch: Any) -> None:
         from ha_mcp.dashboard_screenshot import capture
 
-        async def fake_resolve() -> str:
-            return "http://engine:10000"
+        async def fake_resolve() -> EngineTarget:
+            return EngineTarget(url="http://engine:10000")
 
-        monkeypatch.setattr(capture, "resolve_engine_url", fake_resolve)
+        monkeypatch.setattr(capture, "resolve_engine", fake_resolve)
         _FakeAsyncClient._next = _FakeResponse(502, b"", text="bad gateway")
         monkeypatch.setattr(capture.httpx, "AsyncClient", _FakeAsyncClient)
 
@@ -1177,10 +1181,10 @@ class TestCapture:
     async def test_empty_body_raises_toolerror(self, monkeypatch: Any) -> None:
         from ha_mcp.dashboard_screenshot import capture
 
-        async def fake_resolve() -> str:
-            return "http://engine:10000"
+        async def fake_resolve() -> EngineTarget:
+            return EngineTarget(url="http://engine:10000")
 
-        monkeypatch.setattr(capture, "resolve_engine_url", fake_resolve)
+        monkeypatch.setattr(capture, "resolve_engine", fake_resolve)
         _FakeAsyncClient._next = _FakeResponse(200, b"")
         monkeypatch.setattr(capture.httpx, "AsyncClient", _FakeAsyncClient)
 
@@ -1222,10 +1226,10 @@ class TestCapture:
         percent-encoded (defense-in-depth), not raw."""
         from ha_mcp.dashboard_screenshot import capture
 
-        async def fake_resolve() -> str:
-            return "http://engine:10000"
+        async def fake_resolve() -> EngineTarget:
+            return EngineTarget(url="http://engine:10000")
 
-        monkeypatch.setattr(capture, "resolve_engine_url", fake_resolve)
+        monkeypatch.setattr(capture, "resolve_engine", fake_resolve)
         _FakeAsyncClient._next = _FakeResponse(200, b"\x89PNG\r\n\x1a\nfake")
         monkeypatch.setattr(capture.httpx, "AsyncClient", _FakeAsyncClient)
 
@@ -1976,9 +1980,13 @@ class TestPublicScreenshotOptionForwarding:
         assert {
             key: value
             for key, value in capture_call.items()
-            if key not in {"path", "partial_failures"}
+            if key not in {"path", "partial_failures", "client", "capture_warnings"}
         } == defaults
         assert capture_call["partial_failures"] == []
+        # The theme guard needs the HA client for its non-add-on credential
+        # fallback and an accumulator for its non-fatal warnings.
+        assert capture_call["client"] is not None
+        assert capture_call["capture_warnings"] == []
 
     async def test_get_include_screenshot_forwards_view_path(
         self, monkeypatch: Any

--- a/tests/src/unit/test_dashboard_screenshot.py
+++ b/tests/src/unit/test_dashboard_screenshot.py
@@ -106,7 +106,7 @@ class TestSettings:
             config.Settings()
 
     def test_engine_url_validator_strips_trailing_slash(self, monkeypatch: Any) -> None:
-        # The field validator (not just resolve_engine_url) normalizes the URL.
+        # The field validator (not just resolve_engine) normalizes the URL.
         monkeypatch.setenv(
             "HAMCP_DASHBOARD_SCREENSHOT_ENGINE_URL", "http://engine:10000/"
         )
@@ -210,6 +210,35 @@ class TestStandaloneScreenshotTool:
         assert [
             item["content_index"] for item in result.structured_content["screenshots"]
         ] == [0, 1]
+
+    async def test_theme_guard_warning_reaches_tool_response(
+        self, monkeypatch: Any
+    ) -> None:
+        """A failed theme restore must surface in the standalone tool output."""
+        from ha_mcp.dashboard_screenshot.paths import DashboardRenderTarget
+        from ha_mcp.tools import tools_dashboard_screenshot as mod
+
+        async def resolve(*_a: Any, **_kw: Any) -> DashboardRenderTarget:
+            return DashboardRenderTarget(
+                dashboard_url_path="wall-panel",
+                view_path="home",
+                render_path="wall-panel/home",
+                view_index=0,
+                stable=True,
+            )
+
+        async def capture(*_a: Any, **kwargs: Any) -> list[Any]:
+            kwargs["capture_warnings"].append("theme restore failed (unit)")
+            return [_fake_dashboard_capture()]
+
+        monkeypatch.setattr(mod, "resolve_dashboard_render_target", resolve)
+        monkeypatch.setattr(mod, "capture_dashboard_images", capture)
+
+        result = await mod.DashboardScreenshotTools(
+            object()
+        ).ha_get_dashboard_screenshot(dashboard_url_path="wall-panel", view_path="home")
+
+        assert "theme restore failed (unit)" in result.structured_content["warnings"]
 
     async def test_legacy_full_page_fallback_surfaces_warning(
         self, monkeypatch: Any
@@ -331,7 +360,7 @@ class TestStandaloneScreenshotTool:
 # ---------------------------------------------------------------------------
 
 
-class TestResolveEngineUrl:
+class TestResolveEngine:
     async def test_explicit_url_strips_trailing_slash(self, monkeypatch: Any) -> None:
         from ha_mcp.dashboard_screenshot import provision
 
@@ -342,7 +371,10 @@ class TestResolveEngineUrl:
                 dashboard_screenshot_engine_url="http://engine:10000/"
             ),
         )
-        assert await provision.resolve_engine_url() == "http://engine:10000"
+        target = await provision.resolve_engine()
+        assert target.url == "http://engine:10000"
+        # An explicitly configured engine has no discoverable credential.
+        assert target.addon_credential is None
 
     async def test_stdio_no_token_raises(self, monkeypatch: Any) -> None:
         from ha_mcp.dashboard_screenshot import provision
@@ -353,7 +385,7 @@ class TestResolveEngineUrl:
             lambda: SimpleNamespace(dashboard_screenshot_engine_url=""),
         )
         with pytest.raises(ToolError):
-            await provision.resolve_engine_url()
+            await provision.resolve_engine()
 
 
 # ---------------------------------------------------------------------------
@@ -437,9 +469,13 @@ class TestDiscoverEngineViaSupervisor:
         )
         target = await provision._discover_engine_via_supervisor()
         assert target.url == "http://def-puppet:10000"
-        # The discovered add-on's options ride along so the theme guard can
-        # authenticate as the engine's user without a second discovery.
-        assert target.addon_options == _puppet_options(keep_browser_open=False)
+        # The engine user's credential rides along so the theme guard can
+        # authenticate without a second discovery round-trip.
+        from ha_mcp.dashboard_screenshot.theme_guard import EngineCredential
+
+        assert target.addon_credential == EngineCredential(
+            url="http://homeassistant:8123", token="secret"
+        )
 
     async def test_multiple_verified_started_matches_fail_closed(
         self, monkeypatch: Any
@@ -1959,6 +1995,27 @@ class TestNoteScreenshotIgnored:
         assert any("ignored in search mode" in w for w in result["warnings"])
 
 
+class TestAttachScreenshotToolError:
+    def test_error_payload_warnings_merge_into_result_warnings(self) -> None:
+        """Theme-guard warnings on a failed capture survive the degraded path."""
+        from ha_mcp.tools.tools_config_dashboards import _attach_screenshot_tool_error
+
+        error = ToolError(
+            json.dumps(
+                {
+                    "success": False,
+                    "error": {"code": "SERVICE_CALL_FAILED", "message": "boom"},
+                    "warnings": ["theme restore failed (unit)"],
+                }
+            )
+        )
+        result = _attach_screenshot_tool_error({"success": True}, error)
+
+        assert "theme restore failed (unit)" in result["warnings"]
+        # Kept out of screenshot_error so the warning isn't duplicated.
+        assert "warnings" not in result["screenshot_error"]
+
+
 class TestPublicScreenshotOptionForwarding:
     """Public dashboard get/set methods forward view_path only.
 
@@ -2085,6 +2142,49 @@ class TestPublicScreenshotOptionForwarding:
 
         assert isinstance(result, ToolResult)
         self._assert_capture_call(capture_call)
+
+    async def test_include_screenshot_surfaces_theme_guard_warning(
+        self, monkeypatch: Any
+    ) -> None:
+        """A failed theme restore must surface in the config-tool response."""
+        from fastmcp.tools.tool import ToolResult
+
+        from ha_mcp.dashboard_screenshot import capture
+        from ha_mcp.tools import tools_config_dashboards as dashboard_tools
+
+        monkeypatch.setattr(
+            config,
+            "get_global_settings",
+            lambda: SimpleNamespace(
+                enable_dashboard_screenshot=True,
+                enable_mandatory_bps=False,
+            ),
+        )
+
+        async def record(path: str, **kwargs: Any) -> list[Any]:
+            kwargs["capture_warnings"].append("theme restore failed (unit)")
+            return [_fake_dashboard_capture()]
+
+        monkeypatch.setattr(capture, "capture_dashboard_images", record)
+        client = MagicMock()
+        client.send_websocket_message = AsyncMock(
+            return_value={
+                "result": {
+                    "views": [{"title": "Home", "path": "home"}],
+                }
+            }
+        )
+
+        result = await dashboard_tools.DashboardConfigTools(
+            client
+        ).ha_config_get_dashboard(
+            url_path="wall-panel",
+            include_screenshot=True,
+            view_path="home",
+        )
+
+        assert isinstance(result, ToolResult)
+        assert "theme restore failed (unit)" in result.structured_content["warnings"]
 
 
 def test_public_screenshot_option_names_stay_in_parity() -> None:

--- a/tests/src/unit/test_dashboard_screenshot_theme_guard.py
+++ b/tests/src/unit/test_dashboard_screenshot_theme_guard.py
@@ -1,0 +1,343 @@
+"""Unit tests for the dashboard-screenshot theme guard (issue #1909).
+
+Stock Puppet dispatches a ``settheme`` event on cold renders, and Home
+Assistant persists it server-side on the engine token user's profile —
+flipping that user's real sessions to light mode. The guard snapshots the
+saved theme before a capture batch and restores it afterwards.
+
+Covers credential resolution (add-on options vs ha-mcp's own credentials),
+snapshot/restore semantics against a fake WebSocket client, non-fatal
+failure handling, and the restore bracket around ``capture_dashboard_images``
+— including the regression scenario itself.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from types import SimpleNamespace
+from typing import Any, ClassVar
+
+import pytest
+from fastmcp.exceptions import ToolError
+
+from ha_mcp.dashboard_screenshot.provision import EngineTarget
+from ha_mcp.dashboard_screenshot.theme_guard import (
+    THEME_USER_DATA_KEY,
+    ThemeGuard,
+    _addon_credential,
+    _client_credential,
+)
+
+_PNG = b"\x89PNG\r\n\x1a\nunit"
+_DARK_THEME = {"theme": "default", "dark": True}
+_CLOBBERED_THEME = {"theme": "", "dark": False}
+
+
+class _FakeWsClient:
+    """Scriptable HomeAssistantWebSocketClient stand-in with a user-data store."""
+
+    instances: ClassVar[list[_FakeWsClient]] = []
+    user_data: ClassVar[dict[str, Any]] = {}
+    connect_ok: ClassVar[bool] = True
+    fail_get: ClassVar[bool] = False
+    fail_set: ClassVar[bool] = False
+
+    def __init__(self, url: str, token: str, verify_ssl: Any = None) -> None:
+        self.url = url
+        self.token = token
+        self.commands: list[dict[str, Any]] = []
+        self.disconnected = False
+        self.last_connect_error: str | None = None
+        _FakeWsClient.instances.append(self)
+
+    async def connect(self) -> bool:
+        if not _FakeWsClient.connect_ok:
+            self.last_connect_error = "auth_invalid"
+        return _FakeWsClient.connect_ok
+
+    async def disconnect(self) -> None:
+        self.disconnected = True
+
+    async def send_command(self, command_type: str, **kwargs: Any) -> dict[str, Any]:
+        self.commands.append({"type": command_type, **kwargs})
+        if command_type == "frontend/get_user_data":
+            if _FakeWsClient.fail_get:
+                raise RuntimeError("get_user_data boom")
+            value = _FakeWsClient.user_data.get(kwargs["key"])
+            return {"success": True, "result": {"value": value}}
+        if command_type == "frontend/set_user_data":
+            if _FakeWsClient.fail_set:
+                raise RuntimeError("set_user_data boom")
+            _FakeWsClient.user_data[kwargs["key"]] = kwargs["value"]
+            return {"success": True, "result": None}
+        raise AssertionError(f"unexpected command {command_type}")
+
+
+def _all_commands() -> list[dict[str, Any]]:
+    return [cmd for ws in _FakeWsClient.instances for cmd in ws.commands]
+
+
+@pytest.fixture(autouse=True)
+def _fresh_state(monkeypatch: Any) -> None:
+    monkeypatch.delenv("SUPERVISOR_TOKEN", raising=False)
+    monkeypatch.setattr(
+        "ha_mcp.client.websocket_client.HomeAssistantWebSocketClient",
+        _FakeWsClient,
+    )
+    _FakeWsClient.instances = []
+    _FakeWsClient.user_data = {}
+    _FakeWsClient.connect_ok = True
+    _FakeWsClient.fail_get = False
+    _FakeWsClient.fail_set = False
+
+
+def _addon_options(**overrides: Any) -> dict[str, Any]:
+    options: dict[str, Any] = {
+        "access_token": "puppet-token",
+        "keep_browser_open": False,
+        "home_assistant_url": "http://homeassistant:8123",
+    }
+    options.update(overrides)
+    return options
+
+
+def _client(base_url: str = "http://ha.local:8123", token: str = "own-token") -> Any:
+    return SimpleNamespace(base_url=base_url, token=token)
+
+
+class TestCredentialResolution:
+    def test_addon_options_win(self) -> None:
+        cred = _addon_credential(_addon_options())
+        assert cred is not None
+        assert cred.url == "http://homeassistant:8123"
+        assert cred.token == "puppet-token"
+
+    def test_addon_options_default_url_when_unset(self) -> None:
+        cred = _addon_credential(_addon_options(home_assistant_url=""))
+        assert cred is not None
+        assert cred.url == "http://homeassistant:8123"
+
+    def test_addon_options_without_token_yield_nothing(self) -> None:
+        assert _addon_credential(_addon_options(access_token="")) is None
+        assert _addon_credential(_addon_options(access_token=None)) is None
+        assert _addon_credential(None) is None
+
+    def test_client_credential_used_outside_addon_mode(self) -> None:
+        cred = _client_credential(_client())
+        assert cred is not None
+        assert cred.url == "http://ha.local:8123"
+        assert cred.token == "own-token"
+
+    def test_client_credential_refused_in_addon_mode(self, monkeypatch: Any) -> None:
+        # The Supervisor proxy authenticates as the Supervisor system user,
+        # not the engine's token user — protecting it would be a false no-op.
+        monkeypatch.setenv("SUPERVISOR_TOKEN", "sup")
+        assert _client_credential(_client()) is None
+
+    def test_client_credential_requires_http_url_and_token(self) -> None:
+        assert _client_credential(_client(base_url="oauth://pending")) is None
+        assert _client_credential(_client(token="")) is None
+        assert _client_credential(None) is None
+
+    def test_for_capture_prefers_addon_options_over_client(self) -> None:
+        guard = ThemeGuard.for_capture(_addon_options(), _client())
+        assert guard.credential is not None
+        assert guard.credential.token == "puppet-token"
+
+    def test_for_capture_without_any_credential_is_inactive(self) -> None:
+        guard = ThemeGuard.for_capture(None, None)
+        assert guard.credential is None
+
+
+class TestSnapshotRestore:
+    async def test_restore_writes_back_clobbered_theme(self) -> None:
+        """Regression #1909: an engine write is undone by the restore."""
+        _FakeWsClient.user_data[THEME_USER_DATA_KEY] = dict(_DARK_THEME)
+        guard = ThemeGuard.for_capture(_addon_options(), None)
+
+        await guard.take_snapshot()
+        assert guard.snapshot == _DARK_THEME
+
+        # The engine's settheme dispatch persists light mode server-side.
+        _FakeWsClient.user_data[THEME_USER_DATA_KEY] = dict(_CLOBBERED_THEME)
+
+        await guard.restore()
+        assert _FakeWsClient.user_data[THEME_USER_DATA_KEY] == _DARK_THEME
+        assert guard.warnings == []
+
+    async def test_restore_skips_write_when_unchanged(self) -> None:
+        _FakeWsClient.user_data[THEME_USER_DATA_KEY] = dict(_DARK_THEME)
+        guard = ThemeGuard.for_capture(_addon_options(), None)
+
+        await guard.take_snapshot()
+        await guard.restore()
+
+        set_calls = [
+            cmd for cmd in _all_commands() if cmd["type"] == "frontend/set_user_data"
+        ]
+        assert set_calls == []
+
+    async def test_never_configured_theme_round_trips_as_none(self) -> None:
+        guard = ThemeGuard.for_capture(_addon_options(), None)
+
+        await guard.take_snapshot()
+        assert guard.snapshot is None
+        assert guard.snapshot_taken is True
+
+        _FakeWsClient.user_data[THEME_USER_DATA_KEY] = dict(_CLOBBERED_THEME)
+        await guard.restore()
+        assert _FakeWsClient.user_data[THEME_USER_DATA_KEY] is None
+
+    async def test_sessions_are_closed_after_each_phase(self) -> None:
+        _FakeWsClient.user_data[THEME_USER_DATA_KEY] = dict(_DARK_THEME)
+        guard = ThemeGuard.for_capture(_addon_options(), None)
+        await guard.take_snapshot()
+        _FakeWsClient.user_data[THEME_USER_DATA_KEY] = dict(_CLOBBERED_THEME)
+        await guard.restore()
+        assert len(_FakeWsClient.instances) == 2
+        assert all(ws.disconnected for ws in _FakeWsClient.instances)
+
+    async def test_inactive_guard_touches_nothing(self) -> None:
+        guard = ThemeGuard.for_capture(None, None)
+        await guard.take_snapshot()
+        await guard.restore()
+        assert _FakeWsClient.instances == []
+        assert guard.warnings == []
+
+    async def test_snapshot_failure_warns_and_disables_restore(self) -> None:
+        _FakeWsClient.fail_get = True
+        guard = ThemeGuard.for_capture(_addon_options(), None)
+
+        await guard.take_snapshot()
+        assert guard.snapshot_taken is False
+        assert len(guard.warnings) == 1
+
+        _FakeWsClient.fail_get = False
+        await guard.restore()
+        # Without a trustworthy snapshot the guard must not write anything.
+        set_calls = [
+            cmd for cmd in _all_commands() if cmd["type"] == "frontend/set_user_data"
+        ]
+        assert set_calls == []
+
+    async def test_connect_failure_warns_without_raising(self) -> None:
+        _FakeWsClient.connect_ok = False
+        guard = ThemeGuard.for_capture(_addon_options(), None)
+        await guard.take_snapshot()
+        assert guard.snapshot_taken is False
+        assert len(guard.warnings) == 1
+
+    async def test_restore_failure_warns_without_raising(self) -> None:
+        _FakeWsClient.user_data[THEME_USER_DATA_KEY] = dict(_DARK_THEME)
+        guard = ThemeGuard.for_capture(_addon_options(), None)
+        await guard.take_snapshot()
+
+        _FakeWsClient.user_data[THEME_USER_DATA_KEY] = dict(_CLOBBERED_THEME)
+        _FakeWsClient.fail_set = True
+        await guard.restore()
+        assert len(guard.warnings) == 1
+        assert "restoring it failed" in guard.warnings[0]
+
+
+class _FakeResponse:
+    def __init__(self, status_code: int, content: bytes) -> None:
+        self.status_code = status_code
+        self.content = content
+        self.headers = {"content-type": "image/png"}
+
+    async def aiter_bytes(self) -> AsyncIterator[bytes]:
+        yield self.content
+
+
+class _FakeStreamContext:
+    def __init__(self, response: _FakeResponse) -> None:
+        self._response = response
+
+    async def __aenter__(self) -> _FakeResponse:
+        return self._response
+
+    async def __aexit__(self, *_a: Any) -> None:
+        return None
+
+
+class _ClobberingEngineClient:
+    """Fake httpx.AsyncClient whose render flips the stored theme to light."""
+
+    status_code: ClassVar[int] = 200
+
+    def __init__(self, *_a: Any, **_kw: Any) -> None:
+        pass
+
+    async def __aenter__(self) -> _ClobberingEngineClient:
+        return self
+
+    async def __aexit__(self, *_a: Any) -> None:
+        return None
+
+    def stream(
+        self, method: str, url: str, params: dict[str, Any] | None = None
+    ) -> _FakeStreamContext:
+        # Rendering makes the engine's frontend session persist light mode,
+        # exactly like Puppet's cold-browser settheme dispatch does.
+        _FakeWsClient.user_data[THEME_USER_DATA_KEY] = dict(_CLOBBERED_THEME)
+        return _FakeStreamContext(_FakeResponse(type(self).status_code, _PNG))
+
+
+class TestCaptureBracket:
+    """The guard brackets capture_dashboard_images end to end."""
+
+    @pytest.fixture(autouse=True)
+    def _engine(self, monkeypatch: Any) -> None:
+        from ha_mcp.dashboard_screenshot import capture
+
+        async def fake_resolve() -> EngineTarget:
+            return EngineTarget(
+                url="http://engine:10000", addon_options=_addon_options()
+            )
+
+        monkeypatch.setattr(capture, "resolve_engine", fake_resolve)
+        monkeypatch.setattr(capture.httpx, "AsyncClient", _ClobberingEngineClient)
+        _ClobberingEngineClient.status_code = 200
+
+    async def test_default_render_clobber_is_restored_issue_1909(self) -> None:
+        from ha_mcp.dashboard_screenshot import capture
+
+        _FakeWsClient.user_data[THEME_USER_DATA_KEY] = dict(_DARK_THEME)
+        capture_warnings: list[str] = []
+
+        captures = await capture.capture_dashboard_images(
+            "lovelace/0", capture_warnings=capture_warnings
+        )
+
+        assert captures[0].data == _PNG
+        assert _FakeWsClient.user_data[THEME_USER_DATA_KEY] == _DARK_THEME
+        assert capture_warnings == []
+
+    async def test_restore_runs_even_when_capture_fails(self) -> None:
+        from ha_mcp.dashboard_screenshot import capture
+
+        _FakeWsClient.user_data[THEME_USER_DATA_KEY] = dict(_DARK_THEME)
+        _ClobberingEngineClient.status_code = 500
+        capture_warnings: list[str] = []
+
+        with pytest.raises(ToolError):
+            await capture.capture_dashboard_images(
+                "lovelace/0", capture_warnings=capture_warnings
+            )
+
+        assert _FakeWsClient.user_data[THEME_USER_DATA_KEY] == _DARK_THEME
+
+    async def test_restore_failure_surfaces_as_capture_warning(self) -> None:
+        from ha_mcp.dashboard_screenshot import capture
+
+        _FakeWsClient.user_data[THEME_USER_DATA_KEY] = dict(_DARK_THEME)
+        _FakeWsClient.fail_set = True
+        capture_warnings: list[str] = []
+
+        captures = await capture.capture_dashboard_images(
+            "lovelace/0", capture_warnings=capture_warnings
+        )
+
+        assert captures[0].data == _PNG
+        assert len(capture_warnings) == 1
+        assert "restoring it failed" in capture_warnings[0]

--- a/tests/src/unit/test_dashboard_screenshot_theme_guard.py
+++ b/tests/src/unit/test_dashboard_screenshot_theme_guard.py
@@ -23,14 +23,18 @@ from fastmcp.exceptions import ToolError
 from ha_mcp.dashboard_screenshot.provision import EngineTarget
 from ha_mcp.dashboard_screenshot.theme_guard import (
     THEME_USER_DATA_KEY,
+    EngineCredential,
     ThemeGuard,
-    _addon_credential,
     _client_credential,
+    addon_credential_from_options,
 )
 
 _PNG = b"\x89PNG\r\n\x1a\nunit"
 _DARK_THEME = {"theme": "default", "dark": True}
 _CLOBBERED_THEME = {"theme": "", "dark": False}
+_PUPPET_CREDENTIAL = EngineCredential(
+    url="http://homeassistant:8123", token="puppet-token"
+)
 
 
 class _FakeWsClient:
@@ -39,6 +43,7 @@ class _FakeWsClient:
     instances: ClassVar[list[_FakeWsClient]] = []
     user_data: ClassVar[dict[str, Any]] = {}
     connect_ok: ClassVar[bool] = True
+    connect_error_reason: ClassVar[str | None] = "auth_invalid"
     fail_get: ClassVar[bool] = False
     fail_set: ClassVar[bool] = False
 
@@ -52,7 +57,7 @@ class _FakeWsClient:
 
     async def connect(self) -> bool:
         if not _FakeWsClient.connect_ok:
-            self.last_connect_error = "auth_invalid"
+            self.last_connect_error = _FakeWsClient.connect_error_reason
         return _FakeWsClient.connect_ok
 
     async def disconnect(self) -> None:
@@ -77,6 +82,10 @@ def _all_commands() -> list[dict[str, Any]]:
     return [cmd for ws in _FakeWsClient.instances for cmd in ws.commands]
 
 
+def _set_calls() -> list[dict[str, Any]]:
+    return [cmd for cmd in _all_commands() if cmd["type"] == "frontend/set_user_data"]
+
+
 @pytest.fixture(autouse=True)
 def _fresh_state(monkeypatch: Any) -> None:
     monkeypatch.delenv("SUPERVISOR_TOKEN", raising=False)
@@ -87,6 +96,7 @@ def _fresh_state(monkeypatch: Any) -> None:
     _FakeWsClient.instances = []
     _FakeWsClient.user_data = {}
     _FakeWsClient.connect_ok = True
+    _FakeWsClient.connect_error_reason = "auth_invalid"
     _FakeWsClient.fail_get = False
     _FakeWsClient.fail_set = False
 
@@ -106,27 +116,22 @@ def _client(base_url: str = "http://ha.local:8123", token: str = "own-token") ->
 
 
 class TestCredentialResolution:
-    def test_addon_options_win(self) -> None:
-        cred = _addon_credential(_addon_options())
-        assert cred is not None
-        assert cred.url == "http://homeassistant:8123"
-        assert cred.token == "puppet-token"
+    def test_addon_options_yield_engine_credential(self) -> None:
+        assert addon_credential_from_options(_addon_options()) == _PUPPET_CREDENTIAL
 
     def test_addon_options_default_url_when_unset(self) -> None:
-        cred = _addon_credential(_addon_options(home_assistant_url=""))
+        cred = addon_credential_from_options(_addon_options(home_assistant_url=""))
         assert cred is not None
         assert cred.url == "http://homeassistant:8123"
 
     def test_addon_options_without_token_yield_nothing(self) -> None:
-        assert _addon_credential(_addon_options(access_token="")) is None
-        assert _addon_credential(_addon_options(access_token=None)) is None
-        assert _addon_credential(None) is None
+        assert addon_credential_from_options(_addon_options(access_token="")) is None
+        assert addon_credential_from_options(_addon_options(access_token=None)) is None
+        assert addon_credential_from_options(None) is None
 
     def test_client_credential_used_outside_addon_mode(self) -> None:
         cred = _client_credential(_client())
-        assert cred is not None
-        assert cred.url == "http://ha.local:8123"
-        assert cred.token == "own-token"
+        assert cred == EngineCredential(url="http://ha.local:8123", token="own-token")
 
     def test_client_credential_refused_in_addon_mode(self, monkeypatch: Any) -> None:
         # The Supervisor proxy authenticates as the Supervisor system user,
@@ -134,15 +139,30 @@ class TestCredentialResolution:
         monkeypatch.setenv("SUPERVISOR_TOKEN", "sup")
         assert _client_credential(_client()) is None
 
+    def test_client_credential_allowed_in_embedded_mode(self, monkeypatch: Any) -> None:
+        # Embedded mode runs inside the HA core container (which carries
+        # SUPERVISOR_TOKEN) but authenticates as a plain admin client with a
+        # real user token — the fallback must stay active there.
+        monkeypatch.setenv("SUPERVISOR_TOKEN", "sup")
+        monkeypatch.setenv("HA_MCP_EMBEDDED", "1")
+        assert _client_credential(_client()) == EngineCredential(
+            url="http://ha.local:8123", token="own-token"
+        )
+
     def test_client_credential_requires_http_url_and_token(self) -> None:
         assert _client_credential(_client(base_url="oauth://pending")) is None
         assert _client_credential(_client(token="")) is None
         assert _client_credential(None) is None
 
-    def test_for_capture_prefers_addon_options_over_client(self) -> None:
-        guard = ThemeGuard.for_capture(_addon_options(), _client())
-        assert guard.credential is not None
-        assert guard.credential.token == "puppet-token"
+    def test_for_capture_prefers_addon_credential_over_client(self) -> None:
+        guard = ThemeGuard.for_capture(_PUPPET_CREDENTIAL, _client())
+        assert guard.credential == _PUPPET_CREDENTIAL
+
+    def test_for_capture_falls_back_to_client_credential(self) -> None:
+        guard = ThemeGuard.for_capture(None, _client())
+        assert guard.credential == EngineCredential(
+            url="http://ha.local:8123", token="own-token"
+        )
 
     def test_for_capture_without_any_credential_is_inactive(self) -> None:
         guard = ThemeGuard.for_capture(None, None)
@@ -153,10 +173,9 @@ class TestSnapshotRestore:
     async def test_restore_writes_back_clobbered_theme(self) -> None:
         """Regression #1909: an engine write is undone by the restore."""
         _FakeWsClient.user_data[THEME_USER_DATA_KEY] = dict(_DARK_THEME)
-        guard = ThemeGuard.for_capture(_addon_options(), None)
+        guard = ThemeGuard.for_capture(_PUPPET_CREDENTIAL, None)
 
         await guard.take_snapshot()
-        assert guard.snapshot == _DARK_THEME
 
         # The engine's settheme dispatch persists light mode server-side.
         _FakeWsClient.user_data[THEME_USER_DATA_KEY] = dict(_CLOBBERED_THEME)
@@ -165,32 +184,56 @@ class TestSnapshotRestore:
         assert _FakeWsClient.user_data[THEME_USER_DATA_KEY] == _DARK_THEME
         assert guard.warnings == []
 
+    async def test_sessions_use_the_resolved_credential(self) -> None:
+        _FakeWsClient.user_data[THEME_USER_DATA_KEY] = dict(_DARK_THEME)
+        guard = ThemeGuard.for_capture(_PUPPET_CREDENTIAL, None)
+        await guard.take_snapshot()
+        assert [(ws.url, ws.token) for ws in _FakeWsClient.instances] == [
+            ("http://homeassistant:8123", "puppet-token")
+        ]
+
     async def test_restore_skips_write_when_unchanged(self) -> None:
         _FakeWsClient.user_data[THEME_USER_DATA_KEY] = dict(_DARK_THEME)
-        guard = ThemeGuard.for_capture(_addon_options(), None)
+        guard = ThemeGuard.for_capture(_PUPPET_CREDENTIAL, None)
 
         await guard.take_snapshot()
         await guard.restore()
 
-        set_calls = [
-            cmd for cmd in _all_commands() if cmd["type"] == "frontend/set_user_data"
-        ]
-        assert set_calls == []
+        assert _set_calls() == []
 
-    async def test_never_configured_theme_round_trips_as_none(self) -> None:
-        guard = ThemeGuard.for_capture(_addon_options(), None)
+    async def test_unconfigured_theme_stays_unwritten_when_unchanged(self) -> None:
+        guard = ThemeGuard.for_capture(_PUPPET_CREDENTIAL, None)
+        await guard.take_snapshot()
+        await guard.restore()
+        assert _set_calls() == []
+
+    async def test_never_configured_theme_restores_as_empty_settings(self) -> None:
+        # Live frontend sessions ignore a null subscription push, so a
+        # never-configured baseline restores as {} — equivalent "no explicit
+        # selection" semantics that subscribed sessions actually re-apply.
+        guard = ThemeGuard.for_capture(_PUPPET_CREDENTIAL, None)
 
         await guard.take_snapshot()
-        assert guard.snapshot is None
-        assert guard.snapshot_taken is True
 
         _FakeWsClient.user_data[THEME_USER_DATA_KEY] = dict(_CLOBBERED_THEME)
         await guard.restore()
-        assert _FakeWsClient.user_data[THEME_USER_DATA_KEY] is None
+        assert _FakeWsClient.user_data[THEME_USER_DATA_KEY] == {}
+
+    @pytest.mark.parametrize(
+        "response", [{"success": True, "result": None}, None, "not-a-dict"]
+    )
+    async def test_fetch_theme_tolerates_malformed_responses(
+        self, response: Any
+    ) -> None:
+        class _MalformedWs:
+            async def send_command(self, command_type: str, **kwargs: Any) -> Any:
+                return response
+
+        assert await ThemeGuard._fetch_theme(_MalformedWs()) is None  # type: ignore[arg-type]
 
     async def test_sessions_are_closed_after_each_phase(self) -> None:
         _FakeWsClient.user_data[THEME_USER_DATA_KEY] = dict(_DARK_THEME)
-        guard = ThemeGuard.for_capture(_addon_options(), None)
+        guard = ThemeGuard.for_capture(_PUPPET_CREDENTIAL, None)
         await guard.take_snapshot()
         _FakeWsClient.user_data[THEME_USER_DATA_KEY] = dict(_CLOBBERED_THEME)
         await guard.restore()
@@ -206,30 +249,31 @@ class TestSnapshotRestore:
 
     async def test_snapshot_failure_warns_and_disables_restore(self) -> None:
         _FakeWsClient.fail_get = True
-        guard = ThemeGuard.for_capture(_addon_options(), None)
+        guard = ThemeGuard.for_capture(_PUPPET_CREDENTIAL, None)
 
         await guard.take_snapshot()
-        assert guard.snapshot_taken is False
         assert len(guard.warnings) == 1
 
         _FakeWsClient.fail_get = False
         await guard.restore()
         # Without a trustworthy snapshot the guard must not write anything.
-        set_calls = [
-            cmd for cmd in _all_commands() if cmd["type"] == "frontend/set_user_data"
-        ]
-        assert set_calls == []
+        assert _set_calls() == []
 
-    async def test_connect_failure_warns_without_raising(self) -> None:
+    @pytest.mark.parametrize("reason", ["auth_invalid", None])
+    async def test_connect_failure_warns_without_raising(
+        self, reason: str | None
+    ) -> None:
         _FakeWsClient.connect_ok = False
-        guard = ThemeGuard.for_capture(_addon_options(), None)
+        _FakeWsClient.connect_error_reason = reason
+        guard = ThemeGuard.for_capture(_PUPPET_CREDENTIAL, None)
         await guard.take_snapshot()
-        assert guard.snapshot_taken is False
         assert len(guard.warnings) == 1
+        await guard.restore()
+        assert _set_calls() == []
 
     async def test_restore_failure_warns_without_raising(self) -> None:
         _FakeWsClient.user_data[THEME_USER_DATA_KEY] = dict(_DARK_THEME)
-        guard = ThemeGuard.for_capture(_addon_options(), None)
+        guard = ThemeGuard.for_capture(_PUPPET_CREDENTIAL, None)
         await guard.take_snapshot()
 
         _FakeWsClient.user_data[THEME_USER_DATA_KEY] = dict(_CLOBBERED_THEME)
@@ -283,25 +327,28 @@ class _ClobberingEngineClient:
         return _FakeStreamContext(_FakeResponse(type(self).status_code, _PNG))
 
 
+def _patch_engine(monkeypatch: Any, addon_credential: EngineCredential | None) -> None:
+    from ha_mcp.dashboard_screenshot import capture
+
+    async def fake_resolve() -> EngineTarget:
+        return EngineTarget(
+            url="http://engine:10000", addon_credential=addon_credential
+        )
+
+    monkeypatch.setattr(capture, "resolve_engine", fake_resolve)
+    monkeypatch.setattr(capture.httpx, "AsyncClient", _ClobberingEngineClient)
+    _ClobberingEngineClient.status_code = 200
+
+
 class TestCaptureBracket:
     """The guard brackets capture_dashboard_images end to end."""
 
-    @pytest.fixture(autouse=True)
-    def _engine(self, monkeypatch: Any) -> None:
+    async def test_default_render_clobber_is_restored_issue_1909(
+        self, monkeypatch: Any
+    ) -> None:
         from ha_mcp.dashboard_screenshot import capture
 
-        async def fake_resolve() -> EngineTarget:
-            return EngineTarget(
-                url="http://engine:10000", addon_options=_addon_options()
-            )
-
-        monkeypatch.setattr(capture, "resolve_engine", fake_resolve)
-        monkeypatch.setattr(capture.httpx, "AsyncClient", _ClobberingEngineClient)
-        _ClobberingEngineClient.status_code = 200
-
-    async def test_default_render_clobber_is_restored_issue_1909(self) -> None:
-        from ha_mcp.dashboard_screenshot import capture
-
+        _patch_engine(monkeypatch, _PUPPET_CREDENTIAL)
         _FakeWsClient.user_data[THEME_USER_DATA_KEY] = dict(_DARK_THEME)
         capture_warnings: list[str] = []
 
@@ -313,23 +360,43 @@ class TestCaptureBracket:
         assert _FakeWsClient.user_data[THEME_USER_DATA_KEY] == _DARK_THEME
         assert capture_warnings == []
 
-    async def test_restore_runs_even_when_capture_fails(self) -> None:
+    async def test_client_credential_fallback_restores_via_client(
+        self, monkeypatch: Any
+    ) -> None:
+        """Sidecar/standalone mode: no add-on credential, own HA creds used."""
         from ha_mcp.dashboard_screenshot import capture
 
+        _patch_engine(monkeypatch, None)
+        _FakeWsClient.user_data[THEME_USER_DATA_KEY] = dict(_DARK_THEME)
+
+        captures = await capture.capture_dashboard_images(
+            "lovelace/0", client=_client()
+        )
+
+        assert captures[0].data == _PNG
+        assert _FakeWsClient.user_data[THEME_USER_DATA_KEY] == _DARK_THEME
+        assert {(ws.url, ws.token) for ws in _FakeWsClient.instances} == {
+            ("http://ha.local:8123", "own-token")
+        }
+
+    async def test_restore_runs_even_when_capture_fails(self, monkeypatch: Any) -> None:
+        from ha_mcp.dashboard_screenshot import capture
+
+        _patch_engine(monkeypatch, _PUPPET_CREDENTIAL)
         _FakeWsClient.user_data[THEME_USER_DATA_KEY] = dict(_DARK_THEME)
         _ClobberingEngineClient.status_code = 500
-        capture_warnings: list[str] = []
 
         with pytest.raises(ToolError):
-            await capture.capture_dashboard_images(
-                "lovelace/0", capture_warnings=capture_warnings
-            )
+            await capture.capture_dashboard_images("lovelace/0")
 
         assert _FakeWsClient.user_data[THEME_USER_DATA_KEY] == _DARK_THEME
 
-    async def test_restore_failure_surfaces_as_capture_warning(self) -> None:
+    async def test_restore_failure_surfaces_as_capture_warning(
+        self, monkeypatch: Any
+    ) -> None:
         from ha_mcp.dashboard_screenshot import capture
 
+        _patch_engine(monkeypatch, _PUPPET_CREDENTIAL)
         _FakeWsClient.user_data[THEME_USER_DATA_KEY] = dict(_DARK_THEME)
         _FakeWsClient.fail_set = True
         capture_warnings: list[str] = []
@@ -341,3 +408,26 @@ class TestCaptureBracket:
         assert captures[0].data == _PNG
         assert len(capture_warnings) == 1
         assert "restoring it failed" in capture_warnings[0]
+
+    async def test_restore_failure_rides_on_the_raised_capture_error(
+        self, monkeypatch: Any
+    ) -> None:
+        """Failed render + failed restore: the warning must reach the caller.
+
+        The theme is most likely left flipped exactly when both fail, so the
+        raised ToolError payload has to carry the guard warning.
+        """
+        import json
+
+        from ha_mcp.dashboard_screenshot import capture
+
+        _patch_engine(monkeypatch, _PUPPET_CREDENTIAL)
+        _FakeWsClient.user_data[THEME_USER_DATA_KEY] = dict(_DARK_THEME)
+        _ClobberingEngineClient.status_code = 500
+        _FakeWsClient.fail_set = True
+
+        with pytest.raises(ToolError) as exc_info:
+            await capture.capture_dashboard_images("lovelace/0")
+
+        payload = json.loads(str(exc_info.value))
+        assert any("restoring it failed" in warning for warning in payload["warnings"])

--- a/tests/src/unit/test_dashboard_screenshot_theme_guard.py
+++ b/tests/src/unit/test_dashboard_screenshot_theme_guard.py
@@ -89,6 +89,10 @@ def _set_calls() -> list[dict[str, Any]]:
 @pytest.fixture(autouse=True)
 def _fresh_state(monkeypatch: Any) -> None:
     monkeypatch.delenv("SUPERVISOR_TOKEN", raising=False)
+    # The real write-settle delay only matters against a live engine.
+    monkeypatch.setattr(
+        "ha_mcp.dashboard_screenshot.theme_guard.RESTORE_SETTLE_SECONDS", 0
+    )
     monkeypatch.setattr(
         "ha_mcp.client.websocket_client.HomeAssistantWebSocketClient",
         _FakeWsClient,
@@ -270,6 +274,25 @@ class TestSnapshotRestore:
         assert len(guard.warnings) == 1
         await guard.restore()
         assert _set_calls() == []
+
+    async def test_restore_waits_for_engine_write_to_settle(
+        self, monkeypatch: Any
+    ) -> None:
+        """The post-capture read must not race Puppet's async user-data save."""
+        from ha_mcp.dashboard_screenshot import theme_guard as guard_module
+
+        monkeypatch.setattr(guard_module, "RESTORE_SETTLE_SECONDS", 1.5)
+        sleeps: list[float] = []
+
+        async def record_sleep(seconds: float) -> None:
+            sleeps.append(seconds)
+
+        monkeypatch.setattr(guard_module.asyncio, "sleep", record_sleep)
+
+        guard = ThemeGuard.for_capture(_PUPPET_CREDENTIAL, None)
+        await guard.take_snapshot()
+        await guard.restore()
+        assert sleeps == [1.5]
 
     async def test_restore_failure_warns_without_raising(self) -> None:
         _FakeWsClient.user_data[THEME_USER_DATA_KEY] = dict(_DARK_THEME)


### PR DESCRIPTION
## What does this PR do?

Fixes #1909. Any dashboard screenshot (`ha_get_dashboard_screenshot`, `include_screenshot`, `return_screenshot`) was flipping the frontend theme of the Puppet token's user from dark to light — visibly, on their real web and mobile sessions.

Root cause: stock Puppet dispatches a `settheme` event on every cold-browser render, and its `dark` query flag is presence-based, so "not requested" reaches the frontend as an explicit light selection. The frontend persists that server-side per user (`frontend/set_user_data`, key `"theme"`) and syncs it to all of that user's sessions. Reproduced live: a default render writes `.storage/frontend.user_data_<engine user>` on every call (Puppet 2.6.0 ships `keep_browser_open: false`, so every render is a cold browser).

The fix brackets every capture batch with a `ThemeGuard`: it reads the engine user's saved theme before rendering and writes it back afterwards if the render changed it (an unchanged value is never rewritten). Credential resolution mirrors engine discovery:

- **Add-on mode** — authenticates with the Puppet add-on's own `access_token`/`home_assistant_url` options, which the Supervisor discovery step already fetches; the token stays in server memory for one capture batch and is never logged or returned.
- **Sidecar / standalone / OAuth / embedded** — falls back to ha-mcp's direct HA credentials, which protects the user whenever both tokens belong to the same account (the common single-user setup).
- No usable credential (e.g. Supervisor-proxy auth with an explicit engine URL) — the guard stays inactive and behavior is unchanged.

Guard failures never break a capture; an attempted but failed snapshot/restore surfaces as a `warnings` entry on the tool response. `docs/beta.md` and the `theme`/`dark_mode` parameter descriptions are updated accordingly.

## Type of change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [x] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

## Checklist
- [x] I have updated documentation if needed
