### PR TITLE
refactor(c901): fix UAT harness (4 files) below C901 threshold, remove from grandfather list

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -174,10 +174,6 @@ ignore = [
 "src/ha_mcp/tools/tools_dev.py" = ["C901"]
 "src/ha_mcp/tools/tools_system.py" = ["C901"]
 "tests/src/unit/test_advanced_settings_coverage.py" = ["C901"]
-"tests/uat/ha_wait.py" = ["C901"]
-"tests/uat/openai_agent.py" = ["C901"]
-"tests/uat/run_uat.py" = ["C901"]
-"tests/uat/stories/run_story.py" = ["C901"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/tests/uat/ha_wait.py
+++ b/tests/uat/ha_wait.py
@@ -21,14 +21,8 @@ API_TIMEOUT = 120
 ENTITY_TIMEOUT = 30
 
 
-def wait_for_ha_ready(url: str, token: str) -> None:
-    """Wait until HA is fully ready: components loaded, entities registered.
-
-    Raises TimeoutError if any gate is not reached within its timeout.
-    """
-    headers = {"Authorization": f"Bearer {token}"}
-
-    # Gate 1: API reachable and components loaded
+def _wait_for_components(url: str, headers: dict[str, str]) -> None:
+    """Gate 1: block until the HA API responds and enough components load."""
     logger.info(f"Waiting for HA at {url} ...")
     api_responded = False
     last_component_count = 0
@@ -62,7 +56,9 @@ def wait_for_ha_ready(url: str, token: str) -> None:
             f"Only {last_component_count} components loaded (minimum: {MIN_COMPONENTS})."
         )
 
-    # Gate 2: Entities registered
+
+def _wait_for_entities(url: str, headers: dict[str, str]) -> None:
+    """Gate 2: block until enough entities have registered."""
     logger.info("Waiting for HA entities to register...")
     last_entity_count = 0
     for attempt in range(ENTITY_TIMEOUT):
@@ -88,3 +84,17 @@ def wait_for_ha_ready(url: str, token: str) -> None:
             f"Entity registration timed out after {ENTITY_TIMEOUT}s. "
             f"Only {last_entity_count} entities registered (minimum: {MIN_ENTITIES})."
         )
+
+
+def wait_for_ha_ready(url: str, token: str) -> None:
+    """Wait until HA is fully ready: components loaded, entities registered.
+
+    Raises TimeoutError if any gate is not reached within its timeout.
+    """
+    headers = {"Authorization": f"Bearer {token}"}
+
+    # Gate 1: API reachable and components loaded
+    _wait_for_components(url, headers)
+
+    # Gate 2: Entities registered
+    _wait_for_entities(url, headers)

--- a/tests/uat/openai_agent.py
+++ b/tests/uat/openai_agent.py
@@ -213,6 +213,108 @@ def extract_tool_result_text(result) -> str:
     return str(result)
 
 
