### PR TITLE
refactor(c901): fix final 6 files below C901 threshold, remove emptied grandfather list

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -163,15 +163,6 @@ ignore = [
 [tool.ruff.lint.per-file-ignores]
 "__init__.py" = ["F401"]
 "tests/**/*" = ["E501", "B011"]
-# C901 (mccabe complexity) grandfathered debt: newly enabled rule, these files
-# already exceeded the threshold. Remove a line once its functions are
-# refactored below threshold -- do not add new files here.
-"src/ha_mcp/tools/tools_config_automations.py" = ["C901"]
-"src/ha_mcp/tools/tools_config_scenes.py" = ["C901"]
-"src/ha_mcp/tools/tools_config_scripts.py" = ["C901"]
-"src/ha_mcp/tools/tools_dev.py" = ["C901"]
-"src/ha_mcp/tools/tools_system.py" = ["C901"]
-"tests/src/unit/test_advanced_settings_coverage.py" = ["C901"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/src/ha_mcp/tools/tools_config_automations.py
+++ b/src/ha_mcp/tools/tools_config_automations.py
@@ -839,39 +839,7 @@ class AutomationConfigTools:
                 and e.status_code == 404
             ):
                 await self._raise_automation_not_found(identifier)
-            error_text = str(e)
-            suggestions = [
-                "Check automation configuration format",
-                "Ensure required fields: alias, triggers, actions",
-                "Use entity_id format: automation.morning_routine or unique_id",
-                "Use ha_search(domain_filter='automation') to find automations",
-                "Use ha_get_skill_guide for automation examples",
-            ]
-            if isinstance(e, HomeAssistantAPIError):
-                if "'service'" in error_text and "not allowed" in error_text:
-                    suggestions.insert(
-                        0,
-                        "Use 'action:' not 'service:' for service calls in action steps "
-                        "(renamed in HA 2024.8).",
-                    )
-                elif "unexpected keyword argument" in error_text.lower():
-                    suggestions.insert(
-                        0,
-                        "An action step contains a field that belongs at the automation root "
-                        "(e.g. alias, trigger, condition). Each action step should only contain "
-                        "action/target/data/delay/choose/if/repeat/parallel keys.",
-                    )
-                elif "'variables'" in error_text and "dictionary" in error_text:
-                    suggestions.insert(
-                        0,
-                        "variables must be a dict mapping names to values, "
-                        'e.g. {"variables": {"my_var": 42}}',
-                    )
-            if bp_warnings:
-                suggestions.append(
-                    "Config had best-practice issues that may be related: "
-                    + "; ".join(bp_warnings)
-                )
+            suggestions = self._build_set_automation_suggestions(e, bp_warnings)
             error = exception_to_structured_error(
                 e,
                 context={"identifier": identifier},
@@ -880,6 +848,51 @@ class AutomationConfigTools:
             )
             augment_error_dict_with_skill_content(error, bp_warnings)
             raise_tool_error(error)
+
+    @staticmethod
+    def _build_set_automation_suggestions(
+        e: Exception, bp_warnings: BestPracticeCheckResult
+    ) -> list[str]:
+        """Build the ordered suggestion list for a failed config-replacement set.
+
+        Extracted verbatim from ``ha_config_set_automation``'s exception
+        handler: HA-API messages get a targeted lead suggestion inserted, and
+        any best-practice warnings are appended.
+        """
+        error_text = str(e)
+        suggestions = [
+            "Check automation configuration format",
+            "Ensure required fields: alias, triggers, actions",
+            "Use entity_id format: automation.morning_routine or unique_id",
+            "Use ha_search(domain_filter='automation') to find automations",
+            "Use ha_get_skill_guide for automation examples",
+        ]
+        if isinstance(e, HomeAssistantAPIError):
+            if "'service'" in error_text and "not allowed" in error_text:
+                suggestions.insert(
+                    0,
+                    "Use 'action:' not 'service:' for service calls in action steps "
+                    "(renamed in HA 2024.8).",
+                )
+            elif "unexpected keyword argument" in error_text.lower():
+                suggestions.insert(
+                    0,
+                    "An action step contains a field that belongs at the automation root "
+                    "(e.g. alias, trigger, condition). Each action step should only contain "
+                    "action/target/data/delay/choose/if/repeat/parallel keys.",
+                )
+            elif "'variables'" in error_text and "dictionary" in error_text:
+                suggestions.insert(
+                    0,
+                    "variables must be a dict mapping names to values, "
+                    'e.g. {"variables": {"my_var": 42}}',
+                )
+        if bp_warnings:
+            suggestions.append(
+                "Config had best-practice issues that may be related: "
+                + "; ".join(bp_warnings)
+            )
+        return suggestions
 
     async def _upsert_automation(
         self,

--- a/src/ha_mcp/tools/tools_config_scenes.py
+++ b/src/ha_mcp/tools/tools_config_scenes.py
@@ -137,33 +137,61 @@ class ConfigSceneTools:
         """
         scene_id = scene_id.removeprefix("scene.")
         if allow_component:
-            matches = await fetch_entity_lookup_via_component(
-                self._client, scene_id, domain="scene"
-            )
-            if matches is not None:
-                # Component answered authoritatively. A hit returns at once — the
-                # in-process registry read needs no settle. An EMPTY result right
-                # after an upsert can be HA's async entity-registration lag
-                # (#1168), not a true absence, so recheck ONCE after the same
-                # short delay the legacy path uses before the naive fallback.
-                entity_id = self._first_scene_entity_id(matches)
-                if entity_id is not None:
-                    return entity_id
-                await asyncio.sleep(self._RESOLVE_RETRY_DELAY)
-                recheck = await fetch_entity_lookup_via_component(
-                    self._client, scene_id, domain="scene"
-                )
-                if recheck is not None:
-                    # Authoritative recheck: a hit is returned; a genuine empty
-                    # (still absent after the settle) falls to the naive guess.
-                    entity_id = self._first_scene_entity_id(recheck)
-                    if entity_id is not None:
-                        return entity_id
-                    return f"scene.{scene_id}"
-                # recheck is None: the component went unavailable/errored/downgraded
-                # mid-retry, so the first empty read is NOT authoritative. Fall
-                # through to the legacy list+retry path below (its own retry
-                # absorbs the same registration lag) instead of guessing.
+            resolved = await self._resolve_scene_via_component(scene_id)
+            if resolved is not None:
+                return resolved
+        return await self._resolve_scene_via_registry(scene_id)
+
+    async def _resolve_scene_via_component(self, scene_id: str) -> str | None:
+        """Resolve a scene ``entity_id`` through the in-process component.
+
+        Returns the resolved ``entity_id`` (or the naive ``scene.{scene_id}``
+        guess when the component authoritatively reports the scene still absent
+        after a settle). Returns ``None`` when the component is unavailable or
+        non-authoritative (capability miss, or the recheck went
+        unavailable/errored mid-retry), so the caller falls through to the
+        legacy registry list+retry path. ``scene_id`` must already have its
+        ``scene.`` prefix stripped; see ``_resolve_scene_entity_id`` for the
+        full lag-vs-absence reasoning.
+        """
+        matches = await fetch_entity_lookup_via_component(
+            self._client, scene_id, domain="scene"
+        )
+        if matches is None:
+            return None
+        # Component answered authoritatively. A hit returns at once — the
+        # in-process registry read needs no settle. An EMPTY result right
+        # after an upsert can be HA's async entity-registration lag
+        # (#1168), not a true absence, so recheck ONCE after the same
+        # short delay the legacy path uses before the naive fallback.
+        entity_id = self._first_scene_entity_id(matches)
+        if entity_id is not None:
+            return entity_id
+        await asyncio.sleep(self._RESOLVE_RETRY_DELAY)
+        recheck = await fetch_entity_lookup_via_component(
+            self._client, scene_id, domain="scene"
+        )
+        if recheck is None:
+            # recheck is None: the component went unavailable/errored/downgraded
+            # mid-retry, so the first empty read is NOT authoritative. Fall
+            # through to the legacy list+retry path (its own retry absorbs the
+            # same registration lag) instead of guessing.
+            return None
+        # Authoritative recheck: a hit is returned; a genuine empty
+        # (still absent after the settle) falls to the naive guess.
+        entity_id = self._first_scene_entity_id(recheck)
+        if entity_id is not None:
+            return entity_id
+        return f"scene.{scene_id}"
+
+    async def _resolve_scene_via_registry(self, scene_id: str) -> str:
+        """Resolve a scene ``entity_id`` via the entity-registry list.
+
+        Legacy path used by ``_resolve_scene_entity_id`` when the component is
+        unavailable or non-authoritative: lists the registry with one
+        registration-lag retry, falling back to the naive ``scene.{scene_id}``.
+        ``scene_id`` must already have its ``scene.`` prefix stripped.
+        """
         retried = False
         for attempt in range(2):
             try:
@@ -679,246 +707,15 @@ class ConfigSceneTools:
                     )
                 )
 
-            # python_transform branch
             if python_transform is not None:
-                if config_hash is None:
-                    raise_tool_error(
-                        create_error_response(
-                            ErrorCode.VALIDATION_INVALID_PARAMETER,
-                            "config_hash is required for python_transform",
-                            suggestions=[
-                                "Call ha_config_get_scene() first",
-                                "Use the config_hash from that response",
-                            ],
-                            context={
-                                "action": "python_transform",
-                                "scene_id": scene_id,
-                            },
-                        )
-                    )
-
-                actual_config, resolved_id = await self._fetch_and_verify_hash(
-                    scene_id, config_hash, "python_transform"
+                return await self._run_scene_python_transform(
+                    scene_id,
+                    config_hash,
+                    python_transform,
+                    category,
+                    wait,
+                    MandatoryBPS,
                 )
-                # Capture the scene's own ``id`` BEFORE the transform mutates the
-                # config in place — it is the stable identity the id-change guard
-                # compares against (in production it equals ``resolved_id``; it is
-                # also correct when ``resolved_id`` is None because the envelope
-                # omitted ``scene_id``).
-                original_id = actual_config.get("id")
-
-                try:
-                    transformed_config = safe_execute(python_transform, actual_config)
-                except PythonSandboxError as e:
-                    message, suggestions = format_sandbox_error(e, python_transform)
-                    raise_tool_error(
-                        create_error_response(
-                            ErrorCode.VALIDATION_FAILED,
-                            message,
-                            suggestions=suggestions,
-                            context={
-                                "action": "python_transform",
-                                "scene_id": resolved_id,
-                            },
-                        )
-                    )
-
-                # Issue #1168 R5 blocker 8: a transform that reassigns
-                # config to ``None`` (or returns ``None`` from a list-comp
-                # mistake) used to crash the next ``in`` check with a
-                # ``TypeError`` that surfaced as ``INTERNAL_ERROR``. Catch
-                # the rebind here so the user gets the same VALIDATION
-                # signal the dict-shape checks below produce.
-                if transformed_config is None:
-                    raise_tool_error(
-                        create_error_response(
-                            ErrorCode.VALIDATION_FAILED,
-                            "Transform must not reassign config to None",
-                            suggestions=[
-                                "The transform must produce a dict matching the scene config shape",
-                                "Mutate ``config`` in-place rather than reassigning it",
-                            ],
-                            context={
-                                "action": "python_transform",
-                                "scene_id": resolved_id,
-                            },
-                        )
-                    )
-
-                # Validate transformed config still has the required shape.
-                if "entities" not in transformed_config:
-                    raise_tool_error(
-                        create_error_response(
-                            ErrorCode.VALIDATION_FAILED,
-                            "Transformed config must still include 'entities'",
-                            suggestions=[
-                                "The transform may have removed the required field",
-                                "Ensure the config still has an 'entities' key",
-                            ],
-                            context={
-                                "action": "python_transform",
-                                "scene_id": resolved_id,
-                            },
-                        )
-                    )
-                if not isinstance(transformed_config["entities"], dict):
-                    raise_tool_error(
-                        create_error_response(
-                            ErrorCode.VALIDATION_FAILED,
-                            "Transformed 'entities' must remain a dict keyed by entity_id",
-                            context={
-                                "action": "python_transform",
-                                "scene_id": resolved_id,
-                                "resulting_type": type(
-                                    transformed_config["entities"]
-                                ).__name__,
-                            },
-                        )
-                    )
-
-                # Issue #1168 R5 blocker 10: a transform that mutates
-                # ``config['id']`` produces a duplicate scene at the new
-                # storage key AND orphans the original (state goes
-                # ``unavailable``, registry row left behind). HA itself
-                # accepts the mismatched-id upsert silently. Reject the
-                # rename here — renaming a scene means delete-old +
-                # create-new through the explicit tools, not an in-place
-                # ``id`` rebind. R6 blocker 18: only reject an explicit
-                # mismatched id; a transform that ``del config['id']`` is
-                # legitimate (HA treats ``id`` as optional) and should pass
-                # through. R7 blocker 24: ``transformed_config["id"] = None``
-                # is the in-place equivalent of ``del`` — normalise both
-                # by checking against ``(None, original_id)``, so only an
-                # explicit non-None mismatch triggers the reject. Compare against
-                # the scene's own captured ``id`` (not ``resolved_id``, which may
-                # be None on the structural-invariant path) — in production the
-                # two are equal.
-                if "id" in transformed_config and transformed_config["id"] not in (
-                    None,
-                    original_id,
-                ):
-                    raise_tool_error(
-                        create_error_response(
-                            ErrorCode.VALIDATION_FAILED,
-                            "Transform must not change ``config['id']``",
-                            suggestions=[
-                                f"Original scene_id is {original_id!r} — keep it unchanged",
-                                "To rename a scene, use ha_config_remove_scene + ha_config_set_scene",
-                            ],
-                            context={
-                                "action": "python_transform",
-                                "scene_id": original_id,
-                                "attempted_id": transformed_config.get("id"),
-                            },
-                        )
-                    )
-
-                # Issue #1168 R3 blocker 5: prune orphan ``metadata`` keys
-                # whose entity was deleted by the transform (e.g. a list
-                # comprehension that filters ``entities`` doesn't touch
-                # ``metadata`` and HA keeps the orphan entries on disk).
-                # Full-replace via ``config=`` clears metadata cleanly; the
-                # transform path needs to mirror that contract.
-                metadata = transformed_config.get("metadata")
-                if isinstance(metadata, dict):
-                    valid_keys = set(transformed_config["entities"].keys())
-                    pruned_keys = sorted(k for k in metadata if k not in valid_keys)
-                    if pruned_keys:
-                        # Issue #1168 R5 blocker 12: a buggy transform that
-                        # accidentally drops entities used to silently
-                        # rewrite metadata. Surface the prune so a stray
-                        # ``del entities[k]`` doesn't lose the friendly_name
-                        # without trace.
-                        logger.info(
-                            f"python_transform pruned {len(pruned_keys)} orphan "
-                            f"metadata key(s) from scene {resolved_id}: {pruned_keys}"
-                        )
-                    transformed_config["metadata"] = {
-                        k: v for k, v in metadata.items() if k in valid_keys
-                    }
-
-                # Issue #1168 R6 blocker 15: pre-validate ``category`` BEFORE
-                # the upsert commits. Validating after the write produced the
-                # exact partial-state-mutation pattern this PR's auto-attach
-                # contract was meant to eliminate — scene was rewritten,
-                # caller saw VALIDATION_INVALID_PARAMETER on a phantom
-                # category, and the storage state had already moved.
-                if category:
-                    await self._validate_category_id(category)
-
-                # ``resolved_id`` is the storage key (write target); ``scene_id``
-                # stays the caller id so a missing ``name`` defaults caller-facing
-                # rather than to the storage key (#1935).
-                result = await self._client.upsert_scene_config(
-                    transformed_config, scene_id, resolved_id=resolved_id
-                )
-                # The upsert re-resolves when ``resolved_id`` was None (envelope
-                # omitted the key); re-bind to the authoritative write target it
-                # returned so the re-fetch, entity resolution, and response all
-                # use the resolved storage key rather than a possible None.
-                resolved_id = result.get("scene_id", resolved_id)
-
-                # Re-fetch to get authoritative hash (HA may normalise after save).
-                # ``resolved_id`` is already the storage key, so skip the re-resolve.
-                _, new_config_hash, _ = await self._get_scene_config_internal(
-                    resolved_id, _resolved=True
-                )
-
-                # Resolve actual entity_id and apply wait + category — same
-                # post-upsert finalisation the full-config branch runs. Without
-                # these, ``wait`` and ``category`` are silently dropped on
-                # python_transform calls.
-                entity_id = await self._resolve_scene_entity_id(
-                    resolved_id, allow_component=True
-                )
-                if wait:
-                    try:
-                        registered = await wait_for_entity_registered(
-                            self._client, entity_id
-                        )
-                        if not registered:
-                            result.setdefault("warnings", []).append(
-                                f"Scene updated but {entity_id} not yet queryable. "
-                                "It may take a moment to become available."
-                            )
-                    except (HomeAssistantConnectionError, HomeAssistantAuthError) as e:
-                        result.setdefault("warnings", []).append(
-                            f"Scene updated but verification failed: {e}"
-                        )
-                if category and entity_id:
-                    # Pre-validation of ``category`` already ran before the
-                    # upsert (R6 blocker 15) — apply directly here.
-                    await apply_entity_category(
-                        self._client,
-                        entity_id,
-                        category,
-                        "scene",
-                        result,
-                        "scene",
-                    )
-
-                # Issue #1168 R3 blocker 6: build the response from
-                # ``resolved_id`` directly (not the caller-input ``scene_id``)
-                # so the outer field always matches the storage key carried
-                # in ``result``. ``result["scene_id"]`` is also the storage
-                # key from rest_client; the kwarg-after-spread order means
-                # the explicit assignment wins on key-collision regardless.
-                response: dict[str, Any] = {
-                    "success": True,
-                    **{k: v for k, v in result.items() if k != "success"},
-                    "action": "python_transform",
-                    "scene_id": resolved_id,
-                    "config_hash": new_config_hash,
-                    "python_expression": python_transform,
-                    "message": f"Scene {resolved_id} updated via Python transform",
-                }
-                attach_skill_content(
-                    response,
-                    MandatoryBPS=MandatoryBPS,
-                    canonical_files=_SCENE_SKILL_FILES,
-                    referenced_files=None,
-                )
-                return response
 
             if config is None:
                 raise_tool_error(
@@ -933,130 +730,14 @@ class ConfigSceneTools:
                     )
                 )
 
-            config_dict, effective_category = self._validate_scene_config(
-                config,
+            return await self._run_scene_config_replace(
                 scene_id,
+                config,
+                config_hash,
                 category,
+                wait,
+                MandatoryBPS,
             )
-
-            # Issue #1168 R6 blocker 15: pre-validate ``category`` BEFORE
-            # the hash check + upsert commits. Same partial-state hazard as
-            # the python_transform branch — a phantom category must not
-            # rewrite the scene before erroring.
-            #
-            # Issue #1168 R8 (post-merge follow-up): gate on
-            # ``effective_category`` truthy, not on the user-facing
-            # ``category`` param. ``_validate_scene_config`` promotes a
-            # top-level ``config["category"]`` into ``effective_category``
-            # when the user passed ``category=None``; the R7 fix gated on
-            # ``category is not None`` to skip the WS round-trip when no
-            # category was supplied, but that left the dict-promoted path
-            # uncovered — a phantom category in ``config["category"]``
-            # would skip validation and reach ``apply_entity_category``,
-            # which attaches the phantom ID to the entity registry without
-            # checking it exists. Truthy check covers both sources and
-            # still skips the WS call when neither produces a category.
-            if effective_category:
-                await self._validate_category_id(effective_category)
-
-            # Issue #1168 R3 blocker 7: when caller passes ``config_hash``,
-            # honor the optimistic-locking semantics promised by the field
-            # description. ``_fetch_and_verify_hash`` raises ToolError on
-            # mismatch. We capture ``resolved_id`` from the verified fetch
-            # so subsequent upsert/response builders use the storage key
-            # consistently (issue #1168 R3 blocker 6).
-            #
-            # Path branching: if a hash is supplied for a non-existent
-            # scene, the inner fetch raises 404 and surfaces as
-            # ENTITY_NOT_FOUND via the outer except — which is the right
-            # caller-facing semantics ("you can't lock against a scene
-            # that doesn't exist"). The no-hash branch resolves separately
-            # so a fresh create still threads the resolved id correctly.
-            if config_hash:
-                _, resolved_id = await self._fetch_and_verify_hash(
-                    scene_id, config_hash, "set"
-                )
-            else:
-                resolved_id = await self._client.resolve_scene_id(scene_id)
-
-            # Cross-check literal service and entity references against the
-            # live registries. Soft warnings only.
-            validation_meta = await validate_config_references(
-                self._client, config_dict
-            )
-
-            # ``resolved_id`` is already the storage key (from the hash-verify
-            # fetch or the resolve above) — pass it as the write target to skip
-            # the redundant re-resolve. ``scene_id`` stays the caller id so a
-            # missing ``name`` defaults caller-facing, not to the storage key
-            # (#1935).
-            result = await self._client.upsert_scene_config(
-                config_dict, scene_id, resolved_id=resolved_id
-            )
-            # The upsert re-resolves when ``resolved_id`` was None (envelope
-            # omitted the key); re-bind to the authoritative write target it
-            # returned so entity resolution and the response use the resolved
-            # storage key rather than a possible None.
-            resolved_id = result.get("scene_id", resolved_id)
-
-            # Resolve actual entity_id via registry — HA derives scene
-            # entity_ids from the 'name' slug, not the scene_id storage key,
-            # so f"scene.{scene_id}" is wrong whenever a name is supplied.
-            entity_id = await self._resolve_scene_entity_id(
-                resolved_id, allow_component=True
-            )
-
-            # Wait for scene to be queryable
-            if wait:
-                try:
-                    registered = await wait_for_entity_registered(
-                        self._client, entity_id
-                    )
-                    if not registered:
-                        result.setdefault("warnings", []).append(
-                            f"Scene saved but {entity_id} not yet queryable. "
-                            "It may take a moment to become available."
-                        )
-                except (HomeAssistantConnectionError, HomeAssistantAuthError) as e:
-                    result.setdefault("warnings", []).append(
-                        f"Scene saved but verification failed: {e}"
-                    )
-
-            # Apply category to entity registry if provided.
-            if effective_category and entity_id:
-                # Pre-validation of ``effective_category`` already ran before
-                # the upsert (R6 blocker 15) — apply directly here.
-                await apply_entity_category(
-                    self._client,
-                    entity_id,
-                    effective_category,
-                    "scene",
-                    result,
-                    "scene",
-                )
-
-            merge_validation_meta(result, validation_meta)
-
-            # Issue #1168 R3 blocker 6: build response from ``resolved_id``
-            # so the outer ``scene_id`` always matches the storage key.
-            # ``result["scene_id"]`` is also the storage key (from
-            # rest_client); explicit assignment after the spread guards
-            # against any future result-shape drift.
-            response = {
-                "success": True,
-                **result,
-                "scene_id": resolved_id,
-            }
-            # attach AFTER the outer dict is built so hint lands at
-            # position 0 of the FINAL response (see
-            # util_helpers._SKILL_CONTENT_OPTOUT_HINT).
-            attach_skill_content(
-                response,
-                MandatoryBPS=MandatoryBPS,
-                canonical_files=_SCENE_SKILL_FILES,
-                referenced_files=None,
-            )
-            return response
 
         except ToolError as te:
             raise augment_tool_error_with_skill_content(te, bp_warnings=None) from None
@@ -1074,6 +755,412 @@ class ConfigSceneTools:
             )
             augment_error_dict_with_skill_content(error, bp_warnings=None)
             raise_tool_error(error)
+
+    async def _run_scene_python_transform(
+        self,
+        scene_id: str,
+        config_hash: str | None,
+        python_transform: str,
+        category: str | None,
+        wait: bool,
+        MandatoryBPS: bool,
+    ) -> dict[str, Any]:
+        """Execute ``ha_config_set_scene``'s python_transform mode.
+
+        Extracted verbatim from the inline branch; returns the tool response.
+        """
+        if config_hash is None:
+            raise_tool_error(
+                create_error_response(
+                    ErrorCode.VALIDATION_INVALID_PARAMETER,
+                    "config_hash is required for python_transform",
+                    suggestions=[
+                        "Call ha_config_get_scene() first",
+                        "Use the config_hash from that response",
+                    ],
+                    context={
+                        "action": "python_transform",
+                        "scene_id": scene_id,
+                    },
+                )
+            )
+
+        actual_config, resolved_id = await self._fetch_and_verify_hash(
+            scene_id, config_hash, "python_transform"
+        )
+        # Capture the scene's own ``id`` BEFORE the transform mutates the
+        # config in place — it is the stable identity the id-change guard
+        # compares against (in production it equals ``resolved_id``; it is
+        # also correct when ``resolved_id`` is None because the envelope
+        # omitted ``scene_id``).
+        original_id = actual_config.get("id")
+
+        try:
+            transformed_config = safe_execute(python_transform, actual_config)
+        except PythonSandboxError as e:
+            message, suggestions = format_sandbox_error(e, python_transform)
+            raise_tool_error(
+                create_error_response(
+                    ErrorCode.VALIDATION_FAILED,
+                    message,
+                    suggestions=suggestions,
+                    context={
+                        "action": "python_transform",
+                        "scene_id": resolved_id,
+                    },
+                )
+            )
+
+        self._validate_transformed_scene(transformed_config, resolved_id, original_id)
+        self._prune_scene_metadata(transformed_config, resolved_id)
+
+        # Issue #1168 R6 blocker 15: pre-validate ``category`` BEFORE
+        # the upsert commits. Validating after the write produced the
+        # exact partial-state-mutation pattern this PR's auto-attach
+        # contract was meant to eliminate — scene was rewritten,
+        # caller saw VALIDATION_INVALID_PARAMETER on a phantom
+        # category, and the storage state had already moved.
+        if category:
+            await self._validate_category_id(category)
+
+        # ``resolved_id`` is the storage key (write target); ``scene_id``
+        # stays the caller id so a missing ``name`` defaults caller-facing
+        # rather than to the storage key (#1935).
+        result = await self._client.upsert_scene_config(
+            transformed_config, scene_id, resolved_id=resolved_id
+        )
+        # The upsert re-resolves when ``resolved_id`` was None (envelope
+        # omitted the key); re-bind to the authoritative write target it
+        # returned so the re-fetch, entity resolution, and response all
+        # use the resolved storage key rather than a possible None.
+        resolved_id = result.get("scene_id", resolved_id)
+
+        # Re-fetch to get authoritative hash (HA may normalise after save).
+        # ``resolved_id`` is already the storage key, so skip the re-resolve.
+        _, new_config_hash, _ = await self._get_scene_config_internal(
+            resolved_id, _resolved=True
+        )
+
+        # Resolve actual entity_id and apply wait + category — same
+        # post-upsert finalisation the full-config branch runs. Without
+        # these, ``wait`` and ``category`` are silently dropped on
+        # python_transform calls.
+        entity_id = await self._resolve_scene_entity_id(
+            resolved_id, allow_component=True
+        )
+        if wait:
+            try:
+                registered = await wait_for_entity_registered(self._client, entity_id)
+                if not registered:
+                    result.setdefault("warnings", []).append(
+                        f"Scene updated but {entity_id} not yet queryable. "
+                        "It may take a moment to become available."
+                    )
+            except (HomeAssistantConnectionError, HomeAssistantAuthError) as e:
+                result.setdefault("warnings", []).append(
+                    f"Scene updated but verification failed: {e}"
+                )
+        if category and entity_id:
+            # Pre-validation of ``category`` already ran before the
+            # upsert (R6 blocker 15) — apply directly here.
+            await apply_entity_category(
+                self._client,
+                entity_id,
+                category,
+                "scene",
+                result,
+                "scene",
+            )
+
+        # Issue #1168 R3 blocker 6: build the response from
+        # ``resolved_id`` directly (not the caller-input ``scene_id``)
+        # so the outer field always matches the storage key carried
+        # in ``result``. ``result["scene_id"]`` is also the storage
+        # key from rest_client; the kwarg-after-spread order means
+        # the explicit assignment wins on key-collision regardless.
+        response: dict[str, Any] = {
+            "success": True,
+            **{k: v for k, v in result.items() if k != "success"},
+            "action": "python_transform",
+            "scene_id": resolved_id,
+            "config_hash": new_config_hash,
+            "python_expression": python_transform,
+            "message": f"Scene {resolved_id} updated via Python transform",
+        }
+        attach_skill_content(
+            response,
+            MandatoryBPS=MandatoryBPS,
+            canonical_files=_SCENE_SKILL_FILES,
+            referenced_files=None,
+        )
+        return response
+
+    @staticmethod
+    def _validate_transformed_scene(
+        transformed_config: Any,
+        resolved_id: str | None,
+        original_id: Any,
+    ) -> None:
+        """Validate a python_transform result still matches the scene shape.
+
+        Rejects a ``None`` rebind, a missing/non-dict ``entities`` field, and an
+        in-place ``id`` change (rename). Raises a structured ToolError on any
+        violation; returns normally when the transformed config is valid.
+        Extracted verbatim from ``ha_config_set_scene``'s python_transform branch.
+        """
+        # Issue #1168 R5 blocker 8: a transform that reassigns
+        # config to ``None`` (or returns ``None`` from a list-comp
+        # mistake) used to crash the next ``in`` check with a
+        # ``TypeError`` that surfaced as ``INTERNAL_ERROR``. Catch
+        # the rebind here so the user gets the same VALIDATION
+        # signal the dict-shape checks below produce.
+        if transformed_config is None:
+            raise_tool_error(
+                create_error_response(
+                    ErrorCode.VALIDATION_FAILED,
+                    "Transform must not reassign config to None",
+                    suggestions=[
+                        "The transform must produce a dict matching the scene config shape",
+                        "Mutate ``config`` in-place rather than reassigning it",
+                    ],
+                    context={
+                        "action": "python_transform",
+                        "scene_id": resolved_id,
+                    },
+                )
+            )
+
+        # Validate transformed config still has the required shape.
+        if "entities" not in transformed_config:
+            raise_tool_error(
+                create_error_response(
+                    ErrorCode.VALIDATION_FAILED,
+                    "Transformed config must still include 'entities'",
+                    suggestions=[
+                        "The transform may have removed the required field",
+                        "Ensure the config still has an 'entities' key",
+                    ],
+                    context={
+                        "action": "python_transform",
+                        "scene_id": resolved_id,
+                    },
+                )
+            )
+        if not isinstance(transformed_config["entities"], dict):
+            raise_tool_error(
+                create_error_response(
+                    ErrorCode.VALIDATION_FAILED,
+                    "Transformed 'entities' must remain a dict keyed by entity_id",
+                    context={
+                        "action": "python_transform",
+                        "scene_id": resolved_id,
+                        "resulting_type": type(transformed_config["entities"]).__name__,
+                    },
+                )
+            )
+
+        # Issue #1168 R5 blocker 10: a transform that mutates
+        # ``config['id']`` produces a duplicate scene at the new
+        # storage key AND orphans the original (state goes
+        # ``unavailable``, registry row left behind). HA itself
+        # accepts the mismatched-id upsert silently. Reject the
+        # rename here — renaming a scene means delete-old +
+        # create-new through the explicit tools, not an in-place
+        # ``id`` rebind. R6 blocker 18: only reject an explicit
+        # mismatched id; a transform that ``del config['id']`` is
+        # legitimate (HA treats ``id`` as optional) and should pass
+        # through. R7 blocker 24: ``transformed_config["id"] = None``
+        # is the in-place equivalent of ``del`` — normalise both
+        # by checking against ``(None, original_id)``, so only an
+        # explicit non-None mismatch triggers the reject. Compare against
+        # the scene's own captured ``id`` (not ``resolved_id``, which may
+        # be None on the structural-invariant path) — in production the
+        # two are equal.
+        if "id" in transformed_config and transformed_config["id"] not in (
+            None,
+            original_id,
+        ):
+            raise_tool_error(
+                create_error_response(
+                    ErrorCode.VALIDATION_FAILED,
+                    "Transform must not change ``config['id']``",
+                    suggestions=[
+                        f"Original scene_id is {original_id!r} — keep it unchanged",
+                        "To rename a scene, use ha_config_remove_scene + ha_config_set_scene",
+                    ],
+                    context={
+                        "action": "python_transform",
+                        "scene_id": original_id,
+                        "attempted_id": transformed_config.get("id"),
+                    },
+                )
+            )
+
+    @staticmethod
+    def _prune_scene_metadata(
+        transformed_config: dict[str, Any], resolved_id: str | None
+    ) -> None:
+        """Drop orphan ``metadata`` keys whose entity was removed by the transform.
+
+        Extracted verbatim from ``ha_config_set_scene``'s python_transform branch.
+        """
+        # Issue #1168 R3 blocker 5: prune orphan ``metadata`` keys
+        # whose entity was deleted by the transform (e.g. a list
+        # comprehension that filters ``entities`` doesn't touch
+        # ``metadata`` and HA keeps the orphan entries on disk).
+        # Full-replace via ``config=`` clears metadata cleanly; the
+        # transform path needs to mirror that contract.
+        metadata = transformed_config.get("metadata")
+        if isinstance(metadata, dict):
+            valid_keys = set(transformed_config["entities"].keys())
+            pruned_keys = sorted(k for k in metadata if k not in valid_keys)
+            if pruned_keys:
+                # Issue #1168 R5 blocker 12: a buggy transform that
+                # accidentally drops entities used to silently
+                # rewrite metadata. Surface the prune so a stray
+                # ``del entities[k]`` doesn't lose the friendly_name
+                # without trace.
+                logger.info(
+                    f"python_transform pruned {len(pruned_keys)} orphan "
+                    f"metadata key(s) from scene {resolved_id}: {pruned_keys}"
+                )
+            transformed_config["metadata"] = {
+                k: v for k, v in metadata.items() if k in valid_keys
+            }
+
+    async def _run_scene_config_replace(
+        self,
+        scene_id: str,
+        config: dict[str, Any],
+        config_hash: str | None,
+        category: str | None,
+        wait: bool,
+        MandatoryBPS: bool,
+    ) -> dict[str, Any]:
+        """Execute ``ha_config_set_scene``'s full-config replacement mode.
+
+        Extracted verbatim from the inline branch; returns the tool response.
+        """
+        config_dict, effective_category = self._validate_scene_config(
+            config,
+            scene_id,
+            category,
+        )
+
+        # Issue #1168 R6 blocker 15: pre-validate ``category`` BEFORE
+        # the hash check + upsert commits. Same partial-state hazard as
+        # the python_transform branch — a phantom category must not
+        # rewrite the scene before erroring.
+        #
+        # Issue #1168 R8 (post-merge follow-up): gate on
+        # ``effective_category`` truthy, not on the user-facing
+        # ``category`` param. ``_validate_scene_config`` promotes a
+        # top-level ``config["category"]`` into ``effective_category``
+        # when the user passed ``category=None``; the R7 fix gated on
+        # ``category is not None`` to skip the WS round-trip when no
+        # category was supplied, but that left the dict-promoted path
+        # uncovered — a phantom category in ``config["category"]``
+        # would skip validation and reach ``apply_entity_category``,
+        # which attaches the phantom ID to the entity registry without
+        # checking it exists. Truthy check covers both sources and
+        # still skips the WS call when neither produces a category.
+        if effective_category:
+            await self._validate_category_id(effective_category)
+
+        # Issue #1168 R3 blocker 7: when caller passes ``config_hash``,
+        # honor the optimistic-locking semantics promised by the field
+        # description. ``_fetch_and_verify_hash`` raises ToolError on
+        # mismatch. We capture ``resolved_id`` from the verified fetch
+        # so subsequent upsert/response builders use the storage key
+        # consistently (issue #1168 R3 blocker 6).
+        #
+        # Path branching: if a hash is supplied for a non-existent
+        # scene, the inner fetch raises 404 and surfaces as
+        # ENTITY_NOT_FOUND via the outer except — which is the right
+        # caller-facing semantics ("you can't lock against a scene
+        # that doesn't exist"). The no-hash branch resolves separately
+        # so a fresh create still threads the resolved id correctly.
+        if config_hash:
+            _, resolved_id = await self._fetch_and_verify_hash(
+                scene_id, config_hash, "set"
+            )
+        else:
+            resolved_id = await self._client.resolve_scene_id(scene_id)
+
+        # Cross-check literal service and entity references against the
+        # live registries. Soft warnings only.
+        validation_meta = await validate_config_references(self._client, config_dict)
+
+        # ``resolved_id`` is already the storage key (from the hash-verify
+        # fetch or the resolve above) — pass it as the write target to skip
+        # the redundant re-resolve. ``scene_id`` stays the caller id so a
+        # missing ``name`` defaults caller-facing, not to the storage key
+        # (#1935).
+        result = await self._client.upsert_scene_config(
+            config_dict, scene_id, resolved_id=resolved_id
+        )
+        # The upsert re-resolves when ``resolved_id`` was None (envelope
+        # omitted the key); re-bind to the authoritative write target it
+        # returned so entity resolution and the response use the resolved
+        # storage key rather than a possible None.
+        resolved_id = result.get("scene_id", resolved_id)
+
+        # Resolve actual entity_id via registry — HA derives scene
+        # entity_ids from the 'name' slug, not the scene_id storage key,
+        # so f"scene.{scene_id}" is wrong whenever a name is supplied.
+        entity_id = await self._resolve_scene_entity_id(
+            resolved_id, allow_component=True
+        )
+
+        # Wait for scene to be queryable
+        if wait:
+            try:
+                registered = await wait_for_entity_registered(self._client, entity_id)
+                if not registered:
+                    result.setdefault("warnings", []).append(
+                        f"Scene saved but {entity_id} not yet queryable. "
+                        "It may take a moment to become available."
+                    )
+            except (HomeAssistantConnectionError, HomeAssistantAuthError) as e:
+                result.setdefault("warnings", []).append(
+                    f"Scene saved but verification failed: {e}"
+                )
+
+        # Apply category to entity registry if provided.
+        if effective_category and entity_id:
+            # Pre-validation of ``effective_category`` already ran before
+            # the upsert (R6 blocker 15) — apply directly here.
+            await apply_entity_category(
+                self._client,
+                entity_id,
+                effective_category,
+                "scene",
+                result,
+                "scene",
+            )
+
+        merge_validation_meta(result, validation_meta)
+
+        # Issue #1168 R3 blocker 6: build response from ``resolved_id``
+        # so the outer ``scene_id`` always matches the storage key.
+        # ``result["scene_id"]`` is also the storage key (from
+        # rest_client); explicit assignment after the spread guards
+        # against any future result-shape drift.
+        response = {
+            "success": True,
+            **result,
+            "scene_id": resolved_id,
+        }
+        # attach AFTER the outer dict is built so hint lands at
+        # position 0 of the FINAL response (see
+        # util_helpers._SKILL_CONTENT_OPTOUT_HINT).
+        attach_skill_content(
+            response,
+            MandatoryBPS=MandatoryBPS,
+            canonical_files=_SCENE_SKILL_FILES,
+            referenced_files=None,
+        )
+        return response
 
     @tool(
         name="ha_config_remove_scene",

--- a/src/ha_mcp/tools/tools_config_scripts.py
+++ b/src/ha_mcp/tools/tools_config_scripts.py
@@ -695,99 +695,18 @@ class ConfigScriptTools:
 
             # Handle python_transform mode
             if python_transform is not None:
-                if config_hash is None:
-                    raise_tool_error(
-                        create_error_response(
-                            ErrorCode.VALIDATION_INVALID_PARAMETER,
-                            "config_hash is required for python_transform",
-                            suggestions=[
-                                "Call ha_config_get_script() first",
-                                "Use the config_hash from that response",
-                            ],
-                            context={
-                                "action": "python_transform",
-                                "script_id": script_id,
-                            },
-                        )
-                    )
-
-                # Fetch current config and verify hash
-                actual_config, resolved_id = await self._fetch_and_verify_hash(
-                    script_id, config_hash, "python_transform"
+                transformed_config, resolved_id = await self._prepare_script_transform(
+                    script_id, config_hash, python_transform
                 )
-
-                # Apply Python transformation on the actual script config
-                try:
-                    transformed_config = safe_execute(python_transform, actual_config)
-                except PythonSandboxError as e:
-                    message, suggestions = format_sandbox_error(e, python_transform)
-                    raise_tool_error(
-                        create_error_response(
-                            ErrorCode.VALIDATION_FAILED,
-                            message,
-                            suggestions=suggestions,
-                            context={
-                                "action": "python_transform",
-                                "script_id": script_id,
-                            },
-                        )
-                    )
-
-                # Validate transformed config
-                if (
-                    "sequence" not in transformed_config
-                    and "use_blueprint" not in transformed_config
-                ):
-                    raise_tool_error(
-                        create_error_response(
-                            ErrorCode.VALIDATION_FAILED,
-                            "Transformed config must include either 'sequence' or 'use_blueprint'",
-                            suggestions=[
-                                "The transform may have removed required fields",
-                                "Ensure the config still has a 'sequence' or 'use_blueprint' key",
-                            ],
-                            context={
-                                "action": "python_transform",
-                                "script_id": script_id,
-                            },
-                        )
-                    )
                 bp_warnings = _check_best_practices(transformed_config)
-
-                # Save transformed config. ``_fetch_and_verify_hash`` already
-                # resolved the storage key; pass it as the write target so the
-                # upsert skips the redundant re-resolve (issue #1813 Phase 0).
-                # ``script_id`` stays the caller id (the fetched config already
-                # carries an alias here, so the default is a no-op, but keep the
-                # contract consistent — #1935).
-                result = await self._client.upsert_script_config(
-                    transformed_config, script_id, resolved_id=resolved_id
+                return await self._commit_script_transform(
+                    script_id,
+                    transformed_config,
+                    resolved_id,
+                    python_transform,
+                    bp_warnings,
+                    MandatoryBPS,
                 )
-
-                # Re-fetch to get authoritative hash (HA may normalize after save)
-                _, new_config_hash, _ = await self._get_script_config_internal(
-                    script_id
-                )
-
-                response: dict[str, Any] = {
-                    "success": True,
-                    "action": "python_transform",
-                    "script_id": script_id,
-                    "config_hash": new_config_hash,
-                    "python_expression": python_transform,
-                    "message": f"Script {script_id} updated via Python transform",
-                    # Merge upsert result, excluding "success" (we set it ourselves)
-                    **{k: v for k, v in result.items() if k != "success"},
-                }
-                if bp_warnings:
-                    response["best_practice_warnings"] = list(bp_warnings)
-                attach_skill_content(
-                    response,
-                    MandatoryBPS=MandatoryBPS,
-                    canonical_files=_SCRIPT_SKILL_FILES,
-                    referenced_files=bp_warnings.referenced_files,
-                )
-                return response
 
             if config is None:
                 raise_tool_error(
@@ -821,62 +740,15 @@ class ConfigScriptTools:
             # Pre-check for best-practice issues.
             bp_warnings = _check_best_practices(config_dict)
 
-            # Cross-check literal service and entity references against
-            # the live registries. Soft warnings only — the write still
-            # happens, even when references don't resolve (#940).
-            validation_meta = await validate_config_references(
-                self._client, config_dict
+            return await self._commit_script_config(
+                config_dict,
+                script_id,
+                effective_category,
+                resolved_key,
+                wait,
+                bp_warnings,
+                MandatoryBPS,
             )
-
-            result = await self._upsert_script(config_dict, script_id, resolved_key)
-
-            # Wait for script to be queryable
-            entity_id = f"script.{script_id}"
-            if wait:
-                try:
-                    registered = await wait_for_entity_registered(
-                        self._client, entity_id
-                    )
-                    if not registered:
-                        result.setdefault("warnings", []).append(
-                            f"Script saved but {entity_id} not yet queryable. "
-                            "It may take a moment to become available."
-                        )
-                except (HomeAssistantConnectionError, HomeAssistantAuthError) as e:
-                    result.setdefault("warnings", []).append(
-                        f"Script saved but verification failed: {e}"
-                    )
-
-            # Apply category to entity registry if provided
-            if effective_category and entity_id:
-                await apply_entity_category(
-                    self._client,
-                    entity_id,
-                    effective_category,
-                    "script",
-                    result,
-                    "script",
-                )
-
-            if bp_warnings:
-                result["best_practice_warnings"] = list(bp_warnings)
-
-            merge_validation_meta(result, validation_meta)
-
-            response = {
-                "success": True,
-                **result,
-            }
-            # attach AFTER the outer dict is built so hint lands at
-            # position 0 of the FINAL response (see BAT history in
-            # util_helpers._SKILL_CONTENT_OPTOUT_HINT).
-            attach_skill_content(
-                response,
-                MandatoryBPS=MandatoryBPS,
-                canonical_files=_SCRIPT_SKILL_FILES,
-                referenced_files=bp_warnings.referenced_files,
-            )
-            return response
 
         except ToolError as te:
             raise augment_tool_error_with_skill_content(te, bp_warnings) from None
@@ -907,6 +779,192 @@ class ConfigScriptTools:
             )
             augment_error_dict_with_skill_content(error, bp_warnings)
             raise_tool_error(error)
+
+    async def _prepare_script_transform(
+        self, script_id: str, config_hash: str | None, python_transform: str
+    ) -> tuple[dict[str, Any], str | None]:
+        """Validate + run a script python_transform.
+
+        Returns ``(transformed_config, resolved_id)``. Extracted verbatim from
+        ``ha_config_set_script``'s python_transform branch (the pre-
+        ``_check_best_practices`` head): enforces config_hash, fetches +
+        hash-verifies, executes the sandboxed transform, and validates the
+        result still has a sequence or blueprint. Raises a structured ToolError
+        on any violation.
+        """
+        if config_hash is None:
+            raise_tool_error(
+                create_error_response(
+                    ErrorCode.VALIDATION_INVALID_PARAMETER,
+                    "config_hash is required for python_transform",
+                    suggestions=[
+                        "Call ha_config_get_script() first",
+                        "Use the config_hash from that response",
+                    ],
+                    context={
+                        "action": "python_transform",
+                        "script_id": script_id,
+                    },
+                )
+            )
+
+        # Fetch current config and verify hash
+        actual_config, resolved_id = await self._fetch_and_verify_hash(
+            script_id, config_hash, "python_transform"
+        )
+
+        # Apply Python transformation on the actual script config
+        try:
+            transformed_config = safe_execute(python_transform, actual_config)
+        except PythonSandboxError as e:
+            message, suggestions = format_sandbox_error(e, python_transform)
+            raise_tool_error(
+                create_error_response(
+                    ErrorCode.VALIDATION_FAILED,
+                    message,
+                    suggestions=suggestions,
+                    context={
+                        "action": "python_transform",
+                        "script_id": script_id,
+                    },
+                )
+            )
+
+        # Validate transformed config
+        if (
+            "sequence" not in transformed_config
+            and "use_blueprint" not in transformed_config
+        ):
+            raise_tool_error(
+                create_error_response(
+                    ErrorCode.VALIDATION_FAILED,
+                    "Transformed config must include either 'sequence' or 'use_blueprint'",
+                    suggestions=[
+                        "The transform may have removed required fields",
+                        "Ensure the config still has a 'sequence' or 'use_blueprint' key",
+                    ],
+                    context={
+                        "action": "python_transform",
+                        "script_id": script_id,
+                    },
+                )
+            )
+        return transformed_config, resolved_id
+
+    async def _commit_script_transform(
+        self,
+        script_id: str,
+        transformed_config: dict[str, Any],
+        resolved_id: str | None,
+        python_transform: str,
+        bp_warnings: BestPracticeCheckResult,
+        MandatoryBPS: bool,
+    ) -> dict[str, Any]:
+        """Upsert a transformed script config and build the tool response.
+
+        Extracted verbatim from ``ha_config_set_script``'s python_transform
+        branch (the post-``_check_best_practices`` tail).
+        """
+        # Save transformed config. ``_fetch_and_verify_hash`` already
+        # resolved the storage key; pass it as the write target so the
+        # upsert skips the redundant re-resolve (issue #1813 Phase 0).
+        # ``script_id`` stays the caller id (the fetched config already
+        # carries an alias here, so the default is a no-op, but keep the
+        # contract consistent — #1935).
+        result = await self._client.upsert_script_config(
+            transformed_config, script_id, resolved_id=resolved_id
+        )
+
+        # Re-fetch to get authoritative hash (HA may normalize after save)
+        _, new_config_hash, _ = await self._get_script_config_internal(script_id)
+
+        response: dict[str, Any] = {
+            "success": True,
+            "action": "python_transform",
+            "script_id": script_id,
+            "config_hash": new_config_hash,
+            "python_expression": python_transform,
+            "message": f"Script {script_id} updated via Python transform",
+            # Merge upsert result, excluding "success" (we set it ourselves)
+            **{k: v for k, v in result.items() if k != "success"},
+        }
+        if bp_warnings:
+            response["best_practice_warnings"] = list(bp_warnings)
+        attach_skill_content(
+            response,
+            MandatoryBPS=MandatoryBPS,
+            canonical_files=_SCRIPT_SKILL_FILES,
+            referenced_files=bp_warnings.referenced_files,
+        )
+        return response
+
+    async def _commit_script_config(
+        self,
+        config_dict: dict[str, Any],
+        script_id: str,
+        effective_category: str | None,
+        resolved_key: str | None,
+        wait: bool,
+        bp_warnings: BestPracticeCheckResult,
+        MandatoryBPS: bool,
+    ) -> dict[str, Any]:
+        """Validate references, upsert, wait, and build the tool response.
+
+        Extracted verbatim from ``ha_config_set_script``'s full-config branch
+        (the post-``_check_best_practices`` tail).
+        """
+        # Cross-check literal service and entity references against
+        # the live registries. Soft warnings only — the write still
+        # happens, even when references don't resolve (#940).
+        validation_meta = await validate_config_references(self._client, config_dict)
+
+        result = await self._upsert_script(config_dict, script_id, resolved_key)
+
+        # Wait for script to be queryable
+        entity_id = f"script.{script_id}"
+        if wait:
+            try:
+                registered = await wait_for_entity_registered(self._client, entity_id)
+                if not registered:
+                    result.setdefault("warnings", []).append(
+                        f"Script saved but {entity_id} not yet queryable. "
+                        "It may take a moment to become available."
+                    )
+            except (HomeAssistantConnectionError, HomeAssistantAuthError) as e:
+                result.setdefault("warnings", []).append(
+                    f"Script saved but verification failed: {e}"
+                )
+
+        # Apply category to entity registry if provided
+        if effective_category and entity_id:
+            await apply_entity_category(
+                self._client,
+                entity_id,
+                effective_category,
+                "script",
+                result,
+                "script",
+            )
+
+        if bp_warnings:
+            result["best_practice_warnings"] = list(bp_warnings)
+
+        merge_validation_meta(result, validation_meta)
+
+        response = {
+            "success": True,
+            **result,
+        }
+        # attach AFTER the outer dict is built so hint lands at
+        # position 0 of the FINAL response (see BAT history in
+        # util_helpers._SKILL_CONTENT_OPTOUT_HINT).
+        attach_skill_content(
+            response,
+            MandatoryBPS=MandatoryBPS,
+            canonical_files=_SCRIPT_SKILL_FILES,
+            referenced_files=bp_warnings.referenced_files,
+        )
+        return response
 
     @tool(
         name="ha_config_remove_script",

--- a/src/ha_mcp/tools/tools_dev.py
+++ b/src/ha_mcp/tools/tools_dev.py
@@ -100,6 +100,11 @@ _BACKGROUND_TASKS: set[asyncio.Task[None]] = set()
 # Sentinel marking a key for removal in _merge_file_override (reset action).
 _REMOVE = object()
 
+# Sentinel returned by the per-type ``_coerce_*_setting`` helpers when ``raw``
+# is not coercible to that type — the caller then raises the generic
+# type-mismatch error.
+_COERCE_MISS = object()
+
 
 def is_dev_mode_enabled() -> bool:
     """Check if developer mode is enabled.
@@ -442,40 +447,17 @@ class DevTools:
         for int/float). Raises ``ToolError`` on mismatch.
         """
         if ftype is bool:
-            if isinstance(raw, bool):
-                return raw
-            if isinstance(raw, str) and raw.strip().lower() in ("true", "false"):
-                return raw.strip().lower() == "true"
+            coerced = DevTools._coerce_bool_setting(raw)
         elif ftype is int:
-            if isinstance(raw, bool):
-                pass  # bool is an int subclass; reject below
-            elif isinstance(raw, int):
-                return raw
-            elif isinstance(raw, str):
-                try:
-                    return int(raw.strip())
-                except ValueError:
-                    pass
+            coerced = DevTools._coerce_int_setting(raw)
         elif ftype is float:
-            if isinstance(raw, bool):
-                pass
-            elif isinstance(raw, int | float):
-                return float(raw)
-            elif isinstance(raw, str):
-                try:
-                    return float(raw.strip())
-                except ValueError:
-                    pass
+            coerced = DevTools._coerce_float_setting(raw)
         elif ftype is str:
-            if isinstance(raw, str):
-                if "\x00" in raw:
-                    raise_tool_error(
-                        create_error_response(
-                            ErrorCode.VALIDATION_INVALID_PARAMETER,
-                            f"{fname!r} value contains a null byte",
-                        )
-                    )
-                return raw
+            coerced = DevTools._coerce_str_setting(fname, raw)
+        else:
+            coerced = _COERCE_MISS
+        if coerced is not _COERCE_MISS:
+            return coerced
         raise_tool_error(
             create_error_response(
                 ErrorCode.VALIDATION_INVALID_PARAMETER,
@@ -484,6 +466,60 @@ class DevTools:
             )
         )
         return None  # unreachable; explicit for CodeQL
+
+    @staticmethod
+    def _coerce_bool_setting(raw: Any) -> Any:
+        """Coerce ``raw`` to bool, or ``_COERCE_MISS`` if not coercible."""
+        if isinstance(raw, bool):
+            return raw
+        if isinstance(raw, str) and raw.strip().lower() in ("true", "false"):
+            return raw.strip().lower() == "true"
+        return _COERCE_MISS
+
+    @staticmethod
+    def _coerce_int_setting(raw: Any) -> Any:
+        """Coerce ``raw`` to int, or ``_COERCE_MISS`` if not coercible."""
+        if isinstance(raw, bool):
+            pass  # bool is an int subclass; reject below
+        elif isinstance(raw, int):
+            return raw
+        elif isinstance(raw, str):
+            try:
+                return int(raw.strip())
+            except ValueError:
+                pass
+        return _COERCE_MISS
+
+    @staticmethod
+    def _coerce_float_setting(raw: Any) -> Any:
+        """Coerce ``raw`` to float, or ``_COERCE_MISS`` if not coercible."""
+        if isinstance(raw, bool):
+            pass
+        elif isinstance(raw, int | float):
+            return float(raw)
+        elif isinstance(raw, str):
+            try:
+                return float(raw.strip())
+            except ValueError:
+                pass
+        return _COERCE_MISS
+
+    @staticmethod
+    def _coerce_str_setting(fname: str, raw: Any) -> Any:
+        """Coerce ``raw`` to str, or ``_COERCE_MISS`` if not a string.
+
+        Raises ``ToolError`` when a string contains a null byte.
+        """
+        if isinstance(raw, str):
+            if "\x00" in raw:
+                raise_tool_error(
+                    create_error_response(
+                        ErrorCode.VALIDATION_INVALID_PARAMETER,
+                        f"{fname!r} value contains a null byte",
+                    )
+                )
+            return raw
+        return _COERCE_MISS
 
     @staticmethod
     async def _merge_file_override(changes: dict[str, Any]) -> None:
@@ -657,12 +693,9 @@ class DevTools:
                 _ADVANCED_SETTINGS_SENTINELS,
                 _FEATURE_FLAG_INT_BOUNDS,
                 ADVANCED_SETTINGS_FIELDS,
-                BETA_FEATURE_FIELDS,
                 FEATURE_FLAG_FIELDS,
                 _read_feature_flag_override_file,
-                _reset_global_settings,
                 get_feature_flag_origin,
-                get_global_settings,
             )
 
             features = {f: (e, t) for f, e, t in FEATURE_FLAG_FIELDS}
@@ -697,122 +730,20 @@ class DevTools:
                 )
 
             if action == "reset":
-                if origin == "env":
-                    raise_tool_error(
-                        create_error_response(
-                            ErrorCode.VALIDATION_INVALID_PARAMETER,
-                            f"{setting!r} is pinned by the {env_name} env var; "
-                            "unset the env var instead.",
-                        )
-                    )
-                if origin == "addon":
-                    raise_tool_error(
-                        create_error_response(
-                            ErrorCode.VALIDATION_INVALID_PARAMETER,
-                            f"{setting!r} is managed by the add-on "
-                            "configuration; change it there or via "
-                            "action='set'.",
-                        )
-                    )
-                had_override = origin == "file"
-                if had_override:
-                    await self._merge_file_override({setting: _REMOVE})
-                    _reset_global_settings()
-                return {
-                    "success": True,
-                    "data": {
-                        "setting": setting,
-                        "removed_override": had_override,
-                        "restart_required": had_override,
-                    },
-                }
+                return await self._apply_setting_reset(setting, env_name, origin)
 
             # action == "set"
-            if value is None:
-                raise_tool_error(
-                    create_error_response(
-                        ErrorCode.VALIDATION_MISSING_PARAMETER,
-                        "'value' is required for action='set'",
-                    )
-                )
-            if not editable:
-                raise_tool_error(
-                    create_error_response(
-                        ErrorCode.VALIDATION_INVALID_PARAMETER,
-                        f"{setting!r} is locked by {origin}. "
-                        + (
-                            f"Unset the {env_name} env var to edit it here."
-                            if origin == "env"
-                            else "It is display-only on this surface."
-                        ),
-                    )
-                )
-            coerced = self._coerce_setting_value(setting, value, ftype)
-            if (
-                bounds is not None
-                and coerced != sentinel
-                and not (bounds[0] <= coerced <= bounds[1])
-            ):
-                raise_tool_error(
-                    create_error_response(
-                        ErrorCode.VALIDATION_INVALID_PARAMETER,
-                        f"{setting!r} must be between {bounds[0]} and {bounds[1]}",
-                    )
-                )
-            if choices is not None and coerced not in choices:
-                raise_tool_error(
-                    create_error_response(
-                        ErrorCode.VALIDATION_INVALID_PARAMETER,
-                        f"{setting!r} must be one of {list(choices)}",
-                    )
-                )
-            # Master beta gate: enabling a beta sub-flag while the
-            # effective master is off would be silently forced back off
-            # at runtime — reject loudly instead (same rule as the web
-            # UI save handler).
-            if (
-                setting in BETA_FEATURE_FIELDS
-                and bool(coerced)
-                and not get_global_settings().enable_beta_features
-            ):
-                raise_tool_error(
-                    create_error_response(
-                        ErrorCode.VALIDATION_INVALID_PARAMETER,
-                        f"Cannot enable beta sub-flag {setting!r} while "
-                        "'enable_beta_features' is off.",
-                        suggestions=["Set enable_beta_features=true first, then retry"],
-                    )
-                )
-
-            if origin == "addon":
-                from ..settings_ui._supervisor import _supervisor_merge_and_post_options
-
-                ok, err = await _supervisor_merge_and_post_options(
-                    get_global_settings().verify_ssl, {setting: coerced}
-                )
-                if not ok:
-                    message = err.message if err else "Supervisor update failed"
-                    raise_tool_error(
-                        create_error_response(
-                            ErrorCode.SERVICE_CALL_FAILED,
-                            f"Supervisor rejected the options update: {message}",
-                            suggestions=["Check the Supervisor and add-on logs"],
-                        )
-                    )
-                mode = "addon"
-            else:
-                await self._merge_file_override({setting: coerced})
-                _reset_global_settings()
-                mode = "file"
-            return {
-                "success": True,
-                "data": {
-                    "setting": setting,
-                    "value": coerced,
-                    "mode": mode,
-                    "restart_required": True,
-                },
-            }
+            return await self._apply_setting_set(
+                setting,
+                value,
+                env_name,
+                ftype,
+                origin,
+                editable,
+                bounds,
+                sentinel,
+                choices,
+            )
         except ToolError:
             raise
         except Exception as e:
@@ -822,6 +753,156 @@ class DevTools:
                 suggestions=["Check server logs for details"],
             )
             return None  # unreachable; explicit for CodeQL
+
+    async def _apply_setting_reset(
+        self, setting: str, env_name: str, origin: str
+    ) -> dict[str, Any]:
+        """Handle ``ha_dev_manage_settings`` action='reset'.
+
+        Extracted verbatim from the inline branch: rejects env/addon-managed
+        settings, removes any file override, and reports whether one existed.
+        """
+        from ..config import _reset_global_settings
+
+        if origin == "env":
+            raise_tool_error(
+                create_error_response(
+                    ErrorCode.VALIDATION_INVALID_PARAMETER,
+                    f"{setting!r} is pinned by the {env_name} env var; "
+                    "unset the env var instead.",
+                )
+            )
+        if origin == "addon":
+            raise_tool_error(
+                create_error_response(
+                    ErrorCode.VALIDATION_INVALID_PARAMETER,
+                    f"{setting!r} is managed by the add-on "
+                    "configuration; change it there or via "
+                    "action='set'.",
+                )
+            )
+        had_override = origin == "file"
+        if had_override:
+            await self._merge_file_override({setting: _REMOVE})
+            _reset_global_settings()
+        return {
+            "success": True,
+            "data": {
+                "setting": setting,
+                "removed_override": had_override,
+                "restart_required": had_override,
+            },
+        }
+
+    async def _apply_setting_set(
+        self,
+        setting: str,
+        value: bool | int | float | str | None,
+        env_name: str,
+        ftype: type,
+        origin: str,
+        editable: bool,
+        bounds: tuple[float, float] | None,
+        sentinel: int | None,
+        choices: tuple[str, ...] | None,
+    ) -> dict[str, Any]:
+        """Handle ``ha_dev_manage_settings`` action='set'.
+
+        Extracted verbatim from the inline branch: validates presence +
+        editability, coerces and range/choice/beta-checks the value, then
+        persists via Supervisor (add-on mode) or the override file.
+        """
+        from ..config import (
+            BETA_FEATURE_FIELDS,
+            _reset_global_settings,
+            get_global_settings,
+        )
+
+        if value is None:
+            raise_tool_error(
+                create_error_response(
+                    ErrorCode.VALIDATION_MISSING_PARAMETER,
+                    "'value' is required for action='set'",
+                )
+            )
+        if not editable:
+            raise_tool_error(
+                create_error_response(
+                    ErrorCode.VALIDATION_INVALID_PARAMETER,
+                    f"{setting!r} is locked by {origin}. "
+                    + (
+                        f"Unset the {env_name} env var to edit it here."
+                        if origin == "env"
+                        else "It is display-only on this surface."
+                    ),
+                )
+            )
+        coerced = self._coerce_setting_value(setting, value, ftype)
+        if (
+            bounds is not None
+            and coerced != sentinel
+            and not (bounds[0] <= coerced <= bounds[1])
+        ):
+            raise_tool_error(
+                create_error_response(
+                    ErrorCode.VALIDATION_INVALID_PARAMETER,
+                    f"{setting!r} must be between {bounds[0]} and {bounds[1]}",
+                )
+            )
+        if choices is not None and coerced not in choices:
+            raise_tool_error(
+                create_error_response(
+                    ErrorCode.VALIDATION_INVALID_PARAMETER,
+                    f"{setting!r} must be one of {list(choices)}",
+                )
+            )
+        # Master beta gate: enabling a beta sub-flag while the
+        # effective master is off would be silently forced back off
+        # at runtime — reject loudly instead (same rule as the web
+        # UI save handler).
+        if (
+            setting in BETA_FEATURE_FIELDS
+            and bool(coerced)
+            and not get_global_settings().enable_beta_features
+        ):
+            raise_tool_error(
+                create_error_response(
+                    ErrorCode.VALIDATION_INVALID_PARAMETER,
+                    f"Cannot enable beta sub-flag {setting!r} while "
+                    "'enable_beta_features' is off.",
+                    suggestions=["Set enable_beta_features=true first, then retry"],
+                )
+            )
+
+        if origin == "addon":
+            from ..settings_ui._supervisor import _supervisor_merge_and_post_options
+
+            ok, err = await _supervisor_merge_and_post_options(
+                get_global_settings().verify_ssl, {setting: coerced}
+            )
+            if not ok:
+                message = err.message if err else "Supervisor update failed"
+                raise_tool_error(
+                    create_error_response(
+                        ErrorCode.SERVICE_CALL_FAILED,
+                        f"Supervisor rejected the options update: {message}",
+                        suggestions=["Check the Supervisor and add-on logs"],
+                    )
+                )
+            mode = "addon"
+        else:
+            await self._merge_file_override({setting: coerced})
+            _reset_global_settings()
+            mode = "file"
+        return {
+            "success": True,
+            "data": {
+                "setting": setting,
+                "value": coerced,
+                "mode": mode,
+                "restart_required": True,
+            },
+        }
 
     @tool(
         name="ha_dev_manage_server",
@@ -974,9 +1055,14 @@ class DevTools:
             result["warnings"] = warnings
         return result
 
-    async def _update_source(
-        self, channel: str | None, pip_spec: str | None
-    ) -> dict[str, Any]:
+    @staticmethod
+    def _validate_update_source_args(channel: str | None, pip_spec: str | None) -> None:
+        """Validate ``update_source``'s channel/pip_spec arguments.
+
+        Extracted verbatim from ``_update_source``: raises a structured
+        ToolError when neither is given, the channel is unknown, or the
+        pip_spec is multi-line / over 500 chars.
+        """
         if channel is None and pip_spec is None:
             raise_tool_error(
                 create_error_response(
@@ -1000,6 +1086,11 @@ class DevTools:
                     "pip_spec must be a single-line string under 500 chars",
                 )
             )
+
+    async def _update_source(
+        self, channel: str | None, pip_spec: str | None
+    ) -> dict[str, Any]:
+        self._validate_update_source_args(channel, pip_spec)
 
         if is_embedded():
             # Embedded self-reload: prefer the component's one-hop direct write

--- a/src/ha_mcp/tools/tools_system.py
+++ b/src/ha_mcp/tools/tools_system.py
@@ -398,59 +398,7 @@ class SystemTools:
 
         try:
             if target == "all":
-                # Reload all reloadable components. Fire the calls concurrently
-                # but cap the in-flight count with a semaphore so a large
-                # install doesn't hit HA with ~16 simultaneous service calls.
-                # A single failing target must not cancel its siblings, so the
-                # calls are gathered with ``return_exceptions=True`` and
-                # attributed per target below (preserving RELOAD_TARGETS order).
-                reloadable = [
-                    (name, info)
-                    for name, info in RELOAD_TARGETS.items()
-                    if info is not None
-                ]
-                semaphore = asyncio.Semaphore(4)
-
-                async def _reload_one(domain: str, service: str) -> None:
-                    async with semaphore:
-                        await self._client.call_service(domain, service, {})
-
-                outcomes = await asyncio.gather(
-                    *(
-                        _reload_one(domain, service)
-                        for _, (domain, service) in reloadable
-                    ),
-                    return_exceptions=True,
-                )
-
-                results = []
-                errors = []
-                for (reload_target, _), outcome in zip(
-                    reloadable, outcomes, strict=True
-                ):
-                    if isinstance(outcome, BaseException):
-                        # A non-Exception BaseException (CancelledError,
-                        # KeyboardInterrupt, SystemExit) must still unwind the
-                        # request, exactly as the prior sequential
-                        # ``except Exception`` let it propagate — never demote
-                        # it to a per-target warning.
-                        if not isinstance(outcome, Exception):
-                            raise outcome
-                        # Some services might not be available in all installations
-                        error_msg = str(outcome)
-                        if "not found" not in error_msg.lower():
-                            errors.append(f"{reload_target}: {error_msg}")
-                    else:
-                        results.append(reload_target)
-
-                response: dict[str, Any] = {
-                    "success": True,
-                    "message": f"Reloaded {len(results)} components",
-                    "reloaded": results,
-                }
-                if errors:
-                    response["warnings"] = errors
-                return response
+                return await self._reload_all_targets()
 
             else:
                 # Reload specific component
@@ -486,6 +434,58 @@ class SystemTools:
                 ],
             )
             return None  # unreachable: exception_to_structured_error always raises
+
+    async def _reload_all_targets(self) -> dict[str, Any]:
+        """Reload every reloadable subsystem concurrently, capped by a semaphore.
+
+        Extracted verbatim from ``ha_reload_core``'s ``target == "all"`` branch.
+        """
+        # Reload all reloadable components. Fire the calls concurrently
+        # but cap the in-flight count with a semaphore so a large
+        # install doesn't hit HA with ~16 simultaneous service calls.
+        # A single failing target must not cancel its siblings, so the
+        # calls are gathered with ``return_exceptions=True`` and
+        # attributed per target below (preserving RELOAD_TARGETS order).
+        reloadable = [
+            (name, info) for name, info in RELOAD_TARGETS.items() if info is not None
+        ]
+        semaphore = asyncio.Semaphore(4)
+
+        async def _reload_one(domain: str, service: str) -> None:
+            async with semaphore:
+                await self._client.call_service(domain, service, {})
+
+        outcomes = await asyncio.gather(
+            *(_reload_one(domain, service) for _, (domain, service) in reloadable),
+            return_exceptions=True,
+        )
+
+        results = []
+        errors = []
+        for (reload_target, _), outcome in zip(reloadable, outcomes, strict=True):
+            if isinstance(outcome, BaseException):
+                # A non-Exception BaseException (CancelledError,
+                # KeyboardInterrupt, SystemExit) must still unwind the
+                # request, exactly as the prior sequential
+                # ``except Exception`` let it propagate — never demote
+                # it to a per-target warning.
+                if not isinstance(outcome, Exception):
+                    raise outcome
+                # Some services might not be available in all installations
+                error_msg = str(outcome)
+                if "not found" not in error_msg.lower():
+                    errors.append(f"{reload_target}: {error_msg}")
+            else:
+                results.append(reload_target)
+
+        response: dict[str, Any] = {
+            "success": True,
+            "message": f"Reloaded {len(results)} components",
+            "reloaded": results,
+        }
+        if errors:
+            response["warnings"] = errors
+        return response
 
     async def _reload_config_entry(self, entry_id: str) -> dict[str, Any]:
         """Reload a single config entry via the REST config-entries endpoint.
