### PR TITLE
fix: none-mode webhook connects from claude.ai with no login

### DIFF
--- a/custom_components/ha_mcp_tools/mcp_webhook.py
+++ b/custom_components/ha_mcp_tools/mcp_webhook.py
@@ -347,7 +347,18 @@ class _ProtectedResourceMetadataView(HomeAssistantView):
         self._hass = hass
 
     async def get(self, request: web.Request) -> web.Response:
-        """Serve the protected-resource document (or 404 when no OAuth mode is live)."""
+        """Serve the protected-resource document for the bearer-gated modes only.
+
+        SECURITY (#1976 review): this ANONYMOUS, fixed (guessable) path exposes
+        ``resource: <base>/api/webhook/<id>``. In none mode the webhook id is the
+        SOLE credential, so serving it here would leak it to any unauthenticated
+        GET. Serve only for ``ha_auth``/``legacy`` (where the id is not a secret
+        and the 401 ``WWW-Authenticate`` pointer legitimately directs a client
+        here); 404 otherwise. The PATH-SCOPED well-known view still serves in none
+        mode — its caller must already know the id (it is a route parameter).
+        """
+        if active_auth_mode(self._hass) not in (WEBHOOK_AUTH_HA, WEBHOOK_AUTH_LEGACY):
+            return _json_not_found()
         webhook_id = _active_webhook_id(self._hass)
         if webhook_id is None:
             return _json_not_found()

