### PR TITLE
fix: raise MIN_COMPONENT_VERSION to 1.2.0 so stale 1.1.0 builds fail the gate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -661,13 +661,21 @@ fully validate a component change before merge.
     go straight to that minor, not an extra patch. Never go past the current
     pending version otherwise; per-revision bumps skip never-shipped numbers and
     desync the version from the release cycle.
-- **When the change adds a service or argument the server depends on**, raise
-  `MIN_COMPONENT_VERSION` in `src/ha_mcp/tools/tools_filesystem.py` to match the
-  pending version in the same PR. `get_caller_token` reports the manifest
-  version and the server gates on it, so without the gate the old and new
-  component are indistinguishable: a caller on the old version passes the check
-  and then hits raw "service not found" errors instead of an actionable
-  "update" prompt.
+- **When the change adds a service or argument the server depends on**, this PR
+  must **open a fresh pending component version** (bump `manifest.json` +
+  `COMPONENT_VERSION`) and raise `MIN_COMPONENT_VERSION` in
+  `src/ha_mcp/tools/tools_filesystem.py` to that same new version. This is the
+  one case that **overrides** the "already ahead of stable → do not bump" rule
+  above: bump here even if a pending version already exists. `get_caller_token`
+  reports the manifest version and the server gates on it, so without the gate
+  the old and new component are indistinguishable: a caller on the old version
+  passes the check and then hits raw "service not found" errors instead of an
+  actionable "update" prompt. **Never floor at a version any build lacking the
+  behaviour also reports** – an already-shipped version, or a pending version
+  that was opened *before* this behaviour landed. Such a build passes the gate
+  yet lacks the behaviour, defeating the gate (#1946: the floor was set to a
+  1.1.0 that had already shipped without the gated behaviours, so 1.1.0 builds
+  split into with/without and the gate could not tell them apart).
 - **Keep the component backward-compatible with the released server.** The
   component (HACS) and the server (add-on / PyPI / Docker) follow the same
   release cycle but are updated independently per install, so a new component

--- a/src/ha_mcp/tools/tools_filesystem.py
+++ b/src/ha_mcp/tools/tools_filesystem.py
@@ -76,14 +76,18 @@ CALLER_TOKEN_BOOTSTRAP_SERVICE = "get_caller_token"
 # ENABLE_YAML_EDIT_CONFIRM, default on); a <0.11.0 component's strict
 # (PREVENT_EXTRA) schema rejects the unknown arg with a raw voluptuous
 # error — the gate surfaces an actionable "update" prompt instead.
-# 1.1.0: the YAML fragment read (#1788) needs two component behaviours that a
-# <1.1.0 component reports no differently from a missing key. ``list_files``
-# only now honours the configured packages folder, so ha_config_get_yaml's
+# 1.2.0: the YAML fragment read (#1788, PR #1882) needs two component
+# behaviours that a component reports no differently from a missing key.
+# ``list_files`` honours the configured packages folder, so ha_config_get_yaml's
 # glob/discovery would otherwise come back "Path not allowed" instead of
 # enumerating packages; and ``include_parsed`` on ``read_file`` is a new arg
 # that an older strict (PREVENT_EXTRA) schema rejects with a raw voluptuous
-# error. The gate turns both into the actionable "update" prompt.
-MIN_COMPONENT_VERSION = "1.1.0"
+# error. The gate turns both into the actionable "update" prompt. The floor is
+# 1.2.0, not the 1.1.0 that was current when #1882 landed: #1882 added these
+# behaviours under an *un-bumped* 1.1.0 component, so 1.1.0 splits into builds
+# with and without them and cannot distinguish the two (#1946). 1.2.0 is the
+# first component version cut after #1882, hence the first that guarantees both.
+MIN_COMPONENT_VERSION = "1.2.0"
 
 
 def _version_tuple(version: str) -> tuple[int, ...]:

