### PR TITLE
fix: create all-day calendar events from dates

### DIFF
--- a/src/ha_mcp/tools/tools_calendar.py
+++ b/src/ha_mcp/tools/tools_calendar.py
@@ -233,19 +233,6 @@ class CalendarTools:
     ) -> Any:
         """Create a one-off calendar event via the calendar.create_event service."""
         start_is_date = self._is_date_only(start)
-        end_is_date = self._is_date_only(end)
-        if start_is_date != end_is_date:
-            raise_tool_error(
-                create_error_response(
-                    ErrorCode.VALIDATION_INVALID_PARAMETER,
-                    "Calendar event start and end must both be dates or both be datetimes",
-                    context={"start": start, "end": end},
-                    suggestions=[
-                        "Use YYYY-MM-DD for both values to create an all-day event",
-                        "Use ISO 8601 datetimes for both values to create a timed event",
-                    ],
-                )
-            )
 
         service_data: dict[str, Any] = {
             "entity_id": entity_id,
@@ -304,6 +291,16 @@ class CalendarTools:
             suggestions.insert(0, f"Calendar entity '{entity_id}' not found")
         if "not supported" in error_str.lower():
             suggestions.insert(0, "This calendar does not support event creation")
+        # HA enforces MIN_NEW_EVENT_DURATION (1 second): for all-day events the
+        # end date is exclusive, so start == end has zero duration and is
+        # rejected. Steer the agent to bump the end date by a day.
+        if "duration" in error_str.lower() or "must be" in error_str.lower():
+            suggestions.insert(
+                0,
+                "For an all-day event the end date is exclusive — set end to "
+                "start + 1 day (a single-day all-day event cannot have "
+                "start == end)",
+            )
 
         return suggestions
 
@@ -337,7 +334,14 @@ class CalendarTools:
             str, Field(description="Event start date or datetime in ISO format")
         ],
         end: Annotated[
-            str, Field(description="Event end date or datetime in ISO format")
+            str,
+            Field(
+                description=(
+                    "Event end date or datetime in ISO format. For all-day "
+                    "events (date-only) the end date is exclusive; a "
+                    "single-day all-day event needs end = start + 1 day."
+                )
+            ),
         ],
         description: Annotated[
             str | None,
@@ -397,9 +401,25 @@ class CalendarTools:
             end="2024-01-15T11:00:00",
             rrule="FREQ=WEEKLY;BYDAY=MO;COUNT=10"
         )
