### PR TITLE
fix: join the entity registry on the ha_config_list_helpers legacy fallback

### DIFF
--- a/src/ha_mcp/tools/tools_config_helpers.py
+++ b/src/ha_mcp/tools/tools_config_helpers.py
@@ -4001,11 +4001,11 @@ class HelperConfigTools:
     async def _legacy_helper_list(self, helper_type: str) -> dict[str, Any]:
         """Legacy ``{helper_type}/list`` success envelope, for the § 4 #3 fallback.
 
-        A faithful copy of the tool's inline legacy success path, kept separate
-        (rather than extracted from that body) so the #1794 registry-join PR can
-        patch the inline body without a conflict here. The drift is bounded to
-        the rare component-error fallback and is flagged by the ``warnings[]``
-        entry the caller appends.
+        A copy of the tool's inline legacy success path, kept separate rather
+        than extracted from that body. It flattens and joins the entity registry
+        (issue #1945) exactly like the inline path, so a renamed helper served on
+        this fallback carries its current entity_id/name; the caller additionally
+        appends a ``warnings[]`` entry flagging that the component path was used.
         """
         result = await self._client.send_websocket_message(
             {"type": f"{helper_type}/list"}
@@ -4023,13 +4023,22 @@ class HelperConfigTools:
         # would be a dict here — breaking count, the pagination slice and the
         # all-types merge, which all expect a list of records.
         items = _flatten_helper_list_result(result)
-        return {
+        # Join the entity registry like the inline body (issue #1945): without
+        # this a renamed helper served on the component-error fallback keeps its
+        # stale storage id/name, the same #1794 staleness the inline path fixes.
+        enrich_warnings = await _enrich_helpers_with_current_registry(
+            self._client, helper_type, items
+        )
+        response: dict[str, Any] = {
             "success": True,
             "helper_type": helper_type,
             "count": len(items),
             "helpers": items,
             "message": f"Found {len(items)} {helper_type} helper(s)",
         }
+        if enrich_warnings:
+            response["warnings"] = enrich_warnings
+        return response
 
     async def _list_all_helpers(self) -> dict[str, Any]:
         """Serve ``helper_type="all"``: one merged component listing, or a hard error.
@@ -4145,8 +4154,14 @@ class HelperConfigTools:
                     ],
                 )
             )
+        merge_warnings: list[str] = []
         for helper_type in sorted(SIMPLE_HELPER_TYPES - covered_set):
             legacy = await self._legacy_helper_list(helper_type)
+            # _legacy_helper_list joins the registry (issue #1945) and, degrade-
+            # open, flags a failed registry read in warnings[]; surface those here
+            # instead of dropping them, else an uncovered type is served stale and
+            # silent during an all-types listing.
+            merge_warnings.extend(legacy.get("warnings", []))
             skipped = 0
             for item in legacy.get("helpers", []):
                 if isinstance(item, dict):
@@ -4165,13 +4180,16 @@ class HelperConfigTools:
                     helper_type,
                 )
 
-        return {
+        response: dict[str, Any] = {
             "success": True,
             "helper_type": "all",
             "count": len(helpers),
             "helpers": helpers,
             "message": f"Found {len(helpers)} helper(s)",
         }
+        if merge_warnings:
+            response["warnings"] = merge_warnings
+        return response
 
     @tool(
         name="ha_config_set_helper",

--- a/tests/src/unit/test_ha_config_list_helpers_component_routing.py
+++ b/tests/src/unit/test_ha_config_list_helpers_component_routing.py
@@ -153,6 +153,16 @@ class RoutingClient:
         return {"success": False, "error": "unexpected list type"}
 
 
+class RegistryFailingClient(RoutingClient):
+    """Legacy ``{type}/list`` works, but the entity-registry read fails, so
+    ``_enrich_helpers_with_current_registry`` degrades open with a warning."""
+
+    async def send_websocket_message(self, msg: dict[str, Any]) -> dict[str, Any]:
+        if msg.get("type") == "config/entity_registry/list":
+            return {"success": False, "error": "registry unavailable"}
+        return await super().send_websocket_message(msg)
+
+
 def _build_list_helpers(client: Any) -> Any:
     registered: dict[str, Any] = {}
 
@@ -320,6 +330,13 @@ async def test_raised_command_falls_back_with_warning() -> None:
     assert resp["success"] is True
     assert client.list_calls == 1
     assert any("served via legacy path" in w for w in resp["warnings"])
+    # The fallback record is registry-joined like the inline path (issue #1945):
+    # a renamed helper carries its current entity_id and display name, not the
+    # stale storage values.
+    record = resp["helpers"][0]
+    assert record["entity_id"] == "input_boolean.foo"
+    assert record["name"] == "New Name"
+    assert record["original_name"] == "Old Name"
 
 
 @pytest.mark.asyncio
@@ -342,6 +359,12 @@ async def test_ws_establish_failure_storage_type_falls_back_with_warning() -> No
     assert resp["success"] is True
     assert client.list_calls == 1
     assert any("served via legacy path" in w for w in resp["warnings"])
+    # The transport-failure fallback joins the registry too (issue #1945): the
+    # same _legacy_helper_list serves both this branch and the command-error one.
+    record = resp["helpers"][0]
+    assert record["entity_id"] == "input_boolean.foo"
+    assert record["name"] == "New Name"
+    assert record["original_name"] == "Old Name"
 
 
 @pytest.mark.asyncio
@@ -376,6 +399,34 @@ async def test_raised_command_fallback_flattens_the_person_split_shape() -> None
     assert resp["total_count"] == 2
     assert resp["has_more"] is False
     assert resp["next_offset"] is None
+
+
+@pytest.mark.asyncio
+async def test_all_types_merge_surfaces_legacy_enrichment_warning() -> None:
+    """all-types: an uncovered type served via legacy whose registry read fails
+    surfaces the stale-join warning instead of dropping it (issue #1945).
+
+    The component covers every type except ``tag``, so the merge falls to
+    ``_legacy_helper_list("tag")``; its registry read then fails, and the
+    degrade-open warning must reach the merged response rather than vanish.
+    """
+    covered = sorted(
+        (tools_config_helpers.SIMPLE_HELPER_TYPES - {"tag"})
+        | tools_config_helpers.FLOW_HELPER_TYPES
+    )
+    ws = make_ws(
+        "ha_mcp_tools/helpers_list",
+        info_result=_CAPS_HELPERS,
+        cmd_result={"helpers": [], "count": 0, "covered_types": covered},
+    )
+    client = RegistryFailingClient()
+    list_helpers = _build_list_helpers(client)
+
+    with patch_ws(ws, tools_config_helpers):
+        resp = await list_helpers(helper_type="all")
+
+    assert resp["success"] is True
+    assert tools_config_helpers._REGISTRY_JOIN_STALE_WARNING in resp.get("warnings", [])
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #1945

## What does this PR do?

`ha_config_list_helpers` serves a renamed helper with its current entity_id and
display name by joining the entity registry (#1794). That join lived only on the
inline `{type}/list` path. The component-error fallback `_legacy_helper_list`
(reached from both the command-error and the transport-failure branches of
`_list_helpers_via_component`) flattened its result but never called
`_enrich_helpers_with_current_registry`, so a UI-renamed helper was served with
its stale storage id/name on that path. This routes the fallback through the same
registry join and threads its degrade-open warnings into the response.

The all-types merge (`helper_type="all"`) consumes `_legacy_helper_list` for
uncovered simple types and previously dropped its warnings, harmless only while
that list was always empty; it now propagates them, so a failed registry read is
not served silently stale.

## Type of change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [ ] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

Extended `test_ha_config_list_helpers_component_routing.py`: enrichment is now
asserted on both fallback branches, plus a new test that the all-types merge
surfaces the stale-join warning. Ran that file with the registry-join, rename,
and pagination siblings (67 passed); ruff, ruff-format, and mypy are clean on the
changed source file.

## Checklist
- [ ] I have updated documentation if needed
