### PR TITLE
fix: Escape translated catalog strings before rendering as HTML in settings UI

### DIFF
--- a/.github/workflows/codeql-quality.yml
+++ b/.github/workflows/codeql-quality.yml
@@ -1,6 +1,15 @@
 name: CodeQL Code Quality
 
-# Runs the CodeQL "<language>-code-quality" suites and fails the PR on ANY finding.
+# Runs the CodeQL "<language>-code-quality" suite PLUS the default
+# "<language>-code-scanning" security suite per language and fails the PR on
+# ANY finding.
+#
+# Why the security suite is gated here too: GitHub default setup (the
+# Security tab) only analyzes master after merge and posts no blocking check
+# on PRs, so a PR can introduce security-query findings (e.g.
+# js/xss-through-dom) that surface as code-scanning alerts minutes after
+# merge — that is how alerts 33-40 landed. Running the same default
+# code-scanning suite in this gate catches them pre-merge.
 #
 # Languages gated (one matrix leg each), both scanning the whole tree
 # (--source-root .):
@@ -68,8 +77,10 @@ jobs:
         include:
           - language: python
             suite: codeql/python-queries:codeql-suites/python-code-quality.qls
+            security_suite: codeql/python-queries:codeql-suites/python-code-scanning.qls
           - language: javascript
             suite: codeql/javascript-queries:codeql-suites/javascript-code-quality.qls
+            security_suite: codeql/javascript-queries:codeql-suites/javascript-code-scanning.qls
 
     steps:
       - uses: actions/checkout@v7
@@ -96,12 +107,13 @@ jobs:
             --source-root . \
             --overwrite
 
-      - name: Analyze with ${{ matrix.language }}-code-quality suite
+      - name: Analyze with ${{ matrix.language }} quality + security suites
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           gh codeql database analyze ha-mcp-db \
             ${{ matrix.suite }} \
+            ${{ matrix.security_suite }} \
             --format=sarif-latest \
             --output quality.sarif \
             --download

--- a/custom_components/ha_mcp_tools/ui_panel.py
+++ b/custom_components/ha_mcp_tools/ui_panel.py
@@ -86,7 +86,12 @@ _COOKIE_PATH = f"{_UI_BASE}/app"
 # Keep in sync with ``ha_mcp.settings_ui._i18n.LOCALE_COOKIE`` without
 # importing the separately installed server package into the HA component.
 _LOCALE_COOKIE_NAME = "ha_mcp_locale"
-_LOCALE_COOKIE_VALUE_RE = re.compile(r"[A-Za-z0-9]+(?:[-_][A-Za-z0-9]+)*\Z")
+# Each iteration consumes one optional separator plus exactly one
+# alphanumeric, so the pattern is unambiguous (linear-time, no
+# polynomial backtracking) while accepting the same language as
+# ``[A-Za-z0-9]+(?:[-_][A-Za-z0-9]+)*``: no leading/trailing/doubled
+# separators.
+_LOCALE_COOKIE_VALUE_RE = re.compile(r"[A-Za-z0-9](?:[-_]?[A-Za-z0-9])*\Z")
 
 # Session lifetime. Short by design; the panel re-mints well within it while open.
 _SESSION_TTL_SECONDS = 8 * 60 * 60

--- a/custom_components/ha_mcp_tools/ui_panel.py
+++ b/custom_components/ha_mcp_tools/ui_panel.py
@@ -47,7 +47,6 @@ while the server is running and returns 503 otherwise.
 from __future__ import annotations
 
 import logging
-import re
 import secrets
 import time
 from typing import TYPE_CHECKING, Any
@@ -86,12 +85,28 @@ _COOKIE_PATH = f"{_UI_BASE}/app"
 # Keep in sync with ``ha_mcp.settings_ui._i18n.LOCALE_COOKIE`` without
 # importing the separately installed server package into the HA component.
 _LOCALE_COOKIE_NAME = "ha_mcp_locale"
-# Each iteration consumes one optional separator plus exactly one
-# alphanumeric, so the pattern is unambiguous (linear-time, no
-# polynomial backtracking) while accepting the same language as
-# ``[A-Za-z0-9]+(?:[-_][A-Za-z0-9]+)*``: no leading/trailing/doubled
-# separators.
-_LOCALE_COOKIE_VALUE_RE = re.compile(r"[A-Za-z0-9](?:[-_]?[A-Za-z0-9])*\Z")
+
+
+def _is_valid_locale_cookie_value(value: str) -> bool:
+    """True for BCP-47-like values: ASCII-alphanumeric runs joined by single
+    ``-``/``_`` separators (no leading/trailing/doubled separators).
+
+    A plain character walk instead of a regex: linear by construction, where
+    CodeQL's backtracking model flagged every regex shape for this language
+    as potentially polynomial.
+    """
+    prev_is_sep = True  # a separator may not open the value
+    for ch in value:
+        if ch in "-_":
+            if prev_is_sep:
+                return False
+            prev_is_sep = True
+        elif ch.isascii() and ch.isalnum():
+            prev_is_sep = False
+        else:
+            return False
+    return bool(value) and not prev_is_sep
+
 
 # Session lifetime. Short by design; the panel re-mints well within it while open.
 _SESSION_TTL_SECONDS = 8 * 60 * 60
@@ -145,7 +160,7 @@ def _forwarded_locale_cookie(request: web.Request) -> str | None:
     if (
         not isinstance(value, str)
         or len(value) > 64
-        or _LOCALE_COOKIE_VALUE_RE.fullmatch(value) is None
+        or not _is_valid_locale_cookie_value(value)
     ):
         return None
     return f"{_LOCALE_COOKIE_NAME}={value}"

--- a/homeassistant-addon-webhook-proxy-dev/CHANGELOG.md
+++ b/homeassistant-addon-webhook-proxy-dev/CHANGELOG.md
@@ -9,7 +9,10 @@ history from before the fork.
 -->
 
 
