### PR TITLE
fix: allow reading blueprints/ by default (#1965)

### DIFF
--- a/custom_components/ha_mcp_tools/__init__.py
+++ b/custom_components/ha_mcp_tools/__init__.py
@@ -1000,7 +1000,8 @@ def _is_path_allowed_for_read(
 
     Allowed:
     - Files directly in config dir: configuration.yaml, automations.yaml, etc.
-    - Files in allowed directories: www/, themes/, custom_templates/
+    - Files in allowed directories: www/, themes/, custom_templates/,
+      dashboards/, blueprints/ (blueprints is read-only — issue #1965)
     - Files matching patterns: <packages-folder>/*.yaml, custom_components/**/*.py
     - User-configured extra directories (``extra_dirs``), granted read+write
       (issue #1567)

--- a/custom_components/ha_mcp_tools/const.py
+++ b/custom_components/ha_mcp_tools/const.py
@@ -41,12 +41,15 @@ TOOLS_ENTRY_LEGACY_TITLE = "HA MCP Tools"
 MIN_EMBEDDED_HOME_ASSISTANT_VERSION = "2026.6.0"
 
 # Allowed directories for file operations (relative to config dir).
-# "blueprints" is READ-only — present in ALLOWED_READ_DIRS but deliberately NOT
-# in ALLOWED_WRITE_DIRS. Raw blueprint reads are safe (community YAML, no
-# secrets) and let agents inspect blueprint sources (issue #1965), but writes
-# must go through validated paths (ha_import_blueprint / blueprint/save), never
-# a raw file write. Prefer ha_get_blueprint for the parsed body; raw read is the
-# escape hatch for the exact on-disk text.
+# "blueprints" is read-only BY DEFAULT — in ALLOWED_READ_DIRS but not
+# ALLOWED_WRITE_DIRS, so ha_write_file / ha_delete_file reject it (raw blueprint
+# reads are safe: community YAML, no secrets — issue #1965). This is the default
+# allowlist, not an absolute guarantee: an admin who adds "blueprints" as a
+# custom extra directory (issue #1567, see _current_extra_dirs) grants it
+# read+write, since extra_dirs are honored on the write path too. Blueprint
+# writes should instead go through ha_import_blueprint (which invokes the
+# blueprint/save WS command internally). Prefer ha_get_blueprint for the parsed
+# body; raw read is the escape hatch for the exact on-disk text.
 ALLOWED_READ_DIRS = ["www", "themes", "custom_templates", "dashboards", "blueprints"]
 ALLOWED_WRITE_DIRS = ["www", "themes", "custom_templates", "dashboards"]
 

--- a/custom_components/ha_mcp_tools/const.py
+++ b/custom_components/ha_mcp_tools/const.py
@@ -40,8 +40,14 @@ TOOLS_ENTRY_TITLE = "HA-MCP File & YAML Tools"
 TOOLS_ENTRY_LEGACY_TITLE = "HA MCP Tools"
 MIN_EMBEDDED_HOME_ASSISTANT_VERSION = "2026.6.0"
 
-# Allowed directories for file operations (relative to config dir)
-ALLOWED_READ_DIRS = ["www", "themes", "custom_templates", "dashboards"]
+# Allowed directories for file operations (relative to config dir).
+# "blueprints" is READ-only — present in ALLOWED_READ_DIRS but deliberately NOT
+# in ALLOWED_WRITE_DIRS. Raw blueprint reads are safe (community YAML, no
+# secrets) and let agents inspect blueprint sources (issue #1965), but writes
+# must go through validated paths (ha_import_blueprint / blueprint/save), never
+# a raw file write. Prefer ha_get_blueprint for the parsed body; raw read is the
+# escape hatch for the exact on-disk text.
+ALLOWED_READ_DIRS = ["www", "themes", "custom_templates", "dashboards", "blueprints"]
 ALLOWED_WRITE_DIRS = ["www", "themes", "custom_templates", "dashboards"]
 
 # NON-OVERRIDABLE deny floor for the user-configurable extra read/write

--- a/custom_components/ha_mcp_tools/services.yaml
+++ b/custom_components/ha_mcp_tools/services.yaml
@@ -123,13 +123,13 @@ read_file:
 
 write_file:
   name: Write File
-  description: Write a file to allowed directories (www/, themes/, custom_templates/).
+  description: Write a file to allowed directories (www/, themes/, custom_templates/, dashboards/).
   fields:
     path:
       name: Path
       description: >-
-        Relative path from config directory. Must be in www/, themes/, or
-        custom_templates/.
+        Relative path from config directory. Must be in www/, themes/,
+        custom_templates/, or dashboards/.
       required: true
       example: "www/custom.css"
       selector:
@@ -159,13 +159,13 @@ write_file:
 
 delete_file:
   name: Delete File
-  description: Delete a file from allowed directories (www/, themes/, custom_templates/).
+  description: Delete a file from allowed directories (www/, themes/, custom_templates/, dashboards/).
   fields:
     path:
       name: Path
       description: >-
-        Relative path from config directory. Must be in www/, themes/, or
-        custom_templates/.
+        Relative path from config directory. Must be in www/, themes/,
+        custom_templates/, or dashboards/.
       required: true
       example: "www/old-file.css"
       selector:

--- a/custom_components/ha_mcp_tools/services.yaml
+++ b/custom_components/ha_mcp_tools/services.yaml
@@ -58,7 +58,10 @@ list_files:
   fields:
     path:
       name: Path
-      description: Relative path from config directory (e.g., "www/", "themes/")
+      description: >-
+        Relative path from config directory. Allowed: www/, themes/,
+        custom_templates/, dashboards/, blueprints/, plus your configured
+        packages/ folder (e.g., "www/", "blueprints/automation").
       required: true
       example: "www/"
       selector:
@@ -81,7 +84,8 @@ read_file:
         Relative path from config directory. Allowed paths include
         configuration.yaml, automations.yaml, scripts.yaml, scenes.yaml,
         secrets.yaml (values masked), home-assistant.log, www/**, themes/**,
-        custom_templates/**, packages/*.yaml, custom_components/**/*.py
+        custom_templates/**, dashboards/**, blueprints/**, packages/*.yaml,
+        custom_components/**/*.py
       required: true
       example: "configuration.yaml"
       selector:

--- a/src/ha_mcp/tools/tools_filesystem.py
+++ b/src/ha_mcp/tools/tools_filesystem.py
@@ -406,7 +406,8 @@ class FilesystemTools:
             Field(
                 description=(
                     "Directory path. Relative to the config dir for the built-in "
-                    "allowlist (www/, themes/, custom_templates/, dashboards/). "
+                    "allowlist (www/, themes/, custom_templates/, dashboards/, "
+                    "blueprints/). "
                     "Custom directories and HAOS sibling volumes "
                     "(/share, /media, /ssl, /backup) configured in the ha-mcp "
                     "settings UI are also allowed (pass the absolute path). "
@@ -427,14 +428,18 @@ class FilesystemTools:
     ) -> dict[str, Any]:
         """List files in a directory within the Home Assistant config directory.
 
-        Lists files in allowed directories (www/, themes/, custom_templates/, dashboards/) with
-        optional glob pattern filtering. Returns file names, sizes, and modification times.
+        Lists files in allowed directories (www/, themes/, custom_templates/,
+        dashboards/, blueprints/) with optional glob pattern filtering. Returns
+        file names, sizes, and modification times.
 
         **Allowed Directories:**
         - `www/` - Web assets (CSS, JS, images for dashboards)
         - `themes/` - Theme files
         - `custom_templates/` - Jinja2 template files
         - `dashboards/` - YAML-mode dashboard files
+        - `blueprints/` - Automation/script blueprint sources (read-only)
+        - Your configured `packages/` folder, when `homeassistant: packages:` is
+          set (the folder name you bound, default `packages/`)
         - Plus any custom directories OR HAOS sibling volumes (`/share`,
           `/media`, `/ssl`, `/backup`) configured in the ha-mcp settings UI
           (pass the absolute path for volumes)
@@ -549,6 +554,11 @@ class FilesystemTools:
     ) -> dict[str, Any]:
         """Read a file from the Home Assistant config directory.
 
+        General-purpose escape hatch — prefer a dedicated tool when one exists:
+        ha_get_blueprint for a blueprint body, ha_config_get_yaml for a config
+        key, ha_config_get_automation/script/scene for storage-mode items. Reach
+        for ha_read_file only for raw on-disk text those tools don't expose.
+
         Reads files from allowed paths within the config directory. Some files
         have special handling:
         - `secrets.yaml`: Values are masked for security
@@ -559,7 +569,7 @@ class FilesystemTools:
         - `secrets.yaml` (values masked)
         - `packages/*.yaml`
         - `home-assistant.log` (tail only)
-        - `www/**`, `themes/**`, `custom_templates/**`, `dashboards/**`
+        - `www/**`, `themes/**`, `custom_templates/**`, `dashboards/**`, `blueprints/**`
         - `custom_components/**/*.py` (read-only)
         - Plus any custom directories OR HAOS sibling volumes (`/share`,
           `/media`, `/ssl`, `/backup`) configured in the ha-mcp settings UI

--- a/tests/src/e2e/workflows/filesystem/test_file_operations.py
+++ b/tests/src/e2e/workflows/filesystem/test_file_operations.py
@@ -269,6 +269,28 @@ class TestListFiles:
 
             logger.info(f"Found files: {[f['name'] for f in files]}")
 
+    async def test_list_files_in_blueprints_directory(self, mcp_client_with_filesystem):
+        """Blueprints dir is listable by default (issue #1965)."""
+        service_check = await _check_mcp_tools_service_available(
+            mcp_client_with_filesystem
+        )
+        _skip_if_component_not_installed(service_check, "List files in blueprints")
+
+        async with MCPAssertions(mcp_client_with_filesystem) as mcp:
+            result_data = await mcp.call_tool_success(
+                "ha_list_files",
+                {"path": "blueprints/automation/homeassistant"},
+            )
+
+            data = result_data
+            assert data.get("success") is True, f"List blueprints failed: {data}"
+            names = [f["name"] for f in data.get("files", [])]
+            assert "motion_light.yaml" in names, (
+                f"Expected motion_light.yaml under blueprints/: {names}"
+            )
+
+            logger.info(f"Listed blueprints/automation/homeassistant: {names}")
+
     async def test_list_files_with_pattern_filter(self, mcp_client_with_filesystem):
         """Test listing files with glob pattern filter."""
         service_check = await _check_mcp_tools_service_available(
@@ -362,6 +384,28 @@ class TestReadFile:
             logger.info(
                 f"Successfully read configuration.yaml ({data.get('size', 0)} bytes)"
             )
+
+    async def test_read_blueprint_file(self, mcp_client_with_filesystem):
+        """Blueprint files are readable by default (issue #1965)."""
+        service_check = await _check_mcp_tools_service_available(
+            mcp_client_with_filesystem
+        )
+        _skip_if_component_not_installed(service_check, "Read blueprint file")
+
+        async with MCPAssertions(mcp_client_with_filesystem) as mcp:
+            result_data = await mcp.call_tool_success(
+                "ha_read_file",
+                {"path": "blueprints/automation/homeassistant/motion_light.yaml"},
+            )
+
+            data = result_data
+            assert data.get("success") is True, f"Read blueprint failed: {data}"
+            content = data.get("content", "")
+            assert "blueprint:" in content, (
+                f"Content doesn't look like a blueprint: {content[:200]}"
+            )
+
+            logger.info(f"Successfully read blueprint ({data.get('size', 0)} bytes)")
 
     async def test_read_secrets_yaml_masked(self, mcp_client_with_filesystem):
         """Test reading secrets.yaml - values should be masked."""

--- a/tests/src/unit/test_custom_component_filesystem.py
+++ b/tests/src/unit/test_custom_component_filesystem.py
@@ -185,6 +185,30 @@ class TestIsPathAllowedForDir:
             is True
         )
 
+    def test_allows_blueprints_directory_read_only(self, tmp_path):
+        """blueprints/ is listable/readable but NOT writable (issue #1965)."""
+        # Read/list allowed
+        assert (
+            _is_path_allowed_for_dir(tmp_path, "blueprints/", ALLOWED_READ_DIRS) is True
+        )
+        assert (
+            _is_path_allowed_for_dir(
+                tmp_path, "blueprints/automation/author/thing.yaml", ALLOWED_READ_DIRS
+            )
+            is True
+        )
+        # Writes deliberately denied — blueprints is absent from ALLOWED_WRITE_DIRS
+        assert (
+            _is_path_allowed_for_dir(tmp_path, "blueprints/", ALLOWED_WRITE_DIRS)
+            is False
+        )
+        assert (
+            _is_path_allowed_for_dir(
+                tmp_path, "blueprints/automation/author/thing.yaml", ALLOWED_WRITE_DIRS
+            )
+            is False
+        )
+
 
 class TestIsPathAllowedForRead:
     """Test _is_path_allowed_for_read function."""
@@ -225,6 +249,19 @@ class TestIsPathAllowedForRead:
     def test_allows_packages_yaml(self, tmp_path):
         """Should allow reading packages/*.yaml files."""
         assert _is_path_allowed_for_read(tmp_path, "packages/lights.yaml") is True
+
+    def test_allows_blueprints_files(self, tmp_path):
+        """Should allow reading files under blueprints/ (issue #1965)."""
+        assert (
+            _is_path_allowed_for_read(
+                tmp_path, "blueprints/automation/homeassistant/motion_light.yaml"
+            )
+            is True
+        )
+        assert (
+            _is_path_allowed_for_read(tmp_path, "blueprints/script/author/thing.yaml")
+            is True
+        )
 
     def test_allows_custom_components_py_files(self, tmp_path):
         """Should allow reading custom_components/**/*.py files."""

--- a/tests/src/unit/test_filesystem_doc_parity.py
+++ b/tests/src/unit/test_filesystem_doc_parity.py
@@ -1,0 +1,107 @@
+"""Doc <-> allowlist parity guard for the filesystem tools (issue #1965).
+
+Every directory in the component's ``ALLOWED_READ_DIRS`` / ``ALLOWED_WRITE_DIRS``
+must be documented in both the server tool docstrings
+(``ha_read_file`` / ``ha_list_files`` / ``ha_write_file`` / ``ha_delete_file`` in
+``src/ha_mcp/tools/tools_filesystem.py``) and the component's ``services.yaml``
+``path`` field descriptions. This catches the drift where a directory is added to
+the allowlist but a doc surface is forgotten -- exactly what happened for
+``dashboards/`` and is being corrected here for ``blueprints/``.
+
+Self-contained on purpose: it parses the sources with ``ast`` / ``yaml`` and
+imports nothing from Home Assistant or fastmcp, so it runs in CI *and* locally
+without either installed.
+"""
+
+import ast
+import importlib.util
+from pathlib import Path
+
+import pytest
+import yaml
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_COMPONENT_DIR = _REPO_ROOT / "custom_components" / "ha_mcp_tools"
+_TOOLS_FILE = _REPO_ROOT / "src" / "ha_mcp" / "tools" / "tools_filesystem.py"
+_SERVICES_FILE = _COMPONENT_DIR / "services.yaml"
+
+
+def _load_const_standalone():
+    """Load ``const.py`` directly, bypassing the HA-dependent package __init__."""
+    spec = importlib.util.spec_from_file_location(
+        "_ha_mcp_tools_const_parity", _COMPONENT_DIR / "const.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+_CONST = _load_const_standalone()
+ALLOWED_READ_DIRS = _CONST.ALLOWED_READ_DIRS
+ALLOWED_WRITE_DIRS = _CONST.ALLOWED_WRITE_DIRS
+
+
+def _tool_docstrings():
+    """Map every top-level/def name in tools_filesystem.py to its docstring."""
+    tree = ast.parse(_TOOLS_FILE.read_text(encoding="utf-8"))
+    docs = {}
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            doc = ast.get_docstring(node)
+            if doc is not None:
+                docs[node.name] = doc
+    return docs
+
+
+def _service_path_descriptions():
+    """Map each service name to its ``path`` field description in services.yaml."""
+    data = yaml.safe_load(_SERVICES_FILE.read_text(encoding="utf-8"))
+    return {
+        name: (svc.get("fields", {}).get("path", {}).get("description", "") or "")
+        for name, svc in data.items()
+    }
+
+
+_DOCS = _tool_docstrings()
+_SERVICE_PATH_DESCS = _service_path_descriptions()
+
+_READ_TOOLS = ("ha_read_file", "ha_list_files")
+_WRITE_TOOLS = ("ha_write_file", "ha_delete_file")
+_READ_SERVICES = ("read_file", "list_files")
+_WRITE_SERVICES = ("write_file", "delete_file")
+
+
+@pytest.mark.parametrize("tool", _READ_TOOLS)
+@pytest.mark.parametrize("directory", ALLOWED_READ_DIRS)
+def test_read_dirs_documented_in_tool_docstrings(directory, tool):
+    assert f"{directory}/" in _DOCS[tool], (
+        f"{directory!r} is in ALLOWED_READ_DIRS but not documented in the "
+        f"{tool} docstring (tools_filesystem.py)"
+    )
+
+
+@pytest.mark.parametrize("tool", _WRITE_TOOLS)
+@pytest.mark.parametrize("directory", ALLOWED_WRITE_DIRS)
+def test_write_dirs_documented_in_tool_docstrings(directory, tool):
+    assert f"{directory}/" in _DOCS[tool], (
+        f"{directory!r} is in ALLOWED_WRITE_DIRS but not documented in the "
+        f"{tool} docstring (tools_filesystem.py)"
+    )
+
+
+@pytest.mark.parametrize("service", _READ_SERVICES)
+@pytest.mark.parametrize("directory", ALLOWED_READ_DIRS)
+def test_read_dirs_documented_in_services_yaml(directory, service):
+    assert f"{directory}/" in _SERVICE_PATH_DESCS[service], (
+        f"{directory!r} is in ALLOWED_READ_DIRS but not documented in the "
+        f"services.yaml {service} path description"
+    )
+
+
+@pytest.mark.parametrize("service", _WRITE_SERVICES)
+@pytest.mark.parametrize("directory", ALLOWED_WRITE_DIRS)
+def test_write_dirs_documented_in_services_yaml(directory, service):
+    assert f"{directory}/" in _SERVICE_PATH_DESCS[service], (
+        f"{directory!r} is in ALLOWED_WRITE_DIRS but not documented in the "
+        f"services.yaml {service} path description"
+    )


### PR DESCRIPTION
## What does this PR do?

Adds `blueprints/` to the custom component's built-in read allowlist so `ha_read_file` and `ha_list_files` can read/list blueprint sources without a manually-configured custom directory. Blueprints hold only community YAML (no secrets), so the directory is **read-only** — added to `ALLOWED_READ_DIRS` but deliberately kept out of `ALLOWED_WRITE_DIRS` (raw writes still go through `ha_import_blueprint` / `blueprint/save`).

`ha_get_blueprint` remains the preferred way to read a blueprint body (it returns the parsed triggers/conditions/actions via the component, no allowlist involved). A short "escape hatch" note on `ha_read_file` now steers callers there and to the other dedicated read tools; raw read is for the exact on-disk text those tools don't expose.

Also reconciles the read/list allowlist docs with what is actually enforced:
- `services.yaml` `read_file` was missing `dashboards/**` (it is allowed).
- The `ha_list_files` docs omitted the configured `packages/` folder (allowed when `homeassistant: packages:` is set).

Fixes #1965. Rides the pending component version `1.2.3` (no version bump).

## Type of change
- [x] 🐛 Bug fix
- [x] 📚 Documentation

## Testing
- [ ] I have tested these changes with a LLM agent
- [ ] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

## Checklist
- [x] I have updated documentation if needed
