### PR TITLE
fix: reinstall the embedded server when its pip source changes, not just its version

### DIFF
--- a/custom_components/ha_mcp_tools/embedded_server.py
+++ b/custom_components/ha_mcp_tools/embedded_server.py
@@ -50,6 +50,8 @@ from homeassistant.requirements import (
     pip_kwargs,
 )
 from homeassistant.util.package import install_package
+from packaging.requirements import InvalidRequirement, Requirement
+from packaging.utils import canonicalize_name
 from packaging.version import InvalidVersion, Version
 
 from .const import (
@@ -652,7 +654,7 @@ class EmbeddedServerManager:
         requirements manager; a pinned spec does not move, so there is nothing to
         upgrade to. A CHANGED spec (a new override, a cleared override, a
         toggled auto-update, a channel switch) falls through to the
-        force-install path below — and additionally uninstalls the target
+        force-install path below — and additionally uninstalls the replaced
         distribution first (:meth:`_async_remove_replaced_source`), because
         ``upgrade=True`` alone decides by version and a changed SOURCE can keep
         the version string (issue #1914).
@@ -743,9 +745,7 @@ class EmbeddedServerManager:
         else:
             await self._async_remove_conflicting_dist()
             await self._async_remove_legacy_target(target_dist, installed_version)
-            await self._async_remove_replaced_source(
-                target_dist, stored_spec, installed_version
-            )
+            await self._async_remove_replaced_source(stored_spec, installed_version)
             await self._async_force_install()
 
         version: str | None
@@ -810,13 +810,14 @@ class EmbeddedServerManager:
         """Handle the defer-mutations branch of :meth:`_async_ensure_package`.
 
         A previous bring-up's worker is still importing, so the package files
-        must not be replaced under it. With a build already on disk nothing is
-        touched at all — not even the requirements manager, which installs any
-        unsatisfied spec and would mutate exactly like the deferred force
-        install. When NOTHING usable is installed there are no distribution
-        files to replace under the live importer, and without an install this
-        bring-up cannot produce a server at all, so the requirements manager
-        still runs.
+        must not be replaced under it. With an importable build on disk
+        (``installed_version`` non-None — importability only, compatibility is
+        checked by the caller afterwards) nothing is touched at all — not even
+        the requirements manager, which installs any unsatisfied spec and
+        would mutate exactly like the deferred force install. When nothing
+        imports there are no distribution files to replace under the live
+        importer, and without an install this bring-up cannot produce a
+        server at all, so the requirements manager still runs.
         """
         _LOGGER.warning(
             "Deferring the ha-mcp install/upgrade: a previous bring-up's "
@@ -828,36 +829,78 @@ class EmbeddedServerManager:
         if installed_version is None:
             await self._async_process_requirements_fast()
 
-    async def _async_remove_replaced_source(
-        self, target_dist: str, stored_spec: str | None, installed_version: str | None
-    ) -> None:
-        """Uninstall the target distribution when the requested source changed.
+    def _replaced_dist_name(self) -> str | None:
+        """Return the distribution whose presence could no-op the new spec.
 
-        The forced install that follows relies on ``upgrade=True``, and pip
-        decides "already satisfied" by VERSION alone — but a source change can
-        keep the version string. A GitHub PR tarball carries no git metadata,
-        so it installs with the same base version as the channel release it
-        branched from; clearing that override resolves the channel spec to the
-        exact version already on disk and pip swaps nothing, leaving the PR
-        code running while the entry reports a clean channel install (issue
-        #1914). The same version-blindness bites a manual spec edit that pins
-        the version already installed. pip cannot see the difference, so when
-        the spec that produced the current install differs from the one about
-        to be installed, the installed distribution is removed first — the
-        install that follows is then unconditionally real.
+        This is the distribution the effective spec installs *by name* — the
+        channel's distribution for a channel spec, or the named distribution
+        of an override that parses as a requirement (a pin like
+        ``ha-mcp==X``, matched against the two known channel dists). It is
+        deliberately NOT the channel's dist for every override: a repo
+        tarball installs as ``ha-mcp`` regardless of the selected channel, so
+        keying on the channel would miss the dev-channel + override case.
+
+        Returns None for an override that names an unknown distribution or
+        does not parse as a requirement at all (a direct URL): the installer
+        re-fetches and rebuilds URL requirements under ``upgrade=True``
+        regardless of the installed version, so a URL install is already
+        real and nothing needs removing.
+        """
+        if not self._pip_spec_override:
+            return dist_for_channel(self._channel)
+        try:
+            name = canonicalize_name(Requirement(self._pip_spec_override).name)
+        except InvalidRequirement:
+            return None
+        for dist_name in (DIST_NAME_STABLE, DIST_NAME_DEV):
+            if name == canonicalize_name(dist_name):
+                return dist_name
+        return None
+
+    async def _async_remove_replaced_source(
+        self, stored_spec: str | None, installed_version: str | None
+    ) -> None:
+        """Uninstall the replaced distribution when the requested source changed.
+
+        The forced install that follows relies on ``upgrade=True``, and the
+        installer decides "already satisfied" by VERSION alone — but a source
+        change can keep the version string. A PR branch's committed
+        ``project.version`` equals the release it branched from (only release
+        automation bumps it), so its tarball installs with that same version
+        string; clearing the override then resolves the channel spec to the
+        exact version already on disk and the install swaps nothing, leaving
+        the PR code running while the entry reports a clean channel install
+        (issue #1914). The same version-blindness bites a manual spec edit
+        that pins the version already installed. The installer cannot see the
+        difference, so when the spec that produced the current install
+        differs from the one about to be installed, the distribution the new
+        spec resolves to by name (:meth:`_replaced_dist_name`) is removed
+        first — the install that follows is then unconditionally real.
 
         Skipped when nothing is installed, when the last-installed spec is
         unknown (nothing to compare: first install, or entry data predating
-        the spec tracking), or when the spec is unchanged (the routine
+        the spec tracking), when the spec is unchanged (the routine
         reload/restart path, where ``upgrade=True`` alone is correct and an
         uninstall would churn — and briefly break — a healthy install on
-        every restart).
+        every restart), when the new spec is a direct URL (always installs
+        for real), or when the named distribution is not installed (e.g. a
+        cross-channel switch already removed it).
+
+        Unlike the other pre-install uninstalls this one is NOT best-effort:
+        if the distribution survives a failed uninstall, the forced install
+        would no-op as "already satisfied", the new spec would be persisted,
+        and the next reload would see it as unchanged — reproducing #1914 and
+        then permanently masking it. Raising instead keeps the stored spec on
+        the old value, so the next reload retries the whole source change.
         """
         if installed_version is None or stored_spec is None:
             return
         if stored_spec == self._pip_spec:
             return
-        if not await self._hass.async_add_executor_job(_dist_installed, target_dist):
+        replaced_dist = self._replaced_dist_name()
+        if replaced_dist is None:
+            return
+        if not await self._hass.async_add_executor_job(_dist_installed, replaced_dist):
             return
         _LOGGER.info(
             "The requested server source changed (%r -> %r); removing the "
@@ -865,9 +908,20 @@ class EmbeddedServerManager:
             "already satisfied",
             stored_spec,
             self._pip_spec,
-            target_dist,
+            replaced_dist,
         )
-        await self._async_remove_distribution(target_dist)
+        removed = await self._async_remove_distribution(replaced_dist)
+        if not removed and await self._hass.async_add_executor_job(
+            _dist_installed, replaced_dist
+        ):
+            raise EmbeddedServerError(
+                f"Could not remove the installed {replaced_dist!r} (from "
+                f"{stored_spec!r}) before installing {self._pip_spec!r}: the "
+                "installer would report the new source as already satisfied "
+                "and keep the old code running. Uninstall details are logged "
+                "above; reload the integration to retry the source change.",
+                kind="package",
+            )
 
     async def _async_process_requirements_fast(self) -> None:
         """Fast path: let HA's requirements manager satisfy the override spec."""
@@ -938,20 +992,25 @@ class EmbeddedServerManager:
         )
         await self._async_remove_distribution(other)
 
-    async def _async_remove_distribution(self, dist_name: str) -> None:
+    async def _async_remove_distribution(self, dist_name: str) -> bool:
         """Remove a distribution from the same target used for installation.
 
         Tracked like the install: an uninstall mutates the same package files.
+        Returns whether the uninstall subprocess reported success; callers
+        decide whether a failure is best-effort (channel-conflict / legacy
+        cleanup) or fatal (the replaced-source removal, whose failure would
+        silently void the reinstall — see ``_async_remove_replaced_source``).
         """
         target = pip_kwargs(self._hass.config.config_dir).get("target")
         if target is None:
-            await self._async_run_tracked_install_job(
+            result = await self._async_run_tracked_install_job(
                 partial(_uninstall_distribution, dist_name)
             )
         else:
-            await self._async_run_tracked_install_job(
+            result = await self._async_run_tracked_install_job(
                 partial(_uninstall_distribution, dist_name, target=target)
             )
+        return bool(result)
 
     def _store_installed_spec(self) -> None:
         """Persist the pip spec just installed so a restart skips the reinstall."""

--- a/custom_components/ha_mcp_tools/embedded_server.py
+++ b/custom_components/ha_mcp_tools/embedded_server.py
@@ -897,12 +897,15 @@ class EmbeddedServerManager:
         uninstall would churn — and briefly break — a healthy install on
         every restart), when the new spec is a direct URL (always installs
         for real), when the named distribution is not installed (e.g. a
-        cross-channel switch already removed it), or when the stored spec is
+        cross-channel switch already removed it), when the stored spec is
         an index requirement on the SAME distribution (a repin — e.g.
         toggling auto-update rewrites bare ``ha-mcp`` to ``ha-mcp==X`` —
         draws from the same index either way, so version resolution is
         faithful and uninstalling a healthy install on a preference toggle
-        would only add an offline-breakage window).
+        would only add an offline-breakage window), or when the new spec is
+        an exact pin on a version provably different from the installed one
+        (the install cannot no-op, so the working build stays in place as
+        the fallback if it fails).
 
         Unlike the other pre-install uninstalls this one is NOT best-effort:
         if the distribution survives a failed uninstall, the forced install
@@ -923,6 +926,18 @@ class EmbeddedServerManager:
             # code on disk came from the index too, so "already satisfied by
             # version" is the truth, not the #1914 lie.
             return
+        pinned = _exact_pinned_version(self._pip_spec)
+        if pinned is not None:
+            try:
+                version_moves = Version(pinned) != Version(installed_version)
+            except InvalidVersion:
+                version_moves = False  # unprovable — keep the uninstall
+            if version_moves:
+                # The new pin cannot be satisfied by the installed version, so
+                # the forced install is guaranteed to be real without any
+                # uninstall — and keeping the working build in place preserves
+                # it as the fallback if that install fails (e.g. offline).
+                return
         if not await self._hass.async_add_executor_job(_dist_installed, replaced_dist):
             return
         _LOGGER.info(
@@ -1698,6 +1713,27 @@ def _uninstall_distribution(dist_name: str, *, target: str | None = None) -> boo
         )
         return False
     return True
+
+
+def _exact_pinned_version(spec: str) -> str | None:
+    """Return the version of an exact ``==``/``===`` single-clause pin, or None.
+
+    Anything else — URL specs, bare names, ranges, multi-clause specifiers —
+    returns None: only an exact pin lets the caller prove, without asking the
+    resolver, whether the installed version could satisfy the spec. A
+    wildcard pin (``==7.13.*``) is returned as-is; the caller's ``Version``
+    parse rejects it, which conservatively keeps the uninstall.
+    """
+    try:
+        req = Requirement(spec)
+    except InvalidRequirement:
+        return None
+    if req.url:
+        return None
+    clauses = list(req.specifier)
+    if len(clauses) != 1 or clauses[0].operator not in ("==", "==="):
+        return None
+    return clauses[0].version
 
 
 def _spec_is_index_requirement_on(spec: str, dist_name: str) -> bool:

--- a/custom_components/ha_mcp_tools/embedded_server.py
+++ b/custom_components/ha_mcp_tools/embedded_server.py
@@ -650,9 +650,12 @@ class EmbeddedServerManager:
         When that spec matches the one last installed and the package imports,
         delegate the "already satisfied?" decision to Home Assistant's
         requirements manager; a pinned spec does not move, so there is nothing to
-        upgrade to. A CHANGED spec (a new override, a toggled auto-update, a
-        channel switch) still falls through to the force-install path below so
-        the change actually takes effect.
+        upgrade to. A CHANGED spec (a new override, a cleared override, a
+        toggled auto-update, a channel switch) falls through to the
+        force-install path below — and additionally uninstalls the target
+        distribution first (:meth:`_async_remove_replaced_source`), because
+        ``upgrade=True`` alone decides by version and a changed SOURCE can keep
+        the version string (issue #1914).
 
         On a channel switch the other channel's distribution is uninstalled first
         (:meth:`_async_remove_conflicting_dist`): ``ha-mcp`` and ``ha-mcp-dev``
@@ -731,20 +734,18 @@ class EmbeddedServerManager:
             and installed_version is not None
             and _is_compatible_embedded_version(installed_version)
         )
+        deferred = False
         if fast_path_ok:
             await self._async_process_requirements_fast()
         elif defer_mutations:
-            _LOGGER.warning(
-                "Deferring the ha-mcp install/upgrade: a previous bring-up's "
-                "worker thread is still importing, and replacing the package "
-                "files under it could corrupt that import. The currently "
-                "installed build will be used; reload the integration (or "
-                "restart Home Assistant) to apply the update."
-            )
-            await self._async_process_requirements_fast()
+            deferred = True
+            await self._async_defer_package_mutations(installed_version)
         else:
             await self._async_remove_conflicting_dist()
             await self._async_remove_legacy_target(target_dist, installed_version)
+            await self._async_remove_replaced_source(
+                target_dist, stored_spec, installed_version
+            )
             await self._async_force_install()
 
         version: str | None
@@ -770,7 +771,11 @@ class EmbeddedServerManager:
                 kind="package",
             )
         _LOGGER.info("HA-MCP in-process server package ready (version %s)", version)
-        if stored_spec != self._pip_spec:
+        # A DEFERRED spec change must not be recorded as installed: with the
+        # stored spec advanced, the next reload would see "unchanged", take the
+        # fast path (for a stable spec) and skip the replaced-source uninstall,
+        # so the deferred change would silently never apply.
+        if not deferred and stored_spec != self._pip_spec:
             self._store_installed_spec()
         return version
 
@@ -796,6 +801,71 @@ class EmbeddedServerManager:
             target_installed_version,
             self._pip_spec,
             MIN_EMBEDDED_SERVER_VERSION,
+        )
+        await self._async_remove_distribution(target_dist)
+
+    async def _async_defer_package_mutations(
+        self, installed_version: str | None
+    ) -> None:
+        """Handle the defer-mutations branch of :meth:`_async_ensure_package`.
+
+        A previous bring-up's worker is still importing, so the package files
+        must not be replaced under it. With a build already on disk nothing is
+        touched at all — not even the requirements manager, which installs any
+        unsatisfied spec and would mutate exactly like the deferred force
+        install. When NOTHING usable is installed there are no distribution
+        files to replace under the live importer, and without an install this
+        bring-up cannot produce a server at all, so the requirements manager
+        still runs.
+        """
+        _LOGGER.warning(
+            "Deferring the ha-mcp install/upgrade: a previous bring-up's "
+            "worker thread is still importing, and replacing the package "
+            "files under it could corrupt that import. The currently "
+            "installed build will be used; reload the integration (or "
+            "restart Home Assistant) to apply the update."
+        )
+        if installed_version is None:
+            await self._async_process_requirements_fast()
+
+    async def _async_remove_replaced_source(
+        self, target_dist: str, stored_spec: str | None, installed_version: str | None
+    ) -> None:
+        """Uninstall the target distribution when the requested source changed.
+
+        The forced install that follows relies on ``upgrade=True``, and pip
+        decides "already satisfied" by VERSION alone — but a source change can
+        keep the version string. A GitHub PR tarball carries no git metadata,
+        so it installs with the same base version as the channel release it
+        branched from; clearing that override resolves the channel spec to the
+        exact version already on disk and pip swaps nothing, leaving the PR
+        code running while the entry reports a clean channel install (issue
+        #1914). The same version-blindness bites a manual spec edit that pins
+        the version already installed. pip cannot see the difference, so when
+        the spec that produced the current install differs from the one about
+        to be installed, the installed distribution is removed first — the
+        install that follows is then unconditionally real.
+
+        Skipped when nothing is installed, when the last-installed spec is
+        unknown (nothing to compare: first install, or entry data predating
+        the spec tracking), or when the spec is unchanged (the routine
+        reload/restart path, where ``upgrade=True`` alone is correct and an
+        uninstall would churn — and briefly break — a healthy install on
+        every restart).
+        """
+        if installed_version is None or stored_spec is None:
+            return
+        if stored_spec == self._pip_spec:
+            return
+        if not await self._hass.async_add_executor_job(_dist_installed, target_dist):
+            return
+        _LOGGER.info(
+            "The requested server source changed (%r -> %r); removing the "
+            "installed %r first so the reinstall cannot be skipped as "
+            "already satisfied",
+            stored_spec,
+            self._pip_spec,
+            target_dist,
         )
         await self._async_remove_distribution(target_dist)
 