+
+        # Create an all-day event (date-only, no time component). The end
+        # date is EXCLUSIVE, so this spans 2026-07-04 through 2026-07-10.
+        result = ha_config_set_calendar_event(
+            "calendar.family",
+            summary="Vacation",
+            start="2026-07-04",
+            end="2026-07-11"
+        )
         ```
 
         **Note:**
+        Passing date-only values (``YYYY-MM-DD``) for both ``start`` and
+        ``end`` creates an all-day event; passing full ISO datetimes creates
+        a timed event. The two forms cannot be mixed — a date-only ``start``
+        with a datetime ``end`` (or vice versa) is rejected. Because the
+        all-day ``end`` date is exclusive, a single-day all-day event must
+        set ``end`` to ``start + 1 day``.
+
         Not every calendar integration supports event creation; recurring
         events additionally require the integration to support recurrence
         (the built-in Local Calendar does).
@@ -418,6 +438,23 @@ class CalendarTools:
                         suggestions=[
                             "Use ha_search(query='calendar', domain_filter='calendar') to find calendar entities",
                             "Calendar entity IDs start with 'calendar.' prefix",
+                        ],
+                    )
+                )
+
+            # Reject mixed date/datetime up front so both the simple and the
+            # recurring (rrule) paths give the same clear validation error —
+            # the rrule branch does not route through
+            # ``_create_simple_calendar_event`` where this used to live.
+            if self._is_date_only(start) != self._is_date_only(end):
+                raise_tool_error(
+                    create_error_response(
+                        ErrorCode.VALIDATION_INVALID_PARAMETER,
+                        "Calendar event start and end must both be dates or both be datetimes",
+                        context={"start": start, "end": end},
+                        suggestions=[
+                            "Use YYYY-MM-DD for both values to create an all-day event",
+                            "Use ISO 8601 datetimes for both values to create a timed event",
                         ],
                     )
                 )

--- a/src/ha_mcp/tools/tools_calendar.py
+++ b/src/ha_mcp/tools/tools_calendar.py
@@ -232,12 +232,29 @@ class CalendarTools:
         location: str | None,
     ) -> Any:
         """Create a one-off calendar event via the calendar.create_event service."""
+        start_is_date = self._is_date_only(start)
+        end_is_date = self._is_date_only(end)
+        if start_is_date != end_is_date:
+            raise_tool_error(
+                create_error_response(
+                    ErrorCode.VALIDATION_INVALID_PARAMETER,
+                    "Calendar event start and end must both be dates or both be datetimes",
+                    context={"start": start, "end": end},
+                    suggestions=[
+                        "Use YYYY-MM-DD for both values to create an all-day event",
+                        "Use ISO 8601 datetimes for both values to create a timed event",
+                    ],
+                )
+            )
+
         service_data: dict[str, Any] = {
             "entity_id": entity_id,
             "summary": summary,
-            "start_date_time": start,
-            "end_date_time": end,
         }
+        if start_is_date:
+            service_data.update({"start_date": start, "end_date": end})
+        else:
+            service_data.update({"start_date_time": start, "end_date_time": end})
 
         if description is not None:
             service_data["description"] = description
@@ -245,6 +262,17 @@ class CalendarTools:
             service_data["location"] = location
 
         return await self._client.call_service("calendar", "create_event", service_data)
+
+    @staticmethod
+    def _is_date_only(value: str) -> bool:
+        """Return whether value is a valid date in strict YYYY-MM-DD form."""
+        try:
+            return (
+                len(value) == 10
+                and datetime.strptime(value, "%Y-%m-%d").date().isoformat() == value
+            )
+        except ValueError:
+            return False
 
     def _build_set_calendar_event_error_suggestions(
         self, entity_id: str, rrule: str | None, error: Exception
@@ -305,8 +333,12 @@ class CalendarTools:
             str, Field(description="Calendar entity ID (e.g., 'calendar.family')")
         ],
         summary: Annotated[str, Field(description="Event title/summary")],
-        start: Annotated[str, Field(description="Event start datetime in ISO format")],
-        end: Annotated[str, Field(description="Event end datetime in ISO format")],
+        start: Annotated[
+            str, Field(description="Event start date or datetime in ISO format")
+        ],
+        end: Annotated[
+            str, Field(description="Event end date or datetime in ISO format")
+        ],
         description: Annotated[
             str | None,
             Field(description="Optional event description", default=None),
@@ -337,8 +369,8 @@ class CalendarTools:
         **Parameters:**
         - entity_id: Calendar entity ID (e.g., 'calendar.family')
         - summary: Event title/summary
-        - start: Event start datetime in ISO format
-        - end: Event end datetime in ISO format
+        - start: Event start date or datetime in ISO format
+        - end: Event end date or datetime in ISO format
         - description: Optional event description
         - location: Optional event location
         - rrule: Optional RFC 5545 recurrence rule (creates a recurring series)

--- a/src/ha_mcp/tools/tools_calendar.py
+++ b/src/ha_mcp/tools/tools_calendar.py
@@ -366,6 +366,10 @@ class CalendarTools:
         when ``rrule`` is provided (the REST service schema does not accept
         recurrence rules).
 
+        **When NOT to use:**
+        - To retrieve calendar events, use ``ha_config_get_calendar_events``.
+        - To delete an event, use ``ha_config_remove_calendar_event``.
+
         **Parameters:**
         - entity_id: Calendar entity ID (e.g., 'calendar.family')
         - summary: Event title/summary

--- a/tests/src/e2e/workflows/calendar/test_calendar.py
+++ b/tests/src/e2e/workflows/calendar/test_calendar.py
@@ -277,6 +277,104 @@ class TestCalendarEventLifecycle:
 
         logger.info("ha_config_set_calendar_event test completed")
 
+    async def test_create_all_day_calendar_event(self, mcp_client):
+        """
+        Test: Create an all-day event from date-only values and read it back.
+
+        Passing ``YYYY-MM-DD`` (no time component) for both start and end
+        must produce an all-day event. This proves the round-trip: HA should
+        return the occurrence with a date-only ``{"date": ...}`` start, NOT a
+        ``{"dateTime": ...}`` start. The all-day ``end`` date is exclusive, so
+        a single-day event spans start .. start + 1 day.
+        """
+        calendar_entity = await self._find_writable_calendar(mcp_client)
+        if not calendar_entity:
+            pytest.skip("No calendar entities available for testing")
+
+        summary = f"E2E All-Day Test Event {uuid.uuid4().hex[:8]}"
+        # Date-only, well into the future to avoid colliding with the default
+        # get-events window used elsewhere. end is exclusive -> single day.
+        start_date = (datetime.now(UTC) + timedelta(days=2)).date()
+        end_date = start_date + timedelta(days=1)
+        list_args = {
+            "entity_id": calendar_entity,
+            "start": datetime.combine(
+                start_date, datetime.min.time(), tzinfo=UTC
+            ).isoformat(),
+            "end": datetime.combine(
+                end_date + timedelta(days=1), datetime.min.time(), tzinfo=UTC
+            ).isoformat(),
+        }
+
+        def _match(data: dict) -> list[dict]:
+            return [e for e in data.get("events", []) if e.get("summary") == summary]
+
+        create_data = await safe_call_tool(
+            mcp_client,
+            "ha_config_set_calendar_event",
+            {
+                "entity_id": calendar_entity,
+                "summary": summary,
+                "start": start_date.isoformat(),
+                "end": end_date.isoformat(),
+            },
+        )
+        if not create_data.get("success"):
+            pytest.skip(
+                f"Calendar {calendar_entity} does not support event creation: "
+                f"{extract_error_message(create_data) or 'Unknown'}"
+            )
+
+        event_uid: str | None = None
+        try:
+            events_data = await wait_for_tool_result(
+                mcp_client,
+                "ha_config_get_calendar_events",
+                list_args,
+                predicate=lambda d: bool(_match(d)),
+                timeout=15,
+                description=f"read-back of all-day event '{summary}'",
+            )
+            matches = _match(events_data)
+            assert matches, f"created all-day event '{summary}' did not surface"
+            event = matches[0]
+            event_uid = event.get("uid")
+
+            # Core assertion: an all-day event round-trips as a date-only
+            # start ({"date": ...}), never a timed start ({"dateTime": ...}).
+            start_field = event.get("start")
+            if isinstance(start_field, dict):
+                assert "date" in start_field, (
+                    f"all-day event start should be date-only, got {start_field}"
+                )
+                assert "dateTime" not in start_field, (
+                    f"all-day event start must not be a datetime, got {start_field}"
+                )
+                assert start_field["date"] == start_date.isoformat(), (
+                    f"expected start date {start_date.isoformat()}, got {start_field}"
+                )
+            else:
+                # Some backends flatten to a bare string; it must still be the
+                # date-only form with no time component.
+                assert str(start_field) == start_date.isoformat(), (
+                    f"all-day event start should be date-only "
+                    f"{start_date.isoformat()}, got {start_field!r}"
+                )
+        finally:
+            if event_uid:
+                try:
+                    await mcp_client.call_tool(
+                        "ha_config_remove_calendar_event",
+                        {"entity_id": calendar_entity, "uid": event_uid},
+                    )
+                except Exception as cleanup_error:
+                    logger.warning(
+                        f"Cleanup of all-day test event {event_uid} on "
+                        f"{calendar_entity}: {cleanup_error}"
+                    )
+
+        logger.info("All-day calendar event round-trip test completed")
+
     async def test_create_calendar_event_invalid_entity(self, mcp_client):
         """
         Test: Create event with invalid calendar entity

--- a/tests/src/unit/test_tools_calendar_rrule.py
+++ b/tests/src/unit/test_tools_calendar_rrule.py
@@ -7,8 +7,8 @@ Since issue #1813 that WS command routes through the shared pooled client
 
 These tests pin the transport routing: ``rrule`` present → pooled WS command
 carrying an RFC 5545 event payload (``dtstart``/``dtend`` keys); ``rrule``
-absent → the pre-existing REST service call (``start_date_time``/
-``end_date_time`` keys), unchanged.
+absent → the REST service call. Datetime values use ``start_date_time``/
+``end_date_time`` while date-only values use ``start_date``/``end_date``.
 
 They also cover the rrule-branch failure path: a failed WS command comes back
 from the pooled client as ``{"success": False, ...}`` and is re-raised so the
@@ -147,6 +147,50 @@ async def test_no_rrule_keeps_rest_service_path():
     client.send_websocket_message.assert_not_awaited()
     assert result["success"] is True
     assert result["event"]["rrule"] is None
+
+
+@pytest.mark.asyncio
+async def test_no_rrule_date_only_values_create_all_day_event():
+    """Date-only values must use HA's all-day service fields."""
+    client = _make_mock_client()
+
+    tools = CalendarTools(client)
+    await tools.ha_config_set_calendar_event(
+        entity_id="calendar.test",
+        summary="School holidays",
+        start="2026-07-04",
+        end="2026-08-10",
+    )
+
+    client.call_service.assert_awaited_once_with(
+        "calendar",
+        "create_event",
+        {
+            "entity_id": "calendar.test",
+            "summary": "School holidays",
+            "start_date": "2026-07-04",
+            "end_date": "2026-08-10",
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_no_rrule_rejects_mixed_date_and_datetime_values():
+    """Mixed all-day and timed boundaries are ambiguous and invalid."""
+    client = _make_mock_client()
+
+    tools = CalendarTools(client)
+    with pytest.raises(ToolError) as exc_info:
+        await tools.ha_config_set_calendar_event(
+            entity_id="calendar.test",
+            summary="Mixed event",
+            start="2026-07-04",
+            end="2026-07-04T12:00:00",
+        )
+
+    error = _structured_error(exc_info.value)["error"]
+    assert error["code"] == "VALIDATION_INVALID_PARAMETER"
+    client.call_service.assert_not_awaited()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #1972

## What does this PR do?

Date-only calendar boundaries now use Home Assistant's `start_date` and `end_date` fields, creating true all-day events. Mixed date and datetime boundaries return a validation error instead of creating an ambiguous event.
The calendar creation docstring also routes retrieval and deletion intents to their dedicated tools.

## Type of change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [ ] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

Focused calendar unit tests pass (13 tests), including fail-without-fix/pass-with-fix regression coverage. Targeted Mypy and Ruff checks also pass.

## Checklist
- [x] I have updated documentation if needed

