### PR TITLE
Validate runtime tool translation placeholders

### DIFF
--- a/src/ha_mcp/settings_ui/_i18n.py
+++ b/src/ha_mcp/settings_ui/_i18n.py
@@ -116,7 +116,12 @@ def load_catalogs(directory: Path = LOCALES_DIR) -> dict[str, dict[str, Any]]:
 
 
 def _validate_placeholder_parity(catalogs: dict[str, dict[str, Any]]) -> None:
-    """Reject translations that drop or invent ``{name}`` placeholders."""
+    """Reject catalog-backed translations with mismatched placeholders.
+
+    Tool metadata normally comes from the runtime API rather than ``en.json``;
+    ``settings.js`` performs the corresponding parity check against those
+    canonical values before displaying a translated tool field.
+    """
     english_messages = catalogs[DEFAULT_LOCALE]["messages"]
     english_tools = catalogs[DEFAULT_LOCALE]["tools"]
     for locale, catalog in catalogs.items():

--- a/src/ha_mcp/settings_ui/settings.js
+++ b/src/ha_mcp/settings_ui/settings.js
@@ -35,11 +35,38 @@ function localizedToolGroup(group) {
   return (I18N_PAYLOAD.tool_groups || {})[group] || group;
 }
 
+function _placeholderNames(value) {
+  return Array.from(new Set(Array.from(
+    String(value || '').matchAll(/\{([a-zA-Z_][a-zA-Z0-9_]*)\}/g),
+    match => match[1]
+  ))).sort();
+}
+
+function _translatedToolField(tool, field, expectedSource, fallback = expectedSource) {
+  const translated = ((I18N_PAYLOAD.tools || {})[tool.name] || {})[field];
+  if (!translated) return fallback;
+  const sourceFields = _placeholderNames(expectedSource);
+  const translatedFields = _placeholderNames(translated);
+  if (sourceFields.join('\0') !== translatedFields.join('\0')) {
+    console.warn(
+      `[ha-mcp] ignoring ${field} translation for ${tool.name}: placeholder mismatch`,
+      {source: sourceFields, translated: translatedFields}
+    );
+    return fallback;
+  }
+  return translated;
+}
+
 function localizedToolCopy(tool, description) {
-  const translated = (I18N_PAYLOAD.tools || {})[tool.name] || {};
+  const sourceTitle = tool.title || tool.name;
   return {
-    title: translated.title || tool.title || tool.name,
-    description: translated.description || description,
+    title: _translatedToolField(tool, 'title', sourceTitle),
+    description: _translatedToolField(
+      tool,
+      'description',
+      tool.description || '',
+      description
+    ),
   };
 }
 

--- a/tests/src/unit/test_settings_ui_js_behavior.py
+++ b/tests/src/unit/test_settings_ui_js_behavior.py
@@ -224,10 +224,17 @@ class TestLocalizationBehavior:
     """Russian catalog application and language-selector behaviour."""
 
     @staticmethod
-    def _localized_dom(locale: str = "ru") -> str:
+    def _localized_dom(
+        locale: str = "ru",
+        *,
+        tools: dict[str, dict[str, str]] | None = None,
+    ) -> str:
         from ha_mcp.settings_ui._i18n import build_payload, serialize_payload
 