--- a/custom_components/ha_mcp_tools/embedded_server.py
+++ b/custom_components/ha_mcp_tools/embedded_server.py
@@ -680,9 +680,7 @@ class EmbeddedServerManager:
             _installed_ha_mcp_version
         )
 
-        pending_version = str(
-            self._entry.data.get(DATA_PENDING_INSTALL_VERSION) or ""
-        ).strip()
+        pending_version = self._pending_install_version(defer_mutations)
         target_dist = dist_for_channel(self._channel)
         if not self._pip_spec_override and pending_version:
             # Pin to the requested version. Its own value differs from
@@ -804,6 +802,21 @@ class EmbeddedServerManager:
         )
         await self._async_remove_distribution(target_dist)
 
+    def _pending_install_version(self, defer_mutations: bool) -> str:
+        """Return the update entity's pending-install version, or ``""``.
+
+        Always empty while mutations are deferred, leaving the marker in
+        ``entry.data`` untouched: the deferred branch runs no install, and
+        consuming the marker without an attempt would lose the user's Install
+        click entirely (with auto-update off, the next reload re-pins to the
+        OLD installed version). One-shot means one real ATTEMPT — a deferred
+        bring-up never attempts, so the marker survives to the next
+        undeferred reload (review finding on #1923).
+        """
+        if defer_mutations:
+            return ""
+        return str(self._entry.data.get(DATA_PENDING_INSTALL_VERSION) or "").strip()
+
     async def _async_defer_package_mutations(
         self, installed_version: str | None
     ) -> None:
@@ -883,8 +896,13 @@ class EmbeddedServerManager:
         reload/restart path, where ``upgrade=True`` alone is correct and an
         uninstall would churn — and briefly break — a healthy install on
         every restart), when the new spec is a direct URL (always installs
-        for real), or when the named distribution is not installed (e.g. a
-        cross-channel switch already removed it).
+        for real), when the named distribution is not installed (e.g. a
+        cross-channel switch already removed it), or when the stored spec is
+        an index requirement on the SAME distribution (a repin — e.g.
+        toggling auto-update rewrites bare ``ha-mcp`` to ``ha-mcp==X`` —
+        draws from the same index either way, so version resolution is
+        faithful and uninstalling a healthy install on a preference toggle
+        would only add an offline-breakage window).
 
         Unlike the other pre-install uninstalls this one is NOT best-effort:
         if the distribution survives a failed uninstall, the forced install
@@ -899,6 +917,11 @@ class EmbeddedServerManager:
             return
         replaced_dist = self._replaced_dist_name()
         if replaced_dist is None:
+            return
+        if _spec_is_index_requirement_on(stored_spec, replaced_dist):
+            # Same distribution, same index — only the pin changed. The old
+            # code on disk came from the index too, so "already satisfied by
+            # version" is the truth, not the #1914 lie.
             return
         if not await self._hass.async_add_executor_job(_dist_installed, replaced_dist):
             return
