### PR TITLE
feat: component-backed server-entry direct-write, closing out issue #1813

### DIFF
--- a/custom_components/ha_mcp_tools/websocket_api.py
+++ b/custom_components/ha_mcp_tools/websocket_api.py
@@ -292,6 +292,8 @@ from homeassistant.helpers import (
 )
 
 from .const import (
+    CHANNEL_DEV,
+    CHANNEL_STABLE,
     COMPONENT_VERSION,
     CONF_ENTRY_TYPE,
     DEFAULT_PIP_SPEC,
@@ -816,11 +818,12 @@ def _single_line_pip_spec(value: str) -> str:
 def _server_entry_update_schema() -> dict[Any, Any]:
     # Both fields are optional at the schema level (voluptuous cannot cleanly express
     # "at least one of"); ``_server_entry_update_prep`` raises when NEITHER is present.
-    # ``channel`` stays a bare ``str`` — the SERVER validates it against its channel
-    # set (D6); ``pip_spec`` gets the length + single-line defence-in-depth cap.
+    # ``channel`` is gated to the known set and ``pip_spec`` gets the length +
+    # single-line cap — schema-level defence-in-depth over (and symmetric with) the
+    # server's own channel validation (D6) and pip-spec normalization.
     return {
         vol.Required("type"): WS_SERVER_ENTRY_UPDATE,
-        vol.Optional("channel"): str,
+        vol.Optional("channel"): vol.In((CHANNEL_STABLE, CHANNEL_DEV)),
         vol.Optional("pip_spec"): vol.All(
             str,
             vol.Length(max=SERVER_ENTRY_UPDATE_MAX_PIP_SPEC),

--- a/custom_components/ha_mcp_tools/websocket_api.py
+++ b/custom_components/ha_mcp_tools/websocket_api.py
@@ -122,9 +122,10 @@ and ``info`` itself carries no capability entry):
   applies a ``channel`` / ``pip_spec`` delta to the server entry via
   ``hass.config_entries.async_update_entry`` DIRECTLY (what core's finish-flow
   does), collapsing ``ha_dev_manage_server(update_source)``'s options-flow start +
-  submit round-trip in embedded mode. The new options are MERGED against the LIVE
-  ``entry.options`` (every existing key preserved, no TOCTOU, no blanking of the
-  URL/secret overrides), so no preserved-key resend is needed. The
+  submit round-trip in embedded mode. The delta is MERGED against the LIVE
+  ``entry.options`` AT APPLY time (every existing key preserved — a concurrent
+  change to another key during the flush window is not clobbered — no blanking of
+  the URL/secret overrides), so no preserved-key resend is needed. The
   ``async_update_entry`` fires the entry's own update listener → reload → the
   hardened reinstall; because that reload tears down the very server thread
   answering this frame, the call is NOT made inline — it is scheduled on a
@@ -5182,16 +5183,22 @@ async def _server_entry_update_prep(
        its legacy options-flow submit.
     2. Require at least one of ``channel`` / ``pip_spec`` (the server always sends
        one — this is defence-in-depth).
-    3. MERGE the provided fields onto a COPY of the LIVE ``entry.options`` (read once,
-       here) so every existing key is preserved — no TOCTOU, and none of the
+    3. Snapshot the ``delta`` (the provided fields, keyed by the OPT_* option keys)
+       and the CURRENT ``entry.options`` — used ONLY for the no-op check and the
+       ``previous``/``applying`` response envelope. Every UNtouched key is preserved
+       because the actual write MERGES the delta against the LIVE ``entry.options``
+       at APPLY time (step 5), NOT against this snapshot — so a concurrent change to
+       another key during the flush window is not clobbered, and none of the
        URL/secret overrides get blanked (which is why the server drops its
        preserved-key resend on this path).
-    4. No-op short-circuit: if the merged options equal the current ones, return
-       ``{scheduled: False, unchanged: True, ...}`` WITHOUT scheduling. (The update
-       listener's own ``DATA_LAST_OPTIONS`` guard would also make such an update not
-       reload, but skipping the schedule keeps it explicit.)
-    5. Otherwise schedule the ``async_update_entry`` on a HASS-owned background task
-       after :data:`SERVER_ENTRY_UPDATE_FLUSH_DELAY_S` and return
+    4. No-op short-circuit: if the delta applied to the snapshot equals the current
+       options, return ``{scheduled: False, unchanged: True, ...}`` WITHOUT
+       scheduling. (The update listener's own ``DATA_LAST_OPTIONS`` guard would also
+       make such an update not reload, but skipping the schedule keeps it explicit.)
+    5. Otherwise schedule the deferred ``_apply`` — which re-reads the LIVE
+       ``entry.options`` and merges the delta against THAT before calling
+       ``async_update_entry`` — on a HASS-owned background task after
+       :data:`SERVER_ENTRY_UPDATE_FLUSH_DELAY_S`, and return
        ``{scheduled: True, ...}`` immediately.
 
     **The deferred-reload crux.** ``async_update_entry`` fires the server entry's
@@ -5226,14 +5233,18 @@ async def _server_entry_update_prep(
 
     options = getattr(entry, "options", None)
     current = dict(options) if isinstance(options, Mapping) else {}
-    new_options = dict(current)
+    # ``delta`` is the applied write (merged against the LIVE options at APPLY time);
+    # ``applying`` is its response-envelope view. The prep-time ``new_options`` is a
+    # snapshot used ONLY for the no-op check below, never for the write.
+    delta: dict[str, Any] = {}
     applying: dict[str, Any] = {}
     if has_channel:
-        new_options[OPT_CHANNEL] = msg["channel"]
+        delta[OPT_CHANNEL] = msg["channel"]
         applying["channel"] = msg["channel"]
     if has_pip_spec:
-        new_options[OPT_PIP_SPEC] = msg["pip_spec"]
+        delta[OPT_PIP_SPEC] = msg["pip_spec"]
         applying["pip_spec"] = msg["pip_spec"]
+    new_options = {**current, **delta}
 
     entry_id = getattr(entry, "entry_id", None)
     previous = {
@@ -5254,10 +5265,27 @@ async def _server_entry_update_prep(
 
     async def _apply() -> None:
         # Deferred so the WS response flushes before the reload this triggers tears
-        # down the serving thread. See the docstring for why it is hass-owned.
+        # down the serving thread. See the docstring for why it is hass-owned. The
+        # delta is merged against the LIVE ``entry.options`` HERE (not at prep) so a
+        # concurrent change to another key during the flush window is preserved.
         await asyncio.sleep(SERVER_ENTRY_UPDATE_FLUSH_DELAY_S)
         try:
-            hass.config_entries.async_update_entry(entry, options=new_options)
+            live = getattr(entry, "options", None)
+            merged = {**(dict(live) if isinstance(live, Mapping) else {}), **delta}
+            applied = hass.config_entries.async_update_entry(entry, options=merged)
+            if applied is False:
+                # ``async_update_entry`` returns False when the merged options already
+                # match (e.g. a concurrent write applied the same delta first). No
+                # caller is left to answer, so surface the no-apply in the log.
+                _LOGGER.warning(
+                    "server_entry_update: no change applied to entry %s (options "
+                    "already current)",
+                    entry_id,
+                )
+            else:
+                _LOGGER.info(
+                    "server_entry_update applied %s to entry %s", applying, entry_id
+                )
         except Exception:  # pragma: no cover - defensive; no caller left to raise to
             _LOGGER.exception("server_entry_update deferred apply failed")
 

--- a/custom_components/ha_mcp_tools/websocket_api.py
+++ b/custom_components/ha_mcp_tools/websocket_api.py
@@ -294,6 +294,7 @@ from homeassistant.helpers import (
 from .const import (
     COMPONENT_VERSION,
     CONF_ENTRY_TYPE,
+    DEFAULT_PIP_SPEC,
     DOMAIN,
     ENTRY_TYPE_SERVER,
     OPT_CHANNEL,
@@ -5242,8 +5243,17 @@ async def _server_entry_update_prep(
         delta[OPT_CHANNEL] = msg["channel"]
         applying["channel"] = msg["channel"]
     if has_pip_spec:
-        delta[OPT_PIP_SPEC] = msg["pip_spec"]
-        applying["pip_spec"] = msg["pip_spec"]
+        # Normalize like the options flow's ``_normalize`` (config_flow.py): a
+        # whitespace-only value OR the default unpinned dist (``DEFAULT_PIP_SPEC``)
+        # means "no override" — collapse it to "" so the channel keeps
+        # auto-updating. Persisting it verbatim would read as an intentional
+        # override and disable auto-updates. This keeps the no-op check honest: a
+        # frame that normalizes to the stored value is unchanged, not a schedule.
+        pip_spec = msg["pip_spec"]
+        if str(pip_spec).strip() in ("", DEFAULT_PIP_SPEC):
+            pip_spec = ""
+        delta[OPT_PIP_SPEC] = pip_spec
+        applying["pip_spec"] = pip_spec
     new_options = {**current, **delta}
 
     entry_id = getattr(entry, "entry_id", None)

--- a/custom_components/ha_mcp_tools/websocket_api.py
+++ b/custom_components/ha_mcp_tools/websocket_api.py
@@ -118,6 +118,24 @@ and ``info`` itself carries no capability entry):
   from ``entry.data``) and returns ``{entry_id, channel, pip_spec}`` (channel /
   pip_spec from ``entry.options``), so ``ha_dev_manage_server`` need not probe
   every ``ha_mcp_tools``-domain entry's options-flow schema from the outside.
+* ``ha_mcp_tools/server_entry_update`` — the WRITE counterpart of ``server_entry``:
+  applies a ``channel`` / ``pip_spec`` delta to the server entry via
+  ``hass.config_entries.async_update_entry`` DIRECTLY (what core's finish-flow
+  does), collapsing ``ha_dev_manage_server(update_source)``'s options-flow start +
+  submit round-trip in embedded mode. The new options are MERGED against the LIVE
+  ``entry.options`` (every existing key preserved, no TOCTOU, no blanking of the
+  URL/secret overrides), so no preserved-key resend is needed. The
+  ``async_update_entry`` fires the entry's own update listener → reload → the
+  hardened reinstall; because that reload tears down the very server thread
+  answering this frame, the call is NOT made inline — it is scheduled on a
+  HASS-level background task (:func:`hass.async_create_background_task`, NOT the
+  entry's, so the reload can't cancel it) after :data:`SERVER_ENTRY_UPDATE_FLUSH_DELAY_S`,
+  and the prep returns ``{scheduled: True, ...}`` immediately so the WS response
+  flushes first. A no-op (merged options equal the current ones) returns
+  ``{scheduled: False, unchanged: True, ...}`` without scheduling; no server entry
+  raises ``HomeAssistantError`` (→ the server's command-error fallback to its legacy
+  options-flow path). All awaiting-adjacent work (the deferred apply) lives in
+  :func:`_server_entry_update_prep`; :func:`_do_server_entry_update` is a pure formatter.
 * ``ha_mcp_tools/call_service`` — the FIRST write capability. Fires exactly one
   ``hass.services.async_call`` in-process and returns the REAL pre→post state
   transition for the target ``entity_ids`` — event-confirmed via an
@@ -305,6 +323,7 @@ WS_DASHBOARDS = f"{WS_API_PREFIX}/dashboards"
 WS_SERVICES_LIST = f"{WS_API_PREFIX}/services_list"
 WS_REFERENCE_DATA = f"{WS_API_PREFIX}/reference_data"
 WS_SERVER_ENTRY = f"{WS_API_PREFIX}/server_entry"
+WS_SERVER_ENTRY_UPDATE = f"{WS_API_PREFIX}/server_entry_update"
 WS_CALL_SERVICE = f"{WS_API_PREFIX}/call_service"
 WS_BULK_CALL_SERVICE = f"{WS_API_PREFIX}/bulk_call_service"
 
@@ -342,6 +361,11 @@ CAPABILITIES: list[str] = [
     # routing; the CAPABILITIES flag is what the server gates on).
     "search_visibility",
     "server_entry",
+    # The WRITE counterpart of ``server_entry`` (Phase 3). The server gates its
+    # ``ha_dev_manage_server(update_source)`` embedded-mode direct-write on this; an
+    # old component that lacks it is never sent the frame and the server stays on its
+    # legacy options-flow submit.
+    "server_entry_update",
     # The first WRITE capability (Phase 3). The server gates its ``ha_call_service``
     # component route on this; an old component that lacks it is never sent a
     # component write and stays on the legacy REST path.
@@ -377,6 +401,17 @@ DEFAULT_LIMIT = 10
 # so the wait is bounded and its expiry is ``partial``, never a failure (D4).
 CALL_SERVICE_DEFAULT_TIMEOUT = 10.0
 CALL_SERVICE_MAX_TIMEOUT = 60.0
+
+# Delay before ``server_entry_update``'s deferred ``async_update_entry`` fires, so
+# the WS ``{scheduled: True}`` response flushes to the calling (embedded) server
+# BEFORE the resulting entry reload tears that server's thread down. Mirrors the
+# server side's ``tools_dev._SELF_ACTION_FLUSH_DELAY_S`` (its legacy options-flow
+# self-restart uses the same headroom for the ingress/webhook hop).
+SERVER_ENTRY_UPDATE_FLUSH_DELAY_S = 1.0
+
+# pip_spec defence-in-depth cap (the SERVER already validates per D6): a single-line
+# requirement string under this many chars. Mirrors ``tools_dev._update_source``.
+SERVER_ENTRY_UPDATE_MAX_PIP_SPEC = 500
 
 # Fuzzy floor + hidden penalty, mirrored from the server so the two scorers do
 # not drift (guarded by the golden parity test).
@@ -523,6 +558,15 @@ def _command_specs() -> list[tuple[dict[Any, Any], Any, Any]]:
         (_services_list_schema(), _do_services_list, _services_list_prep),
         (_reference_data_schema(), _do_reference_data, None),
         (_server_entry_schema(), _do_server_entry, None),
+        # The WRITE counterpart of server_entry: the deferred ``async_update_entry``
+        # scheduling is inherently async, so it lives in ``_server_entry_update_prep``
+        # and ``_do_server_entry_update`` is a pure formatter (same seam as the
+        # call_service write below).
+        (
+            _server_entry_update_schema(),
+            _do_server_entry_update,
+            _server_entry_update_prep,
+        ),
         # The first WRITE command: the dispatch + the bounded confirmation wait are
         # inherently async, so ALL of the work lives in the ``_call_service_prep``
         # async pre-step and ``_do_call_service`` is a pure response formatter.
@@ -758,6 +802,29 @@ def _reference_data_schema() -> dict[Any, Any]:
 
 def _server_entry_schema() -> dict[Any, Any]:
     return {vol.Required("type"): WS_SERVER_ENTRY}
+
+
+def _single_line_pip_spec(value: str) -> str:
+    """Reject a multi-line / control-char ``pip_spec`` (defence-in-depth over D6)."""
+    if any(ord(c) < 32 for c in value):
+        raise vol.Invalid("pip_spec must be a single-line string")
+    return value
+
+
+def _server_entry_update_schema() -> dict[Any, Any]:
+    # Both fields are optional at the schema level (voluptuous cannot cleanly express
+    # "at least one of"); ``_server_entry_update_prep`` raises when NEITHER is present.
+    # ``channel`` stays a bare ``str`` — the SERVER validates it against its channel
+    # set (D6); ``pip_spec`` gets the length + single-line defence-in-depth cap.
+    return {
+        vol.Required("type"): WS_SERVER_ENTRY_UPDATE,
+        vol.Optional("channel"): str,
+        vol.Optional("pip_spec"): vol.All(
+            str,
+            vol.Length(max=SERVER_ENTRY_UPDATE_MAX_PIP_SPEC),
+            _single_line_pip_spec,
+        ),
+    }
 
 
 def _call_service_schema() -> dict[Any, Any]:
@@ -5038,30 +5105,43 @@ def _assist_exposure_available(hass: HomeAssistant) -> bool:
 # =============================================================================
 # ha_mcp_tools/server_entry
 # =============================================================================
-def _do_server_entry(hass: HomeAssistant, params: dict[str, Any]) -> dict[str, Any]:
-    """Locate the component's OWN server config entry and return its identity.
+def _find_server_config_entry(hass: HomeAssistant) -> Any | None:
+    """Return the component's OWN server config entry, or ``None`` if absent.
 
-    Iterates the component's ``DOMAIN`` config entries and picks the server-type
-    one by the explicit ``entry.data[CONF_ENTRY_TYPE] == ENTRY_TYPE_SERVER`` marker
-    the component's own config flow stamps — the single ``entry.data`` key this
-    reads (the documented data-minimization exception; nothing else from
-    ``entry.data`` is emitted). ``channel`` / ``pip_spec`` come from
-    ``entry.options`` (``None`` when absent); ``entry_id`` is ``None`` when no
-    server entry exists.
+    Picks the single ``DOMAIN`` entry stamped with
+    ``entry.data[CONF_ENTRY_TYPE] == ENTRY_TYPE_SERVER`` (the one ``entry.data``
+    key the component reads — the documented data-minimization exception). Shared
+    by the ``server_entry`` READ cap (:func:`_do_server_entry`) and the
+    ``server_entry_update`` WRITE cap (:func:`_server_entry_update_prep`), so both
+    discriminate the entry identically.
     """
     for entry in _iter_config_entries(hass):
         if getattr(entry, "domain", None) != DOMAIN:
             continue
         if _entry_marker_type(entry) != ENTRY_TYPE_SERVER:
             continue
-        options = getattr(entry, "options", None)
-        opts = options if isinstance(options, Mapping) else {}
-        return {
-            "entry_id": getattr(entry, "entry_id", None),
-            "channel": opts.get(OPT_CHANNEL),
-            "pip_spec": opts.get(OPT_PIP_SPEC),
-        }
-    return {"entry_id": None, "channel": None, "pip_spec": None}
+        return entry
+    return None
+
+
+def _do_server_entry(hass: HomeAssistant, params: dict[str, Any]) -> dict[str, Any]:
+    """Locate the component's OWN server config entry and return its identity.
+
+    Discriminates the server-type entry via :func:`_find_server_config_entry`
+    (the ``entry.data[CONF_ENTRY_TYPE] == ENTRY_TYPE_SERVER`` marker). ``channel`` /
+    ``pip_spec`` come from ``entry.options`` (``None`` when absent); ``entry_id`` is
+    ``None`` when no server entry exists.
+    """
+    entry = _find_server_config_entry(hass)
+    if entry is None:
+        return {"entry_id": None, "channel": None, "pip_spec": None}
+    options = getattr(entry, "options", None)
+    opts = options if isinstance(options, Mapping) else {}
+    return {
+        "entry_id": getattr(entry, "entry_id", None),
+        "channel": opts.get(OPT_CHANNEL),
+        "pip_spec": opts.get(OPT_PIP_SPEC),
+    }
 
 
 def _entry_marker_type(entry: Any) -> Any:
@@ -5070,6 +5150,128 @@ def _entry_marker_type(entry: Any) -> Any:
     if isinstance(data, Mapping):
         return data.get(CONF_ENTRY_TYPE)
     return None
+
+
+# =============================================================================
+# ha_mcp_tools/server_entry_update  (the server_entry WRITE counterpart — Phase 3)
+# =============================================================================
+def _do_server_entry_update(
+    hass: HomeAssistant, params: dict[str, Any], *, result: dict[str, Any]
+) -> dict[str, Any]:
+    """Pure sync formatter for ``server_entry_update``.
+
+    ALL of the work — locating the entry, merging the delta against the LIVE
+    options, and (unless it is a no-op) scheduling the deferred
+    ``async_update_entry`` — happens in the async :func:`_server_entry_update_prep`,
+    which hands the finished envelope in as ``result``. This only returns it (the WS
+    wrapper's ``send_result`` adds the outer success frame), so no scheduling /
+    awaiting work ever runs in a ``_do_*`` step.
+    """
+    return result
+
+
+async def _server_entry_update_prep(
+    hass: HomeAssistant, msg: dict[str, Any]
+) -> dict[str, Any]:
+    """Apply a ``channel`` / ``pip_spec`` delta to the server entry, DEFERRED.
+
+    Returns ``{"result": <envelope>}``. The order is load-bearing:
+
+    1. Locate the server entry (:func:`_find_server_config_entry`); a missing entry
+       raises ``HomeAssistantError`` so the server's command-error path falls back to
+       its legacy options-flow submit.
+    2. Require at least one of ``channel`` / ``pip_spec`` (the server always sends
+       one — this is defence-in-depth).
+    3. MERGE the provided fields onto a COPY of the LIVE ``entry.options`` (read once,
+       here) so every existing key is preserved — no TOCTOU, and none of the
+       URL/secret overrides get blanked (which is why the server drops its
+       preserved-key resend on this path).
+    4. No-op short-circuit: if the merged options equal the current ones, return
+       ``{scheduled: False, unchanged: True, ...}`` WITHOUT scheduling. (The update
+       listener's own ``DATA_LAST_OPTIONS`` guard would also make such an update not
+       reload, but skipping the schedule keeps it explicit.)
+    5. Otherwise schedule the ``async_update_entry`` on a HASS-owned background task
+       after :data:`SERVER_ENTRY_UPDATE_FLUSH_DELAY_S` and return
+       ``{scheduled: True, ...}`` immediately.
+
+    **The deferred-reload crux.** ``async_update_entry`` fires the server entry's
+    update listener, which reloads the entry — tearing down the very in-process
+    server thread answering THIS frame. Calling it inline would kill that thread
+    before the WS ``{scheduled: True}`` response flushed, so the caller would never
+    get its confirmation. It is therefore scheduled after a flush delay. The task is
+    created with :func:`hass.async_create_background_task` (hass-owned), NOT
+    ``entry.async_create_background_task``: an entry-owned task is cancelled by the
+    unload the reload performs, so it could cancel itself before firing — the exact
+    trap ``embedded_entry._on_version_update`` documents. Being hass-owned, the task
+    survives to invoke ``async_update_entry`` (a synchronous ``@callback`` that
+    returns as soon as it schedules the listener), then completes; the reload it
+    triggers runs as its own hass task after the response has flushed.
+    """
+    import asyncio
+
+    from homeassistant.exceptions import HomeAssistantError
+
+    entry = _find_server_config_entry(hass)
+    if entry is None:
+        raise HomeAssistantError(
+            "no ha_mcp_tools in-process server config entry to update"
+        )
+
+    has_channel = "channel" in msg
+    has_pip_spec = "pip_spec" in msg
+    if not has_channel and not has_pip_spec:
+        raise HomeAssistantError(
+            "server_entry_update needs at least one of channel / pip_spec"
+        )
+
+    options = getattr(entry, "options", None)
+    current = dict(options) if isinstance(options, Mapping) else {}
+    new_options = dict(current)
+    applying: dict[str, Any] = {}
+    if has_channel:
+        new_options[OPT_CHANNEL] = msg["channel"]
+        applying["channel"] = msg["channel"]
+    if has_pip_spec:
+        new_options[OPT_PIP_SPEC] = msg["pip_spec"]
+        applying["pip_spec"] = msg["pip_spec"]
+
+    entry_id = getattr(entry, "entry_id", None)
+    previous = {
+        "channel": current.get(OPT_CHANNEL),
+        "pip_spec": current.get(OPT_PIP_SPEC),
+    }
+
+    if new_options == current:
+        return {
+            "result": {
+                "scheduled": False,
+                "unchanged": True,
+                "entry_id": entry_id,
+                "applying": applying,
+                "previous": previous,
+            }
+        }
+
+    async def _apply() -> None:
+        # Deferred so the WS response flushes before the reload this triggers tears
+        # down the serving thread. See the docstring for why it is hass-owned.
+        await asyncio.sleep(SERVER_ENTRY_UPDATE_FLUSH_DELAY_S)
+        try:
+            hass.config_entries.async_update_entry(entry, options=new_options)
+        except Exception:  # pragma: no cover - defensive; no caller left to raise to
+            _LOGGER.exception("server_entry_update deferred apply failed")
+
+    hass.async_create_background_task(
+        _apply(), name=f"{WS_API_PREFIX} server_entry_update"
+    )
+    return {
+        "result": {
+            "scheduled": True,
+            "entry_id": entry_id,
+            "applying": applying,
+            "previous": previous,
+        }
+    }
 
 
 # =============================================================================

--- a/src/ha_mcp/client/rest_client.py
+++ b/src/ha_mcp/client/rest_client.py
@@ -1755,20 +1755,34 @@ class HomeAssistantClient:
             raise
 
     async def upsert_scene_config(
-        self, config: dict[str, Any], scene_id: str, *, _resolved: bool = False
+        self,
+        config: dict[str, Any],
+        scene_id: str,
+        *,
+        resolved_id: str | None = None,
     ) -> dict[str, Any]:
         """Create or update Home Assistant scene configuration.
 
-        ``_resolved=True`` signals ``scene_id`` is already the resolved storage
-        key, skipping the redundant registry lookup (``resolve_scene_id`` is
-        idempotent, so the endpoint id is unchanged).
+        ``resolved_id``, when provided, is the already-resolved storage key used
+        as the write target (the caller ran :meth:`resolve_scene_id`), skipping
+        the redundant registry lookup. ``scene_id`` stays the CALLER's identifier
+        and is used only to default a missing ``name`` — a renamed scene (whose
+        storage key differs from the slug the caller passed) keeps its
+        caller-facing name rather than resetting to the stale storage key
+        (#1935, mirrors the script fix).
         """
-        resolved_id = scene_id if _resolved else await self.resolve_scene_id(scene_id)
+        write_id = (
+            resolved_id
+            if resolved_id is not None
+            else await self.resolve_scene_id(scene_id)
+        )
         try:
-            endpoint = f"config/scene/config/{resolved_id}"
+            endpoint = f"config/scene/config/{write_id}"
 
-            # Default a name when missing — mirrors the script upsert behaviour
-            # so a bare config dict is still acceptable.
+            # Default a name when missing from the CALLER's ``scene_id`` (not
+            # ``write_id``) — mirrors the script upsert behaviour so a bare
+            # config dict is acceptable, without resetting a renamed scene's
+            # name to the storage key.
             if "name" not in config:
                 config["name"] = scene_id
 
@@ -1790,7 +1804,7 @@ class HomeAssistantClient:
             # activity should diff before/after via ``ha_config_get_scene``.
             return {
                 "success": True,
-                "scene_id": resolved_id,
+                "scene_id": write_id,
                 "result": response.get("result", "ok"),
             }
         except Exception as e:

--- a/src/ha_mcp/client/rest_client.py
+++ b/src/ha_mcp/client/rest_client.py
@@ -1606,22 +1606,33 @@ class HomeAssistantClient:
             raise
 
     async def upsert_script_config(
-        self, config: dict[str, Any], script_id: str, *, _resolved: bool = False
+        self,
+        config: dict[str, Any],
+        script_id: str,
+        *,
+        resolved_id: str | None = None,
     ) -> dict[str, Any]:
         """Create or update Home Assistant script configuration.
 
-        ``_resolved=True`` signals ``script_id`` is already the resolved storage
-        key (the caller ran :meth:`_resolve_script_id`), skipping the redundant
-        entity-registry lookup (``_resolve_script_id`` is idempotent, so the
-        endpoint id is unchanged).
+        ``resolved_id``, when provided, is the already-resolved storage key used
+        as the write target (the caller ran :meth:`_resolve_script_id`),
+        skipping the redundant entity-registry lookup. ``script_id`` stays the
+        CALLER's identifier and is used only to default a missing ``alias`` — a
+        renamed script (whose storage key differs from the entity slug the
+        caller passed) keeps its caller-facing name rather than resetting the
+        user-visible alias to the stale storage key (#1935).
         """
-        resolved_id = (
-            script_id if _resolved else await self._resolve_script_id(script_id)
+        write_id = (
+            resolved_id
+            if resolved_id is not None
+            else await self._resolve_script_id(script_id)
         )
         try:
-            endpoint = f"config/script/config/{resolved_id}"
+            endpoint = f"config/script/config/{write_id}"
 
-            # Validate required fields
+            # Default a missing alias from the CALLER's ``script_id`` (not
+            # ``write_id``) so a renamed script's user-visible name is preserved
+            # instead of being reset to the storage key.
             if "alias" not in config:
                 config["alias"] = script_id
 
@@ -1636,7 +1647,7 @@ class HomeAssistantClient:
 
             return {
                 "success": True,
-                "script_id": resolved_id,
+                "script_id": write_id,
                 "result": response.get("result", "ok"),
                 "operation": "created" if response.get("result") == "ok" else "updated",
             }

--- a/src/ha_mcp/client/rest_client.py
+++ b/src/ha_mcp/client/rest_client.py
@@ -975,7 +975,11 @@ class HomeAssistantClient:
             raise
 
     async def upsert_automation_config(
-        self, config: dict[str, Any], identifier: str | None = None
+        self,
+        config: dict[str, Any],
+        identifier: str | None = None,
+        *,
+        _resolved: bool = False,
     ) -> dict[str, Any]:
         """
         Create new automation or update existing one.
@@ -983,6 +987,12 @@ class HomeAssistantClient:
         Args:
             config: Automation configuration dictionary
             identifier: Optional automation entity_id or unique_id (None = create new)
+            _resolved: When True, ``identifier`` is already the resolved unique_id
+                (the caller ran ``_resolve_automation_id``), so the redundant
+                entity_id→unique_id lookup is skipped. Ignored on the create path
+                (``identifier is None``). The #1404 config-id mismatch guard below
+                is unaffected — it still compares ``config['id']`` to the resolved
+                unique_id.
 
         Returns:
             Result with automation unique_id and status
@@ -996,7 +1006,11 @@ class HomeAssistantClient:
             operation = "created"
             logger.debug(f"Creating new automation with unique_id: {unique_id}")
         else:
-            unique_id = await self._resolve_automation_id(identifier)
+            unique_id = (
+                identifier
+                if _resolved
+                else await self._resolve_automation_id(identifier)
+            )
             operation = "updated"
             logger.debug(f"Updating automation with unique_id: {unique_id}")
 
@@ -1592,10 +1606,18 @@ class HomeAssistantClient:
             raise
 
     async def upsert_script_config(
-        self, config: dict[str, Any], script_id: str
+        self, config: dict[str, Any], script_id: str, *, _resolved: bool = False
     ) -> dict[str, Any]:
-        """Create or update Home Assistant script configuration."""
-        resolved_id = await self._resolve_script_id(script_id)
+        """Create or update Home Assistant script configuration.
+
+        ``_resolved=True`` signals ``script_id`` is already the resolved storage
+        key (the caller ran :meth:`_resolve_script_id`), skipping the redundant
+        entity-registry lookup (``_resolve_script_id`` is idempotent, so the
+        endpoint id is unchanged).
+        """
+        resolved_id = (
+            script_id if _resolved else await self._resolve_script_id(script_id)
+        )
         try:
             endpoint = f"config/script/config/{resolved_id}"
 

--- a/src/ha_mcp/client/rest_client.py
+++ b/src/ha_mcp/client/rest_client.py
@@ -1782,9 +1782,12 @@ class HomeAssistantClient:
             # Default a name when missing from the CALLER's ``scene_id`` (not
             # ``write_id``) — mirrors the script upsert behaviour so a bare
             # config dict is acceptable, without resetting a renamed scene's
-            # name to the storage key.
+            # name to the storage key. Strip the ``scene.`` prefix: a caller may
+            # pass the entity_id form (``resolve_scene_id`` accepts it), and HA
+            # derives the entity_id from the name slug — persisting the prefixed
+            # form would rename the scene and change its entity_id on a plain update.
             if "name" not in config:
-                config["name"] = scene_id
+                config["name"] = scene_id.removeprefix("scene.")
 
             # Validate required field. ``entities`` is a dict keyed by entity_id,
             # not a list — distinct from script ``sequence`` and automation ``action``.

--- a/src/ha_mcp/tools/component_api.py
+++ b/src/ha_mcp/tools/component_api.py
@@ -273,9 +273,17 @@ async def get_component_caps(client: Any) -> ComponentCaps | None:
         if not base_url or not token:
             # Not a credentialed HA client — no WS connection to negotiate over.
             return None
+        # Thread verify_ssl so a verify_ssl=False client keys (and can establish)
+        # its own pooled connection rather than failing the probe or colliding with
+        # a default-verification entry — otherwise EVERY component capability is
+        # silently unreachable on an HTTPS + verify_ssl=False install. ``None`` is
+        # the pool's settings default, so a client without the attr is unchanged.
+        verify_ssl = getattr(client, "verify_ssl", None)
 
         try:
-            ws = await get_websocket_client(url=base_url, token=token)
+            ws = await get_websocket_client(
+                url=base_url, token=token, verify_ssl=verify_ssl
+            )
             response = await ws.send_command(INFO_COMMAND)
         except HomeAssistantCommandError:
             # Old component (unknown_command) or an info handler bug: the

--- a/src/ha_mcp/tools/tools_config_automations.py
+++ b/src/ha_mcp/tools/tools_config_automations.py
@@ -896,11 +896,14 @@ class AutomationConfigTools:
         client resolve — the create path (``identifier is None``) and the
         no-hash update path both land here unchanged.
         """
+        result: dict[str, Any]
         if resolved_id is not None:
-            return await self._client.upsert_automation_config(
+            result = await self._client.upsert_automation_config(
                 config, resolved_id, _resolved=True
             )
-        return await self._client.upsert_automation_config(config, identifier)
+        else:
+            result = await self._client.upsert_automation_config(config, identifier)
+        return result
 
     async def _run_python_transform(
         self,

--- a/src/ha_mcp/tools/tools_config_automations.py
+++ b/src/ha_mcp/tools/tools_config_automations.py
@@ -801,9 +801,15 @@ class AutomationConfigTools:
             # (trigger -> triggers, action -> actions, condition -> conditions).
             config_dict = _normalize_automation_config(config_dict)
 
-            # Optional hash check for full config updates
+            # Optional hash check for full config updates. When it runs it
+            # resolves ``identifier`` to the storage key — thread that through so
+            # the upsert doesn't re-resolve (issue #1813 Phase 0). Stays None on
+            # the no-hash update path (raw identifier resolved once, in upsert).
+            resolved_id: str | None = None
             if identifier and config_hash:
-                await self._fetch_and_verify_hash(identifier, config_hash, "set")
+                _, resolved_id = await self._fetch_and_verify_hash(
+                    identifier, config_hash, "set"
+                )
 
             self._validate_required_fields(config_dict, identifier)
             bp_warnings = _check_best_practices(config_dict)
@@ -820,6 +826,7 @@ class AutomationConfigTools:
                 validation_meta,
                 MandatoryBPS,
                 conflict_warnings,
+                resolved_id,
             )
 
         except ToolError as te:
@@ -874,6 +881,27 @@ class AutomationConfigTools:
             augment_error_dict_with_skill_content(error, bp_warnings)
             raise_tool_error(error)
 
+    async def _upsert_automation(
+        self,
+        config: dict[str, Any],
+        identifier: str | None,
+        resolved_id: str | None,
+    ) -> dict[str, Any]:
+        """Upsert, threading a pre-resolved unique_id when available.
+
+        When ``resolved_id`` is set the caller already resolved ``identifier``
+        (via ``_fetch_and_verify_hash``); pass it with ``_resolved=True`` so the
+        REST client skips the redundant entity_id→unique_id lookup (issue #1813
+        Phase 0). Otherwise fall back to the raw ``identifier`` and let the REST
+        client resolve — the create path (``identifier is None``) and the
+        no-hash update path both land here unchanged.
+        """
+        if resolved_id is not None:
+            return await self._client.upsert_automation_config(
+                config, resolved_id, _resolved=True
+            )
+        return await self._client.upsert_automation_config(config, identifier)
+
     async def _run_python_transform(
         self,
         identifier: str | None,
@@ -908,7 +936,7 @@ class AutomationConfigTools:
                 )
             )
 
-        current_config = await self._fetch_and_verify_hash(
+        current_config, resolved_id = await self._fetch_and_verify_hash(
             identifier, config_hash, "python_transform"
         )
 
@@ -938,8 +966,12 @@ class AutomationConfigTools:
         self._validate_required_fields(transformed_config, identifier)
         bp_warnings = _check_best_practices(transformed_config)
 
-        result = await self._client.upsert_automation_config(
-            transformed_config, identifier
+        # ``_fetch_and_verify_hash`` already resolved ``identifier`` to the
+        # storage key; thread it so the upsert skips the redundant re-resolve
+        # (issue #1813 Phase 0). Fall back to the raw identifier if the fetched
+        # body carried no ``id`` (not expected for a real automation).
+        result = await self._upsert_automation(
+            transformed_config, identifier, resolved_id
         )
         for warning in conflict_warnings:
             result.setdefault("warnings", []).append(warning)
@@ -988,9 +1020,15 @@ class AutomationConfigTools:
         validation_meta: dict[str, Any],
         MandatoryBPS: bool,
         conflict_warnings: list[str] | None = None,
+        resolved_id: str | None = None,
     ) -> dict[str, Any]:
-        """Execute config-replacement mode and return the tool response."""
-        result = await self._client.upsert_automation_config(config_dict, identifier)
+        """Execute config-replacement mode and return the tool response.
+
+        ``resolved_id`` (set only when the optional hash check pre-resolved
+        ``identifier``) is threaded to the upsert so it skips the redundant
+        re-resolve; None falls back to resolving inside the REST client.
+        """
+        result = await self._upsert_automation(config_dict, identifier, resolved_id)
 
         for warning in conflict_warnings or []:
             result.setdefault("warnings", []).append(warning)
@@ -1137,10 +1175,18 @@ class AutomationConfigTools:
 
     async def _fetch_and_verify_hash(
         self, identifier: str, config_hash: str, action: str
-    ) -> dict[str, Any]:
+    ) -> tuple[dict[str, Any], str | None]:
         """Fetch current automation config and verify config_hash for optimistic locking.
 
-        Returns the current normalized config dict.
+        Returns ``(current_normalized_config, resolved_unique_id)``. The fetch
+        already resolved ``identifier`` to the storage key inside
+        ``get_automation_config``; HA returns the stored body keyed by that
+        unique_id, so ``config['id']`` IS the resolved unique_id (the same value
+        the #1404 guard compares against). Threading it lets the caller pass
+        ``_resolved=True`` to ``upsert_automation_config`` and skip the redundant
+        second resolve (issue #1813 Phase 0). ``None`` when the stored body has
+        no ``id`` (not expected for a real automation) — the caller then falls
+        back to re-resolving.
         Raises ToolError if the hash does not match (conflict).
         """
         current_config, current_hash = await self._get_automation_config_internal(
@@ -1158,7 +1204,11 @@ class AutomationConfigTools:
                     context={"action": action, "identifier": identifier},
                 )
             )
-        return current_config
+        raw_id = current_config.get("id")
+        # Stringify to match ``_resolve_automation_id``'s ``str()`` coercion so a
+        # threaded id is byte-for-byte what the unthreaded path would produce.
+        resolved_id = str(raw_id) if raw_id is not None else None
+        return current_config, resolved_id
 
     @staticmethod
     def _parse_and_validate_config(config: str | dict[str, Any]) -> dict[str, Any]:

--- a/src/ha_mcp/tools/tools_config_scenes.py
+++ b/src/ha_mcp/tools/tools_config_scenes.py
@@ -386,7 +386,7 @@ class ConfigSceneTools:
 
     async def _get_scene_config_internal(
         self, scene_id: str, *, _resolved: bool = False
-    ) -> tuple[dict[str, Any], str, str]:
+    ) -> tuple[dict[str, Any], str, str | None]:
         """Fetch scene config without logging or category injection.
 
         Returns ``(actual_config, config_hash, resolved_id)`` where
@@ -394,27 +394,36 @@ class ConfigSceneTools:
         ``resolved_id`` is the storage key the rest-client resolved the input
         to (issue #1168 R3 blocker 6). Used by ``_fetch_and_verify_hash``.
 
+        ``resolved_id`` is ``None`` when the envelope omits ``scene_id`` — the
+        write target must then be re-resolved from the caller's input rather
+        than defaulting to the (unresolved) caller slug, which for a renamed
+        scene would target the wrong storage key. This is a structural
+        invariant, not a live path: ``get_scene_config`` always sets the key.
+
         ``_resolved=True`` forwards to ``get_scene_config`` that ``scene_id`` is
         already a resolved storage key, so the redundant registry lookup is
         skipped (e.g. the python_transform re-fetch, which already resolved).
         """
         envelope = await self._client.get_scene_config(scene_id, _resolved=_resolved)
         actual_config = envelope.get("config", envelope)
-        resolved_id = envelope.get("scene_id", scene_id.removeprefix("scene."))
+        resolved_id = envelope.get("scene_id")
         config_hash_value = compute_config_hash(actual_config)
         return actual_config, config_hash_value, resolved_id
 
     async def _fetch_and_verify_hash(
         self, scene_id: str, config_hash: str, action: str
-    ) -> tuple[dict[str, Any], str]:
+    ) -> tuple[dict[str, Any], str | None]:
         """Fetch current scene config and verify config_hash for optimistic locking.
 
         Returns ``(actual_config, resolved_id)`` — the inner scene body and
-        the storage key the rest-client resolved the input to. Raises
-        ``ToolError`` if the hash does not match (conflict). Issue #1168 R3
-        blocker 6: callers thread ``resolved_id`` into responses so the
-        outer ``scene_id`` matches the inner body's ``id`` regardless of
-        whether the caller passed the entity_id slug or the storage key.
+        the storage key the rest-client resolved the input to. ``resolved_id``
+        is ``None`` when the envelope omitted the key, so the upsert re-resolves
+        rather than writing to the caller slug; the caller then re-binds it from
+        the upsert result. Raises ``ToolError`` if the hash does not match
+        (conflict). Issue #1168 R3 blocker 6: callers thread ``resolved_id`` into
+        responses so the outer ``scene_id`` matches the inner body's ``id``
+        regardless of whether the caller passed the entity_id slug or the
+        storage key.
         """
         (
             actual_config,
@@ -691,6 +700,12 @@ class ConfigSceneTools:
                 actual_config, resolved_id = await self._fetch_and_verify_hash(
                     scene_id, config_hash, "python_transform"
                 )
+                # Capture the scene's own ``id`` BEFORE the transform mutates the
+                # config in place — it is the stable identity the id-change guard
+                # compares against (in production it equals ``resolved_id``; it is
+                # also correct when ``resolved_id`` is None because the envelope
+                # omitted ``scene_id``).
+                original_id = actual_config.get("id")
 
                 try:
                     transformed_config = safe_execute(python_transform, actual_config)
@@ -773,23 +788,26 @@ class ConfigSceneTools:
                 # legitimate (HA treats ``id`` as optional) and should pass
                 # through. R7 blocker 24: ``transformed_config["id"] = None``
                 # is the in-place equivalent of ``del`` — normalise both
-                # by checking against ``(None, resolved_id)``, so only an
-                # explicit non-None mismatch triggers the reject.
+                # by checking against ``(None, original_id)``, so only an
+                # explicit non-None mismatch triggers the reject. Compare against
+                # the scene's own captured ``id`` (not ``resolved_id``, which may
+                # be None on the structural-invariant path) — in production the
+                # two are equal.
                 if "id" in transformed_config and transformed_config["id"] not in (
                     None,
-                    resolved_id,
+                    original_id,
                 ):
                     raise_tool_error(
                         create_error_response(
                             ErrorCode.VALIDATION_FAILED,
                             "Transform must not change ``config['id']``",
                             suggestions=[
-                                f"Original scene_id is {resolved_id!r} — keep it unchanged",
+                                f"Original scene_id is {original_id!r} — keep it unchanged",
                                 "To rename a scene, use ha_config_remove_scene + ha_config_set_scene",
                             ],
                             context={
                                 "action": "python_transform",
-                                "scene_id": resolved_id,
+                                "scene_id": original_id,
                                 "attempted_id": transformed_config.get("id"),
                             },
                         )
@@ -834,6 +852,11 @@ class ConfigSceneTools:
                 result = await self._client.upsert_scene_config(
                     transformed_config, scene_id, resolved_id=resolved_id
                 )
+                # The upsert re-resolves when ``resolved_id`` was None (envelope
+                # omitted the key); re-bind to the authoritative write target it
+                # returned so the re-fetch, entity resolution, and response all
+                # use the resolved storage key rather than a possible None.
+                resolved_id = result.get("scene_id", resolved_id)
 
                 # Re-fetch to get authoritative hash (HA may normalise after save).
                 # ``resolved_id`` is already the storage key, so skip the re-resolve.
@@ -970,6 +993,11 @@ class ConfigSceneTools:
             result = await self._client.upsert_scene_config(
                 config_dict, scene_id, resolved_id=resolved_id
             )
+            # The upsert re-resolves when ``resolved_id`` was None (envelope
+            # omitted the key); re-bind to the authoritative write target it
+            # returned so entity resolution and the response use the resolved
+            # storage key rather than a possible None.
+            resolved_id = result.get("scene_id", resolved_id)
 
             # Resolve actual entity_id via registry — HA derives scene
             # entity_ids from the 'name' slug, not the scene_id storage key,

--- a/src/ha_mcp/tools/tools_config_scenes.py
+++ b/src/ha_mcp/tools/tools_config_scenes.py
@@ -828,8 +828,11 @@ class ConfigSceneTools:
                 if category:
                     await self._validate_category_id(category)
 
+                # ``resolved_id`` is the storage key (write target); ``scene_id``
+                # stays the caller id so a missing ``name`` defaults caller-facing
+                # rather than to the storage key (#1935).
                 result = await self._client.upsert_scene_config(
-                    transformed_config, resolved_id, _resolved=True
+                    transformed_config, scene_id, resolved_id=resolved_id
                 )
 
                 # Re-fetch to get authoritative hash (HA may normalise after save).
@@ -960,9 +963,12 @@ class ConfigSceneTools:
             )
 
             # ``resolved_id`` is already the storage key (from the hash-verify
-            # fetch or the resolve above), so skip the redundant re-resolve.
+            # fetch or the resolve above) — pass it as the write target to skip
+            # the redundant re-resolve. ``scene_id`` stays the caller id so a
+            # missing ``name`` defaults caller-facing, not to the storage key
+            # (#1935).
             result = await self._client.upsert_scene_config(
-                config_dict, resolved_id, _resolved=True
+                config_dict, scene_id, resolved_id=resolved_id
             )
 
             # Resolve actual entity_id via registry — HA derives scene

--- a/src/ha_mcp/tools/tools_config_scripts.py
+++ b/src/ha_mcp/tools/tools_config_scripts.py
@@ -356,20 +356,16 @@ class ConfigScriptTools:
     ) -> dict[str, Any]:
         """Upsert, threading a pre-resolved storage key when available.
 
-        When ``resolved_id`` is set the caller already resolved ``script_id``
-        (via ``_fetch_and_verify_hash``); pass it with ``_resolved=True`` so the
+        ``script_id`` is always the CALLER's identifier (used to default a
+        missing alias). ``resolved_id`` — set only when ``_fetch_and_verify_hash``
+        already resolved the storage key — is passed as the write target so the
         REST client skips the redundant entity-registry lookup (issue #1813
-        Phase 0). Otherwise fall back to the raw ``script_id`` and let the REST
-        client resolve — the no-hash update path lands here unchanged.
+        Phase 0); None lets the REST client resolve. Passing the caller id
+        separately keeps a renamed script's alias caller-facing (#1935).
         """
-        result: dict[str, Any]
-        if resolved_id is not None:
-            result = await self._client.upsert_script_config(
-                config, resolved_id, _resolved=True
-            )
-        else:
-            result = await self._client.upsert_script_config(config, script_id)
-        return result
+        return await self._client.upsert_script_config(
+            config, script_id, resolved_id=resolved_id
+        )
 
     @staticmethod
     def _validate_script_config(
@@ -751,10 +747,13 @@ class ConfigScriptTools:
                 bp_warnings = _check_best_practices(transformed_config)
 
                 # Save transformed config. ``_fetch_and_verify_hash`` already
-                # resolved the storage key; thread it so the upsert skips the
-                # redundant re-resolve (issue #1813 Phase 0).
+                # resolved the storage key; pass it as the write target so the
+                # upsert skips the redundant re-resolve (issue #1813 Phase 0).
+                # ``script_id`` stays the caller id (the fetched config already
+                # carries an alias here, so the default is a no-op, but keep the
+                # contract consistent — #1935).
                 result = await self._client.upsert_script_config(
-                    transformed_config, resolved_id, _resolved=True
+                    transformed_config, script_id, resolved_id=resolved_id
                 )
 
                 # Re-fetch to get authoritative hash (HA may normalize after save)

--- a/src/ha_mcp/tools/tools_config_scripts.py
+++ b/src/ha_mcp/tools/tools_config_scripts.py
@@ -302,7 +302,7 @@ class ConfigScriptTools:
 
     async def _get_script_config_internal(
         self, script_id: str
-    ) -> tuple[dict[str, Any], str, str]:
+    ) -> tuple[dict[str, Any], str, str | None]:
         """Fetch script config without logging or category injection.
 
         Returns ``(actual_config, config_hash, resolved_id)`` where
@@ -312,25 +312,32 @@ class ConfigScriptTools:
         upsert call site skip the redundant re-resolve (issue #1813 Phase 0).
         Used internally by _fetch_and_verify_hash and ha_config_get_script.
 
+        ``resolved_id`` is ``None`` when the envelope omits ``script_id`` — the
+        write target must then be re-resolved from the caller's input rather
+        than defaulting to the (unresolved) caller slug, which for a renamed
+        script would target the wrong storage key. This is a structural
+        invariant, not a live path: ``get_script_config`` always sets the key.
+
         404 responses from the REST client are mapped to a structured
         ``RESOURCE_NOT_FOUND`` ToolError via ``_fetch_script_config_envelope``.
         """
         config_result = await self._fetch_script_config_envelope(script_id)
         actual_config = config_result.get("config", config_result)
         config_hash_value = compute_config_hash(actual_config)
-        resolved_id = config_result.get("script_id", script_id)
+        resolved_id = config_result.get("script_id")
         return actual_config, config_hash_value, resolved_id
 
     async def _fetch_and_verify_hash(
         self, script_id: str, config_hash: str, action: str
-    ) -> tuple[dict[str, Any], str]:
+    ) -> tuple[dict[str, Any], str | None]:
         """Fetch current script config and verify config_hash for optimistic locking.
 
         Returns ``(actual_config, resolved_id)`` — the inner script body and the
         storage key the REST client resolved the input to. Threading
         ``resolved_id`` lets the upsert call site skip the redundant re-resolve
-        (issue #1813 Phase 0). Raises ToolError if the hash does not match
-        (conflict).
+        (issue #1813 Phase 0); it is ``None`` when the envelope omitted the key,
+        so the upsert re-resolves rather than writing to the caller slug. Raises
+        ToolError if the hash does not match (conflict).
         """
         (
             actual_config,

--- a/src/ha_mcp/tools/tools_config_scripts.py
+++ b/src/ha_mcp/tools/tools_config_scripts.py
@@ -302,11 +302,14 @@ class ConfigScriptTools:
 
     async def _get_script_config_internal(
         self, script_id: str
-    ) -> tuple[dict[str, Any], str]:
+    ) -> tuple[dict[str, Any], str, str]:
         """Fetch script config without logging or category injection.
 
-        Returns (actual_config, config_hash) tuple where actual_config is
-        the inner script body (not the REST wrapper).
+        Returns ``(actual_config, config_hash, resolved_id)`` where
+        ``actual_config`` is the inner script body (not the REST wrapper) and
+        ``resolved_id`` is the storage key the REST client resolved the input to
+        (from the envelope's ``script_id``). Threading ``resolved_id`` lets the
+        upsert call site skip the redundant re-resolve (issue #1813 Phase 0).
         Used internally by _fetch_and_verify_hash and ha_config_get_script.
 
         404 responses from the REST client are mapped to a structured
@@ -315,17 +318,25 @@ class ConfigScriptTools:
         config_result = await self._fetch_script_config_envelope(script_id)
         actual_config = config_result.get("config", config_result)
         config_hash_value = compute_config_hash(actual_config)
-        return actual_config, config_hash_value
+        resolved_id = config_result.get("script_id", script_id)
+        return actual_config, config_hash_value, resolved_id
 
     async def _fetch_and_verify_hash(
         self, script_id: str, config_hash: str, action: str
-    ) -> dict[str, Any]:
+    ) -> tuple[dict[str, Any], str]:
         """Fetch current script config and verify config_hash for optimistic locking.
 
-        Returns the actual script config dict (inner body).
-        Raises ToolError if the hash does not match (conflict).
+        Returns ``(actual_config, resolved_id)`` — the inner script body and the
+        storage key the REST client resolved the input to. Threading
+        ``resolved_id`` lets the upsert call site skip the redundant re-resolve
+        (issue #1813 Phase 0). Raises ToolError if the hash does not match
+        (conflict).
         """
-        actual_config, current_hash = await self._get_script_config_internal(script_id)
+        (
+            actual_config,
+            current_hash,
+            resolved_id,
+        ) = await self._get_script_config_internal(script_id)
         if current_hash != config_hash:
             raise_tool_error(
                 create_error_response(
@@ -338,7 +349,24 @@ class ConfigScriptTools:
                     context={"action": action, "script_id": script_id},
                 )
             )
-        return actual_config
+        return actual_config, resolved_id
+
+    async def _upsert_script(
+        self, config: dict[str, Any], script_id: str, resolved_id: str | None
+    ) -> dict[str, Any]:
+        """Upsert, threading a pre-resolved storage key when available.
+
+        When ``resolved_id`` is set the caller already resolved ``script_id``
+        (via ``_fetch_and_verify_hash``); pass it with ``_resolved=True`` so the
+        REST client skips the redundant entity-registry lookup (issue #1813
+        Phase 0). Otherwise fall back to the raw ``script_id`` and let the REST
+        client resolve — the no-hash update path lands here unchanged.
+        """
+        if resolved_id is not None:
+            return await self._client.upsert_script_config(
+                config, resolved_id, _resolved=True
+            )
+        return await self._client.upsert_script_config(config, script_id)
 
     @staticmethod
     def _validate_script_config(
@@ -677,7 +705,7 @@ class ConfigScriptTools:
                     )
 
                 # Fetch current config and verify hash
-                actual_config = await self._fetch_and_verify_hash(
+                actual_config, resolved_id = await self._fetch_and_verify_hash(
                     script_id, config_hash, "python_transform"
                 )
 
@@ -719,13 +747,17 @@ class ConfigScriptTools:
                     )
                 bp_warnings = _check_best_practices(transformed_config)
 
-                # Save transformed config
+                # Save transformed config. ``_fetch_and_verify_hash`` already
+                # resolved the storage key; thread it so the upsert skips the
+                # redundant re-resolve (issue #1813 Phase 0).
                 result = await self._client.upsert_script_config(
-                    transformed_config, script_id
+                    transformed_config, resolved_id, _resolved=True
                 )
 
                 # Re-fetch to get authoritative hash (HA may normalize after save)
-                _, new_config_hash = await self._get_script_config_internal(script_id)
+                _, new_config_hash, _ = await self._get_script_config_internal(
+                    script_id
+                )
 
                 response: dict[str, Any] = {
                     "success": True,
@@ -766,9 +798,15 @@ class ConfigScriptTools:
                 category,
             )
 
-            # Optional hash check for full config updates
+            # Optional hash check for full config updates. When it runs it
+            # resolves ``script_id`` to the storage key — thread that through so
+            # the upsert doesn't re-resolve (issue #1813 Phase 0). Stays None on
+            # the no-hash path (raw script_id resolved once, inside upsert).
+            resolved_id: str | None = None
             if config_hash:
-                await self._fetch_and_verify_hash(script_id, config_hash, "set")
+                _, resolved_id = await self._fetch_and_verify_hash(
+                    script_id, config_hash, "set"
+                )
 
             # Pre-check for best-practice issues.
             bp_warnings = _check_best_practices(config_dict)
@@ -780,7 +818,7 @@ class ConfigScriptTools:
                 self._client, config_dict
             )
 
-            result = await self._client.upsert_script_config(config_dict, script_id)
+            result = await self._upsert_script(config_dict, script_id, resolved_id)
 
             # Wait for script to be queryable
             entity_id = f"script.{script_id}"

--- a/src/ha_mcp/tools/tools_config_scripts.py
+++ b/src/ha_mcp/tools/tools_config_scripts.py
@@ -362,11 +362,14 @@ class ConfigScriptTools:
         Phase 0). Otherwise fall back to the raw ``script_id`` and let the REST
         client resolve — the no-hash update path lands here unchanged.
         """
+        result: dict[str, Any]
         if resolved_id is not None:
-            return await self._client.upsert_script_config(
+            result = await self._client.upsert_script_config(
                 config, resolved_id, _resolved=True
             )
-        return await self._client.upsert_script_config(config, script_id)
+        else:
+            result = await self._client.upsert_script_config(config, script_id)
+        return result
 
     @staticmethod
     def _validate_script_config(
@@ -802,9 +805,9 @@ class ConfigScriptTools:
             # resolves ``script_id`` to the storage key — thread that through so
             # the upsert doesn't re-resolve (issue #1813 Phase 0). Stays None on
             # the no-hash path (raw script_id resolved once, inside upsert).
-            resolved_id: str | None = None
+            resolved_key: str | None = None
             if config_hash:
-                _, resolved_id = await self._fetch_and_verify_hash(
+                _, resolved_key = await self._fetch_and_verify_hash(
                     script_id, config_hash, "set"
                 )
 
@@ -818,7 +821,7 @@ class ConfigScriptTools:
                 self._client, config_dict
             )
 
-            result = await self._upsert_script(config_dict, script_id, resolved_id)
+            result = await self._upsert_script(config_dict, script_id, resolved_key)
 
             # Wait for script to be queryable
             entity_id = f"script.{script_id}"

--- a/src/ha_mcp/tools/tools_config_scripts.py
+++ b/src/ha_mcp/tools/tools_config_scripts.py
@@ -363,9 +363,10 @@ class ConfigScriptTools:
         Phase 0); None lets the REST client resolve. Passing the caller id
         separately keeps a renamed script's alias caller-facing (#1935).
         """
-        return await self._client.upsert_script_config(
+        result: dict[str, Any] = await self._client.upsert_script_config(
             config, script_id, resolved_id=resolved_id
         )
+        return result
 
     @staticmethod
     def _validate_script_config(

--- a/src/ha_mcp/tools/tools_dev.py
+++ b/src/ha_mcp/tools/tools_dev.py
@@ -1189,12 +1189,15 @@ class DevTools:
         """Map a ``server_entry_update`` component reply into update_source's data.
 
         Mirrors the legacy embedded branch's ``scheduled:true`` shape
-        (entry_id/applying/previous/note); a no-op reply carries ``unchanged`` and
-        its own note instead.
+        (entry_id/target/applying/previous/note); a no-op reply carries ``unchanged``
+        and its own note instead. This route is embedded-only, so ``target`` is
+        always the embedded-server phrasing (matches the legacy embedded branch and
+        preserves the #1929 target field).
         """
         data: dict[str, Any] = {
             "scheduled": bool(result.get("scheduled")),
             "entry_id": result.get("entry_id"),
+            "target": "this server (the embedded ha_mcp_tools in-process entry)",
             "applying": result.get("applying"),
             "previous": result.get("previous"),
         }

--- a/src/ha_mcp/tools/tools_dev.py
+++ b/src/ha_mcp/tools/tools_dev.py
@@ -1135,8 +1135,14 @@ class DevTools:
         if not component_supports(caps, "server_entry_update"):
             return None
         try:
+            # verify_ssl included so a verify_ssl=False client never establishes (or
+            # keys) a default-verification pooled connection (mirrors the pooled
+            # ``send_websocket_message`` path). ``getattr`` guards duck-typed clients
+            # that omit the attribute — falling back to the pool's global default.
             ws = await get_websocket_client(
-                url=self._client.base_url, token=self._client.token
+                url=self._client.base_url,
+                token=self._client.token,
+                verify_ssl=getattr(self._client, "verify_ssl", None),
             )
         except Exception as exc:
             logger.warning(

--- a/src/ha_mcp/tools/tools_dev.py
+++ b/src/ha_mcp/tools/tools_dev.py
@@ -1001,6 +1001,23 @@ class DevTools:
                 )
             )
 
+        if is_embedded():
+            # Embedded self-reload: prefer the component's one-hop direct write
+            # (async_update_entry) over the options-flow start+submit — and try it
+            # BEFORE find_server_config_entry opens the legacy options flow, so the
+            # fast path is NOT gated behind (or delayed/broken by) the very flow-open
+            # it exists to bypass. The component locates the entry in-process itself,
+            # so it needs no find. On ANY component error this returns None and we
+            # fall through to the legacy find + options-flow submit below (unchanged).
+            # Non-embedded deployments never route here — they reload the SEPARATE
+            # in-process server entry synchronously and keep this connection, so the
+            # collapse buys nothing there.
+            component_result = await self._update_source_via_component(
+                channel, pip_spec
+            )
+            if component_result is not None:
+                return component_result
+
         found = await find_server_config_entry(self._client)
         if found is None:
             raise_tool_error(
@@ -1018,22 +1035,6 @@ class DevTools:
                 )
             )
         entry_id, flow, current = found
-
-        if is_embedded():
-            # Embedded self-reload: prefer the component's one-hop direct write
-            # (async_update_entry) over the options-flow start+submit. On ANY
-            # component error this returns None and we fall through to the legacy
-            # submit below (unchanged). Non-embedded deployments never route here —
-            # they reload the SEPARATE in-process server entry synchronously and
-            # keep this connection, so the collapse buys nothing there.
-            component_result = await self._update_source_via_component(
-                channel, pip_spec
-            )
-            if component_result is not None:
-                # The component located and will update the entry itself; the flow
-                # find_server_config_entry opened for the legacy path is unused.
-                await abort_options_flow_quietly(self._client, flow)
-                return component_result
 
         # Resend the user's current overrides (see _PRESERVED_OPTION_KEYS) so a
         # channel/pip-spec change here does not blank them — an omitted optional

--- a/src/ha_mcp/tools/tools_dev.py
+++ b/src/ha_mcp/tools/tools_dev.py
@@ -56,6 +56,12 @@ COMPONENT_DOMAIN = "ha_mcp_tools"
 # ha_mcp_tools-domain entry's options-flow schema from the outside.
 WS_SERVER_ENTRY = "ha_mcp_tools/server_entry"
 
+# The WRITE counterpart: applies a channel / pip_spec delta to the server entry via
+# ``async_update_entry`` directly (embedded mode only — see
+# ``_update_source_via_component``), collapsing update_source's options-flow start +
+# submit round-trip. Gated on the ``server_entry_update`` capability.
+WS_SERVER_ENTRY_UPDATE = "ha_mcp_tools/server_entry_update"
+
 # Options-flow field names of the component's server entry
 # (custom_components/ha_mcp_tools/const.py OPT_CHANNEL / OPT_PIP_SPEC).
 _OPT_CHANNEL = "channel"
@@ -1012,6 +1018,23 @@ class DevTools:
                 )
             )
         entry_id, flow, current = found
+
+        if is_embedded():
+            # Embedded self-reload: prefer the component's one-hop direct write
+            # (async_update_entry) over the options-flow start+submit. On ANY
+            # component error this returns None and we fall through to the legacy
+            # submit below (unchanged). Non-embedded deployments never route here —
+            # they reload the SEPARATE in-process server entry synchronously and
+            # keep this connection, so the collapse buys nothing there.
+            component_result = await self._update_source_via_component(
+                channel, pip_spec
+            )
+            if component_result is not None:
+                # The component located and will update the entry itself; the flow
+                # find_server_config_entry opened for the legacy path is unused.
+                await abort_options_flow_quietly(self._client, flow)
+                return component_result
+
         # Resend the user's current overrides (see _PRESERVED_OPTION_KEYS) so a
         # channel/pip-spec change here does not blank them — an omitted optional
         # field reads as "cleared", not "unchanged".
@@ -1086,6 +1109,108 @@ class DevTools:
                 ),
             },
         }
+
+    async def _update_source_via_component(
+        self, channel: str | None, pip_spec: str | None
+    ) -> dict[str, Any] | None:
+        """Apply the channel/pip_spec delta via the component's direct write.
+
+        Embedded-only fast path: when the component advertises
+        ``server_entry_update``, one ``ha_mcp_tools/server_entry_update`` frame
+        applies the delta through ``async_update_entry`` directly — the component
+        merges it against its LIVE ``entry.options`` (so no preserved-key resend is
+        needed) and schedules the resulting self-reload after a flush delay. Returns
+        the final ``{success, data}`` envelope, or ``None`` to fall back to the
+        legacy options-flow submit.
+
+        The write is IDEMPOTENT (it targets a specific merged options set), so —
+        unlike ``ha_call_service`` — a post-send ambiguity is harmless: EVERY
+        component error (capability miss, unknown_command, connection/timeout, or a
+        malformed reply) returns ``None``, and the legacy submit then re-applies the
+        SAME delta, which the entry's ``DATA_LAST_OPTIONS`` guard collapses to a
+        no-op reload if the component's write already landed. ``unknown_command``
+        additionally invalidates the cached caps so the next call re-probes.
+        """
+        caps = await get_component_caps(self._client)
+        if not component_supports(caps, "server_entry_update"):
+            return None
+        try:
+            ws = await get_websocket_client(
+                url=self._client.base_url, token=self._client.token
+            )
+        except Exception as exc:
+            logger.warning(
+                "%s establishment failed; falling back to legacy: %r",
+                WS_SERVER_ENTRY_UPDATE,
+                exc,
+            )
+            return None
+        deltas: dict[str, Any] = {}
+        if channel is not None:
+            deltas[_OPT_CHANNEL] = channel
+        if pip_spec is not None:
+            deltas[_OPT_PIP_SPEC] = pip_spec
+        try:
+            raw = await ws.send_command(WS_SERVER_ENTRY_UPDATE, **deltas)
+        except (HomeAssistantCommandError, HomeAssistantCommandTimeout) as exc:
+            if is_unknown_command(exc):
+                invalidate_caps(self._client)
+            else:
+                logger.warning(
+                    "%s command error; falling back to legacy: %r",
+                    WS_SERVER_ENTRY_UPDATE,
+                    exc,
+                )
+            return None
+        except Exception as exc:
+            # HomeAssistantConnectionError (pooled-WS drop) or a plain post-send
+            # transport failure. The write is idempotent, so a legacy re-apply is
+            # safe (see docstring) — fall back rather than report a phantom error.
+            logger.warning(
+                "%s connection error; falling back to legacy: %r",
+                WS_SERVER_ENTRY_UPDATE,
+                exc,
+            )
+            return None
+        result = raw.get("result")
+        if not isinstance(result, dict) or not (
+            result.get("scheduled") or result.get("unchanged")
+        ):
+            logger.warning(
+                "%s returned an unusable result; falling back to legacy: %r",
+                WS_SERVER_ENTRY_UPDATE,
+                result,
+            )
+            return None
+        return {"success": True, "data": self._component_update_data(result)}
+
+    @staticmethod
+    def _component_update_data(result: dict[str, Any]) -> dict[str, Any]:
+        """Map a ``server_entry_update`` component reply into update_source's data.
+
+        Mirrors the legacy embedded branch's ``scheduled:true`` shape
+        (entry_id/applying/previous/note); a no-op reply carries ``unchanged`` and
+        its own note instead.
+        """
+        data: dict[str, Any] = {
+            "scheduled": bool(result.get("scheduled")),
+            "entry_id": result.get("entry_id"),
+            "applying": result.get("applying"),
+            "previous": result.get("previous"),
+        }
+        if result.get("unchanged"):
+            data["unchanged"] = True
+            data["note"] = (
+                "No change: the requested channel/pip_spec already matches the "
+                "current in-process server source."
+            )
+        else:
+            data["note"] = (
+                "The in-process server will reinstall and restart now; this "
+                "connection will drop. Reconnect in 1-5 minutes and verify with "
+                "ha_dev_manage_server('info')."
+            )
+        return data
 
     async def _restart_server(self) -> dict[str, Any]:
         if is_embedded():

--- a/src/ha_mcp/tools/tools_dev.py
+++ b/src/ha_mcp/tools/tools_dev.py
@@ -1161,6 +1161,12 @@ class DevTools:
             raw = await ws.send_command(WS_SERVER_ENTRY_UPDATE, **deltas)
         except (HomeAssistantCommandError, HomeAssistantCommandTimeout) as exc:
             if is_unknown_command(exc):
+                logger.warning(
+                    "%s unknown_command; invalidating caps and falling back to "
+                    "legacy: %r",
+                    WS_SERVER_ENTRY_UPDATE,
+                    exc,
+                )
                 invalidate_caps(self._client)
             else:
                 logger.warning(

--- a/src/ha_mcp/tools/tools_traces.py
+++ b/src/ha_mcp/tools/tools_traces.py
@@ -14,17 +14,16 @@ from fastmcp.exceptions import ToolError
 from fastmcp.tools import tool
 from pydantic import Field
 
-from ..client.websocket_client import HomeAssistantWebSocketClient
 from ..errors import ErrorCode, create_error_response
 from .helpers import (
     exception_to_structured_error,
-    get_connected_ws_client,
     log_tool_usage,
     raise_tool_error,
     register_tool_methods,
     safe_info,
     safe_progress,
 )
+from .util_helpers import is_connection_error_message
 
 logger = logging.getLogger(__name__)
 
@@ -201,61 +200,47 @@ class TraceTools:
                 message="connecting to Home Assistant WebSocket",
             )
 
-            # Connect to WebSocket
-            ws_client, error = await get_connected_ws_client(
-                self._client.base_url,
-                self._client.token,
-                verify_ssl=self._client.verify_ssl,
+            # Route through the shared pooled WebSocket (issue #1813) instead of
+            # a dedicated connect/auth/disconnect handshake per call. Every trace
+            # command below is a single request/response — no subscription or
+            # streaming needs a dedicated socket — so the pooled client owns the
+            # connection lifecycle. A connection-shaped failure on the fetch
+            # surfaces as CONNECTION_FAILED, the same structured error the old
+            # up-front connect check raised.
+
+            # Home Assistant stores traces by unique_id, not entity_id.
+            # We need to resolve entity_id -> unique_id via entity registry.
+            item_id = await _resolve_trace_item_id(
+                self._client, automation_id, object_id
             )
-            if error or ws_client is None:
-                raise_tool_error(
-                    error
-                    or create_error_response(
-                        ErrorCode.CONNECTION_FAILED,
-                        "Failed to connect to Home Assistant WebSocket",
-                        context={"automation_id": automation_id},
-                    )
-                )
 
-            try:
-                # Home Assistant stores traces by unique_id, not entity_id.
-                # We need to resolve entity_id -> unique_id via entity registry.
-                item_id = await _resolve_trace_item_id(
-                    ws_client, automation_id, object_id
-                )
+            await safe_progress(
+                ctx,
+                progress=1,
+                total=3,
+                message=f"fetching trace {'detail' if run_id else 'list'}",
+            )
 
-                await safe_progress(
-                    ctx,
-                    progress=1,
-                    total=3,
-                    message=f"fetching trace {'detail' if run_id else 'list'}",
-                )
-
-                if run_id:
-                    return await self._fetch_trace_detail(
-                        ws_client,
-                        domain,
-                        item_id,
-                        automation_id,
-                        run_id,
-                        deduplicate=deduplicate,
-                        detailed=detailed,
-                        sections=sections,
-                        ctx=ctx,
-                    )
-                return await self._fetch_trace_list(
-                    ws_client,
+            if run_id:
+                return await self._fetch_trace_detail(
                     domain,
                     item_id,
                     automation_id,
-                    limit=limit,
-                    offset=offset,
-                    order=order,
+                    run_id,
+                    deduplicate=deduplicate,
+                    detailed=detailed,
+                    sections=sections,
                     ctx=ctx,
                 )
-
-            finally:
-                await ws_client.disconnect()
+            return await self._fetch_trace_list(
+                domain,
+                item_id,
+                automation_id,
+                limit=limit,
+                offset=offset,
+                order=order,
+                ctx=ctx,
+            )
 
         except ToolError:
             raise
@@ -276,7 +261,6 @@ class TraceTools:
 
     async def _fetch_trace_detail(
         self,
-        ws_client: Any,
         domain: str,
         item_id: str,
         automation_id: str,
@@ -288,20 +272,19 @@ class TraceTools:
         ctx: Context | None,
     ) -> dict[str, Any]:
         """Retrieve and format a single trace by run_id."""
-        result = await ws_client.send_command(
-            "trace/get",
-            domain=domain,
-            item_id=item_id,
-            run_id=run_id,
+        result = await self._client.send_websocket_message(
+            {
+                "type": "trace/get",
+                "domain": domain,
+                "item_id": item_id,
+                "run_id": run_id,
+            }
         )
 
         if not result.get("success"):
-            raise_tool_error(
-                create_error_response(
-                    ErrorCode.SERVICE_CALL_FAILED,
-                    result.get("error", "Failed to retrieve trace"),
-                    context={"automation_id": automation_id, "run_id": run_id},
-                )
+            _raise_trace_ws_failure(
+                result.get("error", "Failed to retrieve trace"),
+                {"automation_id": automation_id, "run_id": run_id},
             )
 
         trace_data = result.get("result", {})
@@ -317,7 +300,6 @@ class TraceTools:
 
     async def _fetch_trace_list(
         self,
-        ws_client: Any,
         domain: str,
         item_id: str,
         automation_id: str,
@@ -328,19 +310,18 @@ class TraceTools:
         ctx: Context | None,
     ) -> dict[str, Any]:
         """List recent traces, attaching diagnostics when none are stored."""
-        result = await ws_client.send_command(
-            "trace/list",
-            domain=domain,
-            item_id=item_id,
+        result = await self._client.send_websocket_message(
+            {
+                "type": "trace/list",
+                "domain": domain,
+                "item_id": item_id,
+            }
         )
 
         if not result.get("success"):
-            raise_tool_error(
-                create_error_response(
-                    ErrorCode.SERVICE_CALL_FAILED,
-                    result.get("error", "Failed to list traces"),
-                    context={"automation_id": automation_id},
-                )
+            _raise_trace_ws_failure(
+                result.get("error", "Failed to list traces"),
+                {"automation_id": automation_id},
             )
 
         traces_data = result.get("result", [])
@@ -353,7 +334,7 @@ class TraceTools:
                 message="no traces; gathering diagnostics",
             )
             diagnostics = await _gather_diagnostics(
-                ws_client, self._client, automation_id, domain
+                self._client, automation_id, domain
             )
             await safe_progress(
                 ctx, progress=3, total=3, message="diagnostics complete"
@@ -387,8 +368,39 @@ def register_trace_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
     register_tool_methods(mcp, TraceTools(client))
 
 
+def _raise_trace_ws_failure(error_msg: Any, context: dict[str, Any]) -> None:
+    """Raise the structured error for a failed trace WS command.
+
+    The pooled ``send_websocket_message`` collapses transport failures into
+    ``{"success": False, "error": ...}`` — classify connection-shaped errors as
+    CONNECTION_FAILED (the same code the removed dedicated-socket connect check
+    raised) instead of a generic SERVICE_CALL_FAILED during an HA restart. A
+    genuine trace-command failure (unknown item, no such run) keeps its
+    SERVICE_CALL_FAILED shape unchanged.
+    """
+    if is_connection_error_message(error_msg):
+        raise_tool_error(
+            create_error_response(
+                ErrorCode.CONNECTION_FAILED,
+                str(error_msg),
+                context=context,
+                suggestions=[
+                    "Home Assistant may be restarting or unreachable — retry shortly",
+                    "Check the connection to Home Assistant",
+                ],
+            )
+        )
+    raise_tool_error(
+        create_error_response(
+            ErrorCode.SERVICE_CALL_FAILED,
+            error_msg,
+            context=context,
+        )
+    )
+
+
 async def _resolve_trace_item_id(
-    ws_client: Any, entity_id: str, fallback_object_id: str
+    client: Any, entity_id: str, fallback_object_id: str
 ) -> str:
     """
     Resolve entity_id to the unique_id used for trace storage.
@@ -398,7 +410,7 @@ async def _resolve_trace_item_id(
     entity registry and falls back to object_id if not found.
 
     Args:
-        ws_client: Connected WebSocket client
+        client: Pooled REST client exposing ``send_websocket_message``
         entity_id: Full entity_id (e.g., 'automation.morning_routine')
         fallback_object_id: Object ID to use if unique_id lookup fails
 
@@ -406,10 +418,12 @@ async def _resolve_trace_item_id(
         The unique_id for trace lookup, or fallback_object_id
     """
     try:
-        # Query entity registry to get unique_id
-        result = await ws_client.send_command(
-            "config/entity_registry/get",
-            entity_id=entity_id,
+        # Query entity registry to get unique_id. Best-effort: the pooled client
+        # collapses a failure into ``{"success": False, ...}`` (or, for a
+        # programming bug, raises) — either way we fall back to object_id and let
+        # the subsequent trace fetch surface the real error.
+        result = await client.send_websocket_message(
+            {"type": "config/entity_registry/get", "entity_id": entity_id}
         )
 
         if result.get("success") and result.get("result"):
@@ -434,7 +448,6 @@ async def _resolve_trace_item_id(
 
 
 async def _gather_diagnostics(
-    ws_client: HomeAssistantWebSocketClient,
     client: Any,
     automation_id: str,
     domain: str,
@@ -446,8 +459,7 @@ async def _gather_diagnostics(
     an automation or script.
 
     Args:
-        ws_client: Connected WebSocket client
-        client: REST API client
+        client: Pooled REST client (REST reads + ``send_websocket_message``)
         automation_id: Full entity_id (e.g., 'automation.motion_light')
         domain: Either 'automation' or 'script'
 
@@ -488,7 +500,7 @@ async def _gather_diagnostics(
             # (scripts always store traces when enabled)
             if domain == "automation":
                 diagnostics["trace_storage_enabled"] = await _is_trace_storage_enabled(
-                    ws_client, automation_id, attributes
+                    client, automation_id, attributes
                 )
 
             diagnostics["suggestion"] = _diagnostic_suggestion(diagnostics, domain)
@@ -505,7 +517,7 @@ async def _gather_diagnostics(
 
 
 async def _is_trace_storage_enabled(
-    ws_client: HomeAssistantWebSocketClient,
+    client: Any,
     automation_id: str,
     attributes: dict[str, Any],
 ) -> bool:
@@ -513,9 +525,8 @@ async def _is_trace_storage_enabled(
     try:
         unique_id = attributes.get("id")
         if unique_id:
-            config_result = await ws_client.send_command(
-                "automation/config",
-                entity_id=automation_id,
+            config_result = await client.send_websocket_message(
+                {"type": "automation/config", "entity_id": automation_id}
             )
             if config_result.get("success"):
                 config = config_result.get("result", {})

--- a/src/ha_mcp/tools/tools_traces.py
+++ b/src/ha_mcp/tools/tools_traces.py
@@ -333,9 +333,7 @@ class TraceTools:
                 total=3,
                 message="no traces; gathering diagnostics",
             )
-            diagnostics = await _gather_diagnostics(
-                self._client, automation_id, domain
-            )
+            diagnostics = await _gather_diagnostics(self._client, automation_id, domain)
             await safe_progress(
                 ctx, progress=3, total=3, message="diagnostics complete"
             )

--- a/src/ha_mcp/tools/tools_traces.py
+++ b/src/ha_mcp/tools/tools_traces.py
@@ -197,7 +197,7 @@ class TraceTools:
                 ctx,
                 progress=0,
                 total=3,
-                message="connecting to Home Assistant WebSocket",
+                message="resolving trace target",
             )
 
             # Route through the shared pooled WebSocket (issue #1813) instead of

--- a/tests/src/unit/test_component_api.py
+++ b/tests/src/unit/test_component_api.py
@@ -40,9 +40,15 @@ _INFO_OK = {
 class _FakeClient:
     """Weakref-able credentialed client stand-in (real REST client is a class)."""
 
-    def __init__(self, base_url: str = "http://ha.local:8123", token: str = "tok"):
+    def __init__(
+        self,
+        base_url: str = "http://ha.local:8123",
+        token: str = "tok",
+        verify_ssl: bool | None = None,
+    ):
         self.base_url = base_url
         self.token = token
+        self.verify_ssl = verify_ssl
 
 
 class _BareClient:
@@ -90,6 +96,22 @@ async def test_info_probe_parses_capabilities() -> None:
     assert caps.limits == {"max_results": 500}
     # _INFO_OK carries no timezone (a component too old to report it): None.
     assert caps.timezone is None
+
+
+@pytest.mark.asyncio
+async def test_info_probe_threads_verify_ssl() -> None:
+    """The caps probe threads the client's ``verify_ssl`` into
+    ``get_websocket_client`` so a ``verify_ssl=False`` client can establish (and key)
+    its own pooled connection — otherwise every component capability is silently
+    unreachable on an HTTPS + verify_ssl=False install."""
+    ws = _make_ws(info_result=_INFO_OK)
+    factory = AsyncMock(return_value=ws)
+    with patch.object(component_api, "get_websocket_client", factory):
+        caps = await get_component_caps(_FakeClient(verify_ssl=False))
+
+    assert isinstance(caps, ComponentCaps)
+    assert factory.await_args is not None
+    assert factory.await_args.kwargs.get("verify_ssl") is False
 
 
 @pytest.mark.asyncio

--- a/tests/src/unit/test_component_server_entry_update_contract.py
+++ b/tests/src/unit/test_component_server_entry_update_contract.py
@@ -362,6 +362,20 @@ class TestServerEntryUpdateSchema:
         assert out["channel"] == "dev"
         assert out["pip_spec"] == "ha-mcp==1.0.0"
 
+    def test_accepts_stable_channel(self, monkeypatch: Any) -> None:
+        monkeypatch.setattr(wsapi, "vol", _REAL_VOL)
+        schema = _REAL_VOL.Schema(wsapi._server_entry_update_schema())
+        out = schema({"type": wsapi.WS_SERVER_ENTRY_UPDATE, "channel": "stable"})
+        assert out["channel"] == "stable"
+
+    def test_rejects_bogus_channel(self, monkeypatch: Any) -> None:
+        # channel is gated to the known set (defence-in-depth over the server's own
+        # validation) — a bogus channel is rejected by the schema itself.
+        monkeypatch.setattr(wsapi, "vol", _REAL_VOL)
+        schema = _REAL_VOL.Schema(wsapi._server_entry_update_schema())
+        with pytest.raises(_REAL_VOL.Invalid):
+            schema({"type": wsapi.WS_SERVER_ENTRY_UPDATE, "channel": "nightly"})
+
     def test_type_only_validates_prep_enforces_at_least_one(
         self, monkeypatch: Any
     ) -> None:

--- a/tests/src/unit/test_component_server_entry_update_contract.py
+++ b/tests/src/unit/test_component_server_entry_update_contract.py
@@ -117,7 +117,7 @@ async def test_prep_schedules_merged_update_preserving_other_keys() -> None:
     assert len(hass.scheduled) == 1
 
     # Drive the deferred task: now the merged options are applied, other keys kept.
-    await hass.scheduled[0]
+    assert await hass.scheduled[0] is None  # drive the deferred task (returns None)
     assert len(hass.config_entries.update_calls) == 1
     _applied_entry, applied_options = hass.config_entries.update_calls[0]
     assert applied_options == {
@@ -138,7 +138,7 @@ async def test_prep_pip_spec_applied_preserves_channel() -> None:
         {"type": wsapi.WS_SERVER_ENTRY_UPDATE, "pip_spec": "ha-mcp==2.0.0"},
     )
     assert extra["result"]["applying"] == {"pip_spec": "ha-mcp==2.0.0"}
-    await hass.scheduled[0]
+    assert await hass.scheduled[0] is None  # drive the deferred task (returns None)
     _entry, applied = hass.config_entries.update_calls[0]
     assert applied == {"channel": "dev", "pip_spec": "ha-mcp==2.0.0"}
 
@@ -169,7 +169,13 @@ async def test_prep_no_server_entry_raises() -> None:
         domain="ha_mcp_tools", data={"entry_type": "tools"}, entry_id="tools1"
     )
     hass = _BgHass([tools])
-    with pytest.raises(_base._StubHomeAssistantError):
+    # Resolve HomeAssistantError at call time from whatever ``homeassistant.exceptions``
+    # is installed now — the prep's function-local import resolves the same stub, but a
+    # different test's ``_embedded_stubs.install()`` may have replaced the module since
+    # ``_base`` cached ``_StubHomeAssistantError`` (full-suite ordering).
+    from homeassistant.exceptions import HomeAssistantError
+
+    with pytest.raises(HomeAssistantError):
         await wsapi._server_entry_update_prep(
             hass, {"type": wsapi.WS_SERVER_ENTRY_UPDATE, "channel": "dev"}
         )
@@ -181,7 +187,9 @@ async def test_prep_requires_at_least_one_field() -> None:
     """A frame with neither channel nor pip_spec raises (defence-in-depth over the
     server, which always sends at least one)."""
     hass = _BgHass([_server_entry(options={"channel": "stable"})])
-    with pytest.raises(_base._StubHomeAssistantError):
+    from homeassistant.exceptions import HomeAssistantError
+
+    with pytest.raises(HomeAssistantError):
         await wsapi._server_entry_update_prep(
             hass, {"type": wsapi.WS_SERVER_ENTRY_UPDATE}
         )
@@ -198,7 +206,7 @@ async def test_prep_clearing_pip_spec_from_absent_schedules() -> None:
         hass, {"type": wsapi.WS_SERVER_ENTRY_UPDATE, "pip_spec": ""}
     )
     assert extra["result"]["scheduled"] is True
-    await hass.scheduled[0]
+    assert await hass.scheduled[0] is None  # drive the deferred task (returns None)
     _entry, applied = hass.config_entries.update_calls[0]
     assert applied == {"channel": "dev", "pip_spec": ""}
 

--- a/tests/src/unit/test_component_server_entry_update_contract.py
+++ b/tests/src/unit/test_component_server_entry_update_contract.py
@@ -24,7 +24,14 @@ from typing import Any
 import pytest
 
 from . import test_component_ws_search as _base
-from .test_component_ws_search import FakeConfigEntry, wsapi
+from .test_component_ws_search import (
+    FakeConfigEntry,
+    FakeHass,
+    _FakeConnection,
+    _FakeWSApi,
+    _Unauthorized,
+    wsapi,
+)
 
 _REAL_VOL = _base._REAL_VOL
 
@@ -144,6 +151,33 @@ async def test_prep_pip_spec_applied_preserves_channel() -> None:
 
 
 @pytest.mark.asyncio
+async def test_apply_time_merge_preserves_concurrent_change() -> None:
+    """TOCTOU: the delta is merged against the LIVE ``entry.options`` at APPLY time,
+    so a concurrent change to a DIFFERENT key AFTER prep (but before the deferred
+    task runs) survives — it is NOT clobbered by a prep-time options snapshot."""
+    entry = _server_entry(options={"channel": "stable", "pip_spec": ""})
+    hass = _BgHass([entry])
+
+    extra = await wsapi._server_entry_update_prep(
+        hass, {"type": wsapi.WS_SERVER_ENTRY_UPDATE, "channel": "dev"}
+    )
+    assert extra["result"]["scheduled"] is True
+    # A concurrent options write lands in the flush window, adding a key the delta
+    # never touched (e.g. the options flow rewriting the server_url override).
+    entry.options = {**entry.options, "server_url": "http://changed:8123"}
+
+    assert await hass.scheduled[0] is None  # drive the deferred task (returns None)
+    _entry, applied = hass.config_entries.update_calls[0]
+    # The concurrently-added key survived the merge; the delta still applied. A
+    # prep-time snapshot would have dropped ``server_url``.
+    assert applied == {
+        "channel": "dev",
+        "pip_spec": "",
+        "server_url": "http://changed:8123",
+    }
+
+
+@pytest.mark.asyncio
 async def test_prep_noop_returns_unchanged_without_scheduling() -> None:
     """Setting channel to its current value is a no-op: unchanged, nothing
     scheduled, async_update_entry never called."""
@@ -209,6 +243,40 @@ async def test_prep_clearing_pip_spec_from_absent_schedules() -> None:
     assert await hass.scheduled[0] is None  # drive the deferred task (returns None)
     _entry, applied = hass.config_entries.update_calls[0]
     assert applied == {"channel": "dev", "pip_spec": ""}
+
+
+# =============================================================================
+# admin gate (the registered handler, through _build_handler's @require_admin)
+# =============================================================================
+class TestServerEntryUpdateAdminGate:
+    """The registered ``server_entry_update`` handler is admin-gated.
+
+    The prep tests above drive ``_server_entry_update_prep`` DIRECTLY, bypassing the
+    ``_build_handler`` decorator stack (``@require_admin`` over ``@async_response``).
+    This registers the real handler through a functional ``websocket_api`` fake and
+    asserts a non-admin / no-user connection is rejected BEFORE the prep runs — the
+    admin-gate coverage the ``test_component_ws_search`` registration drift note
+    points here for.
+    """
+
+    def _handler(self, monkeypatch: Any) -> Any:
+        fake = _FakeWSApi()
+        monkeypatch.setattr(wsapi, "websocket_api", fake)
+        monkeypatch.setattr(wsapi, "vol", _REAL_VOL)
+        wsapi.async_register_commands(FakeHass())
+        return fake.registered[wsapi.WS_SERVER_ENTRY_UPDATE]
+
+    def test_non_admin_rejected(self, monkeypatch: Any) -> None:
+        handler = self._handler(monkeypatch)
+        conn = _FakeConnection(is_admin=False)
+        with pytest.raises(_Unauthorized):
+            handler(FakeHass(), conn, {"id": 1, "type": wsapi.WS_SERVER_ENTRY_UPDATE})
+
+    def test_no_user_rejected(self, monkeypatch: Any) -> None:
+        handler = self._handler(monkeypatch)
+        conn = _FakeConnection(has_user=False)
+        with pytest.raises(_Unauthorized):
+            handler(FakeHass(), conn, {"id": 2, "type": wsapi.WS_SERVER_ENTRY_UPDATE})
 
 
 # =============================================================================

--- a/tests/src/unit/test_component_server_entry_update_contract.py
+++ b/tests/src/unit/test_component_server_entry_update_contract.py
@@ -1,0 +1,254 @@
+"""Unit + contract tests for the ``server_entry_update`` WRITE capability.
+
+The write counterpart of ``server_entry`` (issue #1813 Phase 3): the component
+applies a ``channel`` / ``pip_spec`` delta to its OWN server config entry via
+``hass.config_entries.async_update_entry`` DIRECTLY, DEFERRED on a hass-level
+background task so the WS response flushes before the resulting self-reload tears
+the serving thread down. These pin the load-bearing behaviours:
+
+* the merged options preserve every existing key (URL/secret overrides included);
+* ``async_update_entry`` is NOT called synchronously — the prep returns first, and
+  only the deferred task applies it (the deferred-reload crux);
+* a no-op (merged == current) returns ``unchanged`` and schedules nothing;
+* a missing server entry / an empty delta raises ``HomeAssistantError`` (→ the
+  server's command-error fallback to its legacy options-flow submit).
+
+Imports the Fake* fixtures + the stub-installing ``wsapi`` handle through
+``test_component_ws_search`` (mirrors ``test_component_ws_phase2_async``).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from . import test_component_ws_search as _base
+from .test_component_ws_search import FakeConfigEntry, wsapi
+
+_REAL_VOL = _base._REAL_VOL
+
+
+class _RecordingConfigEntries:
+    """``hass.config_entries`` fake: enumerates entries + records update writes."""
+
+    def __init__(self, entries: list[Any]) -> None:
+        self._entries = list(entries)
+        self.update_calls: list[tuple[Any, dict[str, Any] | None]] = []
+
+    def async_entries(self) -> list[Any]:
+        return list(self._entries)
+
+    def async_update_entry(
+        self, entry: Any, *, options: Any = None, **_kw: Any
+    ) -> bool:
+        self.update_calls.append(
+            (entry, dict(options) if options is not None else None)
+        )
+        if options is not None:
+            entry.options = dict(options)
+        return True
+
+
+class _BgHass:
+    """Minimal hass whose ``async_create_background_task`` CAPTURES the coroutine.
+
+    Capturing (rather than scheduling) lets a test assert the deferred
+    ``async_update_entry`` has NOT run right after the prep returns, then drive it
+    explicitly by awaiting the captured coroutine — proving the deferral.
+    """
+
+    def __init__(self, entries: list[Any]) -> None:
+        self.config_entries = _RecordingConfigEntries(entries)
+        self.data: dict[str, Any] = {}
+        self.scheduled: list[Any] = []
+
+    def async_create_background_task(self, coro: Any, name: str | None = None) -> Any:
+        self.scheduled.append(coro)
+        return coro
+
+
+def _server_entry(
+    *, options: dict[str, Any] | None = None, entry_id: str = "srv1"
+) -> FakeConfigEntry:
+    return FakeConfigEntry(
+        domain="ha_mcp_tools",
+        data={"entry_type": "server", "webhook_id": "secret-xyz"},
+        options=options or {},
+        entry_id=entry_id,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _fast_flush(monkeypatch: Any) -> None:
+    """Collapse the flush delay so awaiting the deferred task is instant."""
+    monkeypatch.setattr(wsapi, "SERVER_ENTRY_UPDATE_FLUSH_DELAY_S", 0)
+
+
+@pytest.mark.asyncio
+async def test_prep_schedules_merged_update_preserving_other_keys() -> None:
+    """A channel delta schedules async_update_entry with the MERGED options (the
+    server_url override and current pip_spec preserved), returns scheduled:True,
+    and does NOT call async_update_entry synchronously."""
+    entry = _server_entry(
+        options={
+            "channel": "stable",
+            "pip_spec": "",
+            "server_url": "http://ha.local:8123",
+        }
+    )
+    hass = _BgHass([entry])
+
+    extra = await wsapi._server_entry_update_prep(
+        hass, {"type": wsapi.WS_SERVER_ENTRY_UPDATE, "channel": "dev"}
+    )
+    result = wsapi._do_server_entry_update(
+        hass, {"type": wsapi.WS_SERVER_ENTRY_UPDATE, "channel": "dev"}, **extra
+    )
+
+    # Pure formatter returns exactly the prep's envelope.
+    assert result is extra["result"]
+    assert result["scheduled"] is True
+    assert result["entry_id"] == "srv1"
+    assert result["applying"] == {"channel": "dev"}
+    assert result["previous"] == {"channel": "stable", "pip_spec": ""}
+    # Deferred-reload crux: NOT applied synchronously.
+    assert hass.config_entries.update_calls == []
+    assert len(hass.scheduled) == 1
+
+    # Drive the deferred task: now the merged options are applied, other keys kept.
+    await hass.scheduled[0]
+    assert len(hass.config_entries.update_calls) == 1
+    _applied_entry, applied_options = hass.config_entries.update_calls[0]
+    assert applied_options == {
+        "channel": "dev",
+        "pip_spec": "",
+        "server_url": "http://ha.local:8123",
+    }
+
+
+@pytest.mark.asyncio
+async def test_prep_pip_spec_applied_preserves_channel() -> None:
+    """A pip_spec delta preserves the current channel in the merged options."""
+    entry = _server_entry(options={"channel": "dev", "pip_spec": "ha-mcp==1.0.0"})
+    hass = _BgHass([entry])
+
+    extra = await wsapi._server_entry_update_prep(
+        hass,
+        {"type": wsapi.WS_SERVER_ENTRY_UPDATE, "pip_spec": "ha-mcp==2.0.0"},
+    )
+    assert extra["result"]["applying"] == {"pip_spec": "ha-mcp==2.0.0"}
+    await hass.scheduled[0]
+    _entry, applied = hass.config_entries.update_calls[0]
+    assert applied == {"channel": "dev", "pip_spec": "ha-mcp==2.0.0"}
+
+
+@pytest.mark.asyncio
+async def test_prep_noop_returns_unchanged_without_scheduling() -> None:
+    """Setting channel to its current value is a no-op: unchanged, nothing
+    scheduled, async_update_entry never called."""
+    entry = _server_entry(options={"channel": "dev", "pip_spec": ""})
+    hass = _BgHass([entry])
+
+    extra = await wsapi._server_entry_update_prep(
+        hass, {"type": wsapi.WS_SERVER_ENTRY_UPDATE, "channel": "dev"}
+    )
+    result = extra["result"]
+    assert result["scheduled"] is False
+    assert result["unchanged"] is True
+    assert result["previous"] == {"channel": "dev", "pip_spec": ""}
+    assert hass.scheduled == []
+    assert hass.config_entries.update_calls == []
+
+
+@pytest.mark.asyncio
+async def test_prep_no_server_entry_raises() -> None:
+    """No server config entry → HomeAssistantError (server maps it to a
+    command-error fallback)."""
+    tools = FakeConfigEntry(
+        domain="ha_mcp_tools", data={"entry_type": "tools"}, entry_id="tools1"
+    )
+    hass = _BgHass([tools])
+    with pytest.raises(_base._StubHomeAssistantError):
+        await wsapi._server_entry_update_prep(
+            hass, {"type": wsapi.WS_SERVER_ENTRY_UPDATE, "channel": "dev"}
+        )
+    assert hass.scheduled == []
+
+
+@pytest.mark.asyncio
+async def test_prep_requires_at_least_one_field() -> None:
+    """A frame with neither channel nor pip_spec raises (defence-in-depth over the
+    server, which always sends at least one)."""
+    hass = _BgHass([_server_entry(options={"channel": "stable"})])
+    with pytest.raises(_base._StubHomeAssistantError):
+        await wsapi._server_entry_update_prep(
+            hass, {"type": wsapi.WS_SERVER_ENTRY_UPDATE}
+        )
+    assert hass.scheduled == []
+
+
+@pytest.mark.asyncio
+async def test_prep_clearing_pip_spec_from_absent_schedules() -> None:
+    """An empty-string pip_spec on an entry that never had the key is a structural
+    change (clear the override) — it schedules rather than short-circuiting."""
+    entry = _server_entry(options={"channel": "dev"})
+    hass = _BgHass([entry])
+    extra = await wsapi._server_entry_update_prep(
+        hass, {"type": wsapi.WS_SERVER_ENTRY_UPDATE, "pip_spec": ""}
+    )
+    assert extra["result"]["scheduled"] is True
+    await hass.scheduled[0]
+    _entry, applied = hass.config_entries.update_calls[0]
+    assert applied == {"channel": "dev", "pip_spec": ""}
+
+
+# =============================================================================
+# schema (real voluptuous)
+# =============================================================================
+class TestServerEntryUpdateSchema:
+    def test_accepts_channel_and_pip_spec(self, monkeypatch: Any) -> None:
+        monkeypatch.setattr(wsapi, "vol", _REAL_VOL)
+        schema = _REAL_VOL.Schema(wsapi._server_entry_update_schema())
+        out = schema(
+            {
+                "type": wsapi.WS_SERVER_ENTRY_UPDATE,
+                "channel": "dev",
+                "pip_spec": "ha-mcp==1.0.0",
+            }
+        )
+        assert out["channel"] == "dev"
+        assert out["pip_spec"] == "ha-mcp==1.0.0"
+
+    def test_type_only_validates_prep_enforces_at_least_one(
+        self, monkeypatch: Any
+    ) -> None:
+        # The schema alone permits neither field (voluptuous cannot express
+        # "at least one of"); the prep is what rejects an empty delta.
+        monkeypatch.setattr(wsapi, "vol", _REAL_VOL)
+        schema = _REAL_VOL.Schema(wsapi._server_entry_update_schema())
+        out = schema({"type": wsapi.WS_SERVER_ENTRY_UPDATE})
+        assert out == {"type": wsapi.WS_SERVER_ENTRY_UPDATE}
+
+    def test_rejects_multiline_pip_spec(self, monkeypatch: Any) -> None:
+        monkeypatch.setattr(wsapi, "vol", _REAL_VOL)
+        schema = _REAL_VOL.Schema(wsapi._server_entry_update_schema())
+        with pytest.raises(_REAL_VOL.Invalid):
+            schema({"type": wsapi.WS_SERVER_ENTRY_UPDATE, "pip_spec": "a\nb"})
+
+    def test_rejects_overlong_pip_spec(self, monkeypatch: Any) -> None:
+        monkeypatch.setattr(wsapi, "vol", _REAL_VOL)
+        schema = _REAL_VOL.Schema(wsapi._server_entry_update_schema())
+        with pytest.raises(_REAL_VOL.Invalid):
+            schema(
+                {
+                    "type": wsapi.WS_SERVER_ENTRY_UPDATE,
+                    "pip_spec": "x" * (wsapi.SERVER_ENTRY_UPDATE_MAX_PIP_SPEC + 1),
+                }
+            )
+
+    def test_rejects_extra_keys(self, monkeypatch: Any) -> None:
+        monkeypatch.setattr(wsapi, "vol", _REAL_VOL)
+        schema = _REAL_VOL.Schema(wsapi._server_entry_update_schema())
+        with pytest.raises(_REAL_VOL.Invalid):
+            schema({"type": wsapi.WS_SERVER_ENTRY_UPDATE, "bogus": "x"})

--- a/tests/src/unit/test_component_server_entry_update_contract.py
+++ b/tests/src/unit/test_component_server_entry_update_contract.py
@@ -245,6 +245,72 @@ async def test_prep_clearing_pip_spec_from_absent_schedules() -> None:
     assert applied == {"channel": "dev", "pip_spec": ""}
 
 
+@pytest.mark.asyncio
+async def test_prep_clearing_existing_pip_spec_override_schedules() -> None:
+    """Clearing an EXISTING pip_spec override to "" is a real change — it schedules
+    and persists "" (no override)."""
+    entry = _server_entry(options={"channel": "dev", "pip_spec": "ha-mcp==1.0.0"})
+    hass = _BgHass([entry])
+    extra = await wsapi._server_entry_update_prep(
+        hass, {"type": wsapi.WS_SERVER_ENTRY_UPDATE, "pip_spec": ""}
+    )
+    assert extra["result"]["scheduled"] is True
+    assert await hass.scheduled[0] is None  # drive the deferred task (returns None)
+    _entry, applied = hass.config_entries.update_calls[0]
+    assert applied == {"channel": "dev", "pip_spec": ""}
+
+
+@pytest.mark.asyncio
+async def test_prep_normalizes_whitespace_pip_spec_to_empty() -> None:
+    """A whitespace-only pip_spec means "no override" — it normalizes to "" (matches
+    the options flow's _normalize) so the channel keeps auto-updating, and both the
+    applied options AND the response envelope reflect the collapsed value."""
+    entry = _server_entry(options={"channel": "dev", "pip_spec": "ha-mcp==1.0.0"})
+    hass = _BgHass([entry])
+    extra = await wsapi._server_entry_update_prep(
+        hass, {"type": wsapi.WS_SERVER_ENTRY_UPDATE, "pip_spec": "   "}
+    )
+    assert extra["result"]["scheduled"] is True
+    assert extra["result"]["applying"] == {"pip_spec": ""}
+    assert await hass.scheduled[0] is None  # drive the deferred task (returns None)
+    _entry, applied = hass.config_entries.update_calls[0]
+    assert applied == {"channel": "dev", "pip_spec": ""}
+
+
+@pytest.mark.asyncio
+async def test_prep_normalizes_default_dist_pip_spec_to_empty() -> None:
+    """pip_spec == DEFAULT_PIP_SPEC (the unpinned dist) means "no override" — it
+    persists as "" rather than a verbatim value that would read as an intentional
+    override and disable auto-updates."""
+    entry = _server_entry(options={"channel": "dev", "pip_spec": "ha-mcp==1.0.0"})
+    hass = _BgHass([entry])
+    extra = await wsapi._server_entry_update_prep(
+        hass,
+        {"type": wsapi.WS_SERVER_ENTRY_UPDATE, "pip_spec": wsapi.DEFAULT_PIP_SPEC},
+    )
+    assert extra["result"]["applying"] == {"pip_spec": ""}
+    assert await hass.scheduled[0] is None  # drive the deferred task (returns None)
+    _entry, applied = hass.config_entries.update_calls[0]
+    assert applied == {"channel": "dev", "pip_spec": ""}
+
+
+@pytest.mark.asyncio
+async def test_prep_pip_spec_normalizing_to_stored_value_is_noop() -> None:
+    """A pip_spec that NORMALIZES to the currently-stored value is unchanged, not a
+    spurious schedule — the no-op check sees the post-normalization delta."""
+    entry = _server_entry(options={"channel": "dev", "pip_spec": ""})
+    hass = _BgHass([entry])
+    extra = await wsapi._server_entry_update_prep(
+        hass,
+        {"type": wsapi.WS_SERVER_ENTRY_UPDATE, "pip_spec": wsapi.DEFAULT_PIP_SPEC},
+    )
+    result = extra["result"]
+    assert result["scheduled"] is False
+    assert result["unchanged"] is True
+    assert hass.scheduled == []
+    assert hass.config_entries.update_calls == []
+
+
 # =============================================================================
 # admin gate (the registered handler, through _build_handler's @require_admin)
 # =============================================================================

--- a/tests/src/unit/test_component_ws_search.py
+++ b/tests/src/unit/test_component_ws_search.py
@@ -743,6 +743,7 @@ class TestInfo:
             "reference_data",
             "search_visibility",
             "server_entry",
+            "server_entry_update",
             "call_service",
             "bulk_call_service",
         ]
@@ -1850,6 +1851,10 @@ class TestRegistrationAndAdminGate:
             wsapi.WS_SERVICES_LIST,
             wsapi.WS_REFERENCE_DATA,
             wsapi.WS_SERVER_ENTRY,
+            # Phase 3 server-entry WRITE capability; its prep + admin-gate coverage
+            # lives in test_component_server_entry_update_contract.py (this set only
+            # guards drift).
+            wsapi.WS_SERVER_ENTRY_UPDATE,
             # Phase 3 write capability; its prep + admin-gate coverage lives in
             # test_component_ws_phase2_async.py (this set only guards drift).
             wsapi.WS_CALL_SERVICE,

--- a/tests/src/unit/test_context_injection.py
+++ b/tests/src/unit/test_context_injection.py
@@ -188,21 +188,16 @@ async def test_ha_get_automation_traces_works_without_ctx() -> None:
     client.get_entity_state = AsyncMock(
         return_value={"state": "on", "attributes": {"id": "abc"}}
     )
+    # Pooled transport (#1813): the trace commands ride the shared client's
+    # send_websocket_message; there is no per-call dedicated connect/disconnect.
+    client.send_websocket_message = AsyncMock(
+        return_value={"success": True, "result": []}
+    )
     trace_tool = TraceTools(client).ha_get_automation_traces
 
-    fake_ws = AsyncMock()
-    fake_ws.disconnect = AsyncMock()
-    fake_ws.send_command = AsyncMock(return_value={"success": True, "result": []})
-
-    with (
-        patch(
-            "ha_mcp.tools.tools_traces.get_connected_ws_client",
-            new=AsyncMock(return_value=(fake_ws, None)),
-        ),
-        patch(
-            "ha_mcp.tools.tools_traces._resolve_trace_item_id",
-            new=AsyncMock(return_value="abc"),
-        ),
+    with patch(
+        "ha_mcp.tools.tools_traces._resolve_trace_item_id",
+        new=AsyncMock(return_value="abc"),
     ):
         result = await trace_tool(automation_id="automation.demo")
 
@@ -217,15 +212,11 @@ async def test_ha_get_automation_traces_emits_progress_with_ctx() -> None:
     client.get_entity_state = AsyncMock(
         return_value={"state": "on", "attributes": {"id": "abc"}}
     )
-    trace_tool = TraceTools(client).ha_get_automation_traces
-    ctx = _make_ctx()
-
-    fake_ws = AsyncMock()
-    fake_ws.disconnect = AsyncMock()
     # Return a non-empty trace list so we follow the standard "list" branch
     # and skip the diagnostics gather, keeping the progress-event count
-    # deterministic at the expected 3.
-    fake_ws.send_command = AsyncMock(
+    # deterministic at the expected 3. Pooled transport (#1813): the trace
+    # command rides the shared client's send_websocket_message.
+    client.send_websocket_message = AsyncMock(
         return_value={
             "success": True,
             "result": [
@@ -237,16 +228,12 @@ async def test_ha_get_automation_traces_emits_progress_with_ctx() -> None:
             ],
         }
     )
+    trace_tool = TraceTools(client).ha_get_automation_traces
+    ctx = _make_ctx()
 
-    with (
-        patch(
-            "ha_mcp.tools.tools_traces.get_connected_ws_client",
-            new=AsyncMock(return_value=(fake_ws, None)),
-        ),
-        patch(
-            "ha_mcp.tools.tools_traces._resolve_trace_item_id",
-            new=AsyncMock(return_value="abc"),
-        ),
+    with patch(
+        "ha_mcp.tools.tools_traces._resolve_trace_item_id",
+        new=AsyncMock(return_value="abc"),
     ):
         result = await trace_tool(automation_id="automation.demo", ctx=ctx)
 
@@ -523,20 +510,15 @@ async def test_ha_get_automation_traces_run_id_detail_emits_progress() -> None:
     client.get_entity_state = AsyncMock(
         return_value={"state": "on", "attributes": {"id": "abc"}}
     )
+    # Pooled transport (#1813): trace/get rides the shared client's
+    # send_websocket_message.
+    client.send_websocket_message = AsyncMock(
+        return_value={"success": True, "result": {"trace": "data"}}
+    )
     trace_tool = TraceTools(client).ha_get_automation_traces
     ctx = _make_ctx()
 
-    fake_ws = AsyncMock()
-    fake_ws.disconnect = AsyncMock()
-    fake_ws.send_command = AsyncMock(
-        return_value={"success": True, "result": {"trace": "data"}}
-    )
-
     with (
-        patch(
-            "ha_mcp.tools.tools_traces.get_connected_ws_client",
-            new=AsyncMock(return_value=(fake_ws, None)),
-        ),
         patch(
             "ha_mcp.tools.tools_traces._resolve_trace_item_id",
             new=AsyncMock(return_value="abc"),
@@ -565,19 +547,15 @@ async def test_ha_get_automation_traces_empty_diagnostics_emits_progress() -> No
     client.get_entity_state = AsyncMock(
         return_value={"state": "on", "attributes": {"id": "abc"}}
     )
+    # Empty trace list triggers the diagnostics branch. Pooled transport
+    # (#1813): trace/list rides the shared client's send_websocket_message.
+    client.send_websocket_message = AsyncMock(
+        return_value={"success": True, "result": []}
+    )
     trace_tool = TraceTools(client).ha_get_automation_traces
     ctx = _make_ctx()
 
-    fake_ws = AsyncMock()
-    fake_ws.disconnect = AsyncMock()
-    # Empty trace list triggers the diagnostics branch.
-    fake_ws.send_command = AsyncMock(return_value={"success": True, "result": []})
-
     with (
-        patch(
-            "ha_mcp.tools.tools_traces.get_connected_ws_client",
-            new=AsyncMock(return_value=(fake_ws, None)),
-        ),
         patch(
             "ha_mcp.tools.tools_traces._resolve_trace_item_id",
             new=AsyncMock(return_value="abc"),

--- a/tests/src/unit/test_context_injection.py
+++ b/tests/src/unit/test_context_injection.py
@@ -239,10 +239,12 @@ async def test_ha_get_automation_traces_emits_progress_with_ctx() -> None:
 
     assert result["success"] is True
     ctx.info.assert_awaited()
-    # Three events: connect (0), fetch list (1), final listed-N (3).
+    # Three events: resolve target (0), fetch list (1), final listed-N (3).
     assert ctx.report_progress.await_count == 3
     calls = ctx.report_progress.await_args_list
-    _assert_progress_call(calls[0], progress=0, total=3, message_contains="connecting")
+    _assert_progress_call(
+        calls[0], progress=0, total=3, message_contains="resolving trace target"
+    )
     _assert_progress_call(
         calls[1], progress=1, total=3, message_contains="fetching trace list"
     )

--- a/tests/src/unit/test_ha_dev_manage_server_component_contract.py
+++ b/tests/src/unit/test_ha_dev_manage_server_component_contract.py
@@ -86,7 +86,13 @@ def _real_update_ws(component_hass: _ComponentHass) -> AsyncMock:
 
 
 class _ContractClient:
-    """Credentialed client: opens the (unused) legacy flow; submit is a tripwire."""
+    """Credentialed client whose legacy surface is a tripwire.
+
+    Component-first: on the fast path the consumer routes through the component write
+    BEFORE find_server_config_entry, so no options flow is opened here — the
+    start/abort methods exist only for the fallback path, and the submit / legacy
+    config_entries/get methods raise if the component route is ever bypassed.
+    """
 
     def __init__(self) -> None:
         self.base_url = "http://ha.local:8123"
@@ -167,8 +173,9 @@ async def test_real_component_write_maps_and_defers_merged_apply() -> None:
 @pytest.mark.asyncio
 async def test_real_component_no_entry_falls_back_to_component_not_installed() -> None:
     """When the component reports no server entry AND the legacy probe also finds
-    none, the consumer surfaces COMPONENT_NOT_INSTALLED (the primary mapping is the
-    server-side find_server_config_entry that runs first)."""
+    none, the consumer surfaces COMPONENT_NOT_INSTALLED. Component-first: the
+    component write is attempted first and returns None (no entry), so
+    find_server_config_entry runs SECOND and, also finding none, is what raises."""
     from fastmcp.exceptions import ToolError
 
     component_hass = _ComponentHass([])  # no server entry anywhere

--- a/tests/src/unit/test_ha_dev_manage_server_component_contract.py
+++ b/tests/src/unit/test_ha_dev_manage_server_component_contract.py
@@ -148,8 +148,9 @@ async def test_real_component_write_maps_and_defers_merged_apply() -> None:
     assert data["entry_id"] == "srv1"
     assert data["applying"] == {"channel": "dev"}
     assert data["previous"] == {"channel": "stable", "pip_spec": ""}
-    # The consumer aborted the unused legacy flow and never submitted it.
-    assert client.abort_calls == ["flow-srv1"]
+    # Component-first: the consumer tries the component write BEFORE opening the
+    # legacy options flow, so no flow is opened — nothing to submit or abort.
+    assert client.abort_calls == []
 
     # The component deferred the write; drive it and confirm the merged options.
     assert component_hass.config_entries.update_calls == []

--- a/tests/src/unit/test_ha_dev_manage_server_component_contract.py
+++ b/tests/src/unit/test_ha_dev_manage_server_component_contract.py
@@ -35,7 +35,9 @@ class _RecordingConfigEntries:
     def async_entries(self) -> list[Any]:
         return list(self._entries)
 
-    def async_update_entry(self, entry: Any, *, options: Any = None, **_kw: Any) -> bool:
+    def async_update_entry(
+        self, entry: Any, *, options: Any = None, **_kw: Any
+    ) -> bool:
         self.update_calls.append(
             (entry, dict(options) if options is not None else None)
         )

--- a/tests/src/unit/test_ha_dev_manage_server_component_contract.py
+++ b/tests/src/unit/test_ha_dev_manage_server_component_contract.py
@@ -1,0 +1,179 @@
+"""Cross-seam contract test for the ``server_entry_update`` write capability.
+
+Like ``test_component_call_service_contract.py``, this wires the REAL component
+write functions (``_server_entry_update_prep`` -> ``_do_server_entry_update``,
+driven against a component-side fake hass) underneath the mocked WS transport and
+then invokes the REAL server ``ha_dev_manage_server(update_source)`` consumer — so a
+shape drift on either side of the write seam fails here rather than shipping a
+component-served reply the consumer mis-maps.
+
+Two things are pinned end-to-end: the consumer maps the REAL component reply into
+its ``scheduled:true`` data shape (never calling the legacy options-flow submit),
+and driving the DEFERRED component task then applies ``async_update_entry`` with the
+MERGED options (the channel delta applied, the server_url / pip_spec keys preserved).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+from ha_mcp.tools import component_api, tools_dev
+from ha_mcp.tools.tools_dev import DevTools
+
+from ._component_routing_helpers import patch_ws
+from .test_component_ws_search import FakeConfigEntry, wsapi
+
+
+class _RecordingConfigEntries:
+    def __init__(self, entries: list[Any]) -> None:
+        self._entries = list(entries)
+        self.update_calls: list[tuple[Any, dict[str, Any] | None]] = []
+
+    def async_entries(self) -> list[Any]:
+        return list(self._entries)
+
+    def async_update_entry(self, entry: Any, *, options: Any = None, **_kw: Any) -> bool:
+        self.update_calls.append(
+            (entry, dict(options) if options is not None else None)
+        )
+        if options is not None:
+            entry.options = dict(options)
+        return True
+
+
+class _ComponentHass:
+    """Component-side hass: enumerates entries + CAPTURES the deferred apply task."""
+
+    def __init__(self, entries: list[Any]) -> None:
+        self.config_entries = _RecordingConfigEntries(entries)
+        self.data: dict[str, Any] = {}
+        self.scheduled: list[Any] = []
+
+    def async_create_background_task(self, coro: Any, name: str | None = None) -> Any:
+        self.scheduled.append(coro)
+        return coro
+
+
+def _real_update_ws(component_hass: _ComponentHass) -> AsyncMock:
+    """A WS mock whose server_entry / server_entry_update frames run the REAL
+    component functions against ``component_hass``."""
+    ws = AsyncMock()
+
+    async def _send(command_type: str, **kwargs: Any) -> dict[str, Any]:
+        if command_type == "ha_mcp_tools/info":
+            return {"success": True, "result": wsapi._do_info(component_hass)}
+        if command_type == "ha_mcp_tools/server_entry":
+            return {
+                "success": True,
+                "result": wsapi._do_server_entry(component_hass, dict(kwargs)),
+            }
+        if command_type == "ha_mcp_tools/server_entry_update":
+            msg = {"type": wsapi.WS_SERVER_ENTRY_UPDATE, **kwargs}
+            extra = await wsapi._server_entry_update_prep(component_hass, msg)
+            return {
+                "success": True,
+                "result": wsapi._do_server_entry_update(component_hass, msg, **extra),
+            }
+        raise AssertionError(f"unexpected command {command_type!r}")
+
+    ws.send_command = AsyncMock(side_effect=_send)
+    return ws
+
+
+class _ContractClient:
+    """Credentialed client: opens the (unused) legacy flow; submit is a tripwire."""
+
+    def __init__(self) -> None:
+        self.base_url = "http://ha.local:8123"
+        self.token = "tok"
+        self.abort_calls: list[str] = []
+
+    async def start_options_flow(self, entry_id: str) -> dict[str, Any]:
+        return {"flow_id": f"flow-{entry_id}", "type": "form", "data_schema": []}
+
+    async def abort_options_flow(self, flow_id: str) -> dict[str, Any]:
+        self.abort_calls.append(flow_id)
+        return {}
+
+    async def submit_options_flow_step(self, *args: Any, **kwargs: Any) -> Any:
+        raise AssertionError("legacy options-flow submit must not run when routed")
+
+    async def send_websocket_message(self, msg: dict[str, Any]) -> Any:
+        raise AssertionError(f"legacy config_entries/get must not run: {msg!r}")
+
+
+@pytest.fixture(autouse=True)
+def _clear_caps_cache() -> Any:
+    component_api._CAPS_CACHE.clear()
+    component_api._CAPS_LOCKS.clear()
+    yield
+    component_api._CAPS_CACHE.clear()
+    component_api._CAPS_LOCKS.clear()
+
+
+@pytest.fixture(autouse=True)
+def _embedded_fast(monkeypatch: Any) -> Any:
+    monkeypatch.setenv("HA_MCP_EMBEDDED", "1")
+    monkeypatch.setattr(wsapi, "SERVER_ENTRY_UPDATE_FLUSH_DELAY_S", 0)
+    yield
+
+
+@pytest.mark.asyncio
+async def test_real_component_write_maps_and_defers_merged_apply() -> None:
+    """The real component prep, driven through the real update_source consumer:
+    the consumer maps the scheduled reply (no legacy submit), and driving the
+    deferred component task applies the MERGED options."""
+    entry = FakeConfigEntry(
+        domain="ha_mcp_tools",
+        data={"entry_type": "server", "webhook_id": "secret"},
+        options={"channel": "stable", "pip_spec": "", "server_url": "http://ha:8123"},
+        entry_id="srv1",
+    )
+    component_hass = _ComponentHass([entry])
+    ws = _real_update_ws(component_hass)
+    client = _ContractClient()
+
+    with patch_ws(ws, tools_dev):
+        result = await DevTools(client).ha_dev_manage_server(
+            action="update_source", channel="dev"
+        )
+
+    data = result["data"]
+    assert data["scheduled"] is True
+    assert data["entry_id"] == "srv1"
+    assert data["applying"] == {"channel": "dev"}
+    assert data["previous"] == {"channel": "stable", "pip_spec": ""}
+    # The consumer aborted the unused legacy flow and never submitted it.
+    assert client.abort_calls == ["flow-srv1"]
+
+    # The component deferred the write; drive it and confirm the merged options.
+    assert component_hass.config_entries.update_calls == []
+    assert len(component_hass.scheduled) == 1
+    await component_hass.scheduled[0]
+    _entry, applied = component_hass.config_entries.update_calls[0]
+    assert applied == {
+        "channel": "dev",
+        "pip_spec": "",
+        "server_url": "http://ha:8123",
+    }
+
+
+@pytest.mark.asyncio
+async def test_real_component_no_entry_falls_back_to_component_not_installed() -> None:
+    """When the component reports no server entry AND the legacy probe also finds
+    none, the consumer surfaces COMPONENT_NOT_INSTALLED (the primary mapping is the
+    server-side find_server_config_entry that runs first)."""
+    from fastmcp.exceptions import ToolError
+
+    component_hass = _ComponentHass([])  # no server entry anywhere
+    ws = _real_update_ws(component_hass)
+    client = _ContractClient()
+
+    with patch_ws(ws, tools_dev), pytest.raises(ToolError, match="server entry"):
+        await DevTools(client).ha_dev_manage_server(
+            action="update_source", channel="dev"
+        )
+    assert component_hass.scheduled == []

--- a/tests/src/unit/test_ha_dev_manage_server_component_routing.py
+++ b/tests/src/unit/test_ha_dev_manage_server_component_routing.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 
 import asyncio
 from typing import Any
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -337,6 +337,45 @@ async def test_component_write_succeeds_when_find_would_raise(
     assert result["data"]["entry_id"] == "srv1"
     assert client.submit_calls == []
     assert client.start_options_flow_calls == []
+
+
+@pytest.mark.asyncio
+async def test_component_write_threads_verify_ssl_into_get_websocket_client() -> None:
+    """The direct-write frame's ``get_websocket_client`` receives the client's
+    ``verify_ssl``, so a ``verify_ssl=False`` client never establishes (or keys) a
+    default-verification pooled socket. A regression dropping the kwarg fails here.
+
+    The write resolves its WS through ``tools_dev.get_websocket_client`` while the caps
+    probe resolves through ``component_api.get_websocket_client`` — patched with
+    SEPARATE factories so the write factory's single call can be pinned to the exact
+    kwargs delivered."""
+    ws = _update_ws(
+        caps=_CAPS_FULL,
+        update_result={
+            "scheduled": True,
+            "entry_id": "srv1",
+            "applying": {"channel": "dev"},
+            "previous": {"channel": "stable", "pip_spec": None},
+        },
+    )
+    client = UpdateClient()
+    client.verify_ssl = False
+
+    caps_factory = AsyncMock(return_value=ws)
+    write_factory = AsyncMock(return_value=ws)
+    with (
+        patch.object(component_api, "get_websocket_client", caps_factory),
+        patch.object(tools_dev, "get_websocket_client", write_factory),
+    ):
+        result = await DevTools(client).ha_dev_manage_server(
+            action="update_source", channel="dev"
+        )
+
+    assert result["data"]["scheduled"] is True
+    # The write frame resolved its WS with the client's verify_ssl (=False), passed
+    # as an explicit kwarg — not omitted.
+    assert write_factory.call_count == 1
+    assert write_factory.call_args.kwargs["verify_ssl"] is False
 
 
 @pytest.mark.asyncio

--- a/tests/src/unit/test_ha_dev_manage_server_component_routing.py
+++ b/tests/src/unit/test_ha_dev_manage_server_component_routing.py
@@ -85,11 +85,22 @@ def _update_ws(
 
 
 class UpdateClient:
-    """Credentialed client: options-flow surface + a legacy-probe tripwire."""
+    """Credentialed client: options-flow surface + the legacy config_entries bridge.
 
-    def __init__(self) -> None:
+    ``config_entries`` is what ``config_entries/get`` returns for the legacy
+    ``find_server_config_entry`` fallback. Empty by default: the component
+    ``server_entry`` read short-circuits find in the component-served tests, so the
+    legacy probe is never reached. A test drives find DOWN the legacy path by
+    supplying the server entry here — e.g. the establishment-failure case, where the
+    SHARED ``tools_dev.get_websocket_client`` is broken for BOTH the component read
+    and the write, so find must locate the entry through this bridge (which rides
+    ``send_websocket_message``, a different transport that stays up).
+    """
+
+    def __init__(self, config_entries: list[dict[str, Any]] | None = None) -> None:
         self.base_url = "http://ha.local:8123"
         self.token = "tok"
+        self._config_entries = list(config_entries or [])
         self.start_options_flow_calls: list[str] = []
         self.abort_options_flow_calls: list[str] = []
         self.submit_calls: list[tuple[str, dict[str, Any]]] = []
@@ -98,7 +109,7 @@ class UpdateClient:
     async def send_websocket_message(self, msg: dict[str, Any]) -> dict[str, Any]:
         if msg.get("type") == "config_entries/get":
             self.config_entries_get_calls += 1
-            return {"success": True, "result": []}
+            return {"success": True, "result": list(self._config_entries)}
         raise AssertionError(f"unexpected ws message {msg!r}")
 
     async def start_options_flow(self, entry_id: str) -> dict[str, Any]:
@@ -170,6 +181,8 @@ async def test_embedded_capability_present_routes_to_component_write() -> None:
     assert data["applying"] == {"channel": "dev"}
     assert data["previous"] == {"channel": "stable", "pip_spec": None}
     assert "note" in data
+    # Preserves the #1929 target field on the component path (embedded phrasing).
+    assert data["target"] == "this server (the embedded ha_mcp_tools in-process entry)"
     # The component write was used; the legacy options-flow submit was NOT.
     assert client.submit_calls == []
     # The flow find_server_config_entry opened (for the unused legacy path) was
@@ -303,10 +316,21 @@ async def test_embedded_malformed_reply_falls_back() -> None:
 
 @pytest.mark.asyncio
 async def test_embedded_establishment_failure_falls_back() -> None:
-    """A plain establish Exception from get_websocket_client (after caps cached)
-    for the write frame falls back to the legacy submit."""
+    """A plain establish Exception from get_websocket_client falls back to the
+    legacy submit.
+
+    ``patch_ws_establish_failure`` breaks the SHARED ``tools_dev.get_websocket_client``
+    for BOTH the component ``server_entry`` read AND the write frame (one binding
+    serves both), exactly as a real broken pooled socket would. So
+    ``find_server_config_entry``'s component read fails over to the legacy
+    ``config_entries/get`` bridge — which rides ``send_websocket_message``, a
+    different transport that stays up — and locates the entry there; THEN the write
+    frame's establishment fails and the tool falls back to the legacy options-flow
+    submit. The caps probe (``component_api``'s binding) still succeeds, so the write
+    route is attempted and its establishment failure is what triggers the fallback.
+    """
     caps_ws = _update_ws(caps=_CAPS_FULL)
-    client = UpdateClient()
+    client = UpdateClient(config_entries=[{"entry_id": "srv1"}])
 
     with patch_ws_establish_failure(
         caps_ws, tools_dev, Exception("Failed to connect to HA WebSocket")
@@ -317,6 +341,9 @@ async def test_embedded_establishment_failure_falls_back() -> None:
         await _drain_background_tasks()
 
     assert len(client.submit_calls) == 1
+    # find used the legacy config_entries/get bridge (the pooled read socket was
+    # down), not the in-process component server_entry read.
+    assert client.config_entries_get_calls == 1
 
 
 @pytest.mark.asyncio

--- a/tests/src/unit/test_ha_dev_manage_server_component_routing.py
+++ b/tests/src/unit/test_ha_dev_manage_server_component_routing.py
@@ -338,7 +338,10 @@ async def test_non_embedded_never_routes_to_component_write(
         )
 
     # Synchronous legacy submit (non-embedded returns "applied", not "scheduled").
-    assert result["data"]["applied"] == {"server_url": "http://ha:8123", "channel": "dev"}
+    assert result["data"]["applied"] == {
+        "server_url": "http://ha:8123",
+        "channel": "dev",
+    }
     assert len(client.submit_calls) == 1
     sent = [c.args[0] for c in ws.send_command.call_args_list]
     assert "ha_mcp_tools/server_entry_update" not in sent

--- a/tests/src/unit/test_ha_dev_manage_server_component_routing.py
+++ b/tests/src/unit/test_ha_dev_manage_server_component_routing.py
@@ -175,7 +175,9 @@ def _embedded_env(monkeypatch: Any) -> Any:
 @pytest.mark.asyncio
 async def test_embedded_capability_present_routes_to_component_write() -> None:
     """capability present → component direct write; scheduled reply mapped; the
-    legacy submit is never called; the opened flow is aborted."""
+    legacy submit is never called; and find_server_config_entry never runs, so NO
+    options flow is opened (the fast path is not gated behind the flow-open it
+    bypasses)."""
     ws = _update_ws(
         caps=_CAPS_FULL,
         update_result={
@@ -206,9 +208,10 @@ async def test_embedded_capability_present_routes_to_component_write() -> None:
     assert data["target"] == "this server (the embedded ha_mcp_tools in-process entry)"
     # The component write was used; the legacy options-flow submit was NOT.
     assert client.submit_calls == []
-    # The flow find_server_config_entry opened (for the unused legacy path) was
-    # aborted rather than leaked.
-    assert client.abort_options_flow_calls == ["flow-srv1"]
+    # find_server_config_entry never ran on the component-served path, so NO options
+    # flow was opened (nor aborted) — the fast path bypasses the flow-open entirely.
+    assert client.start_options_flow_calls == []
+    assert client.abort_options_flow_calls == []
     # The server_entry_update frame carried EXACTLY the channel delta as kwargs.
     assert _update_frame_kwargs(ws) == {"channel": "dev"}
 
@@ -303,6 +306,40 @@ async def test_embedded_channel_and_pip_spec_delta_delivers_both_kwargs() -> Non
 
 
 @pytest.mark.asyncio
+async def test_component_write_succeeds_when_find_would_raise(
+    monkeypatch: Any,
+) -> None:
+    """The component route runs BEFORE find_server_config_entry, so a legacy find
+    that would raise (a slow/broken options flow) is never even reached on the fast
+    path — the component write still succeeds."""
+    ws = _update_ws(
+        caps=_CAPS_FULL,
+        update_result={
+            "scheduled": True,
+            "entry_id": "srv1",
+            "applying": {"channel": "dev"},
+            "previous": {"channel": "stable", "pip_spec": None},
+        },
+    )
+    client = UpdateClient()
+
+    async def _boom(_client: Any) -> Any:
+        raise AssertionError("find_server_config_entry must not run on the fast path")
+
+    monkeypatch.setattr(tools_dev, "find_server_config_entry", _boom)
+
+    with patch_ws(ws, tools_dev):
+        result = await DevTools(client).ha_dev_manage_server(
+            action="update_source", channel="dev"
+        )
+
+    assert result["data"]["scheduled"] is True
+    assert result["data"]["entry_id"] == "srv1"
+    assert client.submit_calls == []
+    assert client.start_options_flow_calls == []
+
+
+@pytest.mark.asyncio
 async def test_embedded_capability_absent_falls_back_to_options_flow() -> None:
     """No server_entry_update capability → legacy (deferred) options-flow submit,
     resending the preserved server_url override alongside the channel change."""
@@ -327,14 +364,33 @@ async def test_embedded_capability_absent_falls_back_to_options_flow() -> None:
 
 
 @pytest.mark.asyncio
-async def test_embedded_unknown_command_invalidates_caps_and_falls_back() -> None:
+async def test_embedded_unknown_command_invalidates_caps_and_falls_back(
+    monkeypatch: Any,
+) -> None:
     """server_entry_update advertised but returns unknown_command → invalidate the
-    cached caps and fall back to the legacy submit."""
+    cached caps and fall back to the legacy submit.
+
+    The invalidation is asserted via a spy on ``invalidate_caps`` (which delegates to
+    the real one), NOT the end-state cache: with the component write now tried BEFORE
+    the legacy find, the fallback's own ``find_server_config_entry`` legitimately
+    RE-probes ``info`` and re-populates the cache within the SAME call (with the
+    current-real caps — the desirable behaviour), so a post-call cache-empty check
+    would be a false negative.
+    """
     ws = _update_ws(
         caps=_CAPS_FULL,
         update_exc=HomeAssistantCommandError("gone", "unknown_command"),
     )
     client = UpdateClient()
+
+    invalidated: list[Any] = []
+    real_invalidate = tools_dev.invalidate_caps
+
+    def _spy(c: Any) -> None:
+        invalidated.append(c)
+        real_invalidate(c)
+
+    monkeypatch.setattr(tools_dev, "invalidate_caps", _spy)
 
     with patch_ws(ws, tools_dev):
         await DevTools(client).ha_dev_manage_server(
@@ -343,7 +399,7 @@ async def test_embedded_unknown_command_invalidates_caps_and_falls_back() -> Non
         await _drain_background_tasks()
 
     assert len(client.submit_calls) == 1
-    assert client not in component_api._CAPS_CACHE
+    assert invalidated == [client]
 
 
 @pytest.mark.asyncio

--- a/tests/src/unit/test_ha_dev_manage_server_component_routing.py
+++ b/tests/src/unit/test_ha_dev_manage_server_component_routing.py
@@ -84,6 +84,23 @@ def _update_ws(
     return ws
 
 
+def _update_frame_kwargs(ws: AsyncMock) -> dict[str, Any]:
+    """The kwargs delivered on the single ``server_entry_update`` frame.
+
+    The delta reaches the wire as ``send_command`` KWARGS (the security-relevant
+    channel/pip_spec fields), so the routing tests inspect ``.kwargs`` — not just
+    that the command TYPE reached ``.args[0]`` — to catch a dropped / wrong-keyed
+    field.
+    """
+    calls = [
+        c
+        for c in ws.send_command.call_args_list
+        if c.args[0] == "ha_mcp_tools/server_entry_update"
+    ]
+    assert len(calls) == 1
+    return calls[0].kwargs
+
+
 class UpdateClient:
     """Credentialed client: options-flow surface + the legacy config_entries bridge.
 
@@ -180,7 +197,11 @@ async def test_embedded_capability_present_routes_to_component_write() -> None:
     assert data["entry_id"] == "srv1"
     assert data["applying"] == {"channel": "dev"}
     assert data["previous"] == {"channel": "stable", "pip_spec": None}
-    assert "note" in data
+    assert data["note"] == (
+        "The in-process server will reinstall and restart now; this "
+        "connection will drop. Reconnect in 1-5 minutes and verify with "
+        "ha_dev_manage_server('info')."
+    )
     # Preserves the #1929 target field on the component path (embedded phrasing).
     assert data["target"] == "this server (the embedded ha_mcp_tools in-process entry)"
     # The component write was used; the legacy options-flow submit was NOT.
@@ -188,9 +209,8 @@ async def test_embedded_capability_present_routes_to_component_write() -> None:
     # The flow find_server_config_entry opened (for the unused legacy path) was
     # aborted rather than leaked.
     assert client.abort_options_flow_calls == ["flow-srv1"]
-    # The server_entry_update frame was actually sent.
-    sent = [c.args[0] for c in ws.send_command.call_args_list]
-    assert "ha_mcp_tools/server_entry_update" in sent
+    # The server_entry_update frame carried EXACTLY the channel delta as kwargs.
+    assert _update_frame_kwargs(ws) == {"channel": "dev"}
 
 
 @pytest.mark.asyncio
@@ -217,6 +237,68 @@ async def test_embedded_unchanged_reply_maps_without_submit() -> None:
     data = result["data"]
     assert data["scheduled"] is False
     assert data["unchanged"] is True
+    assert data["previous"] == {"channel": "stable", "pip_spec": None}
+    assert data["note"] == (
+        "No change: the requested channel/pip_spec already matches the "
+        "current in-process server source."
+    )
+    assert client.submit_calls == []
+
+
+@pytest.mark.asyncio
+async def test_embedded_pip_spec_delta_delivers_pip_spec_kwargs() -> None:
+    """A pip_spec-only update sends EXACTLY {"pip_spec": ...} on the frame (the
+    security-relevant field is neither dropped nor mis-keyed) and maps the scheduled
+    reply — note text and the embedded target preserved."""
+    ws = _update_ws(
+        caps=_CAPS_FULL,
+        update_result={
+            "scheduled": True,
+            "entry_id": "srv1",
+            "applying": {"pip_spec": "ha-mcp==2.0.0"},
+            "previous": {"channel": "stable", "pip_spec": None},
+        },
+    )
+    client = UpdateClient()
+
+    with patch_ws(ws, tools_dev):
+        result = await DevTools(client).ha_dev_manage_server(
+            action="update_source", pip_spec="ha-mcp==2.0.0"
+        )
+
+    assert _update_frame_kwargs(ws) == {"pip_spec": "ha-mcp==2.0.0"}
+    data = result["data"]
+    assert data["scheduled"] is True
+    assert data["applying"] == {"pip_spec": "ha-mcp==2.0.0"}
+    assert data["target"] == "this server (the embedded ha_mcp_tools in-process entry)"
+    assert data["note"] == (
+        "The in-process server will reinstall and restart now; this "
+        "connection will drop. Reconnect in 1-5 minutes and verify with "
+        "ha_dev_manage_server('info')."
+    )
+    assert client.submit_calls == []
+
+
+@pytest.mark.asyncio
+async def test_embedded_channel_and_pip_spec_delta_delivers_both_kwargs() -> None:
+    """channel AND pip_spec set → the frame carries EXACTLY both fields as kwargs."""
+    ws = _update_ws(
+        caps=_CAPS_FULL,
+        update_result={
+            "scheduled": True,
+            "entry_id": "srv1",
+            "applying": {"channel": "dev", "pip_spec": "ha-mcp==2.0.0"},
+            "previous": {"channel": "stable", "pip_spec": None},
+        },
+    )
+    client = UpdateClient()
+
+    with patch_ws(ws, tools_dev):
+        await DevTools(client).ha_dev_manage_server(
+            action="update_source", channel="dev", pip_spec="ha-mcp==2.0.0"
+        )
+
+    assert _update_frame_kwargs(ws) == {"channel": "dev", "pip_spec": "ha-mcp==2.0.0"}
     assert client.submit_calls == []
 
 

--- a/tests/src/unit/test_ha_dev_manage_server_component_routing.py
+++ b/tests/src/unit/test_ha_dev_manage_server_component_routing.py
@@ -1,0 +1,344 @@
+"""Routing tests for ``ha_dev_manage_server(update_source)`` over the component
+``server_entry_update`` WRITE capability (issue #1813 Phase 3).
+
+In EMBEDDED mode the tool prefers the component's one-hop direct write
+(``ha_mcp_tools/server_entry_update`` → ``async_update_entry``) over the
+options-flow start+submit round-trip. These pin the routing contract:
+
+* capability present → the component write is used, its scheduled reply is mapped,
+  the legacy ``submit_options_flow_step`` is NEVER called, and the flow
+  ``find_server_config_entry`` opened is aborted;
+* capability absent → falls back to the legacy (deferred) options-flow submit;
+* the full component-error taxonomy (unknown_command invalidates caps; a command
+  error / a connection error / an establishment failure all fall back) routes to
+  the legacy submit — the write is idempotent, so a re-apply is safe;
+* NON-embedded mode never routes to the component write (the ``server_entry_update``
+  frame is never sent) and submits the options flow synchronously.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+from ha_mcp.client.rest_client import (
+    HomeAssistantCommandError,
+    HomeAssistantCommandTimeout,
+    HomeAssistantConnectionError,
+)
+from ha_mcp.tools import component_api, tools_dev
+from ha_mcp.tools.tools_dev import DevTools
+
+from ._component_routing_helpers import patch_ws, patch_ws_establish_failure
+
+_CAPS_FULL = {
+    "schema_version": 1,
+    "component_version": "1.2.0",
+    "capabilities": ["server_entry", "server_entry_update"],
+    "limits": {},
+}
+_CAPS_READ_ONLY = {
+    "schema_version": 1,
+    "component_version": "1.2.0",
+    "capabilities": ["server_entry"],
+    "limits": {},
+}
+
+_SERVER_FLOW = {
+    "flow_id": "flow-srv1",
+    "type": "form",
+    "data_schema": [
+        {"name": "channel", "default": "stable"},
+        {"name": "pip_spec", "description": {"suggested_value": None}},
+        {"name": "server_url", "description": {"suggested_value": "http://ha:8123"}},
+    ],
+}
+
+_SERVER_ENTRY_RESULT = {"entry_id": "srv1", "channel": "stable", "pip_spec": None}
+
+
+def _update_ws(
+    *,
+    caps: dict[str, Any],
+    update_result: dict[str, Any] | None = None,
+    update_exc: Exception | None = None,
+) -> AsyncMock:
+    """WS mock serving info + server_entry + (optionally) server_entry_update."""
+    ws = AsyncMock()
+
+    async def _send(command_type: str, **kwargs: Any) -> dict[str, Any]:
+        if command_type == "ha_mcp_tools/info":
+            return {"success": True, "result": caps}
+        if command_type == "ha_mcp_tools/server_entry":
+            return {"success": True, "result": dict(_SERVER_ENTRY_RESULT)}
+        if command_type == "ha_mcp_tools/server_entry_update":
+            if update_exc is not None:
+                raise update_exc
+            return {"success": True, "result": update_result}
+        raise AssertionError(f"unexpected command {command_type!r}")
+
+    ws.send_command = AsyncMock(side_effect=_send)
+    return ws
+
+
+class UpdateClient:
+    """Credentialed client: options-flow surface + a legacy-probe tripwire."""
+
+    def __init__(self) -> None:
+        self.base_url = "http://ha.local:8123"
+        self.token = "tok"
+        self.start_options_flow_calls: list[str] = []
+        self.abort_options_flow_calls: list[str] = []
+        self.submit_calls: list[tuple[str, dict[str, Any]]] = []
+        self.config_entries_get_calls = 0
+
+    async def send_websocket_message(self, msg: dict[str, Any]) -> dict[str, Any]:
+        if msg.get("type") == "config_entries/get":
+            self.config_entries_get_calls += 1
+            return {"success": True, "result": []}
+        raise AssertionError(f"unexpected ws message {msg!r}")
+
+    async def start_options_flow(self, entry_id: str) -> dict[str, Any]:
+        self.start_options_flow_calls.append(entry_id)
+        return dict(_SERVER_FLOW)
+
+    async def abort_options_flow(self, flow_id: str) -> dict[str, Any]:
+        self.abort_options_flow_calls.append(flow_id)
+        return {}
+
+    async def submit_options_flow_step(
+        self, flow_id: str, user_input: dict[str, Any]
+    ) -> dict[str, Any]:
+        self.submit_calls.append((flow_id, dict(user_input)))
+        return {"type": "create_entry"}
+
+
+async def _drain_background_tasks() -> None:
+    tasks = list(tools_dev._BACKGROUND_TASKS)
+    if not tasks:
+        return
+    done, pending = await asyncio.wait(tasks)
+    assert not pending
+    for task in done:
+        task.result()
+
+
+@pytest.fixture(autouse=True)
+def _clear_caps_cache() -> Any:
+    component_api._CAPS_CACHE.clear()
+    component_api._CAPS_LOCKS.clear()
+    yield
+    component_api._CAPS_CACHE.clear()
+    component_api._CAPS_LOCKS.clear()
+
+
+@pytest.fixture(autouse=True)
+def _embedded_env(monkeypatch: Any) -> Any:
+    """Default to embedded mode with a zero flush delay; individual tests may
+    clear the env to exercise the non-embedded path."""
+    monkeypatch.setenv("HA_MCP_EMBEDDED", "1")
+    monkeypatch.setattr(tools_dev, "_SELF_ACTION_FLUSH_DELAY_S", 0)
+    yield
+
+
+@pytest.mark.asyncio
+async def test_embedded_capability_present_routes_to_component_write() -> None:
+    """capability present → component direct write; scheduled reply mapped; the
+    legacy submit is never called; the opened flow is aborted."""
+    ws = _update_ws(
+        caps=_CAPS_FULL,
+        update_result={
+            "scheduled": True,
+            "entry_id": "srv1",
+            "applying": {"channel": "dev"},
+            "previous": {"channel": "stable", "pip_spec": None},
+        },
+    )
+    client = UpdateClient()
+
+    with patch_ws(ws, tools_dev):
+        result = await DevTools(client).ha_dev_manage_server(
+            action="update_source", channel="dev"
+        )
+
+    data = result["data"]
+    assert data["scheduled"] is True
+    assert data["entry_id"] == "srv1"
+    assert data["applying"] == {"channel": "dev"}
+    assert data["previous"] == {"channel": "stable", "pip_spec": None}
+    assert "note" in data
+    # The component write was used; the legacy options-flow submit was NOT.
+    assert client.submit_calls == []
+    # The flow find_server_config_entry opened (for the unused legacy path) was
+    # aborted rather than leaked.
+    assert client.abort_options_flow_calls == ["flow-srv1"]
+    # The server_entry_update frame was actually sent.
+    sent = [c.args[0] for c in ws.send_command.call_args_list]
+    assert "ha_mcp_tools/server_entry_update" in sent
+
+
+@pytest.mark.asyncio
+async def test_embedded_unchanged_reply_maps_without_submit() -> None:
+    """A no-op component reply (unchanged) maps to scheduled:false/unchanged and
+    still bypasses the legacy submit."""
+    ws = _update_ws(
+        caps=_CAPS_FULL,
+        update_result={
+            "scheduled": False,
+            "unchanged": True,
+            "entry_id": "srv1",
+            "applying": {"channel": "stable"},
+            "previous": {"channel": "stable", "pip_spec": None},
+        },
+    )
+    client = UpdateClient()
+
+    with patch_ws(ws, tools_dev):
+        result = await DevTools(client).ha_dev_manage_server(
+            action="update_source", channel="stable"
+        )
+
+    data = result["data"]
+    assert data["scheduled"] is False
+    assert data["unchanged"] is True
+    assert client.submit_calls == []
+
+
+@pytest.mark.asyncio
+async def test_embedded_capability_absent_falls_back_to_options_flow() -> None:
+    """No server_entry_update capability → legacy (deferred) options-flow submit,
+    resending the preserved server_url override alongside the channel change."""
+    ws = _update_ws(caps=_CAPS_READ_ONLY)
+    client = UpdateClient()
+
+    with patch_ws(ws, tools_dev):
+        result = await DevTools(client).ha_dev_manage_server(
+            action="update_source", channel="dev"
+        )
+        assert result["data"]["scheduled"] is True
+        assert client.submit_calls == []  # deferred, not yet run
+        await _drain_background_tasks()
+
+    assert len(client.submit_calls) == 1
+    flow_id, user_input = client.submit_calls[0]
+    assert flow_id == "flow-srv1"
+    assert user_input == {"server_url": "http://ha:8123", "channel": "dev"}
+    # The component write frame was never sent (capability absent).
+    sent = [c.args[0] for c in ws.send_command.call_args_list]
+    assert "ha_mcp_tools/server_entry_update" not in sent
+
+
+@pytest.mark.asyncio
+async def test_embedded_unknown_command_invalidates_caps_and_falls_back() -> None:
+    """server_entry_update advertised but returns unknown_command → invalidate the
+    cached caps and fall back to the legacy submit."""
+    ws = _update_ws(
+        caps=_CAPS_FULL,
+        update_exc=HomeAssistantCommandError("gone", "unknown_command"),
+    )
+    client = UpdateClient()
+
+    with patch_ws(ws, tools_dev):
+        await DevTools(client).ha_dev_manage_server(
+            action="update_source", channel="dev"
+        )
+        await _drain_background_tasks()
+
+    assert len(client.submit_calls) == 1
+    assert client not in component_api._CAPS_CACHE
+
+
+@pytest.mark.asyncio
+async def test_embedded_command_error_falls_back_without_invalidating() -> None:
+    """A non-unknown_command error (timeout) falls back to the legacy submit
+    WITHOUT invalidating the still-advertised capability."""
+    ws = _update_ws(caps=_CAPS_FULL, update_exc=HomeAssistantCommandTimeout("slow"))
+    client = UpdateClient()
+
+    with patch_ws(ws, tools_dev):
+        await DevTools(client).ha_dev_manage_server(
+            action="update_source", channel="dev"
+        )
+        await _drain_background_tasks()
+
+    assert len(client.submit_calls) == 1
+    assert client in component_api._CAPS_CACHE
+
+
+@pytest.mark.asyncio
+async def test_embedded_connection_error_falls_back() -> None:
+    """A WS connection error on the server_entry_update frame falls back to the
+    legacy submit (the write is idempotent, so a re-apply is safe)."""
+    ws = _update_ws(caps=_CAPS_FULL, update_exc=HomeAssistantConnectionError("down"))
+    client = UpdateClient()
+
+    with patch_ws(ws, tools_dev):
+        await DevTools(client).ha_dev_manage_server(
+            action="update_source", channel="dev"
+        )
+        await _drain_background_tasks()
+
+    assert len(client.submit_calls) == 1
+    assert client in component_api._CAPS_CACHE
+
+
+@pytest.mark.asyncio
+async def test_embedded_malformed_reply_falls_back() -> None:
+    """A component reply that is neither scheduled nor unchanged (shape drift) is
+    treated as unusable and falls back to the legacy submit."""
+    ws = _update_ws(caps=_CAPS_FULL, update_result={"entry_id": "srv1"})
+    client = UpdateClient()
+
+    with patch_ws(ws, tools_dev):
+        await DevTools(client).ha_dev_manage_server(
+            action="update_source", channel="dev"
+        )
+        await _drain_background_tasks()
+
+    assert len(client.submit_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_embedded_establishment_failure_falls_back() -> None:
+    """A plain establish Exception from get_websocket_client (after caps cached)
+    for the write frame falls back to the legacy submit."""
+    caps_ws = _update_ws(caps=_CAPS_FULL)
+    client = UpdateClient()
+
+    with patch_ws_establish_failure(
+        caps_ws, tools_dev, Exception("Failed to connect to HA WebSocket")
+    ):
+        await DevTools(client).ha_dev_manage_server(
+            action="update_source", channel="dev"
+        )
+        await _drain_background_tasks()
+
+    assert len(client.submit_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_non_embedded_never_routes_to_component_write(
+    monkeypatch: Any,
+) -> None:
+    """NON-embedded mode submits the options flow SYNCHRONOUSLY and never sends the
+    server_entry_update frame, even though the capability is advertised."""
+    monkeypatch.delenv("HA_MCP_EMBEDDED", raising=False)
+    ws = _update_ws(
+        caps=_CAPS_FULL,
+        update_result={"scheduled": True, "entry_id": "srv1"},
+    )
+    client = UpdateClient()
+
+    with patch_ws(ws, tools_dev):
+        result = await DevTools(client).ha_dev_manage_server(
+            action="update_source", channel="dev"
+        )
+
+    # Synchronous legacy submit (non-embedded returns "applied", not "scheduled").
+    assert result["data"]["applied"] == {"server_url": "http://ha:8123", "channel": "dev"}
+    assert len(client.submit_calls) == 1
+    sent = [c.args[0] for c in ws.send_command.call_args_list]
+    assert "ha_mcp_tools/server_entry_update" not in sent

--- a/tests/src/unit/test_rest_client_automations.py
+++ b/tests/src/unit/test_rest_client_automations.py
@@ -293,6 +293,104 @@ class TestUpsertAutomationConfigIdMismatch:
         assert result["entity_id"] == "automation.new"
 
 
+class TestUpsertAutomationResolvedShortCircuit:
+    """``_resolved=True`` skips the redundant ``_resolve_automation_id`` lookup
+    on ``upsert_automation_config`` (issue #1813 Phase 0 item #6).
+
+    The tool pre-resolves the identifier during its hash-verify fetch and
+    threads the resolved unique_id through, so the second resolve inside the
+    upsert is pure waste. These tests pin that ``_resolved=True`` uses the
+    passed id directly and never consults the resolver, while the default path
+    still resolves — and that the #1404 mismatch guard is unaffected either way.
+    """
+
+    @pytest.fixture
+    def mock_client(self):
+        with patch.object(HomeAssistantClient, "__init__", lambda self, **kwargs: None):
+            client = HomeAssistantClient()
+            client.base_url = "http://test.local:8123"
+            client.token = "test-token"
+            client.timeout = 30
+            client.httpx_client = MagicMock()
+            return client
+
+    @pytest.mark.asyncio
+    async def test_resolved_skips_lookup(self, mock_client):
+        """``_resolved=True`` uses ``identifier`` directly as the unique_id and
+        does not consult the entity_id→unique_id resolver."""
+        mock_client._resolve_automation_id = AsyncMock()
+        mock_client._request = AsyncMock(return_value={"result": "ok"})
+
+        result = await mock_client.upsert_automation_config(
+            {"alias": "x", "trigger": [], "action": []},
+            identifier="AAA",
+            _resolved=True,
+        )
+
+        assert result["unique_id"] == "AAA"
+        assert result["operation"] == "updated"
+        mock_client._resolve_automation_id.assert_not_called()
+        method, url = mock_client._request.call_args.args
+        assert url == "/config/automation/config/AAA"
+        # The resolved id is injected into the body just like the default path.
+        assert mock_client._request.call_args.kwargs["json"]["id"] == "AAA"
+
+    @pytest.mark.asyncio
+    async def test_default_still_resolves(self, mock_client):
+        """Contrast: without ``_resolved`` the entity_id→unique_id resolver is
+        consulted (the pre-#1813 behaviour on a raw identifier)."""
+        mock_client._resolve_automation_id = AsyncMock(return_value="AAA")
+        mock_client._request = AsyncMock(return_value={"result": "ok"})
+
+        result = await mock_client.upsert_automation_config(
+            {"alias": "x", "trigger": [], "action": []},
+            identifier="automation.foo",
+        )
+
+        assert result["unique_id"] == "AAA"
+        mock_client._resolve_automation_id.assert_awaited_once_with("automation.foo")
+
+    @pytest.mark.asyncio
+    async def test_resolved_still_enforces_id_mismatch_guard(self, mock_client):
+        """``_resolved=True`` must not bypass the #1404 mismatch guard: a config
+        ``id`` disagreeing with the threaded unique_id is still rejected before
+        any POST reaches HA."""
+        mock_client._resolve_automation_id = AsyncMock()
+        mock_client._request = AsyncMock()
+
+        with pytest.raises(HomeAssistantAPIError) as exc_info:
+            await mock_client.upsert_automation_config(
+                {"id": "BBB", "alias": "x", "trigger": [], "action": []},
+                identifier="AAA",
+                _resolved=True,
+            )
+
+        assert exc_info.value.status_code == 400
+        assert "Mismatched" in str(exc_info.value)
+        # The resolver is never touched and the offending POST never fires.
+        mock_client._resolve_automation_id.assert_not_called()
+        mock_client._request.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_create_path_ignores_resolved_flag(self, mock_client):
+        """On the create path (``identifier is None``) ``_resolved`` is a no-op —
+        a fresh timestamp unique_id is still generated, resolver untouched."""
+        mock_client._resolve_automation_id = AsyncMock()
+        mock_client._request = AsyncMock(return_value={"result": "ok"})
+        mock_client._poll_for_automation_entity = AsyncMock(
+            return_value="automation.new"
+        )
+
+        result = await mock_client.upsert_automation_config(
+            {"alias": "x", "trigger": [], "action": []},
+            identifier=None,
+            _resolved=True,
+        )
+
+        assert result["operation"] == "created"
+        mock_client._resolve_automation_id.assert_not_called()
+
+
 class TestPollForAutomationEntity:
     """Tests for ``_poll_for_automation_entity`` (issues #1152, #1380, #1395).
 

--- a/tests/src/unit/test_rest_client_scenes.py
+++ b/tests/src/unit/test_rest_client_scenes.py
@@ -267,10 +267,13 @@ class TestResolveSceneId:
 
 
 class TestSceneResolvedShortCircuit:
-    """``_resolved=True`` skips the redundant ``resolve_scene_id`` lookup on the
-    get/upsert/delete scene methods (issue #1813 P5 item 3). ``_make_mock_client``
-    makes ``send_websocket_message`` raise, so ``assert_not_called`` proves the
-    resolver was skipped rather than merely falling back."""
+    """Skipping the redundant ``resolve_scene_id`` lookup on get/upsert/delete
+    scene methods (issue #1813 P5 item 3). ``get``/``delete`` take
+    ``_resolved=True``; ``upsert`` takes a separate ``resolved_id`` write-target
+    (so ``scene_id`` stays the caller's id for the missing-``name`` default —
+    #1935). ``_make_mock_client`` makes ``send_websocket_message`` raise, so
+    ``assert_not_called`` proves the resolver was skipped rather than merely
+    falling back."""
 
     @pytest.fixture
     def mock_client(self):
@@ -289,16 +292,40 @@ class TestSceneResolvedShortCircuit:
         )
 
     @pytest.mark.asyncio
-    async def test_upsert_scene_resolved_skips_lookup(self, mock_client):
+    async def test_upsert_scene_resolved_id_skips_lookup(self, mock_client):
         mock_client._request = AsyncMock(return_value={"result": "ok"})
 
         result = await mock_client.upsert_scene_config(
-            {"entities": {"light.k": {"state": "on"}}}, "storage_key", _resolved=True
+            {"name": "S", "entities": {"light.k": {"state": "on"}}},
+            "renamed_scene",
+            resolved_id="storage_key",
         )
 
         assert result["scene_id"] == "storage_key"
         mock_client.send_websocket_message.assert_not_called()
         assert mock_client._request.call_args[0][1] == "config/scene/config/storage_key"
+
+    @pytest.mark.asyncio
+    async def test_upsert_scene_resolved_id_name_defaults_to_caller_scene_id(
+        self, mock_client
+    ):
+        """#1935 regression: with ``resolved_id`` provided (renamed scene), a
+        missing ``name`` defaults to the CALLER's ``scene_id`` — NOT the storage
+        key — while the write still targets the resolved key with no re-resolve."""
+        mock_client._request = AsyncMock(return_value={"result": "ok"})
+
+        config = {"entities": {"light.k": {"state": "on"}}}  # no name
+        result = await mock_client.upsert_scene_config(
+            config, "new_slug", resolved_id="old_storage_key"
+        )
+
+        # Write targets the resolved storage key; resolver never consulted.
+        assert result["scene_id"] == "old_storage_key"
+        mock_client.send_websocket_message.assert_not_called()
+        method, endpoint = mock_client._request.call_args.args
+        assert endpoint == "config/scene/config/old_storage_key"
+        # Name defaulted from the caller's id, not the stale storage key.
+        assert mock_client._request.call_args.kwargs["json"]["name"] == "new_slug"
 
     @pytest.mark.asyncio
     async def test_delete_scene_resolved_skips_lookup(self, mock_client):

--- a/tests/src/unit/test_rest_client_scenes.py
+++ b/tests/src/unit/test_rest_client_scenes.py
@@ -328,6 +328,20 @@ class TestSceneResolvedShortCircuit:
         assert mock_client._request.call_args.kwargs["json"]["name"] == "new_slug"
 
     @pytest.mark.asyncio
+    async def test_upsert_scene_name_default_strips_entity_prefix(self, mock_client):
+        """A caller-facing ``scene.<slug>`` id must NOT become the scene name
+        verbatim — HA derives the entity_id from the name slug, so a prefixed
+        default would rename the scene and change its entity_id on a plain update."""
+        mock_client._request = AsyncMock(return_value={"result": "ok"})
+
+        config = {"entities": {"light.k": {"state": "on"}}}  # no name
+        await mock_client.upsert_scene_config(
+            config, "scene.movie_night", resolved_id="movie_night"
+        )
+
+        assert mock_client._request.call_args.kwargs["json"]["name"] == "movie_night"
+
+    @pytest.mark.asyncio
     async def test_delete_scene_resolved_skips_lookup(self, mock_client):
         mock_client._request = AsyncMock(return_value={"result": "ok"})
 

--- a/tests/src/unit/test_rest_client_scripts.py
+++ b/tests/src/unit/test_rest_client_scripts.py
@@ -402,3 +402,55 @@ class TestResolveScriptId:
         error_msg = str(exc_info.value)
         assert "renamed_script" in error_msg
         assert "original_key" in error_msg
+
+
+class TestUpsertScriptResolvedShortCircuit:
+    """``_resolved=True`` skips the redundant ``_resolve_script_id`` registry
+    lookup on ``upsert_script_config`` (issue #1813 Phase 0 item #6).
+
+    ``_make_mock_client`` makes ``send_websocket_message`` raise, so
+    ``assert_not_called`` proves the resolver was genuinely skipped rather than
+    merely falling back to the bare id after a failed lookup.
+    """
+
+    @pytest.fixture
+    def mock_client(self):
+        return _make_mock_client()
+
+    @pytest.mark.asyncio
+    async def test_resolved_skips_lookup(self, mock_client):
+        """``_resolved=True`` uses ``script_id`` directly as the storage key and
+        never issues the entity-registry lookup."""
+        mock_client._request = AsyncMock(return_value={"result": "ok"})
+
+        config = {"alias": "x", "sequence": [{"delay": {"seconds": 1}}]}
+        result = await mock_client.upsert_script_config(
+            config, "storage_key", _resolved=True
+        )
+
+        assert result["success"] is True
+        assert result["script_id"] == "storage_key"
+        mock_client.send_websocket_message.assert_not_called()
+        mock_client._request.assert_called_once_with(
+            "POST", "config/script/config/storage_key", json=config
+        )
+
+    @pytest.mark.asyncio
+    async def test_default_still_resolves(self, mock_client):
+        """Contrast: without ``_resolved`` the registry resolver is consulted and
+        the resolved storage key is used for the endpoint."""
+        mock_client.send_websocket_message = AsyncMock(
+            return_value={"result": {"unique_id": "storage_key"}}
+        )
+        mock_client._request = AsyncMock(return_value={"result": "ok"})
+
+        config = {"alias": "x", "sequence": [{"delay": {"seconds": 1}}]}
+        result = await mock_client.upsert_script_config(config, "renamed_script")
+
+        assert result["script_id"] == "storage_key"
+        mock_client.send_websocket_message.assert_called_once_with(
+            {"type": "config/entity_registry/get", "entity_id": "script.renamed_script"}
+        )
+        mock_client._request.assert_called_once_with(
+            "POST", "config/script/config/storage_key", json=config
+        )

--- a/tests/src/unit/test_rest_client_scripts.py
+++ b/tests/src/unit/test_rest_client_scripts.py
@@ -405,8 +405,9 @@ class TestResolveScriptId:
 
 
 class TestUpsertScriptResolvedShortCircuit:
-    """``_resolved=True`` skips the redundant ``_resolve_script_id`` registry
-    lookup on ``upsert_script_config`` (issue #1813 Phase 0 item #6).
+    """``resolved_id`` skips the redundant ``_resolve_script_id`` registry lookup
+    on ``upsert_script_config`` (issue #1813 Phase 0 item #6) — while ``script_id``
+    stays the caller's identifier for alias-defaulting (#1935).
 
     ``_make_mock_client`` makes ``send_websocket_message`` raise, so
     ``assert_not_called`` proves the resolver was genuinely skipped rather than
@@ -418,14 +419,14 @@ class TestUpsertScriptResolvedShortCircuit:
         return _make_mock_client()
 
     @pytest.mark.asyncio
-    async def test_resolved_skips_lookup(self, mock_client):
-        """``_resolved=True`` uses ``script_id`` directly as the storage key and
-        never issues the entity-registry lookup."""
+    async def test_resolved_id_skips_lookup(self, mock_client):
+        """``resolved_id`` is used directly as the write target and no
+        entity-registry lookup is issued."""
         mock_client._request = AsyncMock(return_value={"result": "ok"})
 
         config = {"alias": "x", "sequence": [{"delay": {"seconds": 1}}]}
         result = await mock_client.upsert_script_config(
-            config, "storage_key", _resolved=True
+            config, "renamed_script", resolved_id="storage_key"
         )
 
         assert result["success"] is True
@@ -436,9 +437,30 @@ class TestUpsertScriptResolvedShortCircuit:
         )
 
     @pytest.mark.asyncio
+    async def test_resolved_id_alias_defaults_to_caller_script_id(self, mock_client):
+        """#1935 regression: with ``resolved_id`` provided (renamed script), a
+        missing alias defaults to the CALLER's ``script_id`` — NOT the storage
+        key — while the write still targets the resolved key with no re-resolve."""
+        mock_client._request = AsyncMock(return_value={"result": "ok"})
+
+        config = {"sequence": [{"delay": {"seconds": 1}}]}  # no alias
+        result = await mock_client.upsert_script_config(
+            config, "new_name", resolved_id="old_storage_key"
+        )
+
+        # Write targets the resolved storage key; resolver never consulted.
+        assert result["script_id"] == "old_storage_key"
+        mock_client.send_websocket_message.assert_not_called()
+        method, endpoint = mock_client._request.call_args.args
+        assert endpoint == "config/script/config/old_storage_key"
+        # Alias defaulted from the caller's id, not the stale storage key.
+        assert mock_client._request.call_args.kwargs["json"]["alias"] == "new_name"
+
+    @pytest.mark.asyncio
     async def test_default_still_resolves(self, mock_client):
-        """Contrast: without ``_resolved`` the registry resolver is consulted and
-        the resolved storage key is used for the endpoint."""
+        """Contrast: without ``resolved_id`` the registry resolver is consulted,
+        the resolved storage key is the write target, and a missing alias
+        defaults to the caller's id."""
         mock_client.send_websocket_message = AsyncMock(
             return_value={"result": {"unique_id": "storage_key"}}
         )

--- a/tests/src/unit/test_tools_config_automations.py
+++ b/tests/src/unit/test_tools_config_automations.py
@@ -139,6 +139,10 @@ def transform_tools(tools):
     bypassed so tests don't have to compute matching `compute_config_hash`
     values — the parity key under test depends only on the post-upsert
     `entity_id` resolution, not on the hash arithmetic.
+
+    `_fetch_and_verify_hash` returns ``(config, resolved_id)`` since #1813
+    Phase 0 — the second element is the already-resolved storage key the tool
+    threads into the upsert.
     """
     canonical_config = {
         "alias": "Morning Routine",
@@ -147,7 +151,9 @@ def transform_tools(tools):
             {"service": "light.turn_on", "target": {"entity_id": "light.bedroom"}}
         ],
     }
-    tools._fetch_and_verify_hash = AsyncMock(return_value=dict(canonical_config))
+    tools._fetch_and_verify_hash = AsyncMock(
+        return_value=(dict(canonical_config), "abc123unique")
+    )
     tools._get_automation_config_internal = AsyncMock(
         return_value=(dict(canonical_config), "post_transform_hash")
     )
@@ -307,6 +313,103 @@ class TestFullConfigSetAutomationIdKey:
 
         assert result["success"] is True
         assert "automation_id" not in result
+
+
+class TestAutomationUpsertResolvedThreading:
+    """Issue #1813 Phase 0 item #6: when the tool pre-resolves the identifier
+    (its hash-verify fetch already resolved the storage key), it threads
+    ``_resolved=True`` and the resolved unique_id into
+    ``upsert_automation_config`` so the REST client skips the redundant second
+    resolve. The no-pre-resolve paths (create, no-hash update) stay unthreaded.
+    """
+
+    @pytest.fixture
+    def canonical_config(self):
+        return {
+            "alias": "Morning Routine",
+            "trigger": [{"platform": "time", "at": "07:00:00"}],
+            "action": [
+                {"service": "light.turn_on", "target": {"entity_id": "light.bedroom"}}
+            ],
+        }
+
+    async def test_python_transform_threads_resolved_id(
+        self, transform_tools, mock_client
+    ):
+        """python_transform always hash-verifies first → upsert gets the resolved
+        id with ``_resolved=True``."""
+        result = await transform_tools.ha_config_set_automation(
+            identifier="automation.morning_routine",
+            python_transform="config['mode'] = 'single'",
+            config_hash="prior_hash",
+        )
+
+        assert result["success"] is True
+        args, kwargs = mock_client.upsert_automation_config.call_args
+        assert kwargs.get("_resolved") is True
+        # ``_fetch_and_verify_hash`` (stubbed) resolved to "abc123unique".
+        assert args[1] == "abc123unique"
+
+    async def test_full_config_with_hash_threads_resolved_id(
+        self, tools, mock_client, canonical_config
+    ):
+        """A full-config update that supplies ``config_hash`` pre-resolves via the
+        hash-verify fetch (config['id']), so the upsert is threaded."""
+        import copy
+
+        from ha_mcp.tools.tools_config_automations import (
+            _normalize_config_for_roundtrip,
+        )
+        from ha_mcp.utils.config_hash import compute_config_hash
+
+        # The hash-verify fetch normalizes the stub's returned config; the caller
+        # hash must match that to clear the optimistic-locking gate. Deep-copy
+        # before normalizing so the shared mock return_value the tool re-reads
+        # stays pristine.
+        fetched = await mock_client.get_automation_config("automation.morning_routine")
+        seed_hash = compute_config_hash(
+            _normalize_config_for_roundtrip(copy.deepcopy(fetched))
+        )
+
+        result = await tools.ha_config_set_automation(
+            identifier="automation.morning_routine",
+            config=canonical_config,
+            config_hash=seed_hash,
+            wait=False,
+        )
+
+        assert result["success"] is True
+        args, kwargs = mock_client.upsert_automation_config.call_args
+        assert kwargs.get("_resolved") is True
+        assert args[1] == "abc123unique"
+
+    async def test_full_config_without_hash_is_not_threaded(
+        self, tools, mock_client, canonical_config
+    ):
+        """No ``config_hash`` → no pre-resolve → the raw identifier is passed and
+        the REST client resolves once (``_resolved`` stays False/absent)."""
+        result = await tools.ha_config_set_automation(
+            identifier="automation.morning_routine",
+            config=canonical_config,
+            wait=False,
+        )
+
+        assert result["success"] is True
+        args, kwargs = mock_client.upsert_automation_config.call_args
+        assert kwargs.get("_resolved", False) is False
+        assert args[1] == "automation.morning_routine"
+
+    async def test_create_is_not_threaded(self, tools, mock_client, canonical_config):
+        """Create (identifier omitted) never pre-resolves — upsert gets
+        identifier=None with no ``_resolved`` flag."""
+        result = await tools.ha_config_set_automation(
+            config=canonical_config, wait=False
+        )
+
+        assert result["success"] is True
+        args, kwargs = mock_client.upsert_automation_config.call_args
+        assert kwargs.get("_resolved", False) is False
+        assert args[1] is None
 
 
 class TestDeleteAutomationIdKey:

--- a/tests/src/unit/test_tools_config_scenes.py
+++ b/tests/src/unit/test_tools_config_scenes.py
@@ -987,8 +987,8 @@ class TestSceneResolutionDedup:
                 },
             }
 
-        async def _upsert(config, scene_id, *, _resolved=False):
-            rid = scene_id if _resolved else await resolve(scene_id)
+        async def _upsert(config, scene_id, *, resolved_id=None):
+            rid = resolved_id if resolved_id is not None else await resolve(scene_id)
             return {"success": True, "scene_id": rid, "result": "ok"}
 
         async def _delete(scene_id, *, _resolved=False):
@@ -1034,8 +1034,10 @@ class TestSceneResolutionDedup:
         assert result["success"] is True
         assert result["scene_id"] == "test_scene"
         assert client.resolve_scene_id.await_count == 1
-        _, kwargs = client.upsert_scene_config.call_args
-        assert kwargs.get("_resolved") is True
+        args, kwargs = client.upsert_scene_config.call_args
+        # Caller id passed as scene_id; resolved storage key as resolved_id.
+        assert args[1] == "test_scene"
+        assert kwargs.get("resolved_id") == "test_scene"
 
     async def test_remove_scene_resolves_once(self, monkeypatch):
         client = self._dedup_client()
@@ -1072,6 +1074,55 @@ class TestSceneResolutionDedup:
         assert result["action"] == "python_transform"
         # One resolution total despite hash-verify fetch + upsert + re-fetch.
         assert client.resolve_scene_id.await_count == 1
+
+    async def test_renamed_scene_config_hash_no_name_forwards_caller_id(
+        self, monkeypatch
+    ):
+        """#1935: a renamed scene (caller slug != storage key) updated with
+        config_hash + a config omitting ``name`` forwards the CALLER's id as
+        ``scene_id`` (the REST name-default source) and the resolved storage key
+        as ``resolved_id`` (write target) — so the name is not reset to the
+        storage key."""
+        from ha_mcp.utils.config_hash import compute_config_hash
+
+        client = MagicMock()
+        client.resolve_scene_id = AsyncMock(return_value="storage_key")
+        fetched = {"name": "Old Name", "entities": {"light.kitchen": {"state": "on"}}}
+        client.get_scene_config = AsyncMock(
+            return_value={
+                "success": True,
+                "scene_id": "storage_key",
+                "config": fetched,
+            }
+        )
+        client.upsert_scene_config = AsyncMock(
+            return_value={"success": True, "scene_id": "storage_key", "result": "ok"}
+        )
+        client.get_services = AsyncMock(return_value=[])
+        client.get_states = AsyncMock(return_value=[])
+        client.send_websocket_message = AsyncMock(
+            return_value={"success": True, "result": []}
+        )
+        client.get_entity_state = AsyncMock(
+            return_value={"state": "on", "entity_id": "scene.renamed_scene"}
+        )
+        tools = self._tools(client, monkeypatch)
+
+        result = await tools.ha_config_set_scene(
+            scene_id="renamed_scene",
+            config={"entities": {"light.kitchen": {"state": "on"}}},  # no name
+            config_hash=compute_config_hash(fetched),
+            wait=False,
+        )
+
+        assert result["success"] is True
+        args, kwargs = client.upsert_scene_config.call_args
+        # Caller id is the name-default source; storage key is the write target.
+        assert args[1] == "renamed_scene"
+        assert kwargs.get("resolved_id") == "storage_key"
+        # The config forwarded still has no name — the default is applied inside
+        # upsert_scene_config from scene_id (proven at the REST level).
+        assert "name" not in args[0]
 
 
 @pytest.mark.asyncio

--- a/tests/src/unit/test_tools_config_scenes.py
+++ b/tests/src/unit/test_tools_config_scenes.py
@@ -1124,6 +1124,90 @@ class TestSceneResolutionDedup:
         # upsert_scene_config from scene_id (proven at the REST level).
         assert "name" not in args[0]
 
+    async def test_python_transform_forwards_caller_id_and_resolved_id(
+        self, monkeypatch
+    ):
+        """The python_transform call site is discriminated on a RENAMED scene
+        (caller slug != storage key): it forwards the CALLER id as ``scene_id``
+        and the resolved storage key as ``resolved_id``. With caller == storage
+        (as in test_python_transform_resolves_once) re-passing the storage key
+        as scene_id would slip through — this pins it."""
+        from ha_mcp.utils.config_hash import compute_config_hash
+
+        client = MagicMock()
+        client.resolve_scene_id = AsyncMock(return_value="storage_key")
+        fetched = {"name": "Old", "entities": {"light.kitchen": {"state": "on"}}}
+        client.get_scene_config = AsyncMock(
+            return_value={
+                "success": True,
+                "scene_id": "storage_key",
+                "config": fetched,
+            }
+        )
+        client.upsert_scene_config = AsyncMock(
+            return_value={"success": True, "scene_id": "storage_key", "result": "ok"}
+        )
+        client.get_services = AsyncMock(return_value=[])
+        client.get_states = AsyncMock(return_value=[])
+        client.send_websocket_message = AsyncMock(
+            return_value={"success": True, "result": []}
+        )
+        client.get_entity_state = AsyncMock(
+            return_value={"state": "on", "entity_id": "scene.renamed_scene"}
+        )
+        tools = self._tools(client, monkeypatch)
+
+        result = await tools.ha_config_set_scene(
+            scene_id="renamed_scene",
+            python_transform="config['entities']['light.kitchen']['state'] = 'off'",
+            config_hash=compute_config_hash(fetched),
+            wait=False,
+        )
+
+        assert result["success"] is True
+        assert result["action"] == "python_transform"
+        args, kwargs = client.upsert_scene_config.call_args
+        assert args[1] == "renamed_scene"  # caller id (transform site)
+        assert kwargs.get("resolved_id") == "storage_key"  # storage-key write target
+
+    async def test_missing_envelope_key_reresolves_not_caller_slug(self, monkeypatch):
+        """Structural invariant: if the REST envelope omits ``scene_id`` (never
+        happens today — ``get_scene_config`` always sets it), the tool passes
+        ``resolved_id=None`` so the upsert RE-RESOLVES rather than threading the
+        caller's unresolved slug as the write target."""
+        from ha_mcp.utils.config_hash import compute_config_hash
+
+        client = MagicMock()
+        client.resolve_scene_id = AsyncMock(return_value="storage_key")
+        fetched = {"name": "Old", "entities": {"light.kitchen": {"state": "on"}}}
+        client.get_scene_config = AsyncMock(
+            return_value={"success": True, "config": fetched}  # no scene_id key
+        )
+        client.upsert_scene_config = AsyncMock(
+            return_value={"success": True, "scene_id": "storage_key", "result": "ok"}
+        )
+        client.get_services = AsyncMock(return_value=[])
+        client.get_states = AsyncMock(return_value=[])
+        client.send_websocket_message = AsyncMock(
+            return_value={"success": True, "result": []}
+        )
+        client.get_entity_state = AsyncMock(
+            return_value={"state": "on", "entity_id": "scene.renamed_scene"}
+        )
+        tools = self._tools(client, monkeypatch)
+
+        result = await tools.ha_config_set_scene(
+            scene_id="renamed_scene",
+            config={"entities": {"light.kitchen": {"state": "on"}}},
+            config_hash=compute_config_hash(fetched),
+            wait=False,
+        )
+
+        assert result["success"] is True
+        args, kwargs = client.upsert_scene_config.call_args
+        assert kwargs.get("resolved_id") is None  # re-resolve, not the caller slug
+        assert args[1] == "renamed_scene"
+
 
 @pytest.mark.asyncio
 class TestPythonTransformOrphanMetadata:

--- a/tests/src/unit/test_tools_config_scripts.py
+++ b/tests/src/unit/test_tools_config_scripts.py
@@ -357,6 +357,30 @@ class TestScriptUpsertResolvedThreading:
         assert kwargs.get("resolved_id") is None
         assert args[1] == "renamed_script"
 
+    async def test_missing_envelope_key_reresolves_not_caller_slug(
+        self, tools, mock_client
+    ):
+        """Structural invariant: if the REST envelope omits ``script_id`` (never
+        happens today — ``get_script_config`` always sets it), the tool passes
+        ``resolved_id=None`` so the upsert RE-RESOLVES rather than threading the
+        caller's unresolved slug as the write target (which for a renamed script
+        would hit the wrong storage key)."""
+        mock_client.get_script_config = AsyncMock(
+            return_value={"success": True, "config": dict(self.INNER_CONFIG)}  # no key
+        )
+
+        result = await tools.ha_config_set_script(
+            script_id="renamed_script",
+            config={"alias": "Morning", "sequence": [{"delay": {"seconds": 5}}]},
+            config_hash=self._seed_hash(),
+            wait=False,
+        )
+
+        assert result["success"] is True
+        args, kwargs = mock_client.upsert_script_config.call_args
+        assert kwargs.get("resolved_id") is None  # re-resolve, not the caller slug
+        assert args[1] == "renamed_script"
+
 
 class TestStripEmptyScriptFields:
     """Test the _strip_empty_script_fields helper function."""

--- a/tests/src/unit/test_tools_config_scripts.py
+++ b/tests/src/unit/test_tools_config_scripts.py
@@ -240,6 +240,94 @@ class TestGetScriptCanonicalId:
         )
 
 
+class TestScriptUpsertResolvedThreading:
+    """Issue #1813 Phase 0 item #6: when the tool pre-resolves the storage key
+    (its hash-verify fetch already resolved it via the REST envelope), it
+    threads ``_resolved=True`` and the resolved id into ``upsert_script_config``
+    so the REST client skips the redundant second registry lookup. The no-hash
+    path stays unthreaded (raw script_id resolved once, inside the upsert).
+    """
+
+    # The inner script body the stubbed envelope carries; its hash is the
+    # optimistic-locking token the tool verifies before writing.
+    INNER_CONFIG = {"alias": "Morning", "sequence": [{"delay": {"seconds": 1}}]}
+
+    @pytest.fixture
+    def mock_client(self):
+        client = MagicMock()
+        # get_script_config resolves the alias "renamed_script" to storage key
+        # "storage_key" (mirrors a UI-renamed script), returning the REST
+        # envelope shape ha_config_set_script's fetch consumes.
+        client.get_script_config = AsyncMock(
+            return_value={
+                "success": True,
+                "script_id": "storage_key",
+                "config": dict(self.INNER_CONFIG),
+            }
+        )
+        client.upsert_script_config = AsyncMock(
+            return_value={"success": True, "script_id": "storage_key"}
+        )
+        # Reference validator (#940) walks these during set_script.
+        client.get_services = AsyncMock(return_value=[])
+        client.get_states = AsyncMock(return_value=[])
+        return client
+
+    @pytest.fixture
+    def tools(self, mock_client):
+        return ConfigScriptTools(mock_client)
+
+    @staticmethod
+    def _seed_hash():
+        from ha_mcp.utils.config_hash import compute_config_hash
+
+        return compute_config_hash(
+            dict(TestScriptUpsertResolvedThreading.INNER_CONFIG)
+        )
+
+    async def test_full_config_with_hash_threads_resolved_id(self, tools, mock_client):
+        """A full-config update supplying ``config_hash`` pre-resolves via the
+        hash-verify fetch → upsert is threaded with the resolved storage key."""
+        result = await tools.ha_config_set_script(
+            script_id="renamed_script",
+            config={"alias": "Morning", "sequence": [{"delay": {"seconds": 5}}]},
+            config_hash=self._seed_hash(),
+            wait=False,
+        )
+
+        assert result["success"] is True
+        args, kwargs = mock_client.upsert_script_config.call_args
+        assert kwargs.get("_resolved") is True
+        assert args[1] == "storage_key"
+
+    async def test_python_transform_threads_resolved_id(self, tools, mock_client):
+        """python_transform always hash-verifies first → upsert threaded."""
+        result = await tools.ha_config_set_script(
+            script_id="renamed_script",
+            python_transform="config['mode'] = 'single'",
+            config_hash=self._seed_hash(),
+        )
+
+        assert result["success"] is True
+        args, kwargs = mock_client.upsert_script_config.call_args
+        assert kwargs.get("_resolved") is True
+        assert args[1] == "storage_key"
+
+    async def test_full_config_without_hash_is_not_threaded(self, tools, mock_client):
+        """No ``config_hash`` → no pre-resolve → raw script_id passed, the REST
+        client resolves once (``_resolved`` stays False/absent)."""
+        result = await tools.ha_config_set_script(
+            script_id="renamed_script",
+            config={"alias": "Morning", "sequence": [{"delay": {"seconds": 5}}]},
+            wait=False,
+        )
+
+        assert result["success"] is True
+        args, kwargs = mock_client.upsert_script_config.call_args
+        assert kwargs.get("_resolved", False) is False
+        assert args[1] == "renamed_script"
+
+
 class TestStripEmptyScriptFields:
     """Test the _strip_empty_script_fields helper function."""
 

--- a/tests/src/unit/test_tools_config_scripts.py
+++ b/tests/src/unit/test_tools_config_scripts.py
@@ -7,6 +7,7 @@ especially for blueprint-based scripts (issue #466).
 
 import json
 import logging
+from typing import Any, ClassVar
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -250,7 +251,10 @@ class TestScriptUpsertResolvedThreading:
 
     # The inner script body the stubbed envelope carries; its hash is the
     # optimistic-locking token the tool verifies before writing.
-    INNER_CONFIG = {"alias": "Morning", "sequence": [{"delay": {"seconds": 1}}]}
+    INNER_CONFIG: ClassVar[dict[str, Any]] = {
+        "alias": "Morning",
+        "sequence": [{"delay": {"seconds": 1}}],
+    }
 
     @pytest.fixture
     def mock_client(self):
@@ -281,9 +285,7 @@ class TestScriptUpsertResolvedThreading:
     def _seed_hash():
         from ha_mcp.utils.config_hash import compute_config_hash
 
-        return compute_config_hash(
-            dict(TestScriptUpsertResolvedThreading.INNER_CONFIG)
-        )
+        return compute_config_hash(dict(TestScriptUpsertResolvedThreading.INNER_CONFIG))
 
     async def test_full_config_with_hash_threads_resolved_id(self, tools, mock_client):
         """A full-config update supplying ``config_hash`` pre-resolves via the

--- a/tests/src/unit/test_tools_config_scripts.py
+++ b/tests/src/unit/test_tools_config_scripts.py
@@ -243,10 +243,12 @@ class TestGetScriptCanonicalId:
 
 class TestScriptUpsertResolvedThreading:
     """Issue #1813 Phase 0 item #6: when the tool pre-resolves the storage key
-    (its hash-verify fetch already resolved it via the REST envelope), it
-    threads ``_resolved=True`` and the resolved id into ``upsert_script_config``
-    so the REST client skips the redundant second registry lookup. The no-hash
-    path stays unthreaded (raw script_id resolved once, inside the upsert).
+    (its hash-verify fetch already resolved it via the REST envelope), it passes
+    that key as ``resolved_id`` to ``upsert_script_config`` so the REST client
+    skips the redundant second registry lookup — while ``script_id`` stays the
+    CALLER's identifier so a renamed script's alias is not reset to the storage
+    key (#1935). The no-hash path passes ``resolved_id=None`` (resolved once,
+    inside the upsert).
     """
 
     # The inner script body the stubbed envelope carries; its hash is the
@@ -289,7 +291,8 @@ class TestScriptUpsertResolvedThreading:
 
     async def test_full_config_with_hash_threads_resolved_id(self, tools, mock_client):
         """A full-config update supplying ``config_hash`` pre-resolves via the
-        hash-verify fetch → upsert is threaded with the resolved storage key."""
+        hash-verify fetch → the resolved storage key is passed as ``resolved_id``
+        (write target) while ``script_id`` stays the caller's id."""
         result = await tools.ha_config_set_script(
             script_id="renamed_script",
             config={"alias": "Morning", "sequence": [{"delay": {"seconds": 5}}]},
@@ -299,11 +302,11 @@ class TestScriptUpsertResolvedThreading:
 
         assert result["success"] is True
         args, kwargs = mock_client.upsert_script_config.call_args
-        assert kwargs.get("_resolved") is True
-        assert args[1] == "storage_key"
+        assert kwargs.get("resolved_id") == "storage_key"
+        assert args[1] == "renamed_script"
 
     async def test_python_transform_threads_resolved_id(self, tools, mock_client):
-        """python_transform always hash-verifies first → upsert threaded."""
+        """python_transform always hash-verifies first → threaded the same way."""
         result = await tools.ha_config_set_script(
             script_id="renamed_script",
             python_transform="config['mode'] = 'single'",
@@ -312,12 +315,37 @@ class TestScriptUpsertResolvedThreading:
 
         assert result["success"] is True
         args, kwargs = mock_client.upsert_script_config.call_args
-        assert kwargs.get("_resolved") is True
-        assert args[1] == "storage_key"
+        assert kwargs.get("resolved_id") == "storage_key"
+        assert args[1] == "renamed_script"
+
+    async def test_renamed_config_hash_no_alias_forwards_caller_id_for_alias(
+        self, tools, mock_client
+    ):
+        """#1935: a renamed script updated with config_hash + a config omitting
+        ``alias`` forwards the CALLER's id as ``script_id`` (the REST client's
+        alias-default source) and the resolved storage key as ``resolved_id``
+        (write target) — so the alias is not reset to the storage key, and the
+        resolver runs only once (in the hash-verify fetch)."""
+        result = await tools.ha_config_set_script(
+            script_id="renamed_script",
+            config={"sequence": [{"delay": {"seconds": 5}}]},  # no alias
+            config_hash=self._seed_hash(),
+            wait=False,
+        )
+
+        assert result["success"] is True
+        args, kwargs = mock_client.upsert_script_config.call_args
+        # Caller id is the alias-default source; storage key is the write target.
+        assert args[1] == "renamed_script"
+        assert kwargs.get("resolved_id") == "storage_key"
+        # The config forwarded to the REST client still has no alias — the
+        # default is applied inside upsert_script_config from ``script_id``
+        # (proven by TestUpsertScriptResolvedShortCircuit at the REST level).
+        assert "alias" not in args[0]
 
     async def test_full_config_without_hash_is_not_threaded(self, tools, mock_client):
-        """No ``config_hash`` → no pre-resolve → raw script_id passed, the REST
-        client resolves once (``_resolved`` stays False/absent)."""
+        """No ``config_hash`` → no pre-resolve → ``resolved_id=None``, the REST
+        client resolves once from the caller ``script_id``."""
         result = await tools.ha_config_set_script(
             script_id="renamed_script",
             config={"alias": "Morning", "sequence": [{"delay": {"seconds": 5}}]},
@@ -326,7 +354,7 @@ class TestScriptUpsertResolvedThreading:
 
         assert result["success"] is True
         args, kwargs = mock_client.upsert_script_config.call_args
-        assert kwargs.get("_resolved", False) is False
+        assert kwargs.get("resolved_id") is None
         assert args[1] == "renamed_script"
 
 

--- a/tests/src/unit/test_tools_traces.py
+++ b/tests/src/unit/test_tools_traces.py
@@ -505,6 +505,23 @@ class TestResolveTraceItemIdPooled:
 
         assert item_id == "fallback_obj"
 
+    @pytest.mark.asyncio
+    async def test_falls_back_to_object_id_when_pooled_call_raises(self):
+        """The pooled call may RAISE rather than collapse to ``{success:False}``;
+        the best-effort resolve still falls back to object_id — matching the
+        helper's comment that it works whether the pooled client collapses OR
+        raises."""
+        client = MagicMock()
+        client.send_websocket_message = AsyncMock(
+            side_effect=RuntimeError("pooled connect exploded")
+        )
+
+        item_id = await _resolve_trace_item_id(
+            client, "automation.test", "fallback_obj"
+        )
+
+        assert item_id == "fallback_obj"
+
 
 class TestTraceFetchPooledClient:
     """`ha_get_automation_traces` drives the pooled client end-to-end (issue

--- a/tests/src/unit/test_tools_traces.py
+++ b/tests/src/unit/test_tools_traces.py
@@ -610,3 +610,40 @@ class TestTraceFetchPooledClient:
         error = json.loads(str(exc_info.value))
         assert error["success"] is False
         assert error["error"]["code"] == "SERVICE_CALL_FAILED"
+
+    @pytest.mark.asyncio
+    async def test_detail_connection_error_maps_to_connection_failed(self):
+        """The DETAIL path (run_id set) routes a connection-shaped pooled failure
+        through the same ``_raise_trace_ws_failure`` classifier → CONNECTION_FAILED."""
+        detail_result = {
+            "success": False,
+            "error": "Failed to connect to Home Assistant",
+        }
+        client = _make_pooled_client(self._dispatch(detail_result=detail_result))
+        tools = TraceTools(client)
+
+        with pytest.raises(ToolError) as exc_info:
+            await tools.ha_get_automation_traces(
+                automation_id="automation.test", run_id="r1"
+            )
+
+        error = json.loads(str(exc_info.value))
+        assert error["success"] is False
+        assert error["error"]["code"] == "CONNECTION_FAILED"
+
+    @pytest.mark.asyncio
+    async def test_detail_command_error_maps_to_service_call_failed(self):
+        """The DETAIL path keeps a non-connection pooled failure as
+        SERVICE_CALL_FAILED."""
+        detail_result = {"success": False, "error": "unknown_command"}
+        client = _make_pooled_client(self._dispatch(detail_result=detail_result))
+        tools = TraceTools(client)
+
+        with pytest.raises(ToolError) as exc_info:
+            await tools.ha_get_automation_traces(
+                automation_id="automation.test", run_id="r1"
+            )
+
+        error = json.loads(str(exc_info.value))
+        assert error["success"] is False
+        assert error["error"]["code"] == "SERVICE_CALL_FAILED"

--- a/tests/src/unit/test_tools_traces.py
+++ b/tests/src/unit/test_tools_traces.py
@@ -1,12 +1,16 @@
 """Unit tests for tools_traces module."""
 
-from unittest.mock import AsyncMock
+import json
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from fastmcp.exceptions import ToolError
 
 from ha_mcp.tools.tools_traces import (
+    TraceTools,
     _format_trace_list,
     _gather_diagnostics,
+    _resolve_trace_item_id,
 )
 
 
@@ -272,12 +276,16 @@ class TestFormatTraceList:
 
 
 class TestGatherDiagnostics:
-    """Test _gather_diagnostics function."""
+    """Test _gather_diagnostics function.
+
+    Since #1813 Phase 0 the automation-config probe rides the pooled client's
+    ``send_websocket_message`` (issue #5) rather than a dedicated ``ws_client``
+    socket, so the config-fetch stub is ``client.send_websocket_message``.
+    """
 
     @pytest.mark.asyncio
     async def test_automation_exists_and_enabled(self):
         """Diagnostics correctly identify existing, enabled automation."""
-        ws_client = AsyncMock()
         client = AsyncMock()
         client.get_entity_state.return_value = {
             "state": "on",
@@ -286,24 +294,25 @@ class TestGatherDiagnostics:
                 "last_triggered": "2025-11-30T15:00:00Z",
             },
         }
-        ws_client.send_command.return_value = {
+        client.send_websocket_message.return_value = {
             "success": True,
             "result": {"stored_traces": 5},
         }
 
-        result = await _gather_diagnostics(
-            ws_client, client, "automation.test", "automation"
-        )
+        result = await _gather_diagnostics(client, "automation.test", "automation")
 
         assert result["automation_exists"] is True
         assert result["automation_enabled"] is True
         assert result["last_triggered"] == "2025-11-30T15:00:00Z"
         assert result["trace_storage_enabled"] is True
+        # The config probe went through the pooled client, not a dedicated socket.
+        client.send_websocket_message.assert_awaited_once_with(
+            {"type": "automation/config", "entity_id": "automation.test"}
+        )
 
     @pytest.mark.asyncio
     async def test_automation_disabled(self):
         """Diagnostics correctly identify disabled automation."""
-        ws_client = AsyncMock()
         client = AsyncMock()
         client.get_entity_state.return_value = {
             "state": "off",
@@ -312,15 +321,13 @@ class TestGatherDiagnostics:
                 "last_triggered": None,
             },
         }
-        # Return valid config so ws_client.send_command coroutine is awaited
-        ws_client.send_command.return_value = {
+        # Return valid config so the pooled send_websocket_message is awaited
+        client.send_websocket_message.return_value = {
             "success": True,
             "result": {"stored_traces": 5},
         }
 
-        result = await _gather_diagnostics(
-            ws_client, client, "automation.test", "automation"
-        )
+        result = await _gather_diagnostics(client, "automation.test", "automation")
 
         assert result["automation_exists"] is True
         assert result["automation_enabled"] is False
@@ -329,7 +336,6 @@ class TestGatherDiagnostics:
     @pytest.mark.asyncio
     async def test_automation_never_triggered(self):
         """Diagnostics correctly identify automation that never triggered."""
-        ws_client = AsyncMock()
         client = AsyncMock()
         client.get_entity_state.return_value = {
             "state": "on",
@@ -338,15 +344,13 @@ class TestGatherDiagnostics:
                 "last_triggered": None,
             },
         }
-        # Return valid config so ws_client.send_command coroutine is awaited
-        ws_client.send_command.return_value = {
+        # Return valid config so the pooled send_websocket_message is awaited
+        client.send_websocket_message.return_value = {
             "success": True,
             "result": {"stored_traces": 5},
         }
 
-        result = await _gather_diagnostics(
-            ws_client, client, "automation.test", "automation"
-        )
+        result = await _gather_diagnostics(client, "automation.test", "automation")
 
         assert result["automation_exists"] is True
         assert result["automation_enabled"] is True
@@ -356,13 +360,10 @@ class TestGatherDiagnostics:
     @pytest.mark.asyncio
     async def test_automation_not_found(self):
         """Diagnostics handle non-existent automation gracefully."""
-        ws_client = AsyncMock()
         client = AsyncMock()
         client.get_entity_state.side_effect = Exception("Entity not found")
 
-        result = await _gather_diagnostics(
-            ws_client, client, "automation.test", "automation"
-        )
+        result = await _gather_diagnostics(client, "automation.test", "automation")
 
         assert result["automation_exists"] is False
         assert "could not find" in result["suggestion"].lower()
@@ -370,7 +371,6 @@ class TestGatherDiagnostics:
     @pytest.mark.asyncio
     async def test_trace_storage_disabled(self):
         """Diagnostics detect when trace storage is disabled."""
-        ws_client = AsyncMock()
         client = AsyncMock()
         client.get_entity_state.return_value = {
             "state": "on",
@@ -379,14 +379,12 @@ class TestGatherDiagnostics:
                 "last_triggered": "2025-11-30T15:00:00Z",
             },
         }
-        ws_client.send_command.return_value = {
+        client.send_websocket_message.return_value = {
             "success": True,
             "result": {"stored_traces": 0},
         }
 
-        result = await _gather_diagnostics(
-            ws_client, client, "automation.test", "automation"
-        )
+        result = await _gather_diagnostics(client, "automation.test", "automation")
 
         assert result["trace_storage_enabled"] is False
         assert "trace storage is disabled" in result["suggestion"].lower()
@@ -394,7 +392,6 @@ class TestGatherDiagnostics:
     @pytest.mark.asyncio
     async def test_script_domain(self):
         """Diagnostics work correctly for script domain."""
-        ws_client = AsyncMock()
         client = AsyncMock()
         client.get_entity_state.return_value = {
             "state": "on",
@@ -403,7 +400,7 @@ class TestGatherDiagnostics:
             },
         }
 
-        result = await _gather_diagnostics(ws_client, client, "script.test", "script")
+        result = await _gather_diagnostics(client, "script.test", "script")
 
         assert result["automation_exists"] is True
         # For scripts, we should see "script" in suggestion, not "automation"
@@ -412,7 +409,6 @@ class TestGatherDiagnostics:
     @pytest.mark.asyncio
     async def test_config_fetch_failure_graceful(self):
         """Diagnostics handle config fetch failure gracefully."""
-        ws_client = AsyncMock()
         client = AsyncMock()
         client.get_entity_state.return_value = {
             "state": "on",
@@ -421,11 +417,9 @@ class TestGatherDiagnostics:
                 "last_triggered": "2025-11-30T15:00:00Z",
             },
         }
-        ws_client.send_command.side_effect = Exception("WebSocket error")
+        client.send_websocket_message.side_effect = Exception("WebSocket error")
 
-        result = await _gather_diagnostics(
-            ws_client, client, "automation.test", "automation"
-        )
+        result = await _gather_diagnostics(client, "automation.test", "automation")
 
         # Should still return diagnostics even if config fetch fails
         assert result["automation_exists"] is True
@@ -436,7 +430,6 @@ class TestGatherDiagnostics:
     @pytest.mark.asyncio
     async def test_traces_cleared_or_expired_suggestion(self):
         """Diagnostics suggest traces may have expired for enabled, triggered automation."""
-        ws_client = AsyncMock()
         client = AsyncMock()
         client.get_entity_state.return_value = {
             "state": "on",
@@ -445,15 +438,175 @@ class TestGatherDiagnostics:
                 "last_triggered": "2025-11-30T15:00:00Z",
             },
         }
-        ws_client.send_command.return_value = {
+        client.send_websocket_message.return_value = {
             "success": True,
             "result": {"stored_traces": 5},  # Trace storage enabled
         }
 
-        result = await _gather_diagnostics(
-            ws_client, client, "automation.test", "automation"
-        )
+        result = await _gather_diagnostics(client, "automation.test", "automation")
 
         # For enabled automation with last_triggered and trace storage enabled,
         # suggestion should mention traces may have been cleared or expired
         assert "cleared or expired" in result["suggestion"].lower()
+
+
+def _make_pooled_client(dispatch):
+    """Build a mock REST client whose ``send_websocket_message`` dispatches on
+    message type via ``dispatch`` (``(type, message) -> response dict``).
+
+    Mirrors the pooled client tools_traces now drives (issue #1813 item #5):
+    a single ``send_websocket_message`` owns every trace WS command, so there is
+    no dedicated connect/auth/disconnect per call.
+    """
+    client = MagicMock()
+    client.base_url = "http://test.local:8123"
+    client.token = "test-token"
+    client.verify_ssl = True
+
+    async def _send(message):
+        return dispatch(message["type"], message)
+
+    client.send_websocket_message = AsyncMock(side_effect=_send)
+    client.get_entity_state = AsyncMock(return_value={"state": "on", "attributes": {}})
+    return client
+
+
+class TestResolveTraceItemIdPooled:
+    """``_resolve_trace_item_id`` drives the pooled ``send_websocket_message``
+    (issue #1813 item #5) and keeps its best-effort fall-back semantics."""
+
+    @pytest.mark.asyncio
+    async def test_resolves_unique_id_via_pooled_client(self):
+        client = _make_pooled_client(
+            lambda t, m: {"success": True, "result": {"unique_id": "uid_42"}}
+        )
+
+        item_id = await _resolve_trace_item_id(
+            client, "automation.test", "fallback_obj"
+        )
+
+        assert item_id == "uid_42"
+        client.send_websocket_message.assert_awaited_once_with(
+            {"type": "config/entity_registry/get", "entity_id": "automation.test"}
+        )
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_object_id_on_pooled_failure(self):
+        """A pooled ``{"success": False}`` (transport drop collapsed to a dict
+        rather than raised) falls back to the object_id — the subsequent trace
+        fetch surfaces the real error."""
+        client = _make_pooled_client(
+            lambda t, m: {"success": False, "error": "failed to connect"}
+        )
+
+        item_id = await _resolve_trace_item_id(
+            client, "automation.test", "fallback_obj"
+        )
+
+        assert item_id == "fallback_obj"
+
+
+class TestTraceFetchPooledClient:
+    """`ha_get_automation_traces` drives the pooled client end-to-end (issue
+    #1813 item #5): no dedicated socket, structured errors preserved."""
+
+    @staticmethod
+    def _dispatch(*, list_result=None, detail_result=None):
+        def _d(mtype, message):
+            if mtype == "config/entity_registry/get":
+                return {"success": True, "result": {"unique_id": "uid_1"}}
+            if mtype == "trace/list":
+                return list_result
+            if mtype == "trace/get":
+                return detail_result
+            if mtype == "automation/config":
+                return {"success": True, "result": {}}
+            return {"success": False, "error": f"unexpected {mtype}"}
+
+        return _d
+
+    @pytest.mark.asyncio
+    async def test_list_drives_pooled_client(self):
+        list_result = {
+            "success": True,
+            "result": [
+                {
+                    "run_id": "r1",
+                    "timestamp": "2025-11-30T15:00:00Z",
+                    "state": "stopped",
+                }
+            ],
+        }
+        client = _make_pooled_client(self._dispatch(list_result=list_result))
+        tools = TraceTools(client)
+
+        result = await tools.ha_get_automation_traces(automation_id="automation.test")
+
+        assert result["success"] is True
+        assert result["trace_count"] == 1
+        # Resolve + list both rode the pooled client; no dedicated socket exists.
+        sent_types = [
+            call.args[0]["type"]
+            for call in client.send_websocket_message.await_args_list
+        ]
+        assert "config/entity_registry/get" in sent_types
+        assert "trace/list" in sent_types
+
+    @pytest.mark.asyncio
+    async def test_detail_drives_pooled_client(self):
+        detail_result = {
+            "success": True,
+            "result": {
+                "timestamp": "2025-11-30T15:00:00Z",
+                "state": "stopped",
+                "trace": {},
+                "config": {"alias": "Test"},
+            },
+        }
+        client = _make_pooled_client(self._dispatch(detail_result=detail_result))
+        tools = TraceTools(client)
+
+        result = await tools.ha_get_automation_traces(
+            automation_id="automation.test", run_id="r1"
+        )
+
+        assert result["success"] is True
+        assert result["run_id"] == "r1"
+        sent_types = [
+            call.args[0]["type"]
+            for call in client.send_websocket_message.await_args_list
+        ]
+        assert "trace/get" in sent_types
+
+    @pytest.mark.asyncio
+    async def test_connection_error_maps_to_connection_failed(self):
+        """A connection-shaped pooled failure on the fetch surfaces as
+        CONNECTION_FAILED — the same structured error code the removed up-front
+        connect check raised."""
+        list_result = {
+            "success": False,
+            "error": "Failed to connect to Home Assistant",
+        }
+        client = _make_pooled_client(self._dispatch(list_result=list_result))
+        tools = TraceTools(client)
+
+        with pytest.raises(ToolError) as exc_info:
+            await tools.ha_get_automation_traces(automation_id="automation.test")
+
+        error = json.loads(str(exc_info.value))
+        assert error["success"] is False
+        assert error["error"]["code"] == "CONNECTION_FAILED"
+
+    @pytest.mark.asyncio
+    async def test_trace_command_error_maps_to_service_call_failed(self):
+        """A non-connection pooled failure keeps its SERVICE_CALL_FAILED shape."""
+        list_result = {"success": False, "error": "unknown_command"}
+        client = _make_pooled_client(self._dispatch(list_result=list_result))
+        tools = TraceTools(client)
+
+        with pytest.raises(ToolError) as exc_info:
+            await tools.ha_get_automation_traces(automation_id="automation.test")
+
+        error = json.loads(str(exc_info.value))
+        assert error["success"] is False
+        assert error["error"]["code"] == "SERVICE_CALL_FAILED"


### PR DESCRIPTION
## What does this PR do?

Finishes the last remaining #1813 component-backed items:

- **`server_entry_update`** (component write capability): `ha_dev_manage_server` `update_source` now applies `channel`/`pip_spec` to the in-process server entry via `hass.config_entries.async_update_entry` directly — one in-process frame instead of the options-flow start+submit. Embedded-only and capability-gated; the update reloads the entry that runs the embedded server, so it is deferred onto a hass-owned background task so the response flushes first. Every component error and all non-embedded / component-absent installs fall back to the unchanged options-flow submit.
- automation + script `upsert_*_config` now thread the already-resolved id (the `_resolved` flag `upsert_scene_config` already had), skipping a redundant entity-registry re-resolve.
- `ha_get_automation_traces` uses the shared pooled WebSocket client instead of a per-call dedicated socket.

No component version bump (rides the pending `1.2.0`). Reconciles with #1929 — the component write path preserves its `target` payload field.

Closes #1813.

## Type of change
- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

## Checklist
- [x] I have updated documentation if needed
