### PR TITLE
fix: tolerate setuptools editable-finder KeyError on Python 3.14 bring-up

### DIFF
--- a/custom_components/ha_mcp_tools/embedded_server.py
+++ b/custom_components/ha_mcp_tools/embedded_server.py
@@ -1568,6 +1568,47 @@ _PENDING_INSTALL_DONE: threading.Event | None = None
 _CACHED_IMPORT_VERSION: str | None = None
 
 
+def _safe_invalidate_caches() -> None:
+    """Run ``importlib.invalidate_caches()``, completing it if a finder breaks.
+
+    On Python 3.14 with ``homeassistant`` installed as a setuptools *editable*
+    package (the official HA container image), ``PathFinder.invalidate_caches()``
+    raises ``KeyError`` at its ``del sys.path_importer_cache[name]`` line: the
+    synthetic ``__editable__.<dist>.finder.__path_hook__`` placeholder is not an
+    absolute path, so CPython takes the ``del`` branch on a key an earlier
+    iteration already removed — a CPython 3.14 bug (the ``del`` should be a
+    ``pop``). That aborts ``importlib.invalidate_caches()`` partway and, before
+    this guard, crashed in-process server bring-up on every boot (issues #1891,
+    #1985).
+
+    On that ``KeyError`` we finish the sweep CPython abandoned, using only
+    public ``invalidate_caches`` entry points (safe on any Python): prune dead /
+    relative ``sys.path_importer_cache`` entries with ``pop`` instead of the
+    buggy ``del``, re-invalidate every live path-entry finder, then refresh the
+    metadata finder — the two caches the downstream ``find_spec`` /
+    ``importlib.metadata`` reads depend on. Recovery only ever runs on the broken
+    3.14 path (the top-level call succeeds everywhere else); every
+    non-``KeyError`` still propagates.
+    """
+    try:
+        importlib.invalidate_caches()
+        return
+    except KeyError as err:
+        _LOGGER.debug(
+            "importlib.invalidate_caches() aborted on a broken (setuptools "
+            "editable / Python 3.14) finder; completing it manually: %s",
+            err,
+        )
+    for name, finder in list(sys.path_importer_cache.items()):
+        if finder is None or not os.path.isabs(name):
+            sys.path_importer_cache.pop(name, None)
+        else:
+            invalidate = getattr(finder, "invalidate_caches", None)
+            if invalidate is not None:
+                invalidate()
+    importlib.metadata.MetadataPathFinder.invalidate_caches()
+
+
 def _purge_ha_mcp_modules() -> None:
     """Drop every cached ``ha_mcp`` module so the next import loads fresh code.
 
@@ -1595,7 +1636,7 @@ def _purge_ha_mcp_modules() -> None:
         return
     for name in purged:
         sys.modules.pop(name, None)
-    importlib.invalidate_caches()
+    _safe_invalidate_caches()
     _LOGGER.debug("Purged %d cached ha_mcp module(s) before worker start", len(purged))
 
 
@@ -1608,7 +1649,7 @@ def _installed_ha_mcp_version(preferred_dist: str | None = None) -> str | None:
     provided, checks that channel first so stale metadata from a failed
     best-effort conflicting uninstall cannot mask the package just installed.
     """
-    importlib.invalidate_caches()
+    _safe_invalidate_caches()
     # Metadata alone is not proof: a channel switch's best-effort uninstall
     # can leave ORPHANED .dist-info whose files are gone (the shared ha_mcp/
     # tree belongs to whichever dist installed last). Require the import
@@ -1631,7 +1672,7 @@ def _dist_installed(dist_name: str) -> bool:
 
     Invalidates the import caches first so a just-completed (un)install is seen.
     """
-    importlib.invalidate_caches()
+    _safe_invalidate_caches()
     try:
         importlib.metadata.version(dist_name)
     except importlib.metadata.PackageNotFoundError:
@@ -1648,7 +1689,7 @@ def _installed_dist_version(dist_name: str) -> str | None:
     the auto-update check compares the newest PyPI build against the version of
     the channel actually installed.
     """
-    importlib.invalidate_caches()
+    _safe_invalidate_caches()
     try:
         return importlib.metadata.version(dist_name)
     except importlib.metadata.PackageNotFoundError:

--- a/tests/src/unit/test_embedded_server.py
+++ b/tests/src/unit/test_embedded_server.py
@@ -1402,6 +1402,77 @@ class TestInstalledDistVersion:
         assert es._installed_dist_version(DIST_NAME_STABLE) is None
 
 