@@ -1675,6 +1698,25 @@ def _uninstall_distribution(dist_name: str, *, target: str | None = None) -> boo
         )
         return False
     return True
+
+
+def _spec_is_index_requirement_on(spec: str, dist_name: str) -> bool:
+    """Return whether ``spec`` is a plain index requirement on ``dist_name``.
+
+    True only for a PEP 508 requirement with no direct-URL part whose
+    canonical name matches — i.e. a spec that installs ``dist_name`` from the
+    package index (bare name or version pin). A direct URL (whether a plain
+    URL string, which does not parse as a requirement, or a ``name @ url``
+    form) returns False: its origin is not the index, so it is a genuine
+    source change for the replaced-source check.
+    """
+    try:
+        req = Requirement(spec)
+    except InvalidRequirement:
+        return False
+    if req.url:
+        return False
+    return canonicalize_name(req.name) == canonicalize_name(dist_name)
 
 
 def _is_compatible_embedded_version(version: str) -> bool:

--- a/custom_components/ha_mcp_tools/manifest.json
+++ b/custom_components/ha_mcp_tools/manifest.json
@@ -21,5 +21,5 @@
     "requirements": [
         "ruamel.yaml>=0.18.0"
     ],
-    "version": "1.2.0"
+    "version": "1.2.1"
 }

--- a/custom_components/ha_mcp_tools/manifest.json
+++ b/custom_components/ha_mcp_tools/manifest.json
@@ -21,5 +21,5 @@
     "requirements": [
         "ruamel.yaml>=0.18.0"
     ],
-    "version": "1.2.1"
+    "version": "1.2.0"
 }

--- a/tests/src/unit/test_embedded_server.py
+++ b/tests/src/unit/test_embedded_server.py
@@ -580,6 +580,160 @@ class TestEnsurePackage:
         assert install_pkg.call_args.args[0] == "ha-mcp==7.13.0"
         assert entry.data[DATA_LAST_PIP_SPEC] == "ha-mcp==7.13.0"
 