-        payload = serialize_payload(build_payload(locale))
+        catalog = build_payload(locale)
+        if tools:
+            catalog["tools"].update(tools)
+        payload = serialize_payload(catalog)
         additions = (
             f'<script id="ha-mcp-i18n" type="application/json">{payload}</script>'
             '<select id="languageToggle"></select>'
@@ -306,6 +313,113 @@ class TestLocalizationBehavior:
         assert not result.errors
         assert 'data-localized-search-match="true"' in result.dom
         assert 'data-source-search-match="true"' in result.dom
+
+    def test_tool_translation_placeholder_mismatch_falls_back_to_source(
+        self, settings_script: str
+    ) -> None:
+        fetches = {
+            **DEFAULT_FETCHES,
+            "/api/settings/tools": {
+                "status": 200,
+                "json": {
+                    "tools": [
+                        {
+                            "name": "ha_placeholder_example",
+                            "title": "Open {entity}",
+                            "description": "Inspect {entity}",
+                            "primary_tag": "System",
+                            "category": "read",
+                        }
+                    ],
+                    "states": {},
+                },
+            },
+        }
+        result = run_script(
+            settings_script,
+            initial_html=self._localized_dom(
+                tools={
+                    "ha_placeholder_example": {
+                        "title": "Открыть",
+                        "description": "Проверить {device}",
+                    }
+                }
+            ),
+            fetch_map=fetches,
+            invoke="""
+              await new Promise(r => setTimeout(r, 200));
+              const row = document.querySelector(
+                '[data-name="ha_placeholder_example"]'
+              );
+              document.body.dataset.placeholderRow = row ? row.textContent : '';
+            """,
+        )
+
+        assert not result.errors
+        assert "Open {entity}" in result.dom
+        assert "Inspect {entity}" in result.dom
+        row_text = re.search(r'data-placeholder-row="([^"]*)"', result.dom)
+        assert row_text is not None
+        assert "Открыть" not in row_text.group(1)
+        assert "Проверить {device}" not in row_text.group(1)
+        warnings = [
+            str(entry["args"]) for entry in result.console if entry["level"] == "warn"
+        ]
+        assert any("title translation" in warning for warning in warnings)
+        assert any("description translation" in warning for warning in warnings)
+
+    def test_tool_translation_placeholder_set_matches_full_metadata(
+        self, settings_script: str
+    ) -> None:
+        fetches = {
+            **DEFAULT_FETCHES,
+            "/api/settings/tools": {
+                "status": 200,
+                "json": {
+                    "tools": [
+                        {
+                            "name": "ha_placeholder_valid",
+                            "title": "Open {entity}",
+                            "description": "Inspect entity\nUse {entity} twice: {entity}",
+                            "primary_tag": "System",
+                            "category": "read",
+                        }
+                    ],
+                    "states": {},
+                },
+            },
+        }
+        result = run_script(
+            settings_script,
+            initial_html=self._localized_dom(
+                tools={
+                    "ha_placeholder_valid": {
+                        "title": "{entity} открыть",
+                        "description": "Проверить {entity}",
+                    }
+                }
+            ),
+            fetch_map=fetches,
+            invoke="""
+              await new Promise(r => setTimeout(r, 200));
+              const row = document.querySelector(
+                '[data-name="ha_placeholder_valid"]'
+              );
+              document.body.dataset.placeholderValidRow = row ? row.textContent : '';
+            """,
+        )
+
+        assert not result.errors
+        row_text = re.search(r'data-placeholder-valid-row="([^"]*)"', result.dom)
+        assert row_text is not None
+        assert "{entity} открыть" in row_text.group(1)
+        assert "Проверить {entity}" in row_text.group(1)
+        assert not any(
+            entry["level"] == "warn"
+            and "translation" in str(entry["args"])
+            and "placeholder mismatch" in str(entry["args"])
+            for entry in result.console
+        )
 
     def test_language_selector_sets_cookie_and_reloads(
         self, settings_script: str


### PR DESCRIPTION
## Summary

- validate translated tool title/description placeholders against the actual runtime tool metadata
- fall back only the invalid translated field while keeping the existing shortened source description for display
- use placeholder set semantics and full source metadata so reordered, repeated, or later-line placeholders are handled correctly
- add jsdom regression coverage for invalid and valid runtime tool translations

## Root cause

Follow-up to #1913. The load-time tool placeholder validation compares localized tools with entries in `en.json`, but the English tool catalog is intentionally empty because canonical tool titles and descriptions come from the runtime API. As a result, the shipped Russian tool overrides were not actually covered by that check.

## Impact

A future translation that drops or invents a runtime tool placeholder no longer renders misleading copy. The affected field safely falls back to the canonical source value and emits a console warning; valid fields on the same tool remain localized.

## Validation

- `14 passed` for localization behavior and catalog tests on the rebased branch
- `161 passed` in the broader settings UI/i18n/sidebar proxy suite before isolating this follow-up commit
- repository-wide `ruff check` passed
- changed Python files pass `ruff format --check`
- `node --check src/ha_mcp/settings_ui/settings.js` passed
- `git diff --check` passed
