### PR TITLE
fix: alert on out-of-cycle stable mirror tags and track orphaned install jobs

### DIFF
--- a/.github/workflows/sync-integration-mirror.yml
+++ b/.github/workflows/sync-integration-mirror.yml
@@ -266,9 +266,14 @@ jobs:
           # itself a visible signal; swallowing the failure would defeat
           # the alert's entire purpose.
           if [ "${{ needs.gate.outputs.failopen }}" = "true" ]; then
+            # --body-file (not --body): keeps $VER out of an unquoted
+            # argument interpolation entirely (review note).
+            cat > /tmp/oob_alert.md <<EOF
+          The mirror sync's fail-open gate cut stable tag v${VER} on ha-mcp-integration without a confirmed release behind it (triggering run: ${{ github.event.workflow_run.html_url }}; this sync run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}). Treat v${VER} as published: bump the component manifest version in the next PR that touches the component instead of adding changes onto v${VER}.
+          EOF
             gh issue create --repo "${{ github.repository }}" \
               --title "Out-of-cycle stable mirror tag v${VER} was cut - bump the component version" \
-              --body "The mirror sync's fail-open gate cut stable tag v${VER} on ha-mcp-integration without a confirmed release behind it (triggering run: ${{ github.event.workflow_run.html_url }}; this sync run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}). Treat v${VER} as published: bump the component manifest version in the next PR that touches the component instead of adding changes onto v${VER}." \
+              --body-file /tmp/oob_alert.md \
               || { echo "::error::stable tag v${VER} was cut on a fail-open run but the alert issue could not be filed - bump the component version manually."; exit 1; }
           fi
 

--- a/.github/workflows/sync-integration-mirror.yml
+++ b/.github/workflows/sync-integration-mirror.yml
@@ -95,6 +95,25 @@ jobs:
             echo "proceed=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
+          # A pull_request-event run of the release workflows is the
+          # every-PR validation shell, and an all-skipped run reports an
+          # EMPTY job list — which fell into the job-absent fail-open below
+          # and cut a stable mirror tag with no release behind it (live:
+          # v1.1.1 went stable off a skipped pull_request Hotfix Release
+          # run the first time an untagged manifest version existed).
+          # Neither shape can ever have published a release, so both fail
+          # CLOSED here; the rename fail-open below stays for genuine
+          # release-shaped runs (dispatch/schedule/push, non-skipped).
+          if [ "${{ github.event.workflow_run.event }}" = "pull_request" ]; then
+            echo "Triggering run is a pull_request-event shell - skipping."
+            echo "proceed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [ "${{ github.event.workflow_run.conclusion }}" = "skipped" ]; then
+            echo "Triggering run concluded skipped - nothing was released; skipping."
+            echo "proceed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
           # Fail OPEN on an API error and on a missing job: the snapshot and
           # tag steps are idempotent, so a spurious proceed is harmless, while
           # a suppressed one strands HACS on the old component tag (the bug

--- a/.github/workflows/sync-integration-mirror.yml
+++ b/.github/workflows/sync-integration-mirror.yml
@@ -84,34 +84,24 @@ jobs:
       actions: read
     outputs:
       proceed: ${{ steps.decide.outputs.proceed }}
+      # True when the gate proceeded WITHOUT positive confirmation that a
+      # release happened (API error / job-absent fail-open). The tag step
+      # uses it to raise an alarm if a stable tag actually gets cut on such
+      # a run: fail-open is deliberate (see below), but a stable tag with no
+      # release behind it means the component version must be bumped rather
+      # than piled onto (live: v1.1.1 went stable off a skipped
+      # pull_request Hotfix Release shell whose job list came back empty).
+      failopen: ${{ steps.decide.outputs.failopen }}
     steps:
       - name: Gate on the Semantic Release job, not the whole run
         id: decide
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          echo "failopen=false" >> "$GITHUB_OUTPUT"
           if [ "${{ github.event_name }}" != "workflow_run" ]; then
             echo "Push/dispatch trigger - proceeding."
             echo "proceed=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          # A pull_request-event run of the release workflows is the