+    async def test_failed_replaced_source_uninstall_raises(self, tmp_path, monkeypatch):
+        # If the replaced-source uninstall fails and the distribution is still
+        # present, proceeding would no-op the "forced" install AND persist the
+        # new spec - reproducing #1914 and then masking it as "unchanged" on
+        # every later reload. It must raise instead, keeping the stored spec on
+        # the old value so the next reload retries the source change.
+        tarball = (
+            "https://github.com/homeassistant-ai/ha-mcp/archive/refs/pull/"
+            "1234/head.tar.gz"
+        )
+        install_pkg = MagicMock(return_value=True)
+        uninstall = MagicMock(return_value=False)
+        mgr, _hass, entry = _manager(
+            tmp_path,
+            data={DATA_SECRET_PATH: "/p", DATA_LAST_PIP_SPEC: tarball},
+        )
+        monkeypatch.setattr(es, "install_package", install_pkg)
+        monkeypatch.setattr(es, "pip_kwargs", lambda cfg: {})
+        monkeypatch.setattr(es, "_installed_ha_mcp_version", lambda: "7.13.0")
+        monkeypatch.setattr(
+            es, "_dist_installed", lambda name: name == DIST_NAME_STABLE
+        )
+        monkeypatch.setattr(es, "_uninstall_distribution", uninstall)
+
+        with pytest.raises(es.EmbeddedServerError) as exc:
+            await mgr._async_ensure_package()
+
+        assert exc.value.kind == "package"
+        install_pkg.assert_not_called()
+        assert entry.data[DATA_LAST_PIP_SPEC] == tarball
+
+    async def test_failed_uninstall_with_dist_gone_still_installs(
+        self, tmp_path, monkeypatch
+    ):
+        # A False from the uninstall subprocess is not proof the distribution
+        # survived (e.g. a timeout after the files were removed). When the
+        # re-check shows it gone, the reinstall proceeds normally.
+        tarball = (
+            "https://github.com/homeassistant-ai/ha-mcp/archive/refs/pull/"
+            "1234/head.tar.gz"
+        )
+        install_pkg = MagicMock(return_value=True)
+        uninstall = MagicMock(return_value=False)
+        mgr, _hass, entry = _manager(
+            tmp_path,
+            data={DATA_SECRET_PATH: "/p", DATA_LAST_PIP_SPEC: tarball},
+        )
+        monkeypatch.setattr(es, "install_package", install_pkg)
+        monkeypatch.setattr(es, "pip_kwargs", lambda cfg: {})
+        monkeypatch.setattr(es, "_installed_ha_mcp_version", lambda: "7.13.0")
+        # In call order: conflicting-dist check (ha-mcp-dev absent), then the
+        # replaced-source pre-check (ha-mcp present), then the post-failure
+        # re-check (ha-mcp gone).
+        monkeypatch.setattr(
+            es, "_dist_installed", MagicMock(side_effect=[False, True, False])
+        )
+        monkeypatch.setattr(es, "_uninstall_distribution", uninstall)
+
+        await mgr._async_ensure_package()
+
+        install_pkg.assert_called_once()
+        assert entry.data[DATA_LAST_PIP_SPEC] == DIST_NAME_STABLE
+
+    async def test_dev_channel_override_pin_uninstalls_actual_dist(
+        self, tmp_path, monkeypatch
+    ):
+        # Dev channel + override: a repo tarball occupies the STABLE
+        # distribution name regardless of the selected channel, so re-pointing
+        # the override to a pin must uninstall the dist the pin names
+        # (ha-mcp), not the channel's (ha-mcp-dev) — otherwise the pin looks
+        # already satisfied and the old override code keeps running (#1914 on
+        # the dev channel).
+        tarball = (
+            "https://github.com/homeassistant-ai/ha-mcp/archive/refs/pull/"
+            "1234/head.tar.gz"
+        )
+        install_pkg = MagicMock(return_value=True)
+        uninstall = MagicMock(return_value=True)
+        mgr, _hass, _entry = _manager(
+            tmp_path,
+            options={OPT_CHANNEL: CHANNEL_DEV, OPT_PIP_SPEC: "ha-mcp==7.13.0"},
+            data={DATA_SECRET_PATH: "/p", DATA_LAST_PIP_SPEC: tarball},
+        )
+        monkeypatch.setattr(es, "install_package", install_pkg)
+        monkeypatch.setattr(es, "pip_kwargs", lambda cfg: {})
+        monkeypatch.setattr(es, "_installed_ha_mcp_version", lambda: "7.13.0")
+        monkeypatch.setattr(
+            es, "_dist_installed", lambda name: name == DIST_NAME_STABLE
+        )
+        monkeypatch.setattr(es, "_uninstall_distribution", uninstall)
+
+        await mgr._async_ensure_package()
+
+        uninstall.assert_called_once_with(DIST_NAME_STABLE)
+        install_pkg.assert_called_once()
+        assert install_pkg.call_args.args[0] == "ha-mcp==7.13.0"
+
+    async def test_url_override_change_skips_uninstall(self, tmp_path, monkeypatch):
+        # Re-pointing to a direct-URL spec skips the pre-uninstall: the
+        # installer re-fetches and rebuilds URL requirements under
+        # upgrade=True regardless of the installed version, so the install is
+        # already real — and skipping avoids a needless remove/install gap.
+        old_tarball = (
+            "https://github.com/homeassistant-ai/ha-mcp/archive/refs/pull/"
+            "1111/head.tar.gz"
+        )
+        new_tarball = (
+            "https://github.com/homeassistant-ai/ha-mcp/archive/refs/pull/"
+            "2222/head.tar.gz"
+        )
+        install_pkg = MagicMock(return_value=True)
+        uninstall = MagicMock(return_value=True)
+        mgr, _hass, _entry = _manager(
+            tmp_path,
+            options={OPT_PIP_SPEC: new_tarball},
+            data={DATA_SECRET_PATH: "/p", DATA_LAST_PIP_SPEC: old_tarball},
+        )
+        monkeypatch.setattr(es, "install_package", install_pkg)
+        monkeypatch.setattr(es, "pip_kwargs", lambda cfg: {})
+        monkeypatch.setattr(es, "_installed_ha_mcp_version", lambda: "7.13.0")
+        monkeypatch.setattr(es, "_dist_installed", lambda name: True)
+        monkeypatch.setattr(es, "_uninstall_distribution", uninstall)
+
+        await mgr._async_ensure_package()
+
+        uninstall.assert_not_called()
+        install_pkg.assert_called_once()
+        assert install_pkg.call_args.args[0] == new_tarball
+
+    async def test_replaced_source_skips_when_nothing_installed(
+        self, tmp_path, monkeypatch
+    ):
+        # Stored spec present but the package is gone (externally wiped):
+        # there is nothing to displace, so no uninstall — the force install
+        # alone is already real.
+        install_pkg = MagicMock(return_value=True)
+        uninstall = MagicMock()
+        mgr, _hass, _entry = _manager(
+            tmp_path,
+            data={DATA_SECRET_PATH: "/p", DATA_LAST_PIP_SPEC: "ha-mcp==7.11.0"},
+        )
+        monkeypatch.setattr(es, "install_package", install_pkg)
+        monkeypatch.setattr(es, "pip_kwargs", lambda cfg: {})
+        monkeypatch.setattr(
+            es, "_installed_ha_mcp_version", MagicMock(side_effect=[None, "7.13.0"])
+        )
+        monkeypatch.setattr(es, "_dist_installed", lambda name: False)
+        monkeypatch.setattr(es, "_uninstall_distribution", uninstall)
+
+        await mgr._async_ensure_package()
+
+        uninstall.assert_not_called()
+        install_pkg.assert_called_once()
+
     async def test_unchanged_channel_spec_does_not_uninstall(
         self, tmp_path, monkeypatch
     ):
@@ -895,8 +1049,11 @@ class TestEnsurePackage:
         assert install_pkg.call_args.args[0] == DEFAULT_PIP_SPEC
 
     async def test_no_uninstall_for_explicit_override(self, tmp_path, monkeypatch):
