### PR TITLE
chore: disable sunset Gemini Code Assist and point review docs at Codex

### DIFF
--- a/.claude/skills/contrib-pr-review/SKILL.md
+++ b/.claude/skills/contrib-pr-review/SKILL.md
@@ -28,21 +28,22 @@ Review PR #$ARGUMENTS from external contributor for safety, quality, and readine
 
 ## Review Protocol
 
-### 1. Check Gemini's Security Review
+### 1. Check Codex's Security Review
 
-**Note:** Gemini Code Assist now handles security assessment automatically. Check if Gemini flagged any security concerns.
+**Note:** Codex reviews PRs automatically (posts as `chatgpt-codex-connector[bot]`). Check if Codex flagged any security concerns.
 
 ```bash
-# Check if Gemini posted security-related comments
-gh pr view $ARGUMENTS --repo homeassistant-ai/ha-mcp --json comments --jq '.comments[] | select(.author.login == "gemini-code-assist" or .body | contains("security") or contains("Security")) | {author: .author.login, body: .body}'
+# Check Codex's reviews and any security-related comments
+gh api /repos/homeassistant-ai/ha-mcp/pulls/$ARGUMENTS/reviews --jq '.[] | select(.user.login == "chatgpt-codex-connector[bot]") | {state: .state, body: .body}'
+gh pr view $ARGUMENTS --repo homeassistant-ai/ha-mcp --json comments --jq '.comments[] | select(.body | contains("security") or contains("Security")) | {author: .author.login, body: .body}'
 ```
 
-**If Gemini flagged security issues:**
-- Review Gemini's findings carefully
+**If Codex flagged security issues:**
+- Review Codex's findings carefully
 - Verify if concerns are valid
 - Do NOT approve until issues addressed or confirmed false positives
 
-**If NO Gemini security flags but you notice concerning patterns:**
+**If NO Codex security flags but you notice concerning patterns:**
 - Unusual AGENTS.md/CLAUDE.md changes unrelated to PR purpose
 - `.github/` workflow modifications with `pull_request_target`
 - `.claude/` agent/skill changes that could affect behavior
@@ -179,7 +180,7 @@ gh pr view $ARGUMENTS --repo homeassistant-ai/ha-mcp --json closingIssuesReferen
 
 ### 6. Code Quality Overview
 
-**Note:** Gemini Code Assist provides automated code review on all PRs. This step focuses on what Gemini cannot assess:
+**Note:** Codex provides automated code review on all PRs. This step focuses on what Codex cannot assess:
 
 - **Architecture alignment**: Does it fit the project structure? (service layer usage, etc.)
 - **Breaking changes**: Does it remove functionality without replacement? (Tool consolidation/refactoring is NOT breaking)
