### PR TITLE
fix: name a representative error in the deep-search non-404 failed fragment

### DIFF
--- a/src/ha_mcp/tools/smart_search/_deep.py
+++ b/src/ha_mcp/tools/smart_search/_deep.py
@@ -21,7 +21,7 @@ from ._config import (
     INDIVIDUAL_FETCH_BATCH_SIZE,
     SCRIPT_CONFIG_TIME_BUDGET,
 )
-from ._fetch import is_timeout_error
+from ._fetch import is_timeout_error, summarize_fetch_error
 from ._scenes import SceneSearchMixin
 
 logger = logging.getLogger(__name__)
@@ -136,6 +136,7 @@ class DeepSearchMixin(SceneSearchMixin):
                 "timeout": 0,
                 "integration_skipped": 0,
                 "registry_failed": False,
+                "failed_sample": None,
             }
 
             # Diagnostic counters for the Attempt-C path on automations/
@@ -149,10 +150,12 @@ class DeepSearchMixin(SceneSearchMixin):
             automation_failed = 0
             automation_yaml_skipped = 0
             automation_timeout = 0
+            automation_failed_sample: str | None = None
             script_skipped = 0
             script_failed = 0
             script_yaml_skipped = 0
             script_timeout = 0
+            script_failed_sample: str | None = None
             helper_failed = 0
             dashboard_failed = 0
 
@@ -163,6 +166,7 @@ class DeepSearchMixin(SceneSearchMixin):
                     automation_failed,
                     automation_yaml_skipped,
                     automation_timeout,
+                    automation_failed_sample,
                 ) = await self._deep_search_automations(
                     all_entities,
                     automation_unique_id_map,
@@ -185,6 +189,7 @@ class DeepSearchMixin(SceneSearchMixin):
                     script_failed,
                     script_yaml_skipped,
                     script_timeout,
+                    script_failed_sample,
                 ) = await self._deep_search_scripts(
                     all_entities,
                     query_lower,
@@ -207,6 +212,7 @@ class DeepSearchMixin(SceneSearchMixin):
                     scene_stats["integration_skipped"],
                     scene_stats["registry_failed"],
                     scene_stats["timeout"],
+                    scene_stats["failed_sample"],
                 ) = await self._deep_search_scenes(
                     all_entities,
                     query_lower,
@@ -268,10 +274,12 @@ class DeepSearchMixin(SceneSearchMixin):
                 automation_failed=automation_failed,
                 automation_yaml_skipped=automation_yaml_skipped,
                 automation_timeout=automation_timeout,
+                automation_failed_sample=automation_failed_sample,
                 script_skipped=script_skipped,
                 script_failed=script_failed,
                 script_yaml_skipped=script_yaml_skipped,
                 script_timeout=script_timeout,
+                script_failed_sample=script_failed_sample,
                 helper_failed=helper_failed,
                 dashboard_failed=dashboard_failed,
             )
@@ -318,11 +326,11 @@ class DeepSearchMixin(SceneSearchMixin):
         exact_match: bool,
         *,
         config_time_budget: float | None = None,
-    ) -> tuple[list[dict[str, Any]], int, int, int, int]:
+    ) -> tuple[list[dict[str, Any]], int, int, int, int, str | None]:
         """Deep-search automations: two-tier config fetch (REST bulk -> budgeted individual).
 
         Returns ``(matches, skipped_count, failed_count, yaml_skipped_count,
-        timeout_count)``. ``skipped_count`` is non-zero only when bulk fetch
+        timeout_count, failed_sample)``. ``skipped_count`` is non-zero only when bulk fetch
         fell back to the per-id Attempt-C path AND its wall-clock budget
         exhausted before all configs were fetched; ``failed_count`` is
         non-zero when individual config fetches raised a non-404, non-timeout
@@ -338,6 +346,11 @@ class DeepSearchMixin(SceneSearchMixin):
         distinguish a complete zero-result from an incomplete one —
         skipped/failed ids carry their score-without-config through the
         merge and fall below the match threshold silently otherwise.
+        ``failed_sample`` is one representative
+        ``summarize_fetch_error`` summary of a ``failed``-class exception
+        (``None`` when none occurred), surfaced in the failed fragment so
+        the response names WHAT raised instead of pointing at debug logs
+        (#1784 follow-up).
         """
         automation_entities = [
             e for e in all_entities if e.get("entity_id", "").startswith("automation.")
@@ -376,6 +389,10 @@ class DeepSearchMixin(SceneSearchMixin):
         failed_count = 0
         yaml_skipped_count = 0
         timeout_count = 0
+        # One representative summary per ``failed``-class exception, appended
+        # by the fetch closure below; the first entry rides partial_reason as
+        # an ``e.g.`` (#1784 follow-up). List membership tracks failed_count.
+        failed_errors: list[str] = []
         if not bulk_fetched:
             uids_to_fetch = [
                 uid for _, _, uid, _ in scored if uid and uid not in configs
@@ -405,6 +422,7 @@ class DeepSearchMixin(SceneSearchMixin):
                     logger.debug(
                         f"Automation individual config fetch ({uid}) failed: {e}"
                     )
+                    failed_errors.append(summarize_fetch_error(e))
                     return (uid, None, "failed")
                 except TimeoutError:
                     # asyncio.wait_for hit INDIVIDUAL_CONFIG_TIMEOUT. Classify
@@ -430,6 +448,7 @@ class DeepSearchMixin(SceneSearchMixin):
                     logger.debug(
                         f"Automation individual config fetch ({uid}) failed: {e}"
                     )
+                    failed_errors.append(summarize_fetch_error(e))
                     return (uid, None, "failed")
 
             (
@@ -463,7 +482,14 @@ class DeepSearchMixin(SceneSearchMixin):
                 scored, configs, query_lower, exact_match
             )
         ]
-        return matches, skipped_count, failed_count, yaml_skipped_count, timeout_count
+        return (
+            matches,
+            skipped_count,
+            failed_count,
+            yaml_skipped_count,
+            timeout_count,
+            failed_errors[0] if failed_errors else None,
+        )
 
     async def _deep_search_scripts(
         self,
@@ -472,11 +498,11 @@ class DeepSearchMixin(SceneSearchMixin):
         exact_match: bool,
         *,
         config_time_budget: float | None = None,
-    ) -> tuple[list[dict[str, Any]], int, int, int, int]:
+    ) -> tuple[list[dict[str, Any]], int, int, int, int, str | None]:
         """Deep-search scripts: same two-tier strategy as automations.
 
         Returns ``(matches, skipped_count, failed_count, yaml_skipped_count,
-        timeout_count)``; semantics identical to ``_deep_search_automations``
+        timeout_count, failed_sample)``; semantics identical to ``_deep_search_automations``
         — the 404 path catches YAML-defined scripts (which
         ``client.get_script_config`` re-raises as
         ``HomeAssistantAPIError(status_code=404)``).
@@ -514,6 +540,10 @@ class DeepSearchMixin(SceneSearchMixin):
         failed_count = 0
         yaml_skipped_count = 0
         timeout_count = 0
+        # One representative summary per ``failed``-class exception, appended
+        # by the fetch closure below; the first entry rides partial_reason as
+        # an ``e.g.`` (#1784 follow-up). List membership tracks failed_count.
+        failed_errors: list[str] = []
         if not bulk_fetched:
             sids_to_fetch = [
                 sid for _, _, sid, _ in scored if sid and sid not in configs
@@ -540,6 +570,7 @@ class DeepSearchMixin(SceneSearchMixin):
                         )
                         return (sid, None, "yaml_skipped")
                     logger.debug(f"Script individual config fetch ({sid}) failed: {e}")
+                    failed_errors.append(summarize_fetch_error(e))
                     return (sid, None, "failed")
                 except TimeoutError:
                     # See _fetch_automation_config: per-request timeout under
@@ -559,6 +590,7 @@ class DeepSearchMixin(SceneSearchMixin):
                         )
                         return (sid, None, "timeout")
                     logger.debug(f"Script individual config fetch ({sid}) failed: {e}")
+                    failed_errors.append(summarize_fetch_error(e))
                     return (sid, None, "failed")
 
             (
@@ -593,7 +625,14 @@ class DeepSearchMixin(SceneSearchMixin):
                 scored, configs, query_lower, exact_match
             )
         ]
-        return matches, skipped_count, failed_count, yaml_skipped_count, timeout_count
+        return (
+            matches,
+            skipped_count,
+            failed_count,
+            yaml_skipped_count,
+            timeout_count,
+            failed_errors[0] if failed_errors else None,
+        )
 
     @staticmethod
     def _build_helper_registry_map(
@@ -966,6 +1005,8 @@ class DeepSearchMixin(SceneSearchMixin):
         script_yaml_skipped: int = 0,
         automation_timeout: int = 0,
         script_timeout: int = 0,
+        automation_failed_sample: str | None = None,
+        script_failed_sample: str | None = None,
         helper_failed: int = 0,
         dashboard_failed: int = 0,
     ) -> dict[str, Any]:
@@ -1028,6 +1069,8 @@ class DeepSearchMixin(SceneSearchMixin):
             script_yaml_skipped=script_yaml_skipped,
             automation_timeout=automation_timeout,
             script_timeout=script_timeout,
+            automation_failed_sample=automation_failed_sample,
+            script_failed_sample=script_failed_sample,
             helper_failed=helper_failed,
             dashboard_failed=dashboard_failed,
         )
@@ -1045,6 +1088,8 @@ class DeepSearchMixin(SceneSearchMixin):
         script_yaml_skipped: int = 0,
         automation_timeout: int = 0,
         script_timeout: int = 0,
+        automation_failed_sample: str | None = None,
+        script_failed_sample: str | None = None,
         helper_failed: int = 0,
         dashboard_failed: int = 0,
     ) -> None:
@@ -1077,6 +1122,12 @@ class DeepSearchMixin(SceneSearchMixin):
         rationalised away by blind agents who reported the result as
         complete; the harder phrasing closes that gap.
 
+        ``automation_failed_sample`` / ``script_failed_sample`` carry one
+        representative ``summarize_fetch_error`` summary for the generic
+        ``failed`` class, appended to its fragment as an ``e.g.`` so the
+        response names WHAT raised instead of pointing at debug logs
+        (#1784 follow-up). ``None`` keeps the fragment wording unchanged.
+
         Append-safe: the existing ``partial_reason`` (if any) is preserved
         and the new reasons are concatenated with ``" ; "``.
         """