-        # An explicit override has an unknown distribution name, so nothing is
-        # uninstalled even when the other channel's package is present.
+        # No last-installed spec is recorded (fresh entry data), so there is
+        # nothing to compare the override against and the replaced-source
+        # uninstall must not fire — even though the override names an
+        # installed distribution. Conflicting-dist removal is likewise skipped
+        # for overrides (unknown other-channel relationship).
         mgr, _hass, _entry = _manager(
             tmp_path,
             options={OPT_CHANNEL: CHANNEL_DEV, OPT_PIP_SPEC: "ha-mcp==7.11.0"},
@@ -2940,6 +3097,31 @@ class TestImporterAwareBringUp:
         fast.assert_not_awaited()
         force.assert_not_awaited()
         assert entry.data[DATA_LAST_PIP_SPEC] == tarball
+
+    async def test_deferred_incompatible_build_raises_at_compat_gate(
+        self, tmp_path, monkeypatch
+    ):
+        # defer_mutations with an importable-but-legacy build on disk: the
+        # deferred branch touches nothing (replacing files under the live
+        # importer is the corruption being avoided), so the post-branch
+        # compatibility gate rejects the build loudly instead of silently
+        # serving it. The next (undeferred) reload installs for real.
+        mgr, _hass, entry = _manager(tmp_path)
+        monkeypatch.setattr(
+            es, "_installed_ha_mcp_version", lambda preferred_dist=None: "6.2.0"
+        )
+        fast = AsyncMock()
+        force = AsyncMock()
+        monkeypatch.setattr(mgr, "_async_process_requirements_fast", fast)
+        monkeypatch.setattr(mgr, "_async_force_install", force)
+
+        with pytest.raises(es.EmbeddedServerError) as exc:
+            await mgr._async_ensure_package(defer_mutations=True)
+
+        assert exc.value.kind == "package"
+        fast.assert_not_awaited()
+        force.assert_not_awaited()
+        assert DATA_LAST_PIP_SPEC not in entry.data
 
     async def test_deferred_with_nothing_installed_still_installs(
         self, tmp_path, monkeypatch

--- a/tests/src/unit/test_embedded_server.py
+++ b/tests/src/unit/test_embedded_server.py
@@ -481,7 +481,8 @@ class TestEnsurePackage:
 
     async def test_force_install_when_spec_changed(self, tmp_path, monkeypatch):
         # Configured spec differs from the last-installed one (the pre-release
-        # test channel) ⇒ force a real reinstall (upgrade=True), not the fast path.
+        # test channel) ⇒ force a real reinstall (upgrade=True), not the fast
+        # path — and uninstall the replaced source first (#1914).
         mgr, _hass, entry = _manager(
             tmp_path,
             data={DATA_SECRET_PATH: "/p", DATA_LAST_PIP_SPEC: "ha-mcp==7.11.0"},
@@ -489,19 +490,121 @@ class TestEnsurePackage:
         )
         proc = AsyncMock()
         install_pkg = MagicMock(return_value=True)
+        uninstall = MagicMock(return_value=True)
         monkeypatch.setattr(es, "async_process_requirements", proc)
         monkeypatch.setattr(es, "install_package", install_pkg)
         monkeypatch.setattr(es, "pip_kwargs", lambda cfg: {})
         monkeypatch.setattr(es, "_installed_ha_mcp_version", lambda: "7.12.1")
+        monkeypatch.setattr(
+            es, "_dist_installed", lambda name: name == DIST_NAME_STABLE
+        )
+        monkeypatch.setattr(es, "_uninstall_distribution", uninstall)
 
         await mgr._async_ensure_package()
 
         proc.assert_not_awaited()
+        uninstall.assert_called_once_with(DIST_NAME_STABLE)
         install_pkg.assert_called_once()
         assert install_pkg.call_args.args[0] == "ha-mcp==7.12.1"
         assert install_pkg.call_args.kwargs.get("upgrade") is True
         # The just-installed spec is persisted so the next start takes the fast path.
         assert entry.data[DATA_LAST_PIP_SPEC] == "ha-mcp==7.12.1"
+
+    async def test_cleared_override_uninstalls_replaced_source(
+        self, tmp_path, monkeypatch
+    ):
+        # Issue #1914: a PR tarball installs with the same base version as the
+        # channel release it branched from, so after clearing the override the
+        # unpinned channel spec resolves to the version already on disk and
+        # pip's upgrade=True no-ops — the PR code keeps running behind an entry
+        # that reports a clean channel install. The replaced-source uninstall
+        # must run first so the reinstall is real.
+        tarball = (
+            "https://github.com/homeassistant-ai/ha-mcp/archive/refs/pull/"
+            "1234/head.tar.gz"
+        )
+        calls: list[str] = []
+        install_pkg = MagicMock(side_effect=lambda *a, **k: calls.append("i") or True)
+        uninstall = MagicMock(side_effect=lambda *a, **k: calls.append("u") or True)
+        mgr, _hass, entry = _manager(
+            tmp_path,
+            data={DATA_SECRET_PATH: "/p", DATA_LAST_PIP_SPEC: tarball},
+        )
+        monkeypatch.setattr(es, "install_package", install_pkg)
+        monkeypatch.setattr(es, "pip_kwargs", lambda cfg: {})
+        monkeypatch.setattr(es, "_installed_ha_mcp_version", lambda: "7.13.0")
+        monkeypatch.setattr(
+            es, "_dist_installed", lambda name: name == DIST_NAME_STABLE
+        )
+        monkeypatch.setattr(es, "_uninstall_distribution", uninstall)
+
+        await mgr._async_ensure_package()
+
+        uninstall.assert_called_once_with(DIST_NAME_STABLE)
+        install_pkg.assert_called_once()
+        assert install_pkg.call_args.args[0] == DIST_NAME_STABLE
+        assert install_pkg.call_args.kwargs.get("upgrade") is True
+        assert calls == ["u", "i"]  # uninstall strictly before the install
+        assert entry.data[DATA_LAST_PIP_SPEC] == DIST_NAME_STABLE
+
+    async def test_pin_matching_installed_version_still_reinstalls(
+        self, tmp_path, monkeypatch
+    ):
+        # The manual-edit variant of #1914: after a tarball install, a user who
+        # pins the exact version already on disk (to force a "clean" build)
+        # must still get a real reinstall — the pin's version equals the
+        # installed one, so only the replaced-source uninstall makes pip act.
+        tarball = (
+            "https://github.com/homeassistant-ai/ha-mcp/archive/refs/heads/"
+            "some-branch.tar.gz"
+        )
+        install_pkg = MagicMock(return_value=True)
+        uninstall = MagicMock(return_value=True)
+        mgr, _hass, entry = _manager(
+            tmp_path,
+            options={OPT_PIP_SPEC: "ha-mcp==7.13.0"},
+            data={DATA_SECRET_PATH: "/p", DATA_LAST_PIP_SPEC: tarball},
+        )
+        monkeypatch.setattr(es, "install_package", install_pkg)
+        monkeypatch.setattr(es, "pip_kwargs", lambda cfg: {})
+        monkeypatch.setattr(es, "_installed_ha_mcp_version", lambda: "7.13.0")
+        monkeypatch.setattr(
+            es, "_dist_installed", lambda name: name == DIST_NAME_STABLE
+        )
+        monkeypatch.setattr(es, "_uninstall_distribution", uninstall)
+
+        await mgr._async_ensure_package()
+
+        uninstall.assert_called_once_with(DIST_NAME_STABLE)
+        install_pkg.assert_called_once()
+        assert install_pkg.call_args.args[0] == "ha-mcp==7.13.0"
+        assert entry.data[DATA_LAST_PIP_SPEC] == "ha-mcp==7.13.0"
+
+    async def test_unchanged_channel_spec_does_not_uninstall(
+        self, tmp_path, monkeypatch
+    ):
+        # Routine reload/restart on an unpinned channel: the spec is unchanged,
+        # so the replaced-source uninstall must NOT fire — removing a healthy
+        # install on every restart would churn it (and break it whenever the
+        # reinstall then fails, e.g. offline).
+        mgr, _hass, _entry = _manager(
+            tmp_path,
+            data={DATA_SECRET_PATH: "/p", DATA_LAST_PIP_SPEC: DEFAULT_PIP_SPEC},
+        )
+        install_pkg = MagicMock(return_value=True)
+        uninstall = MagicMock()
+        monkeypatch.setattr(es, "install_package", install_pkg)
+        monkeypatch.setattr(es, "pip_kwargs", lambda cfg: {})
+        monkeypatch.setattr(es, "_installed_ha_mcp_version", lambda: "7.13.0")
+        monkeypatch.setattr(
+            es, "_dist_installed", lambda name: name == DIST_NAME_STABLE
+        )
+        monkeypatch.setattr(es, "_uninstall_distribution", uninstall)
+
+        await mgr._async_ensure_package()
+
+        uninstall.assert_not_called()
+        install_pkg.assert_called_once()
 
     async def test_force_install_when_not_installed(self, tmp_path, monkeypatch):
         # First run: package absent ⇒ force install, then persist the spec (the
@@ -2774,8 +2877,9 @@ class TestImporterAwareBringUp:
         self, tmp_path, monkeypatch, caplog
     ):
         # An unpinned dev channel would normally take the uninstall +
-        # force-install path; with defer_mutations it must fall back to the
-        # non-mutating fast path and say so.
+        # force-install path; with defer_mutations and a build already on disk
+        # it must not touch the package at all (not even the requirements
+        # manager, which installs any unsatisfied spec) and say so.
         mgr, _hass, _entry = _manager(
             tmp_path,
             options={OPT_CHANNEL: CHANNEL_DEV},
@@ -2790,20 +2894,79 @@ class TestImporterAwareBringUp:
         force = AsyncMock()
         remove_conflicting = AsyncMock()
         remove_legacy = AsyncMock()
+        remove_replaced = AsyncMock()
         monkeypatch.setattr(mgr, "_async_process_requirements_fast", fast)
         monkeypatch.setattr(mgr, "_async_force_install", force)
         monkeypatch.setattr(mgr, "_async_remove_conflicting_dist", remove_conflicting)
         monkeypatch.setattr(mgr, "_async_remove_legacy_target", remove_legacy)
+        monkeypatch.setattr(mgr, "_async_remove_replaced_source", remove_replaced)
 
         with caplog.at_level("WARNING"):
             ready = await mgr._async_ensure_package(defer_mutations=True)
 
         assert ready == "7.12.1.dev5"
-        fast.assert_awaited_once()
+        fast.assert_not_awaited()
         force.assert_not_awaited()
         remove_conflicting.assert_not_awaited()
         remove_legacy.assert_not_awaited()
+        remove_replaced.assert_not_awaited()
         assert "Deferring the ha-mcp install/upgrade" in caplog.text
+
+    async def test_deferred_spec_change_is_not_recorded_as_installed(
+        self, tmp_path, monkeypatch
+    ):
+        # A deferred spec change must stay pending: recording the NEW spec as
+        # installed would make the next reload see "unchanged", skip the
+        # replaced-source uninstall (and, for a stable spec, take the fast
+        # path), so the deferred change would silently never apply (#1914).
+        tarball = (
+            "https://github.com/homeassistant-ai/ha-mcp/archive/refs/pull/"
+            "1234/head.tar.gz"
+        )
+        mgr, _hass, entry = _manager(
+            tmp_path,
+            data={DATA_SECRET_PATH: "/p", DATA_LAST_PIP_SPEC: tarball},
+        )
+        monkeypatch.setattr(
+            es, "_installed_ha_mcp_version", lambda preferred_dist=None: "7.13.0"
+        )
+        fast = AsyncMock()
+        force = AsyncMock()
+        monkeypatch.setattr(mgr, "_async_process_requirements_fast", fast)
+        monkeypatch.setattr(mgr, "_async_force_install", force)
+
+        await mgr._async_ensure_package(defer_mutations=True)
+
+        fast.assert_not_awaited()
+        force.assert_not_awaited()
+        assert entry.data[DATA_LAST_PIP_SPEC] == tarball
+
+    async def test_deferred_with_nothing_installed_still_installs(
+        self, tmp_path, monkeypatch
+    ):
+        # defer_mutations with NO build on disk: there are no distribution
+        # files to replace under the live importer, and without an install this
+        # bring-up cannot produce a server at all — the requirements manager
+        # must still run.
+        mgr, _hass, entry = _manager(tmp_path)
+        monkeypatch.setattr(
+            es,
+            "_installed_ha_mcp_version",
+            MagicMock(side_effect=[None, "7.13.0"]),
+        )
+        fast = AsyncMock()
+        force = AsyncMock()
+        monkeypatch.setattr(mgr, "_async_process_requirements_fast", fast)
+        monkeypatch.setattr(mgr, "_async_force_install", force)
+
+        ready = await mgr._async_ensure_package(defer_mutations=True)
+
+        assert ready == "7.13.0"
+        fast.assert_awaited_once()
+        force.assert_not_awaited()
+        # Still a deferred bring-up: nothing is recorded as installed, so the
+        # next (undeferred) reload applies the configured spec for real.
+        assert DATA_LAST_PIP_SPEC not in entry.data
 
 
 class TestPurgeSkippedOnWarmCache:

--- a/tests/src/unit/test_embedded_server.py
+++ b/tests/src/unit/test_embedded_server.py
@@ -480,9 +480,11 @@ class TestEnsurePackage:
         assert install_pkg.call_args.kwargs.get("upgrade") is True
 
     async def test_force_install_when_spec_changed(self, tmp_path, monkeypatch):
-        # Configured spec differs from the last-installed one (the pre-release
-        # test channel) ⇒ force a real reinstall (upgrade=True), not the fast
-        # path — and uninstall the replaced source first (#1914).
+        # Configured spec differs from the last-installed one ⇒ force a real
+        # reinstall (upgrade=True), not the fast path. Both specs are index
+        # pins on the SAME distribution, so no replaced-source uninstall: the
+        # index's version resolution is faithful for a repin, and the version
+        # change makes the install real by itself.
         mgr, _hass, entry = _manager(
             tmp_path,
             data={DATA_SECRET_PATH: "/p", DATA_LAST_PIP_SPEC: "ha-mcp==7.11.0"},
@@ -503,12 +505,42 @@ class TestEnsurePackage:
         await mgr._async_ensure_package()
 
         proc.assert_not_awaited()
-        uninstall.assert_called_once_with(DIST_NAME_STABLE)
+        uninstall.assert_not_called()
         install_pkg.assert_called_once()
         assert install_pkg.call_args.args[0] == "ha-mcp==7.12.1"
         assert install_pkg.call_args.kwargs.get("upgrade") is True
         # The just-installed spec is persisted so the next start takes the fast path.
         assert entry.data[DATA_LAST_PIP_SPEC] == "ha-mcp==7.12.1"
+
+    async def test_auto_update_toggle_repin_does_not_uninstall(
+        self, tmp_path, monkeypatch
+    ):
+        # Turning auto-update off rewrites the stored bare channel spec to a
+        # pin on the installed version. That is a repin on the same index
+        # distribution, not a source change — uninstalling the healthy
+        # install for it would only open an offline-breakage window (review
+        # finding on #1923).
+        install_pkg = MagicMock(return_value=True)
+        uninstall = MagicMock()
+        mgr, _hass, _entry = _manager(
+            tmp_path,
+            options={OPT_AUTO_UPDATE: False},
+            data={DATA_SECRET_PATH: "/p", DATA_LAST_PIP_SPEC: DEFAULT_PIP_SPEC},
+        )
+        monkeypatch.setattr(es, "install_package", install_pkg)
+        monkeypatch.setattr(es, "pip_kwargs", lambda cfg: {})
+        monkeypatch.setattr(es, "_installed_ha_mcp_version", lambda: "7.13.0")
+        monkeypatch.setattr(es, "_installed_dist_version", lambda dist: "7.13.0")
+        monkeypatch.setattr(
+            es, "_dist_installed", lambda name: name == DIST_NAME_STABLE
+        )
+        monkeypatch.setattr(es, "_uninstall_distribution", uninstall)
+
+        await mgr._async_ensure_package()
+
+        uninstall.assert_not_called()
+        install_pkg.assert_called_once()
+        assert install_pkg.call_args.args[0] == f"{DIST_NAME_STABLE}==7.13.0"
 
     async def test_cleared_override_uninstalls_replaced_source(
         self, tmp_path, monkeypatch
@@ -1141,6 +1173,31 @@ class TestPendingInstallMarker:
         await mgr._async_ensure_package()
 
         assert mgr._pip_spec == "ha-mcp==7.10.0"
+
+    async def test_marker_survives_deferred_bringup(self, tmp_path, monkeypatch):
+        # A deferred bring-up runs no install, so it must not consume the
+        # Install click: the marker stays in entry.data for the next
+        # undeferred reload, and the spec is not pinned to the requested
+        # version this round (review finding on #1923 — losing the marker
+        # with auto-update off silently re-pins to the OLD version).
+        mgr, _hass, entry = _manager(
+            tmp_path,
+            data={DATA_SECRET_PATH: "/p", DATA_PENDING_INSTALL_VERSION: "7.12.1"},
+        )
+        monkeypatch.setattr(
+            es, "_installed_ha_mcp_version", lambda preferred_dist=None: "7.13.0"
+        )
+        fast = AsyncMock()
+        force = AsyncMock()
+        monkeypatch.setattr(mgr, "_async_process_requirements_fast", fast)
+        monkeypatch.setattr(mgr, "_async_force_install", force)
+
+        await mgr._async_ensure_package(defer_mutations=True)
+
+        fast.assert_not_awaited()
+        force.assert_not_awaited()
+        assert entry.data[DATA_PENDING_INSTALL_VERSION] == "7.12.1"
+        assert mgr._pip_spec == DIST_NAME_STABLE
 
     async def test_marker_cleared_after_successful_install(self, tmp_path, monkeypatch):
         mgr, _hass, entry = _manager(

--- a/tests/src/unit/test_embedded_server.py
+++ b/tests/src/unit/test_embedded_server.py
@@ -766,6 +766,39 @@ class TestEnsurePackage:
         uninstall.assert_not_called()
         install_pkg.assert_called_once()
 
+    async def test_pin_to_different_version_after_tarball_skips_uninstall(
+        self, tmp_path, monkeypatch
+    ):
+        # Moving from a tarball to a pin on a DIFFERENT version than what is
+        # installed: the pin cannot be satisfied by the installed build, so
+        # the forced install is provably real without an uninstall — and the
+        # working build stays in place as the fallback if the install fails
+        # (review finding on #1923).
+        tarball = (
+            "https://github.com/homeassistant-ai/ha-mcp/archive/refs/pull/"
+            "1234/head.tar.gz"
+        )
+        install_pkg = MagicMock(return_value=True)
+        uninstall = MagicMock()
+        mgr, _hass, _entry = _manager(
+            tmp_path,
+            options={OPT_PIP_SPEC: "ha-mcp==7.14.0"},
+            data={DATA_SECRET_PATH: "/p", DATA_LAST_PIP_SPEC: tarball},
+        )
+        monkeypatch.setattr(es, "install_package", install_pkg)
+        monkeypatch.setattr(es, "pip_kwargs", lambda cfg: {})
+        monkeypatch.setattr(es, "_installed_ha_mcp_version", lambda: "7.13.0")
+        monkeypatch.setattr(
+            es, "_dist_installed", lambda name: name == DIST_NAME_STABLE
+        )
+        monkeypatch.setattr(es, "_uninstall_distribution", uninstall)
+
+        await mgr._async_ensure_package()
+
+        uninstall.assert_not_called()
+        install_pkg.assert_called_once()
+        assert install_pkg.call_args.args[0] == "ha-mcp==7.14.0"
+
     async def test_unchanged_channel_spec_does_not_uninstall(
         self, tmp_path, monkeypatch
     ):


### PR DESCRIPTION
## What does this PR do?

Fixes #1914: clearing a PR-tarball `pip_spec` override (or manually re-pointing the spec) left the previously-installed code running. The forced install relies on `--upgrade` semantics, and the installer decides "already satisfied" by version alone — a PR branch's committed `project.version` equals the release it branched from, so its tarball installs with the same version string as the channel build. Clearing the override then resolved to the version already on disk and swapped nothing, while `info` reported a clean channel install.

The fix is component-side, in `_async_ensure_package`, so it covers the `ha_dev_manage_server` flow *and* manual options-flow edits:

- **Uninstall the replaced source first**: when the spec that produced the current install (`DATA_LAST_PIP_SPEC`) differs from the spec about to be installed, the distribution the new spec resolves to *by name* (channel dist, or a pin's parsed requirement name — a repo tarball occupies `ha-mcp` regardless of channel) is uninstalled before the forced install, making the reinstall unconditionally real. Direct-URL specs skip the pre-uninstall (the installer always re-fetches and rebuilds URL requirements under `--upgrade`). Unchanged specs — routine reloads/restarts — keep pure upgrade semantics: no churn on the normal path.
- **The uninstall is strict, not best-effort**: if the distribution survives a failed uninstall, bring-up raises (package repair issue) instead of proceeding — a silent no-op install would persist the new spec and permanently mask the stale code as "unchanged". The stored spec stays on the old value, so the next reload retries.
- **Deferred mutations stay pending**: the defer-mutations branch no longer records the new spec as installed (the deferred change would otherwise read as "unchanged" on the next reload and silently never apply), and touches nothing while an importable build is on disk (the requirements manager installs any unsatisfied spec — the exact mutation being deferred). With nothing importable it still installs, since there are no files to corrupt and no server otherwise.

No component version bump: master already leads stable (1.2.0 pending vs 1.1.0 released), so this rides under the existing pending version per AGENTS.md.

## Type of change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

## Checklist
- [x] I have updated documentation if needed