-## v1.2.3.dev8 (2026-07-18)
+## v2.0.3.dev1 (2026-07-18)
+
+Version line re-based onto the stable series (stable is 2.0.2, so dev now
+leads it as 2.0.3.devN); the 1.2.3.devN entries below predate this rule.
 
 ### Bug Fixes
 

--- a/homeassistant-addon-webhook-proxy-dev/CHANGELOG.md
+++ b/homeassistant-addon-webhook-proxy-dev/CHANGELOG.md
@@ -9,6 +9,15 @@ history from before the fork.
 -->
 
 
+## v1.2.3.dev8 (2026-07-18)
+
+### Bug Fixes
+
+- Write the proxy-config handoff file with restricted (0600) permissions like
+  the OAuth creds file, falling back to a plain write with a logged warning
+  when the filesystem cannot honor the mode.
+
+
 ## v1.2.3.dev6 (2026-07-05)
 
 ### Documentation

--- a/homeassistant-addon-webhook-proxy-dev/config.yaml
+++ b/homeassistant-addon-webhook-proxy-dev/config.yaml
@@ -1,6 +1,6 @@
 name: "Nabu Casa - Webhook Proxy for HA MCP (Dev)"
 description: "DEV CHANNEL (unstable) — remote access proxy via Nabu Casa or any reverse proxy. Cannot run alongside the stable Webhook Proxy add-on."
-version: "1.2.3.dev7"
+version: "1.2.3.dev8"
 slug: "ha_mcp_webhook_proxy_dev"
 url: "https://github.com/homeassistant-ai/ha-mcp"
 stage: experimental

--- a/homeassistant-addon-webhook-proxy-dev/config.yaml
+++ b/homeassistant-addon-webhook-proxy-dev/config.yaml
@@ -1,6 +1,6 @@
 name: "Nabu Casa - Webhook Proxy for HA MCP (Dev)"
 description: "DEV CHANNEL (unstable) — remote access proxy via Nabu Casa or any reverse proxy. Cannot run alongside the stable Webhook Proxy add-on."
-version: "1.2.3.dev8"
+version: "2.0.3.dev1"
 slug: "ha_mcp_webhook_proxy_dev"
 url: "https://github.com/homeassistant-ai/ha-mcp"
 stage: experimental

--- a/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/manifest.json
+++ b/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/manifest.json
@@ -7,5 +7,5 @@
   "dependencies": ["webhook"],
   "documentation": "https://github.com/homeassistant-ai/ha-mcp",
   "iot_class": "local_push",
-  "version": "1.2.3.dev7"
+  "version": "1.2.3.dev8"
 }

--- a/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/manifest.json
+++ b/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/manifest.json
@@ -7,5 +7,5 @@
   "dependencies": ["webhook"],
   "documentation": "https://github.com/homeassistant-ai/ha-mcp",
   "iot_class": "local_push",
-  "version": "1.2.3.dev8"
+  "version": "2.0.3.dev1"
 }

--- a/homeassistant-addon-webhook-proxy-dev/start.py
+++ b/homeassistant-addon-webhook-proxy-dev/start.py
@@ -1298,8 +1298,20 @@ def main() -> int:
     if debug_logging:
         proxy_config["debug_logging"] = True
     proxy_config_file = Path("/config/.mcp_proxy_dev_config.json")
+    proxy_config_json = json.dumps(proxy_config)
     try:
-        proxy_config_file.write_text(json.dumps(proxy_config))
+        if not _atomic_write_0600(proxy_config_file, proxy_config_json.encode("utf-8")):
+            # False = the restricted-mode create OR the write/replace failed —
+            # same degradation semantics as the OAuth creds path above. The
+            # file carries the OAuth keys when auth is enabled, so it gets the
+            # same 0600-first treatment; a mode-only limitation falls back to
+            # a plain write rather than breaking startup.
+            proxy_config_file.write_text(proxy_config_json)
+            log_error(
+                f"Could not create the proxy config file with restricted "
+                f"permissions at {proxy_config_file}. It may have wider "
+                f"permissions than intended."
+            )
     except OSError as e:
         log_error(f"Failed to write proxy config: {e}")
         return 1

--- a/homeassistant-addon-webhook-proxy/AGENTS.md
+++ b/homeassistant-addon-webhook-proxy/AGENTS.md
@@ -49,13 +49,18 @@ is `started`. `start.py:_sibling_is_running` matches the sibling by exact slug o
 `_<base>` suffix (Supervisor hash-prefixes third-party slugs).
 
 ## Versioning
-- Dev: bump `homeassistant-addon-webhook-proxy-dev/config.yaml` `version` AND
+- Dev: the version is BASED ON THE CURRENT STABLE version — the next stable
+  patch with a `.devN` suffix (stable `2.0.2` → `2.0.3.dev1`, `2.0.3.dev2`, …),
+  so dev always sorts ahead of the stable it will promote into. Bump
+  `homeassistant-addon-webhook-proxy-dev/config.yaml` `version` AND
   `mcp_proxy_dev/manifest.json` `version` together (they must stay equal). The
   `webhook-proxy-dev-version-guard` workflow fails any PR that touches the dev add-on
   without an increase. Use the `Webhook Proxy Dev — Bump Version` workflow
   (`workflow_dispatch`, never scheduled) to do the bump and open a draft PR, or edit the
