### PR TITLE
fix: none-mode auto-approve setup must fail open

### DIFF
--- a/custom_components/ha_mcp_tools/const.py
+++ b/custom_components/ha_mcp_tools/const.py
@@ -24,7 +24,7 @@ DOMAIN = "ha_mcp_tools"
 # manifest bump that forgets this constant (or vice-versa) fails in CI. The
 # capability negotiation — not this version — gates each WS command (see
 # ``websocket_api.CAPABILITIES``).
-COMPONENT_VERSION = "1.2.2"
+COMPONENT_VERSION = "1.2.3"
 
 # Config-entry discriminator (``entry.data[CONF_ENTRY_TYPE]``). A missing value
 # means "tools" so the pre-existing services entry keeps working across the

--- a/custom_components/ha_mcp_tools/manifest.json
+++ b/custom_components/ha_mcp_tools/manifest.json
@@ -22,5 +22,5 @@
     "requirements": [
         "ruamel.yaml>=0.18.0"
     ],
-    "version": "1.2.2"
+    "version": "1.2.3"
 }

--- a/custom_components/ha_mcp_tools/mcp_webhook.py
+++ b/custom_components/ha_mcp_tools/mcp_webhook.py
@@ -486,9 +486,15 @@ def _register_metadata_views(hass: HomeAssistant) -> None:
     """
     if hass.data.get(_OAUTH_VIEWS_REGISTERED_KEY):
         return
+    # Claim the bind BEFORE registering (issue #1978): aiohttp can't unregister a
+    # view and a duplicate register_view raises, so if this loop fails partway, a
+    # later retry (e.g. a mode switch) must NOT re-register the views that already
+    # bound. Setting the guard first caps this at one bind attempt per HA session
+    # — a partial failure leaves some discovery views unbound (they 404 like an
+    # unregistered route) instead of throwing a duplicate-route error next call.
+    hass.data[_OAUTH_VIEWS_REGISTERED_KEY] = True
     for view in _metadata_views(hass):
         hass.http.register_view(view)
-    hass.data[_OAUTH_VIEWS_REGISTERED_KEY] = True
 
 
 def _build_unauthorized_response(request: web.Request) -> web.Response:
@@ -735,9 +741,28 @@ async def async_register_webhook(
                 # login (issue #1969). Both view bundles bind at most once per
                 # HA session; the per-request resolvers gate them on this cfg,
                 # so a none<->ha_auth switch needs no restart.
-                _register_metadata_views(hass)
-                bind_autoapprove_views(hass)
-                cfg[CFG_AUTOAPPROVE_PROVIDER] = AutoApproveProvider()
+                #
+                # Fails OPEN, unlike ha_auth/legacy (issue #1978): none mode is
+                # intentionally unauthenticated, and this discovery is an
+                # enhancement layered on a webhook that (already registered
+                # above) otherwise always forwards. A failure here must NOT fall
+                # through to the outer teardown and take down a webhook the user
+                # configured to need no auth — it only means claude.ai's rare
+                # OAuth-discovery fallback goes unassisted. Mirrors the add-on's
+                # _setup_none_autoapprove. Provider is assigned last, so a
+                # partial bind leaves none-autoapprove inactive (plain proxy)
+                # rather than half-enabled.
+                try:
+                    _register_metadata_views(hass)
+                    bind_autoapprove_views(hass)
+                    cfg[CFG_AUTOAPPROVE_PROVIDER] = AutoApproveProvider()
+                except Exception:
+                    _LOGGER.exception(
+                        "MCP webhook: failed to set up none-mode auto-approve "
+                        "discovery; continuing as a plain unauthenticated proxy "
+                        "(the webhook still forwards — only claude.ai's rare "
+                        "OAuth-discovery fallback is unassisted)."
+                    )
         except Exception:
             # Never leave a live endpoint (or a leaked session) behind a failed
             # auth-setup path. suppress: the ORIGINAL error must be what

--- a/custom_components/ha_mcp_tools/mcp_webhook.py
+++ b/custom_components/ha_mcp_tools/mcp_webhook.py
@@ -486,15 +486,16 @@ def _register_metadata_views(hass: HomeAssistant) -> None:
     """
     if hass.data.get(_OAUTH_VIEWS_REGISTERED_KEY):
         return
