### PR TITLE
fix: prefer an HTTP-500 sample in the deep-search failed fragment

### DIFF
--- a/src/ha_mcp/tools/smart_search/_deep.py
+++ b/src/ha_mcp/tools/smart_search/_deep.py
@@ -393,12 +393,12 @@ class DeepSearchMixin(SceneSearchMixin):
         failed_count = 0
         yaml_skipped_count = 0
         timeout_count = 0
-        # One representative summary — only the FIRST ``failed``-class
-        # exception is kept (the fetch closure guards the append); it rides
-        # partial_reason as an ``e.g.`` (#1784 follow-up). The remaining
-        # failures are counted (``failed_count``) but not summarized, so the
-        # motivating "every per-id fetch 500s" case does N-1 fewer
-        # ``summarize_fetch_error`` calls.
+        # One representative summary — ``record_first_failure`` (which holds
+        # the guard) keeps the first ``failed``-class exception, upgrading
+        # once to the first HTTP 500 so a fast-failing outlier can't suppress
+        # the 500 diagnosis hint; it rides partial_reason as an ``e.g.``
+        # (#1784 follow-up). The remaining failures are counted
+        # (``failed_count``) but not summarized.
         failed_errors: list[str] = []
         if not bulk_fetched:
             uids_to_fetch = [
@@ -547,12 +547,12 @@ class DeepSearchMixin(SceneSearchMixin):
         failed_count = 0
         yaml_skipped_count = 0
         timeout_count = 0
-        # One representative summary — only the FIRST ``failed``-class
-        # exception is kept (the fetch closure guards the append); it rides
-        # partial_reason as an ``e.g.`` (#1784 follow-up). The remaining
-        # failures are counted (``failed_count``) but not summarized, so the
-        # motivating "every per-id fetch 500s" case does N-1 fewer
-        # ``summarize_fetch_error`` calls.
+        # One representative summary — ``record_first_failure`` (which holds
+        # the guard) keeps the first ``failed``-class exception, upgrading
+        # once to the first HTTP 500 so a fast-failing outlier can't suppress
+        # the 500 diagnosis hint; it rides partial_reason as an ``e.g.``
+        # (#1784 follow-up). The remaining failures are counted
+        # (``failed_count``) but not summarized.
         failed_errors: list[str] = []
         if not bulk_fetched:
             sids_to_fetch = [

--- a/src/ha_mcp/tools/smart_search/_fetch.py
+++ b/src/ha_mcp/tools/smart_search/_fetch.py
@@ -40,7 +40,8 @@ def summarize_fetch_error(exc: BaseException) -> str:
 
     HTTP errors render as ``HTTP <code>: <first line of the message>`` (the
     client's own ``API error: <code> - `` prefix is stripped rather than
-    duplicated); everything else as ``<ExceptionType>: <first line>``.
+    duplicated); everything else as ``<ExceptionType>: <first line>``. An
+    empty message renders the bare prefix (``HTTP <code>`` / ``<Type>``).
     """
     lines = str(exc).strip().splitlines()
     text = lines[0].strip() if lines else ""
@@ -55,15 +56,24 @@ def summarize_fetch_error(exc: BaseException) -> str:
     return summary
 
 
-# Marks a rendered ``summarize_fetch_error`` summary whose cause the sample
-# cannot name: an HTTP 500's body is aiohttp's generic "500 Internal Server
-# Error" placeholder, so the real error (a YAMLException the per-id config
-# view raised, most often a ``!secret`` reference it rejects) lives only in
-# the HA log, never in the response.
-_HTTP_500_PREFIX = "HTTP 500:"
+# Matches a rendered ``summarize_fetch_error`` HTTP-500 summary — ``HTTP
+# 500: <text>``, or bare ``HTTP 500`` when the error body was empty. An HTTP
+# 500 is the one sample whose cause the summary cannot name (the body is
+# aiohttp's generic "500 Internal Server Error" placeholder; the real error —
+# most often a ``!secret`` reference the per-id config view rejects — lives
+# only in the HA log). Shared by the sample upgrade in
+# ``record_first_failure`` and by ``http_500_diagnosis_hint`` so the two can
+# never disagree on what counts as a 500.
+_HTTP_500_SAMPLE = re.compile(r"HTTP 500(?::|$)")
+
+
+def _is_http_500_sample(sample: str) -> bool:
+    """True when ``sample`` is a rendered HTTP-500 summary (``_HTTP_500_SAMPLE``)."""
+    return _HTTP_500_SAMPLE.match(sample) is not None
+
 
 # Static diagnosis appended to an HTTP-500 failed fragment. The sample names
-# the status but not the cause (see ``_HTTP_500_PREFIX``); this points the
+# the status but not the cause (see ``_HTTP_500_SAMPLE``); this points the
 # reader at the HA log and the single most common cause, delivering the
 # five-minute diagnosis the #1784 follow-up asked for without claiming a
 # cause the response can't actually confirm. Kept endpoint-agnostic — this
@@ -84,23 +94,35 @@ def http_500_diagnosis_hint(failed_sample: str | None) -> str:
     Returns ``""`` for any other sample (or ``None``), so non-500 fragments
     are byte-identical to before. See ``_HTTP_500_DIAGNOSIS``.
     """
-    if failed_sample and failed_sample.startswith(_HTTP_500_PREFIX):
+    if failed_sample and _is_http_500_sample(failed_sample):
         return _HTTP_500_DIAGNOSIS
     return ""
 
 
 def record_first_failure(failed_errors: list[str], exc: BaseException) -> None:
-    """Capture ``exc``'s summary as the representative ``failed`` sample, once.
+    """Capture ``exc``'s summary as the representative ``failed`` sample.
 
-    Only the FIRST generic-``failed`` exception per fetch pass is summarized
+    The first generic-``failed`` exception per fetch pass is summarized
     (subsequent ones are counted but not summarized) — in the motivating
     "every per-id fetch 500s" case that is N-1 fewer ``summarize_fetch_error``
-    calls. The append is a no-op once ``failed_errors`` is non-empty. Called
-    from the per-id fetch closures, which run under ``asyncio.gather`` but
-    never suspend between the check and the append, so no lock is needed.
+    calls. One exception: the first HTTP 500 upgrades a non-500 sample, once —
+    failure order tracks latency under ``asyncio.gather``, so a fast-failing
+    outlier (e.g. a connection blip losing the race against slower 500
+    round-trips) must not claim the slot and suppress the
+    ``http_500_diagnosis_hint`` diagnosis this sample exists to deliver. At
+    most two summaries are rendered per pass. Called from the per-id fetch
+    closures, which run under ``asyncio.gather`` but never suspend between
+    the check and the write, so no lock is needed.
     """
     if not failed_errors:
         failed_errors.append(summarize_fetch_error(exc))
+        return
+    if (
+        isinstance(exc, HomeAssistantAPIError)
+        and exc.status_code == 500
+        and not _is_http_500_sample(failed_errors[0])
+    ):
+        failed_errors[0] = summarize_fetch_error(exc)
 
 
 def is_timeout_error(exc: BaseException) -> bool:

--- a/src/ha_mcp/tools/smart_search/_scenes.py
+++ b/src/ha_mcp/tools/smart_search/_scenes.py
@@ -273,10 +273,12 @@ class SceneSearchMixin(ConfigFetchMixin):
         skipped_count = 0
         integration_skipped = 0
         timeout_count = 0
-        # One representative summary — only the FIRST ``failed``-class
-        # exception is kept (the fetch closure guards the append); it rides
-        # partial_reason as an ``e.g.`` (#1784 follow-up). The remaining
-        # failures are counted (``failed_count``) but not summarized.
+        # One representative summary — ``record_first_failure`` (which holds
+        # the guard) keeps the first ``failed``-class exception, upgrading
+        # once to the first HTTP 500 so a fast-failing outlier can't suppress
+        # the 500 diagnosis hint; it rides partial_reason as an ``e.g.``
+        # (#1784 follow-up). The remaining failures are counted
+        # (``failed_count``) but not summarized.
         failed_errors: list[str] = []
 
         # Attempt C: parallel per-id fetch with a wall-clock budget so a few

--- a/tests/src/unit/test_deep_search_tier3_parallel.py
+++ b/tests/src/unit/test_deep_search_tier3_parallel.py
@@ -18,7 +18,11 @@ from ha_mcp.client.rest_client import (
     HomeAssistantConnectionError,
 )
 from ha_mcp.tools.smart_search import SmartSearchTools
-from ha_mcp.tools.smart_search._fetch import is_timeout_error, summarize_fetch_error
+from ha_mcp.tools.smart_search._fetch import (
+    is_timeout_error,
+    record_first_failure,
+    summarize_fetch_error,
+)
 
 
 def _make_tools(client):
@@ -479,6 +483,7 @@ class TestYamlSkippedClassification:
         )
         assert skipped_count == 0
         assert matches == []
+        assert _failed_sample is None, "yaml_skipped 404s must not capture a sample"
 
     @pytest.mark.asyncio
     async def test_automation_non_404_classifies_as_failed(
@@ -634,6 +639,7 @@ class TestYamlSkippedClassification:
         assert failed_count == 0
         assert skipped_count == 0
         assert matches == []
+        assert _failed_sample is None, "yaml_skipped 404s must not capture a sample"
 
     @pytest.mark.asyncio
     async def test_mixed_404_and_success_only_404s_yaml_skipped(
@@ -704,6 +710,7 @@ class TestYamlSkippedClassification:
         )
         assert failed_count == 0
         assert skipped_count == 0
+        assert _failed_sample is None, "yaml_skipped 404s must not capture a sample"
         # Two-sided: the successful UI-stored automation must land in
         # matches via its config body (the query matches nothing else).
         matched_ids = [m["entity_id"] for m in matches]
@@ -940,6 +947,7 @@ class TestTimeoutClassification:
         assert yaml_skipped_count == 0
         assert skipped_count == 0
         assert matches == []
+        assert _failed_sample is None, "timeouts must not capture a sample"
 
     @pytest.mark.asyncio
     async def test_script_slow_fetch_classifies_as_timeout(
@@ -980,6 +988,7 @@ class TestTimeoutClassification:
         )
         assert failed_count == 0
         assert yaml_skipped_count == 0
+        assert _failed_sample is None, "timeouts must not capture a sample"
 
     @pytest.mark.asyncio
     async def test_timeout_surfaces_partial_through_deep_search(
@@ -1125,6 +1134,7 @@ class TestSceneTimeoutClassification:
         assert skipped_count == 0
         assert registry_failed is True  # fixture kills the registry walk
         assert results == []
+        assert _failed_sample is None, "scene timeouts must not capture a sample"
 
     @pytest.mark.asyncio
     async def test_scene_timeout_surfaces_partial_through_deep_search(
@@ -1249,6 +1259,7 @@ class TestWrappedClientTimeoutClassification:
         )
         assert failed_count == 0
         assert yaml_skipped_count == 0
+        assert _failed_sample is None, "wrapped timeouts must not capture a sample"
 
     @pytest.mark.asyncio
     async def test_plain_connection_error_still_classifies_as_failed(
@@ -1291,6 +1302,9 @@ class TestWrappedClientTimeoutClassification:
         assert failed_count == 1
         assert timeout_count == 0
         assert yaml_skipped_count == 0
+        assert _failed_sample == (
+            "HomeAssistantConnectionError: Failed to connect to Home Assistant: refused"
+        ), "failed-class connectivity errors must capture their sample"
 
 
 class TestBudgetedFetchCountArithmetic:
@@ -1720,10 +1734,10 @@ class TestFailedSampleThroughDeepSearch:
 
     @pytest.mark.asyncio
     async def test_only_first_failure_is_summarized(self, mock_client, smart_tools):
-        """The fetch closure keeps only the FIRST ``failed``-class sample
-        (``if not failed_errors:`` guard): in the motivating "every per-id
-        fetch 500s" case, ``summarize_fetch_error`` runs once, not once per
-        failure. All failures still COUNT."""
+        """``record_first_failure`` keeps the first ``failed``-class sample:
+        in the motivating "every per-id fetch 500s" case the first failure IS
+        an HTTP 500 (the upgrade never fires), so ``summarize_fetch_error``
+        runs once, not once per failure. All failures still COUNT."""
         scripts = [
             {
                 "entity_id": f"script.secret_{n}",
@@ -1762,4 +1776,185 @@ class TestFailedSampleThroughDeepSearch:
         assert failed_sample == "HTTP 500: 500 Internal Server Error"
         assert spy.call_count == 1, (
             f"guard must summarize only the first failure; got {spy.call_count}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_automation_500_sample_surfaces_through_deep_search(
+        self, mock_client, smart_tools
+    ):
+        """Automation mirror of the script seam test: the sample and the
+        HA-log hint ride the ``automation_failed_sample`` kwarg through
+        ``deep_search`` → ``_paginate_and_build_response`` →
+        ``_apply_per_type_partial_flag``. A forwarding regression on that
+        kwarg alone would pass the component tests."""
+        automations = self._automation_entities()
+        mock_client.get_states = AsyncMock(return_value=automations)
+
+        async def _per_id_500(method: str, url: str) -> dict:
+            if url.rstrip("/") == "/config/automation/config":
+                raise Exception("Bulk fetch unavailable")
+            raise HomeAssistantAPIError(
+                "API error: 500 - 500 Internal Server Error", status_code=500
+            )
+
+        mock_client._request = AsyncMock(side_effect=_per_id_500)
+
+        result = await smart_tools.deep_search(
+            query="anything",
+            search_types=["automation"],
+            limit=10,
+        )
+
+        assert result["partial"] is True
+        reason = result["partial_reason"]
+        assert (
+            "2 automation(s) not scanned (per-id fetch raised a non-404 error; "
+            "e.g. HTTP 500: 500 Internal Server Error)" in reason
+        ), f"automation failed fragment must carry the sample; got {reason!r}"
+        assert "`!secret` reference in the config file HA loads" in reason, (
+            f"HTTP-500 automation fragment must carry the HA-log hint; got {reason!r}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_scene_404_sample_surfaces_without_500_hint(
+        self, mock_client, smart_tools
+    ):
+        """Scenes have no ``yaml_skipped`` branch (integration-managed scenes
+        are pre-filtered upstream via the registry walk), so a scene per-id
+        404 falls into the generic ``failed`` class and surfaces as an
+        ``e.g. HTTP 404`` sample — unlike automations/scripts, whose 404s
+        reclassify to their own fragment and never produce one. Pins the
+        asymmetry the #1930 description disclosed, so a future scene 404
+        branch can't change it silently; the 500 hint must not ride a 404."""
+        scenes = [
+            {
+                "entity_id": "scene.yaml_defined",
+                "state": "scening",
+                "attributes": {"friendly_name": "YAML Defined"},
+            },
+        ]
+        mock_client.get_states = AsyncMock(return_value=scenes)
+
+        async def _scene_404(sid: str) -> dict:
+            raise HomeAssistantAPIError("API error: 404 - Not Found", status_code=404)
+
+        mock_client.get_scene_config = AsyncMock(side_effect=_scene_404)
+
+        result = await smart_tools.deep_search(
+            query="anything",
+            search_types=["scene"],
+            limit=10,
+        )
+
+        assert result["partial"] is True
+        reason = result["partial_reason"]
+        assert (
+            "1 scene(s) not scanned (per-id fetch raised; "
+            "e.g. HTTP 404: Not Found)" in reason
+        ), f"scene 404 must surface as a failed-class sample; got {reason!r}"
+        assert "in the Home Assistant log" not in reason, (
+            f"the 500 hint must not ride a 404 sample; got {reason!r}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_500_sample_preferred_over_faster_non_500(
+        self, mock_client, smart_tools
+    ):
+        """Mixed failures: failure order under ``asyncio.gather`` tracks
+        latency, so a fast-failing non-500 outlier would otherwise claim the
+        sample slot and suppress the 500 diagnosis hint. The 500 must own the
+        sample regardless of which failure lands first."""
+        scripts = [
+            {
+                "entity_id": "script.blip_one",
+                "state": "off",
+                "attributes": {"friendly_name": "Blip One"},
+            },
+            {
+                "entity_id": "script.secret_two",
+                "state": "off",
+                "attributes": {"friendly_name": "Secret Two"},
+            },
+        ]
+        mock_client.get_states = AsyncMock(return_value=scripts)
+
+        async def _mixed_failure(sid: str) -> dict:
+            if "blip" in sid:
+                raise RuntimeError("fast connection blip")
+            raise HomeAssistantAPIError(
+                "API error: 500 - 500 Internal Server Error", status_code=500
+            )
+
+        mock_client.get_script_config = AsyncMock(side_effect=_mixed_failure)
+
+        (
+            _matches,
+            _skipped_count,
+            failed_count,
+            _yaml_skipped_count,
+            _timeout_count,
+            failed_sample,
+        ) = await smart_tools._deep_search_scripts(
+            scripts,
+            query_lower="anything",
+            exact_match=False,
+        )
+        assert failed_count == 2, "both failures must still be counted"
+        assert failed_sample == "HTTP 500: 500 Internal Server Error", (
+            f"the HTTP 500 must own the sample slot; got {failed_sample!r}"
+        )
+
+
+class TestFailedSamplePreference:
+    """``record_first_failure`` selection semantics: first failure wins the
+    sample slot, except the first HTTP 500 upgrades a non-500 sample, once.
+    Failure order under ``asyncio.gather`` tracks latency, so a fast-failing
+    outlier (e.g. a connection blip) would otherwise claim the slot and
+    suppress the ``http_500_diagnosis_hint`` diagnosis — the case the sample
+    exists for (#1784 follow-up)."""
+
+    @staticmethod
+    def _http_500(body: str = "500 Internal Server Error") -> HomeAssistantAPIError:
+        return HomeAssistantAPIError(f"API error: 500 - {body}", status_code=500)
+
+    def test_first_failure_wins_absent_a_500(self):
+        errs: list[str] = []
+        record_first_failure(errs, RuntimeError("first"))
+        record_first_failure(errs, ValueError("second"))
+        assert errs == ["RuntimeError: first"]
+
+    def test_first_http_500_upgrades_non_500_sample_once(self):
+        errs: list[str] = []
+        record_first_failure(errs, RuntimeError("fast blip"))
+        record_first_failure(errs, self._http_500())
+        assert errs == ["HTTP 500: 500 Internal Server Error"]
+        # Later 500s and non-500s never replace the upgraded sample.
+        record_first_failure(errs, self._http_500("a different body"))
+        record_first_failure(errs, RuntimeError("late blip"))
+        assert errs == ["HTTP 500: 500 Internal Server Error"]
+
+    def test_non_500_http_error_does_not_upgrade(self):
+        errs: list[str] = []
+        record_first_failure(errs, RuntimeError("fast blip"))
+        record_first_failure(
+            errs,
+            HomeAssistantAPIError("API error: 502 - Bad Gateway", status_code=502),
+        )
+        assert errs == ["RuntimeError: fast blip"]
+
+    def test_at_most_two_summaries_per_pass(self):
+        """One capture + one upgrade = two renders, no matter how many
+        failures follow — preserves the N-1 economy the guard bought."""
+        errs: list[str] = []
+        with patch(
+            "ha_mcp.tools.smart_search._fetch.summarize_fetch_error",
+            wraps=summarize_fetch_error,
+        ) as spy:
+            record_first_failure(errs, RuntimeError("fast blip"))
+            for _ in range(3):
+                record_first_failure(errs, self._http_500())
+            record_first_failure(errs, ValueError("late"))
+        assert errs == ["HTTP 500: 500 Internal Server Error"]
+        assert spy.call_count == 2, (
+            f"expected one capture + one upgrade; got {spy.call_count}"
         )

--- a/tests/src/unit/test_deep_search_tier3_parallel.py
+++ b/tests/src/unit/test_deep_search_tier3_parallel.py
@@ -1421,6 +1421,15 @@ class TestSummarizeFetchError:
     def test_empty_message_yields_bare_type(self):
         assert summarize_fetch_error(RuntimeError()) == "RuntimeError"
 
+    def test_empty_body_500_renders_bare_http_500(self):
+        """An empty-bodied 500 renders the bare colon-less ``HTTP 500`` —
+        the exact form the ``_HTTP_500_SAMPLE`` regex's ``$`` alternative
+        exists to match, so the hint can't silently drop it. Pins the
+        renderer side of that chain (the hint side is pinned in
+        ``test_bare_http_500_sample_still_carries_hint``)."""
+        exc = HomeAssistantAPIError("API error: 500 - ", status_code=500)
+        assert summarize_fetch_error(exc) == "HTTP 500"
+
     def test_multiline_body_keeps_first_line_only(self):
         exc = HomeAssistantAPIError(
             "API error: 500 - 500 Internal Server Error\n"

--- a/tests/src/unit/test_ha_search_merge.py
+++ b/tests/src/unit/test_ha_search_merge.py
@@ -1046,6 +1046,42 @@ def test_http_500_hint_only_on_http_500_sample() -> None:
     assert "in the Home Assistant log" not in no_sample["partial_reason"]
 
 
+def test_bare_http_500_sample_still_carries_hint() -> None:
+    """An empty-bodied 500 renders as colon-less ``HTTP 500`` (see
+    ``summarize_fetch_error``); the hint predicate matches the bare form too,
+    so the one sample the 500 diagnosis exists for can't silently drop it.
+    Near-misses — another status, or a message merely mentioning 500 — must
+    not match."""
+    bare: dict = {"success": True}
+    DeepSearchMixin._apply_per_type_partial_flag(
+        bare, automation_failed=1, automation_failed_sample="HTTP 500"
+    )
+    assert "in the Home Assistant log" in bare["partial_reason"]
+
+    for near_miss_sample in ("HTTP 5000: not a 500", "RuntimeError: REST 500 body"):
+        near_miss: dict = {"success": True}
+        DeepSearchMixin._apply_per_type_partial_flag(
+            near_miss, automation_failed=1, automation_failed_sample=near_miss_sample
+        )
+        assert "in the Home Assistant log" not in near_miss["partial_reason"], (
+            f"hint must not fire on {near_miss_sample!r}"
+        )
+
+
+def test_double_500_hint_rides_each_fragment() -> None:
+    """Both per-type samples being 500s → each fragment carries its own hint
+    (pins the previously-unspecified both-types-500 composition)."""
+    response: dict = {"success": True}
+    DeepSearchMixin._apply_per_type_partial_flag(
+        response,
+        automation_failed=1,
+        automation_failed_sample="HTTP 500: 500 Internal Server Error",
+        script_failed=2,
+        script_failed_sample="HTTP 500: 500 Internal Server Error",
+    )
+    assert response["partial_reason"].count("in the Home Assistant log") == 2
+
+
 def test_budget_partial_flag_set_when_helper_type_lists_failed() -> None:
     """Helpers run on every default ha_search call; silent per-type-list
     failures previously left callers unable to distinguish a clean


### PR DESCRIPTION
## What does this PR do?

Post-merge polish on #1930 (the #1784 follow-up), closing out the review-round findings:

- `record_first_failure()` now upgrades a non-500 sample once when the first HTTP 500 arrives. Failure order under `asyncio.gather` tracks latency, so a fast-failing outlier (e.g. a connection blip) could claim the sample slot and suppress the `http_500_diagnosis_hint` diagnosis in exactly the mixed-failure runs it exists for. Still at most two `summarize_fetch_error` calls per pass.
- The 500 detection is a shared regex predicate (`HTTP 500` followed by `:` or end-of-string) used by both the upgrade and the hint, replacing the `startswith("HTTP 500:")` coupling — a bare `HTTP 500` sample (empty error body) no longer silently drops the hint, and the two helpers can't disagree on what counts as a 500.
- Call-site comments corrected: the guard lives in `record_first_failure`, not the closures.
- Tests: pins the scene per-id 404 asymmetry disclosed in #1930's description (`e.g. HTTP 404` sample, no 500 hint); an automation seam test through public `deep_search`; `record_first_failure` selection semantics including an at-most-two-summaries spy; bare/near-miss hint predicate cases; the both-types-500 double-hint composition; `failed_sample is None` asserts on the existing timeout/yaml unpacks.

Unit tests for the changed surface pass locally (156 passed across the three deep-search test files, two of which this PR touches); full suite on CI.

## Type of change
- [x] 🐛 Bug fix

## Testing
- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

## Checklist
- [x] I have updated documentation if needed
