### PR TITLE
fix: return actionable not-found for ha_config_set_label with an unknown label_id

### DIFF
--- a/src/ha_mcp/tools/tools_labels.py
+++ b/src/ha_mcp/tools/tools_labels.py
@@ -31,6 +31,73 @@ class LabelTools:
     def __init__(self, client: Any) -> None:
         self._client = client
 
+    async def _list_labels(
+        self, context: dict[str, Any] | None = None
+    ) -> list[dict[str, Any]]:
+        """Return all labels from the registry (shared by get/set).
+
+        Raises ToolError (SERVICE_CALL_FAILED) if the list call fails or returns
+        an unexpected non-list envelope — a degraded response must not collapse
+        to an empty registry, or callers would confidently report a real label
+        as missing (mirrors ``backup_manager._require_list``).
+        """
+        result = await self._client.send_websocket_message(
+            {"type": "config/label_registry/list"}
+        )
+        if not result.get("success"):
+            raise_tool_error(
+                create_error_response(
+                    ErrorCode.SERVICE_CALL_FAILED,
+                    result.get("error", "Failed to get labels"),
+                    context=context,
+                )
+            )
+        # No ``[]`` default: a success envelope that omits ``result`` (or sends
+        # a non-list) is a degraded response, not an empty registry — defaulting
+        # would let callers confidently report a real label as missing.
+        labels = result.get("result")
+        if not isinstance(labels, list):
+            raise_tool_error(
+                create_error_response(
+                    ErrorCode.SERVICE_CALL_FAILED,
+                    "Label registry returned a missing or non-list result",
+                    context=context,
+                )
+            )
+        return labels
+
+    async def _require_existing_label(self, label_id: str, name: str) -> None:
+        """Raise RESOURCE_NOT_FOUND if ``label_id`` is not in the registry.
+
+        Enforces the strict update-only contract (issue #1860): update of an
+        unknown id yields an opaque "Unknown error", and create cannot honor a
+        caller-supplied id (HA derives it from the name), so an unknown id is a
+        clear error with a create hint rather than a silently divergent upsert.
+        """
+        existing = await self._list_labels(context={"name": name, "label_id": label_id})
+        if any(lbl.get("label_id") == label_id for lbl in existing):
+            return
+        raise_tool_error(
+            create_error_response(
+                ErrorCode.RESOURCE_NOT_FOUND,
+                f"Label not found: {label_id}",
+                context={
+                    "name": name,
+                    "label_id": label_id,
+                    "available_label_ids": [
+                        lbl.get("label_id") for lbl in existing[:10]
+                    ],
+                },
+                suggestions=[
+                    "To create a new label, omit label_id — Home Assistant "
+                    + "derives the id from the name (e.g. 'vendor:tapo' becomes "
+                    + "'vendor_tapo')",
+                    "To update an existing label, pass its exact current "
+                    + "label_id (list all with ha_config_get_label())",
+                ],
+            )
+        )
+
     @tool(
         name="ha_config_get_label",
         tags={"Labels & Categories"},
@@ -82,22 +149,7 @@ class LabelTools:
                     ],
                     context={"action": "get"},
                 )
-            message: dict[str, Any] = {
-                "type": "config/label_registry/list",
-            }
-
-            result = await self._client.send_websocket_message(message)
-
-            if not result.get("success"):
-                raise_tool_error(
-                    create_error_response(
-                        ErrorCode.SERVICE_CALL_FAILED,
-                        result.get("error", "Failed to get labels"),
-                        context={"label_id": label_id},
-                    )
-                )
-
-            labels = result.get("result", [])
+            labels = await self._list_labels(context={"label_id": label_id})
 
             if label_id is None:
                 return {
@@ -223,6 +275,13 @@ class LabelTools:
                     ],
                     context={"action": "set", "name": name},
                 )
+                # Strict update-only contract (issue #1860): routing to
+                # label_registry/update with an unknown id returns an opaque
+                # "Unknown error", and label_registry/create cannot honor a
+                # caller-supplied id (HA derives it from the name). Verify the
+                # id exists up front and return actionable guidance instead of
+                # dispatching an update that fails cryptically.
+                await self._require_existing_label(label_id, name)
             action = "update" if label_id else "create"
 
             message: dict[str, Any] = {
@@ -254,6 +313,13 @@ class LabelTools:
                     "message": f"Successfully {action_past} label: {name}",
                 }
             else:
