### PR TITLE
docs: record repo-wide C901 enforcement, guard against new per-file ignores

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -378,6 +378,9 @@ uv run hamcp-test-env --no-interactive   # For automation
 Test token centralized in `tests/test_constants.py`.
 
 ### Code Quality
+
+C901 (mccabe complexity ≤10) is enforced repo-wide with zero per-file exemptions (issue #925 cleared the grandfathered list) — never reintroduce a `["C901"]` per-file-ignore; extract helpers instead.
+
 ```bash
 uv run ruff check src/ tests/ --fix
 # Note: --fix removes unused imports from non-__init__ modules (lefthook runs it on commit with

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -163,6 +163,10 @@ ignore = [
 [tool.ruff.lint.per-file-ignores]
 "__init__.py" = ["F401"]
 "tests/**/*" = ["E501", "B011"]
+# C901 is enforced repo-wide with no per-file exemptions (the grandfathered
+# list was fully cleared by issue #925). Do NOT add "path" = ["C901"] entries
+# here — extract helpers to bring the function below the threshold instead:
+# "some/path.py" = ["C901"]  <- never this
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]


### PR DESCRIPTION
## What does this PR do?

Follow-through on #925: the grandfather list's deletion also removed its "do not add new files here" instruction, leaving nothing in the repo stating the policy. This restores it in the two places a future contributor would look:

- `pyproject.toml`: a comment in `[tool.ruff.lint.per-file-ignores]` — exactly where a new `["C901"]` ignore would be added — stating C901 has zero per-file exemptions and showing the never-do-this form.
- `AGENTS.md` § Code Quality: one line stating C901 is enforced repo-wide with zero exemptions; extract helpers instead of reintroducing ignores.

No code or config behavior change (comment + docs only).

## Type of change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [x] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

- `ruff check` repo-wide: all checks pass (the pyproject comment parses; no config change)
- `ruff format --check`: clean

## Checklist
- [x] I have updated documentation if needed