+class TestSafeInvalidateCaches:
+    """Guard for the Python-3.14 setuptools editable-finder KeyError (#1891, #1985).
+
+    In the official HA container image ``homeassistant`` is a setuptools
+    *editable* install whose generated finder raises ``KeyError`` from its own
+    ``invalidate_caches()`` on Python 3.14. That propagated out of
+    ``importlib.invalidate_caches()`` and aborted in-process server bring-up on
+    every boot. The helper must tolerate that specific failure while letting
+    every other error through.
+    """
+
+    _EDITABLE_KEY = "__editable__.homeassistant-2026.7.2.finder.__path_hook__"
+
+    @pytest.fixture(autouse=True)
+    def _isolate_path_cache(self, monkeypatch):
+        # Recovery prunes/invalidates sys.path_importer_cache entries; hand each
+        # test a private copy so it never mutates the real process cache.
+        monkeypatch.setattr(sys, "path_importer_cache", dict(sys.path_importer_cache))
+
+    def test_swallows_keyerror_from_broken_finder(self, monkeypatch):
+        def _boom():
+            raise KeyError(self._EDITABLE_KEY)
+
+        monkeypatch.setattr(es.importlib, "invalidate_caches", _boom)
+        es._safe_invalidate_caches()  # must not raise
+
+    def test_propagates_non_keyerror(self, monkeypatch):
+        def _boom():
+            raise RuntimeError("unrelated import-system failure")
+
+        monkeypatch.setattr(es.importlib, "invalidate_caches", _boom)
+        with pytest.raises(RuntimeError):
+            es._safe_invalidate_caches()
+
+    def test_recovers_remaining_finders_after_abort(self, monkeypatch):
+        # The point of recovery: a healthy path-entry finder still gets
+        # invalidated even though the top-level sweep aborted on the bad one,
+        # and CPython's dead/relative-entry pruning still happens (via pop).
+        invalidated = []
+
+        class _Finder:
+            def invalidate_caches(self):
+                invalidated.append("called")
+
+        sys.path_importer_cache.clear()
+        sys.path_importer_cache["/abs/deps/dir"] = _Finder()
+        sys.path_importer_cache[""] = None  # non-abs → pruned, not invalidated
+
+        def _boom():
+            raise KeyError(self._EDITABLE_KEY)
+
+        monkeypatch.setattr(es.importlib, "invalidate_caches", _boom)
+        es._safe_invalidate_caches()
+
+        assert invalidated == ["called"]
+        assert "" not in sys.path_importer_cache
+
+    def test_installed_version_survives_editable_finder_keyerror(self, monkeypatch):
+        # End-to-end regression for the exact reported traceback:
+        # _installed_ha_mcp_version() -> importlib.invalidate_caches() raised
+        # KeyError and crashed bring-up. With the guard the version still
+        # resolves.
+        def _boom():
+            raise KeyError(self._EDITABLE_KEY)
+
+        monkeypatch.setattr(es.importlib, "invalidate_caches", _boom)
+        monkeypatch.setattr(es.importlib.util, "find_spec", lambda name: object())
+        monkeypatch.setattr(importlib.metadata, "version", lambda name: "7.14.1")
+        assert es._installed_ha_mcp_version() == "7.14.1"
+
+
 # ---------------------------------------------------------------------------
 # Worker-thread env staging
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

On Python 3.14 with `homeassistant` installed as a setuptools *editable* package
(the official HA container image / HA OS), `PathFinder.invalidate_caches()` raises
`KeyError` at its `del sys.path_importer_cache[name]` line: the synthetic
`__editable__.<dist>.finder.__path_hook__` placeholder is not an absolute path, so
CPython 3.14 takes the `del` branch on a key an earlier iteration already removed —
a CPython bug (the `del` should be a `pop`). That aborts
`importlib.invalidate_caches()` partway and crashes `_installed_ha_mcp_version()` on
the `async_start()` → `_async_ensure_package()` bring-up path, so the in-process
server never starts and every tool fails. It reproduces deterministically on Python
3.14; on 3.13 / non-editable installs the call never raises, which is why earlier
reports looked intermittent.

The four `importlib.invalidate_caches()` call sites in `embedded_server.py`
(`_purge_ha_mcp_modules`, `_installed_ha_mcp_version`, `_dist_installed`,
`_installed_dist_version`) now route through a `_safe_invalidate_caches()` helper.
On that `KeyError` it finishes the sweep CPython abandoned, using only public
`invalidate_caches` entry points: prune dead / relative `sys.path_importer_cache`
entries with `pop` instead of the buggy `del`, re-invalidate each live path-entry
finder, then refresh the metadata finder. Recovery only runs on the broken 3.14
path (the top-level call succeeds everywhere else); every non-`KeyError` still
propagates.

Based on #1984, so it rides under the pending 1.2.3 component version and adds no
version bump of its own. Same root cause as #1891.

Closes #1985.

## Type of change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

New `TestSafeInvalidateCaches` (4 cases): swallows the editable-finder `KeyError`,
propagates non-`KeyError`, still invalidates a healthy finder after the abort while
pruning the dead entry, and the exact `_installed_ha_mcp_version` traceback path now
resolves. Full `tests/src/unit/test_embedded_server.py` green (153) locally; `ruff
check`/`format` clean. The bring-up path can't be fully exercised by CI, so a
post-merge live-test on a Python 3.14 dev instance is still needed.

## Checklist
- [x] I have updated documentation if needed