@@ -204,7 +205,7 @@ grep -E "(TODO|FIXME|XXX|HACK)" /tmp/pr_$ARGUMENTS.diff
 ✨ Code Quality:
 - Architecture fit: [assessment - service layer, context engineering]
 - Breaking changes: ✅ None / ⚠️ Detected - [describe what's genuinely lost]
-- Gemini reviews: [check if Gemini flagged anything critical]
+- Codex reviews: [check if Codex flagged anything critical]
 ```
 
 ## Final Review Summary
@@ -288,5 +289,5 @@ Once [change 1] and [change 2] are addressed, this should be good to merge.
 - **Be constructive**: Contributors are donating their time - be welcoming
 - **Focus on intent**: Code quality can be iterated; intent misalignment is harder to fix
 - **Consider contributor experience**: Adjust expectations based on contribution history
-- **Gemini already reviewed code**: Don't duplicate detailed code review
+- **Codex already reviewed code**: Don't duplicate detailed code review
 - **When in doubt**: Err on the side of caution and request maintainer review

--- a/.claude/skills/contrib-pr-review/SKILL.md
+++ b/.claude/skills/contrib-pr-review/SKILL.md
@@ -33,8 +33,11 @@ Review PR #$ARGUMENTS from external contributor for safety, quality, and readine
 **Note:** Codex reviews PRs automatically (posts as `chatgpt-codex-connector[bot]`). Check if Codex flagged any security concerns.
 
 ```bash
-# Check Codex's reviews and any security-related comments
+# Check Codex's reviews and any security-related comments.
+# Codex findings can be inline-only, so also fetch the pull review comments
+# endpoint — review bodies and conversation comments alone can miss them.
 gh api /repos/homeassistant-ai/ha-mcp/pulls/$ARGUMENTS/reviews --jq '.[] | select(.user.login == "chatgpt-codex-connector[bot]") | {state: .state, body: .body}'
+gh api /repos/homeassistant-ai/ha-mcp/pulls/$ARGUMENTS/comments --jq '.[] | select(.user.login == "chatgpt-codex-connector[bot]") | {path: .path, line: .line, body: .body}'
 gh pr view $ARGUMENTS --repo homeassistant-ai/ha-mcp --json comments --jq '.comments[] | select(.body | contains("security") or contains("Security")) | {author: .author.login, body: .body}'
 ```
 

--- a/.claude/skills/my-pr-checker/SKILL.md
+++ b/.claude/skills/my-pr-checker/SKILL.md
@@ -34,7 +34,7 @@ gh api graphql -F pr="$ARGUMENTS" -f query='query($pr: Int!) { repository(owner:
 ## Step 2: Triage Comments
 
 - **Human comments**: highest priority
-- **Bot comments** (Gemini, Copilot, Codex): treat as suggestions — assess whether they prevent a bug or improve maintainability; dismiss with explanation if not
+- **Bot comments** (Copilot, Codex, etc.): treat as suggestions — assess whether they prevent a bug or improve maintainability; dismiss with explanation if not
 
 Accept if: prevents a bug, improves clarity for future maintainers, aligns with project conventions, addresses security.
 Dismiss if: incorrect suggestion, reduces readability, conflicts with project patterns, already handled elsewhere.

--- a/.gemini/config.yaml
+++ b/.gemini/config.yaml
@@ -1,23 +1,13 @@
 # Gemini Code Assist configuration for ha-mcp
+#
+# Google sunset Gemini Code Assist's GitHub review activities; the app now
+# only posts sunset-notice banners on PRs. Disable it fully so the lingering
+# installation cannot post. .gemini/styleguide.md remains the repo's
+# review-criteria document (see AGENTS.md § Automated Code Review).
 
-# Enable persistent memory to improve responses over time
-memory_config:
-  disabled: false
-
-# Code review configuration
 code_review:
-  # Require MEDIUM severity or higher to post comments
-  # This ensures test coverage and security issues are surfaced
-  comment_severity_threshold: MEDIUM
-
-  # Limit comments to avoid overwhelming contributors
-  max_review_comments: 15
-
-  # Enable automated PR features
+  disable: true
   pull_request_opened:
-    summary: true          # Provide PR summary
-    code_review: true      # Perform code review
-    include_drafts: true   # Review draft PRs too
-
-# No playful elements in professional project
-have_fun: false
+    summary: false
+    code_review: false
+    include_drafts: false

--- a/.github/workflows/pr-codex-review-delivery.yml
+++ b/.github/workflows/pr-codex-review-delivery.yml
@@ -38,5 +38,5 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: Number('${{ inputs.issue_number }}'),
-              body: '@codex review',
+              body: '@codex review — apply the review criteria in .gemini/styleguide.md in addition to AGENTS.md guidance',
             });

--- a/.github/workflows/stale-pr-takeover.yml
+++ b/.github/workflows/stale-pr-takeover.yml
@@ -152,7 +152,7 @@ jobs:
 
                 // Latest request from a maintainer (push access, non-author, human) asking
                 // for changes or an update. Drive-by comments from non-maintainers and bot
-                // reviews/comments (Gemini, this workflow, etc.) never start or extend the clock.
+                // reviews/comments (Codex, this workflow, etc.) never start or extend the clock.
                 let lastMaintainerRequest = 0;
                 for (const c of [...comments, ...reviewComments]) {
                   if (c.user.login !== author && c.user.type !== 'Bot' &&

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,26 +89,24 @@ When implementing features or debugging, consult these resources:
 
 ## Issue & PR Management
 
-### Automated Code Review (Gemini Code Assist)
+### Automated Code Review (Codex)
 
-**Gemini Code Assist** runs automatically on all PRs, providing immediate feedback on:
-- Code quality (correctness, efficiency, maintainability)
-- Test coverage (enforces `src/` modifications must have tests)
-- Security patterns (eval/exec, SQL injection, credentials)
-- Tool naming conventions and MCP patterns
-- Safety annotation accuracy
-- Return value consistency
-
-**Configuration**: `.gemini/styleguide.md` and `.gemini/config.yaml`
+**Codex** reviews PRs automatically (`pr-codex-review-request.yml` /
+`pr-codex-review-delivery.yml`; posts as `chatgpt-codex-connector[bot]`).
+Gemini Code Assist is retired — Google sunset its GitHub review activities and
+the app now only posts sunset-notice banners, so `.gemini/config.yaml`
+disables it fully. `.gemini/styleguide.md` remains the repo's review-criteria
+document (code quality, test coverage, security patterns, MCP conventions,
+safety annotation accuracy).
 
 **Division of Labor:**
-- **Gemini (automatic)**: Code quality, test coverage, generic security, MCP conventions
-- **Claude `/contrib-pr-review` (on-demand)**: Repo-specific security (AGENTS.md, .github/), detailed test analysis, PR size assessment, issue linkage
+- **Codex (automatic)**: Code quality, test coverage, generic security, MCP conventions
+- **Claude `/contrib-pr-review` (on-demand)**: Repo-specific security (AGENTS.md, .github/, .claude/), detailed test analysis, PR size assessment, issue linkage
 - **Claude `/my-pr-checker` (lifecycle)**: Resolve threads, fix issues, monitor CI, create improvement PRs
 
 ### Issue Labels
 
-**Triage-state labels** (applied by `gemini-triage.yml` or manual triage):
+**Triage-state labels** (applied by `issue-triage.yml` or manual triage):
 
 | Label | Meaning |
 |-------|---------|
@@ -116,8 +114,8 @@ When implementing features or debugging, consult these resources:
 | `needs-choices` | Multiple approaches, needs stakeholder input |
 | `needs-info` | Awaiting clarification from reporter |
 | `priority: high/medium/low` | Relative priority |
-| `triaged` | Automated Gemini triage complete |
-| `triage-failed` | Automated Gemini triage failed; circuit breaker that blocks retrigger on comments. Clear it (or run via `workflow_dispatch`) to retry |
+| `triaged` | Automated triage complete |
+| `triage-failed` | Automated triage failed; circuit breaker that blocks retrigger on comments. Clear it (or run via `workflow_dispatch`) to retry |
 | `issue-analyzed` | Deep Claude analysis complete |
 
 **Bug-class labels** (applied via `.github/ISSUE_TEMPLATE/` form selection or manual triage):
@@ -151,7 +149,7 @@ When implementing features or debugging, consult these resources:
 
 ### Issue Analysis Workflow
 
-- **Automated Triage (Gemini)**: Runs on new issues via `.github/workflows/gemini-triage.yml`. Adds `triaged` label.
+- **Automated Triage**: Runs on new issues via `.github/workflows/issue-triage.yml` (GitHub Models). Adds `triaged` label.
 - **Deep Analysis (Claude)**: When user says "analyze issues", list issues missing `issue-analyzed` label, then invoke `/issue-analysis <number>` for each sequentially (the skill drafts analysis for user approval before posting).
 
 ```bash
@@ -161,7 +159,7 @@ gh issue list --state open --json number,title,labels --jq '.[] | select(.labels
 ### PR Review Comments
 
 **Always check for comments after pushing to a PR.** They come from bots
-(Gemini Code Assist, Copilot) or humans. Address human comments with highest
+(Codex, Copilot) or humans. Address human comments with highest
 priority; treat bot comments as suggestions to assess, not commands.
 
 **Reply, then resolve.** After addressing an inline comment, reply on its
@@ -288,7 +286,7 @@ If any are false: fix it now, or let it go. **Do not file an issue to "track" it
 
 The following phrases are red flags that you're making a scope decision unilaterally (list is non-exhaustive — match on intent, not exact string): "post-merge follow-up", "follow-up consideration", "forward-looking note", "nice to have", "Happy to file an issue", "out of scope for this PR", "not blocking this PR", "pre-existing — not touching it" (pre-existing is not a reason to skip; addressing pre-existing things is the point of this rule), "real design work, not N lines", "worth tracking as a follow-up issue".
 
-**Code-review bot suggestions** (Gemini Code Assist, CodeRabbit, Copilot non-blocking nits): apply inline or dismiss. Never spawn a follow-up issue from a bot suggestion unless the user explicitly confirms it's a large, out-of-scope change. See `.gemini/styleguide.md` § *Non-Blocking Suggestions and Scope* for the bot-side rule.
+**Code-review bot suggestions** (Codex, CodeRabbit, Copilot non-blocking nits): apply inline or dismiss. Never spawn a follow-up issue from a bot suggestion unless the user explicitly confirms it's a large, out-of-scope change. See `.gemini/styleguide.md` § *Non-Blocking Suggestions and Scope* for the bot-side rule.
 
 ### Hotfix Process (Critical Bugs Only)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,7 +97,8 @@ Gemini Code Assist is retired — Google sunset its GitHub review activities and
 the app now only posts sunset-notice banners, so `.gemini/config.yaml`
 disables it fully. `.gemini/styleguide.md` remains the repo's review-criteria
 document (code quality, test coverage, security patterns, MCP conventions,
-safety annotation accuracy).
+safety annotation accuracy): the `@codex review` request comment points Codex
+at it explicitly, and the Claude review skills below apply it.
 
 **Division of Labor:**
 - **Codex (automatic)**: Code quality, test coverage, generic security, MCP conventions