--- a/custom_components/ha_mcp_tools/mcp_webhook.py
+++ b/custom_components/ha_mcp_tools/mcp_webhook.py
@@ -8,7 +8,11 @@ reverse proxy) with the webhook id as the shared secret.
 Three auth postures, chosen in the options flow:
 
 * ``none`` — the secret webhook URL *is* the credential (matches the add-on's
-  default). No bearer is required.
+  default). No bearer is required and the forwarder always returns 200. It still
+  serves our own corrected RFC 8414 / RFC 9728 discovery documents plus an
+  invisible auto-approve authorization server (:mod:`oauth_autoapprove`), so
+  claude.ai's intermittent OAuth discovery resolves against us — not HA core's
+  broken origin-root doc — and connects with no HA login (issue #1969).
 * ``ha_auth`` — Home Assistant core is the OAuth authorization server. This
   module serves the RFC 8414 / RFC 9728 discovery documents (so claude.ai /
   ChatGPT can sign in with the user's HA account) and validates inbound bearer
@@ -26,7 +30,9 @@ mapping); the ``ha_auth`` bearer check + discovery documents mirror the add-on's
 provider + its root ``/authorize`` + ``/token`` views live in
 :mod:`oauth_legacy`, ported from the ``legacy`` subset of the add-on's
 ``oauth.py``. The seven RFC 8414 / RFC 9728 discovery views below are shared by
-``ha_auth`` and ``legacy`` — see :func:`active_auth_mode`.
+``ha_auth``, ``legacy``, and ``none`` (which serves a distinct auto-approve
+authorization-server document pointing at :mod:`oauth_autoapprove`'s endpoints)
+— see :func:`active_auth_mode`.
 """
 
 from __future__ import annotations
@@ -50,6 +56,11 @@ from .const import (
     WEBHOOK_AUTH_HA,
     WEBHOOK_AUTH_LEGACY,
     WEBHOOK_AUTH_NONE,
+)
+from .oauth_autoapprove import (
+    CFG_AUTOAPPROVE_PROVIDER,
+    AutoApproveProvider,
+    bind_autoapprove_views,
 )
 from .oauth_legacy import (
     AUTHORIZE_PATH,
@@ -219,14 +230,14 @@ def _active_webhook_cfg(hass: HomeAssistant) -> dict[str, Any] | None:
 def active_auth_mode(hass: HomeAssistant) -> str | None:
     """Return the OAuth-relevant auth mode of the live webhook registration.
 
-    ``WEBHOOK_AUTH_HA`` or ``WEBHOOK_AUTH_LEGACY``, or None when no OAuth
+    ``WEBHOOK_AUTH_HA``, ``WEBHOOK_AUTH_LEGACY``, or ``WEBHOOK_AUTH_NONE`` (the
+    none-mode auto-approve surface, issue #1969), or None when no discovery
     surface is live. Checked via PROVIDER PRESENCE, not the raw configured
     ``auth_mode`` string, so local-only mode (remote webhook disabled by
     option — ``register_endpoint=False`` in ``async_register_webhook``)
-    correctly reports None even when ``webhook_auth`` is set to
-    ``ha_auth``/``legacy``: no provider is constructed for a webhook that was
-    never registered, so there is nothing to advertise or authenticate
-    against. Read live from hass.data (not captured at view/provider
+    correctly reports None even when ``webhook_auth`` is set: no provider is
+    constructed for a webhook that was never registered, so there is nothing to
+    advertise or authenticate against. Read live from hass.data (not captured at view/provider
     construction time) so the SAME registered/bound instances serve whichever
     mode is active now — mirrors the add-on's ``_active_oauth_mode``. Used by
     the discovery views below AND by ``LegacyOAuthProvider.is_active`` (via
@@ -246,6 +257,8 @@ def active_auth_mode(hass: HomeAssistant) -> str | None:
         return WEBHOOK_AUTH_HA
     if cfg.get("oauth_provider") is not None:
         return WEBHOOK_AUTH_LEGACY
+    if cfg.get(CFG_AUTOAPPROVE_PROVIDER) is not None:
+        return WEBHOOK_AUTH_NONE
     return None
 
 
@@ -295,6 +308,32 @@ def _legacy_authorization_server_document(base: str) -> dict[str, Any]:
     }
 
 
+def _none_mode_authorization_server_document(base: str) -> dict[str, Any]:
+    """RFC 8414 authorization-server metadata for none mode's auto-approve server.
+
+    Points at OUR OWN ``OAUTH_BASE`` ``/authorize`` + ``/token`` (the invisible
+    auto-approve endpoints in :mod:`oauth_autoapprove`), NOT HA core's
+    ``/auth/*``. Serving this — with ``token_endpoint_auth_methods_supported:
+    ["none"]`` (public PKCE client) and ``client_id_metadata_document_supported``
+    — is the none-mode fix: claude.ai's intermittent discovery resolves against
+    this corrected document instead of HA core's origin-root
+    ``/.well-known/oauth-authorization-server``, which omits the ``"none"`` auth
+    method and has no ``registration_endpoint`` (issue #1969). No refresh grant:
+    the token is cosmetic (none mode ignores bearers), so only
+    ``authorization_code`` is advertised.
+    """
+    return {
+        "issuer": f"{base}{OAUTH_BASE}",
+        "authorization_endpoint": f"{base}{OAUTH_BASE}/authorize",
+        "token_endpoint": f"{base}{OAUTH_BASE}/token",
+        "response_types_supported": ["code"],
+        "grant_types_supported": ["authorization_code"],
+        "code_challenge_methods_supported": ["S256"],
+        "token_endpoint_auth_methods_supported": ["none"],
+        "client_id_metadata_document_supported": True,
+    }
+
+
 class _ProtectedResourceMetadataView(HomeAssistantView):
     """RFC 9728 Protected Resource Metadata."""
 
@@ -341,6 +380,8 @@ class _AuthorizationServerMetadataView(HomeAssistantView):
         base = _build_base_url(request)
         if mode == WEBHOOK_AUTH_LEGACY:
             return web.json_response(_legacy_authorization_server_document(base))
+        if mode == WEBHOOK_AUTH_NONE:
+            return web.json_response(_none_mode_authorization_server_document(base))
         return web.json_response(_authorization_server_document(base))
 
 
@@ -636,6 +677,7 @@ async def async_register_webhook(
         "auth_mode": auth_mode,
         "resource_server": None,
         "oauth_provider": None,
+        CFG_AUTOAPPROVE_PROVIDER: None,
     }
 
     oauth_restart_needed = False
@@ -672,6 +714,19 @@ async def async_register_webhook(
                         "enable legacy mode again."
                     ) from err
                 cfg["oauth_provider"] = oauth_provider
+            else:
+                # WEBHOOK_AUTH_NONE (the only remaining mode — unknown modes
+                # already raised above). The secret webhook URL is the
+                # credential, but we still serve our own corrected discovery +
+                # an invisible auto-approve authorization server so claude.ai's
+                # intermittent OAuth discovery resolves against us instead of HA
+                # core's broken origin-root document, and completes with no HA
+                # login (issue #1969). Both view bundles bind at most once per
+                # HA session; the per-request resolvers gate them on this cfg,
+                # so a none<->ha_auth switch needs no restart.
+                _register_metadata_views(hass)
+                bind_autoapprove_views(hass)
+                cfg[CFG_AUTOAPPROVE_PROVIDER] = AutoApproveProvider()
         except Exception:
             # Never leave a live endpoint (or a leaked session) behind a failed
             # auth-setup path. suppress: the ORIGINAL error must be what

--- a/custom_components/ha_mcp_tools/oauth_autoapprove.py
+++ b/custom_components/ha_mcp_tools/oauth_autoapprove.py
@@ -1,0 +1,303 @@
+"""None-mode auto-approve OAuth authorization server (issue #1969).
+
+In ``none`` webhook auth mode the secret webhook URL *is* the credential, so no
+bearer is required and the forwarder always returns 200. But claude.ai's
+connector onboarding intermittently front-loads OAuth discovery, and because the
+component registers no ``/.well-known`` views in none mode, claude.ai falls
+through to Home Assistant *core*'s own origin-root
+``/.well-known/oauth-authorization-server`` — which advertises
+``client_id_metadata_document_supported`` but omits
+``token_endpoint_auth_methods_supported: ["none"]`` and has no
+``registration_endpoint``. claude.ai then can neither use CIMD nor do dynamic
+client registration and shows "Automatic client registration isn't supported…".
+
+This module is the none-mode fix's authorization-server half: a pair of
+path-scoped ``OAUTH_BASE`` endpoints that complete OAuth *invisibly* — no login,
+no consent — so a connector that does run discovery resolves against our own
+corrected documents (served by :mod:`mcp_webhook`) instead of HA core's broken
+root doc, and connects with zero HA login:
+
+* ``GET  {OAUTH_BASE}/authorize`` issues a PKCE-bound one-time code and
+  immediately 302-redirects back to the client with ``?code=…&state=…`` — no
+  page is rendered.
+* ``POST {OAUTH_BASE}/token`` exchanges that code (public client, PKCE S256, no
+  ``client_secret``) for an opaque access token. The token is *cosmetic* — none
+  mode ignores bearers entirely — but is a real random string so a spec-strict
+  client is satisfied.
+
+Both views are gated per request off ``hass.data`` (they 404 unless none mode is
+the live webhook auth mode), mirroring the discovery views, so a
+``none``\\ ↔\\ ``ha_auth`` switch needs no restart. The PKCE code store and the
+redirect-URI floor are reused from :mod:`oauth_legacy` rather than copied.
+
+**Open-redirect defence.** ``/authorize`` 302-redirects to a caller-supplied
+``redirect_uri`` on the Home Assistant origin, so an unvalidated target would be
+an open redirector. On top of :func:`oauth_legacy._is_valid_redirect_uri`'s
+scheme/host/port floor, the redirect must EXACTLY match a known MCP callback
+(:data:`_AUTOAPPROVE_REDIRECT_ALLOWLIST`). Anything else is a hard 400 (no
+redirect). A "same origin as the client_id" rule was deliberately NOT used: the
+client_id is fully attacker-controlled, so ``client_id == redirect_uri origin``
+still lets an attacker bounce a victim to any site of their choosing (a real
+open redirect on a public HA origin). Properly honouring an arbitrary CIMD
+client would require fetching the attacker-supplied client_id URL — an SSRF
+vector — so the allowlist is both the safe and the simple choice. Add a client's
+callback here to support it.
+"""
+
+from __future__ import annotations
+
+import secrets
+from typing import TYPE_CHECKING, Any
+
+from aiohttp import web
+from homeassistant.components.http import HomeAssistantView
+
+from .const import DATA_WEBHOOK, DOMAIN, OAUTH_BASE
+from .oauth_legacy import (
+    _PKCE_CHALLENGE_RE,
+    _TOKEN_RESPONSE_HEADERS,
+    ACCESS_TOKEN_TTL,
+    PKCECodeStore,
+    _is_valid_redirect_uri,
+)
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+
+
+# cfg (hass.data[DOMAIN][DATA_WEBHOOK]) key holding the live AutoApproveProvider.
+# Present ONLY in none mode with the remote endpoint enabled; its presence is
+# how :func:`mcp_webhook.active_auth_mode` recognises the none-autoapprove live
+# mode (mirrors the "resource_server"/"oauth_provider" presence keys).
+CFG_AUTOAPPROVE_PROVIDER = "autoapprove_provider"
+
+# TOP-LEVEL hass.data flag recording that the two auto-approve views are bound
+# for this HA session. Not under DOMAIN so it survives async_unload_entry's
+# teardown — aiohttp cannot unregister a bound view until HA restarts, so the
+# views (and this ownership flag) must outlive the config entry (mirrors
+# mcp_webhook._OAUTH_VIEWS_REGISTERED_KEY).
+_AUTOAPPROVE_VIEWS_REGISTERED_KEY = "ha_mcp_tools_oauth_autoapprove_views_registered"
+
+# Known MCP OAuth callback URLs always accepted as a redirect target even when
+# the client_id is not a same-origin URL — claude.ai's connector onboarding
+# posts its authorization code here. Exact-match only (never a prefix test, so
+# ``https://claude.ai/api/mcp/auth_callback.evil.example`` cannot slip through).
+_AUTOAPPROVE_REDIRECT_ALLOWLIST = frozenset(
+    {
+        "https://claude.ai/api/mcp/auth_callback",
+    }
+)
+
+
+def _json_not_found() -> web.Response:
+    """404 JSON body used when none-autoapprove is not the live mode."""
+    return web.json_response({"error": "not_found"}, status=404)
+
+
+def _json_error(
+    error: str, status: int, description: str | None = None
+) -> web.Response:
+    """OAuth-style JSON error (RFC 6749 §5.2 shape) with no-store headers."""
+    body: dict[str, str] = {"error": error}
+    if description is not None:
+        body["error_description"] = description
+    return web.json_response(body, status=status, headers=_TOKEN_RESPONSE_HEADERS)
+
+
+def _is_valid_autoapprove_redirect(redirect_uri: str) -> bool:
+    """Open-redirect gate for the auto-approve ``/authorize`` view.
+
+    Exact-match allowlist only, on top of
+    :func:`oauth_legacy._is_valid_redirect_uri`'s scheme/host/port floor. The
+    ``client_id`` is NOT consulted: it is attacker-controlled, so validating the
+    redirect against it (even "same origin") does not constrain the redirect
+    target to a trusted host. See the module docstring.
+    """
+    return (
+        _is_valid_redirect_uri(redirect_uri)
+        and redirect_uri in _AUTOAPPROVE_REDIRECT_ALLOWLIST
+    )
+
+
+def _redirect_with(redirect_uri: str, **params: str) -> web.Response:
+    """302 to ``redirect_uri`` with ``params`` merged into its query string."""
+    # yarl ships with aiohttp and handles existing-query merging + encoding
+    # correctly — safer than hand-rolling (matches oauth_legacy.AuthorizeView).
+    import yarl
+
+    url = yarl.URL(redirect_uri).update_query(params)
+    return web.Response(status=302, headers={"Location": str(url)})
+
+
+class AutoApproveProvider:
+    """None-mode auto-approve authorization-server state.
+
+    Holds only the PKCE code store shared with :mod:`oauth_legacy`; it owns no
+    signing key and no client credentials (the token it issues is cosmetic).
+    Constructed per registration and stored in ``cfg`` — the views resolve it
+    from ``hass.data`` per request, so a reload minting a fresh provider is
+    transparent (no bound view captures the old one, unlike legacy mode).
+    """
+
+    def __init__(self) -> None:
+        self._code_store = PKCECodeStore()
+
+    def issue_code(self, redirect_uri: str, code_challenge: str) -> str | None:
+        """Issue a one-shot PKCE-bound authorization code (see PKCECodeStore)."""
+        return self._code_store.issue_code(redirect_uri, code_challenge)
+
+    def consume_code(self, code: str, redirect_uri: str, code_verifier: str) -> bool:
+        """Verify PKCE S256 + one-shot consume a code (see PKCECodeStore)."""
+        return self._code_store.consume_code(code, redirect_uri, code_verifier)
+
+    @staticmethod
+    def issue_access_token() -> str:
+        """Mint an opaque access token.
+
+        None mode ignores bearers (the secret webhook URL is the credential),
+        so this token grants nothing — but it is a real random string, so a
+        spec-strict client that stores/echoes it is satisfied.
+        """
+        return secrets.token_urlsafe(32)
+
+
+def _active_autoapprove_provider(hass: HomeAssistant) -> AutoApproveProvider | None:
+    """The live none-mode auto-approve provider, or None when it is not live.
+
+    Read live from ``hass.data`` (not captured at view construction) so the
+    bound views serve only while none-autoapprove is the active mode and 404
+    otherwise — mirrors ``mcp_webhook._active_webhook_id``'s per-request gating.
+    """
+    domain_data = hass.data.get(DOMAIN)
+    if not isinstance(domain_data, dict):
+        return None
+    cfg = domain_data.get(DATA_WEBHOOK)
+    if not isinstance(cfg, dict):
+        return None
+    provider = cfg.get(CFG_AUTOAPPROVE_PROVIDER)
+    return provider if isinstance(provider, AutoApproveProvider) else None
+
+
+class AutoApproveAuthorizeView(HomeAssistantView):
+    """None-mode auto-approve ``/authorize`` — issues a code, 302s, no UI.
+
+    Validates ``response_type=code``, PKCE S256, and the redirect_uri
+    open-redirect gate, then issues a PKCE-bound one-time code and redirects
+    straight back to the client. No login page and no consent screen render, so
+    claude.ai's OAuth flow completes invisibly (issue #1969).
+    """
+
+    requires_auth = False
+    cors_allowed = True
+    url = f"{OAUTH_BASE}/authorize"
+    name = "ha_mcp_tools:oauth:autoapprove-authorize"
+
+    def __init__(self, hass: HomeAssistant) -> None:
+        """Bind the view to the HA instance; liveness is resolved per request."""
+        self._hass = hass
+
+    async def get(self, request: web.Request) -> web.Response:
+        """Auto-approve the authorization request or reject with a 400/404."""
+        provider = _active_autoapprove_provider(self._hass)
+        if provider is None:
+            return _json_not_found()
+
+        params = request.query
+        response_type = params.get("response_type", "")
+        redirect_uri = params.get("redirect_uri", "")
+        state = params.get("state", "")
+        code_challenge = params.get("code_challenge", "")
+        code_challenge_method = params.get("code_challenge_method", "")
+
+        if response_type != "code":
+            return _json_error("unsupported_response_type", 400)
+        if code_challenge_method != "S256":
+            return _json_error(
+                "invalid_request", 400, "code_challenge_method must be S256"
+            )
+        if not _PKCE_CHALLENGE_RE.match(code_challenge):
+            return _json_error(
+                "invalid_request", 400, "invalid code_challenge (43-char base64url)"
+            )
+        # SECURITY: an unvalidated redirect_uri would be an open redirector on
+        # the HA origin. Reject in-place (never redirect) unless it exactly
+        # matches a known MCP callback (client_id is attacker-controlled and is
+        # deliberately not consulted — see module docstring).
+        if not _is_valid_autoapprove_redirect(redirect_uri):
+            return _json_error("invalid_request", 400, "invalid redirect_uri")
+
+        code = provider.issue_code(redirect_uri, code_challenge)
+        if code is None:
+            # Pending-code store at capacity (abuse guard) — surface per
+            # RFC 6749 §4.1.2.1 instead of a silent failure.
+            return _redirect_with(
+                redirect_uri, error="temporarily_unavailable", state=state
+            )
+        redirect_params = {"code": code}
+        if state:
+            redirect_params["state"] = state
+        return _redirect_with(redirect_uri, **redirect_params)
+
+
+class AutoApproveTokenView(HomeAssistantView):
+    """None-mode auto-approve ``/token`` — PKCE code → opaque access token.
+
+    Public client (no ``client_secret``): the PKCE code_verifier is the only
+    proof required. The returned access token is cosmetic (none mode ignores
+    bearers), but real and opaque. Only the ``authorization_code`` grant is
+    supported — none mode has no refresh cycle.
+    """
+
+    requires_auth = False
+    cors_allowed = True
+    url = f"{OAUTH_BASE}/token"
+    name = "ha_mcp_tools:oauth:autoapprove-token"
+
+    def __init__(self, hass: HomeAssistant) -> None:
+        """Bind the view to the HA instance; liveness is resolved per request."""
+        self._hass = hass
+
+    async def post(self, request: web.Request) -> web.Response:
+        """Exchange a PKCE authorization code for an opaque access token."""
+        provider = _active_autoapprove_provider(self._hass)
+        if provider is None:
+            return _json_not_found()
+
+        form: dict[str, Any] = dict(await request.post())
+        if form.get("grant_type", "") != "authorization_code":
+            return _json_error("unsupported_grant_type", 400)
+
+        code = str(form.get("code", ""))
+        redirect_uri = str(form.get("redirect_uri", ""))
+        code_verifier = str(form.get("code_verifier", ""))
+        if not (code and redirect_uri and code_verifier):
+            return _json_error("invalid_request", 400)
+        if not provider.consume_code(code, redirect_uri, code_verifier):
+            return _json_error("invalid_grant", 400)
+
+        return web.json_response(
+            {
+                "access_token": provider.issue_access_token(),
+                "token_type": "Bearer",
+                "expires_in": ACCESS_TOKEN_TTL,
+            },
+            headers=_TOKEN_RESPONSE_HEADERS,
+        )
+
+
+def bind_autoapprove_views(hass: HomeAssistant) -> None:
+    """Bind the two auto-approve views at most once per HA session.
+
+    aiohttp cannot unregister a bound view, so a reload / re-enable / mode
+    switch must reuse the already-bound views — they resolve the active
+    provider from ``hass.data`` per request (see
+    :func:`_active_autoapprove_provider`), so they serve only while
+    none-autoapprove is live and 404 otherwise. The guard flag lives at a
+    top-level ``hass.data`` key that survives config-entry teardown (mirrors
+    :func:`mcp_webhook._register_metadata_views`).
+    """
+    if hass.data.get(_AUTOAPPROVE_VIEWS_REGISTERED_KEY):
+        return
+    hass.http.register_view(AutoApproveAuthorizeView(hass))
+    hass.http.register_view(AutoApproveTokenView(hass))
+    hass.data[_AUTOAPPROVE_VIEWS_REGISTERED_KEY] = True

--- a/custom_components/ha_mcp_tools/oauth_legacy.py
+++ b/custom_components/ha_mcp_tools/oauth_legacy.py
@@ -53,13 +53,16 @@ if TYPE_CHECKING:
 
 _LOGGER = logging.getLogger(__name__)
 
-# Registered at the HA ROOT rather than under a component-namespaced path
-# because MCP clients (claude.ai, and per the reporter, Google Spark too)
-# construct the authorize URL as ``<host>/authorize`` from the resource host
-# root — they do not read the ``authorization_endpoint`` field of the
-# authorization-server metadata document. Registering at the root is the only
-# way to actually catch the redirect. Same paths the add-on's legacy mode
-# uses — see the ownership guard below for why that matters.
+# Registered at the HA ROOT rather than under a component-namespaced path, to
+# match the add-on's legacy mode (see the ownership guard below). This was
+# motivated by an MCP client that builds ``<host>/authorize`` from the resource
+# host root instead of reading the ``authorization_endpoint`` metadata field —
+# observed with Google Gemini Spark, which is what legacy mode exists to serve.
+# claude.ai, by contrast, DOES honor the advertised ``authorization_endpoint``:
+# issue #1969's none-mode auto-approve server advertises a component-scoped
+# ``/authorize`` (see :mod:`oauth_autoapprove`) and claude.ai calls exactly that,
+# proven live. So the root registration is for the metadata-ignoring clients, not
+# a hard requirement for claude.ai.
 AUTHORIZE_PATH = "/authorize"
 TOKEN_PATH = "/token"
 
@@ -376,13 +379,84 @@ def _json_not_found() -> web.Response:
 
 
 class _PendingCode(TypedDict):
-    """Shape of an entry in LegacyOAuthProvider._codes. TypedDict so a typo on
+    """Shape of an entry in PKCECodeStore._codes. TypedDict so a typo on
     one of these keys fails type-check rather than silently treating it as
     missing."""
 
     redirect_uri: str
     code_challenge: str
     expires: float
+
+
+# ---------------------------------------------------------------------------
+# PKCECodeStore (shared PKCE S256 authorization-code lifecycle)
+# ---------------------------------------------------------------------------
+
+
+class PKCECodeStore:
+    """In-memory PKCE (S256) authorization-code store.
+
+    Shared by :class:`LegacyOAuthProvider` and the none-mode auto-approve
+    server (:mod:`oauth_autoapprove`) so the one-shot code lifecycle — issue at
+    ``/authorize``, verify + consume at ``/token`` — has a single
+    implementation instead of two copies. Codes are short-lived
+    (:data:`AUTH_CODE_TTL`), one-shot, bound to the ``redirect_uri`` +
+    ``code_challenge`` presented at issuance, and capped
+    (:data:`MAX_PENDING_CODES`) with an expiry prune on each issue. A restart
+    wipes the store, which only forces in-flight authorize/token round-trips to
+    retry.
+    """
+
+    def __init__(self) -> None:
+        self._codes: dict[str, _PendingCode] = {}
+
+    def issue_code(self, redirect_uri: str, code_challenge: str) -> str | None:
+        """Issue a one-shot authorization code, or None if the pending-code
+        store is at capacity (signals an abuse attempt — see MAX_PENDING_CODES)."""
+        now = time.time()
+        self._codes = {k: v for k, v in self._codes.items() if v["expires"] > now}
+        if len(self._codes) >= MAX_PENDING_CODES:
+            _LOGGER.warning(
+                "HA-MCP OAuth: pending-code store at cap (%d); refusing "
+                "new issuance until existing codes expire or are consumed.",
+                MAX_PENDING_CODES,
+            )
+            return None
+        code = secrets.token_urlsafe(32)
+        self._codes[code] = {
+            "redirect_uri": redirect_uri,
+            "code_challenge": code_challenge,
+            "expires": now + AUTH_CODE_TTL,
+        }
+        return code
+
+    def consume_code(self, code: str, redirect_uri: str, code_verifier: str) -> bool:
+        """One-shot consume ``code``, verifying its PKCE S256 challenge.
+
+        Returns True only for a live, unexpired code whose stored
+        ``redirect_uri`` matches and whose ``code_challenge`` equals
+        ``base64url(SHA-256(code_verifier))``. The code is popped (one-shot)
+        before any check that can fail, so a failed attempt still burns it.
+        """
+        # Validate the verifier shape per RFC 7636 §4.1 before doing any
+        # crypto. A confused client passing an empty/short verifier should be
+        # rejected explicitly rather than silently hashing junk.
+        if not (PKCE_VERIFIER_MIN <= len(code_verifier) <= PKCE_VERIFIER_MAX):
+            return False
+        if not _PKCE_VERIFIER_RE.match(code_verifier):
+            return False
+        entry = self._codes.pop(code, None)
+        if entry is None:
+            return False
+        if entry["expires"] < time.time():
+            return False
+        if entry["redirect_uri"] != redirect_uri:
+            return False
+        # PKCE S256 verification: SHA-256(verifier) base64url(no pad) == challenge
+        derived = _b64url_encode(hashlib.sha256(code_verifier.encode()).digest())
+        return hmac.compare_digest(
+            derived.encode("ascii"), entry["code_challenge"].encode("ascii")
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -419,10 +493,9 @@ class LegacyOAuthProvider:
         self._client_secret = client_secret
         self._signing_key = key_bytes
         self._active_mode_getter = active_mode_getter
-        # In-memory pending authorization codes. Codes are short-lived (5 min)
-        # and one-shot; a restart wipes them, which only forces in-flight
-        # authorize/token round-trips to retry.
-        self._codes: dict[str, _PendingCode] = {}
+        # PKCE authorization codes live in the shared store (also used by the
+        # none-mode auto-approve server) — see :class:`PKCECodeStore`.
+        self._code_store = PKCECodeStore()
 
     @property
     def client_id(self) -> str:
@@ -509,45 +582,12 @@ class LegacyOAuthProvider:
     # -----------------------------------------------------------------
 
     def issue_code(self, redirect_uri: str, code_challenge: str) -> str | None:
-        """Issue a one-shot authorization code, or None if the pending-code
-        store is at capacity (signals an abuse attempt — see MAX_PENDING_CODES)."""
-        now = time.time()
-        self._codes = {k: v for k, v in self._codes.items() if v["expires"] > now}
-        if len(self._codes) >= MAX_PENDING_CODES:
-            _LOGGER.warning(
-                "HA-MCP legacy OAuth: pending-code store at cap (%d); refusing "
-                "new issuance until existing codes expire or are consumed.",
-                MAX_PENDING_CODES,
-            )
-            return None
-        code = secrets.token_urlsafe(32)
-        self._codes[code] = {
-            "redirect_uri": redirect_uri,
-            "code_challenge": code_challenge,
-            "expires": now + AUTH_CODE_TTL,
-        }
-        return code
+        """Issue a one-shot PKCE-bound authorization code (see PKCECodeStore)."""
+        return self._code_store.issue_code(redirect_uri, code_challenge)
 
     def consume_code(self, code: str, redirect_uri: str, code_verifier: str) -> bool:
-        # Validate the verifier shape per RFC 7636 §4.1 before doing any
-        # crypto. A confused client passing an empty/short verifier should be
-        # rejected explicitly rather than silently hashing junk.
-        if not (PKCE_VERIFIER_MIN <= len(code_verifier) <= PKCE_VERIFIER_MAX):
-            return False
-        if not _PKCE_VERIFIER_RE.match(code_verifier):
-            return False
-        entry = self._codes.pop(code, None)
-        if entry is None:
-            return False
-        if entry["expires"] < time.time():
-            return False
-        if entry["redirect_uri"] != redirect_uri:
-            return False
-        # PKCE S256 verification: SHA-256(verifier) base64url(no pad) == challenge
-        derived = _b64url_encode(hashlib.sha256(code_verifier.encode()).digest())
-        return hmac.compare_digest(
-            derived.encode("ascii"), entry["code_challenge"].encode("ascii")
-        )
+        """Verify PKCE S256 + one-shot consume a code (see PKCECodeStore)."""
+        return self._code_store.consume_code(code, redirect_uri, code_verifier)
 
     # -----------------------------------------------------------------
     # Client authentication

--- a/homeassistant-addon-webhook-proxy-dev/CHANGELOG.md
+++ b/homeassistant-addon-webhook-proxy-dev/CHANGELOG.md
@@ -9,6 +9,23 @@ history from before the fork.
 -->
 
 
+## v2.0.3.dev3 (2026-07-19)
+
+### Bug Fixes
+
+- When OAuth is off, serve the add-on's own corrected OAuth discovery documents
+  plus an invisible auto-approve authorization server, so an MCP connector
+  (claude.ai) that intermittently front-loads OAuth discovery resolves against
+  the add-on instead of falling through to Home Assistant core's origin-root
+  `/.well-known/oauth-authorization-server` — which omits
+  `token_endpoint_auth_methods_supported: ["none"]` and has no
+  `registration_endpoint`, so the connector reports "Automatic client
+  registration isn't supported" and cannot connect (issue #1969). The webhook
+  itself stays unauthenticated (URL-only clients are unaffected) and the OAuth
+  flow completes with no Home Assistant login. Switching between OAuth-off and
+  `ha_auth` needs no Home Assistant restart.
+
+
 ## v2.0.3.dev2 (2026-07-18)
 
 ### Refactoring

--- a/homeassistant-addon-webhook-proxy-dev/config.yaml
+++ b/homeassistant-addon-webhook-proxy-dev/config.yaml
@@ -1,6 +1,6 @@
 name: "Nabu Casa - Webhook Proxy for HA MCP (Dev)"
 description: "DEV CHANNEL (unstable) — remote access proxy via Nabu Casa or any reverse proxy. Cannot run alongside the stable Webhook Proxy add-on."
-version: "2.0.3.dev2"
+version: "2.0.3.dev3"
 slug: "ha_mcp_webhook_proxy_dev"
 url: "https://github.com/homeassistant-ai/ha-mcp"
 stage: experimental

--- a/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/__init__.py
+++ b/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/__init__.py
@@ -64,6 +64,20 @@ CONFIG_FILE = Path("/config/.mcp_proxy_dev_config.json")
 # The two are mutually exclusive: exactly one marker is ever set for an entry.
 OAUTH_MODE_HA_AUTH = "ha_auth"
 OAUTH_MODE_LEGACY = "legacy"
+#   none_autoapprove — OAuth is OFF, but we still serve our own corrected
+#             discovery documents + an invisible auto-approve authorization
+#             server (oauth_autoapprove) so claude.ai's flaky discovery resolves
+#             against us instead of HA core's broken root doc (issue #1969). The
+#             webhook stays unauthenticated: this marker is stored under
+#             "oauth_mode" but the provider lives under AUTOAPPROVE_PROVIDER_KEY,
+#             never "oauth", so the forwarder's bearer gate stays off.
+OAUTH_MODE_NONE_AUTOAPPROVE = "none_autoapprove"
+
+# hass.data[DOMAIN] key for the none-mode auto-approve provider (issue #1969).
+# MUST equal oauth.AUTOAPPROVE_PROVIDER_KEY (a test pins them in agreement): the
+# shared discovery views read it via oauth._active_provider, and it is
+# deliberately NOT "oauth" so the webhook forwarder's bearer gate stays off.
+AUTOAPPROVE_PROVIDER_KEY = "autoapprove"
 
 # Service the add-on calls (via the HA Core API) to raise/clear the
 # click-to-restart Repair issues from outside HA — see async_setup.
@@ -481,8 +495,10 @@ async def _setup_legacy_oauth(
             "file, or turn off Enable OAuth in the addon configuration."
         )
     # Root-route collision guard. The OAuth provider registers /authorize
-    # and /token at the HA ROOT (claude.ai builds <host>/authorize from the
-    # host root). HA cannot unregister HTTP views until it restarts, and
+    # and /token at the HA ROOT (a metadata-ignoring client, e.g. Gemini Spark,
+    # builds <host>/authorize from the host root; claude.ai honors the advertised
+    # authorization_endpoint — see #1969). HA cannot unregister HTTP views until
+    # it restarts, and
     # aiohttp lets the first-registered path win — a later duplicate is
     # silently shadowed. So if the OTHER webhook-proxy flavor already owns
     # these routes in this HA instance, registering ours would be shadowed
@@ -568,6 +584,55 @@ async def _setup_legacy_oauth(
     return oauth_restart_needed
 
 
+def _setup_none_autoapprove(
+    hass: HomeAssistant, webhook_id: str, hass_data: dict
+) -> None:
+    """Set up none-mode auto-approve discovery (OAuth off — issue #1969).
+
+    Serves our own corrected RFC 8414/9728 discovery documents plus an invisible
+    auto-approve authorization server so claude.ai's flaky discovery resolves
+    against us, not HA core's broken origin-root doc, and completes OAuth with no
+    HA login. Mutates ``hass_data`` with the provider (under
+    AUTOAPPROVE_PROVIDER_KEY, NOT "oauth" — so the webhook forwarder never 401s)
+    and the mode marker.
+
+    Fails OPEN, unlike ha_auth/legacy: the user did NOT opt into auth here (the
+    webhook is intentionally unauthenticated), and this discovery is an
+    enhancement layered on top of the already-working proxy. A failure must not
+    tear the working webhook down — it only means claude.ai's rare discovery
+    fallback isn't helped; the endpoint still forwards.
+    """
+    try:
+        from .oauth import register_metadata_views
+        from .oauth_autoapprove import (
+            AutoApproveProvider,
+            register_autoapprove_views,
+        )
+
+        # Host-derived base URLs (public_base_url=None), like ha_auth: the same
+        # install must work via any external URL.
+        provider = AutoApproveProvider(hass, webhook_id, None)
+        # Both view bundles bind at most once per HA session (guarded); a
+        # none<->ha_auth switch reuses them, so no restart is needed.
+        register_metadata_views(hass, provider)
+        register_autoapprove_views(hass)
+    except Exception:
+        _LOGGER.exception(
+            "MCP Proxy: failed to set up none-mode auto-approve discovery; "
+            "continuing as a plain unauthenticated proxy (the webhook still "
+            "forwards — only claude.ai's rare OAuth-discovery fallback is "
+            "unassisted)."
+        )
+        return
+    hass_data[AUTOAPPROVE_PROVIDER_KEY] = provider
+    hass_data["oauth_mode"] = OAUTH_MODE_NONE_AUTOAPPROVE
+    _LOGGER.info(
+        "MCP Proxy: OAuth off — serving none-mode auto-approve discovery so "
+        "MCP connectors that run OAuth discovery still resolve against this "
+        "add-on (issue #1969). The webhook itself stays unauthenticated."
+    )
+
+
 async def _setup_oauth_section(
     hass: HomeAssistant,
     webhook_id: str,
@@ -611,6 +676,14 @@ async def _setup_oauth_section(
         return await _setup_legacy_oauth(
             hass, webhook_id, proxy_config, oauth_section, session, hass_data
         )
+    # No OAuth section = OAuth off. Instead of a bare unauthenticated proxy,
+    # serve our own corrected discovery + an invisible auto-approve authorization
+    # server so claude.ai's intermittent OAuth discovery resolves against us, not
+    # HA core's broken origin-root doc (issue #1969). Fails open — the webhook
+    # forwarder stays unauthenticated and never 401s (see _setup_none_autoapprove
+    # / the AUTOAPPROVE_PROVIDER_KEY-not-"oauth" split). No restart is ever
+    # needed, so oauth_restart_needed stays False.
+    _setup_none_autoapprove(hass, webhook_id, hass_data)
     return False
 
 

--- a/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/manifest.json
+++ b/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/manifest.json
@@ -7,5 +7,5 @@
   "dependencies": ["webhook"],
   "documentation": "https://github.com/homeassistant-ai/ha-mcp",
   "iot_class": "local_push",
-  "version": "2.0.3.dev2"
+  "version": "2.0.3.dev3"
 }

--- a/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/oauth.py
+++ b/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/oauth.py
@@ -107,12 +107,6 @@ AUTH_CODE_TTL = 5 * 60  # 5 minutes
 TOKEN_KIND_ACCESS = "access"
 TOKEN_KIND_REFRESH = "refresh"
 
-# RFC 6749 §5.1: a /token response body carries access credentials, so it MUST
-# NOT be cached by any intermediary (reverse proxy, Nabu Casa, etc.). Reused by
-# the none-mode auto-approve token view (oauth_autoapprove) for parity with the
-# component's auto-approve token response (#1976 review).
-_TOKEN_RESPONSE_HEADERS = {"Cache-Control": "no-store", "Pragma": "no-cache"}
-
 # RFC 7636 §4.1: code_verifier is 43-128 chars from the unreserved URL set.
 PKCE_VERIFIER_MIN = 43
 PKCE_VERIFIER_MAX = 128

--- a/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/oauth.py
+++ b/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/oauth.py
@@ -46,12 +46,14 @@ from homeassistant.core import HomeAssistant
 _LOGGER = logging.getLogger(__name__)
 
 OAUTH_BASE = "/api/mcp_proxy_dev/oauth"
-# Authorize/token endpoints live at the root rather than under
-# OAUTH_BASE because Claude.ai (and apparently other MCP clients)
-# construct the authorize URL as `<host>/authorize` from the resource
-# host root — they do not use the `authorization_endpoint` field of
-# our authorization-server metadata document. Registering at the root
-# is the only way to actually catch the redirect.
+# Authorize/token endpoints live at the root rather than under OAUTH_BASE for
+# the legacy flow's original motivation: an MCP client that builds
+# `<host>/authorize` from the resource host root instead of reading the
+# `authorization_endpoint` metadata field (observed with Google Gemini Spark).
+# claude.ai DOES honor the advertised `authorization_endpoint` — issue #1969's
+# none-mode auto-approve server advertises OAUTH_BASE `/authorize` (see
+# oauth_autoapprove) and claude.ai calls exactly that, proven live — so root
+# registration is for the metadata-ignoring clients, not a claude.ai requirement.
 AUTHORIZE_PATH = "/authorize"
 TOKEN_PATH = "/token"
 SECRET_FILE = Path("/config/.mcp_proxy_dev_oauth_secret")
@@ -84,9 +86,20 @@ _METADATA_VIEWS_REGISTERED_KEY = (
 
 # OAuth mode markers. Mirrored as auth_native.HA_AUTH_MODE and __init__.py's
 # OAUTH_MODE_* (a test pins them in agreement). ha_auth = HA core is the
-# authorization server; legacy = this module's embedded authorization server.
+# authorization server; legacy = this module's embedded authorization server;
+# none_autoapprove = OAuth off, but we still serve our own corrected discovery +
+# an invisible auto-approve authorization server so claude.ai's flaky discovery
+# resolves against us instead of HA core's broken root doc (issue #1969, dev-only
+# — see oauth_autoapprove).
 MODE_HA_AUTH = "ha_auth"
 MODE_LEGACY = "legacy"
+MODE_NONE_AUTOAPPROVE = "none_autoapprove"
+
+# hass.data[DOMAIN] key holding the live none-mode AutoApproveProvider (issue
+# #1969). Stored under its OWN key — NOT "oauth" — so the webhook forwarder's
+# bearer gate (which keys off "oauth") stays off in none mode: the secret
+# webhook URL is the credential and the auto-approve token is cosmetic.
+AUTOAPPROVE_PROVIDER_KEY = "autoapprove"
 
 ACCESS_TOKEN_TTL = 60 * 60  # 1 hour
 REFRESH_TOKEN_TTL = 30 * 24 * 60 * 60  # 30 days
@@ -370,10 +383,79 @@ def _active_provider(bound_provider: MetadataProvider) -> MetadataProvider:
     hass = getattr(bound_provider, "_hass", None)
     domain_data = hass.data.get(DOMAIN) if hass is not None else None
     if isinstance(domain_data, dict):
-        active: MetadataProvider | None = domain_data.get("oauth")
+        # ha_auth/legacy store their provider under "oauth"; none-mode
+        # auto-approve (issue #1969) stores its MetadataProvider under
+        # AUTOAPPROVE_PROVIDER_KEY (never "oauth", so the bearer gate stays
+        # off). The two are mutually exclusive, so this resolves the live one.
+        active: MetadataProvider | None = domain_data.get("oauth") or domain_data.get(
+            AUTOAPPROVE_PROVIDER_KEY
+        )
         if active is not None:
             return active
     return bound_provider
+
+
+class PKCECodeStore:
+    """In-memory PKCE (S256) authorization-code store.
+
+    Shared by `OAuthProvider` (legacy) and the none-mode auto-approve server
+    (`oauth_autoapprove`, issue #1969) so the one-shot code lifecycle — issue at
+    `/authorize`, verify + consume at `/token` — has a single implementation
+    instead of two copies. Codes are short-lived (`AUTH_CODE_TTL`), one-shot,
+    bound to the `redirect_uri` + `code_challenge` presented at issuance, and
+    capped (`MAX_PENDING_CODES`) with an expiry prune on each issue. A restart
+    wipes the store, which only forces in-flight authorize/token round-trips to
+    retry.
+    """
+
+    def __init__(self) -> None:
+        self._codes: dict[str, _PendingCode] = {}
+
+    def issue_code(self, redirect_uri: str, code_challenge: str) -> str | None:
+        """Issue a one-shot authorization code, or return None if the
+        pending-code store is at capacity (which signals an abuse attempt
+        — see MAX_PENDING_CODES)."""
+        # Prune expired entries — bounds dict size to O(active codes)
+        # between abusive bursts; the cap below handles the burst case.
+        now = time.time()
+        self._codes = {k: v for k, v in self._codes.items() if v["expires"] > now}
+        if len(self._codes) >= MAX_PENDING_CODES:
+            _LOGGER.warning(
+                "MCP Proxy OAuth: pending-code store at cap (%d); refusing "
+                "new issuance until existing codes expire or are consumed.",
+                MAX_PENDING_CODES,
+            )
+            return None
+        code = secrets.token_urlsafe(32)
+        self._codes[code] = {
+            "redirect_uri": redirect_uri,
+            "code_challenge": code_challenge,
+            "expires": now + AUTH_CODE_TTL,
+        }
+        return code
+
+    def consume_code(self, code: str, redirect_uri: str, code_verifier: str) -> bool:
+        """One-shot consume ``code``, verifying its PKCE S256 challenge."""
+        # Validate the verifier shape per RFC 7636 §4.1 before doing any
+        # crypto. A confused client passing an empty/short verifier should
+        # be rejected explicitly rather than silently hashing junk.
+        if not (PKCE_VERIFIER_MIN <= len(code_verifier) <= PKCE_VERIFIER_MAX):
+            return False
+        if not _PKCE_VERIFIER_RE.match(code_verifier):
+            return False
+        entry = self._codes.pop(code, None)
+        if entry is None:
+            return False
+        if entry["expires"] < time.time():
+            return False
+        if entry["redirect_uri"] != redirect_uri:
+            return False
+        # PKCE S256 verification: SHA-256(verifier) base64url(no pad) == challenge
+        derived = _b64url_encode(hashlib.sha256(code_verifier.encode()).digest())
+        return hmac.compare_digest(
+            derived.encode("ascii"),
+            entry["code_challenge"].encode("ascii"),
+        )
 
 
 class OAuthProvider:
@@ -412,10 +494,9 @@ class OAuthProvider:
         # event loop must not be blocked with sync filesystem I/O during
         # integration setup.
         self._signing_key = signing_key
-        # In-memory pending authorization codes. Codes are short-lived
-        # (5 min) and one-shot; restart wipes them, which only forces
-        # in-flight authorize/token round-trips to retry.
-        self._codes: dict[str, _PendingCode] = {}
+        # PKCE authorization codes live in the shared store (also used by the
+        # none-mode auto-approve server) — see PKCECodeStore.
+        self._code_store = PKCECodeStore()
 
     @property
     def client_id(self) -> str:
@@ -543,49 +624,12 @@ class OAuthProvider:
     # -----------------------------------------------------------------
 
     def issue_code(self, redirect_uri: str, code_challenge: str) -> str | None:
-        """Issue a one-shot authorization code, or return None if the
-        pending-code store is at capacity (which signals an abuse attempt
-        — see MAX_PENDING_CODES)."""
-        # Prune expired entries — bounds dict size to O(active codes)
-        # between abusive bursts; the cap below handles the burst case.
-        now = time.time()
-        self._codes = {k: v for k, v in self._codes.items() if v["expires"] > now}
-        if len(self._codes) >= MAX_PENDING_CODES:
-            _LOGGER.warning(
-                "MCP Proxy OAuth: pending-code store at cap (%d); refusing "
-                "new issuance until existing codes expire or are consumed.",
-                MAX_PENDING_CODES,
-            )
-            return None
-        code = secrets.token_urlsafe(32)
-        self._codes[code] = {
-            "redirect_uri": redirect_uri,
-            "code_challenge": code_challenge,
-            "expires": now + AUTH_CODE_TTL,
-        }
-        return code
+        """Issue a one-shot PKCE-bound authorization code (see PKCECodeStore)."""
+        return self._code_store.issue_code(redirect_uri, code_challenge)
 
     def consume_code(self, code: str, redirect_uri: str, code_verifier: str) -> bool:
-        # Validate the verifier shape per RFC 7636 §4.1 before doing any
-        # crypto. A confused client passing an empty/short verifier should
-        # be rejected explicitly rather than silently hashing junk.
-        if not (PKCE_VERIFIER_MIN <= len(code_verifier) <= PKCE_VERIFIER_MAX):
-            return False
-        if not _PKCE_VERIFIER_RE.match(code_verifier):
-            return False
-        entry = self._codes.pop(code, None)
-        if entry is None:
-            return False
-        if entry["expires"] < time.time():
-            return False
-        if entry["redirect_uri"] != redirect_uri:
-            return False
-        # PKCE S256 verification: SHA-256(verifier) base64url(no pad) == challenge
-        derived = _b64url_encode(hashlib.sha256(code_verifier.encode()).digest())
-        return hmac.compare_digest(
-            derived.encode("ascii"),
-            entry["code_challenge"].encode("ascii"),
-        )
+        """Verify PKCE S256 + one-shot consume a code (see PKCECodeStore)."""
+        return self._code_store.consume_code(code, redirect_uri, code_verifier)
 
     # -----------------------------------------------------------------
     # Client authentication
@@ -668,6 +712,14 @@ class AuthorizationServerMetadataView(HomeAssistantView):
             # + CIMD. Built in auth_native, imported lazily to avoid an import
             # cycle (auth_native imports this module at load).
             from .auth_native import authorization_server_document
+
+            return web.json_response(authorization_server_document(base))
+        if mode == MODE_NONE_AUTOAPPROVE:
+            # OAuth off, but we advertise OUR OWN auto-approve endpoints under
+            # OAUTH_BASE (public PKCE client + CIMD) so claude.ai's flaky
+            # discovery resolves against us, not HA core's broken root doc
+            # (issue #1969). Lazy import mirrors the ha_auth dispatch above.
+            from .oauth_autoapprove import authorization_server_document
 
             return web.json_response(authorization_server_document(base))
         as_url = provider.authorization_server_url(base)

--- a/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/oauth.py
+++ b/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/oauth.py
@@ -107,6 +107,12 @@ AUTH_CODE_TTL = 5 * 60  # 5 minutes
 TOKEN_KIND_ACCESS = "access"
 TOKEN_KIND_REFRESH = "refresh"
 
+# RFC 6749 §5.1: a /token response body carries access credentials, so it MUST
+# NOT be cached by any intermediary (reverse proxy, Nabu Casa, etc.). Reused by
+# the none-mode auto-approve token view (oauth_autoapprove) for parity with the
+# component's auto-approve token response (#1976 review).
+_TOKEN_RESPONSE_HEADERS = {"Cache-Control": "no-store", "Pragma": "no-cache"}
+
 # RFC 7636 §4.1: code_verifier is 43-128 chars from the unreserved URL set.
 PKCE_VERIFIER_MIN = 43
 PKCE_VERIFIER_MAX = 128
@@ -651,24 +657,37 @@ class OAuthProvider:
 
 
 class ProtectedResourceMetadataView(HomeAssistantView):
-    """RFC 9728 Protected Resource Metadata."""
+    """RFC 9728 Protected Resource Metadata (fixed, guessable path)."""
 
     requires_auth = False
     cors_allowed = True
     url = f"{OAUTH_BASE}/protected-resource"
     name = "mcp_proxy_dev:oauth:protected-resource"
 
+    # SECURITY (#1976 review): this fixed path exposes ``resource:
+    # <base>/api/webhook/<id>``. In none-autoapprove mode the webhook id is the
+    # SOLE credential, so this ANONYMOUS, guessable path must NOT serve it there.
+    # The path-scoped subclass flips this True — its URL already embeds the id,
+    # so its caller must already know it (no leak).
+    _serves_in_none_mode = False
+
     def __init__(self, provider: MetadataProvider) -> None:
         self._provider = provider
 
     async def get(self, request: web.Request) -> web.Response:
-        # The protected-resource document has the same shape in both OAuth
-        # modes; only 404 when no mode is live (entry unloaded / OAuth off) so a
+        # The protected-resource document has the same shape in every OAuth
+        # mode; 404 when no mode is live (entry unloaded / OAuth off) so a
         # stale-bound view acts like an unregistered route. URLs are built via
         # the ACTIVE mode's provider, not the instance this view was bound with,
         # so a live mode switch also switches the base-URL policy (legacy:
         # pinned; ha_auth: host-derived).
-        if _active_oauth_mode(self._provider) is None:
+        mode = _active_oauth_mode(self._provider)
+        if mode is None:
+            return _json_not_found()
+        # In none-autoapprove mode only the path-scoped subclass may serve (see
+        # _serves_in_none_mode above); the fixed-path view 404s to avoid leaking
+        # the credential-bearing webhook id anonymously (#1976 review).
+        if mode == MODE_NONE_AUTOAPPROVE and not self._serves_in_none_mode:
             return _json_not_found()
         provider = _active_provider(self._provider)
         base = provider.base_url_for(request)
@@ -760,6 +779,11 @@ class WellKnownProtectedResourceView(ProtectedResourceMetadataView):
     """
 
     name = "mcp_proxy_dev:oauth:wellknown-protected-resource"
+
+    # Path-scoped: the URL already embeds the webhook id, so the caller must
+    # already know it — serving in none-autoapprove mode leaks nothing (#1976).
+    # This is the doc claude.ai's none-mode discovery actually uses.
+    _serves_in_none_mode = True
 
     def __init__(self, provider: MetadataProvider) -> None:
         super().__init__(provider)

--- a/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/oauth_autoapprove.py
+++ b/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/oauth_autoapprove.py
@@ -58,7 +58,6 @@ from homeassistant.core import HomeAssistant
 
 from .oauth import (
     _PKCE_CHALLENGE_RE,
-    _TOKEN_RESPONSE_HEADERS,
     ACCESS_TOKEN_TTL,
     AUTOAPPROVE_PROVIDER_KEY,
     DOMAIN,
@@ -67,6 +66,13 @@ from .oauth import (
     _build_base_url,
     _is_valid_redirect_uri,
 )
+
+# RFC 6749 §5.1: a /token response body carries access credentials, so it MUST
+# NOT be cached by any intermediary (reverse proxy, Nabu Casa, etc.). Defined
+# here — the only user — rather than in oauth.py: the add-on's legacy token views
+# don't set no-store, so a constant living in oauth.py would be flagged unused
+# (#1976 review). Parity with the component's auto-approve token response.
+_TOKEN_RESPONSE_HEADERS = {"Cache-Control": "no-store", "Pragma": "no-cache"}
 
 # TOP-LEVEL hass.data flag recording that the two auto-approve views are bound
 # for this HA session. Not under DOMAIN so it survives async_unload_entry's

--- a/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/oauth_autoapprove.py
+++ b/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/oauth_autoapprove.py
@@ -58,6 +58,7 @@ from homeassistant.core import HomeAssistant
 
 from .oauth import (
     _PKCE_CHALLENGE_RE,
+    _TOKEN_RESPONSE_HEADERS,
     ACCESS_TOKEN_TTL,
     AUTOAPPROVE_PROVIDER_KEY,
     DOMAIN,
@@ -326,7 +327,8 @@ class AutoApproveTokenView(HomeAssistantView):
                 "access_token": provider.issue_access_token(),
                 "token_type": "Bearer",
                 "expires_in": ACCESS_TOKEN_TTL,
-            }
+            },
+            headers=_TOKEN_RESPONSE_HEADERS,
         )
 
 

--- a/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/oauth_autoapprove.py
+++ b/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/oauth_autoapprove.py
@@ -1,0 +1,347 @@
+"""None-mode auto-approve OAuth authorization server (issue #1969, dev-only).
+
+When OAuth is OFF the secret webhook URL *is* the credential, so no bearer is
+required and the proxy forwards everything with a 200. But claude.ai's connector
+onboarding intermittently front-loads OAuth discovery, and because the
+integration registers no ``/.well-known`` views when OAuth is off, claude.ai
+falls through to Home Assistant *core*'s own origin-root
+``/.well-known/oauth-authorization-server`` — which advertises
+``client_id_metadata_document_supported`` but omits
+``token_endpoint_auth_methods_supported: ["none"]`` and has no
+``registration_endpoint``. claude.ai then can neither use CIMD nor do dynamic
+client registration and shows "Automatic client registration isn't supported…".
+
+This module is the none-mode fix's authorization-server half: a pair of
+path-scoped ``OAUTH_BASE`` endpoints that complete OAuth *invisibly* — no login,
+no consent — so a connector that does run discovery resolves against our own
+corrected documents (the mode-aware discovery views in :mod:`oauth`) instead of
+HA core's broken root doc, and connects with zero HA login:
+
+* ``GET  {OAUTH_BASE}/authorize`` issues a PKCE-bound one-time code and
+  immediately 302-redirects back to the client with ``?code=…&state=…`` — no
+  page is rendered.
+* ``POST {OAUTH_BASE}/token`` exchanges that code (public client, PKCE S256, no
+  ``client_secret``) for an opaque access token. The token is *cosmetic* — none
+  mode ignores bearers entirely — but is a real random string so a spec-strict
+  client is satisfied.
+
+Both views are gated per request off ``hass.data`` (they 404 unless
+none-autoapprove is the live mode), mirroring the discovery views, so a
+none ↔ ha_auth switch needs no restart. The PKCE code store, the redirect-URI
+floor, and the base-URL helper are reused from :mod:`oauth` rather than copied.
+The forwarder never sees this provider (it is stored under
+``AUTOAPPROVE_PROVIDER_KEY``, never ``"oauth"``), so the OAuth-off path keeps
+returning 200 with no bearer required and no 401 — URL-only clients keep working.
+
+**Open-redirect defence.** ``/authorize`` 302-redirects to a caller-supplied
+``redirect_uri`` on the Home Assistant origin, so an unvalidated target would be
+an open redirector. On top of :func:`oauth._is_valid_redirect_uri`'s https floor,
+the redirect must EXACTLY match a known MCP callback
+(:data:`_AUTOAPPROVE_REDIRECT_ALLOWLIST`). Anything else is a hard 400 (no
+redirect). A "same origin as the client_id" rule was deliberately NOT used: the
+client_id is fully attacker-controlled, so ``client_id == redirect_uri origin``
+still lets an attacker bounce a victim to any site of their choosing (a real
+open redirect on a public HA origin). Properly honouring an arbitrary CIMD client
+would require fetching the attacker-supplied client_id URL — an SSRF vector — so
+the allowlist is both the safe and the simple choice. Add a client's callback
+here to support it.
+"""
+
+from __future__ import annotations
+
+import secrets
+from typing import Any
+
+from aiohttp import web
+from homeassistant.components.http import HomeAssistantView
+from homeassistant.core import HomeAssistant
+
+from .oauth import (
+    _PKCE_CHALLENGE_RE,
+    ACCESS_TOKEN_TTL,
+    AUTOAPPROVE_PROVIDER_KEY,
+    DOMAIN,
+    OAUTH_BASE,
+    PKCECodeStore,
+    _build_base_url,
+    _is_valid_redirect_uri,
+)
+
+# TOP-LEVEL hass.data flag recording that the two auto-approve views are bound
+# for this HA session. Not under DOMAIN so it survives async_unload_entry's
+# hass.data.pop(DOMAIN) — aiohttp cannot unregister a bound view until HA
+# restarts, so the views (and this flag) must outlive the config entry. Suffixed
+# with DOMAIN so each flavor gets its own flag (mirrors
+# oauth._METADATA_VIEWS_REGISTERED_KEY).
+_AUTOAPPROVE_VIEWS_REGISTERED_KEY = (
+    f"webhook_proxy_oauth_autoapprove_views_registered_{DOMAIN}"
+)
+
+# Known MCP OAuth callback URLs always accepted as a redirect target. claude.ai's
+# connector onboarding posts its authorization code here. Exact-match only (never
+# a prefix test, so ``https://claude.ai/api/mcp/auth_callback.evil.example``
+# cannot slip through).
+_AUTOAPPROVE_REDIRECT_ALLOWLIST = frozenset(
+    {
+        "https://claude.ai/api/mcp/auth_callback",
+    }
+)
+
+
+def authorization_server_document(base: str) -> dict:
+    """RFC 8414 authorization-server metadata for none-mode auto-approve.
+
+    Points MCP clients at OUR OWN ``OAUTH_BASE`` ``/authorize`` + ``/token`` (the
+    invisible auto-approve endpoints below), NOT HA core's ``/auth/*``. Serving
+    this — with ``token_endpoint_auth_methods_supported: ["none"]`` (public PKCE
+    client) and ``client_id_metadata_document_supported`` — is the none-mode fix:
+    claude.ai's intermittent discovery resolves against this corrected document
+    instead of HA core's origin-root ``/.well-known/oauth-authorization-server``,
+    which omits the ``"none"`` method and has no ``registration_endpoint`` (issue
+    #1969). No refresh grant: the token is cosmetic (none mode ignores bearers),
+    so only ``authorization_code`` is advertised.
+    """
+    return {
+        "issuer": f"{base}{OAUTH_BASE}",
+        "authorization_endpoint": f"{base}{OAUTH_BASE}/authorize",
+        "token_endpoint": f"{base}{OAUTH_BASE}/token",
+        "response_types_supported": ["code"],
+        "grant_types_supported": ["authorization_code"],
+        "code_challenge_methods_supported": ["S256"],
+        "token_endpoint_auth_methods_supported": ["none"],
+        "client_id_metadata_document_supported": True,
+    }
+
+
+def _json_not_found() -> web.Response:
+    """404 JSON body used when none-autoapprove is not the live mode."""
+    return web.json_response({"error": "not_found"}, status=404)
+
+
+def _json_error(
+    error: str, status: int, description: str | None = None
+) -> web.Response:
+    """OAuth-style JSON error (RFC 6749 §5.2 shape)."""
+    body: dict[str, str] = {"error": error}
+    if description is not None:
+        body["error_description"] = description
+    return web.json_response(body, status=status)
+
+
+def _is_valid_autoapprove_redirect(redirect_uri: str) -> bool:
+    """Open-redirect gate for the auto-approve ``/authorize`` view.
+
+    Exact-match allowlist only, on top of :func:`oauth._is_valid_redirect_uri`'s
+    https floor. The ``client_id`` is NOT consulted: it is attacker-controlled,
+    so validating the redirect against it (even "same origin") would not
+    constrain the redirect target to a trusted host. See the module docstring.
+    """
+    return (
+        _is_valid_redirect_uri(redirect_uri)
+        and redirect_uri in _AUTOAPPROVE_REDIRECT_ALLOWLIST
+    )
+
+
+def _redirect_with(redirect_uri: str, **params: str) -> web.Response:
+    """302 to ``redirect_uri`` with ``params`` merged into its query string."""
+    # yarl ships with aiohttp and handles existing-query merging + encoding
+    # correctly — safer than hand-rolling (matches oauth.AuthorizeView).
+    import yarl
+
+    url = yarl.URL(redirect_uri).update_query(params)
+    return web.Response(status=302, headers={"Location": str(url)})
+
+
+class AutoApproveProvider:
+    """None-mode auto-approve authorization-server state + metadata provider.
+
+    Implements the same metadata surface the discovery views need
+    (``webhook_id`` / ``resource_url`` / ``authorization_server_url`` /
+    ``base_url_for`` — satisfying ``oauth.MetadataProvider``) so the shared views
+    can build documents for none mode too, PLUS the PKCE code store shared with
+    :mod:`oauth`. It owns NO signing key and NO client credentials (the token it
+    issues is cosmetic). Base URLs are host-derived (``public_base_url=None``),
+    like ha_auth, so the same install works via any external URL. Constructed per
+    setup and stored in ``hass.data[DOMAIN][AUTOAPPROVE_PROVIDER_KEY]``; the views
+    resolve it from ``hass.data`` per request, so a reload minting a fresh
+    provider is transparent.
+    """
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        webhook_id: str,
+        public_base_url: str | None = None,
+    ) -> None:
+        self._hass = hass
+        self._webhook_id = webhook_id
+        self._public_base_url = public_base_url
+        self._code_store = PKCECodeStore()
+
+    @property
+    def webhook_id(self) -> str:
+        return self._webhook_id
+
+    def resource_url(self, base_url: str) -> str:
+        return f"{base_url}/api/webhook/{self._webhook_id}"
+
+    def authorization_server_url(self, base_url: str) -> str:
+        return f"{base_url}{OAUTH_BASE}"
+
+    def base_url_for(self, request: web.Request) -> str:
+        return _build_base_url(request, self._public_base_url)
+
+    def issue_code(self, redirect_uri: str, code_challenge: str) -> str | None:
+        """Issue a one-shot PKCE-bound authorization code (see PKCECodeStore)."""
+        return self._code_store.issue_code(redirect_uri, code_challenge)
+
+    def consume_code(self, code: str, redirect_uri: str, code_verifier: str) -> bool:
+        """Verify PKCE S256 + one-shot consume a code (see PKCECodeStore)."""
+        return self._code_store.consume_code(code, redirect_uri, code_verifier)
+
+    @staticmethod
+    def issue_access_token() -> str:
+        """Mint an opaque access token.
+
+        None mode ignores bearers (the secret webhook URL is the credential), so
+        this token grants nothing — but it is a real random string, so a
+        spec-strict client that stores/echoes it is satisfied.
+        """
+        return secrets.token_urlsafe(32)
+
+
+def _active_autoapprove_provider(hass: HomeAssistant) -> AutoApproveProvider | None:
+    """The live none-mode auto-approve provider, or None when it is not live.
+
+    Read live from ``hass.data`` (not captured at view construction) so the bound
+    views serve only while none-autoapprove is the active mode and 404 otherwise
+    — mirrors ``oauth._active_oauth_mode``'s per-request gating.
+    """
+    domain_data = hass.data.get(DOMAIN)
+    if not isinstance(domain_data, dict):
+        return None
+    provider = domain_data.get(AUTOAPPROVE_PROVIDER_KEY)
+    return provider if isinstance(provider, AutoApproveProvider) else None
+
+
+class AutoApproveAuthorizeView(HomeAssistantView):
+    """None-mode auto-approve ``/authorize`` — issues a code, 302s, no UI.
+
+    Validates ``response_type=code``, PKCE S256, and the redirect_uri
+    open-redirect gate, then issues a PKCE-bound one-time code and redirects
+    straight back to the client. No login page and no consent screen render, so
+    claude.ai's OAuth flow completes invisibly (issue #1969).
+    """
+
+    requires_auth = False
+    cors_allowed = True
+    url = f"{OAUTH_BASE}/authorize"
+    name = "mcp_proxy_dev:oauth:autoapprove-authorize"
+
+    def __init__(self, hass: HomeAssistant) -> None:
+        """Bind the view to the HA instance; liveness is resolved per request."""
+        self._hass = hass
+
+    async def get(self, request: web.Request) -> web.Response:
+        """Auto-approve the authorization request or reject with a 400/404."""
+        provider = _active_autoapprove_provider(self._hass)
+        if provider is None:
+            return _json_not_found()
+
+        params = request.query
+        response_type = params.get("response_type", "")
+        redirect_uri = params.get("redirect_uri", "")
+        state = params.get("state", "")
+        code_challenge = params.get("code_challenge", "")
+        code_challenge_method = params.get("code_challenge_method", "")
+
+        if response_type != "code":
+            return _json_error("unsupported_response_type", 400)
+        if code_challenge_method != "S256":
+            return _json_error(
+                "invalid_request", 400, "code_challenge_method must be S256"
+            )
+        if not _PKCE_CHALLENGE_RE.match(code_challenge):
+            return _json_error(
+                "invalid_request", 400, "invalid code_challenge (43-char base64url)"
+            )
+        # SECURITY: an unvalidated redirect_uri would be an open redirector on
+        # the HA origin. Reject in-place (never redirect) unless it exactly
+        # matches a known MCP callback (client_id is attacker-controlled and is
+        # deliberately not consulted — see module docstring).
+        if not _is_valid_autoapprove_redirect(redirect_uri):
+            return _json_error("invalid_request", 400, "invalid redirect_uri")
+
+        code = provider.issue_code(redirect_uri, code_challenge)
+        if code is None:
+            # Pending-code store at capacity (abuse guard) — surface per
+            # RFC 6749 §4.1.2.1 instead of a silent failure.
+            return _redirect_with(
+                redirect_uri, error="temporarily_unavailable", state=state
+            )
+        redirect_params = {"code": code}
+        if state:
+            redirect_params["state"] = state
+        return _redirect_with(redirect_uri, **redirect_params)
+
+
+class AutoApproveTokenView(HomeAssistantView):
+    """None-mode auto-approve ``/token`` — PKCE code → opaque access token.
+
+    Public client (no ``client_secret``): the PKCE code_verifier is the only
+    proof required. The returned access token is cosmetic (none mode ignores
+    bearers), but real and opaque. Only the ``authorization_code`` grant is
+    supported — none mode has no refresh cycle.
+    """
+
+    requires_auth = False
+    cors_allowed = True
+    url = f"{OAUTH_BASE}/token"
+    name = "mcp_proxy_dev:oauth:autoapprove-token"
+
+    def __init__(self, hass: HomeAssistant) -> None:
+        """Bind the view to the HA instance; liveness is resolved per request."""
+        self._hass = hass
+
+    async def post(self, request: web.Request) -> web.Response:
+        """Exchange a PKCE authorization code for an opaque access token."""
+        provider = _active_autoapprove_provider(self._hass)
+        if provider is None:
+            return _json_not_found()
+
+        form: dict[str, Any] = dict(await request.post())
+        if form.get("grant_type", "") != "authorization_code":
+            return _json_error("unsupported_grant_type", 400)
+
+        code = str(form.get("code", ""))
+        redirect_uri = str(form.get("redirect_uri", ""))
+        code_verifier = str(form.get("code_verifier", ""))
+        if not (code and redirect_uri and code_verifier):
+            return _json_error("invalid_request", 400)
+        if not provider.consume_code(code, redirect_uri, code_verifier):
+            return _json_error("invalid_grant", 400)
+
+        return web.json_response(
+            {
+                "access_token": provider.issue_access_token(),
+                "token_type": "Bearer",
+                "expires_in": ACCESS_TOKEN_TTL,
+            }
+        )
+
+
+def register_autoapprove_views(hass: HomeAssistant) -> None:
+    """Bind the two auto-approve views at most once per HA session.
+
+    aiohttp cannot unregister a bound view, so a reload / re-enable / mode switch
+    must reuse the already-bound views — they resolve the active provider from
+    ``hass.data`` per request (see :func:`_active_autoapprove_provider`), so they
+    serve only while none-autoapprove is live and 404 otherwise. The guard flag
+    lives at a top-level ``hass.data`` key that survives config-entry teardown
+    (mirrors :func:`oauth.register_metadata_views`).
+    """
+    if hass.data.get(_AUTOAPPROVE_VIEWS_REGISTERED_KEY):
+        return
+    hass.http.register_view(AutoApproveAuthorizeView(hass))
+    hass.http.register_view(AutoApproveTokenView(hass))
+    hass.data[_AUTOAPPROVE_VIEWS_REGISTERED_KEY] = True

--- a/tests/addon/test_webhook_proxy.py
+++ b/tests/addon/test_webhook_proxy.py
@@ -6192,7 +6192,10 @@ class TestNoneAutoApproveMode:
         assert "refresh_token" not in body
         # RFC 6749 §5.1: the token body carries credentials and must not be
         # cached — parity with the component's auto-approve token view (#1976).
-        assert jr.call_args.kwargs["headers"] == oauth._TOKEN_RESPONSE_HEADERS
+        assert jr.call_args.kwargs["headers"] == {
+            "Cache-Control": "no-store",
+            "Pragma": "no-cache",
+        }
         assert jr.call_args.kwargs["headers"]["Cache-Control"] == "no-store"
 
     async def test_token_wrong_verifier_is_invalid_grant(self):

--- a/tests/addon/test_webhook_proxy.py
+++ b/tests/addon/test_webhook_proxy.py
@@ -5991,22 +5991,34 @@ class TestNoneAutoApproveMode:
         assert doc["authorization_endpoint"] == f"https://legit.example{base}/authorize"
         assert doc["token_endpoint_auth_methods_supported"] == ["none"]
 
-    async def test_protected_resource_serves_in_none_mode(self):
+    async def test_fixed_path_protected_resource_404s_in_none_mode(self):
+        # SECURITY (#1976): the fixed, guessable /protected-resource path must
+        # NOT leak the webhook id (the sole credential in none mode) to an
+        # anonymous GET — it 404s in none-autoapprove mode.
         _mod, oauth, autoapprove, _an = _import_none_autoapprove_stack()
         hass, provider = self._none_live_hass(oauth, autoapprove)
         request = _make_view_request(headers={"Host": "legit.example"})
         with patch.object(oauth.web, "json_response") as jr:
             await oauth.ProtectedResourceMetadataView(provider).get(request)
-        body = jr.call_args.args[0]
-        base = CURRENT["oauth_base"]
-        assert body["resource"] == "https://legit.example/api/webhook/mcp_test"
-        assert body["authorization_servers"] == [f"https://legit.example{base}"]
-        # The path-scoped variant claude.ai probes first must serve the same doc.
+        assert jr.call_args.kwargs["status"] == 404
+
+    async def test_path_scoped_protected_resource_still_serves_in_none_mode(self):
+        # The path-scoped view (URL embeds the id) KEEPS serving in none mode —
+        # its caller already knows the id, so nothing leaks (#1976). This is the
+        # doc claude.ai's none-mode discovery actually uses.
+        _mod, oauth, autoapprove, _an = _import_none_autoapprove_stack()
+        hass, provider = self._none_live_hass(oauth, autoapprove)
+        request = _make_view_request(headers={"Host": "legit.example"})
         wk = oauth.WellKnownProtectedResourceView(provider)
         assert wk.url == "/.well-known/oauth-protected-resource/api/webhook/mcp_test"
         with patch.object(oauth.web, "json_response") as jr:
             await wk.get(request)
-        assert jr.call_args.args[0] == body
+        body = jr.call_args.args[0]
+        base = CURRENT["oauth_base"]
+        assert body["resource"] == "https://legit.example/api/webhook/mcp_test"
+        assert body["authorization_servers"] == [f"https://legit.example{base}"]
+        # It served (200) rather than 404ing.
+        assert jr.call_args.kwargs.get("status") in (None, 200)
 
     # ---- AutoApproveProvider (PKCE store + cosmetic token) ----
 
@@ -6178,6 +6190,10 @@ class TestNoneAutoApproveMode:
         assert isinstance(body["expires_in"], int)
         # None mode issues no refresh token.
         assert "refresh_token" not in body
+        # RFC 6749 §5.1: the token body carries credentials and must not be
+        # cached — parity with the component's auto-approve token view (#1976).
+        assert jr.call_args.kwargs["headers"] == oauth._TOKEN_RESPONSE_HEADERS
+        assert jr.call_args.kwargs["headers"]["Cache-Control"] == "no-store"
 
     async def test_token_wrong_verifier_is_invalid_grant(self):
         _mod, oauth, autoapprove, _an = _import_none_autoapprove_stack()

--- a/tests/addon/test_webhook_proxy.py
+++ b/tests/addon/test_webhook_proxy.py
@@ -296,6 +296,46 @@ def _ha_auth_supported() -> bool:
     )
 
 
+def _none_autoapprove_supported() -> bool:
+    """Feature-detect whether the CURRENT flavor ships none-mode auto-approve
+    discovery (its `oauth_autoapprove.py` module, issue #1969). The stable
+    flavor skips these tests until the module is promoted — same
+    lockstep-with-code approach as `_ha_auth_supported`."""
+    return os.path.exists(
+        os.path.join(PROXY_ADDON_DIR, CURRENT["component"], "oauth_autoapprove.py")
+    )
+
+
+def _import_none_autoapprove_stack():
+    """Import the integration wired so none-mode auto-approve resolves.
+
+    Loads __init__, oauth, oauth_autoapprove, and auth_native as submodules of
+    ONE package so the relative imports resolve in every direction to the same
+    instances: oauth_autoapprove does `from .oauth import ...` at load, the AS
+    view does `from .oauth_autoapprove import ...` (none) / `from .auth_native
+    import ...` (ha_auth) at request time, and auth_native does `from .oauth
+    import ...` at load. Returns (init_mod, oauth_mod, autoapprove_mod,
+    auth_native_mod).
+    """
+    _install_runtime_stubs()
+    component_dir = os.path.join(PROXY_ADDON_DIR, CURRENT["component"])
+    pkg_name = f"mcp_proxy_init_{CURRENT['key']}"
+    for suffix in ("", ".oauth", ".oauth_autoapprove", ".auth_native", ".repairs"):
+        sys.modules.pop(f"{pkg_name}{suffix}", None)
+    init_path = os.path.join(component_dir, "__init__.py")
+    init_spec = importlib.util.spec_from_file_location(
+        pkg_name, init_path, submodule_search_locations=[component_dir]
+    )
+    pkg = importlib.util.module_from_spec(init_spec)
+    sys.modules[pkg_name] = pkg
+    # oauth first (oauth_autoapprove + auth_native both `from .oauth` at load).
+    oauth = _load_pkg_submodule(pkg_name, component_dir, "oauth")
+    autoapprove = _load_pkg_submodule(pkg_name, component_dir, "oauth_autoapprove")
+    auth_native = _load_pkg_submodule(pkg_name, component_dir, "auth_native")
+    init_spec.loader.exec_module(pkg)
+    return pkg, oauth, autoapprove, auth_native
+
+
 def _load_pkg_submodule(pkg_name, component_dir, sub):
     """Load `<pkg_name>.<sub>` from `<component_dir>/<sub>.py` and register it in
     sys.modules under that dotted name so relative imports resolve to it."""
@@ -1426,9 +1466,11 @@ class TestOAuthOffPreservesBehavior:
         return h
 
     async def test_setup_without_oauth_section_omits_oauth_key(self, mod, hass):
-        """The OFF path must not even add an "oauth" key to hass.data —
-        v1.0.2 had three keys (target_url, webhook_id, session) and the OFF
-        path of v1.0.3-beta.1 must produce identical shape."""
+        """The OFF path must never add the "oauth" key (which arms the bearer
+        gate). On stable that leaves exactly the legacy three keys; on dev the
+        none-mode auto-approve fix (#1969) additionally serves discovery, so it
+        adds "autoapprove" + "oauth_mode" — but still NOT "oauth", so the
+        forwarder stays unauthenticated."""
         proxy_config = {
             "target_url": "http://127.0.0.1:9583/private_zctpwlX7ZkIAr7oqdfLPxw",
             "webhook_id": "mcp_test_webhook_id_12345",
@@ -1440,18 +1482,23 @@ class TestOAuthOffPreservesBehavior:
         ):
             await mod.async_setup_entry(hass, MagicMock())
 
+        # The bearer-gate key is never set on the OFF path, in EITHER flavor.
         assert "oauth" not in hass.data[mod.DOMAIN]
-        # And the rest of the dict shape matches the legacy three keys
-        assert set(hass.data[mod.DOMAIN].keys()) == {
-            "target_url",
-            "webhook_id",
-            "session",
-        }
+        expected = {"target_url", "webhook_id", "session"}
+        if _none_autoapprove_supported():
+            # Dev serves none-mode auto-approve discovery (issue #1969): the
+            # provider under "autoapprove" (not "oauth") + the mode marker.
+            expected |= {"autoapprove", "oauth_mode"}
+            assert (
+                hass.data[mod.DOMAIN]["oauth_mode"] == mod.OAUTH_MODE_NONE_AUTOAPPROVE
+            )
+        assert set(hass.data[mod.DOMAIN].keys()) == expected
 
     async def test_setup_does_not_import_oauth_module_when_off(self, mod, hass):
-        """Confirms the lazy-import: oauth submodule shouldn't be loaded
-        unless OAuth is configured. If this regresses, the OFF path picks up
-        new dependencies and the 'no behavior change' guarantee breaks."""
+        """Confirms the lazy-import: the oauth submodule shouldn't be loaded on
+        the OFF path — UNLESS the flavor ships none-mode auto-approve (dev,
+        #1969), whose discovery deliberately reuses oauth's metadata views +
+        shared PKCE store, so loading it on the OFF path is expected there."""
         proxy_config = {
             "target_url": "http://127.0.0.1:9583/private_zctpwlX7ZkIAr7oqdfLPxw",
             "webhook_id": "mcp_test_webhook_id_12345",
@@ -1467,9 +1514,14 @@ class TestOAuthOffPreservesBehavior:
             await mod.async_setup_entry(hass, MagicMock())
 
         # The submodule name follows from the parent's package name
-        # ("mcp_proxy_init_<variant>"). If it ever appears here, the OFF path
-        # imported it.
-        assert oauth_submodule_name not in sys.modules
+        # ("mcp_proxy_init_<variant>").
+        if _none_autoapprove_supported():
+            # Dev's OFF path serves auto-approve discovery, which reuses oauth's
+            # metadata views + PKCE store — so oauth IS loaded, by design.
+            assert oauth_submodule_name in sys.modules
+        else:
+            # Stable keeps the original lazy-import guarantee.
+            assert oauth_submodule_name not in sys.modules
 
     async def test_blank_creds_raises_config_entry_error(self, mod, hass):
         """Blank creds in an oauth section signal a config bug — the user
@@ -1585,11 +1637,12 @@ class TestDebugLogging:
             await mod.async_setup_entry(hass, MagicMock())
 
         assert "debug_logging" not in hass.data[mod.DOMAIN]
-        assert set(hass.data[mod.DOMAIN].keys()) == {
-            "target_url",
-            "webhook_id",
-            "session",
-        }
+        expected = {"target_url", "webhook_id", "session"}
+        if _none_autoapprove_supported():
+            # Dev's OAuth-off path also serves none-mode auto-approve discovery
+            # (issue #1969): provider under "autoapprove" + the mode marker.
+            expected |= {"autoapprove", "oauth_mode"}
+        assert set(hass.data[mod.DOMAIN].keys()) == expected
 
     async def test_debug_on_stores_flag(self, mod, hass):
         proxy_config = {
@@ -3804,16 +3857,13 @@ class TestPendingCodeCap:
     def test_issue_code_returns_none_at_cap(self, provider, tmp_path):
         oauth = _import_oauth(tmp_secret_dir=tmp_path)
         challenge = "X" * 43
-        # Fill the dict directly — pruning would clear expired entries on
-        # re-issue but here we want non-expired entries at the cap.
-        for i in range(oauth.MAX_PENDING_CODES):
-            provider._codes[f"k{i}"] = {
-                "redirect_uri": "https://x/",
-                "code_challenge": challenge,
-                "expires": time.time() + 60,
-            }
-        result = provider.issue_code("https://claude.ai/cb", challenge)
-        assert result is None
+        # Fill to the cap via the public API — none of these expire within the
+        # 5-min TTL, so the prune on each issue keeps them and the cap is hit.
+        # (Poking the internal dict is avoided so this stays agnostic to whether
+        # the flavor stores codes inline or in the shared PKCECodeStore.)
+        for _ in range(oauth.MAX_PENDING_CODES):
+            assert provider.issue_code("https://claude.ai/cb", challenge) is not None
+        assert provider.issue_code("https://claude.ai/cb", challenge) is None
 
 
 class TestTokenExpiryBoundary:
@@ -4824,8 +4874,10 @@ class TestHaAuthMode:
         assert auth_native_name not in sys.modules
 
     async def test_off_path_imports_neither_oauth_nor_auth_native(self, hass, tmp_path):
-        """The OAuth-off path must import neither oauth NOR auth_native (mirror
-        of the existing 'off path imports nothing' pin, extended to ha_auth)."""
+        """The OAuth-off path must never import auth_native (ha_auth stays lazy).
+        oauth stays lazy too UNLESS the flavor ships none-mode auto-approve
+        (dev, #1969), whose off-path discovery deliberately reuses oauth's
+        metadata views + shared PKCE store."""
         mod = _import_mcp_proxy()
         oauth_name = f"{mod.__name__}.oauth"
         an_name = f"{mod.__name__}.auth_native"
@@ -4841,7 +4893,12 @@ class TestHaAuthMode:
             patch.object(mod.aiohttp, "ClientSession", return_value=MagicMock()),
         ):
             await mod.async_setup_entry(hass, MagicMock())
-        assert oauth_name not in sys.modules
+        if _none_autoapprove_supported():
+            # None-mode auto-approve reuses oauth (metadata views + PKCE store).
+            assert oauth_name in sys.modules
+        else:
+            assert oauth_name not in sys.modules
+        # auth_native (ha_auth) is never pulled in on the OFF path.
         assert an_name not in sys.modules
 
     # ---- documents ----
@@ -5828,3 +5885,493 @@ class TestProxyConfigFilePersistence:
         assert isinstance(json.loads(config_path.read_text()), dict)
         err = capsys.readouterr().err
         assert "Could not create the proxy config file" in err
+
+
+class TestNoneAutoApproveMode:
+    """None-mode auto-approve discovery (OAuth off — issue #1969, dev-only).
+
+    When OAuth is off the add-on serves its own corrected RFC 8414/9728 discovery
+    documents plus an invisible auto-approve authorization server, so claude.ai's
+    intermittent discovery resolves against the add-on instead of HA core's
+    broken origin-root doc — and completes with no HA login. The webhook stays
+    unauthenticated (the forwarder never 401s). Skips on flavors that don't ship
+    oauth_autoapprove yet."""
+
+    @pytest.fixture(autouse=True)
+    def _skip_on_stable(self, _webhook_proxy_variant):
+        if not _none_autoapprove_supported():
+            pytest.skip("flavor does not ship none-mode auto-approve yet")
+
+    @pytest.fixture
+    def hass(self):
+        h = MagicMock()
+        h.data = {}
+        h.http = MagicMock()
+        h.http.register_view = MagicMock()
+
+        async def fake_executor(func, *args):
+            return func(*args)
+
+        h.async_add_executor_job = AsyncMock(side_effect=fake_executor)
+        return h
+
+    @staticmethod
+    def _pkce_pair():
+        """A valid (code_verifier, code_challenge) pair per RFC 7636 S256."""
+        import base64
+        import hashlib
+        import secrets
+
+        verifier = secrets.token_urlsafe(64)
+        challenge = (
+            base64.urlsafe_b64encode(hashlib.sha256(verifier.encode()).digest())
+            .rstrip(b"=")
+            .decode("ascii")
+        )
+        return verifier, challenge
+
+    @staticmethod
+    def _none_live_hass(oauth, autoapprove, webhook_id="mcp_test"):
+        """A hass whose live cfg is none-mode auto-approve (provider under the
+        AUTOAPPROVE_PROVIDER_KEY, mode marker set, NO "oauth" key)."""
+        hass = MagicMock()
+        hass.data = {}
+        hass.http = MagicMock()
+        provider = autoapprove.AutoApproveProvider(hass, webhook_id, None)
+        hass.data[oauth.DOMAIN] = {
+            "target_url": "http://127.0.0.1:9583/private_aaaaaaaaaaaaaaaa",
+            "webhook_id": webhook_id,
+            "session": MagicMock(),
+            "oauth_mode": oauth.MODE_NONE_AUTOAPPROVE,
+            oauth.AUTOAPPROVE_PROVIDER_KEY: provider,
+        }
+        return hass, provider
+
+    CLAUDE_REDIRECT = "https://claude.ai/api/mcp/auth_callback"
+
+    # ---- literals agree across the modules ----
+
+    def test_mode_and_key_literals_agree(self):
+        mod, oauth, autoapprove, _an = _import_none_autoapprove_stack()
+        assert oauth.MODE_NONE_AUTOAPPROVE == "none_autoapprove"
+        assert mod.OAUTH_MODE_NONE_AUTOAPPROVE == oauth.MODE_NONE_AUTOAPPROVE
+        # The provider key the discovery views read (oauth._active_provider) must
+        # equal the one the handler writes (mod._setup_none_autoapprove).
+        assert oauth.AUTOAPPROVE_PROVIDER_KEY == mod.AUTOAPPROVE_PROVIDER_KEY
+        assert oauth.AUTOAPPROVE_PROVIDER_KEY == "autoapprove"
+
+    # ---- none-mode authorization-server document ----
+
+    def test_as_document_shape(self):
+        _mod, _oauth, autoapprove, _an = _import_none_autoapprove_stack()
+        doc = autoapprove.authorization_server_document("https://x.example")
+        base = CURRENT["oauth_base"]
+        assert doc["issuer"] == f"https://x.example{base}"
+        # Points at OUR auto-approve endpoints, NOT HA core's /auth/*.
+        assert doc["authorization_endpoint"] == f"https://x.example{base}/authorize"
+        assert doc["token_endpoint"] == f"https://x.example{base}/token"
+        assert doc["response_types_supported"] == ["code"]
+        assert doc["grant_types_supported"] == ["authorization_code"]
+        assert doc["code_challenge_methods_supported"] == ["S256"]
+        # The two fields HA core's root doc lacks — the whole reason for #1969.
+        assert doc["token_endpoint_auth_methods_supported"] == ["none"]
+        assert doc["client_id_metadata_document_supported"] is True
+        # No DCR: fixed/auto flow, so no registration endpoint advertised.
+        assert "registration_endpoint" not in doc
+
+    async def test_as_view_serves_none_document_when_live(self):
+        _mod, oauth, autoapprove, _an = _import_none_autoapprove_stack()
+        hass, provider = self._none_live_hass(oauth, autoapprove)
+        view = oauth.AuthorizationServerMetadataView(provider)
+        request = _make_view_request(headers={"Host": "legit.example"})
+        with patch.object(oauth.web, "json_response") as jr:
+            await view.get(request)
+        doc = jr.call_args.args[0]
+        base = CURRENT["oauth_base"]
+        assert doc["authorization_endpoint"] == f"https://legit.example{base}/authorize"
+        assert doc["token_endpoint_auth_methods_supported"] == ["none"]
+
+    async def test_protected_resource_serves_in_none_mode(self):
+        _mod, oauth, autoapprove, _an = _import_none_autoapprove_stack()
+        hass, provider = self._none_live_hass(oauth, autoapprove)
+        request = _make_view_request(headers={"Host": "legit.example"})
+        with patch.object(oauth.web, "json_response") as jr:
+            await oauth.ProtectedResourceMetadataView(provider).get(request)
+        body = jr.call_args.args[0]
+        base = CURRENT["oauth_base"]
+        assert body["resource"] == "https://legit.example/api/webhook/mcp_test"
+        assert body["authorization_servers"] == [f"https://legit.example{base}"]
+        # The path-scoped variant claude.ai probes first must serve the same doc.
+        wk = oauth.WellKnownProtectedResourceView(provider)
+        assert wk.url == "/.well-known/oauth-protected-resource/api/webhook/mcp_test"
+        with patch.object(oauth.web, "json_response") as jr:
+            await wk.get(request)
+        assert jr.call_args.args[0] == body
+
+    # ---- AutoApproveProvider (PKCE store + cosmetic token) ----
+
+    def test_provider_pkce_roundtrip_and_one_shot(self):
+        _mod, _oauth, autoapprove, _an = _import_none_autoapprove_stack()
+        provider = autoapprove.AutoApproveProvider(MagicMock(), "mcp_test", None)
+        verifier, challenge = self._pkce_pair()
+        code = provider.issue_code(self.CLAUDE_REDIRECT, challenge)
+        assert code
+        assert provider.consume_code(code, self.CLAUDE_REDIRECT, verifier) is True
+        # One-shot: a second consume of the same code fails.
+        assert provider.consume_code(code, self.CLAUDE_REDIRECT, verifier) is False
+
+    def test_provider_rejects_wrong_verifier(self):
+        _mod, _oauth, autoapprove, _an = _import_none_autoapprove_stack()
+        provider = autoapprove.AutoApproveProvider(MagicMock(), "mcp_test", None)
+        _v, challenge = self._pkce_pair()
+        other_verifier, _c = self._pkce_pair()
+        code = provider.issue_code(self.CLAUDE_REDIRECT, challenge)
+        assert (
+            provider.consume_code(code, self.CLAUDE_REDIRECT, other_verifier) is False
+        )
+
+    def test_access_token_is_opaque_and_unique(self):
+        _mod, _oauth, autoapprove, _an = _import_none_autoapprove_stack()
+        t1 = autoapprove.AutoApproveProvider.issue_access_token()
+        t2 = autoapprove.AutoApproveProvider.issue_access_token()
+        assert isinstance(t1, str) and len(t1) >= 20
+        assert t1 != t2
+
+    # ---- redirect open-redirect gate (allowlist-only) ----
+
+    def test_redirect_gate_allows_claude_callback_only(self):
+        _mod, _oauth, autoapprove, _an = _import_none_autoapprove_stack()
+        assert autoapprove._is_valid_autoapprove_redirect(self.CLAUDE_REDIRECT) is True
+        # A same-host-different-path or any other https URL is NOT allowlisted.
+        assert (
+            autoapprove._is_valid_autoapprove_redirect("https://claude.ai/evil")
+            is False
+        )
+        assert (
+            autoapprove._is_valid_autoapprove_redirect("https://evil.example/cb")
+            is False
+        )
+        # http (non-https) fails the floor before the allowlist even matters.
+        assert (
+            autoapprove._is_valid_autoapprove_redirect(
+                "http://claude.ai/api/mcp/auth_callback"
+            )
+            is False
+        )
+
+    # ---- AutoApproveAuthorizeView (GET: issue code, 302, no UI) ----
+
+    async def test_authorize_404_when_not_live(self):
+        _mod, _oauth, autoapprove, _an = _import_none_autoapprove_stack()
+        hass = MagicMock()
+        hass.data = {}
+        view = autoapprove.AutoApproveAuthorizeView(hass)
+        request = _make_view_request(query={"response_type": "code"})
+        with patch.object(autoapprove.web, "json_response") as jr:
+            await view.get(request)
+        assert jr.call_args.kwargs["status"] == 404
+
+    async def test_authorize_happy_path_issues_code_and_redirects(self):
+        _mod, oauth, autoapprove, _an = _import_none_autoapprove_stack()
+        hass, provider = self._none_live_hass(oauth, autoapprove)
+        view = autoapprove.AutoApproveAuthorizeView(hass)
+        verifier, challenge = self._pkce_pair()
+        request = _make_view_request(
+            query={
+                "response_type": "code",
+                "client_id": "https://claude.ai/whatever",
+                "redirect_uri": self.CLAUDE_REDIRECT,
+                "code_challenge": challenge,
+                "code_challenge_method": "S256",
+                "state": "st-1",
+            }
+        )
+        with patch.object(autoapprove.web, "Response") as resp:
+            await view.get(request)
+        # 302 straight back — no consent page rendered.
+        assert resp.call_args.kwargs["status"] == 302
+        location = resp.call_args.kwargs["headers"]["Location"]
+        from urllib.parse import parse_qs, urlparse
+
+        q = parse_qs(urlparse(location).query)
+        assert q["state"][0] == "st-1"
+        # The issued code is real: it consumes with the matching verifier.
+        assert provider.consume_code(q["code"][0], self.CLAUDE_REDIRECT, verifier)
+
+    async def test_authorize_rejects_non_allowlisted_redirect_with_400(self):
+        _mod, oauth, autoapprove, _an = _import_none_autoapprove_stack()
+        hass, _provider = self._none_live_hass(oauth, autoapprove)
+        view = autoapprove.AutoApproveAuthorizeView(hass)
+        _v, challenge = self._pkce_pair()
+        request = _make_view_request(
+            query={
+                "response_type": "code",
+                "client_id": "https://evil.example/cimd",
+                "redirect_uri": "https://evil.example/steal",
+                "code_challenge": challenge,
+                "code_challenge_method": "S256",
+                "state": "st",
+            }
+        )
+        with (
+            patch.object(autoapprove.web, "json_response") as jr,
+            patch.object(autoapprove.web, "Response") as resp,
+        ):
+            await view.get(request)
+        # 400 in place — NEVER a 302 to an unvalidated target.
+        assert jr.call_args.kwargs["status"] == 400
+        resp.assert_not_called()
+
+    async def test_authorize_rejects_non_s256(self):
+        _mod, oauth, autoapprove, _an = _import_none_autoapprove_stack()
+        hass, _provider = self._none_live_hass(oauth, autoapprove)
+        view = autoapprove.AutoApproveAuthorizeView(hass)
+        _v, challenge = self._pkce_pair()
+        request = _make_view_request(
+            query={
+                "response_type": "code",
+                "redirect_uri": self.CLAUDE_REDIRECT,
+                "code_challenge": challenge,
+                "code_challenge_method": "plain",
+                "state": "st",
+            }
+        )
+        with patch.object(autoapprove.web, "json_response") as jr:
+            await view.get(request)
+        assert jr.call_args.kwargs["status"] == 400
+
+    # ---- AutoApproveTokenView (POST: PKCE exchange, public client) ----
+
+    async def test_token_404_when_not_live(self):
+        _mod, _oauth, autoapprove, _an = _import_none_autoapprove_stack()
+        hass = MagicMock()
+        hass.data = {}
+        view = autoapprove.AutoApproveTokenView(hass)
+        request = _make_view_request(post_data={}, method="POST")
+        with patch.object(autoapprove.web, "json_response") as jr:
+            await view.post(request)
+        assert jr.call_args.kwargs["status"] == 404
+
+    async def test_token_valid_pkce_no_client_secret(self):
+        _mod, oauth, autoapprove, _an = _import_none_autoapprove_stack()
+        hass, provider = self._none_live_hass(oauth, autoapprove)
+        verifier, challenge = self._pkce_pair()
+        code = provider.issue_code(self.CLAUDE_REDIRECT, challenge)
+        view = autoapprove.AutoApproveTokenView(hass)
+        # NOTE: no client_secret in the form — public client.
+        request = _make_view_request(
+            post_data={
+                "grant_type": "authorization_code",
+                "code": code,
+                "redirect_uri": self.CLAUDE_REDIRECT,
+                "code_verifier": verifier,
+            },
+            method="POST",
+        )
+        with patch.object(autoapprove.web, "json_response") as jr:
+            await view.post(request)
+        # Success is a bare json_response (default 200, no status kwarg).
+        assert jr.call_args.kwargs.get("status") in (None, 200)
+        body = jr.call_args.args[0]
+        assert body["token_type"] == "Bearer"
+        assert body["access_token"]
+        assert isinstance(body["expires_in"], int)
+        # None mode issues no refresh token.
+        assert "refresh_token" not in body
+
+    async def test_token_wrong_verifier_is_invalid_grant(self):
+        _mod, oauth, autoapprove, _an = _import_none_autoapprove_stack()
+        hass, provider = self._none_live_hass(oauth, autoapprove)
+        _v, challenge = self._pkce_pair()
+        code = provider.issue_code(self.CLAUDE_REDIRECT, challenge)
+        wrong_verifier, _c = self._pkce_pair()
+        view = autoapprove.AutoApproveTokenView(hass)
+        request = _make_view_request(
+            post_data={
+                "grant_type": "authorization_code",
+                "code": code,
+                "redirect_uri": self.CLAUDE_REDIRECT,
+                "code_verifier": wrong_verifier,
+            },
+            method="POST",
+        )
+        with patch.object(autoapprove.web, "json_response") as jr:
+            await view.post(request)
+        assert jr.call_args.kwargs["status"] == 400
+        assert jr.call_args.args[0]["error"] == "invalid_grant"
+
+    async def test_token_code_is_one_time(self):
+        _mod, oauth, autoapprove, _an = _import_none_autoapprove_stack()
+        hass, provider = self._none_live_hass(oauth, autoapprove)
+        verifier, challenge = self._pkce_pair()
+        code = provider.issue_code(self.CLAUDE_REDIRECT, challenge)
+        view = autoapprove.AutoApproveTokenView(hass)
+        post_data = {
+            "grant_type": "authorization_code",
+            "code": code,
+            "redirect_uri": self.CLAUDE_REDIRECT,
+            "code_verifier": verifier,
+        }
+        with patch.object(autoapprove.web, "json_response") as jr:
+            await view.post(
+                _make_view_request(post_data=dict(post_data), method="POST")
+            )
+        assert jr.call_args.kwargs.get("status") in (None, 200)
+        with patch.object(autoapprove.web, "json_response") as jr:
+            await view.post(
+                _make_view_request(post_data=dict(post_data), method="POST")
+            )
+        assert jr.call_args.kwargs["status"] == 400
+        assert jr.call_args.args[0]["error"] == "invalid_grant"
+
+    # ---- full setup registers the views + marks the mode ----
+
+    async def test_setup_registers_metadata_and_autoapprove_views(self, hass, tmp_path):
+        mod, oauth, autoapprove, _an = _import_none_autoapprove_stack()
+        repairs = _bind_repairs(mod, tmp_path)
+        repairs.RESTART_MARKER_FILE.write_text('{"reason": "stale"}')
+        # No "oauth" section = OAuth off = none-mode auto-approve.
+        config = {
+            "target_url": "http://127.0.0.1:9583/private_zctpwlX7ZkIAr7oqdfLPxw",
+            "webhook_id": "mcp_test",
+        }
+        with (
+            patch.object(mod, "_read_config", return_value=config),
+            patch.object(mod, "async_register"),
+            patch.object(mod.aiohttp, "ClientSession", return_value=MagicMock()),
+            patch.object(repairs, "create_issue") as mock_create,
+            patch.object(repairs, "_write_marker") as mock_write,
+            patch.object(repairs, "_delete_issue_only") as mock_delete,
+        ):
+            result = await mod.async_setup_entry(hass, MagicMock())
+
+        assert result is True
+        registered = {
+            call.args[0].url for call in hass.http.register_view.call_args_list
+        }
+        metadata = {
+            f"{CURRENT['oauth_base']}/protected-resource",
+            f"{CURRENT['oauth_base']}/authorization-server",
+        } | _wellknown_oauth_urls(oauth, "mcp_test")
+        autoapprove_urls = {
+            f"{CURRENT['oauth_base']}/authorize",
+            f"{CURRENT['oauth_base']}/token",
+        }
+        assert registered == metadata | autoapprove_urls
+        assert len(registered) == 9  # 7 discovery + 2 auto-approve
+        # Mode marker + provider under the non-"oauth" key.
+        assert hass.data[mod.DOMAIN]["oauth_mode"] == mod.OAUTH_MODE_NONE_AUTOAPPROVE
+        assert isinstance(
+            hass.data[mod.DOMAIN]["autoapprove"], autoapprove.AutoApproveProvider
+        )
+        # The bearer-gate key stays off — the webhook is unauthenticated.
+        assert "oauth" not in hass.data[mod.DOMAIN]
+        # No root /authorize or /token (those are legacy-only).
+        assert "/authorize" not in registered
+        assert "/token" not in registered
+        # No restart repair — none-mode binds path-scoped views only.
+        assert not repairs.RESTART_MARKER_FILE.exists()
+        mock_delete.assert_called_once_with(hass, mod.DOMAIN)
+        mock_create.assert_not_called()
+        mock_write.assert_not_called()
+
+    async def test_setup_failure_fails_open_keeps_plain_proxy(self, hass, tmp_path):
+        """Unlike ha_auth/legacy, a none-mode auto-approve setup failure must NOT
+        tear down the (intentionally unauthenticated) webhook — it just skips the
+        discovery enhancement and keeps forwarding."""
+        mod, oauth, _aa, _an = _import_none_autoapprove_stack()
+        _bind_repairs(mod, tmp_path)
+        config = {
+            "target_url": "http://127.0.0.1:9583/private_zctpwlX7ZkIAr7oqdfLPxw",
+            "webhook_id": "mcp_test",
+        }
+        with (
+            patch.object(mod, "_read_config", return_value=config),
+            patch.object(mod, "async_register"),
+            patch.object(mod, "async_unregister") as mock_unreg,
+            patch.object(mod.aiohttp, "ClientSession", return_value=MagicMock()),
+            patch.object(
+                oauth, "register_metadata_views", side_effect=RuntimeError("boom")
+            ),
+        ):
+            result = await mod.async_setup_entry(hass, MagicMock())
+
+        assert result is True  # setup still succeeds (fail-open)
+        # Webhook was NOT torn down.
+        mock_unreg.assert_not_called()
+        # Discovery not marked live, but the plain proxy config is present.
+        data = hass.data[mod.DOMAIN]
+        assert "autoapprove" not in data
+        assert "oauth_mode" not in data
+        assert "oauth" not in data
+        assert data["target_url"].endswith("private_zctpwlX7ZkIAr7oqdfLPxw")
+
+    # ---- mode switch none <-> ha_auth with no rebind (hard requirement) ----
+
+    async def test_as_document_switches_none_ha_auth_without_rebind(self):
+        _mod, oauth, autoapprove, auth_native = _import_none_autoapprove_stack()
+        hass = MagicMock()
+        hass.data = {}
+        aa_provider = autoapprove.AutoApproveProvider(hass, "mcp_test", None)
+        # none-autoapprove live
+        hass.data[oauth.DOMAIN] = {
+            "oauth_mode": oauth.MODE_NONE_AUTOAPPROVE,
+            oauth.AUTOAPPROVE_PROVIDER_KEY: aa_provider,
+        }
+        view = oauth.AuthorizationServerMetadataView(aa_provider)  # bound once
+        request = _make_view_request(headers={"Host": "legit.example"})
+        base = CURRENT["oauth_base"]
+
+        with patch.object(oauth.web, "json_response") as jr:
+            await view.get(request)
+        assert jr.call_args.args[0]["authorization_endpoint"] == (
+            f"https://legit.example{base}/authorize"
+        )
+
+        # Flip to ha_auth by mutating hass.data — no rebind, no restart.
+        rs = auth_native.ResourceServer(hass, "mcp_test", None)
+        hass.data[oauth.DOMAIN] = {"oauth_mode": oauth.MODE_HA_AUTH, "oauth": rs}
+        with patch.object(oauth.web, "json_response") as jr:
+            await view.get(request)
+        assert jr.call_args.args[0]["authorization_endpoint"] == (
+            "https://legit.example/auth/authorize"
+        )
+
+        # Flip back to none — the same bound view serves the auto-approve doc.
+        hass.data[oauth.DOMAIN] = {
+            "oauth_mode": oauth.MODE_NONE_AUTOAPPROVE,
+            oauth.AUTOAPPROVE_PROVIDER_KEY: aa_provider,
+        }
+        with patch.object(oauth.web, "json_response") as jr:
+            await view.get(request)
+        assert jr.call_args.args[0]["authorization_endpoint"] == (
+            f"https://legit.example{base}/authorize"
+        )
+
+    # ---- forwarder stays unauthenticated (no 401) with auto-approve live ----
+
+    async def test_webhook_forwarder_ignores_bearer_in_none_mode(self):
+        mod, oauth, autoapprove, _an = _import_none_autoapprove_stack()
+        hass = MagicMock()
+        provider = autoapprove.AutoApproveProvider(hass, "mcp_test", None)
+        hass.data = {
+            mod.DOMAIN: {
+                "target_url": "http://127.0.0.1:9583/private_aaaaaaaaaaaaaaaa",
+                "webhook_id": "mcp_test",
+                "session": MagicMock(),
+                "oauth_mode": mod.OAUTH_MODE_NONE_AUTOAPPROVE,
+                "autoapprove": provider,
+            }
+        }
+        request = MagicMock()
+        request.headers = {"Authorization": "Bearer whatever-cosmetic-or-forged"}
+        request.read = AsyncMock(return_value=b"")
+        request.method = "POST"
+        sentinel = mod.aiohttp.ClientError("stop here")
+        hass.data[mod.DOMAIN]["session"].request = MagicMock(side_effect=sentinel)
+
+        await mod._handle_webhook(hass, "mcp_test", request)
+
+        # The gate keys off "oauth" (absent here), so it never 401s — the body
+        # is read and forwarded upstream (which raises the sentinel -> 502).
+        request.read.assert_awaited_once()

--- a/tests/src/unit/test_mcp_webhook.py
+++ b/tests/src/unit/test_mcp_webhook.py
@@ -64,6 +64,7 @@ def _store_cfg(
     auth_mode: str = WEBHOOK_AUTH_NONE,
     resource_server: object | None = None,
     oauth_provider: object | None = None,
+    autoapprove_provider: object | None = None,
 ) -> None:
     hass.data[DOMAIN] = {
         DATA_WEBHOOK: {
@@ -73,6 +74,7 @@ def _store_cfg(
             "auth_mode": auth_mode,
             "resource_server": resource_server,
             "oauth_provider": oauth_provider,
+            mw.CFG_AUTOAPPROVE_PROVIDER: autoapprove_provider,
         }
     }
 
@@ -285,6 +287,23 @@ class TestForwardingHandler:
 
         resp = await mw._async_handle_webhook(hass, WEBHOOK_ID, make_request())
         assert resp.status == 500
+
+    async def test_none_mode_forwards_200_and_ignores_bearer(self):
+        # #1969: none mode advertises an auto-approve authorization server, but
+        # the FORWARDER must still never 401 and never validate a bearer — the
+        # secret webhook URL is the credential and the OAuth token is cosmetic.
+        session = FakeSession(upstream=FakeUpstream(status=200, body=b"{}"))
+        hass = _make_hass()
+        _store_cfg(hass, session=session, autoapprove_provider=mw.AutoApproveProvider())
+
+        request = make_request(
+            headers={"Authorization": "Bearer whatever-cosmetic-or-forged"}
+        )
+        resp = await mw._async_handle_webhook(hass, WEBHOOK_ID, request)
+
+        assert resp.status == 200
+        assert len(session.calls) == 1  # forwarded upstream, not challenged
+        request.read.assert_awaited()
 
 
 # ---------------------------------------------------------------------------
@@ -702,6 +721,118 @@ class TestDiscoveryViews:
 
 
 # ---------------------------------------------------------------------------
+# None-mode auto-approve discovery (issue #1969)
+# ---------------------------------------------------------------------------
+
+
+def _none_live_hass(webhook_id: str = WEBHOOK_ID) -> MagicMock:
+    """A hass whose live webhook cfg is none-mode auto-approve (provider set) —
+    mirrors what async_register_webhook stores in none mode with the endpoint
+    enabled. Distinct from _live_hass(WEBHOOK_AUTH_NONE), which models the
+    local-only cfg (no provider) that advertises nothing."""
+    hass = _make_hass()
+    hass.data[DOMAIN] = {
+        DATA_WEBHOOK: {
+            "webhook_id": webhook_id,
+            "auth_mode": WEBHOOK_AUTH_NONE,
+            "resource_server": None,
+            "oauth_provider": None,
+            mw.CFG_AUTOAPPROVE_PROVIDER: mw.AutoApproveProvider(),
+        }
+    }
+    return hass
+
+
+class TestNoneModeDiscovery:
+    def test_none_mode_as_document_shape(self):
+        doc = mw._none_mode_authorization_server_document("https://x.nabu.casa")
+        assert doc["issuer"] == f"https://x.nabu.casa{OAUTH_BASE}"
+        # Points at OUR auto-approve endpoints, NOT HA core's /auth/*.
+        assert (
+            doc["authorization_endpoint"]
+            == f"https://x.nabu.casa{OAUTH_BASE}/authorize"
+        )
+        assert doc["token_endpoint"] == f"https://x.nabu.casa{OAUTH_BASE}/token"
+        assert doc["response_types_supported"] == ["code"]
+        assert doc["grant_types_supported"] == ["authorization_code"]
+        assert doc["code_challenge_methods_supported"] == ["S256"]
+        # The two fields HA core's root doc lacks — the whole reason for #1969.
+        assert doc["token_endpoint_auth_methods_supported"] == ["none"]
+        assert doc["client_id_metadata_document_supported"] is True
+
+    def test_active_auth_mode_reports_none_when_autoapprove_live(self):
+        assert mw.active_auth_mode(_none_live_hass()) == WEBHOOK_AUTH_NONE
+
+    async def test_as_view_serves_none_document_when_live(self):
+        hass = _none_live_hass()
+        view = mw._AuthorizationServerMetadataView(hass)
+        resp = await view.get(make_request(headers={"Host": "abc.ui.nabu.casa"}))
+        assert resp.status == 200
+        doc = resp.json_body
+        assert doc["authorization_endpoint"] == (
+            f"https://abc.ui.nabu.casa{OAUTH_BASE}/authorize"
+        )
+        assert doc["token_endpoint_auth_methods_supported"] == ["none"]
+
+    async def test_protected_resource_views_live_in_none_mode(self):
+        hass = _none_live_hass()
+        request = make_request(headers={"Host": "abc.ui.nabu.casa"})
+        plain = mw._ProtectedResourceMetadataView(hass)
+        plain_resp = await plain.get(request)
+        assert plain_resp.status == 200
+        assert plain_resp.json_body["authorization_servers"] == [
+            f"https://abc.ui.nabu.casa{OAUTH_BASE}"
+        ]
+        # The path-scoped variant claude.ai probes first must also serve.
+        wellknown = mw._WellKnownProtectedResourceView(hass)
+        wk_resp = await wellknown.get(request, webhook_id=WEBHOOK_ID)
+        assert wk_resp.status == 200
+        assert wk_resp.json_body["resource"] == (
+            f"https://abc.ui.nabu.casa/api/webhook/{WEBHOOK_ID}"
+        )
+
+    async def test_as_document_switches_on_mode_flip_without_rebinding(self):
+        # Hard requirement: with the ONE bound AS view, flipping the live mode
+        # none -> ha_auth -> none swaps which document is served, all by
+        # mutating hass.data cfg (no re-bind, no restart).
+        hass = _none_live_hass()
+        view = mw._AuthorizationServerMetadataView(hass)  # bound once
+        request = make_request(headers={"Host": "abc.ui.nabu.casa"})
+
+        none_doc = (await view.get(request)).json_body
+        assert none_doc["authorization_endpoint"] == (
+            f"https://abc.ui.nabu.casa{OAUTH_BASE}/authorize"
+        )
+
+        # Flip to ha_auth: HA-core-pointing document.
+        hass.data[DOMAIN][DATA_WEBHOOK] = {
+            "webhook_id": WEBHOOK_ID,
+            "auth_mode": WEBHOOK_AUTH_HA,
+            "resource_server": mw.ResourceServer(hass, WEBHOOK_ID),
+            "oauth_provider": None,
+            mw.CFG_AUTOAPPROVE_PROVIDER: None,
+        }
+        ha_doc = (await view.get(request)).json_body
+        assert (
+            ha_doc["authorization_endpoint"]
+            == "https://abc.ui.nabu.casa/auth/authorize"
+        )
+
+        # Flip back to none: auto-approve document again.
+        hass.data[DOMAIN][DATA_WEBHOOK] = {
+            "webhook_id": WEBHOOK_ID,
+            "auth_mode": WEBHOOK_AUTH_NONE,
+            "resource_server": None,
+            "oauth_provider": None,
+            mw.CFG_AUTOAPPROVE_PROVIDER: mw.AutoApproveProvider(),
+        }
+        back_doc = (await view.get(request)).json_body
+        assert back_doc["authorization_endpoint"] == (
+            f"https://abc.ui.nabu.casa{OAUTH_BASE}/authorize"
+        )
+
+
+# ---------------------------------------------------------------------------
 # Registration / teardown
 # ---------------------------------------------------------------------------
 
@@ -753,6 +884,72 @@ class TestRegisterWebhook:
         mw.async_register.assert_called_once()
         # Reload-safe: clears any stale registration before (re)registering.
         mw.async_unregister.assert_called_once_with(hass, WEBHOOK_ID)
+
+    async def test_none_auth_binds_discovery_and_autoapprove_views(self, monkeypatch):
+        # #1969: none mode now serves our corrected discovery + the auto-approve
+        # authorization server, so it binds the 7 discovery views AND the 2
+        # auto-approve views and registers an AutoApproveProvider in cfg.
+        hass = _register_hass()
+        monkeypatch.setattr(mw.aiohttp, "ClientSession", lambda **kw: FakeSession())
+        assert mw._OAUTH_VIEWS_REGISTERED_KEY not in hass.data
+
+        await mw.async_register_webhook(
+            hass,
+            _entry(),
+            port=9584,
+            secret_path="/private_x",
+            auth_mode=WEBHOOK_AUTH_NONE,
+        )
+
+        cfg = hass.data[DOMAIN][DATA_WEBHOOK]
+        assert isinstance(cfg[mw.CFG_AUTOAPPROVE_PROVIDER], mw.AutoApproveProvider)
+        assert cfg["resource_server"] is None
+        assert cfg["oauth_provider"] is None
+        # 7 discovery views + 2 auto-approve views.
+        assert hass.http.register_view.call_count == 9
+        assert mw.active_auth_mode(hass) == WEBHOOK_AUTH_NONE
+
+    async def test_none_ha_auth_none_switch_reuses_bound_views(self, monkeypatch):
+        # aiohttp cannot rebind a view; a none->ha_auth->none cycle in one HA
+        # session must REUSE the already-bound view bundles (no new bindings, no
+        # raise) while active_auth_mode swaps which document is served.
+        hass = _register_hass()
+        monkeypatch.setattr(mw.aiohttp, "ClientSession", lambda **kw: FakeSession())
+
+        await mw.async_register_webhook(
+            hass,
+            _entry(),
+            port=9584,
+            secret_path="/private_x",
+            auth_mode=WEBHOOK_AUTH_NONE,
+        )
+        assert hass.http.register_view.call_count == 9
+        assert mw.active_auth_mode(hass) == WEBHOOK_AUTH_NONE
+        await mw.async_unregister_webhook(hass)
+
+        # Switch to ha_auth: discovery views already bound (guarded), the
+        # auto-approve views are simply left bound (they 404 while inactive).
+        await mw.async_register_webhook(
+            hass,
+            _entry(),
+            port=9584,
+            secret_path="/private_x",
+            auth_mode=WEBHOOK_AUTH_HA,
+        )
+        assert hass.http.register_view.call_count == 9
+        assert mw.active_auth_mode(hass) == WEBHOOK_AUTH_HA
+        await mw.async_unregister_webhook(hass)
+
+        # Switch back to none: still no re-bind, auto-approve live again.
+        await mw.async_register_webhook(
+            hass,
+            _entry(),
+            port=9584,
+            secret_path="/private_x",
+            auth_mode=WEBHOOK_AUTH_NONE,
+        )
+        assert hass.http.register_view.call_count == 9
+        assert mw.active_auth_mode(hass) == WEBHOOK_AUTH_NONE
 
     async def test_ha_auth_registers_resource_server_and_views(self, monkeypatch):
         hass = _register_hass()
@@ -994,7 +1191,12 @@ class TestRegisterWebhook:
         assert cfg["target_url"] == "http://127.0.0.1:9584/private_x"
         assert cfg["session"] is fake_session
         assert cfg["resource_server"] is None
+        # Local-only none mode advertises nothing: no auto-approve provider, so
+        # active_auth_mode is None and every discovery/auto-approve view 404s.
+        assert cfg[mw.CFG_AUTOAPPROVE_PROVIDER] is None
+        assert mw.active_auth_mode(hass) is None
         mw.async_register.assert_not_called()
+        hass.http.register_view.assert_not_called()
         # Off means off: a leftover endpoint from a crashed unload is cleared
         # even though nothing gets (re)registered.
         mw.async_unregister.assert_called_once_with(hass, WEBHOOK_ID)

--- a/tests/src/unit/test_mcp_webhook.py
+++ b/tests/src/unit/test_mcp_webhook.py
@@ -774,22 +774,31 @@ class TestNoneModeDiscovery:
         )
         assert doc["token_endpoint_auth_methods_supported"] == ["none"]
 
-    async def test_protected_resource_views_live_in_none_mode(self):
+    async def test_fixed_path_protected_resource_404s_in_none_mode(self):
+        # SECURITY (#1976): the fixed, guessable /protected-resource path must
+        # NOT leak the webhook id (the sole credential in none mode) to an
+        # anonymous GET. It 404s in none mode, serving only the bearer-gated
+        # modes (see test_protected_resource_view_payload_when_live for ha_auth).
         hass = _none_live_hass()
         request = make_request(headers={"Host": "abc.ui.nabu.casa"})
         plain = mw._ProtectedResourceMetadataView(hass)
-        plain_resp = await plain.get(request)
-        assert plain_resp.status == 200
-        assert plain_resp.json_body["authorization_servers"] == [
-            f"https://abc.ui.nabu.casa{OAUTH_BASE}"
-        ]
-        # The path-scoped variant claude.ai probes first must also serve.
+        assert (await plain.get(request)).status == 404
+
+    async def test_path_scoped_protected_resource_still_serves_in_none_mode(self):
+        # The path-scoped view claude.ai's none-mode discovery actually uses
+        # KEEPS serving: its URL embeds the id (a route param), so the caller
+        # already knows it — no leak (#1976).
+        hass = _none_live_hass()
+        request = make_request(headers={"Host": "abc.ui.nabu.casa"})
         wellknown = mw._WellKnownProtectedResourceView(hass)
         wk_resp = await wellknown.get(request, webhook_id=WEBHOOK_ID)
         assert wk_resp.status == 200
         assert wk_resp.json_body["resource"] == (
             f"https://abc.ui.nabu.casa/api/webhook/{WEBHOOK_ID}"
         )
+        assert wk_resp.json_body["authorization_servers"] == [
+            f"https://abc.ui.nabu.casa{OAUTH_BASE}"
+        ]
 
     async def test_as_document_switches_on_mode_flip_without_rebinding(self):
         # Hard requirement: with the ONE bound AS view, flipping the live mode

--- a/tests/src/unit/test_oauth_autoapprove.py
+++ b/tests/src/unit/test_oauth_autoapprove.py
@@ -1,0 +1,430 @@
+"""Unit tests for the none-mode auto-approve OAuth server (issue #1969).
+
+Covers ``custom_components/ha_mcp_tools/oauth_autoapprove.py``: the invisible
+``/authorize`` (issues a PKCE code + 302, no UI) and ``/token`` (public-client
+PKCE exchange, cosmetic opaque token) views, the ``AutoApproveProvider`` code
+lifecycle, and — most importantly — the open-redirect gate layered on top of
+:func:`oauth_legacy._is_valid_redirect_uri` (a strict exact-match allowlist of
+known MCP callbacks).
+
+Home Assistant / aiohttp are stubbed via ``_embedded_stubs``. ``yarl`` (an
+aiohttp dependency also absent here) is stubbed with the tiny
+``URL.update_query`` surface ``_redirect_with`` uses — same convention as
+``test_oauth_legacy_component.py``.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import secrets
+import sys
+from types import ModuleType
+from unittest.mock import AsyncMock, MagicMock
+
+from ._embedded_stubs import install
+
+install()
+
+
+class _FakeURL:
+    """Stand-in for ``yarl.URL`` covering only ``update_query`` + ``str()``."""
+
+    def __init__(self, url: str) -> None:
+        self._url = url
+
+    def update_query(self, params: dict[str, str]) -> _FakeURL:
+        sep = "&" if "?" in self._url else "?"
+        query = "&".join(f"{k}={v}" for k, v in params.items())
+        return _FakeURL(f"{self._url}{sep}{query}" if query else self._url)
+
+    def __str__(self) -> str:
+        return self._url
+
+
+if "yarl" not in sys.modules:
+    _yarl = ModuleType("yarl")
+    _yarl.URL = _FakeURL  # type: ignore[attr-defined]
+    sys.modules["yarl"] = _yarl
+
+import custom_components.ha_mcp_tools.oauth_autoapprove as aa  # noqa: E402
+from custom_components.ha_mcp_tools.const import (  # noqa: E402
+    DATA_WEBHOOK,
+    DOMAIN,
+)
+
+CLAUDE_CLIENT_ID = "https://claude.ai/api/mcp/client_metadata"
+CLAUDE_REDIRECT = "https://claude.ai/api/mcp/auth_callback"
+
+
+def _pkce_pair() -> tuple[str, str]:
+    """A valid (code_verifier, code_challenge) pair per RFC 7636 S256."""
+    verifier = secrets.token_urlsafe(64)
+    digest = hashlib.sha256(verifier.encode()).digest()
+    challenge = base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
+    return verifier, challenge
+
+
+def _make_hass() -> MagicMock:
+    hass = MagicMock(name="hass")
+    hass.data = {}
+    return hass
+
+
+def _live_hass(provider: aa.AutoApproveProvider | None = None) -> MagicMock:
+    """A hass whose live webhook cfg is none-mode auto-approve (provider set)."""
+    hass = _make_hass()
+    hass.data[DOMAIN] = {
+        DATA_WEBHOOK: {
+            "webhook_id": "mcp_x",
+            "auth_mode": "none",
+            "resource_server": None,
+            "oauth_provider": None,
+            aa.CFG_AUTOAPPROVE_PROVIDER: provider or aa.AutoApproveProvider(),
+        }
+    }
+    return hass
+
+
+def _get_request(query: dict[str, str]) -> MagicMock:
+    request = MagicMock(name="Request")
+    request.query = query
+    return request
+
+
+def _authorize_query(**overrides: str) -> dict[str, str]:
+    _, challenge = _pkce_pair()
+    params = {
+        "response_type": "code",
+        "client_id": CLAUDE_CLIENT_ID,
+        "redirect_uri": CLAUDE_REDIRECT,
+        "state": "st-1",
+        "code_challenge": challenge,
+        "code_challenge_method": "S256",
+    }
+    params.update(overrides)
+    return params
+
+
+def _parse_location(location: str) -> tuple[str, dict[str, str]]:
+    from urllib.parse import parse_qs, urlparse
+
+    parsed = urlparse(location)
+    flat = {k: v[0] for k, v in parse_qs(parsed.query).items()}
+    base = f"{parsed.scheme}://{parsed.netloc}{parsed.path}"
+    return base, flat
+
+
+# ---------------------------------------------------------------------------
+# Open-redirect gate
+# ---------------------------------------------------------------------------
+
+
+class TestRedirectValidation:
+    def test_allowlisted_claude_callback_is_valid(self):
+        # The known MCP callback is accepted.
+        assert aa._is_valid_autoapprove_redirect(CLAUDE_REDIRECT) is True
+
+    def test_same_origin_non_allowlisted_is_rejected(self):
+        # SECURITY: client_id is attacker-controlled, so "redirect shares the
+        # client_id origin" is NOT a trust anchor — an attacker sets both to a
+        # site they own and bounces a victim there (open redirect). Only the
+        # allowlist is trusted, so a non-allowlisted target is rejected.
+        assert aa._is_valid_autoapprove_redirect("https://myclient.example/cb") is False
+
+    def test_cross_origin_redirect_is_rejected(self):
+        # SECURITY: the classic open-redirect / phishing target.
+        assert aa._is_valid_autoapprove_redirect("https://evil.example/steal") is False
+
+    def test_non_allowlisted_https_target_is_rejected(self):
+        assert (
+            aa._is_valid_autoapprove_redirect("https://somewhere.example/cb") is False
+        )
+
+    def test_redirect_failing_scheme_floor_is_rejected(self):
+        # http non-loopback fails the oauth_legacy floor before the allowlist check.
+        assert (
+            aa._is_valid_autoapprove_redirect("http://claude.ai/api/mcp/auth_callback")
+            is False
+        )
+
+
+# ---------------------------------------------------------------------------
+# AutoApproveProvider
+# ---------------------------------------------------------------------------
+
+
+class TestAutoApproveProvider:
+    def test_issue_and_consume_roundtrip(self):
+        provider = aa.AutoApproveProvider()
+        verifier, challenge = _pkce_pair()
+        code = provider.issue_code(CLAUDE_REDIRECT, challenge)
+        assert code
+        assert provider.consume_code(code, CLAUDE_REDIRECT, verifier) is True
+
+    def test_wrong_verifier_rejected(self):
+        provider = aa.AutoApproveProvider()
+        _, challenge = _pkce_pair()
+        code = provider.issue_code(CLAUDE_REDIRECT, challenge)
+        other_verifier, _ = _pkce_pair()
+        assert provider.consume_code(code, CLAUDE_REDIRECT, other_verifier) is False
+
+    def test_code_is_one_shot(self):
+        provider = aa.AutoApproveProvider()
+        verifier, challenge = _pkce_pair()
+        code = provider.issue_code(CLAUDE_REDIRECT, challenge)
+        assert provider.consume_code(code, CLAUDE_REDIRECT, verifier) is True
+        assert provider.consume_code(code, CLAUDE_REDIRECT, verifier) is False
+
+    def test_access_token_is_opaque_and_unique(self):
+        t1 = aa.AutoApproveProvider.issue_access_token()
+        t2 = aa.AutoApproveProvider.issue_access_token()
+        assert isinstance(t1, str) and len(t1) >= 20
+        assert t1 != t2
+
+
+# ---------------------------------------------------------------------------
+# AutoApproveAuthorizeView (GET: issue code, 302, no UI)
+# ---------------------------------------------------------------------------
+
+
+class TestAuthorizeView:
+    async def test_404_when_not_live(self):
+        hass = _make_hass()  # no autoapprove provider in cfg
+        view = aa.AutoApproveAuthorizeView(hass)
+        resp = await view.get(_get_request(_authorize_query()))
+        assert resp.status == 404
+
+    async def test_happy_path_issues_code_and_redirects_no_ui(self):
+        provider = aa.AutoApproveProvider()
+        hass = _live_hass(provider)
+        view = aa.AutoApproveAuthorizeView(hass)
+        verifier, challenge = _pkce_pair()
+        query = _authorize_query(
+            code_challenge=challenge
+        )  # allowlisted CLAUDE_REDIRECT
+        resp = await view.get(_get_request(query))
+
+        assert resp.status == 302
+        base, params = _parse_location(resp.headers["Location"])
+        assert base == CLAUDE_REDIRECT
+        assert params["state"] == "st-1"
+        # The issued code is real: it consumes with the matching verifier.
+        assert provider.consume_code(params["code"], CLAUDE_REDIRECT, verifier) is True
+
+    async def test_allowlisted_claude_redirect_is_approved(self):
+        hass = _live_hass()
+        view = aa.AutoApproveAuthorizeView(hass)
+        resp = await view.get(_get_request(_authorize_query()))
+        assert resp.status == 302
+        base, _ = _parse_location(resp.headers["Location"])
+        assert base == CLAUDE_REDIRECT
+
+    async def test_cross_origin_redirect_is_400_not_redirect(self):
+        # SECURITY: never 302 to an unvalidated target — answer 400 in place.
+        hass = _live_hass()
+        view = aa.AutoApproveAuthorizeView(hass)
+        query = _authorize_query(redirect_uri="https://evil.example/steal")
+        resp = await view.get(_get_request(query))
+        assert resp.status == 400
+        assert "Location" not in resp.headers
+
+    async def test_non_s256_method_rejected(self):
+        hass = _live_hass()
+        view = aa.AutoApproveAuthorizeView(hass)
+        resp = await view.get(
+            _get_request(_authorize_query(code_challenge_method="plain"))
+        )
+        assert resp.status == 400
+
+    async def test_non_code_response_type_rejected(self):
+        hass = _live_hass()
+        view = aa.AutoApproveAuthorizeView(hass)
+        resp = await view.get(_get_request(_authorize_query(response_type="token")))
+        assert resp.status == 400
+
+    async def test_malformed_code_challenge_rejected(self):
+        hass = _live_hass()
+        view = aa.AutoApproveAuthorizeView(hass)
+        resp = await view.get(
+            _get_request(_authorize_query(code_challenge="too-short"))
+        )
+        assert resp.status == 400
+
+    async def test_code_store_at_capacity_redirects_temporarily_unavailable(self):
+        provider = aa.AutoApproveProvider()
+        provider.issue_code = lambda *a, **k: None  # type: ignore[method-assign]
+        hass = _live_hass(provider)
+        view = aa.AutoApproveAuthorizeView(hass)
+        resp = await view.get(_get_request(_authorize_query()))
+        assert resp.status == 302
+        _, params = _parse_location(resp.headers["Location"])
+        assert params["error"] == "temporarily_unavailable"
+        assert params["state"] == "st-1"
+
+
+# ---------------------------------------------------------------------------
+# AutoApproveTokenView (POST: PKCE exchange, public client)
+# ---------------------------------------------------------------------------
+
+
+def _token_request(form: dict[str, str]) -> MagicMock:
+    request = MagicMock(name="Request")
+    request.post = AsyncMock(return_value=form)
+    return request
+
+
+class TestTokenView:
+    async def test_404_when_not_live(self):
+        hass = _make_hass()
+        view = aa.AutoApproveTokenView(hass)
+        resp = await view.post(_token_request({}))
+        assert resp.status == 404
+
+    async def test_valid_pkce_exchange_returns_opaque_token_no_secret(self):
+        provider = aa.AutoApproveProvider()
+        hass = _live_hass(provider)
+        verifier, challenge = _pkce_pair()
+        code = provider.issue_code(CLAUDE_REDIRECT, challenge)
+        view = aa.AutoApproveTokenView(hass)
+        # NOTE: no client_secret in the form — public client.
+        resp = await view.post(
+            _token_request(
+                {
+                    "grant_type": "authorization_code",
+                    "code": code,
+                    "redirect_uri": CLAUDE_REDIRECT,
+                    "code_verifier": verifier,
+                }
+            )
+        )
+        assert resp.status == 200
+        body = resp.json_body
+        assert body["token_type"] == "Bearer"
+        assert body["access_token"]
+        assert isinstance(body["expires_in"], int)
+        # None mode issues no refresh token.
+        assert "refresh_token" not in body
+        # RFC 6749 §5.1: the token body must not be cached.
+        assert resp.headers["Cache-Control"] == "no-store"
+        assert resp.headers["Pragma"] == "no-cache"
+
+    async def test_wrong_verifier_rejected(self):
+        provider = aa.AutoApproveProvider()
+        hass = _live_hass(provider)
+        _, challenge = _pkce_pair()
+        code = provider.issue_code(CLAUDE_REDIRECT, challenge)
+        wrong_verifier, _ = _pkce_pair()
+        view = aa.AutoApproveTokenView(hass)
+        resp = await view.post(
+            _token_request(
+                {
+                    "grant_type": "authorization_code",
+                    "code": code,
+                    "redirect_uri": CLAUDE_REDIRECT,
+                    "code_verifier": wrong_verifier,
+                }
+            )
+        )
+        assert resp.status == 400
+        assert resp.json_body["error"] == "invalid_grant"
+
+    async def test_code_is_one_time_at_token_endpoint(self):
+        provider = aa.AutoApproveProvider()
+        hass = _live_hass(provider)
+        verifier, challenge = _pkce_pair()
+        code = provider.issue_code(CLAUDE_REDIRECT, challenge)
+        view = aa.AutoApproveTokenView(hass)
+        form = {
+            "grant_type": "authorization_code",
+            "code": code,
+            "redirect_uri": CLAUDE_REDIRECT,
+            "code_verifier": verifier,
+        }
+        first = await view.post(_token_request(dict(form)))
+        assert first.status == 200
+        second = await view.post(_token_request(dict(form)))
+        assert second.status == 400
+        assert second.json_body["error"] == "invalid_grant"
+
+    async def test_missing_params_returns_invalid_request(self):
+        provider = aa.AutoApproveProvider()
+        hass = _live_hass(provider)
+        _, challenge = _pkce_pair()
+        code = provider.issue_code(CLAUDE_REDIRECT, challenge)
+        view = aa.AutoApproveTokenView(hass)
+        resp = await view.post(
+            _token_request(
+                {
+                    "grant_type": "authorization_code",
+                    "code": code,
+                    "redirect_uri": CLAUDE_REDIRECT,
+                    # code_verifier omitted
+                }
+            )
+        )
+        assert resp.status == 400
+        assert resp.json_body["error"] == "invalid_request"
+
+    async def test_unsupported_grant_type_rejected(self):
+        hass = _live_hass()
+        view = aa.AutoApproveTokenView(hass)
+        resp = await view.post(_token_request({"grant_type": "refresh_token"}))
+        assert resp.status == 400
+        assert resp.json_body["error"] == "unsupported_grant_type"
+
+
+# ---------------------------------------------------------------------------
+# bind_autoapprove_views (bind-once guard)
+# ---------------------------------------------------------------------------
+
+
+class TestBindAutoApproveViews:
+    def test_first_bind_registers_two_views(self):
+        hass = _make_hass()
+        hass.http = MagicMock()
+        aa.bind_autoapprove_views(hass)
+        assert hass.http.register_view.call_count == 2
+        assert hass.data.get(aa._AUTOAPPROVE_VIEWS_REGISTERED_KEY) is True
+
+    def test_second_bind_is_a_noop(self):
+        # aiohttp cannot rebind a view — a re-enable must reuse the bound pair.
+        hass = _make_hass()
+        hass.http = MagicMock()
+        aa.bind_autoapprove_views(hass)
+        aa.bind_autoapprove_views(hass)
+        assert hass.http.register_view.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# Full round-trip through both views
+# ---------------------------------------------------------------------------
+
+
+class TestFullFlow:
+    async def test_authorize_then_token_completes_invisibly(self):
+        provider = aa.AutoApproveProvider()
+        hass = _live_hass(provider)
+        authorize = aa.AutoApproveAuthorizeView(hass)
+        token = aa.AutoApproveTokenView(hass)
+        verifier, challenge = _pkce_pair()
+
+        auth_resp = await authorize.get(
+            _get_request(_authorize_query(code_challenge=challenge))
+        )
+        assert auth_resp.status == 302  # no consent UI rendered
+        _, params = _parse_location(auth_resp.headers["Location"])
+        code = params["code"]
+
+        token_resp = await token.post(
+            _token_request(
+                {
+                    "grant_type": "authorization_code",
+                    "code": code,
+                    "redirect_uri": CLAUDE_REDIRECT,
+                    "code_verifier": verifier,
+                }
+            )
+        )
+        assert token_resp.status == 200
+        assert token_resp.json_body["access_token"]


### PR DESCRIPTION
## What does this PR do?

Fixes #1969. Adding a Home Assistant MCP webhook as a claude.ai custom connector intermittently failed with **"Automatic client registration isn't supported… Edit the connector and add an OAuth Client ID"** even with webhook OAuth **off** (`none` mode).

**Root cause.** claude.ai's connector onboarding intermittently front-loads OAuth discovery. In `none` mode the component registered no `/.well-known/*` views, so claude.ai fell through to **Home Assistant core's** own origin-root `/.well-known/oauth-authorization-server`, which advertises `client_id_metadata_document_supported: true` but omits `token_endpoint_auth_methods_supported: ["none"]` and has no `registration_endpoint`. claude.ai can then neither use CIMD nor do dynamic registration. HA core registers that route at bootstrap (first-writer-wins), so we can neither remove nor override it.

**Fix.** In `none` mode the component now serves its **own** corrected, path-scoped RFC 8414/9728 discovery — which claude.ai probes before HA core's root — plus an **invisible auto-approve authorization server** (`oauth_autoapprove.py`): `/authorize` issues a PKCE-bound code and 302s straight back with no login/consent UI, and `/token` exchanges it (public client, PKCE S256) for a cosmetic opaque token. The webhook forwarder is unchanged in `none` mode — it still returns 200 with no bearer required, so URL-only clients (Claude Code CLI, etc.) keep working. When claude.ai does run discovery it now resolves against our documents and completes OAuth **invisibly, with no Home Assistant login**.

The **webhook-proxy add-on** has the identical bug, so the same fix is mirrored into its **dev** integration (`homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev`, `2.0.3.dev2` → `2.0.3.dev3`). The stable add-on tree is untouched (promote-only).

Notes:
- **Open-redirect defence:** `/authorize` only 302s to an exact-match allowlist of known MCP callbacks. The `client_id` is attacker-controlled, so a "same origin as client_id" rule is not a trust anchor (and fetching the client_id URL would be an SSRF vector) — the allowlist is the safe choice.
- **No restart on mode change:** the discovery views are mode-aware and resolve per request from `hass.data`, so switching `none`↔`ha_auth` swaps documents live with no HA restart.
- The `legacy` PKCE code store was extracted into a shared `PKCECodeStore` (public API unchanged) and reused, in both the component and the add-on.
- In none mode the auto-approve provider is kept under a **separate** `hass.data` key from `oauth`, so the webhook forwarder's bearer gate never engages — none mode stays fully unauthenticated (URL is the credential).

## Type of change
- [x] 🐛 Bug fix

## Testing
- [x] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

Live-validated on a real HA instance over Nabu Casa with a **fresh claude.ai connector for each** of: `none` → `ha_auth` → `none`, every mode switch via config reload with **no HA restart** — `none` auto-connects with zero login both times; `ha_auth` correctly enters the HA OAuth flow.