-          # every-PR validation shell, and an all-skipped run reports an
-          # EMPTY job list — which fell into the job-absent fail-open below
-          # and cut a stable mirror tag with no release behind it (live:
-          # v1.1.1 went stable off a skipped pull_request Hotfix Release
-          # run the first time an untagged manifest version existed).
-          # Neither shape can ever have published a release, so both fail
-          # CLOSED here; the rename fail-open below stays for genuine
-          # release-shaped runs (dispatch/schedule/push, non-skipped).
-          if [ "${{ github.event.workflow_run.event }}" = "pull_request" ]; then
-            echo "Triggering run is a pull_request-event shell - skipping."
-            echo "proceed=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          if [ "${{ github.event.workflow_run.conclusion }}" = "skipped" ]; then
-            echo "Triggering run concluded skipped - nothing was released; skipping."
-            echo "proceed=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           # Fail OPEN on an API error and on a missing job: the snapshot and
@@ -125,6 +115,7 @@ jobs:
             --jq '[.jobs[] | select(.name == "Semantic Release") | .conclusion] | first // empty'); then
             echo "::warning::Could not query the triggering run's jobs; failing open."
             echo "proceed=true" >> "$GITHUB_OUTPUT"
+            echo "failopen=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           echo "Semantic Release job conclusion: ${conclusion:-<job absent>}"
@@ -135,6 +126,7 @@ jobs:
             "")
               echo "::warning::No 'Semantic Release' job in the triggering run - the job-name coupling with the release workflows may be broken; failing open."
               echo "proceed=true" >> "$GITHUB_OUTPUT"
+              echo "failopen=true" >> "$GITHUB_OUTPUT"
               ;;
             *)
               echo "No successful release in the triggering run - skipping the mirror sync."
@@ -146,6 +138,11 @@ jobs:
     needs: gate
     if: needs.gate.outputs.proceed == 'true'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # For the out-of-cycle alert issue the stable-tag step files when a
+      # tag is cut on a fail-open gate run.
+      issues: write
     steps:
       - uses: actions/checkout@v7
         with:
@@ -238,6 +235,7 @@ jobs:
           (github.event_name == 'workflow_dispatch' && inputs.channel == 'stable')
         env:
           GIT_SSH_COMMAND: ssh -i ~/.ssh/mirror_key -o IdentitiesOnly=yes
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           VER=$(python3 -c "import json; print(json.load(open('custom_components/ha_mcp_tools/manifest.json'))['version'])")
           # Capture instead of `| grep -q .`: without pipefail a FAILED
@@ -257,6 +255,22 @@ jobs:
           cd /tmp/mirror
           git tag -a "v${VER}" -F /tmp/mirror_notes.md --cleanup=verbatim
           git push origin "v${VER}"
+          # A NEW stable tag cut on a fail-open gate run had no CONFIRMED
+          # release behind it. Keeping fail-open is deliberate (a suppressed
+          # tag strands HACS on the old component version — worse), so the
+          # response is an alarm, not prevention: file an issue so the
+          # component version gets BUMPED next rather than piled onto (the
+          # accidental v1.1.1 stable took further master changes with no
+          # installable release until 1.1.2). Fail the step if the alert
+          # cannot be filed — the tag is already pushed, and a red run is
+          # itself a visible signal; swallowing the failure would defeat
+          # the alert's entire purpose.
+          if [ "${{ needs.gate.outputs.failopen }}" = "true" ]; then
+            gh issue create --repo "${{ github.repository }}" \
+              --title "Out-of-cycle stable mirror tag v${VER} was cut - bump the component version" \
+              --body "The mirror sync's fail-open gate cut stable tag v${VER} on ha-mcp-integration without a confirmed release behind it (triggering run: ${{ github.event.workflow_run.html_url || github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}). Treat v${VER} as published: bump the component manifest version in the next PR that touches the component instead of adding changes onto v${VER}." \
+              || { echo "::error::stable tag v${VER} was cut on a fail-open run but the alert issue could not be filed - bump the component version manually."; exit 1; }
+          fi
 
       - name: Tag mirror dev pre-release
         # Publishes the master component snapshot as a HACS pre-release

--- a/.github/workflows/sync-integration-mirror.yml
+++ b/.github/workflows/sync-integration-mirror.yml
@@ -268,7 +268,7 @@ jobs:
           if [ "${{ needs.gate.outputs.failopen }}" = "true" ]; then
             gh issue create --repo "${{ github.repository }}" \
               --title "Out-of-cycle stable mirror tag v${VER} was cut - bump the component version" \
-              --body "The mirror sync's fail-open gate cut stable tag v${VER} on ha-mcp-integration without a confirmed release behind it (triggering run: ${{ github.event.workflow_run.html_url || github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}). Treat v${VER} as published: bump the component manifest version in the next PR that touches the component instead of adding changes onto v${VER}." \
+              --body "The mirror sync's fail-open gate cut stable tag v${VER} on ha-mcp-integration without a confirmed release behind it (triggering run: ${{ github.event.workflow_run.html_url }}; this sync run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}). Treat v${VER} as published: bump the component manifest version in the next PR that touches the component instead of adding changes onto v${VER}." \
               || { echo "::error::stable tag v${VER} was cut on a fail-open run but the alert issue could not be filed - bump the component version manually."; exit 1; }
           fi
 