@@ -732,23 +732,7 @@ class SystemTools:
                 }
 
             # Warn about unrecognized include values
-            VALID_INCLUDES = {
-                "repairs",
-                "zha_network",
-                "zha_network_full",
-                "zwave_network",
-                "thread_network",
-                "matter_network",
-                "diagnostics",
-                "config_check",
-                "themes",
-                "dead_entities",
-            }
-            unknown = includes - VALID_INCLUDES
-            if unknown:
-                result.setdefault("warnings", []).append(
-                    f"Unknown include sections ignored: {', '.join(sorted(unknown))}"
-                )
+            self._warn_unknown_includes(result, includes)
 
             # Fetch optional sections concurrently. The ws_client serialises
             # outgoing writes via its internal `_send_lock`, but per-message
@@ -774,25 +758,17 @@ class SystemTools:
                 # sub-dict under its own key (same shape the section carries when
                 # the baseline is up but the fetch fails), plus a summary
                 # warning, then skip them so the REST sections below still run.
-                ws_error = "requires the system_health WebSocket, which is unavailable"
-                if want_repairs:
-                    result["repairs"] = {"error": ws_error}
-                if want_zha:
-                    result["zha_network"] = {"error": ws_error}
-                if want_zwave:
-                    result["zwave_network"] = {"error": ws_error}
-                if want_thread:
-                    result["thread_network"] = {"error": ws_error}
-                if want_matter:
-                    result["matter_network"] = {"error": ws_error}
-                if want_themes:
-                    result["themes"] = {"error": ws_error}
-                unavailable = sorted(includes & ws_backed)
-                if unavailable:
-                    result.setdefault("warnings", []).append(
-                        "These sections require the system_health WebSocket, "
-                        f"which is unavailable: {', '.join(unavailable)}"
-                    )
+                self._stub_ws_unavailable(
+                    result,
+                    includes,
+                    ws_backed,
+                    want_repairs=want_repairs,
+                    want_zha=want_zha,
+                    want_zwave=want_zwave,
+                    want_thread=want_thread,
+                    want_matter=want_matter,
+                    want_themes=want_themes,
+                )
                 want_repairs = want_zha = want_zwave = want_thread = want_matter = (
                     want_themes
                 ) = False
