### PR TITLE
fix: state which server ha_dev_manage_server update_source actually changes

### DIFF
--- a/src/ha_mcp/tools/tools_dev.py
+++ b/src/ha_mcp/tools/tools_dev.py
@@ -834,7 +834,9 @@ class DevTools:
             Field(
                 description=(
                     "info: deployment/version report; update_source: point the "
-                    "in-process server at a channel or pip spec and reinstall; "
+                    "ha_mcp_tools component's separate in-process server at a "
+                    "channel or pip spec and reinstall it (never changes the "
+                    "server serving this connection, unless embedded); "
                     "restart: restart this server"
                 )
             ),
@@ -871,14 +873,21 @@ class DevTools:
         as a PR tarball, and restarting the server so config or code
         changes take effect.
 
-        Caveats: restart interrupts this MCP connection in embedded and
-        add-on deployments (the reply arrives just before the server
-        goes down); update_source only self-interrupts in embedded mode
-        — elsewhere it reloads the separate in-process server entry
-        without dropping this connection. Reinstalls can take minutes.
-        update_source requires the ha_mcp_tools component's in-process
-        server entry; restart supports embedded and add-on deployments
-        only (standalone processes must be restarted externally).
+        Caveats: update_source changes ONLY the ha_mcp_tools custom
+        component's separate in-process server entry — it never updates
+        the add-on, Docker, standalone, or PyPI server that may be
+        serving this connection (update those via ha_manage_addon /
+        docker pull / pip). In embedded mode that entry IS this server,
+        so the update self-interrupts; elsewhere this connection is
+        untouched and keeps its current version. Success means the
+        entry's options were applied — the component then reinstalls in
+        the background, which can take minutes and can still fail
+        (check HA logs). update_source requires the component's
+        in-process server entry to exist. restart interrupts this MCP
+        connection in embedded and add-on deployments (the reply
+        arrives just before the server goes down) and supports those
+        two deployments only (standalone processes must be restarted
+        externally).
 
         EXAMPLES:
         ha_dev_manage_server("info")
@@ -936,6 +945,17 @@ class DevTools:
                     "entry_id": entry_id,
                     "channel": options.get(_OPT_CHANNEL),
                     "pip_spec": options.get(_OPT_PIP_SPEC),
+                    "role": (
+                        "this server (embedded)"
+                        if mode == "embedded"
+                        else (
+                            "separate in-process server run by the "
+                            "ha_mcp_tools component; the update_source "
+                            "target. server_version above describes the "
+                            f"{mode} server handling this connection, not "
+                            "this entry."
+                        )
+                    ),
                 }
         except Exception as exc:
             # Best-effort probe: a failure here (including the ToolError the
@@ -1020,6 +1040,9 @@ class DevTools:
                 "data": {
                     "scheduled": True,
                     "entry_id": entry_id,
+                    "target": (
+                        "this server (the embedded ha_mcp_tools in-process entry)"
+                    ),
                     "applying": user_input,
                     "previous": {
                         _OPT_CHANNEL: current.get(_OPT_CHANNEL),
@@ -1047,14 +1070,19 @@ class DevTools:
             "success": True,
             "data": {
                 "entry_id": entry_id,
+                "target": "ha_mcp_tools in-process server entry",
                 "applied": user_input,
                 "previous": {
                     _OPT_CHANNEL: current.get(_OPT_CHANNEL),
                     _OPT_PIP_SPEC: current.get(_OPT_PIP_SPEC),
                 },
                 "note": (
-                    "The component is reloading the in-process server with "
-                    "the new source; installs can take a few minutes."
+                    "Applied to the ha_mcp_tools component's SEPARATE "
+                    "in-process server entry, which is now reinstalling in "
+                    "the background (can take minutes and can still fail — "
+                    "check HA logs). The server handling this connection is "
+                    "NOT affected and keeps its current version; verify the "
+                    "in-process server on its own connect URL, not here."
                 ),
             },
         }

--- a/tests/src/unit/test_tools_dev.py
+++ b/tests/src/unit/test_tools_dev.py
@@ -288,11 +288,9 @@ class TestManageServer:
         )
         result = await DevTools(client).ha_dev_manage_server(action="info")
         entry = result["data"]["component_server_entry"]