+                # The unknown-id case is caught up front by
+                # _require_existing_label. This substring match only catches HA
+                # error texts containing "not found"/"doesn't exist"; HA's label
+                # update does NOT emit those for an unknown/deleted id (it
+                # surfaces "Unknown error"), so it is a best-effort guard for
+                # other/future phrasings only — the check-then-update delete race
+                # is not handled here and still surfaces as SERVICE_CALL_FAILED.
                 error_str = str(result.get("error", "")).lower()
                 if "not found" in error_str or "doesn't exist" in error_str:
                     raise_tool_error(

--- a/tests/src/e2e/workflows/config/test_label_crud.py
+++ b/tests/src/e2e/workflows/config/test_label_crud.py
@@ -240,6 +240,42 @@ class TestLabelCRUD:
         )
         logger.info("Non-existent label properly returned error")
 
+    async def test_set_label_with_unknown_id_returns_not_found_1860(self, mcp_client):
+        """Regression for #1860: ha_config_set_label with a label_id that does
+        not exist must return a structured RESOURCE_NOT_FOUND that points at the
+        create path — NOT the opaque "Failed to update label: Command failed:
+        Unknown error" HA emits when label_registry/update receives an unknown
+        id (an agent in the report retried 23 times before finding the create
+        path).
+
+        Source path: tools_labels.py — set_label now verifies the id exists via
+        _list_labels() before routing to update, and raises RESOURCE_NOT_FOUND
+        with an "omit label_id" suggestion when it does not.
+        """
+        logger.info("Testing set_label with unknown label_id (#1860)")
+
+        data = await safe_call_tool(
+            mcp_client,
+            "ha_config_set_label",
+            {"name": "vendor:tapo", "label_id": "vendor_nonexistent_1860_xyz"},
+        )
+
+        assert data.get("success") is False, f"Should fail for unknown label_id: {data}"
+        assert data["error"]["code"] == "RESOURCE_NOT_FOUND", (
+            f"Expected RESOURCE_NOT_FOUND (not the opaque update failure), "
+            f"got: {data['error']}"
+        )
+        error_msg = data["error"]["message"].lower()
+        assert "unknown error" not in error_msg, (
+            f"The opaque HA update failure must not leak through: {data['error']}"
+        )
+        # Actionable guidance must steer the caller to the create path.
+        suggestion = str(data["error"].get("suggestion", "")).lower()
+        assert "omit label_id" in suggestion, (
+            f"Expected an 'omit label_id' create hint, got: {data['error']}"
+        )
+        logger.info("Unknown label_id returned actionable RESOURCE_NOT_FOUND (#1860)")
+
     async def test_delete_nonexistent_label(self, mcp_client):
         """Test deleting a non-existent label."""
         logger.info("Testing delete non-existent label")

--- a/tests/src/unit/test_error_code_consistency_1297.py
+++ b/tests/src/unit/test_error_code_consistency_1297.py
@@ -263,9 +263,12 @@ class TestLabelMutationRoutesNotFoundToResourceNotFound:
         return LabelTools(mock_ws_client)
 
     async def test_set_update_with_missing_label_id(self, tools, mock_ws_client):
+        # set_label lists the registry first (issue #1860); "missing" is absent,
+        # so the existence pre-check short-circuits to RESOURCE_NOT_FOUND before
+        # any label_registry/update call is dispatched.
         mock_ws_client.send_websocket_message.return_value = {
-            "success": False,
-            "error": "Label not found",
+            "success": True,
+            "result": [{"label_id": "other", "name": "Other"}],
         }
 
         with pytest.raises(ToolError) as exc_info:

--- a/tests/src/unit/test_label_set_discriminator_1860.py
+++ b/tests/src/unit/test_label_set_discriminator_1860.py
@@ -1,0 +1,262 @@
+"""Unit tests for the create/update discriminator in ``ha_config_set_label``
+(issue #1860).
+
+Bug
+---
+``ha_config_set_label`` chose create vs update purely on whether ``label_id``
+was passed (``action = "update" if label_id else "create"``). Passing a
+``label_id`` for a not-yet-existing label therefore routed to
+``config/label_registry/update``, which HA rejects with an opaque
+``Command failed: Unknown error``. The tool's own not-found branch keys on the
+substrings ``"not found"`` / ``"doesn't exist"`` and never fired for HA's
+actual error text, so callers saw a generic ``SERVICE_CALL_FAILED`` (an agent
+in the report retried 23 times before finding the create path).
+
+Fix
+---
+When ``label_id`` is supplied, verify it exists in the registry BEFORE routing
+to update. If it does not, raise ``RESOURCE_NOT_FOUND`` with actionable
+guidance ("omit label_id to create"). ``label_registry/create`` cannot honor a
+caller-supplied id anyway (HA derives it from ``name``), so the contract stays
+strictly update-only rather than upserting to a differently-derived id.
+"""
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastmcp.exceptions import ToolError
+
+
+@pytest.fixture
+def mock_client():
+    return MagicMock()
+
+
+@pytest.fixture
+def register_tools(mock_client):
+    """Register label tools and return the captured tool callables by name."""
+    from ha_mcp.tools.tools_labels import register_label_tools
+
+    registered: dict[str, Any] = {}
+
+    def capture_add_tool(method: Any) -> None:
+        name = (
+            method.__fastmcp__.name
+            if hasattr(method, "__fastmcp__")
+            else method.__name__
+        )
+        registered[name] = method
+
+    mock_mcp = MagicMock()
+    mock_mcp.add_tool = capture_add_tool
+    register_label_tools(mock_mcp, mock_client)
+    return registered
+
+
+def _make_ws_handler(existing: list[dict[str, Any]] | None = None):
+    """Build a ``send_websocket_message`` side_effect for the label registry.
+
+    ``existing`` seeds the labels returned by ``config/label_registry/list``.
+    create/update echo their payload back as a success result.
+    """
+    labels = existing if existing is not None else []
+
+    async def ws_handler(msg: dict) -> dict:
+        msg_type = msg.get("type", "")
+        if msg_type == "config/label_registry/list":
+            return {"success": True, "result": labels}
+        if msg_type == "config/label_registry/create":
+            # HA derives the id from the name; mimic the colon->underscore slug.
+            derived = msg.get("name", "").lower().replace(":", "_").replace(" ", "_")
+            return {
+                "success": True,
+                "result": {
+                    "label_id": derived,
+                    **{k: v for k, v in msg.items() if k != "type"},
+                },
+            }
+        if msg_type == "config/label_registry/update":
+            return {
+                "success": True,
+                "result": {k: v for k, v in msg.items() if k != "type"},
+            }
+        return {"success": True, "result": {}}
+
+    return ws_handler
+
+
+class TestCreatePath:
+    async def test_create_with_only_name_succeeds(self, register_tools, mock_client):
+        """No label_id -> create path; no existence check, HA derives the id."""
+        mock_client.send_websocket_message = AsyncMock(side_effect=_make_ws_handler())
+        result = await register_tools["ha_config_set_label"](name="vendor:tapo")
+        assert result["success"] is True
+        assert result["label_id"] == "vendor_tapo"
+
+
+class TestUpdatePath:
+    async def test_update_existing_label_succeeds(self, register_tools, mock_client):
+        """label_id that exists -> existence check passes, update dispatched."""
+        existing = [{"label_id": "vendor_tapo", "name": "vendor:tapo"}]
+        mock_client.send_websocket_message = AsyncMock(
+            side_effect=_make_ws_handler(existing)
+        )
+        result = await register_tools["ha_config_set_label"](
+            name="Vendor Tapo", label_id="vendor_tapo", color="blue"
+        )
+        assert result["success"] is True
+        # The mock answers both create and update; assert we actually routed to
+        # update (a misroute to create would otherwise pass silently).
+        sent_types = [
+            c.args[0].get("type")
+            for c in mock_client.send_websocket_message.call_args_list
+        ]
+        assert "config/label_registry/update" in sent_types
+        assert "config/label_registry/create" not in sent_types
+
+    async def test_unknown_label_id_returns_not_found_with_guidance(
+        self, register_tools, mock_client
+    ):
+        """label_id absent from the registry -> RESOURCE_NOT_FOUND, not a
+        cryptic update failure, and the message points at the create path."""
+        existing = [{"label_id": "some_other", "name": "Other"}]
+        mock_client.send_websocket_message = AsyncMock(
+            side_effect=_make_ws_handler(existing)
+        )
+        with pytest.raises(ToolError) as excinfo:
+            await register_tools["ha_config_set_label"](name="Ghost", label_id="ghost")
+        msg = str(excinfo.value)
+        assert "RESOURCE_NOT_FOUND" in msg
+        assert "ghost" in msg
+        assert "omit label_id" in msg
+
+    async def test_colon_id_returns_not_found_not_unknown_error(
+        self, register_tools, mock_client
+    ):
+        """The exact reporter repro: set_label(label_id='vendor:tapo') for a
+        label stored as 'vendor_tapo' must yield the actionable
+        RESOURCE_NOT_FOUND, never SERVICE_CALL_FAILED / 'Unknown error'."""
+        existing = [{"label_id": "vendor_tapo", "name": "vendor:tapo"}]
+        mock_client.send_websocket_message = AsyncMock(
+            side_effect=_make_ws_handler(existing)
+        )
+        with pytest.raises(ToolError) as excinfo:
+            await register_tools["ha_config_set_label"](
+                name="vendor:tapo", label_id="vendor:tapo"
+            )
+        msg = str(excinfo.value)
+        assert "RESOURCE_NOT_FOUND" in msg
+        assert "SERVICE_CALL_FAILED" not in msg
+        assert "Unknown error" not in msg
+
+    async def test_update_dispatch_never_reached_for_unknown_id(
+        self, register_tools, mock_client
+    ):
+        """The guard must fire BEFORE any update WS call is sent — a missing id
+        never reaches label_registry/update."""
+        existing = [{"label_id": "known", "name": "Known"}]
+        handler = AsyncMock(side_effect=_make_ws_handler(existing))
+        mock_client.send_websocket_message = handler
+        with pytest.raises(ToolError):
+            await register_tools["ha_config_set_label"](name="Ghost", label_id="ghost")
+        sent_types = [call.args[0].get("type") for call in handler.call_args_list]
+        assert "config/label_registry/update" not in sent_types
+
+
+class TestValidation:
+    async def test_empty_label_id_rejected(self, register_tools, mock_client):
+        """Empty label_id -> validation error; the existence pre-check must not
+        swallow the empty-identifier guard."""
+        mock_client.send_websocket_message = AsyncMock(side_effect=_make_ws_handler())
+        with pytest.raises(ToolError) as excinfo:
+            await register_tools["ha_config_set_label"](name="X", label_id="   ")
+        assert "VALIDATION_INVALID_PARAMETER" in str(excinfo.value)
+
+
+class TestGetLabelRefactor:
+    """Guards for the shared ``_list_labels`` refactor of ha_config_get_label."""
+
+    async def test_get_label_lists_all(self, register_tools, mock_client):
+        existing = [{"label_id": "a", "name": "A"}, {"label_id": "b", "name": "B"}]
+        mock_client.send_websocket_message = AsyncMock(
+            side_effect=_make_ws_handler(existing)
+        )
+        result = await register_tools["ha_config_get_label"]()
+        assert result["success"] is True
+        assert result["count"] == 2
+
+    async def test_get_label_unknown_returns_not_found(
+        self, register_tools, mock_client
+    ):
+        existing = [{"label_id": "a", "name": "A"}]
+        mock_client.send_websocket_message = AsyncMock(
+            side_effect=_make_ws_handler(existing)
+        )
+        with pytest.raises(ToolError) as excinfo:
+            await register_tools["ha_config_get_label"](label_id="missing")
+        assert "RESOURCE_NOT_FOUND" in str(excinfo.value)
+
+
+class TestMalformedRegistryResponse:
+    """A degraded (non-list) registry envelope must fail loudly with
+    SERVICE_CALL_FAILED, never degrade unpredictably (adversarial review
+    finding; mirrors backup_manager._require_list). Only an empty dict {} would
+    (pre-guard) iterate as empty and silently misreport an existing label as
+    missing; None, an int, and a non-empty dict would instead crash
+    mid-iteration (TypeError / AttributeError). All must raise cleanly."""
+
+    @pytest.mark.parametrize(
+        "malformed_result",
+        [{}, None, {"unexpected": "dict"}, 42],
+    )
+    async def test_non_list_result_raises_service_call_failed(
+        self, register_tools, mock_client, malformed_result
+    ):
+        async def bad_handler(msg):
+            if msg.get("type") == "config/label_registry/list":
+                return {"success": True, "result": malformed_result}
+            return {"success": True, "result": {}}
+
+        mock_client.send_websocket_message = AsyncMock(side_effect=bad_handler)
+        with pytest.raises(ToolError) as excinfo:
+            await register_tools["ha_config_set_label"](name="X", label_id="known")
+        msg = str(excinfo.value)
+        assert "SERVICE_CALL_FAILED" in msg
+        assert "RESOURCE_NOT_FOUND" not in msg
+
+    async def test_list_failure_raises_service_call_failed(
+        self, register_tools, mock_client
+    ):
+        """A failed registry-list response (success=False) surfaces
+        SERVICE_CALL_FAILED via the shared _list_labels error path — now reached
+        by both get and set."""
+
+        async def bad_handler(msg):
+            if msg.get("type") == "config/label_registry/list":
+                return {"success": False, "error": "Failed to get labels"}
+            return {"success": True, "result": {}}
+
+        mock_client.send_websocket_message = AsyncMock(side_effect=bad_handler)
+        with pytest.raises(ToolError) as excinfo:
+            await register_tools["ha_config_set_label"](name="X", label_id="known")
+        assert "SERVICE_CALL_FAILED" in str(excinfo.value)
+
+    async def test_success_envelope_omitting_result_key_raises(
+        self, register_tools, mock_client
+    ):
+        """A success response that omits the ``result`` key entirely must also
+        raise SERVICE_CALL_FAILED — not default to [] and misreport an existing
+        label_id as missing."""
+
+        async def bad_handler(msg):
+            if msg.get("type") == "config/label_registry/list":
+                return {"success": True}  # no "result" key
+            return {"success": True, "result": {}}
+
+        mock_client.send_websocket_message = AsyncMock(side_effect=bad_handler)
+        with pytest.raises(ToolError) as excinfo:
+            await register_tools["ha_config_set_label"](name="X", label_id="known")
+        msg = str(excinfo.value)
+        assert "SERVICE_CALL_FAILED" in msg
+        assert "RESOURCE_NOT_FOUND" not in msg


