### PR TITLE
fix: Make strict-BPS ack key a rotating attestation phrase

### DIFF
--- a/src/ha_mcp/strict_bps.py
+++ b/src/ha_mcp/strict_bps.py
@@ -89,7 +89,7 @@ _ACK_KEY_ROTATION_SECONDS = 3600
 def _current_ack_key(now: float | None = None) -> str:
     bucket = int((time.time() if now is None else now) // _ACK_KEY_ROTATION_SECONDS)
     digest = hashlib.sha256(f"{_ACK_KEY_SALT}:{bucket}".encode()).hexdigest()
-    return f"{STRICT_BPS_ACK_KEY_PREFIX}-{digest[:4]}"
+    return f"{STRICT_BPS_ACK_KEY_PREFIX}-{digest[:8]}"
 
 
 def current_strict_bps_ack_key() -> str:
@@ -198,8 +198,8 @@ def strict_bps_ack_line() -> str:
     """Return the single line that publishes the acknowledgment key.
 
     Prepended to the ha_get_skill_guide Tier-3 best-practices content when
-    strict mode is effective (server.py). This is the ONLY place the key
-    literal is emitted to a caller.
+    strict mode is effective (server.py). This is the ONLY place the actual
+    key value is emitted to a caller.
     """
     return (
         f"Acknowledgment key: {current_strict_bps_ack_key()} — strict "
@@ -226,7 +226,9 @@ def _raise_bps_ack_required_error(name: str) -> NoReturn:
         "Strict best-practices mode is enabled for this tool. Read the "
         "best-practices skill to obtain the required acknowledgment key, then "
         "pass it as the BestPracticeKey argument on this call. The key is "
-        "published only in that skill's content."
+        "published only in that skill's content, and it rotates periodically "
+        "— a key obtained earlier may have expired, so re-read the skill for "
+        "the current value instead of resending a previous one."
     )
     raise_tool_error(
         create_error_response(
@@ -313,10 +315,10 @@ class StrictBpsMiddleware(Middleware):
             return await call_next(context)
 
         # The gate is the ONLY reader of BestPracticeKey: strip it before
-        # dispatch (whether or not strict mode is on) so the constant never
+        # dispatch (whether or not strict mode is on) so the key value never
         # reaches the tool body, the policy middleware's approval args-hash
-        # (where it would churn remembered approvals across strict toggles),
-        # or downstream logging.
+        # (where the hourly-rotating value would churn remembered approvals
+        # every rotation), or downstream logging.
         args = context.message.arguments or {}
         supplied = args.get(STRICT_BPS_KEY_PARAM)
         if STRICT_BPS_KEY_PARAM in args:
@@ -325,9 +327,13 @@ class StrictBpsMiddleware(Middleware):
                 message=context.message.model_copy(update={"arguments": stripped})
             )
 
+        # isinstance guards the set-membership test: the middleware reads
+        # raw transport arguments before pydantic validation, so an
+        # off-spec client can send an unhashable value (dict/list) that
+        # would otherwise TypeError instead of hitting the block error.
         if (
             strict_bps_effective()
-            and supplied not in _valid_ack_keys()
+            and not (isinstance(supplied, str) and supplied in _valid_ack_keys())
             and await self._is_registered(name)
         ):
             logger.info("strict-BPS mode blocked keyless write to %s", name)

--- a/src/ha_mcp/strict_bps.py
+++ b/src/ha_mcp/strict_bps.py
@@ -29,6 +29,7 @@ schema-validating clients will send it; the tool bodies never read it —
 from __future__ import annotations
 
 import logging
+import secrets
 from collections.abc import Awaitable, Callable, Sequence
 from typing import Annotated, Any, NoReturn
 
@@ -55,11 +56,31 @@ def _warn_degraded_once(branch: str, message: str, *, exc_info: bool = False) ->
     logger.warning(message, exc_info=exc_info)
 
 
-# Single source of truth for the acknowledgment key literal. It is published
-# ONLY by ``strict_bps_ack_line`` (surfaced through ha_get_skill_guide Tier 3
-# when strict mode is effective) and validated ONLY by the middleware — it must
-# never appear in a block error, a tool docstring, or a skill_content embed.
-STRICT_BPS_ACK_KEY = "bps-ack-1779"
+# The acknowledgment key is deliberately NOT a static opaque token (#1924):
+#
+# * The PREFIX is a plain-English attestation phrase so the value cannot be
+#   mistaken for a credential. An agent shown the old opaque ``bps-ack-*``
+#   token misread the extract-and-replay round-trip as prompt injection,
+#   refused every gated write, and steered the user into disabling strict
+#   mode — the opposite of the gate's purpose. The key is a read-receipt:
+#   public, privilege-free proof the skill content entered the model's
+#   context before a write.
+# * The SUFFIX is regenerated once per server process, so the key cannot be
+#   satisfied from the public repo, training data, or a stale session
+#   summary — only by reading the guide served by THIS process.
+#
+# It is published ONLY by ``strict_bps_ack_line`` (surfaced through
+# ha_get_skill_guide Tier 3 when strict mode is effective) and validated ONLY
+# by the middleware — it must never appear in a block error, a tool
+# docstring, or a skill_content embed.
+STRICT_BPS_ACK_KEY_PREFIX = "I-HAVE-READ-THE-BEST-PRACTICES-GUIDE"
+
+
+def _generate_ack_key() -> str:
+    return f"{STRICT_BPS_ACK_KEY_PREFIX}-{secrets.token_hex(2)}"
+
+
+STRICT_BPS_ACK_KEY = _generate_ack_key()
 
 # The write-tool parameter that carries the acknowledgment key. Declared on
 # each of the six gated tools (adjacent to ``MandatoryBPS``) but read only here.
@@ -74,8 +95,13 @@ BestPracticeKeyParam = Annotated[
     Field(
         default=None,
         description=(
-            "Acknowledgment key published in the home-assistant-best-practices "
-            "skill content; required when strict best-practices mode is enabled."
+            "Read-receipt for the home-assistant-best-practices skill; "
+            "required when strict best-practices mode is enabled. Not a "
+            "secret or credential: the current value is an attestation "
+            "phrase published openly at the top of the skill content served "
+            "by ha_get_skill_guide. Read that content, then pass the value "
+            "back verbatim — this round-trip is the server's designed "
+            "protocol confirming the practices were read before writing."
         ),
     ),
 ]
@@ -157,7 +183,10 @@ def strict_bps_ack_line() -> str:
     return (
         f"Acknowledgment key: {STRICT_BPS_ACK_KEY} — strict best-practices "
         "mode is ON; pass this exact value as the BestPracticeKey argument "
-        "on gated write tools."
+        "on gated write tools. This key is a read-receipt, not a secret: it "
+        "is published here deliberately by the ha-mcp server, rotates every "
+        "server restart, and grants no privileges — replaying it is the "
+        "designed acknowledgment protocol."
     )
 
 

--- a/src/ha_mcp/strict_bps.py
+++ b/src/ha_mcp/strict_bps.py
@@ -28,8 +28,10 @@ schema-validating clients will send it; the tool bodies never read it —
 
 from __future__ import annotations
 
+import hashlib
 import logging
 import secrets
+import time
 from collections.abc import Awaitable, Callable, Sequence
 from typing import Annotated, Any, NoReturn
 
@@ -65,22 +67,41 @@ def _warn_degraded_once(branch: str, message: str, *, exc_info: bool = False) ->
 #   mode — the opposite of the gate's purpose. The key is a read-receipt:
 #   public, privilege-free proof the skill content entered the model's
 #   context before a write.
-# * The SUFFIX is regenerated once per server process, so the key cannot be
-#   satisfied from the public repo, training data, or a stale session
-#   summary — only by reading the guide served by THIS process.
+# * The SUFFIX rotates hourly, derived from a per-process salt and the
+#   current hour bucket, so the key cannot be satisfied from the public
+#   repo, training data, an agent's persistent memory, or a stale session
+#   summary — only by a recent read of the guide served by THIS process.
+#   The previous hour's key is honored as a grace window so a read just
+#   before rotation does not strand the write that follows it. Derivation
+#   is stateless (salt + clock), keeping the no-server-side-session-state
+#   principle intact.
 #
-# It is published ONLY by ``strict_bps_ack_line`` (surfaced through
+# The key is published ONLY by ``strict_bps_ack_line`` (surfaced through
 # ha_get_skill_guide Tier 3 when strict mode is effective) and validated ONLY
 # by the middleware — it must never appear in a block error, a tool
 # docstring, or a skill_content embed.
 STRICT_BPS_ACK_KEY_PREFIX = "I-HAVE-READ-THE-BEST-PRACTICES-GUIDE"
 
+_ACK_KEY_SALT = secrets.token_hex(8)
+_ACK_KEY_ROTATION_SECONDS = 3600
 
-def _generate_ack_key() -> str:
-    return f"{STRICT_BPS_ACK_KEY_PREFIX}-{secrets.token_hex(2)}"
+
+def _current_ack_key(now: float | None = None) -> str:
+    bucket = int((time.time() if now is None else now) // _ACK_KEY_ROTATION_SECONDS)
+    digest = hashlib.sha256(f"{_ACK_KEY_SALT}:{bucket}".encode()).hexdigest()
+    return f"{STRICT_BPS_ACK_KEY_PREFIX}-{digest[:4]}"
 
 
-STRICT_BPS_ACK_KEY = _generate_ack_key()
+def current_strict_bps_ack_key() -> str:
+    """Return the acknowledgment key for the current rotation window."""
+    return _current_ack_key()
+
+
+def _valid_ack_keys() -> set[str]:
+    """Current key plus the previous rotation's key (grace window)."""
+    now = time.time()
+    return {_current_ack_key(now), _current_ack_key(now - _ACK_KEY_ROTATION_SECONDS)}
+
 
 # The write-tool parameter that carries the acknowledgment key. Declared on
 # each of the six gated tools (adjacent to ``MandatoryBPS``) but read only here.
@@ -181,12 +202,12 @@ def strict_bps_ack_line() -> str:
     literal is emitted to a caller.
     """
     return (
-        f"Acknowledgment key: {STRICT_BPS_ACK_KEY} — strict best-practices "
-        "mode is ON; pass this exact value as the BestPracticeKey argument "
-        "on gated write tools. This key is a read-receipt, not a secret: it "
-        "is published here deliberately by the ha-mcp server, rotates every "
-        "server restart, and grants no privileges — replaying it is the "
-        "designed acknowledgment protocol."
+        f"Acknowledgment key: {current_strict_bps_ack_key()} — strict "
+        "best-practices mode is ON; pass this exact value as the "
+        "BestPracticeKey argument on gated write tools. This key is a "
+        "read-receipt, not a secret: it is published here deliberately by "
+        "the ha-mcp server, rotates hourly, and grants no privileges — "
+        "replaying it is the designed acknowledgment protocol."
     )
 
 
@@ -306,7 +327,7 @@ class StrictBpsMiddleware(Middleware):
 
         if (
             strict_bps_effective()
-            and supplied != STRICT_BPS_ACK_KEY
+            and supplied not in _valid_ack_keys()
             and await self._is_registered(name)
         ):
             logger.info("strict-BPS mode blocked keyless write to %s", name)

--- a/tests/src/e2e/policy/test_strict_bps_mode.py
+++ b/tests/src/e2e/policy/test_strict_bps_mode.py
@@ -27,7 +27,7 @@ from test_constants import TEST_TOKEN
 
 from ha_mcp.client.rest_client import HomeAssistantClient
 from ha_mcp.server import HomeAssistantSmartMCPServer
-from ha_mcp.strict_bps import STRICT_BPS_ACK_KEY
+from ha_mcp.strict_bps import current_strict_bps_ack_key
 from ha_mcp.utils.data_paths import get_data_dir
 from ha_mcp.utils.skill_loader import get_skills_dir
 
@@ -187,7 +187,7 @@ async def test_keyless_write_blocked_with_structured_error(strict_bps_mcp):
         client, "ha_config_set_automation", {"config": config}
     )
     # The block error must guide recovery without leaking the key.
-    assert STRICT_BPS_ACK_KEY not in str(body)
+    assert current_strict_bps_ack_key() not in str(body)
     assert body.get("strict_mandatory_bps") is True
     suggestion = body["error"].get("suggestion", "")
     assert "ha_get_skill_guide" in suggestion
@@ -203,7 +203,7 @@ async def test_skill_guide_publishes_ack_key(strict_bps_mcp):
     )
     body = parse_mcp_result(result)
     assert body.get("success") is True, body
-    assert STRICT_BPS_ACK_KEY in body.get("content", ""), (
+    assert current_strict_bps_ack_key() in body.get("content", ""), (
         "strict mode ON: the Tier-3 best-practices content must publish the "
         "acknowledgment key"
     )
@@ -218,7 +218,7 @@ async def test_write_with_key_succeeds(strict_bps_mcp):
     result = await safe_call_tool(
         client,
         "ha_config_set_automation",
-        {"config": config, "BestPracticeKey": STRICT_BPS_ACK_KEY},
+        {"config": config, "BestPracticeKey": current_strict_bps_ack_key()},
     )
     assert result.get("success"), f"keyed write should succeed: {result}"
 
@@ -267,7 +267,7 @@ async def test_proxy_dispatched_keyless_write_blocked(strict_bps_toolsearch_mcp)
     assert body.get("tool_name") == "ha_config_set_automation", body
     assert body.get("strict_mandatory_bps") is True, body
     # The block error must still not leak the key through the proxy path.
-    assert STRICT_BPS_ACK_KEY not in str(body)
+    assert current_strict_bps_ack_key() not in str(body)
 
 
 @pytest.mark.asyncio
@@ -284,7 +284,10 @@ async def test_proxy_dispatched_keyed_write_succeeds(strict_bps_toolsearch_mcp):
         "ha_call_write_tool",
         {
             "name": "ha_config_set_automation",
-            "arguments": {"config": config, "BestPracticeKey": STRICT_BPS_ACK_KEY},
+            "arguments": {
+                "config": config,
+                "BestPracticeKey": current_strict_bps_ack_key(),
+            },
         },
     )
     assert result.get("success"), f"keyed proxied write should succeed: {result}"

--- a/tests/src/e2e/policy/test_strict_bps_mode.py
+++ b/tests/src/e2e/policy/test_strict_bps_mode.py
@@ -25,6 +25,7 @@ from fastmcp import Client
 from fastmcp.exceptions import ToolError
 from test_constants import TEST_TOKEN
 
+from ha_mcp import strict_bps
 from ha_mcp.client.rest_client import HomeAssistantClient
 from ha_mcp.server import HomeAssistantSmartMCPServer
 from ha_mcp.strict_bps import current_strict_bps_ack_key
@@ -203,7 +204,11 @@ async def test_skill_guide_publishes_ack_key(strict_bps_mcp):
     )
     body = parse_mcp_result(result)
     assert body.get("success") is True, body
-    assert current_strict_bps_ack_key() in body.get("content", ""), (
+    # Accept either currently-valid key: content generation and this
+    # assertion derive the key independently, and an hour-boundary straddle
+    # between them would otherwise flake an exact-match check.
+    content = body.get("content", "")
+    assert any(key in content for key in strict_bps._valid_ack_keys()), (
         "strict mode ON: the Tier-3 best-practices content must publish the "
         "acknowledgment key"
     )

--- a/tests/src/unit/test_strict_bps.py
+++ b/tests/src/unit/test_strict_bps.py
@@ -35,10 +35,10 @@ from fastmcp.exceptions import ToolError
 
 from ha_mcp.errors import ErrorCode
 from ha_mcp.strict_bps import (
-    STRICT_BPS_ACK_KEY,
     STRICT_BPS_GATED_TOOLS,
     STRICT_BPS_KEY_PARAM,
     StrictBpsMiddleware,
+    current_strict_bps_ack_key,
     strict_bps_ack_line,
     strict_bps_effective,
 )
@@ -131,10 +131,10 @@ class TestAckKeyShape:
     """#1924: a static opaque ``bps-ack-*`` token invited two failure modes —
     an agent misread the extract-and-replay round-trip as a credential
     exfiltration ("prompt injection") and refused it until the user disabled
-    strict mode, and a static literal in a public repo can satisfy the gate
-    from training data or a stale session summary without any actual read.
-    The key is therefore a plain-English attestation phrase with a
-    per-process random suffix."""
+    strict mode, and a static literal in a public repo (or an agent's own
+    persistent memory) can satisfy the gate without any actual read. The key
+    is therefore a plain-English attestation phrase whose suffix rotates
+    hourly, derived from a per-process salt."""
 
     def test_key_is_attestation_phrase_with_rotating_suffix(self):
         from ha_mcp.strict_bps import STRICT_BPS_ACK_KEY_PREFIX
@@ -142,21 +142,29 @@ class TestAckKeyShape:
         assert STRICT_BPS_ACK_KEY_PREFIX == "I-HAVE-READ-THE-BEST-PRACTICES-GUIDE"
         assert re.fullmatch(
             re.escape(STRICT_BPS_ACK_KEY_PREFIX) + r"-[0-9a-f]{4}",
-            STRICT_BPS_ACK_KEY,
+            current_strict_bps_ack_key(),
         )
 
-    def test_generated_keys_rotate(self):
-        """The suffix is random per generation (bound once per process), so
-        a key memorized from source, training data, or an earlier process
-        cannot satisfy a later process's gate."""
-        from ha_mcp.strict_bps import _generate_ack_key
+    def test_key_stable_within_a_bucket_and_rotates_across(self):
+        from ha_mcp.strict_bps import _ACK_KEY_ROTATION_SECONDS, _current_ack_key
 
-        keys = {_generate_ack_key() for _ in range(8)}
-        assert len(keys) > 1
-        assert all(
-            re.fullmatch(r"I-HAVE-READ-THE-BEST-PRACTICES-GUIDE-[0-9a-f]{4}", k)
-            for k in keys
+        base = 1_000_000_000.0
+        start = base - (base % _ACK_KEY_ROTATION_SECONDS)
+        assert _current_ack_key(start) == _current_ack_key(start + 100)
+        assert _current_ack_key(start) != _current_ack_key(
+            start + _ACK_KEY_ROTATION_SECONDS
         )
+
+    def test_key_salted_per_process(self, monkeypatch):
+        """Without the process salt the suffix is not derivable — a key
+        computed by one process (or reconstructed from the public formula)
+        does not satisfy another process's gate."""
+        from ha_mcp import strict_bps
+
+        k1 = strict_bps._current_ack_key(1_000_000_000.0)
+        monkeypatch.setattr(strict_bps, "_ACK_KEY_SALT", "different-salt")
+        k2 = strict_bps._current_ack_key(1_000_000_000.0)
+        assert k1 != k2
 
     def test_param_schema_documents_protocol_not_a_secret(self):
         """The tool schema (trusted metadata, unlike tool output) must carry
@@ -172,11 +180,11 @@ class TestAckKeyShape:
         assert "ha_get_skill_guide" in desc
         assert "read" in desc.lower()
         # The key VALUE must never live in the schema — only how to get it.
-        assert STRICT_BPS_ACK_KEY not in desc
+        assert current_strict_bps_ack_key() not in desc
 
     def test_ack_line_frames_key_as_read_receipt(self):
         line = strict_bps_ack_line()
-        assert STRICT_BPS_ACK_KEY in line
+        assert current_strict_bps_ack_key() in line
         assert STRICT_BPS_KEY_PARAM in line
         assert "not a secret" in line.lower()
 
@@ -237,7 +245,7 @@ class TestStrictBpsMiddleware:
         assert body["strict_mandatory_bps"] is True
         assert body["tool_name"] == "ha_config_set_automation"
         # The key literal must NEVER appear in the block error.
-        assert STRICT_BPS_ACK_KEY not in raw
+        assert current_strict_bps_ack_key() not in raw
         # The suggestion names the exact recovery call for this tool.
         suggestion = body["error"]["suggestion"]
         assert "ha_get_skill_guide" in suggestion
@@ -278,14 +286,56 @@ class TestStrictBpsMiddleware:
         assert "must NOT have additional properties" in stale_hint
         assert "Developer: Reload Window" in stale_hint
         # The key literal must still never appear anywhere in the error.
-        assert STRICT_BPS_ACK_KEY not in raw
+        assert current_strict_bps_ack_key() not in raw
+
+    async def test_previous_rotation_key_accepted_as_grace(
+        self, strict_on, monkeypatch
+    ):
+        """A key obtained just before an hourly rotation must not strand
+        the agent mid-workflow — the previous bucket's key stays valid for
+        one rotation period."""
+        from ha_mcp import strict_bps
+
+        fixed = 1_000_000_000.0
+        monkeypatch.setattr(strict_bps, "time", SimpleNamespace(time=lambda: fixed))
+        prev_key = strict_bps._current_ack_key(
+            fixed - strict_bps._ACK_KEY_ROTATION_SECONDS
+        )
+        mw = StrictBpsMiddleware()
+        call_next = AsyncMock(return_value="ok")
+        ctx = make_context(
+            "ha_config_set_automation",
+            {"config": {}, "BestPracticeKey": prev_key},
+        )
+        assert await mw.on_call_tool(ctx, call_next) == "ok"
+        call_next.assert_awaited_once()
+
+    async def test_key_two_rotations_old_rejected(self, strict_on, monkeypatch):
+        """A key held past the grace window is stale — an agent that saved
+        the key to persistent memory must re-read the guide."""
+        from ha_mcp import strict_bps
+
+        fixed = 1_000_000_000.0
+        monkeypatch.setattr(strict_bps, "time", SimpleNamespace(time=lambda: fixed))
+        stale = strict_bps._current_ack_key(
+            fixed - 2 * strict_bps._ACK_KEY_ROTATION_SECONDS
+        )
+        mw = StrictBpsMiddleware()
+        call_next = AsyncMock(return_value="ok")
+        ctx = make_context(
+            "ha_config_set_automation",
+            {"config": {}, "BestPracticeKey": stale},
+        )
+        with pytest.raises(ToolError):
+            await mw.on_call_tool(ctx, call_next)
+        call_next.assert_not_awaited()
 
     async def test_gated_with_correct_key_passes_and_strips_key(self, strict_on):
         mw = StrictBpsMiddleware()
         call_next = AsyncMock(return_value="ok")
         ctx = make_context(
             "ha_config_set_automation",
-            {"config": {"alias": "x"}, "BestPracticeKey": STRICT_BPS_ACK_KEY},
+            {"config": {"alias": "x"}, "BestPracticeKey": current_strict_bps_ack_key()},
         )
         result = await mw.on_call_tool(ctx, call_next)
         assert result == "ok"
@@ -305,7 +355,7 @@ class TestStrictBpsMiddleware:
         call_next = AsyncMock(return_value="ok")
         ctx = make_context(
             "ha_config_set_automation",
-            {"config": {}, "BestPracticeKey": STRICT_BPS_ACK_KEY},
+            {"config": {}, "BestPracticeKey": current_strict_bps_ack_key()},
         )
         result = await mw.on_call_tool(ctx, call_next)
         assert result == "ok"
@@ -546,7 +596,7 @@ class TestSkillGuideKeyInjection:
         )
         assert result["success"] is True
         assert result["content"].startswith(strict_bps_ack_line())
-        assert STRICT_BPS_ACK_KEY in result["content"]
+        assert current_strict_bps_ack_key() in result["content"]
         # Original body still follows the injected line.
         assert "Real content here." in result["content"]
 
@@ -558,7 +608,7 @@ class TestSkillGuideKeyInjection:
             skills_dir, "home-assistant-best-practices", "SKILL.md"
         )
         assert result["success"] is True
-        assert STRICT_BPS_ACK_KEY not in result["content"]
+        assert current_strict_bps_ack_key() not in result["content"]
 
     def test_ack_line_absent_for_other_skill_even_if_strict(
         self, monkeypatch, tmp_path
@@ -571,4 +621,4 @@ class TestSkillGuideKeyInjection:
         (other / "SKILL.md").write_text("# Other\nUnrelated.\n")
         result = srv._handle_skill_guide_call(tmp_path, "some-other-skill", "SKILL.md")
         assert result["success"] is True
-        assert STRICT_BPS_ACK_KEY not in result["content"]
+        assert current_strict_bps_ack_key() not in result["content"]

--- a/tests/src/unit/test_strict_bps.py
+++ b/tests/src/unit/test_strict_bps.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 import importlib
 import json
 import logging
+import re
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
@@ -119,6 +120,65 @@ class TestStrictBpsEffective:
             assert strict_bps_effective() is False
         warned = [r for r in caplog.records if "skills-vendor" in r.getMessage()]
         assert len(warned) == 1
+
+
+# ---------------------------------------------------------------------------
+# Acknowledgment key shape + schema-published protocol framing (#1924)
+# ---------------------------------------------------------------------------
+
+
+class TestAckKeyShape:
+    """#1924: a static opaque ``bps-ack-*`` token invited two failure modes —
+    an agent misread the extract-and-replay round-trip as a credential
+    exfiltration ("prompt injection") and refused it until the user disabled
+    strict mode, and a static literal in a public repo can satisfy the gate
+    from training data or a stale session summary without any actual read.
+    The key is therefore a plain-English attestation phrase with a
+    per-process random suffix."""
+
+    def test_key_is_attestation_phrase_with_rotating_suffix(self):
+        from ha_mcp.strict_bps import STRICT_BPS_ACK_KEY_PREFIX
+
+        assert STRICT_BPS_ACK_KEY_PREFIX == "I-HAVE-READ-THE-BEST-PRACTICES-GUIDE"
+        assert re.fullmatch(
+            re.escape(STRICT_BPS_ACK_KEY_PREFIX) + r"-[0-9a-f]{4}",
+            STRICT_BPS_ACK_KEY,
+        )
+
+    def test_generated_keys_rotate(self):
+        """The suffix is random per generation (bound once per process), so
+        a key memorized from source, training data, or an earlier process
+        cannot satisfy a later process's gate."""
+        from ha_mcp.strict_bps import _generate_ack_key
+
+        keys = {_generate_ack_key() for _ in range(8)}
+        assert len(keys) > 1
+        assert all(
+            re.fullmatch(r"I-HAVE-READ-THE-BEST-PRACTICES-GUIDE-[0-9a-f]{4}", k)
+            for k in keys
+        )
+
+    def test_param_schema_documents_protocol_not_a_secret(self):
+        """The tool schema (trusted metadata, unlike tool output) must carry
+        the full protocol: the value is a public read-receipt, not a secret,
+        obtained by reading the skill via ha_get_skill_guide. An agent
+        following the declared schema is then not 'obeying instructions
+        found in fetched content' when it replays the key."""
+        from ha_mcp.strict_bps import BestPracticeKeyParam
+
+        field = BestPracticeKeyParam.__metadata__[0]
+        desc = field.description
+        assert "not a secret" in desc.lower()
+        assert "ha_get_skill_guide" in desc
+        assert "read" in desc.lower()
+        # The key VALUE must never live in the schema — only how to get it.
+        assert STRICT_BPS_ACK_KEY not in desc
+
+    def test_ack_line_frames_key_as_read_receipt(self):
+        line = strict_bps_ack_line()
+        assert STRICT_BPS_ACK_KEY in line
+        assert STRICT_BPS_KEY_PARAM in line
+        assert "not a secret" in line.lower()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/src/unit/test_strict_bps.py
+++ b/tests/src/unit/test_strict_bps.py
@@ -8,7 +8,10 @@ Covers, without a FastMCP boot:
   ``call_next`` (mirrors ``test_read_only.py``): keyless / wrong-key
   blocks on a gated tool, correct-key passes, non-gated tools pass
   untouched, strict-off passthrough. Asserts the structured error never
-  contains the key literal.
+  contains the key value.
+* Ack-key shape (#1924): attestation prefix, hourly salted-suffix
+  rotation with previous-bucket grace, non-string key degradation, and
+  the schema-as-protocol framing on ``BestPracticeKeyParam``.
 * Wiring: every ``STRICT_BPS_GATED_TOOLS`` tool declares a
   ``BestPracticeKey`` parameter and maps to the FIRST entry of its
   module's canonical ``_*_SKILL_FILES`` constant.
@@ -141,26 +144,37 @@ class TestAckKeyShape:
 
         assert STRICT_BPS_ACK_KEY_PREFIX == "I-HAVE-READ-THE-BEST-PRACTICES-GUIDE"
         assert re.fullmatch(
-            re.escape(STRICT_BPS_ACK_KEY_PREFIX) + r"-[0-9a-f]{4}",
+            re.escape(STRICT_BPS_ACK_KEY_PREFIX) + r"-[0-9a-f]{8}",
             current_strict_bps_ack_key(),
         )
 
-    def test_key_stable_within_a_bucket_and_rotates_across(self):
-        from ha_mcp.strict_bps import _ACK_KEY_ROTATION_SECONDS, _current_ack_key
+    def test_key_stable_within_a_bucket_and_rotates_across(self, monkeypatch):
+        """Salt pinned so the cross-bucket inequality is deterministic, not
+        a per-process dice roll on a suffix hash collision."""
+        from ha_mcp import strict_bps
+
+        monkeypatch.setattr(strict_bps, "_ACK_KEY_SALT", "fixed-test-salt")
+        # The prose everywhere says "rotates hourly" — pin the period so a
+        # silent change to the constant can't make that claim false.
+        assert strict_bps._ACK_KEY_ROTATION_SECONDS == 3600
 
         base = 1_000_000_000.0
-        start = base - (base % _ACK_KEY_ROTATION_SECONDS)
-        assert _current_ack_key(start) == _current_ack_key(start + 100)
-        assert _current_ack_key(start) != _current_ack_key(
-            start + _ACK_KEY_ROTATION_SECONDS
+        start = base - (base % strict_bps._ACK_KEY_ROTATION_SECONDS)
+        assert strict_bps._current_ack_key(start) == strict_bps._current_ack_key(
+            start + 100
+        )
+        assert strict_bps._current_ack_key(start) != strict_bps._current_ack_key(
+            start + strict_bps._ACK_KEY_ROTATION_SECONDS
         )
 
     def test_key_salted_per_process(self, monkeypatch):
         """Without the process salt the suffix is not derivable — a key
         computed by one process (or reconstructed from the public formula)
-        does not satisfy another process's gate."""
+        does not satisfy another process's gate. Both salts pinned for
+        determinism."""
         from ha_mcp import strict_bps
 
+        monkeypatch.setattr(strict_bps, "_ACK_KEY_SALT", "fixed-test-salt")
         k1 = strict_bps._current_ack_key(1_000_000_000.0)
         monkeypatch.setattr(strict_bps, "_ACK_KEY_SALT", "different-salt")
         k2 = strict_bps._current_ack_key(1_000_000_000.0)
@@ -182,7 +196,14 @@ class TestAckKeyShape:
         # The key VALUE must never live in the schema — only how to get it.
         assert current_strict_bps_ack_key() not in desc
 
-    def test_ack_line_frames_key_as_read_receipt(self):
+    def test_ack_line_frames_key_as_read_receipt(self, monkeypatch):
+        from ha_mcp import strict_bps
+
+        # Freeze the clock: the line and the assertion each derive the key,
+        # and an hour-boundary straddle between the two would flake.
+        monkeypatch.setattr(
+            strict_bps, "time", SimpleNamespace(time=lambda: 1_000_000_000.0)
+        )
         line = strict_bps_ack_line()
         assert current_strict_bps_ack_key() in line
         assert STRICT_BPS_KEY_PARAM in line
@@ -244,7 +265,13 @@ class TestStrictBpsMiddleware:
         assert body["error"]["code"] == ErrorCode.BPS_ACKNOWLEDGMENT_REQUIRED.value
         assert body["strict_mandatory_bps"] is True
         assert body["tool_name"] == "ha_config_set_automation"
-        # The key literal must NEVER appear in the block error.
+        # The message must say the key rotates and must be refreshed by
+        # re-reading — an agent holding an expired key would otherwise
+        # replay the stale value in a loop (#1924's failure class).
+        message = body["error"]["message"]
+        assert "rotates" in message
+        assert "re-read" in message
+        # The key value must NEVER appear in the block error.
         assert current_strict_bps_ack_key() not in raw
         # The suggestion names the exact recovery call for this tool.
         suggestion = body["error"]["suggestion"]
@@ -285,7 +312,7 @@ class TestStrictBpsMiddleware:
         # Names the client-side error verbatim so the model can match it.
         assert "must NOT have additional properties" in stale_hint
         assert "Developer: Reload Window" in stale_hint
-        # The key literal must still never appear anywhere in the error.
+        # The key value must still never appear anywhere in the error.
         assert current_strict_bps_ack_key() not in raw
 
     async def test_previous_rotation_key_accepted_as_grace(
@@ -297,6 +324,7 @@ class TestStrictBpsMiddleware:
         from ha_mcp import strict_bps
 
         fixed = 1_000_000_000.0
+        monkeypatch.setattr(strict_bps, "_ACK_KEY_SALT", "fixed-test-salt")
         monkeypatch.setattr(strict_bps, "time", SimpleNamespace(time=lambda: fixed))
         prev_key = strict_bps._current_ack_key(
             fixed - strict_bps._ACK_KEY_ROTATION_SECONDS
@@ -312,10 +340,13 @@ class TestStrictBpsMiddleware:
 
     async def test_key_two_rotations_old_rejected(self, strict_on, monkeypatch):
         """A key held past the grace window is stale — an agent that saved
-        the key to persistent memory must re-read the guide."""
+        the key to persistent memory must re-read the guide. Salt pinned so
+        a suffix collision with a valid bucket can't spuriously pass the
+        stale key."""
         from ha_mcp import strict_bps
 
         fixed = 1_000_000_000.0
+        monkeypatch.setattr(strict_bps, "_ACK_KEY_SALT", "fixed-test-salt")
         monkeypatch.setattr(strict_bps, "time", SimpleNamespace(time=lambda: fixed))
         stale = strict_bps._current_ack_key(
             fixed - 2 * strict_bps._ACK_KEY_ROTATION_SECONDS
@@ -379,6 +410,23 @@ class TestStrictBpsMiddleware:
         result = await mw.on_call_tool(ctx, call_next)
         assert result == "ok"
         call_next.assert_awaited_once()
+
+    async def test_non_string_key_treated_as_missing(self, strict_on):
+        """A malformed (non-string) BestPracticeKey from an off-spec client
+        must degrade to the actionable block error, not a TypeError — the
+        middleware reads raw transport arguments before pydantic validation,
+        and an unhashable value must not crash the set-membership check."""
+        mw = StrictBpsMiddleware()
+        call_next = AsyncMock(return_value="ok")
+        ctx = make_context(
+            "ha_config_set_automation",
+            {"config": {}, "BestPracticeKey": {"nested": "object"}},
+        )
+        with pytest.raises(ToolError) as excinfo:
+            await mw.on_call_tool(ctx, call_next)
+        call_next.assert_not_awaited()
+        body = json.loads(excinfo.value.args[0])
+        assert body["error"]["code"] == ErrorCode.BPS_ACKNOWLEDGMENT_REQUIRED.value
 
     async def test_none_arguments_treated_as_empty(self, strict_on):
         """A gated call with arguments=None is blocked, not a crash."""
@@ -513,7 +561,12 @@ def test_gated_tool_declares_key_and_maps_first_canonical_file(tool_name: str):
         f"{tool_name} must declare {STRICT_BPS_KEY_PARAM} so FastMCP accepts "
         f"the middleware's acknowledgment kwarg and clients can send it"
     )
-    assert "description" in props[STRICT_BPS_KEY_PARAM]
+    # The per-tool derived schema must carry the shared protocol framing —
+    # a tool diverging from BestPracticeKeyParam with its own stale
+    # description would silently drop the not-a-secret protocol (#1924).
+    tool_desc = props[STRICT_BPS_KEY_PARAM].get("description", "")
+    assert "not a secret" in tool_desc.lower()
+    assert "ha_get_skill_guide" in tool_desc
 
 
 # ---------------------------------------------------------------------------
@@ -588,7 +641,14 @@ def _best_practices_skills_dir(tmp_path: Path) -> Path:
 
 class TestSkillGuideKeyInjection:
     def test_ack_line_prepended_when_strict_effective(self, monkeypatch, tmp_path):
+        from ha_mcp import strict_bps
+
         monkeypatch.setattr("ha_mcp.strict_bps.strict_bps_effective", lambda: True)
+        # Freeze the clock: content generation and the assertions each
+        # derive the key; an hour-boundary straddle between them would flake.
+        monkeypatch.setattr(
+            strict_bps, "time", SimpleNamespace(time=lambda: 1_000_000_000.0)
+        )
         srv = _make_bare_server()
         skills_dir = _best_practices_skills_dir(tmp_path)
         result = srv._handle_skill_guide_call(


### PR DESCRIPTION
## What does this PR do?

Fixes #1924 — an agent treated the strict best-practices acknowledgment flow as a prompt-injection attempt: the opaque `bps-ack-1779` token, delivered inside fetched skill content with an instruction to replay it as `BestPracticeKey`, pattern-matched "extract and replay a credential", so the agent refused every gated write until the user disabled strict mode entirely.

Two changes, no mechanism change:

1. **The acknowledgment key is now an attestation phrase with an hourly-rotating suffix** — `I-HAVE-READ-THE-BEST-PRACTICES-GUIDE-<8 hex>`.
   - The plain-English prefix cannot be mistaken for a secret; it reads as what it is — a read-receipt.
   - The suffix is derived from a per-process salt plus the current hour bucket (stateless: salt + clock, no server-side session state). The old static literal sat in this public repo, so a model could satisfy the gate from training data, persistent agent memory, or a stale session summary without reading the guide; now only a recent read served by the current process yields a valid key. The previous hour's key is honored as a grace window so a read just before rotation does not strand the write that follows it.
2. **The `BestPracticeKey` schema description documents the protocol** — the value is public, not a credential, and is obtained by reading the skill via `ha_get_skill_guide`. With the round-trip sanctioned by trusted tool metadata, replaying the key is following the tool's declared protocol rather than obeying instructions found in tool output.

The block error states the key rotates and must be refreshed by re-reading (so an expired key is not replayed in a loop), and a non-string `BestPracticeKey` from an off-spec client degrades to that block error instead of raising. The `ha_get_skill_guide` ack line gets matching read-receipt framing. The e2e strict-BPS suite boots the server in-process, so it obtains the live key via `current_strict_bps_ack_key()`.

## Type of change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

`tests/src/unit/test_strict_bps.py` gains a `TestAckKeyShape` class (key shape, within-bucket stability and cross-bucket rotation, per-process salting, schema-description protocol markers, ack-line framing) plus middleware tests for the previous-hour grace window and rejection of keys two rotations old — written first, watched fail, then implemented. All 38 tests in the file pass; ruff and mypy clean.

## Checklist
- [x] I have updated documentation if needed