-    # Claim the bind BEFORE registering (issue #1978): aiohttp can't unregister a
-    # view and a duplicate register_view raises, so if this loop fails partway, a
-    # later retry (e.g. a mode switch) must NOT re-register the views that already
-    # bound. Setting the guard first caps this at one bind attempt per HA session
-    # — a partial failure leaves some discovery views unbound (they 404 like an
-    # unregistered route) instead of throwing a duplicate-route error next call.
-    hass.data[_OAUTH_VIEWS_REGISTERED_KEY] = True
+    # Set the flag only AFTER every view registers (issue #1978): it must mean
+    # "the full bundle is bound", so a partial bind stays distinguishable from a
+    # complete one. Marking it bound early would let a later setup assign a
+    # provider and advertise discovery while some RFC metadata routes are still
+    # unbound — a 404 for the clients that probe them. On a partial bind the flag
+    # stays unset; the none-mode caller then fails open (the retry's duplicate
+    # register is caught harmlessly) while ha_auth/legacy fail closed.
     for view in _metadata_views(hass):
         hass.http.register_view(view)
+    hass.data[_OAUTH_VIEWS_REGISTERED_KEY] = True
 
 
 def _build_unauthorized_response(request: web.Request) -> web.Response:

--- a/custom_components/ha_mcp_tools/oauth_autoapprove.py
+++ b/custom_components/ha_mcp_tools/oauth_autoapprove.py
@@ -185,6 +185,18 @@ class AutoApproveAuthorizeView(HomeAssistantView):
     open-redirect gate, then issues a PKCE-bound one-time code and redirects
     straight back to the client. No login page and no consent screen render, so
     claude.ai's OAuth flow completes invisibly (issue #1969).
+
+    ACCEPTED RISK (issue #1978): this endpoint is anonymous by design — none
+    mode requires zero HA login — so it consults neither the webhook id nor a
+    client identity. Anyone who knows the HA origin can therefore fill the
+    shared pending-code store (``MAX_PENDING_CODES``) with S256 challenges bound
+    to the public claude.ai callback, at which point a *brand-new* connector's
+    handshake gets ``temporarily_unavailable`` until those codes expire
+    (``AUTH_CODE_TTL``, 5 min). Accepted because it is self-healing, exposes no
+    data, and grants no access: completing the flow needs the PKCE verifier the
+    attacker never has, and the issued token is cosmetic (none mode ignores
+    bearers). The webhook URL itself keeps forwarding throughout — only the rare
+    OAuth-discovery fallback for a *first* connect is briefly delayed.
     """
 
     requires_auth = False
@@ -298,6 +310,10 @@ def bind_autoapprove_views(hass: HomeAssistant) -> None:
     """
     if hass.data.get(_AUTOAPPROVE_VIEWS_REGISTERED_KEY):
         return
+    # Claim the bind BEFORE registering (issue #1978): see
+    # mcp_webhook._register_metadata_views — one bind attempt per HA session so a
+    # partial failure can't wedge a retry into re-registering an already-bound
+    # view. Pairs with the none-mode caller's fail-open handling.
+    hass.data[_AUTOAPPROVE_VIEWS_REGISTERED_KEY] = True
     hass.http.register_view(AutoApproveAuthorizeView(hass))
     hass.http.register_view(AutoApproveTokenView(hass))
-    hass.data[_AUTOAPPROVE_VIEWS_REGISTERED_KEY] = True

--- a/custom_components/ha_mcp_tools/oauth_autoapprove.py
+++ b/custom_components/ha_mcp_tools/oauth_autoapprove.py
@@ -310,10 +310,11 @@ def bind_autoapprove_views(hass: HomeAssistant) -> None:
     """
     if hass.data.get(_AUTOAPPROVE_VIEWS_REGISTERED_KEY):
         return
-    # Claim the bind BEFORE registering (issue #1978): see
-    # mcp_webhook._register_metadata_views — one bind attempt per HA session so a
-    # partial failure can't wedge a retry into re-registering an already-bound
-    # view. Pairs with the none-mode caller's fail-open handling.
-    hass.data[_AUTOAPPROVE_VIEWS_REGISTERED_KEY] = True
+    # Set the flag only AFTER both views register (issue #1978): see
+    # mcp_webhook._register_metadata_views. Marking the bundle bound before
+    # /token registers would let a later none-mode setup assign the provider and
+    # advertise OAuth with an unbound /token — a 404 on the token exchange. The
+    # flag must mean the full bundle succeeded; a partial bind leaves it unset.
     hass.http.register_view(AutoApproveAuthorizeView(hass))
     hass.http.register_view(AutoApproveTokenView(hass))
+    hass.data[_AUTOAPPROVE_VIEWS_REGISTERED_KEY] = True

--- a/custom_components/ha_mcp_tools/oauth_legacy.py
+++ b/custom_components/ha_mcp_tools/oauth_legacy.py
@@ -436,7 +436,11 @@ class PKCECodeStore:
         Returns True only for a live, unexpired code whose stored
         ``redirect_uri`` matches and whose ``code_challenge`` equals
         ``base64url(SHA-256(code_verifier))``. The code is popped (one-shot)
-        before any check that can fail, so a failed attempt still burns it.
+        once the verifier clears the cheap RFC 7636 shape guard below, so every
+        well-formed attempt burns it — a wrong verifier, expired code, or
+        redirect mismatch still consumes the code. A malformed verifier is
+        rejected before the pop and does NOT burn the code, so a client that
+        sends a syntactically broken verifier can retry.
         """
         # Validate the verifier shape per RFC 7636 §4.1 before doing any
         # crypto. A confused client passing an empty/short verifier should be

--- a/tests/src/unit/test_component_ws_phase2_async.py
+++ b/tests/src/unit/test_component_ws_phase2_async.py
@@ -140,11 +140,11 @@ class TestCapabilityPresence:
             assert cap in wsapi.CAPABILITIES
 
     def test_component_version(self):
-        # Pending 1.2.2 (1.2.1 is the released stable). Capabilities are
+        # Pending 1.2.3 (1.2.2 is the released stable). Capabilities are
         # advertised by name, never version-inferred, so new caps ride any
         # pending version without a bump; this assertion just pins the
         # declared version (the write caps shipped in 1.2.1).
-        assert wsapi.COMPONENT_VERSION == "1.2.2"
+        assert wsapi.COMPONENT_VERSION == "1.2.3"
 
 
 # =============================================================================

--- a/tests/src/unit/test_component_ws_search.py
+++ b/tests/src/unit/test_component_ws_search.py
@@ -768,7 +768,7 @@ class TestInfo:
                 _REPO_ROOT / "custom_components" / "ha_mcp_tools" / "manifest.json"
             ).read_text(encoding="utf-8")
         )