--- a/custom_components/ha_mcp_tools/embedded_server.py
+++ b/custom_components/ha_mcp_tools/embedded_server.py
@@ -124,10 +124,13 @@ _PIP_UNINSTALL_TIMEOUT_SECONDS = 120
 
 # How long a bring-up waits for an install job orphaned by a CANCELLED
 # previous bring-up before giving up: asyncio cancellation detaches the
-# awaiter but an executor pip job runs to completion regardless. Sized just
-# above the per-download install timeout so a healthy-but-slow job is waited
-# out rather than raced.
-_PENDING_INSTALL_WAIT_SECONDS = 330.0
+# awaiter but an executor pip job runs to completion regardless. Sized to
+# the same absolute budget as the readiness cap: pip's own timeout (300s)
+# is per-download, so a healthy cold install pulling the whole dependency
+# tree on slow hardware can legitimately run for minutes — a tighter bound
+# would misreport it as stuck. On expiry the bring-up fails with a clear
+# message and the next reload retries.
+_PENDING_INSTALL_WAIT_SECONDS = 600.0
 
 # The in-process connection API was added with the embedded server in 7.10.0.
 # Older distributions can be left behind by an unsupported Core version's
@@ -540,8 +543,9 @@ class EmbeddedServerManager:
         """Run a package-mutating executor job, tracked process-wide.
 
         Registration happens BEFORE dispatch and completion is signalled on
-        the executor thread in a finally, so a bring-up cancelled mid-install
-        leaves behind a waitable job instead of an invisible one.
+        the executor thread in a finally, so a bring-up cancelled mid-job
+        (install or uninstall) leaves behind a waitable job instead of an
+        invisible one.
         """
         global _PENDING_INSTALL_DONE
         done = threading.Event()
@@ -559,7 +563,23 @@ class EmbeddedServerManager:
                     if _PENDING_INSTALL_DONE is done:
                         _PENDING_INSTALL_DONE = None
 
-        return await self._hass.async_add_executor_job(_run)
+        try:
+            return await self._hass.async_add_executor_job(_run)
+        except asyncio.CancelledError:
+            # The job is queued or running and its finally will clear the
+            # slot; leaving it registered is the whole point — the next
+            # bring-up must wait it out.
+            raise
+        except BaseException:
+            # A DISPATCH failure (e.g. executor already shut down) means
+            # _run never ran and nothing will ever set the event — clear our
+            # own registration or the next bring-up waits the full budget on
+            # a job that does not exist. The identity check makes this a
+            # no-op if _run did run and already cleaned up.
+            with _PENDING_INSTALL_LOCK:
+                if _PENDING_INSTALL_DONE is done:
+                    _PENDING_INSTALL_DONE = None
+            raise
 
     async def _async_wait_for_pending_install(self) -> None:
         """Wait out an install job orphaned by a cancelled previous bring-up.
@@ -568,6 +588,11 @@ class EmbeddedServerManager:
         bounded wait — mutating the package (or importing from it) underneath
         a live pip job is the same corruption class as purging sys.modules
         under a live importer.
+
+        The wait occupies one pooled executor thread (bounded): the setter
+        runs on an executor thread with no handle to this loop, so a
+        loop-side wakeup would need cross-thread plumbing this rare recovery
+        path does not justify.
         """
         with _PENDING_INSTALL_LOCK:
             pending = _PENDING_INSTALL_DONE
@@ -1340,12 +1365,19 @@ def _prune_and_check_importing_workers() -> bool:
 # the executor, if any. asyncio cancellation of a bring-up detaches the
 # awaiter, but the executor job keeps running to completion — untracked, an
 # orphaned pip could swap the distribution's files under the NEXT bring-up's
-# install or its worker's cold import (found in review of the #1904 fixes;
-# pre-existing). The dispatching coroutine registers the event BEFORE handing
+# install or its worker's cold import (found in review of PR #1911, the
+# #1904 fixes; pre-existing). The dispatching coroutine registers the event BEFORE handing
 # the job to the executor, and the executor fn sets it in a finally that
 # survives cancellation; the next bring-up waits on it before mutating
 # anything. Process-global for the same reason as _IMPORTING_WORKERS: a
 # manager is recreated on every bring-up.
+#
+# Single slot BY DESIGN: at most one tracked job can exist at a time — the
+# server entry is single-instance, an entry reload cancels-and-awaits the
+# previous bring-up before setting up, and every dispatch site sits behind
+# _async_wait_for_pending_install. A second concurrent dispatcher would
+# overwrite the slot and silently lose the older live job — keep any new
+# package-mutating call site behind the wait gate.
 _PENDING_INSTALL_LOCK = threading.Lock()
 _PENDING_INSTALL_DONE: threading.Event | None = None
 

