### PR TITLE
fix: keep MCP URL on one log line; document dev/stable add-on conflict

### DIFF
--- a/homeassistant-addon-dev/README.md
+++ b/homeassistant-addon-dev/README.md
@@ -27,7 +27,8 @@ This is the **development version** of the MCP Server add-on. It receives update
 
 1. Enable "Advanced Mode" in your Home Assistant profile
 2. This add-on will appear in the add-on store (marked as experimental)
-3. Install and configure as normal
+3. **Stop the stable "Home Assistant MCP Server" add-on if you have it installed.** Both add-ons use host networking and bind the same port (9583), so they cannot run at the same time — starting this one while stable is running fails with "address already in use". Changing the port in this add-on's Network configuration does not help: with host networking that setting has no effect.
+4. Install and configure as normal
 
 ## Support
 

--- a/homeassistant-addon/start.py
+++ b/homeassistant-addon/start.py
@@ -47,9 +47,16 @@ def widen_fastmcp_log_console(width: int = 200) -> None:
 
     from rich.logging import RichHandler
 
+    widened = 0
     for handler in logging.getLogger("fastmcp").handlers:
         if isinstance(handler, RichHandler):
             handler.console.width = width
+            widened += 1
+    if not widened:
+        log_warning(
+            "No rich handlers found on the fastmcp logger — "
+            "the MCP URL may wrap across log lines"
+        )
 
 
 def generate_secret_path() -> str:
@@ -762,7 +769,11 @@ def main() -> int:
 
     # Importing ha_mcp pulled in fastmcp, which attached its rich log
     # handlers — widen them before any URL-bearing line is logged (#1918).
-    widen_fastmcp_log_console()
+    # Wrapped because log cosmetics must never block addon startup.
+    try:
+        widen_fastmcp_log_console()
+    except Exception as e:
+        log_warning(f"Could not widen fastmcp log console: {e!r}; continuing")
 
     # Log the ha-mcp version + a self-update banner when a newer release is
     # available. In the add-on that comes from the Supervisor add-on store, not
@@ -830,6 +841,9 @@ def main() -> int:
         log_info("Starting MCP server...")
         if bind_host != "0.0.0.0":
             log_info(f"Bind host overridden via MCP_HOST: {bind_host}")