-  two files by hand.
-- Stable keeps its own independent version line and never inherits a `.devN` label.
+  two files by hand. (Dev entries below `v2.0.3.dev1` in the dev CHANGELOG predate this
+  rule — the line originally counted independently from the 1.2.2 fork point.)
+- Stable keeps its own version line and never inherits a `.devN` label; the promote
+  workflow assigns the stable number.
 
 ## Promotion (dev -> stable)
 When the dev flavor is ready to become stable, run the `Webhook Proxy — Promote Dev to

--- a/scripts/codeql_quality_gate.py
+++ b/scripts/codeql_quality_gate.py
@@ -163,6 +163,171 @@ ALLOWLIST: tuple[tuple[str, str, str, str], ...] = (
         "heuristic to have correctly caught. mypy already confirms this file is "
         "clean under that typing.",
     ),
+    # ---- Security-suite entries (the workflow also gates the default
+    # <language>-code-scanning suites; see codeql-quality.yml header). Entries
+    # whose message substring is generic ("as clear text", "hashing algorithm")
+    # are PATH-WIDE for that rule+file — a future finding of the same rule in
+    # the same file would be suppressed too. Accepted for the same reason as
+    # the quality entries above: the files are small and each reason names the
+    # exact intended pattern. Re-audit when one of these files grows.
+    (
+        "py/clear-text-logging-sensitive-data",
+        "custom_components/ha_mcp_tools/embedded_setup.py",
+        "as clear text",
+        "Deliberate admin-only connect instructions: the startup log prints the "
+        "legacy-OAuth Client ID/Secret so the admin can paste them into an MCP "
+        "client. The SECURITY note from the #1880 review in this file governs "
+        "the pattern: credentials are withheld while a rotation is pending and "
+        "never placed in the persistent notification all users can see.",
+    ),
+    (
+        "py/clear-text-logging-sensitive-data",
+        "homeassistant-addon-webhook-proxy/mcp_proxy/__init__.py",
+        "as clear text",
+        "False positive: the log line emits oauth_provider.client_id_masked(), "
+        "not the raw value; CodeQL tracks taint through the masking helper.",
+    ),
+    (
+        "py/clear-text-logging-sensitive-data",
+        "homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/__init__.py",
+        "as clear text",
+        "False positive (dev flavor, identical code to stable): the log line "
+        "emits client_id_masked(), not the raw value; CodeQL tracks taint "
+        "through the masking helper.",
+    ),
+    (
+        "py/clear-text-logging-sensitive-data",
+        "homeassistant-addon-webhook-proxy/start.py",
+        "as clear text",
+        "Deliberate add-on startup log: prints the connect URL and legacy-OAuth "
+        "credentials to the Supervisor add-on log (admin-only) as the user's "
+        "setup instructions — the add-on-side mirror of embedded_setup.py's "
+        "admin-only connect log.",
+    ),
+    (
+        "py/clear-text-logging-sensitive-data",
+        "homeassistant-addon-webhook-proxy-dev/start.py",
+        "as clear text",
+        "Deliberate add-on startup log (dev flavor, identical code to stable): "
+        "prints the connect URL and legacy-OAuth credentials to the Supervisor "
+        "add-on log (admin-only) as the user's setup instructions.",
+    ),
+    (
+        "py/clear-text-logging-sensitive-data",
+        "src/ha_mcp/stdio_settings_sidecar.py",
+        "as clear text",
+        "Deliberate: logs the sidecar's own loopback settings URL "
+        "(http://127.0.0.1:<port><secret_path>/settings) so the local operator "
+        "can open it. Local-process log/stderr only; the URL is unreachable off "
+        "the host.",
+    ),
+    (
+        "py/clear-text-logging-sensitive-data",
+        "tests/test_env_manager.py",
+        "as clear text",
+        "Interactive test-environment helper printing the seeded throwaway "
+        "credentials of the disposable HA test container (tests/test_constants.py). "
+        "Printing them for copy-paste is the tool's purpose.",
+    ),
+    (
+        "py/clear-text-storage-sensitive-data",
+        "homeassistant-addon-webhook-proxy/mcp_proxy/oauth.py",
+        "as clear text",
+        "Warned fallback: the primary path writes the signing key via "
+        "_atomic_write_0600; the flagged plain write only runs when the "
+        "filesystem cannot honor 0600 and it logs a warning. Persisting the key "
+        "is the feature (it must survive restarts).",
+    ),
+    (
+        "py/clear-text-storage-sensitive-data",
+        "homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/oauth.py",
+        "as clear text",
+        "Warned fallback (dev flavor, identical code to stable): plain write of "
+        "the signing key only when the filesystem cannot honor 0600, with a "
+        "warning. Persistence is the feature.",
+    ),
+    (
+        "py/clear-text-storage-sensitive-data",
+        "homeassistant-addon-webhook-proxy/start.py",
+        "as clear text",
+        "Stable flavor pending promote: the creds file uses _atomic_write_0600 "
+        "with a warned plain-write fallback; the proxy-config handoff write "
+        "gained the same 0600-first treatment on the dev flavor (v1.2.3.dev8) "
+        "and reaches this tree via the promote workflow — the stable-guard "
+        "blocks editing it directly here. Remove the plain-write half of this "
+        "reason after the next promote.",
+    ),
+    (
+        "py/clear-text-storage-sensitive-data",
+        "homeassistant-addon-webhook-proxy-dev/start.py",
+        "as clear text",
+        "Warned fallbacks (dev flavor): both the creds file and the "
+        "proxy-config handoff file write via _atomic_write_0600; the flagged "
+        "plain writes only run when the filesystem cannot honor 0600 and each "
+        "logs a warning. Persistence is the feature.",
+    ),
+    (
+        "py/weak-sensitive-data-hashing",
+        "custom_components/ha_mcp_tools/oauth_legacy.py",
+        "hashing algorithm (SHA256)",
+        "Not password storage: SHA256 builds a change-detection fingerprint of "
+        "the OAuth identity bound to the root views (machine-generated client "
+        "secret + 256-bit signing key) to decide when routes must be rebound. "
+        "KDFs exist to slow guessing of low-entropy human passwords; a "
+        "fingerprint of high-entropy random material has no guessing surface.",
+    ),
+    (
+        "py/weak-sensitive-data-hashing",
+        "homeassistant-addon-webhook-proxy/mcp_proxy/__init__.py",
+        "hashing algorithm (SHA256)",
+        "Not password storage: same _oauth_route_fingerprint helper as "
+        "oauth_legacy.py — a SHA256 change-detection fingerprint of "
+        "machine-generated high-entropy credentials, not a stored password hash.",
+    ),
+    (
+        "py/weak-sensitive-data-hashing",
+        "homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/__init__.py",
+        "hashing algorithm (SHA256)",
+        "Not password storage (dev flavor, identical code to stable): SHA256 "
+        "change-detection fingerprint of machine-generated high-entropy "
+        "credentials, not a stored password hash.",
+    ),
+    (
+        "py/bad-tag-filter",
+        "tests/src/unit/_js_harness.py",
+        "does not match upper case",
+        "Not a sanitizer: the JSDOM harness extracts <script> bodies from "
+        "repo-authored, lowercase templates for parse/behaviour testing; "
+        "untrusted HTML never flows through it.",
+    ),
+    (
+        "py/incomplete-url-substring-sanitization",
+        "tests/src/unit/test_best_practice_checker.py",
+        "may be at an arbitrary position",
+        "Test assertion, not URL validation: checks that a warning message "
+        "mentions the configured skill-prefix host.",
+    ),
+    (
+        "py/incomplete-url-substring-sanitization",
+        "tests/src/unit/test_browser_landing.py",
+        "may be at an arbitrary position",
+        "Test assertion, not URL validation: checks that the landing page's "
+        "help copy mentions dash.cloudflare.com.",
+    ),
+    (
+        "py/incomplete-url-substring-sanitization",
+        "tests/src/unit/test_oauth.py",
+        "may be at an arbitrary position",
+        "Test assertion, not URL validation: checks that the consent HTML "
+        "displays the redirect host to the user.",
+    ),
+    (
+        "py/incomplete-url-substring-sanitization",
+        "tests/src/unit/test_oauth_legacy_component.py",
+        "may be at an arbitrary position",
+        "Test assertion, not URL validation: the XSS-escape test checks the "
+        "redirect host appears (escaped) in the response body.",
+    ),
 )
 
 

--- a/scripts/codeql_quality_gate.py
+++ b/scripts/codeql_quality_gate.py
@@ -1,11 +1,14 @@
 #!/usr/bin/env python3
-"""Parse a CodeQL code-quality SARIF file, report findings, and gate on them.
+"""Parse a CodeQL SARIF file, report findings, and gate on them.
 
 CodeQL's Code Quality preview (the GitHub Settings → Security → Code quality
 page) is only available to Team/Enterprise Cloud org plans, so it cannot be
 enabled on this repo's free org. This script provides an equivalent gate by
-running the ``python-code-quality.qls`` suite via the CodeQL CLI in CI and
-failing the job when any finding remains.
+running the ``<language>-code-quality.qls`` suite via the CodeQL CLI in CI
+and failing the job when any finding remains. The workflow also feeds the
+default ``<language>-code-scanning.qls`` security suite through the same
+gate, because GitHub default setup only analyzes master post-merge and does
+not block PRs (see the header of codeql-quality.yml).
 
 Usage:
     codeql_quality_gate.py <quality.sarif>

--- a/scripts/codeql_quality_gate.py
+++ b/scripts/codeql_quality_gate.py
@@ -252,7 +252,7 @@ ALLOWLIST: tuple[tuple[str, str, str, str], ...] = (
         "as clear text",
         "Stable flavor pending promote: the creds file uses _atomic_write_0600 "
         "with a warned plain-write fallback; the proxy-config handoff write "
-        "gained the same 0600-first treatment on the dev flavor (v1.2.3.dev8) "
+        "gained the same 0600-first treatment on the dev flavor (v2.0.3.dev1) "
         "and reaches this tree via the promote workflow — the stable-guard "
         "blocks editing it directly here. Remove the plain-write half of this "
         "reason after the next promote.",

--- a/src/ha_mcp/settings_ui/_i18n.py
+++ b/src/ha_mcp/settings_ui/_i18n.py
@@ -112,6 +112,7 @@ def load_catalogs(directory: Path = LOCALES_DIR) -> dict[str, dict[str, Any]]:
             f"The settings UI requires {DEFAULT_LOCALE}.json in {directory}"
         )
     _validate_placeholder_parity(catalogs)
+    _validate_inline_markup(catalogs)
     return catalogs
 
 
@@ -151,6 +152,39 @@ def _validate_placeholder_parity(catalogs: dict[str, dict[str, Any]]) -> None:
                         f"Locale {locale} tool {tool_name!r} field {field!r} "
                         f"has placeholders {sorted(translated_fields)}, expected "
                         f"{sorted(source_fields)}"
+                    )
+
+
+# Anything that looks like an HTML tag in a catalog message. A bare "<" in
+# prose (e.g. "< 5") deliberately does not match — it renders fine escaped.
+_TAG_LIKE_RE = re.compile(r"</?[a-zA-Z][^>]*>")
+# The exact tag shapes settings.js::tHtml restores after escaping. Keep in
+# sync with the restore regexes there — any other spelling (case, spacing,
+# attribute order) survives escaping and shows the user literal markup text.
+_ALLOWED_TAGS_RE = re.compile(
+    r'</?code>|</?strong>|</a>|<a href="#" data-panel-link="[a-z][a-z-]*">'
+)
+
+
+def _validate_inline_markup(catalogs: dict[str, dict[str, Any]]) -> None:
+    """Reject catalog messages whose markup ``tHtml`` cannot restore.
+
+    ``settings.js::tHtml`` escapes every translated value and restores only
+    the exact allowlisted tag shapes, so a translation written with
+    ``<CODE>`` or ``<code >`` would silently render as literal escaped text.
+    Fail fast at load time instead, mirroring the placeholder-parity check.
+    Scoped to ``messages``: tool translations are plain text rendered through
+    ``escapeHtml`` and carry no markup contract.
+    """
+    for locale, catalog in catalogs.items():
+        for key, value in catalog["messages"].items():
+            for tag in _TAG_LIKE_RE.findall(value):
+                if _ALLOWED_TAGS_RE.fullmatch(tag) is None:
+                    raise ValueError(
+                        f"Locale {locale} message {key!r} contains inline "
+                        f"markup {tag!r} that the settings UI cannot render; "
+                        f"allowed: <code>, <strong>, </a>, and "
+                        f'<a href="#" data-panel-link="...">'
                     )
 
 

--- a/src/ha_mcp/settings_ui/settings.js
+++ b/src/ha_mcp/settings_ui/settings.js
@@ -2063,7 +2063,7 @@ function renderFeatureFlags(flags) {
         `${escapeHtml(ORIGIN_INFO_NOTE[f.origin])}</div>`
       : '';
     info.innerHTML =
-      `<div class="feature-name" id="label-feature-${fieldName}">${escapeHtml(meta.label)}</div>` +
+      `<div class="feature-name" id="label-feature-${escapeHtml(fieldName)}">${escapeHtml(meta.label)}</div>` +
       `<div class="feature-help">${escapeHtml(meta.help)}</div>` +
       lockedNote + infoNote;
 
@@ -2237,7 +2237,7 @@ function renderSubFlagRows(flags, parentEl, subFieldNames, { cssClass, lockedByG
         `${escapeHtml(ORIGIN_INFO_NOTE[f.origin])}</div>`
       : '';
     info.innerHTML =
-      `<div class="feature-name" id="label-feature-${fieldName}">${escapeHtml(meta.label)}</div>` +
+      `<div class="feature-name" id="label-feature-${escapeHtml(fieldName)}">${escapeHtml(meta.label)}</div>` +
       `<div class="feature-help">${escapeHtml(meta.help)}</div>` +
       lockedNote + infoNote;
 
@@ -2323,7 +2323,7 @@ function renderCodeModeSubRows(parentEl, masterOn, codeModeOn) {
         `<div class="feature-locked-note">${envLockedNoteHtml(f.env_var, f.field)}</div>`;
     }
     info.innerHTML =
-      `<div class="feature-name" id="label-feature-${f.field}">${escapeHtml(meta.label)}</div>` +
+      `<div class="feature-name" id="label-feature-${escapeHtml(f.field)}">${escapeHtml(meta.label)}</div>` +
       `<div class="feature-help">${escapeHtml(meta.help)}</div>` +
       lockedNote;
 

--- a/src/ha_mcp/settings_ui/settings.js
+++ b/src/ha_mcp/settings_ui/settings.js
@@ -23,6 +23,27 @@ function t(key, params = {}, fallback = key) {
   return value;
 }
 
+// Translation for HTML contexts (innerHTML sinks). Catalog strings are data,
+// not markup: the whole value is HTML-escaped first, then only the allowlist
+// of inline formatting tags the catalogs use (<code>, <strong>, and the
+// internal tab links) is restored, so a translated string can never
+// contribute any other markup. Placeholders are substituted AFTER escaping:
+// params are trusted HTML fragments built by the caller (escape any dynamic
+// text inside them with escapeHtml at the call site).
+function tHtml(key, params = {}, fallback = key) {
+  const raw = Object.prototype.hasOwnProperty.call(I18N_PAYLOAD.messages || {}, key)
+    ? I18N_PAYLOAD.messages[key]
+    : fallback;
+  let value = escapeHtml(raw)
+    .replace(/&lt;(\/?)(code|strong)&gt;/g, '<$1$2>')
+    .replace(/&lt;a href=&quot;#&quot; data-panel-link=&quot;([a-z][a-z-]*)&quot;&gt;/g, '<a href="#" data-panel-link="$1">')
+    .replace(/&lt;\/a&gt;/g, '</a>');
+  Object.keys(params).forEach(name => {
+    value = value.replaceAll(`{${name}}`, String(params[name]));
+  });
+  return value;
+}
+
 function localizeMeta(section, field, meta) {
   return {
     ...meta,
@@ -76,7 +97,14 @@ function applyStaticTranslations(root = document) {
     el.textContent = t(el.dataset.i18n, {}, el.textContent);
   });
   root.querySelectorAll('[data-i18n-html]').forEach(el => {
-    el.innerHTML = t(el.dataset.i18nHtml, {}, el.innerHTML);
+    // Rewrite only from the catalog: the server-rendered markup already is
+    // the English copy, and routing it back through the escape+allowlist
+    // pipeline would depend on attribute serialization being round-trip
+    // stable, which it is not guaranteed to be.
+    const key = el.dataset.i18nHtml;
+    if (Object.prototype.hasOwnProperty.call(I18N_PAYLOAD.messages || {}, key)) {
+      el.innerHTML = tHtml(key);
+    }
   });
   for (const attribute of ['placeholder', 'title', 'aria-label']) {
     const dataName = `i18n${attribute.split('-').map(part => part[0].toUpperCase() + part.slice(1)).join('')}`;
@@ -908,17 +936,17 @@ function render() {
       else badges += `<span class="badge unknown">${escapeHtml(category) || '?'}</span>`;
 
       const gatedNote = disabledBy
-        ? `<div class="disabled-by-note">${tr(
+        ? `<div class="disabled-by-note">${tHtml(
             'tools.notes.beta_disabled',
             {setting: `<code>${escapeHtml(disabledBy)}</code>`},
-            `Beta. Set <code>${escapeHtml(disabledBy)}</code> in the dev App (add-on) config or the matching env var (see docs/beta.md).`
+            'Beta. Set {setting} in the dev App (add-on) config or the matching env var (see docs/beta.md).'
           )}</div>`
         : '';
       const envPinnedNote = isEnvPinned
-        ? `<div class="feature-locked-note">${tr(
+        ? `<div class="feature-locked-note">${tHtml(
             'tools.notes.env_pinned',
             {variable: `<code>${escapeHtml(envPinVar)}</code>`},
-            `env-pinned via <code>${envPinVar}</code>. Unset the env var to edit here.`
+            'Pinned by {variable}. Unset the environment variable to edit here.'
           )}</div>`
         : '';
       const bpsLockedNote = isBpsLocked
@@ -1277,10 +1305,10 @@ const BACKUP_FIELD_LABELS = {
 };
 
 const BACKUP_ORIGIN_LABELS = {
-  addon: t('backup.origins.addon', {}, 'Synced to Supervisor. Restart required after save.'),
+  addon: escapeHtml(t('backup.origins.addon', {}, 'Synced to Supervisor. Restart required after save.')),
   env: null,  // banner generated dynamically with the env var name
-  file: t('backup.origins.file', {}, 'Persisted locally; takes effect immediately.'),
-  default: t('backup.origins.default', {}, 'Using default; first save creates a local override file.'),
+  file: escapeHtml(t('backup.origins.file', {}, 'Persisted locally; takes effect immediately.')),
+  default: escapeHtml(t('backup.origins.default', {}, 'Using default; first save creates a local override file.')),
 };
 
 async function loadBackupConfig() {
@@ -1476,8 +1504,8 @@ function renderFsCustomPathsSubForm(parentEl, masterOn, fsOn) {
       : '.storage, secrets.yaml';
   info.innerHTML =
     `<div class="feature-name">${escapeHtml(t('filesystem.custom.title', {}, 'Custom filesystem directories (advanced)'))}</div>` +
-    `<div class="feature-help">${t('filesystem.custom.help', {}, 'Extra directories (one per line) that the file tools may READ and WRITE, either relative to your config dir or an absolute allowed HAOS sibling volume. Each entry grants both read and write. Applies immediately; no restart needed.')}</div>` +
-    `<div class="feature-help">${t('filesystem.custom.blocked', {paths: `<code>${escapeHtml(denyList)}</code>`}, `Always blocked (cannot be added): <code>${escapeHtml(denyList)}</code>, path traversal (<code>..</code>), and any absolute path outside the HAOS sibling volumes.`)}</div>`;
+    `<div class="feature-help">${tHtml('filesystem.custom.help', {}, 'Extra directories (one per line) that the file tools may READ and WRITE, either relative to your config dir or an absolute allowed HAOS sibling volume. Each entry grants both read and write. Applies immediately; no restart needed.')}</div>` +
+    `<div class="feature-help">${tHtml('filesystem.custom.blocked', {paths: `<code>${escapeHtml(denyList)}</code>`}, 'Always blocked (cannot be added): {paths}, path traversal (<code>..</code>), and any absolute path outside the HAOS sibling volumes.')}</div>`;
 
   const control = document.createElement('div');
   control.className = 'feature-control';
@@ -1922,19 +1950,19 @@ const ORIGIN_INFO_NOTE = {
 function envLockedNoteHtml(envVar, fieldName) {
   const envVarTag = `<code>${escapeHtml(envVar)}</code>`;
   if (!IS_ADDON_MODE) {
-    return t('origins.env_var_unset', {variable: envVarTag}, `Set via env var ${envVarTag}; unset it to edit here.`);
+    return tHtml('origins.env_var_unset', {variable: envVarTag}, 'Set via env var {variable}; unset it to edit here.');
   }
   if (fieldName === 'enable_beta_features') {
-    return t(
+    return tHtml(
       'origins.beta_legacy_bridge',
       {variable: envVarTag},
-      `Auto-enabled in App (add-on) mode (legacy bridge; your options.json predates the master toggle schema entry). Set <code>enable_beta_features</code> explicitly in the App (add-on) Configuration tab to take direct control. (env: ${envVarTag})`
+      'Auto-enabled in App (add-on) mode (legacy bridge; your options.json predates the master toggle schema entry). Set <code>enable_beta_features</code> explicitly in the App (add-on) Configuration tab to take direct control. (env: {variable})'
     );
   }
-  return t(
+  return tHtml(
     'origins.addon_runtime',
     {variable: envVarTag},
-    `Set by the App (add-on) runtime environment, managed by Home Assistant Supervisor; cannot be changed from this web UI. (env: ${envVarTag})`
+    'Set by the App (add-on) runtime environment, managed by Home Assistant Supervisor; cannot be changed from this web UI. (env: {variable})'
   );
 }
 
@@ -2275,7 +2303,7 @@ function renderCodeModeSubRows(parentEl, masterOn, codeModeOn) {
     let lockedNote = '';
     if (f.field === 'code_mode_saved_tools_path') {
       if (IS_ADDON_MODE) {
-        lockedNote = `<div class="feature-locked-note">${t(
+        lockedNote = `<div class="feature-locked-note">${tHtml(
           'advanced.code_mode_saved_tools_path.addon_locked',
           {},
           'Hardcoded to <code>/data/saved_tools.json</code> in App (add-on) mode and cannot be changed (fixed here so saved tools survive App (add-on) updates).'
@@ -2472,7 +2500,7 @@ function renderPolicyCards(policy) {
   // see/edit them all.
   const byTool = {};
   rules.forEach((r, idx) => {
-    const key = r.tool_name + ' ' + idx;
+    const key = r.tool_name + '\0' + idx;
     byTool[key] = {tool_name: r.tool_name, rule: r, originalIndex: idx};
   });
   Object.keys(byTool).forEach(key => {

--- a/tests/addon/test_webhook_proxy.py
+++ b/tests/addon/test_webhook_proxy.py
@@ -5793,3 +5793,38 @@ class TestStartOAuthOffConfigShape:
         assert set(written.keys()) == {"target_url", "webhook_id"}
         assert "oauth" not in written
         assert "public_base_url" not in written
+
+
+class TestProxyConfigFilePersistence:
+    """The proxy-config handoff file carries the OAuth keys when auth is
+    enabled, so it must actually land on disk with the flavor's expected
+    permissions: the dev flavor writes it via _atomic_write_0600 (with a
+    warned plain-write fallback); stable still plain-writes until the next
+    promote carries the dev change over."""
+
+    def _run(self, tmp_path):
+        return TestMainDismissesMutexBanners()._run_main_to_keepalive(tmp_path)
+
+    def test_config_file_written_and_dev_gets_0600(self, tmp_path):
+        rc, _api_calls, _start = self._run(tmp_path)
+        assert rc == 0
+        config_path = tmp_path / "proxy_config.json"
+        assert config_path.exists()
+        assert isinstance(json.loads(config_path.read_text()), dict)
+        if CURRENT["key"] == "dev":
+            assert oct(config_path.stat().st_mode & 0o777) == "0o600"
+
+    def test_dev_falls_back_and_warns_when_0600_unavailable(self, tmp_path, capsys):
+        if CURRENT["key"] != "dev":
+            pytest.skip("stable plain-writes until the dev 0600 change promotes")
+        # os.open is only reached via _atomic_write_0600 on this path (OAuth
+        # off, creds resolution skipped), so failing it exercises exactly the
+        # proxy-config fallback branch.
+        with patch.object(os, "open", side_effect=OSError("no mode bits")):
+            rc, _api_calls, _start = self._run(tmp_path)
+        assert rc == 0
+        config_path = tmp_path / "proxy_config.json"
+        assert config_path.exists()
+        assert isinstance(json.loads(config_path.read_text()), dict)
+        err = capsys.readouterr().err
+        assert "Could not create the proxy config file" in err

--- a/tests/src/unit/test_settings_ui_i18n.py
+++ b/tests/src/unit/test_settings_ui_i18n.py
@@ -192,3 +192,36 @@ def test_de_catalog_loads_and_is_registered() -> None:
     assert "de" in CATALOGS
     assert CATALOGS["de"]["meta"]["native_name"] == "Deutsch"
     assert CATALOGS["de"]["meta"]["dir"] == "ltr"
+
+
+def test_disallowed_inline_markup_is_rejected(tmp_path: Path) -> None:
+    _write_catalog(
+        tmp_path,
+        "en",
+        native_name="English",
+        messages={"note": "Use <code>x</code>"},
+    )
+    _write_catalog(
+        tmp_path,
+        "de",
+        native_name="Deutsch",
+        messages={"note": "Nutze <Code >x</Code>"},
+    )
+    with pytest.raises(ValueError, match="inline markup"):
+        load_catalogs(tmp_path)
+
+
+def test_allowlisted_inline_markup_loads(tmp_path: Path) -> None:
+    _write_catalog(
+        tmp_path,
+        "en",
+        native_name="English",
+        messages={
+            "note": (
+                "See <strong>docs</strong>, <code>x</code> or the "
+                '<a href="#" data-panel-link="tools">Tools</a> tab; 1 < 5 is prose.'
+            )
+        },
+    )
+    catalogs = load_catalogs(tmp_path)
+    assert "note" in catalogs["en"]["messages"]

--- a/tests/src/unit/test_settings_ui_js_behavior.py
+++ b/tests/src/unit/test_settings_ui_js_behavior.py
@@ -471,6 +471,121 @@ class TestLocalizationBehavior:
         )
 
 
+class TestTranslationHtmlSanitization:
+    """Catalog strings rendered into ``innerHTML`` go through ``tHtml``:
+    the whole value is HTML-escaped and only the fixed allowlist of
+    formatting tags (``<code>``, ``<strong>``, the internal tab links) is
+    restored, so a hostile or vandalized community translation cannot
+    contribute any other markup (CodeQL js/xss-through-dom).
+    """
+
+    @staticmethod
+    def _dom_with_catalog(messages: dict[str, str], extra_html: str = "") -> str:
+        from ha_mcp.settings_ui._i18n import build_payload, serialize_payload
+
+        catalog = build_payload("en")
+        catalog["messages"].update(messages)
+        payload = serialize_payload(catalog)
+        additions = (
+            f'<script id="ha-mcp-i18n" type="application/json">{payload}</script>'
+            + extra_html
+        )
+        return MIN_DOM.replace("</body>", additions + "</body>")
+
+    def test_malicious_static_html_translation_is_neutralized(
+        self, settings_script: str
+    ) -> None:
+        """A ``[data-i18n-html]`` catalog value carrying a non-allowlisted
+        element renders as escaped text, while allowlisted formatting
+        survives.
+        """
+        result = run_script(
+            settings_script,
+            initial_html=self._dom_with_catalog(
+                {
+                    "notice.env_pins": (
+                        'evil <img src=x onerror="document.title=1"> but '
+                        "<code>kept-code</code> and <strong>kept-strong</strong>"
+                    )
+                },
+                '<div id="xssProbe" data-i18n-html="notice.env_pins">original</div>',
+            ),
+            fetch_map=DEFAULT_FETCHES,
+        )
+        _assert_clean_init(result)
+        assert "<img" not in result.dom
+        assert "&lt;img" in result.dom
+        assert "<code>kept-code</code>" in result.dom
+        assert "<strong>kept-strong</strong>" in result.dom
+
+    def test_allowlisted_panel_link_is_restored(self, settings_script: str) -> None:
+        """The internal tab-link shape used by ``policies.rules.empty`` is
+        restored exactly; a link with any other attribute set stays escaped.
+        """
+        result = run_script(
+            settings_script,
+            initial_html=self._dom_with_catalog(
+                {
+                    "policies.rules.empty": (
+                        'Go to the <a href="#" data-panel-link="tools">Tools</a> tab, '
+                        'not <a href="https://evil.example">elsewhere</a>'
+                    )
+                },
+                '<div id="linkProbe" data-i18n-html="policies.rules.empty">x</div>',
+            ),
+            fetch_map=DEFAULT_FETCHES,
+        )
+        _assert_clean_init(result)
+        assert '<a href="#" data-panel-link="tools">Tools</a>' in result.dom
+        assert '<a href="https://evil.example">' not in result.dom
+        assert "&lt;a href=" in result.dom
+
+    def test_env_pinned_note_params_substituted_after_escaping(
+        self, settings_script: str
+    ) -> None:
+        """Placeholder params are trusted fragments injected after the
+        catalog string is escaped: a hostile translation around
+        ``{variable}`` is neutralized while the built ``<code>`` fragment
+        with the env var name still renders as markup.
+        """
+        fetches = {
+            **DEFAULT_FETCHES,
+            "/api/settings/tools": {
+                "status": 200,
+                "json": {
+                    "tools": [
+                        {
+                            "name": "ha_foo",
+                            "title": "Foo",
+                            "primary_tag": "Utilities",
+                            "tags": ["Utilities"],
+                            "description": "Test tool",
+                            "annotations": {},
+                        }
+                    ],
+                    "states": {"ha_foo": "disabled"},
+                    "env_pinned": {"ha_foo": "disabled"},
+                },
+            },
+        }
+        result = run_script(
+            settings_script,
+            initial_html=self._dom_with_catalog(
+                {
+                    "tools.notes.env_pinned": (
+                        'Pwn <em onmouseover="x()">{variable}</em> here'
+                    )
+                }
+            ),
+            fetch_map=fetches,
+            invoke="await new Promise(r => setTimeout(r, 200));",
+        )
+        _assert_clean_init(result)
+        assert "<code>DISABLED_TOOLS</code>" in result.dom
+        assert "&lt;em" in result.dom
+        assert "<em onmouseover" not in result.dom
+
+
 def _assert_clean_init(result: HarnessResult) -> None:
     """Fail loud on any script-init or transpile error.
 

--- a/tests/src/unit/test_ui_panel.py
+++ b/tests/src/unit/test_ui_panel.py
@@ -550,3 +550,23 @@ class TestBootPage:
         finally:
             os.unlink(path)
         assert result.returncode == 0, result.stderr
+
+
+@pytest.mark.parametrize(
+    ("value", "ok"),
+    [
+        ("ru-RU", True),
+        ("en_US", True),
+        ("de", True),
+        ("a" * 64, True),
+        ("-ru", False),
+        ("ru-", False),
+        ("ru--RU", False),
+        ("en__US", False),
+        ("", False),
+        ("café", False),
+        ("٣", False),
+    ],
+)
+def test_is_valid_locale_cookie_value(value: str, ok: bool) -> None:
+    assert ui_panel._is_valid_locale_cookie_value(value) is ok


### PR DESCRIPTION
## What does this PR do?

Resolves all 8 open CodeQL code-scanning alerts (`js/xss-through-dom`, alerts 33–40) in `settings_ui/settings.js`, and closes the CI gap that let them reach master unflagged.

**The fix.** The settings-UI localization system (#1913) interpolates translation-catalog strings into `innerHTML` unescaped so they can carry inline markup. The locale catalogs are community-editable data (and CodeQL treats the embedded `ha-mcp-i18n` payload as a DOM-text source), so raw interpolation is an HTML-injection surface.

A new `tHtml()` helper renders catalog strings for HTML contexts: the whole value is escaped with `escapeHtml()`, then only the fixed allowlist of formatting tags the catalogs use (`<code>`, `<strong>`, and the internal `<a href="#" data-panel-link="...">` tab links) is restored; `{placeholders}` are substituted after escaping with caller-built, pre-escaped fragments. All raw interpolation sites now go through it (`[data-i18n-html]` static translations, tool-row beta/env-pinned notes, `envLockedNoteHtml()`, filesystem custom-paths copy, code-mode saved-tools-path note), and the plain-text `BACKUP_ORIGIN_LABELS` values are escaped. The `[data-i18n-html]` branch now also skips rewriting when no catalog entry exists instead of round-tripping the server-rendered markup through `innerHTML`.

Also replaces a literal NUL byte in a string with the `'\0'` escape (it made tools treat `settings.js` as a binary file).

**The CI gap.** These flows passed PR CI because `codeql-quality.yml` runs only the `<language>-code-quality` suites, which contain no security queries, while the security suite (GitHub default setup) analyzes master post-merge and posts no blocking PR check — the alerts appeared one minute after #1913 merged. The workflow now feeds the default `<language>-code-scanning` security suites through the same fail-on-any-finding gate for both languages, so the exact queries default setup runs are blocking at PR time. Job/check names are unchanged so any required-check references keep working.

**Security-suite triage.** The new gate's first run surfaced 28 python findings: two were real and fixed in code (the webhook-proxy dev flavor now writes the proxy-config handoff file via `_atomic_write_0600` like the creds file; the ui_panel locale-cookie regex became a linear character-walk validator); the rest are verified false positives or reviewed-by-design patterns, each allowlisted in `codeql_quality_gate.py` with its rationale.

**Webhook-proxy dev versioning.** The dev flavor's version line still counted from its 1.2.2 fork point while stable moved to 2.0.2, sorting dev behind the stable it promotes into. Re-based to `2.0.3.dev1` (next stable patch + `.devN`) and the rule is now documented in the shared AGENTS.md. The stable flavor's proxy-config write is fixed via the promote flow after merge (the stable-guard blocks direct edits here).

**Hardening from review.** Catalog loading now rejects messages whose inline markup `tHtml` cannot restore (mirroring the placeholder-parity check), so a mistyped tag in a community translation fails fast at load instead of silently rendering literal text. Added tests: proxy-config persistence/permissions, locale-validator edge cases, and hostile-catalog sanitization.

## Type of change
- [x] 🐛 Bug fix
- [x] 🔧 Maintenance/refactor

## Testing
- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`) — new `TestTranslationHtmlSanitization` jsdom tests (hostile catalog neutralized, allowlist restored, post-escape placeholder substitution) plus existing localization, env-pinned, parse, and i18n suites
- [x] Code follows style guidelines (`uv run ruff check`)

## Checklist
- [x] I have updated documentation if needed

