### PR TITLE
fix: allow ha_manage_backup(scope="edits", action="diff") in read-only mode

### DIFF
--- a/src/ha_mcp/read_only.py
+++ b/src/ha_mcp/read_only.py
@@ -66,9 +66,11 @@ class ReadOnlyExemption(NamedTuple):
 def _backup_write(args: dict[str, Any]) -> str | None:
     scope = args.get("scope")
     action = args.get("action")
-    # Read-only-safe: per-edit backup listing/viewing, and snapshot listing
+    # Read-only-safe: per-edit backup listing/viewing/diffing, and snapshot listing
     # (issue #1586 — pure ``backup/info`` read, no tarball mutation).
-    if scope == "edits" and action in ("list", "view"):
+    # ``diff`` (added in #1632) only reads the stored snapshot and fetches
+    # the live config to compare; it never mutates (issue #1944).
+    if scope == "edits" and action in ("list", "view", "diff"):
         return None
     if scope == "snapshot" and action == "list":
         return None
@@ -195,8 +197,9 @@ READ_ONLY_EXEMPT_TOOLS: dict[str, ReadOnlyExemption] = {
     ),
     "ha_manage_backup": ReadOnlyExemption(
         _backup_write,
-        "listing and viewing per-edit backups (scope='edits', action='list' or "
-        "'view') and listing snapshots (scope='snapshot', action='list')",
+        "listing, viewing, and diffing per-edit backups (scope='edits', "
+        "action='list', 'view', or 'diff') and listing snapshots "
+        "(scope='snapshot', action='list')",
     ),
     "ha_manage_addon": ReadOnlyExemption(
         _addon_write,

--- a/tests/src/unit/test_read_only.py
+++ b/tests/src/unit/test_read_only.py
@@ -118,6 +118,9 @@ class TestExemptionRules:
         [
             ({"scope": "edits", "action": "list"}, True),
             ({"scope": "edits", "action": "view", "backup_name": "x"}, True),
+            # #1944: diff reads the snapshot and live config to compare, it
+            # never mutates, so it stays callable in read-only mode.
+            ({"scope": "edits", "action": "diff", "backup_name": "x"}, True),
             ({"scope": "edits", "action": "create"}, False),
             ({"scope": "edits", "action": "restore"}, False),
             ({"scope": "edits", "action": "delete"}, False),


### PR DESCRIPTION
Closes #1944

## What does this PR do?

Read-only mode was raising `READ_ONLY_MODE` on
`ha_manage_backup(scope="edits", action="diff")`, even though `diff` only reads
the stored snapshot and fetches the live config to compare; it never mutates.
The write-classifier `_backup_write` in `read_only.py` exempted only
`("list", "view")`; `diff` (added in #1632) was missing, so `ReadOnlyMiddleware`
blocked a genuinely read-only call.

This adds `"diff"` to the exemption predicate, syncs the exemption's
human-readable description, and adds a parametrize case pinning `edits/diff` as
allowed (the drift shipped untested).

## Type of change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [ ] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

The targeted unit suite `tests/src/unit/test_read_only.py` passes (163); ruff
and ruff-format are clean on both changed files; mypy is clean on the changed
source file (`src/ha_mcp/read_only.py`). The full suite runs in CI.

## Checklist
- [ ] I have updated documentation if needed