+        # Do not pass log_level here: fastmcp's temporary_log_level would
+        # rebuild its rich log handlers at the default 80-column width,
+        # undoing widen_fastmcp_log_console (#1918).
         mcp.run(
             transport="http",
             host=bind_host,

--- a/homeassistant-addon/start.py
+++ b/homeassistant-addon/start.py
@@ -34,6 +34,24 @@ def log_error(message: str) -> None:
     _log_with_timestamp("ERROR", message, sys.stderr)
 
 
+def widen_fastmcp_log_console(width: int = 200) -> None:
+    """Widen FastMCP's rich log consoles so the MCP URL never wraps.
+
+    Rich defaults to an 80-column console when stderr is not a TTY (as in
+    the add-on container), which wraps FastMCP's own "Starting MCP server
+    ... on http://0.0.0.0:9583/<secret>" line in the middle of the secret
+    path. A secret split across lines survives the find/replace users do
+    to sanitize logs before sharing them (#1918).
+    """
+    import logging
+
+    from rich.logging import RichHandler
+
+    for handler in logging.getLogger("fastmcp").handlers:
+        if isinstance(handler, RichHandler):
+            handler.console.width = width
+
+
 def generate_secret_path() -> str:
     """Generate a secure random path with 128-bit entropy.
 
@@ -741,6 +759,10 @@ def main() -> int:
         register_browser_landing,
     )
     from ha_mcp.settings_ui import register_settings_routes
+
+    # Importing ha_mcp pulled in fastmcp, which attached its rich log
+    # handlers — widen them before any URL-bearing line is logged (#1918).
+    widen_fastmcp_log_console()
 
     # Log the ha-mcp version + a self-update banner when a newer release is
     # available. In the add-on that comes from the Supervisor add-on store, not

--- a/tests/addon/test_addon_startup.py
+++ b/tests/addon/test_addon_startup.py
@@ -455,6 +455,11 @@ class TestWidenFastmcpLogConsole:
         # Explicit width=80 mirrors rich's non-TTY default in the container.
         handler = RichHandler(console=Console(file=stream, width=80))
         logger = logging.getLogger("fastmcp")
+        # Detach any real fastmcp handlers so the widen only touches the
+        # test's handler (and the fake URL line stays out of stderr).
+        saved = logger.handlers[:]
+        for pre_existing in saved:
+            logger.removeHandler(pre_existing)
         logger.addHandler(handler)
         old_level = logger.level
         logger.setLevel(logging.INFO)
@@ -468,18 +473,61 @@ class TestWidenFastmcpLogConsole:
             assert url in stream.getvalue()
         finally:
             logger.removeHandler(handler)
+            for pre_existing in saved:
+                logger.addHandler(pre_existing)
             logger.setLevel(old_level)
 
     def test_non_rich_handlers_untouched(self):
+        import io
         import logging
+
+        from rich.console import Console
+        from rich.logging import RichHandler
 
         logger = logging.getLogger("fastmcp")
         plain = logging.StreamHandler()
+        rich_handler = RichHandler(console=Console(file=io.StringIO(), width=80))
+        saved = logger.handlers[:]
+        for pre_existing in saved:
+            logger.removeHandler(pre_existing)
         logger.addHandler(plain)
+        logger.addHandler(rich_handler)
+        try:
+            # Must not raise on the console-less StreamHandler, and must
+            # still widen the rich handler sitting next to it.
+            self.addon.widen_fastmcp_log_console()
+            assert rich_handler.console.width == 200
+            assert not hasattr(plain, "console")
+        finally:
+            logger.removeHandler(plain)
+            logger.removeHandler(rich_handler)
+            for pre_existing in saved:
+                logger.addHandler(pre_existing)
+
+    def test_warns_when_no_rich_handlers(self, capfd):
+        """Going inert must leave a signal — support can't otherwise tell
+        whether the widening took effect (same rationale as the DEBUG
+        canary in main())."""
+        import logging
+
+        logger = logging.getLogger("fastmcp")
+        saved = logger.handlers[:]
+        for handler in saved:
+            logger.removeHandler(handler)
         try:
             self.addon.widen_fastmcp_log_console()
         finally:
-            logger.removeHandler(plain)
+            for handler in saved:
+                logger.addHandler(handler)
+        assert "No rich handlers" in capfd.readouterr().err
+
+    def test_main_calls_widen_at_startup(self):
+        """The fix only works if main() actually invokes it after the
+        ha_mcp import attaches fastmcp's handlers — guard the call site."""
+        content = (
+            Path(__file__).parents[2] / "homeassistant-addon" / "start.py"
+        ).read_text(encoding="utf-8")
+        assert "widen_fastmcp_log_console()" in content
 
 
 class TestCleanupStaleMigrationMarker:

--- a/tests/addon/test_addon_startup.py
+++ b/tests/addon/test_addon_startup.py
@@ -430,6 +430,58 @@ class TestResolveEffectiveLogLevel:
         assert "resolve_effective_log_level" in content
 
 
+class TestWidenFastmcpLogConsole:
+    """Unit tests for widen_fastmcp_log_console (#1918).
+
+    FastMCP logs its startup line ("Starting MCP server ... on
+    http://0.0.0.0:9583/<secret>") through a rich console that defaults to
+    80 columns when stderr is not a TTY, wrapping the URL mid-secret. A
+    secret split across lines survives the find/replace users do to
+    sanitize logs before sharing them.
+    """
+
+    @pytest.fixture(autouse=True)
+    def addon(self):
+        self.addon = _load_addon_start()
+
+    def test_startup_url_stays_on_one_line(self):
+        import io
+        import logging
+
+        from rich.console import Console
+        from rich.logging import RichHandler
+
+        stream = io.StringIO()
+        # Explicit width=80 mirrors rich's non-TTY default in the container.
+        handler = RichHandler(console=Console(file=stream, width=80))
+        logger = logging.getLogger("fastmcp")
+        logger.addHandler(handler)
+        old_level = logger.level
+        logger.setLevel(logging.INFO)
+        try:
+            self.addon.widen_fastmcp_log_console()
+            url = f"http://0.0.0.0:9583{self.addon.generate_secret_path()}"
+            logger.info(
+                "Starting MCP server 'ha-mcp' with transport 'http' (stateless) on %s",
+                url,
+            )
+            assert url in stream.getvalue()
+        finally:
+            logger.removeHandler(handler)
+            logger.setLevel(old_level)
+
+    def test_non_rich_handlers_untouched(self):
+        import logging
+
+        logger = logging.getLogger("fastmcp")
+        plain = logging.StreamHandler()
+        logger.addHandler(plain)
+        try:
+            self.addon.widen_fastmcp_log_console()
+        finally:
+            logger.removeHandler(plain)
+
+
 class TestCleanupStaleMigrationMarker:
     """Unit tests for cleanup_stale_migration_marker.
 


### PR DESCRIPTION
## What does this PR do?

Fixes #1918.

- **Dev add-on install docs**: the install steps never said the stable add-on must be stopped first. Both add-on flavors use host networking and bind host port 9583, so they cannot run at the same time — and the port shown in the add-on's Network configuration has no effect with host networking (which is why changing it didn't help the reporter). Added this to the installation steps in `homeassistant-addon-dev/README.md`.
- **Secret URL log wrapping**: FastMCP logs its startup line (`Starting MCP server ... on http://0.0.0.0:9583/<secret>`) through a rich console that defaults to 80 columns when stderr is not a TTY, wrapping the URL in the middle of the secret path. A secret split across lines survives the find/replace users do to sanitize logs before sharing them. `start.py` now widens FastMCP's rich log consoles so the URL stays on one line, logs a warning if it finds no rich handlers to widen (so going inert is diagnosable from logs), and documents at the `mcp.run()` call that passing `log_level` there would rebuild fastmcp's handlers at 80 columns and undo the widen.

## Type of change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [x] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`) — regression tests added in `tests/addon/test_addon_startup.py` (URL stays unwrapped at the new width, zero-handler warning, call-site guard, non-rich handlers tolerated)
- [x] Code follows style guidelines (`uv run ruff check`)

## Checklist
- [x] I have updated documentation if needed