@@ -821,159 +797,31 @@ class SystemTools:
                     include_states=want_dead_entities,
                 )
 
-            sections: list[tuple[str, Coroutine[Any, Any, dict[str, Any]]]] = []
-            if want_repairs:
-                sections.append(
-                    (
-                        "repairs",
-                        self._fetch_repairs(
-                            ws_client,
-                            include_dismissed=include_dismissed_repairs_bool,
-                            prefetched_repairs=(snapshot.repairs if snapshot else None),
-                        ),
-                    )
-                )
-            if want_zha:
-                sections.append(
-                    ("zha_network", self._fetch_zha_network(ws_client, full=zha_full))
-                )
-            if want_zwave:
-                sections.append(
-                    (
-                        "zwave_network",
-                        self._fetch_zwave_network(
-                            ws_client,
-                            prefetched_entries=(
-                                snapshot.config_entries if snapshot else None
-                            ),
-                        ),
-                    )
-                )
-            if want_thread:
-                sections.append(
-                    ("thread_network", self._fetch_thread_network(ws_client))
-                )
-            if want_matter:
-                sections.append(
-                    (
-                        "matter_network",
-                        self._fetch_matter_network(
-                            ws_client,
-                            prefetched_entries=(
-                                snapshot.config_entries if snapshot else None
-                            ),
-                        ),
-                    )
-                )
-            if want_themes:
-                sections.append(("themes", self._fetch_themes(ws_client)))
-
-            if sections:
-                gathered = await asyncio.gather(
-                    *[coro for _, coro in sections], return_exceptions=True
-                )
-                # Pre-pass: re-raise anything that must unwind the request
-                # rather than land as an embedded section error. ``gather``
-                # with ``return_exceptions=True`` returns ``CancelledError``
-                # (and any other ``BaseException``) as a result element
-                # instead of propagating, and a ``ToolError`` raised from
-                # inside a helper would otherwise be silently demoted to
-                # ``{"error": "ToolError: …"}`` and break the MCP
-                # ``isError=true`` contract for the whole tool.
-                # ``_reraise_if_fatal`` encapsulates the policy (cancellation,
-                # interpreter-exit, ``ToolError``, and the codebase's transport
-                # ``HomeAssistantConnectionError``) — the single source of
-                # truth shared with each section helper's ``except`` chain.
-                for section_result in gathered:
-                    if isinstance(section_result, BaseException):
-                        _reraise_if_fatal(section_result)
-                for (section_name, _), section_result in zip(
-                    sections, gathered, strict=True
-                ):
-                    if isinstance(section_result, Exception):
-                        # Last-resort fallback: emit a minimal ``{error: ...}``
-                        # dict so an unexpected exception attributes to its
-                        # section instead of bubbling out and dropping siblings.
-                        # The helpers themselves return richer
-                        # ``{<key>: <baseline>, ..., error: ...}`` shapes on
-                        # their own (caught) failures; this branch is the
-                        # belt-and-suspenders path that fires only on a
-                        # helper-edit regression that lets an exception escape.
-                        logger.warning(
-                            "Concurrent fetch for section %r raised: %s: %s",
-                            section_name,
-                            type(section_result).__name__,
-                            section_result,
-                        )
-                        result[section_name] = {
-                            "error": (
-                                f"{type(section_result).__name__}: {section_result}"
-                            )
-                        }
-                    else:
-                        result[section_name] = section_result
-
-            # Diagnostics-related coercions live outside the includes branch
-            # so the orphan-args warning at the ``elif`` after the
-            # ``if "diagnostics" in includes`` block (see below) can see
-            # canonicalised values — passing ``diagnostics_data_offset=20``
-            # without ``include=diagnostics`` would otherwise slip past the gate.
-            fields_list = parse_diagnostics_fields(diagnostics_fields)
-            truncate_bytes = diagnostics_truncate_at_bytes
-            data_offset_int = (
-                diagnostics_data_offset if diagnostics_data_offset is not None else 0
+            sections = self._build_ws_sections(
+                ws_client,
+                snapshot,
+                include_dismissed_repairs_bool,
+                zha_full,
+                want_repairs=want_repairs,
+                want_zha=want_zha,
+                want_zwave=want_zwave,
+                want_thread=want_thread,
+                want_matter=want_matter,
+                want_themes=want_themes,
             )
-            data_limit_int = diagnostics_data_limit
-            # Type-guard ``diagnostics_data_path`` here so a bad caller (dict /
-            # list) surfaces as ``VALIDATION_INVALID_PARAMETER`` instead of
-            # leaking as ``INTERNAL_ERROR`` from the resolver's ``.strip()``
-            # downstream.
-            if diagnostics_data_path is not None and not isinstance(
-                diagnostics_data_path, str
-            ):
-                raise_tool_error(
-                    create_error_response(
-                        ErrorCode.VALIDATION_INVALID_PARAMETER,
-                        "diagnostics_data_path must be a string, got "
-                        f"{type(diagnostics_data_path).__name__}",
-                        context={"parameter": "diagnostics_data_path"},
-                    )
-                )
+            await self._gather_and_attribute(sections, result)
 
-            if "diagnostics" in includes:
-                # ``fetch_integration_diagnostics`` carries the empty-id guard
-                # (returns {"config_entry_id": ..., "error": ...}); calling it
-                # unconditionally keeps the missing-id error shape consistent
-                # with the populated path instead of returning a bare
-                # ``{"error": ...}`` sub-dict on the inline branch. Forward
-                # ``config_entry_id`` as-is (None / "") so the helper's echo
-                # field reflects what the caller actually passed.
-                result["diagnostics"] = await fetch_integration_diagnostics(
-                    self._client,
-                    config_entry_id,
-                    device_id,
-                    fields=fields_list,
-                    truncate_at_bytes=truncate_bytes,
-                    data_path=diagnostics_data_path,
-                    data_offset=data_offset_int,
-                    data_limit=data_limit_int,
-                )
-            elif (
-                config_entry_id
-                or device_id
-                or diagnostics_fields is not None
-                or diagnostics_truncate_at_bytes is not None
-                or diagnostics_data_path is not None
-                or diagnostics_data_limit is not None
-                or data_offset_int > 0
-            ):
-                result.setdefault("warnings", []).append(
-                    "config_entry_id, device_id, diagnostics_fields, "
-                    "diagnostics_truncate_at_bytes, diagnostics_data_path, "
-                    "diagnostics_data_offset, and/or diagnostics_data_limit "
-                    "were provided but ignored because 'diagnostics' is not "
-                    "in include"
-                )
+            await self._run_diagnostics_section(
+                result,
+                includes,
+                config_entry_id,
+                device_id,
+                diagnostics_fields,
+                diagnostics_truncate_at_bytes,
+                diagnostics_data_path,
+                diagnostics_data_offset,
+                diagnostics_data_limit,
+            )
 
             if "config_check" in includes:
                 # REST call on self._client (POST /config/core/check_config),
@@ -983,27 +831,7 @@ class SystemTools:
                 # in one call.
                 result["config_check"] = await self._fetch_config_check()
 
-            if want_dead_entities:
-                # REST + the REST client's own per-client WebSocket bridge
-                # (states via /api/states, registry + config-entries via the
-                # bridge), not the health ws_client — so it runs inline like
-                # config_check and survives a baseline-WS-down install. When
-                # the snapshot fetched above succeeded, its entities/states/
-                # config_entries slices replace all three fetches.
-                dead_section = await self._fetch_dead_entities(
-                    prefetched_states=snapshot.states if snapshot else None,
-                    prefetched_registry=snapshot.registry if snapshot else None,
-                    prefetched_entries=(snapshot.config_entries if snapshot else None),
-                )
-                # Pop the ``_warnings`` sentinel and bubble it to the top-level
-                # ``result["warnings"]`` (the documented contract location).
-                # The section helper uses this sentinel so its return signature
-                # stays uniform with every other section (a plain dict) while
-                # avoiding a collision with the reserved ``warnings`` term.
-                section_warnings = dead_section.pop("_warnings", None)
-                if section_warnings:
-                    result.setdefault("warnings", []).extend(section_warnings)
-                result["dead_entities"] = dead_section
+            await self._run_dead_entities_section(result, snapshot, want_dead_entities)
 
             # Surface the MCP server's own update status so the model can relay
             # it in chat. ``get_update_field`` is best-effort, thread-offloaded,
@@ -1030,6 +858,297 @@ class SystemTools:
             return None  # unreachable: exception_to_structured_error always raises
         finally:
             await self._safe_disconnect(ws_client)
+
+    @staticmethod
+    def _warn_unknown_includes(result: dict[str, Any], includes: set[str]) -> None:
+        """Append a warning to ``result`` for any unrecognized include sections.
+
+        Extracted verbatim from ``ha_get_system_health``.
+        """
+        VALID_INCLUDES = {
+            "repairs",
+            "zha_network",
+            "zha_network_full",
+            "zwave_network",
+            "thread_network",
+            "matter_network",
+            "diagnostics",
+            "config_check",
+            "themes",
+            "dead_entities",
+        }
+        unknown = includes - VALID_INCLUDES
+        if unknown:
+            result.setdefault("warnings", []).append(
+                f"Unknown include sections ignored: {', '.join(sorted(unknown))}"
+            )
+
+    @staticmethod
+    def _stub_ws_unavailable(
+        result: dict[str, Any],
+        includes: set[str],
+        ws_backed: set[str],
+        *,
+        want_repairs: bool,
+        want_zha: bool,
+        want_zwave: bool,
+        want_thread: bool,
+        want_matter: bool,
+        want_themes: bool,
+    ) -> None:
+        """Stub each requested WS-backed section as an error and add a summary
+        warning when the health WebSocket is unavailable.
+
+        Extracted verbatim from ``ha_get_system_health``.
+        """
+        ws_error = "requires the system_health WebSocket, which is unavailable"
+        if want_repairs:
+            result["repairs"] = {"error": ws_error}
+        if want_zha:
+            result["zha_network"] = {"error": ws_error}
+        if want_zwave:
+            result["zwave_network"] = {"error": ws_error}
+        if want_thread:
+            result["thread_network"] = {"error": ws_error}
+        if want_matter:
+            result["matter_network"] = {"error": ws_error}
+        if want_themes:
+            result["themes"] = {"error": ws_error}
+        unavailable = sorted(includes & ws_backed)
+        if unavailable:
+            result.setdefault("warnings", []).append(
+                "These sections require the system_health WebSocket, "
+                f"which is unavailable: {', '.join(unavailable)}"
+            )
+
+    def _build_ws_sections(
+        self,
+        ws_client: Any,
+        snapshot: _SystemSnapshotSlices | None,
+        include_dismissed_repairs_bool: bool,
+        zha_full: bool,
+        *,
+        want_repairs: bool,
+        want_zha: bool,
+        want_zwave: bool,
+        want_thread: bool,
+        want_matter: bool,
+        want_themes: bool,
+    ) -> list[tuple[str, Coroutine[Any, Any, dict[str, Any]]]]:
+        """Build the list of ``(name, coroutine)`` WS-backed sections to gather.
+
+        Extracted verbatim from ``ha_get_system_health``.
+        """
+        sections: list[tuple[str, Coroutine[Any, Any, dict[str, Any]]]] = []
+        if want_repairs:
+            sections.append(
+                (
+                    "repairs",
+                    self._fetch_repairs(
+                        ws_client,
+                        include_dismissed=include_dismissed_repairs_bool,
+                        prefetched_repairs=(snapshot.repairs if snapshot else None),
+                    ),
+                )
+            )
+        if want_zha:
+            sections.append(
+                ("zha_network", self._fetch_zha_network(ws_client, full=zha_full))
+            )
+        if want_zwave:
+            sections.append(
+                (
+                    "zwave_network",
+                    self._fetch_zwave_network(
+                        ws_client,
+                        prefetched_entries=(
+                            snapshot.config_entries if snapshot else None
+                        ),
+                    ),
+                )
+            )
+        if want_thread:
+            sections.append(("thread_network", self._fetch_thread_network(ws_client)))
+        if want_matter:
+            sections.append(
+                (
+                    "matter_network",
+                    self._fetch_matter_network(
+                        ws_client,
+                        prefetched_entries=(
+                            snapshot.config_entries if snapshot else None
+                        ),
+                    ),
+                )
+            )
+        if want_themes:
+            sections.append(("themes", self._fetch_themes(ws_client)))
+        return sections
+
+    @staticmethod
+    async def _gather_and_attribute(
+        sections: list[tuple[str, Coroutine[Any, Any, dict[str, Any]]]],
+        result: dict[str, Any],
+    ) -> None:
+        """Gather the WS-backed section coroutines and attribute each outcome to
+        ``result[<section>]``, re-raising fatal exceptions.
+
+        Extracted verbatim from ``ha_get_system_health``.
+        """
+        if not sections:
+            return
+        gathered = await asyncio.gather(
+            *[coro for _, coro in sections], return_exceptions=True
+        )
+        # Pre-pass: re-raise anything that must unwind the request
+        # rather than land as an embedded section error. ``gather``
+        # with ``return_exceptions=True`` returns ``CancelledError``
+        # (and any other ``BaseException``) as a result element
+        # instead of propagating, and a ``ToolError`` raised from
+        # inside a helper would otherwise be silently demoted to
+        # ``{"error": "ToolError: …"}`` and break the MCP
+        # ``isError=true`` contract for the whole tool.
+        # ``_reraise_if_fatal`` encapsulates the policy (cancellation,
+        # interpreter-exit, ``ToolError``, and the codebase's transport
+        # ``HomeAssistantConnectionError``) — the single source of
+        # truth shared with each section helper's ``except`` chain.
+        for section_result in gathered:
+            if isinstance(section_result, BaseException):
+                _reraise_if_fatal(section_result)
+        for (section_name, _), section_result in zip(sections, gathered, strict=True):
+            if isinstance(section_result, Exception):
+                # Last-resort fallback: emit a minimal ``{error: ...}``
+                # dict so an unexpected exception attributes to its
+                # section instead of bubbling out and dropping siblings.
+                # The helpers themselves return richer
+                # ``{<key>: <baseline>, ..., error: ...}`` shapes on
+                # their own (caught) failures; this branch is the
+                # belt-and-suspenders path that fires only on a
+                # helper-edit regression that lets an exception escape.
+                logger.warning(
+                    "Concurrent fetch for section %r raised: %s: %s",
+                    section_name,
+                    type(section_result).__name__,
+                    section_result,
+                )
+                result[section_name] = {
+                    "error": (f"{type(section_result).__name__}: {section_result}")
+                }
+            else:
+                result[section_name] = section_result
+
+    async def _run_diagnostics_section(
+        self,
+        result: dict[str, Any],
+        includes: set[str],
+        config_entry_id: str | None,
+        device_id: str | None,
+        diagnostics_fields: list[str] | str | None,
+        diagnostics_truncate_at_bytes: int | None,
+        diagnostics_data_path: str | None,
+        diagnostics_data_offset: int | None,
+        diagnostics_data_limit: int | None,
+    ) -> None:
+        """Coerce diagnostics args and run the diagnostics section, or warn when
+        diagnostics-only args were passed without ``include=diagnostics``.
+
+        Extracted verbatim from ``ha_get_system_health``.
+        """
+        # Diagnostics-related coercions live outside the includes branch
+        # so the orphan-args warning at the ``elif`` after the
+        # ``if "diagnostics" in includes`` block (see below) can see
+        # canonicalised values — passing ``diagnostics_data_offset=20``
+        # without ``include=diagnostics`` would otherwise slip past the gate.
+        fields_list = parse_diagnostics_fields(diagnostics_fields)
+        truncate_bytes = diagnostics_truncate_at_bytes
+        data_offset_int = (
+            diagnostics_data_offset if diagnostics_data_offset is not None else 0
+        )
+        data_limit_int = diagnostics_data_limit
+        # Type-guard ``diagnostics_data_path`` here so a bad caller (dict /
+        # list) surfaces as ``VALIDATION_INVALID_PARAMETER`` instead of
+        # leaking as ``INTERNAL_ERROR`` from the resolver's ``.strip()``
+        # downstream.
+        if diagnostics_data_path is not None and not isinstance(
+            diagnostics_data_path, str
+        ):
+            raise_tool_error(
+                create_error_response(
+                    ErrorCode.VALIDATION_INVALID_PARAMETER,
+                    "diagnostics_data_path must be a string, got "
+                    f"{type(diagnostics_data_path).__name__}",
+                    context={"parameter": "diagnostics_data_path"},
+                )
+            )
+
+        if "diagnostics" in includes:
+            # ``fetch_integration_diagnostics`` carries the empty-id guard
+            # (returns {"config_entry_id": ..., "error": ...}); calling it
+            # unconditionally keeps the missing-id error shape consistent
+            # with the populated path instead of returning a bare
+            # ``{"error": ...}`` sub-dict on the inline branch. Forward
+            # ``config_entry_id`` as-is (None / "") so the helper's echo
+            # field reflects what the caller actually passed.
+            result["diagnostics"] = await fetch_integration_diagnostics(
+                self._client,
+                config_entry_id,
+                device_id,
+                fields=fields_list,
+                truncate_at_bytes=truncate_bytes,
+                data_path=diagnostics_data_path,
+                data_offset=data_offset_int,
+                data_limit=data_limit_int,
+            )
+        elif (
+            config_entry_id
+            or device_id
+            or diagnostics_fields is not None
+            or diagnostics_truncate_at_bytes is not None
+            or diagnostics_data_path is not None
+            or diagnostics_data_limit is not None
+            or data_offset_int > 0
+        ):
+            result.setdefault("warnings", []).append(
+                "config_entry_id, device_id, diagnostics_fields, "
+                "diagnostics_truncate_at_bytes, diagnostics_data_path, "
+                "diagnostics_data_offset, and/or diagnostics_data_limit "
+                "were provided but ignored because 'diagnostics' is not "
+                "in include"
+            )
+
+    async def _run_dead_entities_section(
+        self,
+        result: dict[str, Any],
+        snapshot: _SystemSnapshotSlices | None,
+        want_dead_entities: bool,
+    ) -> None:
+        """Run the dead-entities section and bubble its warnings to
+        ``result["warnings"]`` when requested.
+
+        Extracted verbatim from ``ha_get_system_health``.
+        """
+        if not want_dead_entities:
+            return
+        # REST + the REST client's own per-client WebSocket bridge
+        # (states via /api/states, registry + config-entries via the
+        # bridge), not the health ws_client — so it runs inline like
+        # config_check and survives a baseline-WS-down install. When
+        # the snapshot fetched above succeeded, its entities/states/
+        # config_entries slices replace all three fetches.
+        dead_section = await self._fetch_dead_entities(
+            prefetched_states=snapshot.states if snapshot else None,
+            prefetched_registry=snapshot.registry if snapshot else None,
+            prefetched_entries=(snapshot.config_entries if snapshot else None),
+        )
+        # Pop the ``_warnings`` sentinel and bubble it to the top-level
+        # ``result["warnings"]`` (the documented contract location).
+        # The section helper uses this sentinel so its return signature
+        # stays uniform with every other section (a plain dict) while
+        # avoiding a collision with the reserved ``warnings`` term.
+        section_warnings = dead_section.pop("_warnings", None)
+        if section_warnings:
+            result.setdefault("warnings", []).extend(section_warnings)
+        result["dead_entities"] = dead_section
 
     @staticmethod
     def _parse_includes(include: str | None) -> set[str]:
@@ -1553,6 +1672,176 @@ class SystemTools:
             return result, None
         return None, f"unexpected result shape: {type(result).__name__}"
 
+    async def _acquire_dead_entity_sources(
+        self,
+        prefetched_states: list[dict[str, Any]] | None,
+        prefetched_registry: dict[str, Any] | None,
+        prefetched_entries: dict[str, Any] | None,
+        dead: dict[str, Any],
+        bubble_warnings: list[str],
+    ) -> tuple[dict[str, Any], list[dict[str, Any]], set[str] | None] | None:
+        """Fetch + validate the states / registry / config-entries sources.
+
+        Returns ``(state_by_id, registry, live_entry_ids)`` on success, or
+        ``None`` after recording a hard-error message on ``dead`` (the caller
+        then returns ``dead``). Degradable config-entries issues append to
+        ``bubble_warnings`` and still return the tuple. Extracted verbatim from
+        ``_fetch_dead_entities``.
+        """
+        # All three slices are supplied together by the caller as one
+        # unit (the ``system_snapshot`` contract guarantees they're
+        # never partial — see ``_build_system_snapshot_slices``), so the
+        # gate requires all three rather than just ``prefetched_registry``
+        # to keep that invariant explicit here rather than relying on the
+        # call site.
+        if (
+            prefetched_states is not None
+            and prefetched_registry is not None
+            and prefetched_entries is not None
+        ):
+            states: Any = prefetched_states
+            registry_raw: Any = prefetched_registry
+            entries_raw: Any = prefetched_entries
+        else:
+            # Index the gather result (rather than tuple-unpack) so mypy
+            # can type each element through the return_exceptions=True
+            # overload; mirrors smart_search/_entities.py::_fetch_search_entities.
+            results = await asyncio.gather(
+                self._client.get_states(),
+                self._client.send_websocket_message(
+                    {"type": "config/entity_registry/list"}
+                ),
+                self._client.send_websocket_message({"type": "config_entries/get"}),
+                return_exceptions=True,
+            )
+            states = results[0]
+            registry_raw = results[1]
+            entries_raw = results[2]
+
+        if isinstance(states, BaseException):
+            # Truly-fatal errors must propagate, not demote to a section
+            # error string (mirrors the ws sections gather pre-pass).
+            _reraise_if_fatal(states)
+            dead["error"] = f"Could not fetch entity states: {states}"
+            return None
+        if not isinstance(states, list):
+            dead["error"] = (
+                "Could not fetch entity states: expected list, got "
+                f"{type(states).__name__}"
+            )
+            return None
+        registry, registry_err = self._ws_result_list(registry_raw)
+        if registry is None:
+            # Preserve the underlying cause (envelope error message,
+            # exception type, or wrong-shape description) so the client
+            # can distinguish auth vs command vs malformed envelope
+            # rather than see a fixed "unavailable" substitute.
+            dead["error"] = (
+                f"Could not fetch entity registry "
+                f"(config/entity_registry/list: {registry_err})"
+            )
+            return None
+
+        # config-entries is the only optional source: without it the
+        # definitive orphan tier can't be computed, but stale_restored still
+        # can — so degrade rather than fail the whole section.
+        entries, entries_err = self._ws_result_list(entries_raw)
+        live_entry_ids: set[str] | None = None
+        if entries is None:
+            # Genuine fetch failure — preserve the cause so a backend
+            # failure isn't reported as "no entries".
+            dead["config_entries_checked"] = False
+            bubble_warnings.append(
+                f"config_entries/get failed ({entries_err}); "
+                "config_entry_orphans tier skipped (cannot distinguish a "
+                "removed integration from a failed fetch). stale_restored "
+                "still computed."
+            )
+        elif not entries:
+            # Real empty list — HA reports no config entries configured.
+            # Distinct from a fetch failure: the message names the actual
+            # state. The orphan tier still skips since there is no live
+            # set to diff against; stale_restored still computed.
+            dead["config_entries_checked"] = False
+            bubble_warnings.append(
+                "config_entries/get returned an empty list (no "
+                "integrations configured); config_entry_orphans tier "
+                "skipped. stale_restored still computed."
+            )
+        else:
+            live_entry_ids = {
+                e["entry_id"]
+                for e in entries
+                if isinstance(e, dict) and e.get("entry_id")
+            }
+            dead["config_entries_checked"] = True
+
+        state_by_id = {
+            s["entity_id"]: s
+            for s in states
+            if isinstance(s, dict) and s.get("entity_id")
+        }
+        return state_by_id, registry, live_entry_ids
+
+    @staticmethod
+    def _classify_registry_entries(
+        registry: list[dict[str, Any]],
+        state_by_id: dict[str, Any],
+        live_entry_ids: set[str] | None,
+    ) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+        """Classify registry entries into ``(orphans, stale_restored)`` buckets.
+
+        Extracted verbatim from ``_fetch_dead_entities``' classification loop.
+        """
+        orphans: list[dict[str, Any]] = []
+        stale: list[dict[str, Any]] = []
+        for entry in registry:
+            if not isinstance(entry, dict):
+                continue
+            eid = entry.get("entity_id")
+            if not eid:
+                continue
+            cfg = entry.get("config_entry_id")
+            disabled_by = entry.get("disabled_by")
+
+            # Tier 1 — config-entry orphan (only when the live set loaded).
+            # Covers disabled leftovers too: a disabled entity whose config
+            # entry is gone is still dead cruft (disabled_by is surfaced on
+            # the item so the client sees why it lingered).
+            if live_entry_ids is not None and cfg and cfg not in live_entry_ids:
+                orphans.append(
+                    {
+                        "entity_id": eid,
+                        "platform": entry.get("platform"),
+                        "config_entry_id": cfg,
+                        "disabled_by": disabled_by,
+                        "has_state": eid in state_by_id,
+                    }
+                )
+                continue
+
+            # Tier 2 — stale restored. Skip intentionally-disabled entries
+            # (they normally have no state object anyway).
+            if disabled_by is not None:
+                continue
+            state_obj = state_by_id.get(eid)
+            if state_obj is None:
+                continue
+            attrs = state_obj.get("attributes")
+            if (
+                state_obj.get("state") == "unavailable"
+                and isinstance(attrs, dict)
+                and attrs.get("restored")
+            ):
+                stale.append(
+                    {
+                        "entity_id": eid,
+                        "platform": entry.get("platform"),
+                        "config_entry_id": cfg,
+                    }
+                )
+        return orphans, stale
+
     async def _fetch_dead_entities(
         self,
         *,
@@ -1617,147 +1906,20 @@ class SystemTools:
         # ``warnings`` key would collide with.
         bubble_warnings: list[str] = []
         try:
-            # All three slices are supplied together by the caller as one
-            # unit (the ``system_snapshot`` contract guarantees they're
-            # never partial — see ``_build_system_snapshot_slices``), so the
-            # gate requires all three rather than just ``prefetched_registry``
-            # to keep that invariant explicit here rather than relying on the
-            # call site.
-            if (
-                prefetched_states is not None
-                and prefetched_registry is not None
-                and prefetched_entries is not None
-            ):
-                states: Any = prefetched_states
-                registry_raw: Any = prefetched_registry
-                entries_raw: Any = prefetched_entries
-            else:
-                # Index the gather result (rather than tuple-unpack) so mypy
-                # can type each element through the return_exceptions=True
-                # overload; mirrors smart_search/_entities.py::_fetch_search_entities.
-                results = await asyncio.gather(
-                    self._client.get_states(),
-                    self._client.send_websocket_message(
-                        {"type": "config/entity_registry/list"}
-                    ),
-                    self._client.send_websocket_message({"type": "config_entries/get"}),
-                    return_exceptions=True,
-                )
-                states = results[0]
-                registry_raw = results[1]
-                entries_raw = results[2]
-
-            if isinstance(states, BaseException):
-                # Truly-fatal errors must propagate, not demote to a section
-                # error string (mirrors the ws sections gather pre-pass).
-                _reraise_if_fatal(states)
-                dead["error"] = f"Could not fetch entity states: {states}"
+            sources = await self._acquire_dead_entity_sources(
+                prefetched_states,
+                prefetched_registry,
+                prefetched_entries,
+                dead,
+                bubble_warnings,
+            )
+            if sources is None:
                 return dead
-            if not isinstance(states, list):
-                dead["error"] = (
-                    "Could not fetch entity states: expected list, got "
-                    f"{type(states).__name__}"
-                )
-                return dead
-            registry, registry_err = self._ws_result_list(registry_raw)
-            if registry is None:
-                # Preserve the underlying cause (envelope error message,
-                # exception type, or wrong-shape description) so the client
-                # can distinguish auth vs command vs malformed envelope
-                # rather than see a fixed "unavailable" substitute.
-                dead["error"] = (
-                    f"Could not fetch entity registry "
-                    f"(config/entity_registry/list: {registry_err})"
-                )
-                return dead
+            state_by_id, registry, live_entry_ids = sources
 
-            # config-entries is the only optional source: without it the
-            # definitive orphan tier can't be computed, but stale_restored still
-            # can — so degrade rather than fail the whole section.
-            entries, entries_err = self._ws_result_list(entries_raw)
-            live_entry_ids: set[str] | None = None
-            if entries is None:
-                # Genuine fetch failure — preserve the cause so a backend
-                # failure isn't reported as "no entries".
-                dead["config_entries_checked"] = False
-                bubble_warnings.append(
-                    f"config_entries/get failed ({entries_err}); "
-                    "config_entry_orphans tier skipped (cannot distinguish a "
-                    "removed integration from a failed fetch). stale_restored "
-                    "still computed."
-                )
-            elif not entries:
-                # Real empty list — HA reports no config entries configured.
-                # Distinct from a fetch failure: the message names the actual
-                # state. The orphan tier still skips since there is no live
-                # set to diff against; stale_restored still computed.
-                dead["config_entries_checked"] = False
-                bubble_warnings.append(
-                    "config_entries/get returned an empty list (no "
-                    "integrations configured); config_entry_orphans tier "
-                    "skipped. stale_restored still computed."
-                )
-            else:
-                live_entry_ids = {
-                    e["entry_id"]
-                    for e in entries
-                    if isinstance(e, dict) and e.get("entry_id")
-                }
-                dead["config_entries_checked"] = True
-
-            state_by_id = {
-                s["entity_id"]: s
-                for s in states
-                if isinstance(s, dict) and s.get("entity_id")
-            }
-
-            orphans: list[dict[str, Any]] = []
-            stale: list[dict[str, Any]] = []
-            for entry in registry:
-                if not isinstance(entry, dict):
-                    continue
-                eid = entry.get("entity_id")
-                if not eid:
-                    continue
-                cfg = entry.get("config_entry_id")
-                disabled_by = entry.get("disabled_by")
-
-                # Tier 1 — config-entry orphan (only when the live set loaded).
-                # Covers disabled leftovers too: a disabled entity whose config
-                # entry is gone is still dead cruft (disabled_by is surfaced on
-                # the item so the client sees why it lingered).
-                if live_entry_ids is not None and cfg and cfg not in live_entry_ids:
-                    orphans.append(
-                        {
-                            "entity_id": eid,
-                            "platform": entry.get("platform"),
-                            "config_entry_id": cfg,
-                            "disabled_by": disabled_by,
-                            "has_state": eid in state_by_id,
-                        }
-                    )
-                    continue
-
-                # Tier 2 — stale restored. Skip intentionally-disabled entries
-                # (they normally have no state object anyway).
-                if disabled_by is not None:
-                    continue
-                state_obj = state_by_id.get(eid)
-                if state_obj is None:
-                    continue
-                attrs = state_obj.get("attributes")
-                if (
-                    state_obj.get("state") == "unavailable"
-                    and isinstance(attrs, dict)
-                    and attrs.get("restored")
-                ):
-                    stale.append(
-                        {
-                            "entity_id": eid,
-                            "platform": entry.get("platform"),
-                            "config_entry_id": cfg,
-                        }
-                    )
+            orphans, stale = self._classify_registry_entries(
+                registry, state_by_id, live_entry_ids
+            )
 
             def _bucket(items: list[dict[str, Any]]) -> dict[str, Any]:
                 total = len(items)

--- a/tests/src/unit/test_advanced_settings_coverage.py
+++ b/tests/src/unit/test_advanced_settings_coverage.py
@@ -238,6 +238,15 @@ def _first_literal(args: list[ast.expr]) -> str | None:
 def _env_reads_in_tree(tree: ast.Module) -> set[str]:
     """Resolve per-file aliases for the ``os`` module and the ``environ`` /
     ``getenv`` names, then collect every literal env var read through them."""
+    os_aliases, environ_aliases, getenv_aliases = _resolve_env_aliases(tree)
+    return _collect_env_reads(tree, os_aliases, environ_aliases, getenv_aliases)
+
+
+def _resolve_env_aliases(
+    tree: ast.Module,
+) -> tuple[set[str], set[str], set[str]]:
+    """Resolve the per-file ``os`` / ``environ`` / ``getenv`` aliases, including
+    the ``from os import ...`` and ``as``-aliased variants."""
     os_aliases: set[str] = set()  # names bound to the ``os`` module
     environ_aliases: set[str] = set()  # names bound to ``os.environ``
     getenv_aliases: set[str] = set()  # names bound to ``os.getenv``
@@ -252,42 +261,60 @@ def _env_reads_in_tree(tree: ast.Module) -> set[str]:
                     environ_aliases.add(alias.asname or "environ")
                 elif alias.name == "getenv":
                     getenv_aliases.add(alias.asname or "getenv")
+    return os_aliases, environ_aliases, getenv_aliases
 
-    def _is_environ(node: ast.expr) -> bool:
-        # ``os.environ`` (attribute on the os module) or a bare ``environ``
-        # imported via ``from os import environ``.
-        if isinstance(node, ast.Name):
-            return node.id in environ_aliases
-        return (
-            isinstance(node, ast.Attribute)
-            and node.attr == "environ"
-            and isinstance(node.value, ast.Name)
-            and node.value.id in os_aliases
-        )
 
-    def _is_getenv(node: ast.expr) -> bool:
-        # ``os.getenv`` or a bare ``getenv`` imported via ``from os import``.
-        if isinstance(node, ast.Name):
-            return node.id in getenv_aliases
-        return (
-            isinstance(node, ast.Attribute)
-            and node.attr == "getenv"
-            and isinstance(node.value, ast.Name)
-            and node.value.id in os_aliases
-        )
+def _is_environ_ref(
+    node: ast.expr, os_aliases: set[str], environ_aliases: set[str]
+) -> bool:
+    # ``os.environ`` (attribute on the os module) or a bare ``environ``
+    # imported via ``from os import environ``.
+    if isinstance(node, ast.Name):
+        return node.id in environ_aliases
+    return (
+        isinstance(node, ast.Attribute)
+        and node.attr == "environ"
+        and isinstance(node.value, ast.Name)
+        and node.value.id in os_aliases
+    )
 
+
+def _is_getenv_ref(
+    node: ast.expr, os_aliases: set[str], getenv_aliases: set[str]
+) -> bool:
+    # ``os.getenv`` or a bare ``getenv`` imported via ``from os import``.
+    if isinstance(node, ast.Name):
+        return node.id in getenv_aliases
+    return (
+        isinstance(node, ast.Attribute)
+        and node.attr == "getenv"
+        and isinstance(node.value, ast.Name)
+        and node.value.id in os_aliases
+    )
+
+
+def _collect_env_reads(
+    tree: ast.Module,
+    os_aliases: set[str],
+    environ_aliases: set[str],
+    getenv_aliases: set[str],
+) -> set[str]:
+    """Collect every literal env var read through the resolved ``os`` /
+    ``environ`` / ``getenv`` aliases in ``tree``."""
     names: set[str] = set()
     for node in ast.walk(tree):
         name: str | None = None
         if isinstance(node, ast.Call):
             fn = node.func
-            if _is_getenv(fn) or (
+            if _is_getenv_ref(fn, os_aliases, getenv_aliases) or (
                 isinstance(fn, ast.Attribute)
                 and fn.attr in {"get", "setdefault", "pop"}
-                and _is_environ(fn.value)
+                and _is_environ_ref(fn.value, os_aliases, environ_aliases)
             ):
                 name = _first_literal(node.args)
-        elif isinstance(node, ast.Subscript) and _is_environ(node.value):
+        elif isinstance(node, ast.Subscript) and _is_environ_ref(
+            node.value, os_aliases, environ_aliases
+        ):
             sl = node.slice
             if isinstance(sl, ast.Constant) and isinstance(sl.value, str):
                 name = sl.value


### PR DESCRIPTION
## What does this PR do?

Closes #925.

Fixes the final 6 files from the C901 (McCabe complexity) grandfather list by extracting private helper functions with no behavior change — and, with the list now empty, deletes the per-file-ignore block and its comment entirely. C901 is enforced repo-wide with zero exemptions.

- `tools_config_automations.py`: `ha_config_set_automation` (14)
- `tools_config_scenes.py`: `ha_config_set_scene` (25), `_resolve_scene_entity_id` (13)
- `tools_config_scripts.py`: `ha_config_set_script` (18)
- `tools_dev.py`: `ha_dev_manage_settings` (18), `_coerce_setting_value` (17), `_update_source` (12)
- `tools_system.py`: `ha_get_system_health` (33), `_fetch_dead_entities` (20), `ha_reload_core` (14)
- `tests/src/unit/test_advanced_settings_coverage.py`: `_env_reads_in_tree` (19)

All six were re-scanned on current master after #1935/#1934/#1906 merged (which is how `_update_source`, introduced by #1935, made the list).

No docstring, tool-signature, or user-facing change: an AST-level comparison of before/after confirms docstrings, signatures, decorators, and every pre-existing string literal are byte-identical; the only additions are private `_helper` functions carrying relocated logic.

## Type of change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [x] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

- `ruff check` repo-wide with the grandfather block deleted (C901 fully live, zero ignores): all checks pass
- `ruff format --check`: clean
- `mypy src/`: clean (138 files)
- 359 unit tests pass across config automations/scenes/scripts, dev-server manage/update contracts and routing, system health/overview/reload, and the advanced-settings coverage meta-test

## Checklist
- [x] I have updated documentation if needed