@@ -1084,7 +1135,16 @@ class DeepSearchMixin(SceneSearchMixin):
         # The automation and script fragments are symmetric (noun, per-id
         # endpoint, budget env var); loop rather than duplicating the four
         # per-class fragments per type.
-        for noun, endpoint, budget_env, skipped, failed, yaml_skipped, timeout in (
+        for (
+            noun,
+            endpoint,
+            budget_env,
+            skipped,
+            failed,
+            yaml_skipped,
+            timeout,
+            failed_sample,
+        ) in (
             (
                 "automation",
                 "/config/automation/config",
@@ -1093,6 +1153,7 @@ class DeepSearchMixin(SceneSearchMixin):
                 automation_failed,
                 automation_yaml_skipped,
                 automation_timeout,
+                automation_failed_sample,
             ),
             (
                 "script",
@@ -1102,6 +1163,7 @@ class DeepSearchMixin(SceneSearchMixin):
                 script_failed,
                 script_yaml_skipped,
                 script_timeout,
+                script_failed_sample,
             ),
         ):
             if skipped:
@@ -1114,10 +1176,16 @@ class DeepSearchMixin(SceneSearchMixin):
                     "the web Settings UI's Advanced section)."
                 )
             if failed:
+                # Name ONE representative error inline when the fetch path
+                # captured one — the opaque bucket alone sent users on a
+                # debug-log dive for trivially-diagnosable server errors
+                # (#1784 follow-up: every per-id script fetch 500ing on a
+                # ``!secret`` reference in scripts.yaml).
+                sample_suffix = f"; e.g. {failed_sample}" if failed_sample else ""
                 reasons.append(
                     f"{failed} {noun}(s) not scanned (per-id fetch raised "
-                    "a non-404 error) — their match status is unknown; this "
-                    "result is not exhaustive."
+                    f"a non-404 error{sample_suffix}) — their match status "
+                    "is unknown; this result is not exhaustive."
                 )
             if yaml_skipped:
                 reasons.append(

--- a/src/ha_mcp/tools/smart_search/_deep.py
+++ b/src/ha_mcp/tools/smart_search/_deep.py
@@ -21,7 +21,11 @@ from ._config import (
     INDIVIDUAL_FETCH_BATCH_SIZE,
     SCRIPT_CONFIG_TIME_BUDGET,
 )
-from ._fetch import is_timeout_error, summarize_fetch_error
+from ._fetch import (
+    http_500_diagnosis_hint,
+    is_timeout_error,
+    record_first_failure,
+)
 from ._scenes import SceneSearchMixin
 
 logger = logging.getLogger(__name__)
@@ -389,9 +393,12 @@ class DeepSearchMixin(SceneSearchMixin):
         failed_count = 0
         yaml_skipped_count = 0
         timeout_count = 0
-        # One representative summary per ``failed``-class exception, appended
-        # by the fetch closure below; the first entry rides partial_reason as
-        # an ``e.g.`` (#1784 follow-up). List membership tracks failed_count.
+        # One representative summary — only the FIRST ``failed``-class
+        # exception is kept (the fetch closure guards the append); it rides
+        # partial_reason as an ``e.g.`` (#1784 follow-up). The remaining
+        # failures are counted (``failed_count``) but not summarized, so the
+        # motivating "every per-id fetch 500s" case does N-1 fewer
+        # ``summarize_fetch_error`` calls.
         failed_errors: list[str] = []
         if not bulk_fetched:
             uids_to_fetch = [
@@ -422,7 +429,7 @@ class DeepSearchMixin(SceneSearchMixin):
                     logger.debug(
                         f"Automation individual config fetch ({uid}) failed: {e}"
                     )
-                    failed_errors.append(summarize_fetch_error(e))
+                    record_first_failure(failed_errors, e)
                     return (uid, None, "failed")
                 except TimeoutError:
                     # asyncio.wait_for hit INDIVIDUAL_CONFIG_TIMEOUT. Classify
@@ -448,7 +455,7 @@ class DeepSearchMixin(SceneSearchMixin):
                     logger.debug(
                         f"Automation individual config fetch ({uid}) failed: {e}"
                     )
-                    failed_errors.append(summarize_fetch_error(e))
+                    record_first_failure(failed_errors, e)
                     return (uid, None, "failed")
 
             (
@@ -540,9 +547,12 @@ class DeepSearchMixin(SceneSearchMixin):
         failed_count = 0
         yaml_skipped_count = 0
         timeout_count = 0
-        # One representative summary per ``failed``-class exception, appended
-        # by the fetch closure below; the first entry rides partial_reason as
-        # an ``e.g.`` (#1784 follow-up). List membership tracks failed_count.
+        # One representative summary — only the FIRST ``failed``-class
+        # exception is kept (the fetch closure guards the append); it rides
+        # partial_reason as an ``e.g.`` (#1784 follow-up). The remaining
+        # failures are counted (``failed_count``) but not summarized, so the
+        # motivating "every per-id fetch 500s" case does N-1 fewer
+        # ``summarize_fetch_error`` calls.
         failed_errors: list[str] = []
         if not bulk_fetched:
             sids_to_fetch = [
@@ -570,7 +580,7 @@ class DeepSearchMixin(SceneSearchMixin):
                         )
                         return (sid, None, "yaml_skipped")
                     logger.debug(f"Script individual config fetch ({sid}) failed: {e}")
-                    failed_errors.append(summarize_fetch_error(e))
+                    record_first_failure(failed_errors, e)
                     return (sid, None, "failed")
                 except TimeoutError:
                     # See _fetch_automation_config: per-request timeout under
@@ -590,7 +600,7 @@ class DeepSearchMixin(SceneSearchMixin):
                         )
                         return (sid, None, "timeout")
                     logger.debug(f"Script individual config fetch ({sid}) failed: {e}")
-                    failed_errors.append(summarize_fetch_error(e))
+                    record_first_failure(failed_errors, e)
                     return (sid, None, "failed")
 
             (
@@ -1126,7 +1136,10 @@ class DeepSearchMixin(SceneSearchMixin):
         representative ``summarize_fetch_error`` summary for the generic
         ``failed`` class, appended to its fragment as an ``e.g.`` so the
         response names WHAT raised instead of pointing at debug logs
-        (#1784 follow-up). ``None`` keeps the fragment wording unchanged.
+        (#1784 follow-up). When that sample is an HTTP 500 — whose body is
+        aiohttp's generic placeholder, so the sample can't name the cause —
+        a static HA-log diagnosis is appended too (``http_500_diagnosis_hint``).
+        ``None`` keeps the fragment wording unchanged.
 
         Append-safe: the existing ``partial_reason`` (if any) is preserved
         and the new reasons are concatenated with ``" ; "``.
@@ -1182,10 +1195,16 @@ class DeepSearchMixin(SceneSearchMixin):
                 # (#1784 follow-up: every per-id script fetch 500ing on a
                 # ``!secret`` reference in scripts.yaml).
                 sample_suffix = f"; e.g. {failed_sample}" if failed_sample else ""
+                # An HTTP 500 body is aiohttp's generic "500 Internal Server
+                # Error" — the real cause (e.g. a ``!secret`` the per-id
+                # config endpoint rejects) is HA-log-only, never in the
+                # response — so the sample can't name it. Append the static
+                # diagnosis the sample can't carry (#1784 follow-up).
+                hint = http_500_diagnosis_hint(failed_sample)
                 reasons.append(
                     f"{failed} {noun}(s) not scanned (per-id fetch raised "
                     f"a non-404 error{sample_suffix}) — their match status "
-                    "is unknown; this result is not exhaustive."
+                    f"is unknown; this result is not exhaustive.{hint}"
                 )
             if yaml_skipped:
                 reasons.append(

--- a/src/ha_mcp/tools/smart_search/_fetch.py
+++ b/src/ha_mcp/tools/smart_search/_fetch.py
@@ -2,16 +2,57 @@
 
 import asyncio
 import logging
+import re
 import time
 from collections.abc import Awaitable, Callable
 from typing import Any
 
 import httpx
 
+from ...client.rest_client import HomeAssistantAPIError
 from ._config import INDIVIDUAL_FETCH_BATCH_SIZE
 from ._scoring import ScoringMixin
 
 logger = logging.getLogger(__name__)
+
+# The REST client's own message prefix ("API error: <code> - "); stripped by
+# ``summarize_fetch_error`` so the summary doesn't state the status twice.
+_API_ERROR_PREFIX = re.compile(r"^API error:\s*\d+\s*-\s*")
+
+# Hard cap on a ``summarize_fetch_error`` summary. partial_reason fragments
+# are read inline by agents; one representative error needs a first line,
+# not a body dump.
+_ERROR_SAMPLE_MAX_LEN = 160
+
+
+def summarize_fetch_error(exc: BaseException) -> str:
+    """One-line, length-capped summary of a per-id config-fetch failure.
+
+    The generic ``failed`` bucket collapses every non-404, non-timeout
+    exception into one opaque partial_reason fragment ("per-id fetch raised
+    a non-404 error"), with the real exception visible only at debug-level
+    logging. The follow-up report on issue #1784 showed what that hides: a
+    box where every per-id script fetch returns a fast HTTP 500 because
+    ``scripts.yaml`` contains a ``!secret`` reference (HA core's config view
+    file-loads the YAML per request and rejects secrets before the id
+    lookup) — a five-minute diagnosis if the response named the error, a
+    log dive otherwise. This summary rides the fragment as an ``e.g.``.
+
+    HTTP errors render as ``HTTP <code>: <first line of the message>`` (the
+    client's own ``API error: <code> - `` prefix is stripped rather than
+    duplicated); everything else as ``<ExceptionType>: <first line>``.
+    """
+    lines = str(exc).strip().splitlines()
+    text = lines[0].strip() if lines else ""
+    if isinstance(exc, HomeAssistantAPIError) and exc.status_code is not None:
+        text = _API_ERROR_PREFIX.sub("", text)
+        prefix = f"HTTP {exc.status_code}"
+    else:
+        prefix = type(exc).__name__
+    summary = f"{prefix}: {text}" if text else prefix
+    if len(summary) > _ERROR_SAMPLE_MAX_LEN:
+        summary = summary[: _ERROR_SAMPLE_MAX_LEN - 1] + "…"
+    return summary
 
 
 def is_timeout_error(exc: BaseException) -> bool:

--- a/src/ha_mcp/tools/smart_search/_fetch.py
+++ b/src/ha_mcp/tools/smart_search/_fetch.py
@@ -55,6 +55,54 @@ def summarize_fetch_error(exc: BaseException) -> str:
     return summary
 
 
+# Marks a rendered ``summarize_fetch_error`` summary whose cause the sample
+# cannot name: an HTTP 500's body is aiohttp's generic "500 Internal Server
+# Error" placeholder, so the real error (a YAMLException the per-id config
+# view raised, most often a ``!secret`` reference it rejects) lives only in
+# the HA log, never in the response.
+_HTTP_500_PREFIX = "HTTP 500:"
+
+# Static diagnosis appended to an HTTP-500 failed fragment. The sample names
+# the status but not the cause (see ``_HTTP_500_PREFIX``); this points the
+# reader at the HA log and the single most common cause, delivering the
+# five-minute diagnosis the #1784 follow-up asked for without claiming a
+# cause the response can't actually confirm. Kept endpoint-agnostic — this
+# same string rides the automation, script, AND scene fragments, so it names
+# no specific YAML file (a scene 500 has nothing to do with scripts.yaml);
+# "the config file HA loads for this entity" covers all three.
+_HTTP_500_DIAGNOSIS = (
+    " A per-id config fetch returning HTTP 500 is most often a `!secret` "
+    "reference in the config file HA loads for this entity, which the per-id "
+    "config endpoint rejects; the specific cause is in the Home Assistant log "
+    "(the 500 body is a generic placeholder), not in this response."
+)
+
+
+def http_500_diagnosis_hint(failed_sample: str | None) -> str:
+    """Static HA-log hint to append when ``failed_sample`` is an HTTP 500.
+
+    Returns ``""`` for any other sample (or ``None``), so non-500 fragments
+    are byte-identical to before. See ``_HTTP_500_DIAGNOSIS``.
+    """
+    if failed_sample and failed_sample.startswith(_HTTP_500_PREFIX):
+        return _HTTP_500_DIAGNOSIS
+    return ""
+
+
+def record_first_failure(failed_errors: list[str], exc: BaseException) -> None:
+    """Capture ``exc``'s summary as the representative ``failed`` sample, once.
+
+    Only the FIRST generic-``failed`` exception per fetch pass is summarized
+    (subsequent ones are counted but not summarized) — in the motivating
+    "every per-id fetch 500s" case that is N-1 fewer ``summarize_fetch_error``
+    calls. The append is a no-op once ``failed_errors`` is non-empty. Called
+    from the per-id fetch closures, which run under ``asyncio.gather`` but
+    never suspend between the check and the append, so no lock is needed.
+    """
+    if not failed_errors:
+        failed_errors.append(summarize_fetch_error(exc))
+
+
 def is_timeout_error(exc: BaseException) -> bool:
     """True when ``exc`` is, or was directly caused by, a request timeout.
 

--- a/src/ha_mcp/tools/smart_search/_scenes.py
+++ b/src/ha_mcp/tools/smart_search/_scenes.py
@@ -10,7 +10,12 @@ from ._config import (
     INDIVIDUAL_FETCH_BATCH_SIZE,
     SCENE_CONFIG_TIME_BUDGET,
 )
-from ._fetch import ConfigFetchMixin, is_timeout_error, summarize_fetch_error
+from ._fetch import (
+    ConfigFetchMixin,
+    http_500_diagnosis_hint,
+    is_timeout_error,
+    record_first_failure,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -268,9 +273,10 @@ class SceneSearchMixin(ConfigFetchMixin):
         skipped_count = 0
         integration_skipped = 0
         timeout_count = 0
-        # One representative summary per ``failed``-class exception, appended
-        # by the fetch closure below; the first entry rides partial_reason as
-        # an ``e.g.`` (#1784 follow-up). List membership tracks failed_count.
+        # One representative summary — only the FIRST ``failed``-class
+        # exception is kept (the fetch closure guards the append); it rides
+        # partial_reason as an ``e.g.`` (#1784 follow-up). The remaining
+        # failures are counted (``failed_count``) but not summarized.
         failed_errors: list[str] = []
 
         # Attempt C: parallel per-id fetch with a wall-clock budget so a few
@@ -308,7 +314,7 @@ class SceneSearchMixin(ConfigFetchMixin):
                         )
                         return (sid, None, "timeout")
                     logger.debug(f"Scene individual config fetch ({sid}) failed: {e}")
-                    failed_errors.append(summarize_fetch_error(e))
+                    record_first_failure(failed_errors, e)
                     return (sid, None, "failed")
 
             (
@@ -391,10 +397,15 @@ class SceneSearchMixin(ConfigFetchMixin):
             # mirrors the automation/script ``e.g.`` sample, #1784 follow-up.
             failed_sample = scene_stats.get("failed_sample")
             sample_suffix = f"; e.g. {failed_sample}" if failed_sample else ""
+            # An HTTP 500 sample names the status but not the cause (the body
+            # is aiohttp's generic placeholder); append the static HA-log
+            # diagnosis, mirroring the automation/script fragment (#1784).
+            hint = http_500_diagnosis_hint(failed_sample)
             reason_parts.append(
                 f"{failed} scene(s) not scanned (per-id fetch raised"
                 f"{sample_suffix}) — "
-                "their match status is unknown; this result is not exhaustive."
+                f"their match status is unknown; this result is not "
+                f"exhaustive.{hint}"
             )
         if timeout:
             reason_parts.append(

--- a/src/ha_mcp/tools/smart_search/_scenes.py
+++ b/src/ha_mcp/tools/smart_search/_scenes.py
@@ -10,7 +10,7 @@ from ._config import (
     INDIVIDUAL_FETCH_BATCH_SIZE,
     SCENE_CONFIG_TIME_BUDGET,
 )
-from ._fetch import ConfigFetchMixin, is_timeout_error
+from ._fetch import ConfigFetchMixin, is_timeout_error, summarize_fetch_error
 
 logger = logging.getLogger(__name__)
 
@@ -211,15 +211,19 @@ class SceneSearchMixin(ConfigFetchMixin):
         *,
         config_time_budget: float | None = None,
         prefetched_registry: Any = None,
-    ) -> tuple[list[dict[str, Any]], int, int, int, bool, int]:
+    ) -> tuple[list[dict[str, Any]], int, int, int, bool, int, str | None]:
         """Deep-search scenes: two-tier strategy plus registry-walk augmentation.
 
         Scenes have no listing primitive, so entities are enumerated from
         get_states() and configs fetched per id. Returns the scene results plus
-        the five diagnostic signals feeding the response ``partial`` /
+        the six diagnostic signals feeding the response ``partial`` /
         ``partial_reason``:
         ``(results, failed_count, skipped_count, integration_skipped,
-        registry_failed, timeout_count)``.
+        registry_failed, timeout_count, failed_sample)``. ``failed_sample``
+        is one representative ``summarize_fetch_error`` summary of a
+        ``failed``-class exception (``None`` when none occurred) — see the
+        automation/script mirror in ``_deep_search_automations`` (#1784
+        follow-up).
         """
         scene_entities = [
             e for e in all_entities if e.get("entity_id", "").startswith("scene.")
@@ -264,6 +268,10 @@ class SceneSearchMixin(ConfigFetchMixin):
         skipped_count = 0
         integration_skipped = 0
         timeout_count = 0
+        # One representative summary per ``failed``-class exception, appended
+        # by the fetch closure below; the first entry rides partial_reason as
+        # an ``e.g.`` (#1784 follow-up). List membership tracks failed_count.
+        failed_errors: list[str] = []
 
         # Attempt C: parallel per-id fetch with a wall-clock budget so a few
         # slow scenes don't tank the whole search.
@@ -300,6 +308,7 @@ class SceneSearchMixin(ConfigFetchMixin):
                         )
                         return (sid, None, "timeout")
                     logger.debug(f"Scene individual config fetch ({sid}) failed: {e}")
+                    failed_errors.append(summarize_fetch_error(e))
                     return (sid, None, "failed")
 
             (
@@ -347,6 +356,7 @@ class SceneSearchMixin(ConfigFetchMixin):
             integration_skipped,
             registry_failed,
             timeout_count,
+            failed_errors[0] if failed_errors else None,
         )
 
     @staticmethod
@@ -376,8 +386,14 @@ class SceneSearchMixin(ConfigFetchMixin):
         response["partial"] = True
         reason_parts: list[str] = []
         if failed:
+            # Name ONE representative error inline when Attempt C captured
+            # one (.get(): tolerate stats dicts built without the key) —
+            # mirrors the automation/script ``e.g.`` sample, #1784 follow-up.
+            failed_sample = scene_stats.get("failed_sample")
+            sample_suffix = f"; e.g. {failed_sample}" if failed_sample else ""
             reason_parts.append(
-                f"{failed} scene(s) not scanned (per-id fetch raised) — "
+                f"{failed} scene(s) not scanned (per-id fetch raised"
+                f"{sample_suffix}) — "
                 "their match status is unknown; this result is not exhaustive."
             )
         if timeout:

--- a/tests/src/unit/test_deep_search_tier3_parallel.py
+++ b/tests/src/unit/test_deep_search_tier3_parallel.py
@@ -386,7 +386,7 @@ class TestYamlSkippedClassification:
     """Component-level coverage of the 404 → ``yaml_skipped`` classification.
 
     These tests drive ``_deep_search_automations`` / ``_deep_search_scripts``
-    directly and assert on their returned 5-tuple, pinning the
+    directly and assert on their returned 6-tuple, pinning the
     FETCH→CLASSIFY→COUNT path *inside* each per-type helper (wrong exception
     type, wrong status-code attribute, wrong return slot) so a regression
     surfaces here rather than silently misclassifying YAML-defined entities
@@ -718,7 +718,7 @@ class TestYamlSkippedThroughDeepSearch:
     ``deep_search`` entrypoint.
 
     ``TestYamlSkippedClassification`` pins each per-type helper's returned
-    5-tuple; these tests pin the wiring *between* that return and the
+    6-tuple; these tests pin the wiring *between* that return and the
     response — ``deep_search`` unpacks the 4th slot (the ``if "automation"``
     / ``if "script"`` blocks in ``deep_search``) and forwards it via the
     ``_paginate_and_build_response`` call to
@@ -1379,14 +1379,14 @@ class TestSummarizeFetchError:
     behind a debug-log dive)."""
 
     def test_api_error_strips_client_prefix_and_names_status(self):
+        # The realistic per-id 500 body: aiohttp's generic placeholder (the
+        # ``!secret`` cause is HA-log-only). The client's "API error: 500 - "
+        # prefix is stripped so the status isn't stated twice.
         exc = HomeAssistantAPIError(
-            "API error: 500 - Secrets not supported in this YAML file",
+            "API error: 500 - 500 Internal Server Error",
             status_code=500,
         )
-        assert (
-            summarize_fetch_error(exc)
-            == "HTTP 500: Secrets not supported in this YAML file"
-        )
+        assert summarize_fetch_error(exc) == "HTTP 500: 500 Internal Server Error"
 
     def test_api_error_without_prefix_keeps_message(self):
         exc = HomeAssistantAPIError("Script not found: foo", status_code=502)
@@ -1409,14 +1409,11 @@ class TestSummarizeFetchError:
 
     def test_multiline_body_keeps_first_line_only(self):
         exc = HomeAssistantAPIError(
-            "API error: 500 - Secrets not supported in this YAML file\n"
+            "API error: 500 - 500 Internal Server Error\n"
             "Traceback (most recent call last):\n  boom",
             status_code=500,
         )
-        assert (
-            summarize_fetch_error(exc)
-            == "HTTP 500: Secrets not supported in this YAML file"
-        )
+        assert summarize_fetch_error(exc) == "HTTP 500: 500 Internal Server Error"
 
     def test_long_message_truncated(self):
         out = summarize_fetch_error(RuntimeError("x" * 500))
@@ -1480,8 +1477,10 @@ class TestFailedSampleThroughDeepSearch:
         async def _per_id_500(method: str, url: str) -> dict:
             if url.rstrip("/") == "/config/automation/config":
                 raise Exception("Bulk fetch unavailable")
+            # aiohttp's generic production 500 body — the realistic sample for
+            # the ``!secret`` scenario (the cause is HA-log-only).
             raise HomeAssistantAPIError(
-                "API error: 500 - Secrets not supported in this YAML file",
+                "API error: 500 - 500 Internal Server Error",
                 status_code=500,
             )
 
@@ -1501,7 +1500,7 @@ class TestFailedSampleThroughDeepSearch:
             exact_match=False,
         )
         assert failed_count == 2
-        assert failed_sample == "HTTP 500: Secrets not supported in this YAML file"
+        assert failed_sample == "HTTP 500: 500 Internal Server Error"
 
     @pytest.mark.asyncio
     async def test_automation_generic_exception_sample_names_type(
@@ -1529,6 +1528,44 @@ class TestFailedSampleThroughDeepSearch:
         ) = await smart_tools._deep_search_automations(
             automations,
             {"automation.secret_one": "uid_one"},
+            query_lower="anything",
+            exact_match=False,
+        )
+        assert failed_count == 1
+        assert failed_sample == "RuntimeError: generic explosion"
+
+    @pytest.mark.asyncio
+    async def test_script_generic_exception_sample_names_type(
+        self, mock_client, smart_tools
+    ):
+        """The script closure's generic ``except Exception`` branch
+        (``_deep.py`` ``_fetch_script_config``, the non-``HomeAssistantAPIError``
+        non-timeout path) captures a ``Type: message`` summary. Covers the
+        branch the maintainer flagged as untested: unlike the 500 path it
+        exercises a bare ``RuntimeError`` raised by ``get_script_config``."""
+        scripts = [
+            {
+                "entity_id": "script.boom_one",
+                "state": "off",
+                "attributes": {"friendly_name": "Boom One"},
+            },
+        ]
+        mock_client.get_states = AsyncMock(return_value=scripts)
+
+        async def _script_boom(sid: str) -> dict:
+            raise RuntimeError("generic explosion")
+
+        mock_client.get_script_config = AsyncMock(side_effect=_script_boom)
+
+        (
+            _matches,
+            _skipped_count,
+            failed_count,
+            _yaml_skipped_count,
+            _timeout_count,
+            failed_sample,
+        ) = await smart_tools._deep_search_scripts(
+            scripts,
             query_lower="anything",
             exact_match=False,
         )
@@ -1584,8 +1621,13 @@ class TestFailedSampleThroughDeepSearch:
         self, mock_client, smart_tools
     ):
         """The reporter's exact scenario: every per-id script fetch 500s on
-        a ``!secret`` reference. The fragment must carry the count AND the
-        representative error through the public entrypoint."""
+        a ``!secret`` reference. The per-id config view raises a YAMLException
+        that escapes to aiohttp, whose production 500 body is the generic
+        ``500 Internal Server Error`` placeholder (the ``!secret`` detail goes
+        to the HA log, never the HTTP body), so the rendered sample names the
+        500 — not the cause — and the static HA-log hint carries the
+        diagnosis. The fragment must carry the count, the representative
+        error, AND that hint through the public entrypoint."""
         scripts = [
             {
                 "entity_id": "script.secret_one",
@@ -1601,8 +1643,10 @@ class TestFailedSampleThroughDeepSearch:
         mock_client.get_states = AsyncMock(return_value=scripts)
 
         async def _script_500(sid: str) -> dict:
+            # aiohttp's generic production 500 body — what the client actually
+            # sees when the per-id config view's YAMLException escapes.
             raise HomeAssistantAPIError(
-                "API error: 500 - Secrets not supported in this YAML file",
+                "API error: 500 - 500 Internal Server Error",
                 status_code=500,
             )
 
@@ -1618,8 +1662,11 @@ class TestFailedSampleThroughDeepSearch:
         reason = result["partial_reason"]
         assert (
             "2 script(s) not scanned (per-id fetch raised a non-404 error; "
-            "e.g. HTTP 500: Secrets not supported in this YAML file)" in reason
+            "e.g. HTTP 500: 500 Internal Server Error)" in reason
         ), f"failed fragment must carry the representative error; got {reason!r}"
+        assert "`!secret` reference in the config file HA loads" in reason, (
+            f"HTTP-500 fragment must carry the static HA-log hint; got {reason!r}"
+        )
 
     @pytest.mark.asyncio
     async def test_scene_500_sample_surfaces_through_deep_search(
@@ -1642,8 +1689,9 @@ class TestFailedSampleThroughDeepSearch:
         mock_client.get_states = AsyncMock(return_value=scenes)
 
         async def _scene_500(sid: str) -> dict:
+            # aiohttp's generic production 500 body (see the script mirror).
             raise HomeAssistantAPIError(
-                "API error: 500 - Internal Server Error", status_code=500
+                "API error: 500 - 500 Internal Server Error", status_code=500
             )
 
         mock_client.get_scene_config = AsyncMock(side_effect=_scene_500)
@@ -1658,5 +1706,60 @@ class TestFailedSampleThroughDeepSearch:
         reason = result["partial_reason"]
         assert (
             "2 scene(s) not scanned (per-id fetch raised; "
-            "e.g. HTTP 500: Internal Server Error)" in reason
+            "e.g. HTTP 500: 500 Internal Server Error)" in reason
         ), f"scene failed fragment must carry the representative error; got {reason!r}"
+        assert "`!secret` reference in the config file HA loads" in reason, (
+            f"HTTP-500 scene fragment must carry the static HA-log hint; got {reason!r}"
+        )
+        # The shared hint is endpoint-agnostic: a scene 500 has nothing to do
+        # with scripts.yaml/automations.yaml, so those filenames must NOT
+        # appear on the scene path (Codex review P2).
+        assert "scripts.yaml" not in reason and "automations.yaml" not in reason, (
+            f"scene hint must not name script/automation files; got {reason!r}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_only_first_failure_is_summarized(self, mock_client, smart_tools):
+        """The fetch closure keeps only the FIRST ``failed``-class sample
+        (``if not failed_errors:`` guard): in the motivating "every per-id
+        fetch 500s" case, ``summarize_fetch_error`` runs once, not once per
+        failure. All failures still COUNT."""
+        scripts = [
+            {
+                "entity_id": f"script.secret_{n}",
+                "state": "off",
+                "attributes": {"friendly_name": f"Secret {n}"},
+            }
+            for n in range(5)
+        ]
+        mock_client.get_states = AsyncMock(return_value=scripts)
+
+        async def _script_500(sid: str) -> dict:
+            raise HomeAssistantAPIError(
+                "API error: 500 - 500 Internal Server Error", status_code=500
+            )
+
+        mock_client.get_script_config = AsyncMock(side_effect=_script_500)
+
+        with patch(
+            "ha_mcp.tools.smart_search._fetch.summarize_fetch_error",
+            wraps=summarize_fetch_error,
+        ) as spy:
+            (
+                _matches,
+                _skipped_count,
+                failed_count,
+                _yaml_skipped_count,
+                _timeout_count,
+                failed_sample,
+            ) = await smart_tools._deep_search_scripts(
+                scripts,
+                query_lower="anything",
+                exact_match=False,
+            )
+
+        assert failed_count == 5, "every failure must still be counted"
+        assert failed_sample == "HTTP 500: 500 Internal Server Error"
+        assert spy.call_count == 1, (
+            f"guard must summarize only the first failure; got {spy.call_count}"
+        )

--- a/tests/src/unit/test_deep_search_tier3_parallel.py
+++ b/tests/src/unit/test_deep_search_tier3_parallel.py
@@ -18,7 +18,7 @@ from ha_mcp.client.rest_client import (
     HomeAssistantConnectionError,
 )
 from ha_mcp.tools.smart_search import SmartSearchTools
-from ha_mcp.tools.smart_search._fetch import is_timeout_error
+from ha_mcp.tools.smart_search._fetch import is_timeout_error, summarize_fetch_error
 
 
 def _make_tools(client):
@@ -460,6 +460,7 @@ class TestYamlSkippedClassification:
             failed_count,
             yaml_skipped_count,
             _timeout_count,
+            _failed_sample,
         ) = await smart_tools._deep_search_automations(
             automations,
             {
@@ -523,6 +524,7 @@ class TestYamlSkippedClassification:
             failed_count,
             yaml_skipped_count,
             _timeout_count,
+            _failed_sample,
         ) = await smart_tools._deep_search_automations(
             automations,
             {
@@ -572,6 +574,7 @@ class TestYamlSkippedClassification:
             failed_count,
             yaml_skipped_count,
             _timeout_count,
+            _failed_sample,
         ) = await smart_tools._deep_search_automations(
             automations,
             {"automation.none_status": "uid_none"},
@@ -618,6 +621,7 @@ class TestYamlSkippedClassification:
             failed_count,
             yaml_skipped_count,
             _timeout_count,
+            _failed_sample,
         ) = await smart_tools._deep_search_scripts(
             scripts,
             query_lower="anything",
@@ -684,6 +688,7 @@ class TestYamlSkippedClassification:
             failed_count,
             yaml_skipped_count,
             _timeout_count,
+            _failed_sample,
         ) = await smart_tools._deep_search_automations(
             automations,
             {
@@ -915,6 +920,7 @@ class TestTimeoutClassification:
                 failed_count,
                 yaml_skipped_count,
                 timeout_count,
+                _failed_sample,
             ) = await smart_tools._deep_search_automations(
                 automations,
                 {
@@ -962,6 +968,7 @@ class TestTimeoutClassification:
                 failed_count,
                 yaml_skipped_count,
                 timeout_count,
+                _failed_sample,
             ) = await smart_tools._deep_search_scripts(
                 scripts,
                 query_lower="anything",
@@ -1101,6 +1108,7 @@ class TestSceneTimeoutClassification:
                 _integration_skipped,
                 registry_failed,
                 timeout_count,
+                _failed_sample,
             ) = await smart_tools._deep_search_scenes(
                 scenes,
                 query_lower="anything",
@@ -1228,6 +1236,7 @@ class TestWrappedClientTimeoutClassification:
             failed_count,
             yaml_skipped_count,
             timeout_count,
+            _failed_sample,
         ) = await smart_tools._deep_search_automations(
             automations,
             {"automation.capped": "uid_capped"},
@@ -1272,6 +1281,7 @@ class TestWrappedClientTimeoutClassification:
             failed_count,
             yaml_skipped_count,
             timeout_count,
+            _failed_sample,
         ) = await smart_tools._deep_search_automations(
             automations,
             {"automation.down": "uid_down"},
@@ -1359,3 +1369,294 @@ class TestBudgetedFetchCountArithmetic:
             f"skipped must exclude fetched AND timed-out ids; got "
             f"skipped={skipped_count}"
         )
+
+
+class TestSummarizeFetchError:
+    """Unit coverage of ``summarize_fetch_error`` — the one-line summary the
+    generic ``failed`` bucket attaches to ``partial_reason`` (#1784
+    follow-up: the opaque "raised a non-404 error" hid a trivially-
+    diagnosable per-id 500 — a ``!secret`` reference in scripts.yaml —
+    behind a debug-log dive)."""
+
+    def test_api_error_strips_client_prefix_and_names_status(self):
+        exc = HomeAssistantAPIError(
+            "API error: 500 - Secrets not supported in this YAML file",
+            status_code=500,
+        )
+        assert (
+            summarize_fetch_error(exc)
+            == "HTTP 500: Secrets not supported in this YAML file"
+        )
+
+    def test_api_error_without_prefix_keeps_message(self):
+        exc = HomeAssistantAPIError("Script not found: foo", status_code=502)
+        assert summarize_fetch_error(exc) == "HTTP 502: Script not found: foo"
+
+    def test_api_error_status_none_falls_back_to_exception_form(self):
+        """``status_code=None`` means we can't claim an HTTP code — render
+        as a plain exception summary instead of ``HTTP None``."""
+        exc = HomeAssistantAPIError("connection reset")
+        assert summarize_fetch_error(exc) == ("HomeAssistantAPIError: connection reset")
+
+    def test_generic_exception_names_type(self):
+        assert (
+            summarize_fetch_error(RuntimeError("generic explosion"))
+            == "RuntimeError: generic explosion"
+        )
+
+    def test_empty_message_yields_bare_type(self):
+        assert summarize_fetch_error(RuntimeError()) == "RuntimeError"
+
+    def test_multiline_body_keeps_first_line_only(self):
+        exc = HomeAssistantAPIError(
+            "API error: 500 - Secrets not supported in this YAML file\n"
+            "Traceback (most recent call last):\n  boom",
+            status_code=500,
+        )
+        assert (
+            summarize_fetch_error(exc)
+            == "HTTP 500: Secrets not supported in this YAML file"
+        )
+
+    def test_long_message_truncated(self):
+        out = summarize_fetch_error(RuntimeError("x" * 500))
+        assert len(out) == 160
+        assert out.endswith("…")
+
+
+class TestFailedSampleThroughDeepSearch:
+    """Component + seam coverage of the representative-error sample on the
+    generic ``failed`` bucket (#1784 follow-up).
+
+    ``_deep_search_automations`` / ``_deep_search_scripts`` return the
+    sample in a new 6th tuple slot (scenes: 7th), ``deep_search`` forwards
+    it via ``_paginate_and_build_response`` into
+    ``_apply_per_type_partial_flag`` (scenes: ``scene_stats["failed_sample"]``
+    into ``_apply_scene_partial_flag``), and the failed fragment carries it
+    as an ``e.g.``. Without the sample the response can't explain WHAT
+    raised: the follow-up report on #1784 was a box where every per-id
+    script fetch 500s on a ``!secret`` reference in scripts.yaml —
+    indistinguishable from any other failure without a debug-log dive."""
+
+    @pytest.fixture
+    def mock_client(self):
+        client = MagicMock()
+        client.get_config = AsyncMock(return_value={"time_zone": "UTC"})
+        # Bulk fetch fails (triggers Tier 3 per-id fallback).
+        client._request = AsyncMock(side_effect=Exception("Bulk fetch unavailable"))
+        client.send_websocket_message = AsyncMock(
+            side_effect=Exception("WebSocket unavailable")
+        )
+        return client
+
+    @pytest.fixture
+    def smart_tools(self, mock_client):
+        return _make_tools(mock_client)
+
+    @staticmethod
+    def _automation_entities() -> list[dict]:
+        return [
+            {
+                "entity_id": "automation.secret_one",
+                "state": "on",
+                "attributes": {"friendly_name": "Secret One", "id": "uid_one"},
+            },
+            {
+                "entity_id": "automation.secret_two",
+                "state": "on",
+                "attributes": {"friendly_name": "Secret Two", "id": "uid_two"},
+            },
+        ]
+
+    @pytest.mark.asyncio
+    async def test_automation_500_sample_lands_in_sixth_slot(
+        self, mock_client, smart_tools
+    ):
+        """A per-id 500 must both count as ``failed`` AND surface its
+        summary in the new 6th slot."""
+        automations = self._automation_entities()
+        mock_client.get_states = AsyncMock(return_value=automations)
+
+        async def _per_id_500(method: str, url: str) -> dict:
+            if url.rstrip("/") == "/config/automation/config":
+                raise Exception("Bulk fetch unavailable")
+            raise HomeAssistantAPIError(
+                "API error: 500 - Secrets not supported in this YAML file",
+                status_code=500,
+            )
+
+        mock_client._request = AsyncMock(side_effect=_per_id_500)
+
+        (
+            _matches,
+            _skipped_count,
+            failed_count,
+            _yaml_skipped_count,
+            _timeout_count,
+            failed_sample,
+        ) = await smart_tools._deep_search_automations(
+            automations,
+            {"automation.secret_one": "uid_one", "automation.secret_two": "uid_two"},
+            query_lower="anything",
+            exact_match=False,
+        )
+        assert failed_count == 2
+        assert failed_sample == "HTTP 500: Secrets not supported in this YAML file"
+
+    @pytest.mark.asyncio
+    async def test_automation_generic_exception_sample_names_type(
+        self, mock_client, smart_tools
+    ):
+        """The generic ``except Exception`` branch captures a
+        ``Type: message`` summary."""
+        automations = self._automation_entities()[:1]
+        mock_client.get_states = AsyncMock(return_value=automations)
+
+        async def _per_id_boom(method: str, url: str) -> dict:
+            if url.rstrip("/") == "/config/automation/config":
+                raise Exception("Bulk fetch unavailable")
+            raise RuntimeError("generic explosion")
+
+        mock_client._request = AsyncMock(side_effect=_per_id_boom)
+
+        (
+            _matches,
+            _skipped_count,
+            failed_count,
+            _yaml_skipped_count,
+            _timeout_count,
+            failed_sample,
+        ) = await smart_tools._deep_search_automations(
+            automations,
+            {"automation.secret_one": "uid_one"},
+            query_lower="anything",
+            exact_match=False,
+        )
+        assert failed_count == 1
+        assert failed_sample == "RuntimeError: generic explosion"
+
+    @pytest.mark.asyncio
+    async def test_automation_404_and_timeout_produce_no_sample(
+        self, mock_client, smart_tools
+    ):
+        """Only the generic ``failed`` class captures a sample: 404s
+        (yaml_skipped) and per-request timeouts have their own dedicated
+        fragments and must leave the 6th slot at ``None``."""
+        automations = self._automation_entities()
+        mock_client.get_states = AsyncMock(return_value=automations)
+
+        async def _per_id_mixed(method: str, url: str) -> dict:
+            if url.rstrip("/") == "/config/automation/config":
+                raise Exception("Bulk fetch unavailable")
+            if url.endswith("uid_one"):
+                raise HomeAssistantAPIError(
+                    "API error: 404 - Not Found", status_code=404
+                )
+            await asyncio.sleep(0.2)
+            return {}
+
+        mock_client._request = AsyncMock(side_effect=_per_id_mixed)
+
+        with patch("ha_mcp.tools.smart_search._deep.INDIVIDUAL_CONFIG_TIMEOUT", 0.05):
+            (
+                _matches,
+                _skipped_count,
+                failed_count,
+                yaml_skipped_count,
+                timeout_count,
+                failed_sample,
+            ) = await smart_tools._deep_search_automations(
+                automations,
+                {
+                    "automation.secret_one": "uid_one",
+                    "automation.secret_two": "uid_two",
+                },
+                query_lower="anything",
+                exact_match=False,
+            )
+        assert failed_count == 0
+        assert yaml_skipped_count == 1
+        assert timeout_count == 1
+        assert failed_sample is None
+
+    @pytest.mark.asyncio
+    async def test_script_500_sample_surfaces_through_deep_search(
+        self, mock_client, smart_tools
+    ):
+        """The reporter's exact scenario: every per-id script fetch 500s on
+        a ``!secret`` reference. The fragment must carry the count AND the
+        representative error through the public entrypoint."""
+        scripts = [
+            {
+                "entity_id": "script.secret_one",
+                "state": "off",
+                "attributes": {"friendly_name": "Secret One"},
+            },
+            {
+                "entity_id": "script.secret_two",
+                "state": "off",
+                "attributes": {"friendly_name": "Secret Two"},
+            },
+        ]
+        mock_client.get_states = AsyncMock(return_value=scripts)
+
+        async def _script_500(sid: str) -> dict:
+            raise HomeAssistantAPIError(
+                "API error: 500 - Secrets not supported in this YAML file",
+                status_code=500,
+            )
+
+        mock_client.get_script_config = AsyncMock(side_effect=_script_500)
+
+        result = await smart_tools.deep_search(
+            query="anything",
+            search_types=["script"],
+            limit=10,
+        )
+
+        assert result["partial"] is True
+        reason = result["partial_reason"]
+        assert (
+            "2 script(s) not scanned (per-id fetch raised a non-404 error; "
+            "e.g. HTTP 500: Secrets not supported in this YAML file)" in reason
+        ), f"failed fragment must carry the representative error; got {reason!r}"
+
+    @pytest.mark.asyncio
+    async def test_scene_500_sample_surfaces_through_deep_search(
+        self, mock_client, smart_tools
+    ):
+        """Scene mirror: the sample rides ``scene_stats["failed_sample"]``
+        into ``_apply_scene_partial_flag``'s failed fragment."""
+        scenes = [
+            {
+                "entity_id": "scene.broken_one",
+                "state": "scening",
+                "attributes": {"friendly_name": "Broken One"},
+            },
+            {
+                "entity_id": "scene.broken_two",
+                "state": "scening",
+                "attributes": {"friendly_name": "Broken Two"},
+            },
+        ]
+        mock_client.get_states = AsyncMock(return_value=scenes)
+
+        async def _scene_500(sid: str) -> dict:
+            raise HomeAssistantAPIError(
+                "API error: 500 - Internal Server Error", status_code=500
+            )
+
+        mock_client.get_scene_config = AsyncMock(side_effect=_scene_500)
+
+        result = await smart_tools.deep_search(
+            query="anything",
+            search_types=["scene"],
+            limit=10,
+        )
+
+        assert result["partial"] is True
+        reason = result["partial_reason"]
+        assert (
+            "2 scene(s) not scanned (per-id fetch raised; "
+            "e.g. HTTP 500: Internal Server Error)" in reason
+        ), f"scene failed fragment must carry the representative error; got {reason!r}"

--- a/tests/src/unit/test_ha_search_merge.py
+++ b/tests/src/unit/test_ha_search_merge.py
@@ -972,22 +972,26 @@ def test_failed_fragment_carries_error_sample_when_provided() -> None:
     fetch path captured one (#1784 follow-up): the opaque "raised a non-404
     error" hid a trivially-diagnosable server-side failure — every per-id
     script fetch 500ing on a ``!secret`` reference in scripts.yaml —
-    behind a debug-log dive. The sample makes the response itself carry
-    the diagnosis."""
+    behind a debug-log dive. The sample makes the response itself carry the
+    diagnosis; because an HTTP 500's body is aiohttp's generic placeholder
+    (the ``!secret`` cause is HA-log-only), the static HA-log hint rides
+    alongside the sample."""
     response: dict = {"success": True}
     DeepSearchMixin._apply_per_type_partial_flag(
         response,
         script_failed=27,
-        script_failed_sample="HTTP 500: Secrets not supported in this YAML file",
+        script_failed_sample="HTTP 500: 500 Internal Server Error",
     )
     assert response["partial"] is True
     reason = response["partial_reason"]
     assert (
         "27 script(s) not scanned (per-id fetch raised a non-404 error; "
-        "e.g. HTTP 500: Secrets not supported in this YAML file)" in reason
+        "e.g. HTTP 500: 500 Internal Server Error)" in reason
     )
     assert "match status is unknown" in reason
     assert "not exhaustive" in reason
+    assert "`!secret` reference in the config file HA loads" in reason
+    assert "in the Home Assistant log" in reason
 
 
 def test_failed_fragment_unchanged_without_sample() -> None:
@@ -1014,6 +1018,32 @@ def test_failed_sample_is_per_type() -> None:
     reason = response["partial_reason"]
     assert "non-404 error; e.g. RuntimeError: automation boom)" in reason
     assert "non-404 error; e.g. HTTP 500: script boom)" in reason
+    # The static HA-log hint is scoped to HTTP-500 samples: the 500 script
+    # fragment carries it, the RuntimeError automation fragment does not.
+    assert reason.count("in the Home Assistant log") == 1
+
+
+def test_http_500_hint_only_on_http_500_sample() -> None:
+    """The static HA-log hint rides an HTTP-500 sample (whose body can't name
+    the cause) but not a non-500 sample, which already names its own type +
+    message. Scoping it keeps every non-500 fragment byte-identical."""
+    http500: dict = {"success": True}
+    DeepSearchMixin._apply_per_type_partial_flag(
+        http500, automation_failed=1, automation_failed_sample="HTTP 500: boom"
+    )
+    assert "in the Home Assistant log" in http500["partial_reason"]
+
+    non500: dict = {"success": True}
+    DeepSearchMixin._apply_per_type_partial_flag(
+        non500,
+        automation_failed=1,
+        automation_failed_sample="HTTP 502: Bad Gateway",
+    )
+    assert "in the Home Assistant log" not in non500["partial_reason"]
+
+    no_sample: dict = {"success": True}
+    DeepSearchMixin._apply_per_type_partial_flag(no_sample, automation_failed=1)
+    assert "in the Home Assistant log" not in no_sample["partial_reason"]
 
 
 def test_budget_partial_flag_set_when_helper_type_lists_failed() -> None:

--- a/tests/src/unit/test_ha_search_merge.py
+++ b/tests/src/unit/test_ha_search_merge.py
@@ -967,6 +967,55 @@ def test_budget_partial_flag_distinguishes_timeout_from_failed() -> None:
     assert reason.count(" ; ") == 1
 
 
+def test_failed_fragment_carries_error_sample_when_provided() -> None:
+    """The generic non-404 fragment names ONE representative error when the
+    fetch path captured one (#1784 follow-up): the opaque "raised a non-404
+    error" hid a trivially-diagnosable server-side failure — every per-id
+    script fetch 500ing on a ``!secret`` reference in scripts.yaml —
+    behind a debug-log dive. The sample makes the response itself carry
+    the diagnosis."""
+    response: dict = {"success": True}
+    DeepSearchMixin._apply_per_type_partial_flag(
+        response,
+        script_failed=27,
+        script_failed_sample="HTTP 500: Secrets not supported in this YAML file",
+    )
+    assert response["partial"] is True
+    reason = response["partial_reason"]
+    assert (
+        "27 script(s) not scanned (per-id fetch raised a non-404 error; "
+        "e.g. HTTP 500: Secrets not supported in this YAML file)" in reason
+    )
+    assert "match status is unknown" in reason
+    assert "not exhaustive" in reason
+
+
+def test_failed_fragment_unchanged_without_sample() -> None:
+    """No captured sample → the exact prior wording, with no dangling
+    ``e.g.`` (pins backward compatibility of the fragment)."""
+    response: dict = {"success": True}
+    DeepSearchMixin._apply_per_type_partial_flag(response, automation_failed=4)
+    reason = response["partial_reason"]
+    assert "4 automation(s) not scanned (per-id fetch raised a non-404 error)" in reason
+    assert "e.g." not in reason
+
+
+def test_failed_sample_is_per_type() -> None:
+    """Automation and script samples ride their own fragments — no
+    cross-type bleed."""
+    response: dict = {"success": True}
+    DeepSearchMixin._apply_per_type_partial_flag(
+        response,
+        automation_failed=1,
+        automation_failed_sample="RuntimeError: automation boom",
+        script_failed=2,
+        script_failed_sample="HTTP 500: script boom",
+    )
+    reason = response["partial_reason"]
+    assert "non-404 error; e.g. RuntimeError: automation boom)" in reason
+    assert "non-404 error; e.g. HTTP 500: script boom)" in reason
+
+
 def test_budget_partial_flag_set_when_helper_type_lists_failed() -> None:
     """Helpers run on every default ha_search call; silent per-type-list
     failures previously left callers unable to distinguish a clean

--- a/tests/src/unit/test_smart_search_scene_phase25.py
+++ b/tests/src/unit/test_smart_search_scene_phase25.py
@@ -618,7 +618,10 @@ class TestApplyScenePartialFlag:
         """The scene failed fragment names ONE representative error when
         Attempt C captured one (#1784 follow-up) — mirrors the
         automation/script ``e.g.`` sample so the response itself carries
-        the diagnosis instead of pointing at a debug-log dive."""
+        the diagnosis instead of pointing at a debug-log dive. An HTTP 500's
+        body is aiohttp's generic placeholder, so the static HA-log hint
+        rides alongside the sample (also mirroring the automation/script
+        path)."""
         from ha_mcp.tools.smart_search._scenes import SceneSearchMixin
 
         response: dict[str, Any] = {"success": True}
@@ -629,17 +632,18 @@ class TestApplyScenePartialFlag:
                 "skipped": 0,
                 "integration_skipped": 0,
                 "registry_failed": False,
-                "failed_sample": "HTTP 500: Internal Server Error",
+                "failed_sample": "HTTP 500: 500 Internal Server Error",
             },
         )
         assert response["partial"] is True
         reason = response["partial_reason"]
         assert (
             "2 scene(s) not scanned (per-id fetch raised; "
-            "e.g. HTTP 500: Internal Server Error)" in reason
+            "e.g. HTTP 500: 500 Internal Server Error)" in reason
         )
         assert "match status is unknown" in reason
         assert "not exhaustive" in reason
+        assert "in the Home Assistant log" in reason
 
     def test_stats_dict_without_failed_sample_key_is_tolerated(self) -> None:
         """``failed_sample`` is read with ``.get()`` — older stats-dict

--- a/tests/src/unit/test_smart_search_scene_phase25.py
+++ b/tests/src/unit/test_smart_search_scene_phase25.py
@@ -383,8 +383,13 @@ class TestSceneIntegrationFilter:
         reason = result.get("partial_reason", "")
         # The real failure is named (so the operator knows something broke).
         # Wording strengthened in PR #1529 R5 — every per-type/scene
-        # incompleteness fragment carries the "not scanned" triad.
-        assert "scene(s) not scanned (per-id fetch raised)" in reason
+        # incompleteness fragment carries the "not scanned" triad — and the
+        # #1784 follow-up added the representative-error ``e.g.`` so the
+        # response itself says WHAT raised.
+        assert (
+            "scene(s) not scanned (per-id fetch raised; "
+            "e.g. RuntimeError: REST 500 on movie_night)" in reason
+        )
         assert "match status is unknown" in reason.lower()
         # Integration-managed scenes are surfaced separately so their
         # 100+ count on Hue installs doesn't read as "everything broken".
@@ -608,6 +613,53 @@ class TestApplyScenePartialFlag:
         # automation/script paths in PR #1529 R5.
         assert "match status is unknown" in reason
         assert "not exhaustive" in reason
+
+    def test_failed_fragment_carries_error_sample_when_provided(self) -> None:
+        """The scene failed fragment names ONE representative error when
+        Attempt C captured one (#1784 follow-up) — mirrors the
+        automation/script ``e.g.`` sample so the response itself carries
+        the diagnosis instead of pointing at a debug-log dive."""
+        from ha_mcp.tools.smart_search._scenes import SceneSearchMixin
+
+        response: dict[str, Any] = {"success": True}
+        SceneSearchMixin._apply_scene_partial_flag(
+            response,
+            {
+                "failed": 2,
+                "skipped": 0,
+                "integration_skipped": 0,
+                "registry_failed": False,
+                "failed_sample": "HTTP 500: Internal Server Error",
+            },
+        )
+        assert response["partial"] is True
+        reason = response["partial_reason"]
+        assert (
+            "2 scene(s) not scanned (per-id fetch raised; "
+            "e.g. HTTP 500: Internal Server Error)" in reason
+        )
+        assert "match status is unknown" in reason
+        assert "not exhaustive" in reason
+
+    def test_stats_dict_without_failed_sample_key_is_tolerated(self) -> None:
+        """``failed_sample`` is read with ``.get()`` — older stats-dict
+        builders without the key keep the exact prior wording, with no
+        dangling ``e.g.``."""
+        from ha_mcp.tools.smart_search._scenes import SceneSearchMixin
+
+        response: dict[str, Any] = {"success": True}
+        SceneSearchMixin._apply_scene_partial_flag(
+            response,
+            {
+                "failed": 3,
+                "skipped": 0,
+                "integration_skipped": 0,
+                "registry_failed": False,
+            },
+        )
+        reason = response["partial_reason"]
+        assert "3 scene(s) not scanned (per-id fetch raised)" in reason
+        assert "e.g." not in reason
 
     def test_timeout_sets_partial_pointing_at_concurrency_knobs(self) -> None:
         """Per-request timeouts (issue #1784) must surface as their own


### PR DESCRIPTION
## What does this PR do?

Follow-up to my comment on #1784. That fix split the timeout class out of the generic "per-id fetch raised a non-404 error" bucket, but every other non-404 exception still collapses into the same opaque string. On my box that bucket was hiding a fast HTTP 500 on every per-id script fetch: HA core's script config view file-loads scripts.yaml on each request and dies on a `!secret` reference (`annotatedyaml.YAMLException: Secrets not supported in this YAML file`) before it ever gets to the id lookup. Nothing timed out, but the warning read identically to the pre-#1810 timeout case, and the actual error was only visible after a debug-log dive. I know ha_search is reworked in the custom component, but the container/addon/uvx server path in `src/` still carries this exact bucket, so filing the fix there.

This PR makes the failed fragment name one representative error inline:

```
27 script(s) not scanned (per-id fetch raised a non-404 error; e.g. HTTP 500: 500 Internal Server Error) — their match status is unknown; this result is not exhaustive. A per-id config fetch returning HTTP 500 is most often a `!secret` reference in the config file HA loads for this entity, which the per-id config endpoint rejects; the specific cause is in the Home Assistant log (the 500 body is a generic placeholder), not in this response.
```

**Correction from the first revision** (thanks @kingpanther13 for catching it): the rendered sample is `HTTP 500: 500 Internal Server Error`, **not** `HTTP 500: Secrets not supported in this YAML file`. That `YAMLException` message never reaches the HTTP body — core's `BaseEditConfigView.get()` file-loads the YAML with no try/except and the request handler only catches `vol.Invalid`/`ServiceNotFound`/`Unauthorized`, so the exception escapes to aiohttp, whose production 500 body is the fixed `500 Internal Server Error` text. The `!secret` detail goes to the HA log only. So the sample can name the *status* but not the *cause* — which is why the fragment now also appends a static hint pointing at the HA log and the single most common cause (a `!secret` the per-id config endpoint rejects). The hint is deliberately endpoint-agnostic — it names no specific YAML file, since the same string rides the automation, script, and scene fragments and a scene 500 has nothing to do with scripts.yaml. That delivers the five-minute diagnosis the report asked for without the response claiming a cause it can't actually confirm. My test mocks now use the realistic `500 Internal Server Error` body throughout.

Implementation: a new `summarize_fetch_error()` in `_fetch.py` renders an exception as `HTTP <code>: <first line of the message>` for `HomeAssistantAPIError` (stripping the client's own `API error: <code> - ` prefix so the code isn't stated twice) or `<ExceptionType>: <first line>` otherwise, capped at 160 chars. A companion `http_500_diagnosis_hint()` returns the static HA-log hint for an `HTTP 500:` sample and `""` for anything else (so non-500 fragments stay byte-identical). The Attempt-C fetch closures for automations, scripts, and scenes capture a summary on the generic failed class only, and only the **first** one — the append is now guarded (`if not failed_errors:`), so the motivating "every per-id fetch 500s" case does N−1 fewer `summarize_fetch_error` calls; every failure still counts. The per-type helpers return the sample as a new trailing tuple slot, and `_apply_per_type_partial_flag` / `_apply_scene_partial_flag` append it as an `e.g.` (plus the 500 hint) when present. With no sample the fragment wording is byte-identical to today, so anything matching on the current string is unaffected.

One asymmetry worth flagging: automations and scripts have a dedicated `yaml_skipped` branch that classifies a per-id 404 out of the generic bucket, so their 404s never produce a sample. Scenes have no such branch (their integration-managed scenes are pre-filtered upstream via the registry walk instead), so a scene per-id 404 does fall through to the generic `failed` class and *can* surface an `e.g. HTTP 404: …` sample. I left that as-is rather than adding a scene 404 branch — it's a faithful "this scene fetch failed with a 404" signal, not a misclassification — but calling it out so the "404s never produce a sample" statement is scoped to automations/scripts, not scenes.

Tests were written first per the TDD guideline: unit tests for the summarizer and the 500-hint scoping, fragment-assembly tests for both flag helpers with and without a sample (including that the hint rides only HTTP-500 samples), component tests pinning the new tuple slot (including that 404s and timeouts leave it `None` on the automation/script path, and a new test through the script closure's generic `except Exception` branch), a test proving the first-error guard summarizes exactly once for N failures, and seam tests driving my exact scenario end to end through public `deep_search` for scripts and scenes. One existing scene test (`test_partial_reason_distinguishes_integration_from_failure`) pinned the exact old fragment while its fixture drives a real `RuntimeError`; updated it to pin the new sample-carrying wording. Full unit suite is green locally apart from 3 failures in `test_helper_response_shape.py` that fail identically on a clean master checkout here, so I'm reading those as environment-specific; I didn't run the Docker e2e suite locally and am counting on CI for that.

## Type of change
- [x] 🐛 Bug fix

## Testing
- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

## Checklist
- [x] I have updated documentation if needed