--- a/custom_components/ha_mcp_tools/embedded_server.py
+++ b/custom_components/ha_mcp_tools/embedded_server.py
@@ -564,7 +564,14 @@ class EmbeddedServerManager:
                         _PENDING_INSTALL_DONE = None
 
         try:
-            return await self._hass.async_add_executor_job(_run)
+            # Shielded: cancelling the awaiter must NOT cancel the executor
+            # job. Unshielded, a cancel landing while the job is still
+            # QUEUED removes it from the pool — _run never starts, nothing
+            # ever sets the event, and the next bring-up waits the full
+            # budget on a job that does not exist (review finding). With the
+            # shield, _run always runs and its finally always fires; the
+            # awaiter still detaches immediately on cancel.
+            return await asyncio.shield(self._hass.async_add_executor_job(_run))
         except asyncio.CancelledError:
             # The job is queued or running and its finally will clear the
             # slot; leaving it registered is the whole point — the next

--- a/custom_components/ha_mcp_tools/embedded_server.py
+++ b/custom_components/ha_mcp_tools/embedded_server.py
@@ -1384,7 +1384,11 @@ def _prune_and_check_importing_workers() -> bool:
 # previous bring-up before setting up, and every dispatch site sits behind
 # _async_wait_for_pending_install. A second concurrent dispatcher would
 # overwrite the slot and silently lose the older live job — keep any new
-# package-mutating call site behind the wait gate.
+# package-mutating call site behind the wait gate. The slot tracking wraps
+# the DIRECT-pip sites (force install, uninstalls); the fast path goes
+# through HA's requirements manager, which is behind the gate but untracked —
+# it only dispatches pip when the package is missing outright, which cannot
+# co-occur with a live orphaned job worth waiting on.
 _PENDING_INSTALL_LOCK = threading.Lock()
 _PENDING_INSTALL_DONE: threading.Event | None = None
 

--- a/custom_components/ha_mcp_tools/embedded_server.py
+++ b/custom_components/ha_mcp_tools/embedded_server.py
@@ -83,6 +83,8 @@ from .const import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from homeassistant.config_entries import ConfigEntry
 
 _LOGGER = logging.getLogger(__name__)
@@ -119,6 +121,13 @@ _PIP_INSTALL_TIMEOUT_SECONDS = 300
 # Uninstall just removes files/metadata, so it is quick; cap it so a wedged
 # subprocess can never tie up an executor thread indefinitely.
 _PIP_UNINSTALL_TIMEOUT_SECONDS = 120
+
+# How long a bring-up waits for an install job orphaned by a CANCELLED
+# previous bring-up before giving up: asyncio cancellation detaches the
+# awaiter but an executor pip job runs to completion regardless. Sized just
+# above the per-download install timeout so a healthy-but-slow job is waited
+# out rather than raced.
+_PENDING_INSTALL_WAIT_SECONDS = 330.0
 
 # The in-process connection API was added with the embedded server in 7.10.0.
 # Older distributions can be left behind by an unsupported Core version's
@@ -525,6 +534,62 @@ class EmbeddedServerManager:
         else:
             _purge_ha_mcp_modules()
 
+    async def _async_run_tracked_install_job(
+        self, func: Callable[[], object]
+    ) -> object:
+        """Run a package-mutating executor job, tracked process-wide.
+
+        Registration happens BEFORE dispatch and completion is signalled on
+        the executor thread in a finally, so a bring-up cancelled mid-install
+        leaves behind a waitable job instead of an invisible one.
+        """
+        global _PENDING_INSTALL_DONE
+        done = threading.Event()
+        with _PENDING_INSTALL_LOCK:
+            _PENDING_INSTALL_DONE = done
+
+        def _run() -> object:
+            global _PENDING_INSTALL_DONE
+            try:
+                return func()
+            finally:
+                done.set()
+                with _PENDING_INSTALL_LOCK:
+                    # A newer job may already have replaced the slot.
+                    if _PENDING_INSTALL_DONE is done:
+                        _PENDING_INSTALL_DONE = None
+
+        return await self._hass.async_add_executor_job(_run)
+
+    async def _async_wait_for_pending_install(self) -> None:
+        """Wait out an install job orphaned by a cancelled previous bring-up.
+
+        Raises :class:`EmbeddedServerError` if it is still running after the
+        bounded wait — mutating the package (or importing from it) underneath
+        a live pip job is the same corruption class as purging sys.modules
+        under a live importer.
+        """
+        with _PENDING_INSTALL_LOCK:
+            pending = _PENDING_INSTALL_DONE
+        if pending is None or pending.is_set():
+            return
+        _LOGGER.warning(
+            "A previous bring-up's install job is still running on the "
+            "executor (the bring-up was cancelled but pip cannot be); "
+            "waiting for it to finish before touching the ha-mcp package."
+        )
+        finished = await self._hass.async_add_executor_job(
+            pending.wait, _PENDING_INSTALL_WAIT_SECONDS
+        )
+        if not finished:
+            raise EmbeddedServerError(
+                f"A previous install job was still running after "
+                f"{_PENDING_INSTALL_WAIT_SECONDS:.0f}s; refusing to modify "
+                "the ha-mcp package underneath it. Reload the integration "
+                "to retry.",
+                kind="package",
+            )
+
     async def _async_ensure_package(
         self, *, defer_mutations: bool = False
     ) -> str | None:
@@ -571,6 +636,8 @@ class EmbeddedServerManager:
         Never imports ``ha_mcp`` in this (main) process — that happens only inside
         the worker thread.
         """
+        await self._async_wait_for_pending_install()
+
         stored_spec = self._entry.data.get(DATA_LAST_PIP_SPEC)
         installed_version = await self._hass.async_add_executor_job(
             _installed_ha_mcp_version
@@ -728,7 +795,7 @@ class EmbeddedServerManager:
         kwargs["timeout"] = max(
             int(kwargs.get("timeout") or 0), _PIP_INSTALL_TIMEOUT_SECONDS
         )
-        installed = await self._hass.async_add_executor_job(
+        installed = await self._async_run_tracked_install_job(
             partial(install_package, self._pip_spec, upgrade=True, **kwargs)
         )
         if not installed:
@@ -770,12 +837,17 @@ class EmbeddedServerManager:
         await self._async_remove_distribution(other)
 
     async def _async_remove_distribution(self, dist_name: str) -> None:
-        """Remove a distribution from the same target used for installation."""
+        """Remove a distribution from the same target used for installation.
+
+        Tracked like the install: an uninstall mutates the same package files.
+        """
         target = pip_kwargs(self._hass.config.config_dir).get("target")
         if target is None:
-            await self._hass.async_add_executor_job(_uninstall_distribution, dist_name)
+            await self._async_run_tracked_install_job(
+                partial(_uninstall_distribution, dist_name)
+            )
         else:
-            await self._hass.async_add_executor_job(
+            await self._async_run_tracked_install_job(
                 partial(_uninstall_distribution, dist_name, target=target)
             )
 
@@ -1262,6 +1334,20 @@ def _prune_and_check_importing_workers() -> bool:
             [t for t in _IMPORTING_WORKERS if not t.is_alive()]
         )
         return bool(_IMPORTING_WORKERS)
+
+
+# Completion event of the package-mutating install/uninstall job currently on
+# the executor, if any. asyncio cancellation of a bring-up detaches the
+# awaiter, but the executor job keeps running to completion — untracked, an
+# orphaned pip could swap the distribution's files under the NEXT bring-up's
+# install or its worker's cold import (found in review of the #1904 fixes;
+# pre-existing). The dispatching coroutine registers the event BEFORE handing
+# the job to the executor, and the executor fn sets it in a finally that
+# survives cancellation; the next bring-up waits on it before mutating
+# anything. Process-global for the same reason as _IMPORTING_WORKERS: a
+# manager is recreated on every bring-up.
+_PENDING_INSTALL_LOCK = threading.Lock()
+_PENDING_INSTALL_DONE: threading.Event | None = None
 
 
 # Version of the ha_mcp generation currently cached in sys.modules — set by

--- a/scripts/codeql_quality_gate.py
+++ b/scripts/codeql_quality_gate.py
@@ -68,6 +68,14 @@ ALLOWLIST: tuple[tuple[str, str, str, str], ...] = (
         "completion, which is the required shutdown-sequencing effect.",
     ),
     (
+        "py/ineffectual-statement",
+        "tests/src/unit/test_embedded_server.py",
+        "This statement has no effect",
+        "False positive on bare 'await task' inside pytest.raises("
+        "CancelledError): the await IS the assertion's effect - it delivers "
+        "the cancellation the context manager verifies (shield-contract test).",
+    ),
+    (
         "py/unused-global-variable",
         "src/ha_mcp/__main__.py",
         "_shutdown_in_progress",

--- a/scripts/codeql_quality_gate.py
+++ b/scripts/codeql_quality_gate.py
@@ -77,6 +77,16 @@ ALLOWLIST: tuple[tuple[str, str, str, str], ...] = (
     ),
     (
         "py/unused-global-variable",
+        "custom_components/ha_mcp_tools/embedded_server.py",
+        "_PENDING_INSTALL_DONE",
+        "Cross-method use: _async_run_tracked_install_job registers/clears the "
+        "slot under a 'global' declaration and _async_wait_for_pending_install "
+        "reads it on the NEXT bring-up (a different coroutine). CodeQL's "
+        "single-pass dead-store analysis misses the cross-method read, so the "
+        "assignment looks dead.",
+    ),
+    (
+        "py/unused-global-variable",
         "homeassistant-addon-webhook-proxy/mcp_proxy/__init__.py",
         "_LOGGER_LEVEL_RAISED",
         "Cross-invocation use: set when the debug toggle raises the logger to "

--- a/scripts/codeql_quality_gate.py
+++ b/scripts/codeql_quality_gate.py
@@ -68,14 +68,6 @@ ALLOWLIST: tuple[tuple[str, str, str, str], ...] = (
         "completion, which is the required shutdown-sequencing effect.",
     ),
     (
-        "py/ineffectual-statement",
-        "tests/src/unit/test_embedded_server.py",
-        "This statement has no effect",
-        "False positive on bare 'await task' inside pytest.raises("
-        "CancelledError): the await IS the assertion's effect - it delivers "
-        "the cancellation the context manager verifies (shield-contract test).",
-    ),
-    (
         "py/unused-global-variable",
         "src/ha_mcp/__main__.py",
         "_shutdown_in_progress",

--- a/tests/src/unit/test_embedded_server.py
+++ b/tests/src/unit/test_embedded_server.py
@@ -2490,6 +2490,93 @@ class TestImportingWorkerRegistry:
         assert isinstance(mgr._thread_exc, _StopServe)
 
 
+class TestPendingInstallTracking:
+    """Package-mutating executor jobs must be waitable across bring-ups.
+
+    asyncio cancellation of a bring-up detaches the awaiter but the executor
+    pip job runs to completion; untracked, an orphaned pip could swap the
+    package files under the next bring-up's install or its worker's cold
+    import (review finding on the #1904 fixes).
+    """
+
+    async def test_tracked_job_registers_and_clears(self, tmp_path, monkeypatch):
+        mgr, _hass, _entry = _manager(tmp_path)
+        monkeypatch.setattr(es, "_PENDING_INSTALL_DONE", None)
+        observed: list[bool] = []
+
+        def _job() -> str:
+            with es._PENDING_INSTALL_LOCK:
+                observed.append(es._PENDING_INSTALL_DONE is not None)
+            return "done"
+
+        result = await mgr._async_run_tracked_install_job(_job)
+
+        assert result == "done"
+        assert observed == [True]
+        with es._PENDING_INSTALL_LOCK:
+            assert es._PENDING_INSTALL_DONE is None
+
+    async def test_tracked_job_clears_even_when_the_job_raises(
+        self, tmp_path, monkeypatch
+    ):
+        mgr, _hass, _entry = _manager(tmp_path)
+        monkeypatch.setattr(es, "_PENDING_INSTALL_DONE", None)
+
+        def _job() -> None:
+            raise RuntimeError("pip exploded")
+
+        with pytest.raises(RuntimeError, match="pip exploded"):
+            await mgr._async_run_tracked_install_job(_job)
+
+        with es._PENDING_INSTALL_LOCK:
+            assert es._PENDING_INSTALL_DONE is None
+
+    async def test_wait_returns_once_orphan_finishes(
+        self, tmp_path, monkeypatch, caplog
+    ):
+        mgr, _hass, _entry = _manager(tmp_path)
+        pending = threading.Event()
+        monkeypatch.setattr(es, "_PENDING_INSTALL_DONE", pending)
+        threading.Timer(0.2, pending.set).start()
+
+        with caplog.at_level("WARNING"):
+            await mgr._async_wait_for_pending_install()  # must not raise
+
+        assert "install job is still running on the executor" in caplog.text
+
+    async def test_wait_raises_when_orphan_never_finishes(self, tmp_path, monkeypatch):
+        mgr, _hass, _entry = _manager(tmp_path)
+        monkeypatch.setattr(es, "_PENDING_INSTALL_DONE", threading.Event())
+        monkeypatch.setattr(es, "_PENDING_INSTALL_WAIT_SECONDS", 0.1)
+
+        with pytest.raises(
+            es.EmbeddedServerError, match="refusing to modify"
+        ) as excinfo:
+            await mgr._async_wait_for_pending_install()
+        assert excinfo.value.kind == "package"
+
+    async def test_wait_noop_when_nothing_pending(self, tmp_path, monkeypatch):
+        mgr, _hass, _entry = _manager(tmp_path)
+        monkeypatch.setattr(es, "_PENDING_INSTALL_DONE", None)
+        await mgr._async_wait_for_pending_install()  # must not raise or block
+
+    async def test_ensure_package_waits_before_touching_anything(
+        self, tmp_path, monkeypatch
+    ):
+        mgr, _hass, _entry = _manager(tmp_path)
+
+        class _Sentinel(Exception):
+            pass
+
+        monkeypatch.setattr(
+            mgr,
+            "_async_wait_for_pending_install",
+            AsyncMock(side_effect=_Sentinel),
+        )
+        with pytest.raises(_Sentinel):
+            await mgr._async_ensure_package()
+
+
 class TestImporterAwareBringUp:
     """async_start must register its worker itself and defer package
     mutations while a previous worker is still importing (review findings:

--- a/tests/src/unit/test_embedded_server.py
+++ b/tests/src/unit/test_embedded_server.py
@@ -2639,7 +2639,11 @@ class TestPendingInstallTracking:
         await asyncio.sleep(0)  # let the task reach the shielded await
         task.cancel()
         with pytest.raises(asyncio.CancelledError):
-            await task
+            # Assignment form only to keep CodeQL's ineffectual-statement
+            # heuristic quiet: the await IS the effect (it delivers the
+            # cancellation this context manager asserts) and raises before
+            # the bind ever happens.
+            _ = await task
 
         assert not inner.cancelled()  # the job survives the awaiter's cancel
         inner.set_result(None)

--- a/tests/src/unit/test_embedded_server.py
+++ b/tests/src/unit/test_embedded_server.py
@@ -2560,6 +2560,102 @@ class TestPendingInstallTracking:
         monkeypatch.setattr(es, "_PENDING_INSTALL_DONE", None)
         await mgr._async_wait_for_pending_install()  # must not raise or block
 
+    async def test_finally_leaves_a_foreign_slot_untouched(self, tmp_path, monkeypatch):
+        # The identity guard in the tracked job's finally: if a NEWER job has
+        # already replaced the slot, the older job's cleanup must not clear
+        # it — an unconditional clear would let the next bring-up skip the
+        # wait and mutate the package under the newer, still-running pip.
+        mgr, _hass, _entry = _manager(tmp_path)
+        monkeypatch.setattr(es, "_PENDING_INSTALL_DONE", None)
+        foreign = threading.Event()
+
+        def _job() -> str:
+            with es._PENDING_INSTALL_LOCK:
+                es._PENDING_INSTALL_DONE = foreign
+            return "ok"
+
+        await mgr._async_run_tracked_install_job(_job)
+
+        with es._PENDING_INSTALL_LOCK:
+            assert es._PENDING_INSTALL_DONE is foreign
+
+    async def test_force_install_routes_through_tracking(self, tmp_path, monkeypatch):
+        # The wiring IS the behavioral payload: a revert to a bare
+        # async_add_executor_job would silently reintroduce the orphaned,
+        # untrackable install. Observe the slot from inside the pip stub.
+        mgr, _hass, _entry = _manager(tmp_path)
+        monkeypatch.setattr(es, "_PENDING_INSTALL_DONE", None)
+        monkeypatch.setattr(es, "pip_kwargs", lambda cfg: {})
+        observed: list[bool] = []
+
+        def _fake_install(spec: str, **kwargs: object) -> bool:
+            with es._PENDING_INSTALL_LOCK:
+                observed.append(es._PENDING_INSTALL_DONE is not None)
+            return True
+
+        monkeypatch.setattr(es, "install_package", _fake_install)
+
+        await mgr._async_force_install()
+
+        assert observed == [True]
+        with es._PENDING_INSTALL_LOCK:
+            assert es._PENDING_INSTALL_DONE is None
+
+    async def test_remove_distribution_routes_through_tracking(
+        self, tmp_path, monkeypatch
+    ):
+        mgr, _hass, _entry = _manager(tmp_path)
+        monkeypatch.setattr(es, "_PENDING_INSTALL_DONE", None)
+        monkeypatch.setattr(es, "pip_kwargs", lambda cfg: {})
+        observed: list[bool] = []
+
+        def _fake_uninstall(dist_name: str, *, target: str | None = None) -> bool:
+            with es._PENDING_INSTALL_LOCK:
+                observed.append(es._PENDING_INSTALL_DONE is not None)
+            return True
+
+        monkeypatch.setattr(es, "_uninstall_distribution", _fake_uninstall)
+
+        await mgr._async_remove_distribution("ha-mcp-dev")
+
+        assert observed == [True]
+        with es._PENDING_INSTALL_LOCK:
+            assert es._PENDING_INSTALL_DONE is None
+
+    async def test_dispatch_failure_clears_own_registration(
+        self, tmp_path, monkeypatch
+    ):
+        # If dispatch itself raises (executor shut down), _run never starts
+        # and nothing would ever set the event - the registration must be
+        # rolled back or the next bring-up waits the full budget on a job
+        # that does not exist.
+        mgr, hass, _entry = _manager(tmp_path)
+        monkeypatch.setattr(es, "_PENDING_INSTALL_DONE", None)
+
+        def _refuse(func, *args):
+            raise RuntimeError("cannot schedule new futures after shutdown")
+
+        monkeypatch.setattr(hass, "async_add_executor_job", _refuse)
+
+        with pytest.raises(RuntimeError, match="cannot schedule"):
+            await mgr._async_run_tracked_install_job(lambda: "never runs")
+
+        with es._PENDING_INSTALL_LOCK:
+            assert es._PENDING_INSTALL_DONE is None
+
+    async def test_wait_noop_when_pending_already_set(
+        self, tmp_path, monkeypatch, caplog
+    ):
+        mgr, _hass, _entry = _manager(tmp_path)
+        done = threading.Event()
+        done.set()
+        monkeypatch.setattr(es, "_PENDING_INSTALL_DONE", done)
+
+        with caplog.at_level("WARNING"):
+            await mgr._async_wait_for_pending_install()  # must not raise
+
+        assert "install job is still running" not in caplog.text
+
     async def test_ensure_package_waits_before_touching_anything(
         self, tmp_path, monkeypatch
     ):

--- a/tests/src/unit/test_embedded_server.py
+++ b/tests/src/unit/test_embedded_server.py
@@ -2622,6 +2622,29 @@ class TestPendingInstallTracking:
         with es._PENDING_INSTALL_LOCK:
             assert es._PENDING_INSTALL_DONE is None
 
+    async def test_cancelled_awaiter_does_not_cancel_the_executor_job(
+        self, tmp_path, monkeypatch
+    ):
+        # The dispatch is shielded: cancelling the awaiting bring-up must
+        # leave the executor job to run (a QUEUED job cancelled with the
+        # awaiter would never run _run, stranding the registration forever).
+        mgr, hass, _entry = _manager(tmp_path)
+        monkeypatch.setattr(es, "_PENDING_INSTALL_DONE", None)
+        inner: asyncio.Future = asyncio.get_running_loop().create_future()
+        monkeypatch.setattr(hass, "async_add_executor_job", lambda fn, *a: inner)
+
+        task = asyncio.create_task(
+            mgr._async_run_tracked_install_job(lambda: "never observed")
+        )
+        await asyncio.sleep(0)  # let the task reach the shielded await
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        assert not inner.cancelled()  # the job survives the awaiter's cancel
+        inner.set_result(None)
+        await asyncio.sleep(0)
+
     async def test_dispatch_failure_clears_own_registration(
         self, tmp_path, monkeypatch
     ):


### PR DESCRIPTION
## What does this PR do?

**Alert on out-of-cycle stable mirror tags.** Stable `v1.1.1` was cut on the mirror with no release behind it: an all-skipped, `pull_request`-triggered "Hotfix Release" shell reports an empty job list, which routed the sync gate into its job-absent fail-open ("degrade to tagging") the first time an untagged manifest version existed. The gate's fail-open behavior is deliberately left untouched — fail-closed variants would strand genuine hotfix releases, which publish exclusively from `pull_request` runs. Instead the gate now reports whether it proceeded via fail-open, and the stable-tag step files an alert issue whenever it cuts a **new** tag on such a run — so an accidental out-of-cycle stable is known immediately and the component version gets bumped rather than piled onto. The alert step fails red if the issue cannot be filed; deliberate `workflow_dispatch` re-tags never trigger it.

**Orphaned install jobs.** asyncio cancellation of a bring-up detaches the awaiter, but an executor pip job runs to completion — untracked, it could swap the distribution's files under the next bring-up's install or its worker's cold import (found in review of #1911; pre-existing). The force install and uninstalls now register a completion event before dispatch (set in an executor-side `finally` that survives cancellation, with the dispatch wrapped in `asyncio.shield` so a cancelled awaiter can never queue-cancel the job), and the next bring-up waits — bounded at 600s, matching the readiness cap — for any pending job before touching the package. A dispatch failure rolls the registration back rather than stranding a never-set event.

No version change: the component rides the released 1.2.0, and this ships as its next dev build.

## Type of change
- [x] 🐛 Bug fix

## Testing
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

## Checklist
- [x] I have updated documentation if needed