-        assert manifest["version"] == COMPONENT_VERSION == "1.2.2"
+        assert manifest["version"] == COMPONENT_VERSION == "1.2.3"
 
 
 # =============================================================================

--- a/tests/src/unit/test_mcp_webhook.py
+++ b/tests/src/unit/test_mcp_webhook.py
@@ -1157,6 +1157,48 @@ class TestRegisterWebhook:
         assert fake_session.closed is True
         assert DATA_WEBHOOK not in hass.data.get(DOMAIN, {})
 
+    async def test_none_mode_discovery_failure_keeps_webhook_registered(
+        self, monkeypatch
+    ):
+        # #1978: none mode is intentionally unauthenticated, so a failure in the
+        # (cosmetic) auto-approve discovery layer must FAIL OPEN — the webhook
+        # stays registered and forwarding, unlike ha_auth/legacy where the failed
+        # piece IS the auth. Contrast test_registration_failure_closes_session_
+        # and_unregisters above, which injects into async_register itself: the
+        # webhook never bound there, so tearing down is the correct behavior.
+        hass = _register_hass()
+        fake_session = FakeSession()
+        monkeypatch.setattr(mw.aiohttp, "ClientSession", lambda **kw: fake_session)
+        # Raise INSIDE the none-mode discovery block, after the webhook bound.
+        monkeypatch.setattr(
+            mw,
+            "bind_autoapprove_views",
+            MagicMock(side_effect=RuntimeError("router frozen")),
+        )
+
+        # No exception propagates: the failure is swallowed (fail open).
+        await mw.async_register_webhook(
+            hass,
+            _entry(),
+            port=9584,
+            secret_path="/private_x",
+            auth_mode=WEBHOOK_AUTH_NONE,
+        )
+
+        # Webhook stays registered (cfg was stored → we reached the end of the
+        # function) and the session is NOT closed. The outer fail-closed teardown
+        # would do both — unregister + close the session + re-raise — so its
+        # absence here is the fail-open proof. (async_unregister IS called once
+        # near the top as a defensive pre-clear, so its count is not the signal.)
+        assert DATA_WEBHOOK in hass.data[DOMAIN]
+        cfg = hass.data[DOMAIN][DATA_WEBHOOK]
+        assert fake_session.closed is False
+        # none-autoapprove discovery is inactive (plain proxy): the provider was
+        # never assigned, so active_auth_mode reports None and the bound
+        # discovery views 404 per request.
+        assert cfg.get(mw.CFG_AUTOAPPROVE_PROVIDER) is None
+        assert mw.active_auth_mode(hass) is None
+
     async def test_unregister_pops_cfg_and_closes_session(self, monkeypatch):
         hass = _register_hass()
         fake_session = FakeSession()