-        assert entry == {
-            "entry_id": "server-e",
-            "channel": "stable",
-            "pip_spec": "",
-        }
+        assert entry["entry_id"] == "server-e"
+        assert entry["channel"] == "stable"
+        assert entry["pip_spec"] == ""
         client.abort_options_flow.assert_awaited_with("flow-1")
 
     async def test_info_quietly_aborts_the_tools_entry_info_form(self):
@@ -424,6 +422,53 @@ class TestManageServer:
         client.submit_options_flow_step.assert_not_awaited()
         await _drain_background_tasks()
         client.submit_options_flow_step.assert_awaited_once()
+
+    async def test_update_source_result_names_component_target(self):
+        """The non-embedded success payload must say WHICH server changed.
+
+        Regression: an agent connected to the ADD-ON called update_source,
+        read success:true plus a generic "the component is reloading" note,
+        and concluded the server it was talking to would change version. It
+        never does — only the ha_mcp_tools component's separate in-process
+        entry is updated, and success means the entry options were applied,
+        not that the background install finished.
+        """
+        client = _mock_client(
+            entries=[{"entry_id": "server-e"}], flows=[dict(_SERVER_FLOW)]
+        )
+        result = await DevTools(client).ha_dev_manage_server(
+            action="update_source", channel="dev"
+        )
+        data = result["data"]
+        assert data["target"] == "ha_mcp_tools in-process server entry"
+        assert "NOT" in data["note"]
+        assert "this connection" in data["note"]
+        assert "background" in data["note"]
+        assert "fail" in data["note"]
+
+    async def test_update_source_embedded_target_says_this_server(self, monkeypatch):
+        monkeypatch.setenv("HA_MCP_EMBEDDED", "1")
+        monkeypatch.setattr(tools_dev, "_SELF_ACTION_FLUSH_DELAY_S", 0)
+        client = _mock_client(
+            entries=[{"entry_id": "server-e"}], flows=[dict(_SERVER_FLOW)]
+        )
+        result = await DevTools(client).ha_dev_manage_server(
+            action="update_source", channel="dev"
+        )
+        assert "this server" in result["data"]["target"]
+        await _drain_background_tasks()
+
+    async def test_info_distinguishes_serving_server_from_component_entry(self):
+        """info must label the component entry as a separate server, so its
+        channel/pip_spec can't be conflated with the serving server's
+        version (deployment_mode 'standalone'/'addon')."""
+        client = _mock_client(
+            entries=[{"entry_id": "server-e"}], flows=[dict(_SERVER_FLOW)]
+        )
+        result = await DevTools(client).ha_dev_manage_server(action="info")
+        entry = result["data"]["component_server_entry"]
+        assert "separate" in entry["role"]
+        assert "update_source" in entry["role"]
 
     async def test_restart_standalone_errors(self):
         with pytest.raises(ToolError, match="standalone"):


### PR DESCRIPTION
## What does this PR do?

`ha_dev_manage_server(action="update_source")` only ever changes the ha_mcp_tools custom component's separate in-process server entry — but its docstring and success payload didn't say so. During live testing of #1926, an agent connected to the add-on called it, read `success: true` plus "the component is reloading the in-process server", and concluded the server it was talking to would change version. It never does, which presents as "the install silently failed" and triggers a debugging spiral. `success: true` on this path means HA accepted the entry's options-flow submit — not that the install finished (that runs in the component in the background and can still fail), and not that the serving server changed.

- The non-embedded `update_source` success payload now carries `target: "ha_mcp_tools in-process server entry"` and a note stating that the server handling this connection is NOT affected, that the reinstall continues in the background and can still fail, and that verification belongs on the in-process server's own connect URL. The embedded payload gets a matching `target` ("this server …").
- `info` labels `component_server_entry` with a `role` field so its channel/pip_spec can't be conflated with the serving server's `server_version`/`deployment_mode`.
- The tool docstring and the `action` field description state the target rule explicitly. The missing-entry case already fails fast with `COMPONENT_NOT_INSTALLED` — unchanged.

## Type of change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`) — three regression tests added in `tests/src/unit/test_tools_dev.py` (written first, red → green)
- [x] Code follows style guidelines (`uv run ruff check`)

## Checklist
- [x] I have updated documentation if needed