+def _maybe_warn_no_think(
+    no_think: bool,
+    no_think_warned: bool,
+    message,
+    reasoning_this_turn: int,
+    model: str,
+) -> bool:
+    """Warn once if --no-think was requested but the model still reasoned.
+
+    Returns the updated ``no_think_warned`` flag.
+    """
+    # If --no-think was requested but the model still reasoned, the backend
+    # didn't honor it (e.g. LM Studio can't map enable_thinking to some
+    # Qwen3.6 GGUFs). Warn once so the no-op is visible instead of silently
+    # paying full reasoning-decode cost. reasoning_tokens is the structured
+    # signal; reasoning_content and an inline <think> block in content cover
+    # servers that emit reasoning without a separate token detail.
+    if no_think and not no_think_warned:
+        still_reasoning = (
+            reasoning_this_turn
+            or getattr(message, "reasoning_content", None)
+            or "<think>" in (message.content or "").lower()
+        )
+        if still_reasoning:
+            detail = (
+                f"{reasoning_this_turn} reasoning tokens"
+                if reasoning_this_turn
+                else "reasoning in output, token count unavailable"
+            )
+            logger.warning(
+                "--no-think requested but model %s still produced reasoning "
+                "(%s); backend may not honor enable_thinking",
+                model,
+                detail,
+            )
+            no_think_warned = True
+    return no_think_warned
+
+
+async def _dispatch_tool_calls(
+    message,
+    messages: list[dict],
+    mcp_client: MCPClient,
+    tool_trace_sink: list[str] | None,
+    total_calls: int,
+    total_success: int,
+    total_fail: int,
+) -> tuple[int, int, int]:
+    """Execute one turn's tool calls, appending each result to ``messages``.
+
+    Returns the updated ``(total_calls, total_success, total_fail)`` counters.
+    """
+    for tc in message.tool_calls:
+        total_calls += 1
+        tool_name = tc.function.name
+        try:
+            tool_args = json.loads(tc.function.arguments)
+        except json.JSONDecodeError as e:
+            malformed_line = (
+                f"  [tool] {tool_name}: malformed arguments: {tc.function.arguments!r}"
+            )
+            logger.info(malformed_line)
+            if tool_trace_sink is not None:
+                tool_trace_sink.append(malformed_line.strip())
+            total_fail += 1
+            messages.append(
+                {
+                    "role": "tool",
+                    "tool_call_id": tc.id,
+                    "content": f"Error: Invalid JSON in tool arguments: {e}",
+                }
+            )
+            continue
+
+        call_line = f"  [tool] {tool_name}({tool_args})"
+        logger.info(call_line)
+        if tool_trace_sink is not None:
+            tool_trace_sink.append(call_line.strip())
+
+        try:
+            result = await mcp_client.call_tool(tool_name, tool_args)
+            result_text = extract_tool_result_text(result)
+            total_success += 1
+        except Exception as e:
+            err_text = _strip_pydantic_url(str(e))
+            result_text = f"Error: {err_text}"
+            total_fail += 1
+            # Server-side WARNING log already shows the failure details;
+            # only record to the trace sink for test artifacts.
+            if tool_trace_sink is not None:
+                tool_trace_sink.append(f"[tool] {tool_name} failed: {err_text}")
+
+        messages.append(
+            {
+                "role": "tool",
+                "tool_call_id": tc.id,
+                "content": result_text,
+            }
+        )
+    return total_calls, total_success, total_fail
+
+
 async def tool_call_loop(
     client: openai.AsyncOpenAI,
     model: str,
@@ -292,31 +394,9 @@ async def tool_call_loop(
         choice = response.choices[0]
         message = choice.message
 
-        # If --no-think was requested but the model still reasoned, the backend
-        # didn't honor it (e.g. LM Studio can't map enable_thinking to some
-        # Qwen3.6 GGUFs). Warn once so the no-op is visible instead of silently
-        # paying full reasoning-decode cost. reasoning_tokens is the structured
-        # signal; reasoning_content and an inline <think> block in content cover
-        # servers that emit reasoning without a separate token detail.
-        if no_think and not no_think_warned:
-            still_reasoning = (
-                reasoning_this_turn
-                or getattr(message, "reasoning_content", None)
-                or "<think>" in (message.content or "").lower()
-            )
-            if still_reasoning:
-                detail = (
-                    f"{reasoning_this_turn} reasoning tokens"
-                    if reasoning_this_turn
-                    else "reasoning in output, token count unavailable"
-                )
-                logger.warning(
-                    "--no-think requested but model %s still produced reasoning "
-                    "(%s); backend may not honor enable_thinking",
-                    model,
-                    detail,
-                )
-                no_think_warned = True
+        no_think_warned = _maybe_warn_no_think(
+            no_think, no_think_warned, message, reasoning_this_turn, model
+        )
 
         # No tool calls — we have a final response
         if not message.tool_calls:
@@ -354,54 +434,15 @@ async def tool_call_loop(
             }
         )
 
-        for tc in message.tool_calls:
-            total_calls += 1
-            tool_name = tc.function.name
-            try:
-                tool_args = json.loads(tc.function.arguments)
-            except json.JSONDecodeError as e:
-                malformed_line = (
-                    f"  [tool] {tool_name}: malformed arguments: "
-                    f"{tc.function.arguments!r}"
-                )
-                logger.info(malformed_line)
-                if tool_trace_sink is not None:
-                    tool_trace_sink.append(malformed_line.strip())
-                total_fail += 1
-                messages.append(
-                    {
-                        "role": "tool",
-                        "tool_call_id": tc.id,
-                        "content": f"Error: Invalid JSON in tool arguments: {e}",
-                    }
-                )
-                continue
-
-            call_line = f"  [tool] {tool_name}({tool_args})"
-            logger.info(call_line)
-            if tool_trace_sink is not None:
-                tool_trace_sink.append(call_line.strip())
-
-            try:
-                result = await mcp_client.call_tool(tool_name, tool_args)
-                result_text = extract_tool_result_text(result)
-                total_success += 1
-            except Exception as e:
-                err_text = _strip_pydantic_url(str(e))
-                result_text = f"Error: {err_text}"
-                total_fail += 1
-                # Server-side WARNING log already shows the failure details;
-                # only record to the trace sink for test artifacts.
-                if tool_trace_sink is not None:
-                    tool_trace_sink.append(f"[tool] {tool_name} failed: {err_text}")
-
-            messages.append(
-                {
-                    "role": "tool",
-                    "tool_call_id": tc.id,
-                    "content": result_text,
-                }
-            )
+        total_calls, total_success, total_fail = await _dispatch_tool_calls(
+            message,
+            messages,
+            mcp_client,
+            tool_trace_sink,
+            total_calls,
+            total_success,
+            total_fail,
+        )
 
     # Max iterations reached without a final message. Flag it so callers can
     # surface it as a test failure — otherwise a model stuck in a tool-call

--- a/tests/uat/run_uat.py
+++ b/tests/uat/run_uat.py
@@ -303,6 +303,86 @@ def check_agent_available(name: str) -> bool:
     return shutil.which(name) is not None
 
 
+def _extract_cli_json_fields(raw_json: object, stdout_text: str) -> dict:
+    """Pull the optional output/stat/token fields out of an agent's JSON stdout.
+
+    Returns a dict whose values are ``None`` for fields absent from
+    ``raw_json`` (or when ``raw_json`` is not a dict).
+    """
+    output_text = stdout_text
+    num_turns = None
+    tool_stats = None
+    session_id = None
+    cost_usd = None
+    tokens_input = None
+    tokens_output = None
+    tokens_thoughts = None
+    tokens_first_input = None
+    if raw_json and isinstance(raw_json, dict):
+        # Claude JSON format
+        if "result" in raw_json:
+            output_text = raw_json.get("result", stdout_text)
+        # Gemini JSON format
+        if "response" in raw_json:
+            output_text = raw_json.get("response", stdout_text)
+        num_turns = raw_json.get("num_turns")
+        tool_stats = raw_json.get("tool_stats")
+        session_id = raw_json.get("session_id")
+        cost_usd = raw_json.get("total_cost_usd") or raw_json.get("cost_usd")
+        # Gemini stats
+        if "stats" in raw_json and isinstance(raw_json["stats"], dict):
+            tool_stats = raw_json["stats"].get("tools")
+        # OpenAI agent token counts and first-input baseline (included directly in JSON output)
+        tokens_input = raw_json.get("tokens_input")
+        tokens_output = raw_json.get("tokens_output")
+        tokens_thoughts = raw_json.get("tokens_thoughts")
+        tokens_first_input = raw_json.get("tokens_first_input")
+    return {
+        "output_text": output_text,
+        "num_turns": num_turns,
+        "tool_stats": tool_stats,
+        "session_id": session_id,
+        "cost_usd": cost_usd,
+        "tokens_input": tokens_input,
+        "tokens_output": tokens_output,
+        "tokens_thoughts": tokens_thoughts,
+        "tokens_first_input": tokens_first_input,
+    }
+
+
+def _assemble_cli_result(
+    returncode: int | None,
+    duration_ms: int,
+    stderr_text: str,
+    fields: dict,
+) -> dict:
+    """Build the run_cli result dict from extracted stdout fields."""
+    result: dict = {
+        "completed": returncode == 0,
+        "output": fields["output_text"],
+        "duration_ms": duration_ms,
+        "exit_code": returncode,
+        "stderr": stderr_text,
+    }
+    if fields["num_turns"] is not None:
+        result["num_turns"] = fields["num_turns"]
+    if fields["tool_stats"] is not None:
+        result["tool_stats"] = fields["tool_stats"]
+    if fields["session_id"] is not None:
+        result["session_id"] = fields["session_id"]
+    if fields["cost_usd"] is not None:
+        result["cost_usd"] = fields["cost_usd"]
+    if fields["tokens_input"] is not None:
+        result["tokens_input"] = fields["tokens_input"]
+    if fields["tokens_output"] is not None:
+        result["tokens_output"] = fields["tokens_output"]
+    if fields["tokens_thoughts"] is not None:
+        result["tokens_thoughts"] = fields["tokens_thoughts"]
+    if fields["tokens_first_input"] is not None:
+        result["tokens_first_input"] = fields["tokens_first_input"]
+    return result
+
+
 async def run_cli(cmd: list[str], timeout: int, cwd: Path | None = None) -> dict:
     """Run a CLI command and capture output."""
     # Strip CLAUDECODE env var to allow nested Claude CLI sessions
@@ -337,58 +417,8 @@ async def run_cli(cmd: list[str], timeout: int, cwd: Path | None = None) -> dict
             pass
 
         # Extract fields from JSON if available
-        output_text = stdout_text
-        num_turns = None
-        tool_stats = None
-        session_id = None
-        cost_usd = None
-        tokens_input = None
-        tokens_output = None
-        tokens_thoughts = None
-        tokens_first_input = None
-        if raw_json and isinstance(raw_json, dict):
-            # Claude JSON format
-            if "result" in raw_json:
-                output_text = raw_json.get("result", stdout_text)
-            # Gemini JSON format
-            if "response" in raw_json:
-                output_text = raw_json.get("response", stdout_text)
-            num_turns = raw_json.get("num_turns")
-            tool_stats = raw_json.get("tool_stats")
-            session_id = raw_json.get("session_id")
-            cost_usd = raw_json.get("total_cost_usd") or raw_json.get("cost_usd")
-            # Gemini stats
-            if "stats" in raw_json and isinstance(raw_json["stats"], dict):
-                tool_stats = raw_json["stats"].get("tools")
-            # OpenAI agent token counts and first-input baseline (included directly in JSON output)
-            tokens_input = raw_json.get("tokens_input")
-            tokens_output = raw_json.get("tokens_output")
-            tokens_thoughts = raw_json.get("tokens_thoughts")
-            tokens_first_input = raw_json.get("tokens_first_input")
-
-        result: dict = {
-            "completed": proc.returncode == 0,
-            "output": output_text,
-            "duration_ms": duration_ms,
-            "exit_code": proc.returncode,
-            "stderr": stderr_text,
-        }
-        if num_turns is not None:
-            result["num_turns"] = num_turns
-        if tool_stats is not None:
-            result["tool_stats"] = tool_stats
-        if session_id is not None:
-            result["session_id"] = session_id
-        if cost_usd is not None:
-            result["cost_usd"] = cost_usd
-        if tokens_input is not None:
-            result["tokens_input"] = tokens_input
-        if tokens_output is not None:
-            result["tokens_output"] = tokens_output
-        if tokens_thoughts is not None:
-            result["tokens_thoughts"] = tokens_thoughts
-        if tokens_first_input is not None:
-            result["tokens_first_input"] = tokens_first_input
+        fields = _extract_cli_json_fields(raw_json, stdout_text)
+        result = _assemble_cli_result(proc.returncode, duration_ms, stderr_text, fields)
         if raw_json is not None:
             result["raw_json"] = raw_json
         return result
@@ -480,6 +510,73 @@ def build_openai_cmd(
     return cmd
 
 
+async def _run_agent_phase(
+    agent_name: str,
+    prompt: str,
+    stdio_config_path: Path | None,
+    gemini_workdir: Path | None,
+    timeout: int,
+    *,
+    model: str | None,
+    base_url: str | None,
+    api_key: str,
+    max_tools: int | None,
+    no_think: bool,
+    max_tokens: int | None,
+) -> dict:
+    """Build the agent command for one phase and run it, returning the result."""
+    if agent_name == "claude":
+        assert stdio_config_path is not None
+        cmd = build_claude_cmd(prompt, stdio_config_path, model=model or "sonnet")
+        return await run_cli(cmd, timeout)
+    elif agent_name == "gemini":
+        cmd = build_gemini_cmd(prompt)
+        return await run_cli(cmd, timeout, cwd=gemini_workdir)
+    elif agent_name == "openai":
+        assert stdio_config_path is not None
+        assert base_url is not None  # validated in run()
+        cmd = build_openai_cmd(
+            prompt,
+            stdio_config_path,
+            base_url=base_url,
+            model=model,
+            api_key=api_key,
+            max_tools=max_tools,
+            no_think=no_think,
+            max_tokens=max_tokens,
+        )
+        return await run_cli(cmd, timeout)
+    else:
+        return {
+            "completed": False,
+            "output": f"Unknown agent: {agent_name}",
+            "duration_ms": 0,
+            "exit_code": -1,
+            "stderr": "",
+        }
+
+
+def _forward_agent_stderr(agent_name: str, result: dict) -> None:
+    # Forward agent stderr on failure so the error is visible to the user
+    if result["exit_code"] != 0 and result.get("stderr"):
+        _BOX_CHARS = frozenset("│╭╰╮─▄█▀ \t")
+        for line in result["stderr"].splitlines():
+            if "error" in line.lower():
+                logger.info(f"  [{agent_name}] !! {line.strip()}")
+            elif not all(c in _BOX_CHARS for c in line):
+                logger.info(f"  [{agent_name}] stderr: {line}")
+
+
+def _cleanup_scenario_temp(
+    stdio_config_path: Path | None, gemini_workdir: Path | None
+) -> None:
+    # Cleanup temp files
+    if stdio_config_path and stdio_config_path.exists():
+        stdio_config_path.unlink()
+    if gemini_workdir and gemini_workdir.exists():
+        shutil.rmtree(gemini_workdir, ignore_errors=True)
+
+
 async def run_agent_scenario(
     agent_name: str,
     scenario: dict,
@@ -517,56 +614,27 @@ async def run_agent_scenario(
             phase_key = phase.replace("_prompt", "")
             logger.info(f"  [{agent_name}] Running {phase_key}...")
 
-            if agent_name == "claude":
-                assert stdio_config_path is not None
-                cmd = build_claude_cmd(
-                    prompt, stdio_config_path, model=model or "sonnet"
-                )
-                result = await run_cli(cmd, timeout)
-            elif agent_name == "gemini":
-                cmd = build_gemini_cmd(prompt)
-                result = await run_cli(cmd, timeout, cwd=gemini_workdir)
-            elif agent_name == "openai":
-                assert stdio_config_path is not None
-                assert base_url is not None  # validated in run()
-                cmd = build_openai_cmd(
-                    prompt,
-                    stdio_config_path,
-                    base_url=base_url,
-                    model=model,
-                    api_key=api_key,
-                    max_tools=max_tools,
-                    no_think=no_think,
-                    max_tokens=max_tokens,
-                )
-                result = await run_cli(cmd, timeout)
-            else:
-                result = {
-                    "completed": False,
-                    "output": f"Unknown agent: {agent_name}",
-                    "duration_ms": 0,
-                    "exit_code": -1,
-                    "stderr": "",
-                }
+            result = await _run_agent_phase(
+                agent_name,
+                prompt,
+                stdio_config_path,
+                gemini_workdir,
+                timeout,
+                model=model,
+                base_url=base_url,
+                api_key=api_key,
+                max_tools=max_tools,
+                no_think=no_think,
+                max_tokens=max_tokens,
+            )
 
             results[phase_key] = result
             logger.info(
                 f"  [{agent_name}] {phase_key} completed (exit={result['exit_code']}, {result['duration_ms']}ms)"
             )
-            # Forward agent stderr on failure so the error is visible to the user
-            if result["exit_code"] != 0 and result.get("stderr"):
-                _BOX_CHARS = frozenset("│╭╰╮─▄█▀ \t")
-                for line in result["stderr"].splitlines():
-                    if "error" in line.lower():
-                        logger.info(f"  [{agent_name}] !! {line.strip()}")
-                    elif not all(c in _BOX_CHARS for c in line):
-                        logger.info(f"  [{agent_name}] stderr: {line}")
+            _forward_agent_stderr(agent_name, result)
     finally:
-        # Cleanup temp files
-        if stdio_config_path and stdio_config_path.exists():
-            stdio_config_path.unlink()
-        if gemini_workdir and gemini_workdir.exists():
-            shutil.rmtree(gemini_workdir, ignore_errors=True)
+        _cleanup_scenario_temp(stdio_config_path, gemini_workdir)
 
     return results
 
@@ -574,6 +642,24 @@ async def run_agent_scenario(
 # ---------------------------------------------------------------------------
 # Summary Generation
 # ---------------------------------------------------------------------------
+def _add_phase_stats(summary: dict, phase_result: dict) -> None:
+    # Always include stats (for comparison between branches)
+    if phase_result.get("num_turns") is not None:
+        summary["num_turns"] = phase_result["num_turns"]
+    if phase_result.get("session_id") is not None:
+        summary["session_id"] = phase_result["session_id"]
+    if phase_result.get("cost_usd") is not None:
+        summary["cost_usd"] = phase_result["cost_usd"]
+    if phase_result.get("tool_stats") is not None:
+        summary["tool_stats"] = phase_result["tool_stats"]
+    if phase_result.get("tokens_input") is not None:
+        summary["tokens_input"] = phase_result["tokens_input"]
+    if phase_result.get("tokens_output") is not None:
+        summary["tokens_output"] = phase_result["tokens_output"]
+    if phase_result.get("tokens_thoughts") is not None:
+        summary["tokens_thoughts"] = phase_result["tokens_thoughts"]
+
+
 def make_phase_summary(phase_key: str, phase_result: dict) -> dict:
     """Extract concise summary from a phase result (no raw_json)."""
     summary: dict = {
@@ -591,21 +677,7 @@ def make_phase_summary(phase_key: str, phase_result: dict) -> dict:
             summary["tool_trace"] = tool_lines
     if not phase_result["completed"] and stderr:
         summary["stderr"] = stderr
-    # Always include stats (for comparison between branches)
-    if phase_result.get("num_turns") is not None:
-        summary["num_turns"] = phase_result["num_turns"]
-    if phase_result.get("session_id") is not None:
-        summary["session_id"] = phase_result["session_id"]
-    if phase_result.get("cost_usd") is not None:
-        summary["cost_usd"] = phase_result["cost_usd"]
-    if phase_result.get("tool_stats") is not None:
-        summary["tool_stats"] = phase_result["tool_stats"]
-    if phase_result.get("tokens_input") is not None:
-        summary["tokens_input"] = phase_result["tokens_input"]
-    if phase_result.get("tokens_output") is not None:
-        summary["tokens_output"] = phase_result["tokens_output"]
-    if phase_result.get("tokens_thoughts") is not None:
-        summary["tokens_thoughts"] = phase_result["tokens_thoughts"]
+    _add_phase_stats(summary, phase_result)
     return summary
 
 
@@ -690,24 +762,14 @@ def make_summary(full_results: dict) -> dict:
 # ---------------------------------------------------------------------------
 # Main
 # ---------------------------------------------------------------------------
-async def run(args: argparse.Namespace) -> dict:
-    """Execute the BAT scenario and return results."""
-    # Read scenario
-    if args.scenario_file:
-        scenario = json.loads(Path(args.scenario_file).read_text())  # noqa: ASYNC240
-    else:
-        if sys.stdin.isatty():
-            raise ValueError(
-                "No scenario provided. Pipe scenario JSON via stdin, or pass --scenario-file.\n"
-                '  echo \'{"test_prompt":"..."}\' | uv run python tests/uat/run_uat.py --agents gemini\n'
-                "  uv run python tests/uat/run_uat.py --scenario-file scenario.json --agents gemini\n"
-                "For the pre-built story catalog, use tests/uat/stories/run_story.py --all."
-            )
-        scenario = json.loads(sys.stdin.read())
+def _resolve_active_agents(
+    args: argparse.Namespace,
+) -> tuple[dict[str, bool], list[str]]:
+    """Resolve requested agents to (availability map, active list).
 
-    if "test_prompt" not in scenario:
-        raise ValueError("scenario must contain 'test_prompt'")
-
+    Raises ValueError if no agent is available, or if the openai agent is
+    requested without --base-url.
+    """
     # Determine agents
     requested_agents = [a.strip() for a in args.agents.split(",")]
     agents: dict[str, bool] = {}
@@ -726,7 +788,10 @@ async def run(args: argparse.Namespace) -> dict:
             "--base-url is required when using the openai agent. "
             "Example: --base-url http://localhost:1234/v1"
         )
+    return agents, active_agents
 
+
+def _run_preflight_checks(args: argparse.Namespace, active_agents: list[str]) -> None:
     # Preflight: fail fast if Docker or the OpenAI endpoint is unreachable,
     # rather than stalling inside container startup / model warmup.
     if not args.ha_url:
@@ -737,6 +802,65 @@ async def run(args: argparse.Namespace) -> dict:
         err = preflight_check_base_url(args.base_url)
         if err:
             raise RuntimeError(err)
+
+
+async def _run_all_agents(
+    active_agents: list[str],
+    agents: dict[str, bool],
+    scenario: dict,
+    ha_url: str,
+    ha_token: str,
+    args: argparse.Namespace,
+    extra_env: dict[str, str],
+) -> dict:
+    """Run each active agent's scenario sequentially; mark unavailable agents."""
+    # Run agents sequentially to avoid resource contention
+    agent_results = {}
+    for name in active_agents:
+        agent_results[name] = await run_agent_scenario(
+            name,
+            scenario,
+            ha_url,
+            ha_token,
+            args.branch,
+            args.timeout,
+            model=getattr(args, "model", None),
+            base_url=getattr(args, "base_url", None),
+            api_key=getattr(args, "api_key", "no-key"),
+            max_tools=getattr(args, "max_tools", None),
+            no_think=getattr(args, "no_think", False),
+            max_tokens=getattr(args, "max_tokens", None),
+            extra_env=extra_env,
+        )
+
+    # Add unavailable agents
+    for name, avail in agents.items():
+        if not avail:
+            agent_results[name] = {"available": False}
+    return agent_results
+
+
+async def run(args: argparse.Namespace) -> dict:
+    """Execute the BAT scenario and return results."""
+    # Read scenario
+    if args.scenario_file:
+        scenario = json.loads(Path(args.scenario_file).read_text())  # noqa: ASYNC240
+    else:
+        if sys.stdin.isatty():
+            raise ValueError(
+                "No scenario provided. Pipe scenario JSON via stdin, or pass --scenario-file.\n"
+                '  echo \'{"test_prompt":"..."}\' | uv run python tests/uat/run_uat.py --agents gemini\n'
+                "  uv run python tests/uat/run_uat.py --scenario-file scenario.json --agents gemini\n"
+                "For the pre-built story catalog, use tests/uat/stories/run_story.py --all."
+            )
+        scenario = json.loads(sys.stdin.read())
+
+    if "test_prompt" not in scenario:
+        raise ValueError("scenario must contain 'test_prompt'")
+
+    agents, active_agents = _resolve_active_agents(args)
+
+    _run_preflight_checks(args, active_agents)
 
     # Start HA (container or external)
     ha_url = args.ha_url
@@ -763,29 +887,9 @@ async def run(args: argparse.Namespace) -> dict:
             on_default_applied=logger.info,
         )
 
-        # Run agents sequentially to avoid resource contention
-        agent_results = {}
-        for name in active_agents:
-            agent_results[name] = await run_agent_scenario(
-                name,
-                scenario,
-                ha_url,
-                ha_token,
-                args.branch,
-                args.timeout,
-                model=getattr(args, "model", None),
-                base_url=getattr(args, "base_url", None),
-                api_key=getattr(args, "api_key", "no-key"),
-                max_tools=getattr(args, "max_tools", None),
-                no_think=getattr(args, "no_think", False),
-                max_tokens=getattr(args, "max_tokens", None),
-                extra_env=extra_env,
-            )
-
-        # Add unavailable agents
-        for name, avail in agents.items():
-            if not avail:
-                agent_results[name] = {"available": False}
+        agent_results = await _run_all_agents(
+            active_agents, agents, scenario, ha_url, ha_token, args, extra_env
+        )
 
         return {
             "scenario": scenario,

--- a/tests/uat/stories/run_story.py
+++ b/tests/uat/stories/run_story.py
@@ -242,6 +242,32 @@ def _extract_tool_calls(session_file: str | None, agent: str) -> int | None:
     return None if seq is None else len(seq)
 
 
+def _gemini_tool_sequence(session_file: str) -> list[str]:
+    """Ordered tool-call names from a gemini session file."""
+    data = json.loads(Path(session_file).read_text())
+    seq: list[str] = []
+    for msg in data.get("messages", []):
+        for call in msg.get("toolCalls", []):
+            name = call.get("name") or call.get("toolName")
+            if name:
+                seq.append(name)
+    return seq
+
+
+def _claude_tool_sequence(session_file: str) -> list[str]:
+    """Ordered tool-call names from a claude session file."""
+    seq: list[str] = []
+    for line in Path(session_file).read_text().splitlines():
+        entry = json.loads(line)
+        if entry.get("type") == "assistant":
+            for block in entry.get("message", {}).get("content", []):
+                if block.get("type") == "tool_use":
+                    name = block.get("name")
+                    if name:
+                        seq.append(name)
+    return seq
+
+
 def _extract_tool_sequence(session_file: str | None, agent: str) -> list[str] | None:
     """Extract the ordered tool-call sequence (names only) from a session file.
 
@@ -254,26 +280,10 @@ def _extract_tool_sequence(session_file: str | None, agent: str) -> list[str] | 
 
     try:
         if agent == "gemini":
-            data = json.loads(Path(session_file).read_text())
-            seq: list[str] = []
-            for msg in data.get("messages", []):
-                for call in msg.get("toolCalls", []):
-                    name = call.get("name") or call.get("toolName")
-                    if name:
-                        seq.append(name)
-            return seq
+            return _gemini_tool_sequence(session_file)
 
         if agent == "claude":
-            seq = []
-            for line in Path(session_file).read_text().splitlines():
-                entry = json.loads(line)
-                if entry.get("type") == "assistant":
-                    for block in entry.get("message", {}).get("content", []):
-                        if block.get("type") == "tool_use":
-                            name = block.get("name")
-                            if name:
-                                seq.append(name)
-            return seq
+            return _claude_tool_sequence(session_file)
     except Exception as exc:
         logger.warning(f"  Tool sequence extraction failed: {exc}")
         return None
@@ -347,24 +357,19 @@ async def _run_mcp_steps(mcp_client: MCPClient, steps: list[dict], phase: str) -
 # ---------------------------------------------------------------------------
 # Test prompt execution via agent CLI
 # ---------------------------------------------------------------------------
-def _run_test_prompt(
-    prompt: str,
+def _build_run_uat_cmd(
     agent: str,
     ha_url: str,
     ha_token: str,
-    branch: str | None = None,
-    extra_args: list[str] | None = None,
-    model: str | None = None,
-    base_url: str | None = None,
-    api_key: str | None = None,
-    max_tools: int | None = None,
-    no_think: bool = False,
-    max_tokens: int | None = None,
-    mcp_env: list[str] | None = None,
-) -> tuple[int, dict | None]:
-    """Run test prompt via run_uat.py for a single agent. Returns (exit_code, parsed_summary)."""
-    scenario = {"test_prompt": prompt.strip()}
-
+    branch: str | None,
+    model: str | None,
+    base_url: str | None,
+    api_key: str | None,
+    max_tools: int | None,
+    no_think: bool,
+    max_tokens: int | None,
+) -> list[str]:
+    """Assemble the base run_uat.py subprocess command and its simple flags."""
     cmd = [
         sys.executable,
         str(RUN_UAT),
@@ -389,6 +394,39 @@ def _run_test_prompt(
         cmd.append("--no-think")
     if max_tokens is not None:
         cmd.extend(["--max-tokens", str(max_tokens)])
+    return cmd
+
+
+def _run_test_prompt(
+    prompt: str,
+    agent: str,
+    ha_url: str,
+    ha_token: str,
+    branch: str | None = None,
+    extra_args: list[str] | None = None,
+    model: str | None = None,
+    base_url: str | None = None,
+    api_key: str | None = None,
+    max_tools: int | None = None,
+    no_think: bool = False,
+    max_tokens: int | None = None,
+    mcp_env: list[str] | None = None,
+) -> tuple[int, dict | None]:
+    """Run test prompt via run_uat.py for a single agent. Returns (exit_code, parsed_summary)."""
+    scenario = {"test_prompt": prompt.strip()}
+
+    cmd = _build_run_uat_cmd(
+        agent,
+        ha_url,
+        ha_token,
+        branch,
+        model,
+        base_url,
+        api_key,
+        max_tools,
+        no_think,
+        max_tokens,
+    )
     if mcp_env:
         for pair in mcp_env:
             cmd.extend(["--mcp-env", pair])
@@ -709,6 +747,83 @@ def _suite_exit_code(all_results: list, backend_aborted: bool) -> int:
 # ---------------------------------------------------------------------------
 # JSONL results
 # ---------------------------------------------------------------------------
+def _add_result_markers(record: dict, test_phase: dict) -> None:
+    # Surface the failure-reason marker so reports can tell an incomplete run
+    # (e.g. context_window_exceeded, hit_iteration_limit) apart from a run that
+    # finished but failed its checks.
+    error = test_phase.get("error")
+    if error:
+        record["error"] = error
+    context_overflow = test_phase.get("context_overflow")
+    if context_overflow:
+        record["context_overflow"] = context_overflow
+
+    # Cost from Claude's JSON output (direct, no session file needed)
+    cost_usd = test_phase.get("cost_usd")
+    if cost_usd is not None:
+        record["cost_usd"] = cost_usd
+
+
+def _add_tool_sequence(record: dict, session_file: str | None, agent: str) -> None:
+    # Extract tool call count from session file if not in summary.
+    # Always extract the ordered sequence too — flip-flop count is the BAT's
+    # primary native-path metric (openai path emits the sequence directly).
+    seq = _extract_tool_sequence(session_file, agent)
+    if record["tool_calls"] is None and seq is not None:
+        record["tool_calls"] = len(seq)
+    if seq:
+        record["tool_sequence"] = seq
+
+
+def _add_token_usage(
+    record: dict, test_phase: dict, session_file: str | None, agent: str
+) -> None:
+    # Extract token usage: from phase summary (openai) or session file (claude/gemini)
+    tokens = _extract_tokens(session_file, agent)
+    if tokens is None:
+        ti = test_phase.get("tokens_input")
+        to = test_phase.get("tokens_output")
+        if ti is not None or to is not None:
+            # reasoning_tokens are a subset of completion_tokens, so tokens_output
+            # already counts them; tokens_thoughts is the informational breakdown.
+            tokens = {
+                "input": ti or 0,
+                "output": to or 0,
+                "cached": 0,
+                "thoughts": test_phase.get("tokens_thoughts") or 0,
+            }
+    if tokens:
+        record["tokens_input"] = tokens["input"]
+        record["tokens_output"] = tokens["output"]
+        record["tokens_cached"] = tokens["cached"]
+        record["tokens_thoughts"] = tokens["thoughts"]
+        record["tokens_billable"] = (tokens["input"] - tokens["cached"]) + tokens[
+            "output"
+        ]
+
+
+def _add_response_and_verify(
+    record: dict, test_phase: dict, verify_results: list[dict] | None
+) -> None:
+    # Always include agent_response so passing runs are inspectable.
+    agent_response = test_phase.get("output", "")
+    if agent_response:
+        record["agent_response"] = agent_response
+
+    # Always include tool_trace (openai path: ordered name+args from
+    # tool_trace_sink) — the BAT's primary signal for tool-pick analysis,
+    # not just for failure debug.
+    tool_trace = test_phase.get("tool_trace")
+    if tool_trace:
+        record["tool_trace"] = tool_trace
+
+    # verify_results stays failure-only — too verbose for the BAT result
+    # file otherwise, and verify_results.passed is already captured in
+    # record["passed"].
+    if verify_results is not None and not all(r["passed"] for r in verify_results):
+        record["verify_results"] = verify_results
+
+
 def append_result(
     results_file: Path,
     story: dict,
@@ -751,52 +866,11 @@ def append_result(
     if session_file:
         record["session_file"] = session_file
 
-    # Surface the failure-reason marker so reports can tell an incomplete run
-    # (e.g. context_window_exceeded, hit_iteration_limit) apart from a run that
-    # finished but failed its checks.
-    error = test_phase.get("error")
-    if error:
-        record["error"] = error
-    context_overflow = test_phase.get("context_overflow")
-    if context_overflow:
-        record["context_overflow"] = context_overflow
+    _add_result_markers(record, test_phase)
 
-    # Cost from Claude's JSON output (direct, no session file needed)
-    cost_usd = test_phase.get("cost_usd")
-    if cost_usd is not None:
-        record["cost_usd"] = cost_usd
+    _add_tool_sequence(record, session_file, agent)
 
-    # Extract tool call count from session file if not in summary.
-    # Always extract the ordered sequence too — flip-flop count is the BAT's
-    # primary native-path metric (openai path emits the sequence directly).
-    seq = _extract_tool_sequence(session_file, agent)
-    if record["tool_calls"] is None and seq is not None:
-        record["tool_calls"] = len(seq)
-    if seq:
-        record["tool_sequence"] = seq
-
-    # Extract token usage: from phase summary (openai) or session file (claude/gemini)
-    tokens = _extract_tokens(session_file, agent)
-    if tokens is None:
-        ti = test_phase.get("tokens_input")
-        to = test_phase.get("tokens_output")
-        if ti is not None or to is not None:
-            # reasoning_tokens are a subset of completion_tokens, so tokens_output
-            # already counts them; tokens_thoughts is the informational breakdown.
-            tokens = {
-                "input": ti or 0,
-                "output": to or 0,
-                "cached": 0,
-                "thoughts": test_phase.get("tokens_thoughts") or 0,
-            }
-    if tokens:
-        record["tokens_input"] = tokens["input"]
-        record["tokens_output"] = tokens["output"]
-        record["tokens_cached"] = tokens["cached"]
-        record["tokens_thoughts"] = tokens["thoughts"]
-        record["tokens_billable"] = (tokens["input"] - tokens["cached"]) + tokens[
-            "output"
-        ]
+    _add_token_usage(record, test_phase, session_file, agent)
 
     # First-turn input tokens: most direct measure of idle context size (openai agent only).
     # Comes from aggregate (not test_phase) since make_phase_summary doesn't propagate it.
@@ -804,23 +878,7 @@ def append_result(
     if tokens_first_input is not None:
         record["tokens_first_input"] = tokens_first_input
 
-    # Always include agent_response so passing runs are inspectable.
-    agent_response = test_phase.get("output", "")
-    if agent_response:
-        record["agent_response"] = agent_response
-
-    # Always include tool_trace (openai path: ordered name+args from
-    # tool_trace_sink) — the BAT's primary signal for tool-pick analysis,
-    # not just for failure debug.
-    tool_trace = test_phase.get("tool_trace")
-    if tool_trace:
-        record["tool_trace"] = tool_trace
-
-    # verify_results stays failure-only — too verbose for the BAT result
-    # file otherwise, and verify_results.passed is already captured in
-    # record["passed"].
-    if verify_results is not None and not all(r["passed"] for r in verify_results):
-        record["verify_results"] = verify_results
+    _add_response_and_verify(record, test_phase, verify_results)
 
     results_file.parent.mkdir(parents=True, exist_ok=True)
     with open(results_file, "a") as f:
@@ -909,25 +967,14 @@ def _record_backend_abort(
 # ---------------------------------------------------------------------------
 # Main
 # ---------------------------------------------------------------------------
-async def run_stories(
-    args: argparse.Namespace, filtered: list[tuple[Path, dict]]
-) -> int:
-    """Run stories with a fresh container per agent.
+def _preflight_stories(
+    args: argparse.Namespace, agent_list: list[str], using_external_ha: bool
+) -> int | None:
+    """Fail-fast preflight for docker/openai reachability.
 
-    For each agent: start container -> run all stories -> stop container.
-    When --ha-url is provided, all agents share the external instance.
+    Returns a nonzero exit code to abort the run, or None to proceed.
     """
-    run_start = time.monotonic()
-    sha, describe = get_git_info()
-    agent_list = [a.strip() for a in args.agents.split(",")]
-    using_external_ha = bool(args.ha_url)
-
-    from uat.run_uat import (
-        build_stdio_mcp_config,
-        parse_mcp_env,
-        preflight_check_base_url,
-        preflight_check_docker,
-    )
+    from uat.run_uat import preflight_check_base_url, preflight_check_docker
 
     if not using_external_ha:
         err = preflight_check_docker()
@@ -939,293 +986,499 @@ async def run_stories(
         if err:
             logger.critical(err)
             return 2
+    return None
 
-    all_results: list[tuple[str, str, dict, int, dict | None, str | None, bool]] = []
-    # Each entry: (agent, story_id, story, exit_code, summary, session_file, passed)
-    backend_aborted = False  # set if any agent aborted on an unreachable backend
 
-    mcp_env_dict = parse_mcp_env(
-        getattr(args, "mcp_env", None),
-        base_url=args.base_url,
-        on_default_applied=logger.info,
+def _log_kept_container(agent: str, ha: dict | None, keep_container: bool) -> None:
+    if ha and keep_container:
+        logger.info(f"\n[{agent}] Container kept alive: {ha['url']}")
+        logger.info(f"[{agent}] Token: {ha['token']}")
+        logger.info(f"[{agent}] Config dir: {ha['config_dir']}")
+        logger.info(f"[{agent}] Stop manually: docker stop <container>")
+
+
+async def _setup_inline_agent(
+    agent: str,
+    ha_url: str,
+    ha_token: str,
+    args: argparse.Namespace,
+    agent_stack: contextlib.AsyncExitStack,
+    mcp_env_dict: dict[str, str],
+    filtered: list[tuple[Path, dict]],
+    all_results: list,
+    sha: str,
+    describe: str,
+) -> tuple[openai.AsyncOpenAI, str, str | None, MCPClient, list[dict]] | None:
+    """Warm the OpenAI client and start the shared MCP server for an inline agent.
+
+    Returns ``(openai_client, resolved_model, resolved_quant, inline_mcp_client,
+    openai_tools)`` on success, or ``None`` if setup failed (a per-story failure
+    row is recorded before returning).
+    """
+    from fastmcp import Client as _MCPClient
+    from uat.openai_agent import (
+        create_and_warm_openai_client,
+        fetch_openai_tools,
     )
-    effective_mcp_env: list[str] = [f"{k}={v}" for k, v in mcp_env_dict.items()]
+    from uat.run_uat import build_stdio_mcp_config
 
-    for agent in agent_list:
-        logger.info(f"\n{'#' * 60}")
-        logger.info(f"Agent: {agent}")
-        logger.info(f"{'#' * 60}")
+    config = build_stdio_mcp_config(ha_url, ha_token, args.branch, mcp_env_dict or None)
+    try:
+        (
+            openai_client,
+            resolved_model,
+            resolved_quant,
+        ) = await create_and_warm_openai_client(
+            base_url=args.base_url,
+            api_key=args.api_key,
+            model=args.model,
+        )
+        agent_stack.push_async_callback(openai_client.close)
+    except Exception as e:
+        error_msg = f"Failed to initialise OpenAI client: {type(e).__name__}: {e}"
+        logger.error(f"[{agent}] {error_msg}")
+        _record_setup_failure(
+            filtered,
+            agent,
+            error_msg,
+            all_results=all_results,
+            results_file=args.results_file,
+            sha=sha,
+            describe=describe,
+            branch=args.branch,
+        )
+        return None
+    try:
+        source = f"uvx download @ {args.branch}" if args.branch else "local"
+        logger.info(f"[{agent}] Starting MCP server ({source})...")
+        inline_mcp_client = await agent_stack.enter_async_context(_MCPClient(config))
+        openai_tools = await fetch_openai_tools(
+            inline_mcp_client, max_tools=args.max_tools
+        )
+        logger.info(f"[{agent}] MCP server ready ({len(openai_tools)} tools)")
+    except Exception as e:
+        error_msg = f"Failed to start MCP server: {type(e).__name__}: {e}"
+        logger.error(f"[{agent}] {error_msg}")
+        _record_setup_failure(
+            filtered,
+            agent,
+            error_msg,
+            all_results=all_results,
+            results_file=args.results_file,
+            sha=sha,
+            describe=describe,
+            branch=args.branch,
+        )
+        return None
+    return (
+        openai_client,
+        resolved_model,
+        resolved_quant,
+        inline_mcp_client,
+        openai_tools,
+    )
 
-        ha = None
-        ha_url = args.ha_url
-        ha_token = args.ha_token
-        if not using_external_ha:
-            ha = _start_container(keep_alive=args.keep_container)
-            ha_url = ha["url"]
-            ha_token = ha["token"]
 
-        # Inline agents (see INLINE_AGENTS) hold one MCP server + one OpenAI
-        # client across all stories for this agent, skipping the per-story
-        # MCP server spawn and model warmup. Other agents take the subprocess
-        # path via _run_test_prompt.
-        use_inline = agent in INLINE_AGENTS
-        inline_mcp_client: MCPClient | None = None
-        openai_client: openai.AsyncOpenAI | None = None
-        resolved_model: str | None = None
-        resolved_quant: str | None = None
-        openai_tools: list[dict] = []
+async def _execute_prompt(
+    story_index: int,
+    story: dict,
+    *,
+    agent: str,
+    use_inline: bool,
+    ha_url: str,
+    ha_token: str,
+    openai_client,
+    inline_mcp_client,
+    resolved_model: str | None,
+    openai_tools: list[dict],
+    args: argparse.Namespace,
+    effective_mcp_env: list[str],
+    filtered: list[tuple[Path, dict]],
+    sha: str,
+    describe: str,
+) -> tuple[int | None, dict | None, bool]:
+    """Execute one story's test prompt (inline or subprocess).
 
-        async with contextlib.AsyncExitStack() as agent_stack:
-            if ha and not args.keep_container:
-                agent_stack.callback(_stop_container, ha)
+    Returns ``(rc, summary, aborted)``. ``aborted`` is True only when the
+    inline backend connection was refused/reset, in which case a backend-abort
+    marker has already been recorded and the caller should stop this agent.
+    """
+    sid = story["id"]
+    if use_inline:
+        import openai
 
-            if use_inline:
-                import openai  # runtime ref for APIConnectionError in the story loop
-                from fastmcp import Client as _MCPClient
-                from uat.openai_agent import (
-                    create_and_warm_openai_client,
-                    fetch_openai_tools,
-                )
-
-                config = build_stdio_mcp_config(
-                    ha_url, ha_token, args.branch, mcp_env_dict or None
-                )
-                try:
-                    (
-                        openai_client,
-                        resolved_model,
-                        resolved_quant,
-                    ) = await create_and_warm_openai_client(
-                        base_url=args.base_url,
-                        api_key=args.api_key,
-                        model=args.model,
-                    )
-                    agent_stack.push_async_callback(openai_client.close)
-                except Exception as e:
-                    error_msg = (
-                        f"Failed to initialise OpenAI client: {type(e).__name__}: {e}"
-                    )
-                    logger.error(f"[{agent}] {error_msg}")
-                    _record_setup_failure(
-                        filtered,
-                        agent,
-                        error_msg,
-                        all_results=all_results,
-                        results_file=args.results_file,
-                        sha=sha,
-                        describe=describe,
-                        branch=args.branch,
-                    )
-                    continue
-                try:
-                    source = f"uvx download @ {args.branch}" if args.branch else "local"
-                    logger.info(f"[{agent}] Starting MCP server ({source})...")
-                    inline_mcp_client = await agent_stack.enter_async_context(
-                        _MCPClient(config)
-                    )
-                    openai_tools = await fetch_openai_tools(
-                        inline_mcp_client, max_tools=args.max_tools
-                    )
-                    logger.info(
-                        f"[{agent}] MCP server ready ({len(openai_tools)} tools)"
-                    )
-                except Exception as e:
-                    error_msg = f"Failed to start MCP server: {type(e).__name__}: {e}"
-                    logger.error(f"[{agent}] {error_msg}")
-                    _record_setup_failure(
-                        filtered,
-                        agent,
-                        error_msg,
-                        all_results=all_results,
-                        results_file=args.results_file,
-                        sha=sha,
-                        describe=describe,
-                        branch=args.branch,
-                    )
-                    continue
-
-            if ha and args.keep_container:
-                logger.info(f"\n[{agent}] Container kept alive: {ha['url']}")
-                logger.info(f"[{agent}] Token: {ha['token']}")
-                logger.info(f"[{agent}] Config dir: {ha['config_dir']}")
-                logger.info(f"[{agent}] Stop manually: docker stop <container>")
-
-            shared_mcp = await agent_stack.enter_async_context(
-                inprocess_mcp_client(ha_url, ha_token)
+        assert (
+            openai_client is not None
+            and inline_mcp_client is not None
+            and resolved_model is not None
+        ), "inline setup invariant: clients/model are populated when use_inline is True"
+        try:
+            rc, summary = await _run_test_prompt_inline(
+                story["prompt"],
+                agent_name=agent,
+                openai_client=openai_client,
+                mcp_client=inline_mcp_client,
+                model=resolved_model,
+                openai_tools=openai_tools,
+                no_think=args.no_think,
+                max_tokens=getattr(args, "max_tokens", None),
             )
+        except openai.APIConnectionError as e:
+            # A refused/reset connection (NOT a timeout; those are
+            # handled per-story inside _run_test_prompt_inline). The
+            # backend is gone, so abort this agent's remaining stories
+            # rather than failing each one in turn. The current story
+            # never validly ran, so it is skipped too (not recorded).
+            _record_backend_abort(
+                args.results_file,
+                agent,
+                sid,
+                [s["id"] for _p, s in filtered[story_index:]],
+                f"{type(e).__name__}: {e}",
+                sha=sha,
+                describe=describe,
+                branch=args.branch,
+            )
+            return None, None, True
+    else:
+        rc, summary = _run_test_prompt(
+            story["prompt"],
+            agent,
+            ha_url,
+            ha_token,
+            args.branch,
+            args.extra_args or None,
+            model=args.model,
+            base_url=args.base_url,
+            api_key=args.api_key,
+            max_tools=args.max_tools,
+            no_think=args.no_think,
+            max_tokens=getattr(args, "max_tokens", None),
+            mcp_env=effective_mcp_env or None,
+        )
 
-            # Consecutive per-story timeouts; reset by any non-timeout story.
-            # Hitting CONSECUTIVE_TIMEOUT_ABORT aborts the agent (backend gone).
-            consecutive_timeouts = 0
+    return rc, summary, False
 
-            for story_index, (_path, story) in enumerate(filtered):
-                sid = story["id"]
-                logger.info(f"\n{'=' * 60}")
-                logger.info(f"[{agent}] Story {sid}: {story['title']}")
-                logger.info(f"{'=' * 60}")
 
-                setup_steps = story.get("setup") or []
-                if setup_steps:
-                    logger.info(
-                        f"[{agent}/{sid}] Setup ({len(setup_steps)} steps via FastMCP)..."
-                    )
-                    await _run_mcp_steps(shared_mcp, setup_steps, "setup")
+def _resolve_session_file(
+    summary: dict | None, agent: str, prompt_start: float
+) -> tuple[str | None, dict]:
+    """Locate the agent's session file and return (session_file, test_phase)."""
+    session_file = None
+    test_phase = (summary or {}).get("agents", {}).get(agent, {}).get("test", {})
+    claude_session_id = test_phase.get("session_id")
+    if claude_session_id:
+        session_file = _find_session_file_by_id(claude_session_id)
+    if not session_file:
+        session_file = _find_latest_session_file(agent, after=prompt_start)
+    return session_file, test_phase
 
-                logger.info(f"[{agent}/{sid}] Running test prompt...")
-                # ``prompt_start`` is compared to file ``st_mtime`` in
-                # ``_find_latest_session_file`` below, so it MUST be a
-                # wall-clock Unix epoch (not ``time.monotonic()``).
-                prompt_start = time.time()
-                summary: dict | None
-                if use_inline:
-                    assert (
-                        openai_client is not None
-                        and inline_mcp_client is not None
-                        and resolved_model is not None
-                    ), (
-                        "inline setup invariant: clients/model are populated when use_inline is True"
-                    )
-                    try:
-                        rc, summary = await _run_test_prompt_inline(
-                            story["prompt"],
-                            agent_name=agent,
-                            openai_client=openai_client,
-                            mcp_client=inline_mcp_client,
-                            model=resolved_model,
-                            openai_tools=openai_tools,
-                            no_think=args.no_think,
-                            max_tokens=getattr(args, "max_tokens", None),
-                        )
-                    except openai.APIConnectionError as e:
-                        # A refused/reset connection (NOT a timeout; those are
-                        # handled per-story inside _run_test_prompt_inline). The
-                        # backend is gone, so abort this agent's remaining stories
-                        # rather than failing each one in turn. The current story
-                        # never validly ran, so it is skipped too (not recorded).
-                        _record_backend_abort(
-                            args.results_file,
-                            agent,
-                            sid,
-                            [s["id"] for _p, s in filtered[story_index:]],
-                            f"{type(e).__name__}: {e}",
-                            sha=sha,
-                            describe=describe,
-                            branch=args.branch,
-                        )
-                        backend_aborted = True
-                        break
-                else:
-                    rc, summary = _run_test_prompt(
-                        story["prompt"],
-                        agent,
-                        ha_url,
-                        ha_token,
-                        args.branch,
-                        args.extra_args or None,
-                        model=args.model,
-                        base_url=args.base_url,
-                        api_key=args.api_key,
-                        max_tools=args.max_tools,
-                        no_think=args.no_think,
-                        max_tokens=getattr(args, "max_tokens", None),
-                        mcp_env=effective_mcp_env or None,
-                    )
 
-                session_file = None
-                test_phase = (
-                    (summary or {}).get("agents", {}).get(agent, {}).get("test", {})
-                )
-                claude_session_id = test_phase.get("session_id")
-                if claude_session_id:
-                    session_file = _find_session_file_by_id(claude_session_id)
-                if not session_file:
-                    session_file = _find_latest_session_file(agent, after=prompt_start)
+async def _verify_story(
+    story: dict,
+    summary: dict | None,
+    agent: str,
+    sid: str,
+    ha_url: str,
+    ha_token: str,
+    shared_mcp,
+) -> list[dict] | None:
+    """Run the story's ha_checks (if any) and return the verify results."""
+    verify_results = None
+    ha_checks = (story.get("verify") or {}).get("ha_checks")
+    if ha_checks:
+        agent_output = (
+            (summary or {})
+            .get("agents", {})
+            .get(agent, {})
+            .get("test", {})
+            .get("output", "")
+        )
+        logger.info(f"[{agent}/{sid}] Verifying {len(ha_checks)} ha_check(s)...")
+        verify_results = await verify_ha_checks(
+            ha_url, ha_token, ha_checks, agent_output, shared_mcp
+        )
+        failed_checks = [r for r in verify_results if not r["passed"]]
+        if failed_checks:
+            logger.warning(
+                f"[{agent}/{sid}] {len(failed_checks)}/{len(ha_checks)} check(s) FAILED"
+            )
+            for r in failed_checks:
+                logger.warning(f"  FAIL [{r['type']}] {r['detail']}")
+        else:
+            logger.info(f"[{agent}/{sid}] All checks passed")
+    return verify_results
 
-                verify_results = None
-                ha_checks = (story.get("verify") or {}).get("ha_checks")
-                if ha_checks:
-                    agent_output = (
-                        (summary or {})
-                        .get("agents", {})
-                        .get(agent, {})
-                        .get("test", {})
-                        .get("output", "")
-                    )
-                    logger.info(
-                        f"[{agent}/{sid}] Verifying {len(ha_checks)} ha_check(s)..."
-                    )
-                    verify_results = await verify_ha_checks(
-                        ha_url, ha_token, ha_checks, agent_output, shared_mcp
-                    )
-                    failed_checks = [r for r in verify_results if not r["passed"]]
-                    if failed_checks:
-                        logger.warning(
-                            f"[{agent}/{sid}] {len(failed_checks)}/{len(ha_checks)} check(s) FAILED"
-                        )
-                        for r in failed_checks:
-                            logger.warning(f"  FAIL [{r['type']}] {r['detail']}")
-                    else:
-                        logger.info(f"[{agent}/{sid}] All checks passed")
 
-                agg = (
-                    (summary or {})
-                    .get("agents", {})
-                    .get(agent, {})
-                    .get("aggregate", {})
-                )
-                passed = _compute_passed(
-                    exit_code=rc,
-                    tool_calls=agg.get("total_tool_calls"),
-                    verify_results=verify_results,
-                    completed=_run_completed(test_phase, summary, rc),
-                )
-                all_results.append(
-                    (agent, sid, story, rc, summary, session_file, passed)
-                )
+def _record_story_result(
+    story: dict,
+    summary: dict | None,
+    agent: str,
+    sid: str,
+    rc: int | None,
+    session_file: str | None,
+    test_phase: dict,
+    verify_results: list[dict] | None,
+    all_results: list,
+    args: argparse.Namespace,
+    resolved_model: str | None,
+    resolved_quant: str | None,
+    sha: str,
+    describe: str,
+) -> None:
+    """Compute pass/fail, append to all_results, and persist the JSONL row."""
+    agg = (summary or {}).get("agents", {}).get(agent, {}).get("aggregate", {})
+    passed = _compute_passed(
+        exit_code=rc,
+        tool_calls=agg.get("total_tool_calls"),
+        verify_results=verify_results,
+        completed=_run_completed(test_phase, summary, rc),
+    )
+    all_results.append((agent, sid, story, rc, summary, session_file, passed))
 
-                if summary or verify_results is not None:
-                    append_result(
-                        args.results_file,
-                        story,
-                        agent,
-                        sha,
-                        describe,
-                        args.branch,
-                        summary or {},
-                        session_file,
-                        passed=passed,
-                        verify_results=verify_results,
-                        model=resolved_model or args.model,
-                        quantization=resolved_quant,
-                    )
+    if summary or verify_results is not None:
+        append_result(
+            args.results_file,
+            story,
+            agent,
+            sha,
+            describe,
+            args.branch,
+            summary or {},
+            session_file,
+            passed=passed,
+            verify_results=verify_results,
+            model=resolved_model or args.model,
+            quantization=resolved_quant,
+        )
 
-                if session_file:
-                    logger.info(f"[{agent}/{sid}] Session file: {session_file}")
+    if session_file:
+        logger.info(f"[{agent}/{sid}] Session file: {session_file}")
 
-                # A request timeout is recorded above as a per-story failure, but
-                # several in a row mean the backend has stopped responding: abort
-                # rather than time out on every remaining story. Unlike the
-                # connection-error path (which skips the current story, never
-                # validly run), the timed-out story here WAS recorded, so only
-                # the stories after it are skipped.
-                consecutive_timeouts = _update_timeout_streak(
-                    consecutive_timeouts,
-                    was_timeout=test_phase.get("error") == TIMEOUT_ERROR_MARKER,
-                )
-                if consecutive_timeouts >= CONSECUTIVE_TIMEOUT_ABORT:
-                    _record_backend_abort(
-                        args.results_file,
-                        agent,
-                        sid,
-                        _stories_after(filtered, story_index),
-                        f"{consecutive_timeouts} consecutive request timeouts",
-                        sha=sha,
-                        describe=describe,
-                        branch=args.branch,
-                    )
-                    backend_aborted = True
-                    break
 
+async def _run_one_story(
+    story_index: int,
+    story: dict,
+    *,
+    agent: str,
+    use_inline: bool,
+    ha_url: str,
+    ha_token: str,
+    shared_mcp,
+    openai_client,
+    inline_mcp_client,
+    resolved_model: str | None,
+    resolved_quant: str | None,
+    openai_tools: list[dict],
+    args: argparse.Namespace,
+    effective_mcp_env: list[str],
+    filtered: list[tuple[Path, dict]],
+    all_results: list,
+    consecutive_timeouts: int,
+    sha: str,
+    describe: str,
+) -> tuple[bool, int]:
+    """Run one story end-to-end for an agent.
+
+    Returns ``(should_abort, consecutive_timeouts)``. ``should_abort`` is True
+    when the LLM backend went unreachable (connection error or the
+    consecutive-timeout threshold), signalling the caller to stop this agent.
+    """
+    sid = story["id"]
+    logger.info(f"\n{'=' * 60}")
+    logger.info(f"[{agent}] Story {sid}: {story['title']}")
+    logger.info(f"{'=' * 60}")
+
+    setup_steps = story.get("setup") or []
+    if setup_steps:
+        logger.info(f"[{agent}/{sid}] Setup ({len(setup_steps)} steps via FastMCP)...")
+        await _run_mcp_steps(shared_mcp, setup_steps, "setup")
+
+    logger.info(f"[{agent}/{sid}] Running test prompt...")
+    # ``prompt_start`` is compared to file ``st_mtime`` in
+    # ``_find_latest_session_file`` below, so it MUST be a
+    # wall-clock Unix epoch (not ``time.monotonic()``).
+    prompt_start = time.time()
+    rc, summary, aborted = await _execute_prompt(
+        story_index,
+        story,
+        agent=agent,
+        use_inline=use_inline,
+        ha_url=ha_url,
+        ha_token=ha_token,
+        openai_client=openai_client,
+        inline_mcp_client=inline_mcp_client,
+        resolved_model=resolved_model,
+        openai_tools=openai_tools,
+        args=args,
+        effective_mcp_env=effective_mcp_env,
+        filtered=filtered,
+        sha=sha,
+        describe=describe,
+    )
+    if aborted:
+        return True, consecutive_timeouts
+
+    session_file, test_phase = _resolve_session_file(summary, agent, prompt_start)
+
+    verify_results = await _verify_story(
+        story, summary, agent, sid, ha_url, ha_token, shared_mcp
+    )
+
+    _record_story_result(
+        story,
+        summary,
+        agent,
+        sid,
+        rc,
+        session_file,
+        test_phase,
+        verify_results,
+        all_results,
+        args,
+        resolved_model,
+        resolved_quant,
+        sha,
+        describe,
+    )
+
+    # A request timeout is recorded above as a per-story failure, but
+    # several in a row mean the backend has stopped responding: abort
+    # rather than time out on every remaining story. Unlike the
+    # connection-error path (which skips the current story, never
+    # validly run), the timed-out story here WAS recorded, so only
+    # the stories after it are skipped.
+    consecutive_timeouts = _update_timeout_streak(
+        consecutive_timeouts,
+        was_timeout=test_phase.get("error") == TIMEOUT_ERROR_MARKER,
+    )
+    if consecutive_timeouts >= CONSECUTIVE_TIMEOUT_ABORT:
+        _record_backend_abort(
+            args.results_file,
+            agent,
+            sid,
+            _stories_after(filtered, story_index),
+            f"{consecutive_timeouts} consecutive request timeouts",
+            sha=sha,
+            describe=describe,
+            branch=args.branch,
+        )
+        return True, consecutive_timeouts
+
+    return False, consecutive_timeouts
+
+
+async def _run_agent_stories(
+    agent: str,
+    args: argparse.Namespace,
+    filtered: list[tuple[Path, dict]],
+    all_results: list,
+    using_external_ha: bool,
+    mcp_env_dict: dict[str, str],
+    effective_mcp_env: list[str],
+    sha: str,
+    describe: str,
+) -> bool:
+    """Run all stories for one agent with a fresh container.
+
+    Returns whether the LLM backend became unreachable (aborting this agent's
+    remaining stories).
+    """
+    logger.info(f"\n{'#' * 60}")
+    logger.info(f"Agent: {agent}")
+    logger.info(f"{'#' * 60}")
+
+    ha = None
+    ha_url = args.ha_url
+    ha_token = args.ha_token
+    if not using_external_ha:
+        ha = _start_container(keep_alive=args.keep_container)
+        ha_url = ha["url"]
+        ha_token = ha["token"]
+
+    # Inline agents (see INLINE_AGENTS) hold one MCP server + one OpenAI
+    # client across all stories for this agent, skipping the per-story
+    # MCP server spawn and model warmup. Other agents take the subprocess
+    # path via _run_test_prompt.
+    use_inline = agent in INLINE_AGENTS
+    inline_mcp_client: MCPClient | None = None
+    openai_client: openai.AsyncOpenAI | None = None
+    resolved_model: str | None = None
+    resolved_quant: str | None = None
+    openai_tools: list[dict] = []
+
+    async with contextlib.AsyncExitStack() as agent_stack:
+        if ha and not args.keep_container:
+            agent_stack.callback(_stop_container, ha)
+
+        if use_inline:
+            setup = await _setup_inline_agent(
+                agent,
+                ha_url,
+                ha_token,
+                args,
+                agent_stack,
+                mcp_env_dict,
+                filtered,
+                all_results,
+                sha,
+                describe,
+            )
+            if setup is None:
+                return False
+            (
+                openai_client,
+                resolved_model,
+                resolved_quant,
+                inline_mcp_client,
+                openai_tools,
+            ) = setup
+
+        _log_kept_container(agent, ha, args.keep_container)
+
+        shared_mcp = await agent_stack.enter_async_context(
+            inprocess_mcp_client(ha_url, ha_token)
+        )
+
+        # Consecutive per-story timeouts; reset by any non-timeout story.
+        # Hitting CONSECUTIVE_TIMEOUT_ABORT aborts the agent (backend gone).
+        consecutive_timeouts = 0
+
+        for story_index, (_path, story) in enumerate(filtered):
+            should_abort, consecutive_timeouts = await _run_one_story(
+                story_index,
+                story,
+                agent=agent,
+                use_inline=use_inline,
+                ha_url=ha_url,
+                ha_token=ha_token,
+                shared_mcp=shared_mcp,
+                openai_client=openai_client,
+                inline_mcp_client=inline_mcp_client,
+                resolved_model=resolved_model,
+                resolved_quant=resolved_quant,
+                openai_tools=openai_tools,
+                args=args,
+                effective_mcp_env=effective_mcp_env,
+                filtered=filtered,
+                all_results=all_results,
+                consecutive_timeouts=consecutive_timeouts,
+                sha=sha,
+                describe=describe,
+            )
+            if should_abort:
+                return True
+
+    return False
+
+
+def _log_run_summary(
+    all_results: list,
+    backend_aborted: bool,
+    run_start: float,
+    args: argparse.Namespace,
+) -> int:
+    """Log the per-story summary table and totals; return the suite exit code."""
     # Summary
     logger.info(f"\n{'=' * 60}")
     logger.info("Summary")
@@ -1252,6 +1505,53 @@ async def run_stories(
     else:
         logger.info(f"\nAll {total} story runs passed")
     return _suite_exit_code(all_results, backend_aborted)
+
+
+async def run_stories(
+    args: argparse.Namespace, filtered: list[tuple[Path, dict]]
+) -> int:
+    """Run stories with a fresh container per agent.
+
+    For each agent: start container -> run all stories -> stop container.
+    When --ha-url is provided, all agents share the external instance.
+    """
+    run_start = time.monotonic()
+    sha, describe = get_git_info()
+    agent_list = [a.strip() for a in args.agents.split(",")]
+    using_external_ha = bool(args.ha_url)
+
+    from uat.run_uat import parse_mcp_env
+
+    rc = _preflight_stories(args, agent_list, using_external_ha)
+    if rc is not None:
+        return rc
+
+    all_results: list[tuple[str, str, dict, int, dict | None, str | None, bool]] = []
+    # Each entry: (agent, story_id, story, exit_code, summary, session_file, passed)
+    backend_aborted = False  # set if any agent aborted on an unreachable backend
+
+    mcp_env_dict = parse_mcp_env(
+        getattr(args, "mcp_env", None),
+        base_url=args.base_url,
+        on_default_applied=logger.info,
+    )
+    effective_mcp_env: list[str] = [f"{k}={v}" for k, v in mcp_env_dict.items()]
+
+    for agent in agent_list:
+        if await _run_agent_stories(
+            agent,
+            args,
+            filtered,
+            all_results,
+            using_external_ha,
+            mcp_env_dict,
+            effective_mcp_env,
+            sha,
+            describe,
+        ):
+            backend_aborted = True
+
+    return _log_run_summary(all_results, backend_aborted, run_start, args)
 
 
 def main() -> None:


### PR DESCRIPTION
## What does this PR do?

Fixes the 4 UAT-harness files from the C901 (McCabe complexity) grandfather list tracked in issue #925, by extracting private helper functions with no behavior change:

- `tests/uat/ha_wait.py`: `wait_for_ha_ready` (12)
- `tests/uat/openai_agent.py`: `tool_call_loop` (18)
- `tests/uat/run_uat.py`: `run_cli` (17), `run` (17), `run_agent_scenario` (14), `make_phase_summary` (11)
- `tests/uat/stories/run_story.py`: `run_stories` (27), `_run_test_prompt` (14), `append_result` (14), `_extract_tool_sequence` (13)

Removes all 4 from `pyproject.toml`'s C901 per-file-ignore list.

Stacked on #1953 (which stacks on #1940) to keep the shared grandfather-list edits conflict-free; base retargets to master as its parents merge.

No docstring, CLI-argument, or string-literal change: an AST-level comparison of before/after confirms docstrings, signatures, and every pre-existing string literal (prompts, report text, CLI help) are byte-identical; the only additions are private `_helper` functions carrying relocated logic.

## Type of change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [x] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

- `ruff check` repo-wide with the 4 per-file ignores removed (C901 live): all checks pass
- `ruff format --check`: clean
- `python -m py_compile` on all 4 files: clean
- The UAT harness has no automated test coverage by design (it drives live LLM agents); verification is lint + compile + AST-level identity of all pre-existing defs and strings

## Checklist
- [x] I have updated documentation if needed