### PR TITLE
fix: raise on parse error for a single explicit ha_config_get_yaml target

### DIFF
--- a/src/ha_mcp/tools/tools_yaml_read.py
+++ b/src/ha_mcp/tools/tools_yaml_read.py
@@ -82,6 +82,28 @@ def _failure_text(payload: dict[str, Any]) -> str:
     return str(error or "read failed")
 
 
+def _parse_error_result(
+    target: str, yaml_path: str, parse_error: str, *, is_glob: bool
+) -> tuple[None, str]:
+    """Decide a file the component could not parse: raise for a single target.
+
+    A single explicit target has no siblings to salvage, so a parse failure
+    raises rather than soft-degrading to a warning that reads as "key absent".
+    Under a glob it stays a per-file warning so one broken file does not sink
+    the whole search.
+    """
+    if not is_glob:
+        raise_tool_error(
+            create_error_response(
+                ErrorCode.CONFIG_INVALID,
+                f"{target} could not be parsed as YAML: {parse_error}",
+                suggestions=[f"Fix the YAML syntax error in {target} and retry."],
+                context={"file": target, "yaml_path": yaml_path},
+            )
+        )
+    return None, f"{target} was not searched: {parse_error}."
+
+
 def _evaluate_read(
     response: Any,
     target: str,
@@ -125,7 +147,7 @@ def _evaluate_read(
 
     parse_error = unwrapped.get("parse_error")
     if parse_error:
-        return None, f"{target} was not searched: {parse_error}."
+        return _parse_error_result(target, yaml_path, str(parse_error), is_glob=is_glob)
 
     if unwrapped.get("subtree") is None:
         return None, None

--- a/tests/src/unit/test_yaml_read_tool.py
+++ b/tests/src/unit/test_yaml_read_tool.py
@@ -470,6 +470,28 @@ async def test_parse_error_warns_instead_of_reading_as_a_non_match():
     ]
 
 
+async def test_single_file_parse_error_raises_instead_of_reporting_no_match():
+    """A single explicit target that will not parse has no siblings to salvage.
+
+    Soft-degrading to a warning would make a real parse failure indistinguishable
+    from "key absent" at the success/count level, so it raises instead.
+    """
+    fn, _ = await _make_tool(
+        {
+            "read_file": {
+                "success": True,
+                "path": "configuration.yaml",
+                "content": "...",
+                "subtree": None,
+                "parse_error": "not valid YAML at line 3, column 5",
+            }
+        }
+    )
+
+    with pytest.raises(ToolError):
+        await fn(yaml_path="rest", file="configuration.yaml")
+
+
 async def test_no_warnings_key_when_nothing_degraded():
     """`warnings` is omitted when empty, per the tool return contract."""
     fn, _ = await _make_tool({"read_file": _read_ok("method: GET\n")})


### PR DESCRIPTION
Closes #1948

## What does this PR do?

`ha_config_get_yaml` on a single explicit (non-glob) file whose YAML will not parse returned `success: true` with an empty `matches` list and a warning. A real parse failure was indistinguishable from "key absent" at the success/count level.

The two sibling failure branches in `_evaluate_read` already gate on `is_glob` and raise for a single explicit target (there are no siblings to salvage). The `parse_error` branch did not, contradicting the function's own documented contract ("A single explicit target has no siblings to salvage, so it raises instead"). This gates that branch the same way: a single-target parse error now raises a structured `CONFIG_INVALID` error, while a glob keeps the per-file warning so one broken file does not sink the whole search.

The parse-error triage is extracted into a small `_parse_error_result` helper, which keeps `_evaluate_read` under the cyclomatic-complexity limit. A non-glob regression test covers the raising path.

## Type of change
- [x] 🐛 Bug fix

## Testing
- [ ] I have tested these changes with a LLM agent
- [ ] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

## Checklist
- [ ] I have updated documentation if needed