--- a/tests/src/unit/test_caller_token_auth.py
+++ b/tests/src/unit/test_caller_token_auth.py
@@ -568,8 +568,8 @@ class TestCallMcpToolsServiceInjectsToken:
         exclude ``1.1.0`` (it is ``1.2.0``, the first version cut after #1882),
         else a stale ``1.1.0`` install passes the gate and then hits raw
         failures instead of the actionable "update" prompt. Pins that ``1.1.0``
-        never passes – true for any floor above it, so it also guards against a
-        regression that lowers the floor back to ``1.1.0``.
+        never passes; this holds for any floor above it, so it also guards
+        against a regression that lowers the floor back to ``1.1.0``.
         """
         client = AsyncMock()
         client.get_services.return_value = [

--- a/tests/src/unit/test_caller_token_auth.py
+++ b/tests/src/unit/test_caller_token_auth.py
@@ -558,6 +558,42 @@ class TestCallMcpToolsServiceInjectsToken:
         await call_mcp_tools_service(client, "list_files", {"path": "www"})
 
     @pytest.mark.asyncio
+    async def test_stale_1_1_0_component_rejected(self):
+        """Regression for #1946: a component reporting exactly ``1.1.0`` is
+        rejected as too old.
+
+        #1882 added the packages-aware ``list_files`` + ``read_file``
+        ``include_parsed`` behaviours under an *un-bumped* ``1.1.0`` component,
+        so a ``1.1.0`` build may or may not carry them. The floor must therefore
+        exclude ``1.1.0`` (it is ``1.2.0``, the first version cut after #1882),
+        else a stale ``1.1.0`` install passes the gate and then hits raw
+        failures instead of the actionable "update" prompt. Pins that ``1.1.0``
+        never passes – true for any floor above it, so it also guards against a
+        regression that lowers the floor back to ``1.1.0``.
+        """
+        client = AsyncMock()
+        client.get_services.return_value = [
+            {
+                "domain": MCP_TOOLS_DOMAIN,
+                "services": {CALLER_TOKEN_BOOTSTRAP_SERVICE: {}, "list_files": {}},
+            }
+        ]
+        client.call_service = AsyncMock(
+            return_value={
+                "service_response": {
+                    "success": True,
+                    "token": "tok-stale",
+                    "version": "1.1.0",
+                }
+            }
+        )
+        with pytest.raises(ToolError) as exc_info:
+            await call_mcp_tools_service(client, "list_files", {"path": "www"})
+        msg = str(exc_info.value)
+        assert "too old" in msg
+        assert "1.1.0" in msg
+
+    @pytest.mark.asyncio
     async def test_version_above_minimum_accepted(self):
         """A component reporting a version strictly ABOVE
         ``MIN_COMPONENT_VERSION`` is accepted. Guards against a future


### PR DESCRIPTION
## What does this PR do?

Fixes #1946. `MIN_COMPONENT_VERSION` in `src/ha_mcp/tools/tools_filesystem.py` was set to `1.1.0` – a component version that had **already shipped** before it carried the behaviours the gate protects (packages-aware `list_files`, `read_file(include_parsed=...)`). #1882 added those behaviours to the component but under an un-bumped `1.1.0`, so a stale `1.1.0` install passes the version check and then hits raw failures (unrecognised `include_parsed` arg, "Path not allowed" for a packages folder) instead of the actionable "update the component" message the gate exists to produce.

This raises the floor to `1.2.0` – the first component version cut after #1882 (commit `9e808087`), and therefore the first that guarantees both behaviours. Any build reporting `1.2.0`+ postdates #1882; `1.1.0` is ambiguous (it splits into builds with and without the behaviours) and must be rejected. Flooring at the current `1.2.1` would over-reject valid `1.2.0` installs, so `1.2.0` is the tight floor.

Changes:
- Raise `MIN_COMPONENT_VERSION` `1.1.0` → `1.2.0` and rewrite the rationale comment to explain why `1.2.0`, not `1.1.0`.
- Add regression test `test_stale_1_1_0_component_rejected` pinning that a component reporting `1.1.0` is rejected as "too old". The assertion holds for any floor above `1.1.0`, so it also guards against a future change that lowers the floor back.
- Harden the AGENTS.md component version-bump rule: a PR that adds a server-gated behaviour must open a fresh pending component version and floor at it, never at a version any pre-behaviour build also reports. This overrides the "already ahead of stable → do not bump" rule for that one case.

**Testing:** the affected unit suites pass locally (`test_caller_token_auth`, `test_tools_filesystem`, `test_yaml_read_tool`, `test_yaml_config_tool`, `test_component_api`, `test_constants`); `ruff check` clean on the changed files. The full suite runs in CI.

## Type of change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [x] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [ ] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

## Checklist
- [x] I have updated documentation if needed