--- a/tests/src/unit/test_mcp_webhook.py
+++ b/tests/src/unit/test_mcp_webhook.py
@@ -1199,6 +1199,20 @@ class TestRegisterWebhook:
         assert cfg.get(mw.CFG_AUTOAPPROVE_PROVIDER) is None
         assert mw.active_auth_mode(hass) is None
 
+    async def test_partial_metadata_bind_leaves_guard_flag_unset(self):
+        # #1978 (Codex P2): the discovery-views "bound" flag must mean the FULL
+        # bundle registered. If a register_view raises partway, the flag stays
+        # unset so the bundle is never treated as complete — otherwise a later
+        # setup would assign a provider and advertise discovery with an unbound
+        # metadata route, 404-ing clients that probe it. bind_autoapprove_views
+        # uses the same flag-only-after-all-register pattern.
+        hass = _register_hass()
+        # 7 metadata views; fail on the 3rd register_view, mid-bundle.
+        hass.http.register_view.side_effect = [None, None, RuntimeError("frozen")]
+        with pytest.raises(RuntimeError):
+            mw._register_metadata_views(hass)
+        assert mw._OAUTH_VIEWS_REGISTERED_KEY not in hass.data
+
     async def test_unregister_pops_cfg_and_closes_session(self, monkeypatch):
         hass = _register_hass()
         fake_session = FakeSession()


### PR DESCRIPTION
## What does this PR do?

Post-merge follow-up to #1976 (issue #1978). In none mode the webhook is
intentionally unauthenticated, but the auto-approve discovery setup ran inside
the shared `try` whose `except` unregisters the webhook + closes the session —
so a failure in a cosmetic discovery layer tore down a webhook the user
configured to need no auth. The add-on twin already fails open
(`_setup_none_autoapprove`); this makes the component match.

- **Fail open (main):** wrap the none-mode discovery block in its own
  `try/except` that logs and continues; the webhook stays registered and
  forwarding. Provider is assigned last, so a partial bind leaves
  none-autoapprove inactive (plain proxy) rather than half-enabled. New unit
  test asserts the webhook survives a failure injected into the discovery block.
- **Guard-flag semantics:** `_register_metadata_views` / `bind_autoapprove_views`
  set their "bound once" flag only *after* the full bundle registers (per Codex
  review), so a partial bind stays distinguishable and none-autoapprove never
  advertises discovery with an unbound route. Regression test added.
- **Anonymous `/authorize` (concern 3):** documented as an accepted risk — the
  endpoint is anonymous by design (zero-login none mode); filling the pending-
  code store only delays a *first* connect's OAuth-discovery fallback by ≤5 min
  (self-healing), grants no access, and never affects the forwarding webhook.
- **`consume_code` docstring:** corrected to match the intentional ordering
  (shape guard runs before the one-shot pop).
- Opens the pending component version `1.2.3`.

The two add-on minors from #1978 (error-response header parity; a stale
`_active_oauth_mode` docstring + duplicated literal) ride the stable promotion
PR #1977, not this one.

## Type of change
- [x] 🐛 Bug fix

## Testing
- [x] All automated tests pass — 199 component unit tests green
- [x] Code follows style guidelines (`uv run ruff check`)

## Checklist
- [x] I have updated documentation if needed

Closes #1978