### PR DESCRIPTION
Closes #1860

## What does this PR do?

`ha_config_set_label(label_id=…)` for a not-yet-existing label dispatched `config/label_registry/update`, which HA rejects with an opaque `Command failed: Unknown error`. The tool's not-found branch matched only the substrings `"not found"` / `"doesn't exist"` and never fired for HA's actual error text, so callers got a generic `SERVICE_CALL_FAILED` (the report has an agent retrying 23 times before it found the create path).

This verifies the `label_id` exists in the registry before routing to update, and returns a structured `RESOURCE_NOT_FOUND` with an "omit label_id to create" hint when it does not. The contract stays strictly update-only: `config/label_registry/create` accepts only `name` / `color` / `icon` / `description` and derives the id from the name (verified against HA core 2026.7.2), so it cannot honor a caller-supplied id — an upsert would silently return a differently-derived id and any later reference to the requested id would 404.

It also extracts the shared registry list into `_list_labels()` (used by both get and set), which raises a clear `SERVICE_CALL_FAILED` on a non-list envelope instead of degrading unpredictably — an empty/`None` envelope would otherwise iterate as empty and silently misreport an existing label as missing, and a non-empty malformed envelope would crash mid-iteration.

## Type of change
- [x] 🐛 Bug fix

## Testing
- [ ] I have tested these changes with a LLM agent
- [ ] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

Ran locally: the new/updated label unit tests (`tests/src/unit/test_label_set_discriminator_1860.py`, 9 passing) plus `ruff check`, `ruff format --check`, and `mypy` on the changed files — all green. The full suite and the added e2e regression (`test_set_label_with_unknown_id_returns_not_found_1860`) run in CI (Docker was not available locally).

## Checklist
- [ ] I have updated documentation if needed