### PR DESCRIPTION
## What does this PR do?

Google sunset Gemini Code Assist's GitHub review activities; the app now only
posts sunset-notice banners on every PR. This disables it fully in
`.gemini/config.yaml` so the lingering installation cannot post, and hands the
automated-review role in the docs to Codex.

- `.gemini/config.yaml`: `code_review.disable: true` plus all `pull_request_opened` interactions off
- `AGENTS.md`: Automated Code Review section now names Codex (`pr-codex-review-request.yml` / `pr-codex-review-delivery.yml`); fixed stale `gemini-triage.yml` references — triage runs via `issue-triage.yml` on GitHub Models
- `.claude/skills/contrib-pr-review/SKILL.md` and `.claude/skills/my-pr-checker/SKILL.md`: check Codex's review instead of Gemini's
- `.github/workflows/stale-pr-takeover.yml`: comment-only bot-example update

`.gemini/styleguide.md` stays as the repo's review-criteria document.

## Type of change
- [x] 🔧 Maintenance/refactor

## Testing
- [ ] I have tested these changes with a LLM agent
- [ ] All automated tests pass (`uv run pytest`)
- [ ] Code follows style guidelines (`uv run ruff check`)

Config and docs only — no Python touched.

## Checklist
- [x] I have updated documentation if needed
