### PR TITLE
feat: surface connect URLs for every network interface (#1862)

### DIFF
--- a/custom_components/ha_mcp_tools/config_flow.py
+++ b/custom_components/ha_mcp_tools/config_flow.py
@@ -447,7 +447,7 @@ class HaMcpServerOptionsFlow(OptionsFlow):
             data_schema=schema,
             description_placeholders={
                 "versions": await self._versions_hint(),
-                "connect_url": self._connect_url_hint(),
+                "connect_url": await self._connect_url_hint(),
                 "oauth_creds": self._oauth_creds_hint(),
                 "llm_api_docs_url": LLM_API_DOCS_URL,
                 "panel_hint": panel_hint,
@@ -535,7 +535,7 @@ class HaMcpServerOptionsFlow(OptionsFlow):
             f"Server ha-mcp {server_version} ({channel} channel)"
         )
 
-    def _connect_url_hint(self) -> str:
+    async def _connect_url_hint(self) -> str:
         """Return the connect URLs for the options form.
 
         The Configure screen is admin-only, so it shows the real resolved
@@ -555,10 +555,13 @@ class HaMcpServerOptionsFlow(OptionsFlow):
         hass = getattr(self, "hass", None)
         if hass is not None:
             try:
-                from .embedded_setup import build_connect_urls
+                from .embedded_setup import async_get_lan_hosts, build_connect_urls
 
                 urls = build_connect_urls(
-                    hass, self.config_entry, webhook_enabled=webhook_enabled
+                    hass,
+                    self.config_entry,
+                    webhook_enabled=webhook_enabled,
+                    extra_hosts=await async_get_lan_hosts(hass),
                 )
                 if urls:
                     return "Connect URL(s):\n" + "\n".join(f"- {u}" for u in urls)

--- a/custom_components/ha_mcp_tools/embedded_setup.py
+++ b/custom_components/ha_mcp_tools/embedded_setup.py
@@ -156,6 +156,7 @@ async def async_bring_up_server(hass: HomeAssistant, entry: ConfigEntry) -> None
             entry,
             auth_mode,
             webhook_enabled=webhook_enabled,
+            extra_hosts=await async_get_lan_hosts(hass),
             oauth_client_id=oauth_client_id,
             oauth_client_secret=oauth_client_secret,
             oauth_creds_active=oauth_creds_active,
@@ -229,11 +230,85 @@ async def async_revoke_credentials_on_remove(
     ir.async_delete_issue(hass, DOMAIN, ISSUE_LEGACY_OAUTH_RESTART)
 
 
+async def async_get_lan_hosts(hass: HomeAssistant) -> list[str]:
+    """Every IPv4 address on an enabled network adapter, in adapter order (#1862).
+
+    Lets the connect-URL surfaces list one entry per interface on a
+    multi-interface / multi-VLAN host, instead of only the single address
+    ``get_url`` resolves. IPv4 only: adapter IPv6 addresses carry a
+    ``%scope_id`` zone suffix that is not a usable URL host, and the reported
+    setups are IPv4. Best-effort: any failure yields an empty list so URL
+    surfacing degrades to the single ``get_url`` host rather than taking down
+    the caller (bring-up would otherwise file a repair issue for a display-only
+    lookup).
+    """
+    try:
+        from homeassistant.components import network
+
+        adapters = await network.async_get_adapters(hass)
+        # The whole extraction is inside the try (not just the fetch): a
+        # malformed adapter entry must degrade to the single get_url host too,
+        # never escape into async_bring_up_server's handler, which would tear
+        # the running server down and file a start-failure for a display-only
+        # lookup.
+        return [
+            ipv4["address"]
+            for adapter in adapters
+            if adapter["enabled"]
+            for ipv4 in adapter["ipv4"]
+        ]
+    except Exception:  # display-only enumeration; must never fail the caller
+        _LOGGER.warning(
+            "Adapter enumeration failed; using the single resolved host",
+            exc_info=True,
+        )
+        return []
+
+
+def _swap_url_host(base: str, host: str) -> str:
+    """Return ``base`` with its host replaced by ``host`` (scheme/port/path kept)."""
+    parsed = urlparse(base)
+    netloc = host if parsed.port is None else f"{host}:{parsed.port}"
+    return parsed._replace(netloc=netloc).geturl()
+
+
+def _dedup_hosts(primary: str | None, extra: list[str] | None) -> list[str]:
+    """Ordered unique hosts, ``primary`` (the canonical get_url host) first."""
+    ordered: list[str] = []
+    for host in (primary, *(extra or [])):
+        if host and host not in ordered:
+            ordered.append(host)
+    return ordered
+
+
+def _resolve_local_url(hass: HomeAssistant) -> tuple[str | None, str | None]:
+    """The get_url internal base URL and its host, or ``(None, None)``."""
+    from homeassistant.helpers.network import NoURLAvailableError, get_url
+
+    try:
+        base = get_url(hass, allow_external=False, prefer_external=False)
+    except NoURLAvailableError:
+        return None, None  # No internal/local URL configured - hint form instead.
+    return base, urlparse(base).hostname
+
+
+def _local_webhook_urls(
+    local_base: str, local_host: str | None, lan_hosts: list[str], webhook_id: str
+) -> list[str]:
+    """One local webhook URL per LAN host (canonical ``local_base`` verbatim)."""
+    return [
+        f"{local_base if host == local_host else _swap_url_host(local_base, host)}"
+        f"/api/webhook/{webhook_id}"
+        for host in lan_hosts
+    ]
+
+
 def build_connect_urls(
     hass: HomeAssistant,
     entry: ConfigEntry,
     *,
     webhook_enabled: bool = True,
+    extra_hosts: list[str] | None = None,
 ) -> list[str]:
     """Resolve the entry's connect URLs (webhook forms first, then direct).
 
@@ -241,9 +316,13 @@ def build_connect_urls(
     log on start-up and the entry's Configure screen (the notification
     deliberately carries none - it is visible to every signed-in user). Each
     source is best-effort: a URL that cannot be resolved is omitted.
-    """
-    from homeassistant.helpers.network import NoURLAvailableError, get_url
 
+    ``extra_hosts`` (from :func:`async_get_lan_hosts`) adds one webhook and one
+    direct-access URL per additional LAN address, so a multi-interface /
+    multi-VLAN host surfaces every reachable interface rather than only the
+    single host ``get_url`` picks (#1862). The ``get_url`` host stays canonical
+    and first; any repeat of it in ``extra_hosts`` is deduped away.
+    """
     webhook_id = entry.data.get(DATA_WEBHOOK_ID)
     urls: list[str] = []
     external = str(entry.options.get(OPT_EXTERNAL_URL) or "").rstrip("/")
@@ -272,14 +351,15 @@ def build_connect_urls(
     except ImportError:
         pass  # Cloud integration not installed (e.g. HA Core) - local URL only.
 
-    local_host: str | None = None
-    try:
-        local_base = get_url(hass, allow_external=False, prefer_external=False)
-        local_host = urlparse(local_base).hostname
-        if webhook_id:
-            urls.append(f"{local_base}/api/webhook/{webhook_id}")
-    except NoURLAvailableError:
-        pass  # No internal/local URL configured - fall through to the hint form.
+    local_base, local_host = _resolve_local_url(hass)
+
+    # One entry per enabled LAN address so a multi-interface / multi-VLAN host
+    # surfaces every reachable interface rather than get_url's single pick
+    # (#1862). The get_url host stays canonical and first.
+    lan_hosts = _dedup_hosts(local_host, extra_hosts)
+
+    if local_base and webhook_id:
+        urls.extend(_local_webhook_urls(local_base, local_host, lan_hosts, webhook_id))
 
     if not urls and webhook_id:
         urls.append(f"/api/webhook/{webhook_id}  (prefix with your Home Assistant URL)")
@@ -291,9 +371,9 @@ def build_connect_urls(
         # Direct-access URL: admin-gated surfaces only (log + Configure screen).
         # Guarded on the secret path so a missing one omits the line instead of
         # rendering a valid-looking URL without its credential segment.
-        urls.append(
-            f"http://{local_host or '<home-assistant-ip>'}:{port}{secret_path}"
-            " (direct access)"
+        urls.extend(
+            f"http://{host}:{port}{secret_path} (direct access)"
+            for host in lan_hosts or ["<home-assistant-ip>"]
         )
     return urls
 
@@ -304,13 +384,16 @@ def _surface_connect_urls(
     auth_mode: str,
     *,
     webhook_enabled: bool = True,
+    extra_hosts: list[str] | None = None,
     oauth_client_id: str | None = None,
     oauth_client_secret: str | None = None,
     oauth_creds_active: bool = True,
     oauth_restart_pending: bool = False,
 ) -> None:
     """Log the connect URLs and (re)create a persistent notification."""
-    urls = build_connect_urls(hass, entry, webhook_enabled=webhook_enabled)
+    urls = build_connect_urls(
+        hass, entry, webhook_enabled=webhook_enabled, extra_hosts=extra_hosts
+    )
     if not webhook_enabled:
         auth_note = "Webhook access is disabled (local-only mode)."
     elif auth_mode == WEBHOOK_AUTH_NONE:

--- a/custom_components/ha_mcp_tools/embedded_setup.py
+++ b/custom_components/ha_mcp_tools/embedded_setup.py
@@ -238,8 +238,8 @@ async def async_get_lan_hosts(hass: HomeAssistant) -> list[str]:
     ``get_url`` resolves. IPv4 only: ``async_get_adapters`` returns a bare
     IPv6 ``address`` with a separate ``scope_id`` int, so a link-local adapter
     address is not a usable URL host without rejoining that zone id (and every
-    IPv6 host additionally needs bracket-wrapping) – building those correctly
-    is out of scope, and the reported setups are IPv4. Best-effort: any failure
+    IPv6 host additionally needs bracket-wrapping), so building those correctly
+    is out of scope; the reported setups are IPv4. Best-effort: any failure
     yields an empty list so URL
     surfacing degrades to the single ``get_url`` host rather than taking down
     the caller (bring-up would otherwise file a repair issue for a display-only

--- a/custom_components/ha_mcp_tools/embedded_setup.py
+++ b/custom_components/ha_mcp_tools/embedded_setup.py
@@ -235,9 +235,12 @@ async def async_get_lan_hosts(hass: HomeAssistant) -> list[str]:
 
     Lets the connect-URL surfaces list one entry per interface on a
     multi-interface / multi-VLAN host, instead of only the single address
-    ``get_url`` resolves. IPv4 only: adapter IPv6 addresses carry a
-    ``%scope_id`` zone suffix that is not a usable URL host, and the reported
-    setups are IPv4. Best-effort: any failure yields an empty list so URL
+    ``get_url`` resolves. IPv4 only: ``async_get_adapters`` returns a bare
+    IPv6 ``address`` with a separate ``scope_id`` int, so a link-local adapter
+    address is not a usable URL host without rejoining that zone id (and every
+    IPv6 host additionally needs bracket-wrapping) – building those correctly
+    is out of scope, and the reported setups are IPv4. Best-effort: any failure
+    yields an empty list so URL
     surfacing degrades to the single ``get_url`` host rather than taking down
     the caller (bring-up would otherwise file a repair issue for a display-only
     lookup).

--- a/custom_components/ha_mcp_tools/manifest.json
+++ b/custom_components/ha_mcp_tools/manifest.json
@@ -6,7 +6,8 @@
         "cloud",
         "frontend",
         "http",
-        "lovelace"
+        "lovelace",
+        "network"
     ],
     "codeowners": [
         "@homeassistant-ai"

--- a/tests/src/unit/test_config_flow.py
+++ b/tests/src/unit/test_config_flow.py
@@ -725,14 +725,14 @@ class TestServerOptionsFlow:
                 const.DATA_SECRET_PATH: "/private_x",
             },
         )
-        hint = flow._connect_url_hint()
+        hint = asyncio.run(flow._connect_url_hint())
         assert "/api/webhook/mcp_abc" in hint
         # The LAN hint uses the CONFIGURED port, not the 9584 default.
         assert ":9999/private_x" in hint
 
     def test_connect_url_hint_before_start_points_at_log(self):
         flow = _make_options_flow(data={})
-        hint = flow._connect_url_hint().lower()
+        hint = asyncio.run(flow._connect_url_hint()).lower()
         assert "once the server has started" in hint
         assert "notification" not in hint
 
@@ -746,15 +746,25 @@ class TestServerOptionsFlow:
         """
         calls: list[dict] = []
 
-        def fake_builder(hass, entry, *, webhook_enabled=True):
-            calls.append({"hass": hass, "webhook_enabled": webhook_enabled})
+        def fake_builder(hass, entry, *, webhook_enabled=True, extra_hosts=None):
+            calls.append(
+                {
+                    "hass": hass,
+                    "webhook_enabled": webhook_enabled,
+                    "extra_hosts": extra_hosts,
+                }
+            )
             return [
                 "https://example.duckdns.org/api/webhook/mcp_abc",
                 "http://192.168.1.150:9584/private_x (direct access)",
             ]
 
+        async def fake_lan_hosts(hass):
+            return ["10.0.1.3"]
+
         stub = ModuleType("custom_components.ha_mcp_tools.embedded_setup")
         stub.build_connect_urls = fake_builder
+        stub.async_get_lan_hosts = fake_lan_hosts
         flow = _make_options_flow(
             options={const.OPT_ENABLE_WEBHOOK: False},
             data={"webhook_id": "mcp_abc", "secret_path": "/private_x"},
@@ -763,7 +773,7 @@ class TestServerOptionsFlow:
         orig = sys.modules.get("custom_components.ha_mcp_tools.embedded_setup")
         sys.modules["custom_components.ha_mcp_tools.embedded_setup"] = stub
         try:
-            hint = flow._connect_url_hint()
+            hint = asyncio.run(flow._connect_url_hint())
         finally:
             if orig is None:
                 del sys.modules["custom_components.ha_mcp_tools.embedded_setup"]
@@ -774,6 +784,9 @@ class TestServerOptionsFlow:
         assert "<your-home-assistant-url>" not in hint
         # The enable_webhook option is forwarded to the builder.
         assert calls and calls[0]["webhook_enabled"] is False
+        # The enumerated adapter hosts are forwarded so per-interface URLs
+        # surface on the Configure screen too (#1862).
+        assert calls[0]["extra_hosts"] == ["10.0.1.3"]
 
     def _hint_with_stub_builder(self, builder, *, data, options=None):
         """Call ``_connect_url_hint`` with ``build_connect_urls`` stubbed.
@@ -782,14 +795,19 @@ class TestServerOptionsFlow:
         ``from .embedded_setup import build_connect_urls`` resolves to ``builder``
         without importing the real module (which needs a full HA install).
         """
+
+        async def fake_lan_hosts(hass):
+            return []
+
         stub = ModuleType("custom_components.ha_mcp_tools.embedded_setup")
         stub.build_connect_urls = builder
+        stub.async_get_lan_hosts = fake_lan_hosts
         flow = _make_options_flow(data=data, options=options)
         flow.hass = MagicMock()
         orig = sys.modules.get("custom_components.ha_mcp_tools.embedded_setup")
         sys.modules["custom_components.ha_mcp_tools.embedded_setup"] = stub
         try:
-            return flow._connect_url_hint()
+            return asyncio.run(flow._connect_url_hint())
         finally:
             if orig is None:
                 del sys.modules["custom_components.ha_mcp_tools.embedded_setup"]
@@ -799,7 +817,7 @@ class TestServerOptionsFlow:
     def test_connect_url_hint_falls_back_when_builder_raises(self):
         # A resolution bug in build_connect_urls must not escape and take down
         # the whole options form: the hint degrades to the placeholder form.
-        def boom_builder(hass, entry, *, webhook_enabled=True):
+        def boom_builder(hass, entry, *, webhook_enabled=True, extra_hosts=None):
             raise RuntimeError("resolution boom")
 
         hint = self._hint_with_stub_builder(
@@ -811,7 +829,7 @@ class TestServerOptionsFlow:
     def test_connect_url_hint_falls_back_when_builder_returns_empty(self):
         # An empty resolver result (nothing resolvable yet) also degrades to the
         # placeholder form rather than an empty "Connect URL(s):" header.
-        def empty_builder(hass, entry, *, webhook_enabled=True):
+        def empty_builder(hass, entry, *, webhook_enabled=True, extra_hosts=None):
             return []
 
         hint = self._hint_with_stub_builder(
@@ -828,7 +846,7 @@ class TestServerOptionsFlow:
         loopback direct URL instead of rendering a webhook URL that 404s.
         """
 
-        def empty_builder(hass, entry, *, webhook_enabled=True):
+        def empty_builder(hass, entry, *, webhook_enabled=True, extra_hosts=None):
             return []
 
         hint = self._hint_with_stub_builder(
@@ -848,7 +866,7 @@ class TestServerOptionsFlow:
         — a resolution error must not resurrect a webhook URL that 404s.
         """
 
-        def boom_builder(hass, entry, *, webhook_enabled=True):
+        def boom_builder(hass, entry, *, webhook_enabled=True, extra_hosts=None):
             raise RuntimeError("resolution boom")
 
         hint = self._hint_with_stub_builder(

--- a/tests/src/unit/test_embedded_setup.py
+++ b/tests/src/unit/test_embedded_setup.py
@@ -424,6 +424,28 @@ def _install_network_cloud(*, cloud_url=None, local_url=None):
     sys.modules["homeassistant.components.cloud"] = cloud
 
 
+def _install_adapters(adapters=None, *, error=None):
+    """Install a fake ``homeassistant.components.network.async_get_adapters``.
+
+    ``error`` set ⇒ the lookup raises it (the degrade-to-empty branch). The
+    parent-package attribute is set too: ``homeassistant.components`` is a
+    MagicMock here, so ``from homeassistant.components import network`` reads the
+    child attribute rather than the ``sys.modules`` entry alone.
+    """
+
+    net = ModuleType("homeassistant.components.network")
+
+    async def async_get_adapters(hass):
+        if error is not None:
+            raise error
+        return adapters or []
+
+    net.async_get_adapters = async_get_adapters
+    sys.modules["homeassistant.components.network"] = net
+    sys.modules["homeassistant.components"].network = net
+    return net
+
+
 class TestSurfaceConnectUrls:
     @pytest.fixture(autouse=True)
     def _restore_surface(self, monkeypatch, _spy):
@@ -461,6 +483,32 @@ class TestSurfaceConnectUrls:
         assert "Configure" in message
         assert "https://abc.ui.nabu.casa/api/webhook/mcp_id" in caplog.text
         assert "http://192.168.1.5:8123/api/webhook/mcp_id" in caplog.text
+
+    def test_notification_excludes_multi_interface_urls(self, caplog):
+        # #1862: the per-interface expansion multiplies the secret-bearing
+        # direct-access lines; none of the extra hosts (or the secret path) may
+        # leak into the all-users persistent notification - they belong to the
+        # admin-only log only.
+        import logging
+
+        _install_network_cloud(cloud_url=None, local_url="http://10.0.2.3:8123")
+        hass = _make_hass()
+        entry = _make_entry(
+            data={DATA_WEBHOOK_ID: "mcp_id", DATA_SECRET_PATH: "/private_x"},
+            options={esetup.OPT_BIND_HOST: esetup.BIND_HOST_ALL},
+        )
+        with caplog.at_level(logging.INFO):
+            esetup._surface_connect_urls(
+                hass, entry, "none", extra_hosts=["10.0.2.3", "10.0.1.3"]
+            )
+        message = self._message()
+        assert "10.0.1.3" not in message
+        assert "10.0.2.3" not in message
+        assert "/private_x" not in message
+        # Both interfaces' URLs DID reach the admin-only log.
+        assert "http://10.0.2.3:8123/api/webhook/mcp_id" in caplog.text
+        assert "http://10.0.1.3:8123/api/webhook/mcp_id" in caplog.text
+        assert "http://10.0.1.3:9584/private_x" in caplog.text
 
     def test_external_url_option_leads_the_list(self, caplog):
         # Owner request (webhook-proxy app parity): a configured external URL
@@ -781,6 +829,89 @@ class TestBuildConnectUrls:
         )
         urls = esetup.build_connect_urls(hass, entry, webhook_enabled=False)
         assert not any("/api/webhook/" in u for u in urls)
+
+    def test_multiple_interfaces_expand_both_lines(self):
+        # #1862: a multi-interface / multi-VLAN host surfaces one webhook and one
+        # direct-access URL per enabled LAN address, canonical get_url host first.
+        _install_network_cloud(cloud_url=None, local_url="http://10.0.2.3:8123")
+        hass = _make_hass()
+        entry = _make_entry(
+            data={DATA_WEBHOOK_ID: "mcp_id", DATA_SECRET_PATH: "/private_x"},
+            options={esetup.OPT_BIND_HOST: esetup.BIND_HOST_ALL},
+        )
+        urls = esetup.build_connect_urls(
+            hass, entry, extra_hosts=["10.0.2.3", "10.0.1.3"]
+        )
+        webhook = [u for u in urls if "/api/webhook/" in u]
+        direct = [u for u in urls if "(direct access)" in u]
+        assert webhook == [
+            "http://10.0.2.3:8123/api/webhook/mcp_id",
+            "http://10.0.1.3:8123/api/webhook/mcp_id",
+        ]
+        assert direct == [
+            "http://10.0.2.3:9584/private_x (direct access)",
+            "http://10.0.1.3:9584/private_x (direct access)",
+        ]
+
+    def test_extra_hosts_deduped_against_get_url_host(self):
+        # The get_url host repeated in the adapter list must not double-list.
+        _install_network_cloud(cloud_url=None, local_url="http://10.0.2.3:8123")
+        hass = _make_hass()
+        entry = _make_entry(
+            data={DATA_WEBHOOK_ID: "mcp_id", DATA_SECRET_PATH: "/private_x"},
+            options={esetup.OPT_BIND_HOST: esetup.BIND_HOST_ALL},
+        )
+        urls = esetup.build_connect_urls(hass, entry, extra_hosts=["10.0.2.3"])
+        assert sum("(direct access)" in u for u in urls) == 1
+        assert sum("/api/webhook/" in u for u in urls) == 1
+
+    def test_extra_hosts_surface_direct_line_without_get_url(self):
+        # get_url unavailable but adapters known: the direct-access line still
+        # lists the real adapter hosts rather than only a placeholder.
+        _install_network_cloud(cloud_url=None, local_url=None)
+        hass = _make_hass()
+        entry = _make_entry(
+            data={DATA_WEBHOOK_ID: "mcp_id", DATA_SECRET_PATH: "/private_x"},
+            options={esetup.OPT_BIND_HOST: esetup.BIND_HOST_ALL},
+        )
+        urls = esetup.build_connect_urls(hass, entry, extra_hosts=["10.0.1.3"])
+        direct = [u for u in urls if "(direct access)" in u]
+        assert direct == ["http://10.0.1.3:9584/private_x (direct access)"]
+
+
+class TestAsyncGetLanHosts:
+    """Coverage of ``async_get_lan_hosts`` — the per-interface IPv4 enumeration
+    that feeds ``build_connect_urls`` ``extra_hosts`` (#1862)."""
+
+    async def test_lists_enabled_adapter_ipv4_in_order(self):
+        _install_adapters(
+            [
+                {"enabled": True, "ipv4": [{"address": "10.0.2.3"}]},
+                {
+                    "enabled": True,
+                    "ipv4": [{"address": "10.0.1.3"}, {"address": "10.0.1.4"}],
+                },
+                {"enabled": False, "ipv4": [{"address": "10.9.9.9"}]},
+            ]
+        )
+        hosts = await esetup.async_get_lan_hosts(_make_hass())
+        # Disabled adapter dropped; enabled addresses kept in adapter order.
+        assert hosts == ["10.0.2.3", "10.0.1.3", "10.0.1.4"]
+
+    async def test_degrades_to_empty_on_error(self):
+        # A lookup failure must yield [] so URL surfacing (and bring-up) never
+        # breaks for a display-only enumeration.
+        _install_adapters(error=RuntimeError("no network component"))
+        hosts = await esetup.async_get_lan_hosts(_make_hass())
+        assert hosts == []
+
+    async def test_degrades_to_empty_on_malformed_adapter(self):
+        # A malformed adapter entry (missing keys) must also degrade to [] rather
+        # than escaping the loop into async_bring_up_server's handler, which would
+        # tear the running server down for a display-only lookup.
+        _install_adapters([{"enabled": True}])  # no "ipv4" key
+        hosts = await esetup.async_get_lan_hosts(_make_hass())
+        assert hosts == []
 
 
 # ---------------------------------------------------------------------------

--- a/tests/src/unit/test_embedded_setup.py
+++ b/tests/src/unit/test_embedded_setup.py
@@ -169,7 +169,16 @@ class TestBringUp:
             is True
         )
 
-    async def test_success_starts_registers_and_surfaces(self, fake_manager):
+    async def test_success_starts_registers_and_surfaces(
+        self, fake_manager, monkeypatch
+    ):
+        # The enumerated adapter hosts must be forwarded into the connect-URL
+        # surfacing, or the startup log – the feature's primary surface – silently
+        # loses the per-interface URLs while every other test stays green
+        # (#1862). Mirrors the config-flow forwarding assertion.
+        monkeypatch.setattr(
+            esetup, "async_get_lan_hosts", AsyncMock(return_value=["10.0.1.3"])
+        )
         hass = _make_hass()
         entry = _make_entry()
 
@@ -178,6 +187,9 @@ class TestBringUp:
         fake_manager.async_start.assert_awaited_once()
         esetup.async_register_webhook.assert_awaited_once()
         esetup._surface_connect_urls.assert_called_once()
+        assert esetup._surface_connect_urls.call_args.kwargs["extra_hosts"] == [
+            "10.0.1.3"
+        ]
         assert isinstance(hass.data[DOMAIN][DATA_MANAGER], fake_manager)
         esetup.ir.async_create_issue.assert_not_called()
         # Conversation-agent LLM API (#1745): registered with the running
@@ -877,6 +889,33 @@ class TestBuildConnectUrls:
         urls = esetup.build_connect_urls(hass, entry, extra_hosts=["10.0.1.3"])
         direct = [u for u in urls if "(direct access)" in u]
         assert direct == ["http://10.0.1.3:9584/private_x (direct access)"]
+
+    def test_portless_internal_url_swaps_host_without_a_port(self):
+        # A reverse-proxied internal URL has no port; _swap_url_host must keep it
+        # port-less for the extra adapter host rather than inventing one.
+        _install_network_cloud(cloud_url=None, local_url="https://ha.internal")
+        hass = _make_hass()
+        entry = _make_entry(data={DATA_WEBHOOK_ID: "mcp_id", DATA_SECRET_PATH: "/priv"})
+        urls = esetup.build_connect_urls(hass, entry, extra_hosts=["10.0.1.3"])
+        webhook = [u for u in urls if "/api/webhook/" in u]
+        assert webhook == [
+            "https://ha.internal/api/webhook/mcp_id",
+            "https://10.0.1.3/api/webhook/mcp_id",
+        ]
+
+    def test_direct_line_uses_placeholder_when_no_host_resolves(self):
+        # bind-all + secret present but no get_url host and no adapters: the
+        # direct line falls back to the <home-assistant-ip> placeholder rather
+        # than dropping the line or rendering a host-less URL.
+        _install_network_cloud(cloud_url=None, local_url=None)
+        hass = _make_hass()
+        entry = _make_entry(
+            data={DATA_WEBHOOK_ID: "mcp_id", DATA_SECRET_PATH: "/priv"},
+            options={esetup.OPT_BIND_HOST: esetup.BIND_HOST_ALL},
+        )
+        urls = esetup.build_connect_urls(hass, entry)
+        direct = [u for u in urls if "(direct access)" in u]
+        assert direct == ["http://<home-assistant-ip>:9584/priv (direct access)"]
 
 
 class TestAsyncGetLanHosts:

--- a/tests/src/unit/test_embedded_setup.py
+++ b/tests/src/unit/test_embedded_setup.py
@@ -173,7 +173,7 @@ class TestBringUp:
         self, fake_manager, monkeypatch
     ):
         # The enumerated adapter hosts must be forwarded into the connect-URL
-        # surfacing, or the startup log – the feature's primary surface – silently
+        # surfacing, or the startup log (the feature's primary surface) silently
         # loses the per-interface URLs while every other test stays green
         # (#1862). Mirrors the config-flow forwarding assertion.
         monkeypatch.setattr(


### PR DESCRIPTION
Closes #1862

## What does this PR do?

On a Home Assistant host with more than one network interface (multiple NICs or
VLANs), the connect URLs shown at server start — in the startup log, the
Configure-screen hint, and the setup notification — only listed the single host
that `homeassistant.helpers.network.get_url()` resolves. Users on any other
subnet had to hand-edit the IP to reach the server.

This surfaces a connect URL for **every** IPv4 address on an enabled network
adapter, expanding both the webhook line and the direct-access line per adapter:

- Enumeration goes through `homeassistant.components.network.async_get_adapters()`,
  filtered to `enabled` adapters, IPv4 only, in adapter order.
- The canonical `get_url()` host is kept first and deduplicated against the
  adapter list, so the primary URL never moves and never repeats.
- All expansion happens inside the existing `build_connect_urls` choke point, so
  the three display surfaces stay consistent.
- Enumeration is best-effort and display-only: any failure (import, fetch, or a
  malformed adapter entry) degrades to the single resolved host and logs a
  warning — it never fails server bring-up.

Security posture is unchanged: the extra secret-bearing lines reach only the
admin-only startup log and the Configure screen. The persistent notification —
visible to every authenticated user — still carries no connect URLs or secrets
(covered by a regression test).

## Type of change
- [x] ✨ New feature

## Testing
- [x] All automated tests pass (`uv run pytest` — 126 unit tests)
- [x] Code follows style guidelines (`uv run ruff check` + `ruff format --check` + `mypy` clean)

Added unit coverage: multi-interface expansion of both lines, dedup against the
`get_url` host, direct-access line when `get_url` is unavailable, adapter-order
enumeration, degrade-to-empty on error and on a malformed adapter, and a
regression test that the multi-interface path keeps URLs out of the persistent
notification.

## Checklist
- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing unit tests pass locally
