### PR TITLE
feat!: rework tool security policy semantics (ANY-match) + developer tools to drive the settings UI

### DIFF
--- a/src/ha_mcp/llm_exposure.py
+++ b/src/ha_mcp/llm_exposure.py
@@ -14,9 +14,10 @@ axis from the global enable/disable in the settings UI:
 
 The single source of truth travels **in-band**: :class:`LlmExposureMiddleware`
 stamps every ``tools/list`` entry with
-``_meta.ha_mcp = {"llm_api_exposed": bool, "pinned": bool}`` so the component
-(one more loopback MCP client) filters on data that can never drift from the
-server's settings, with zero extra round-trips. Stamping re-reads the
+``_meta.ha_mcp = {"llm_api_exposed": bool, "pinned": bool, "policy": {...}}``
+so the component (one more loopback MCP client) filters on data that can never
+drift from the server's settings, with zero extra round-trips. The ``policy``
+block reports the serving server's gating state (#1990 — see META_POLICY_KEY). Stamping re-reads the
 persisted settings behind a short coalescing cache (2s TTL), so settings-UI
 changes apply on the agent's next conversation turn without a restart.
 

--- a/src/ha_mcp/llm_exposure.py
+++ b/src/ha_mcp/llm_exposure.py
@@ -31,7 +31,7 @@ from __future__ import annotations
 
 import logging
 import time
-from collections.abc import Mapping, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from typing import TYPE_CHECKING, Any
 
 from fastmcp.server.middleware import Middleware
@@ -49,6 +49,15 @@ logger = logging.getLogger(__name__)
 META_NAMESPACE = "ha_mcp"
 META_EXPOSED_KEY = "llm_api_exposed"
 META_PINNED_KEY = "pinned"
+
+# Serving-server policy/identity block stamped alongside the per-tool keys
+# (#1990). A client (or a debugging agent) reading tools/list can see the
+# ACTUAL gating state of the server answering this connection — configured
+# flag, live middleware, and rule count — plus the deployment mode. Without
+# this, a client pointed at a different server than the one the user
+# configured rules on fails silently: calls execute ungated and nothing
+# anywhere says "this server has zero rules".
+META_POLICY_KEY = "policy"
 
 # Key in tool_config.json holding the user's per-tool overrides
 # ({tool_name: bool}). Sparse on purpose: only tools the user explicitly
@@ -153,9 +162,17 @@ class LlmExposureMiddleware(Middleware):
     is hidden or altered for regular MCP clients.
     """
 
-    def __init__(self) -> None:
-        """Initialize the short-lived settings cache."""
+    def __init__(self, policy_live: Callable[[], bool] | None = None) -> None:
+        """Initialize the short-lived settings cache.
+
+        ``policy_live`` reports whether the gating middleware/queue are
+        actually wired on this server (they only wire at startup); the
+        stamp carries it so "configured but not enforcing until restart"
+        is visible on the wire.
+        """
         self._cache: tuple[float, dict[str, bool], set[str]] | None = None
+        self._policy_live = policy_live
+        self._policy_cache: tuple[float, dict[str, Any]] | None = None
 
     def _current_settings(self) -> tuple[dict[str, bool], set[str]]:
         """Return (overrides, pinned) with a short TTL over the file reads."""
@@ -192,6 +209,47 @@ class LlmExposureMiddleware(Middleware):
         self._cache = (now, overrides, pinned)
         return overrides, pinned
 
+    def _policy_block(self) -> dict[str, Any]:
+        """Serving-server policy/identity block (TTL-cached like the overrides).
+
+        Best-effort: a failure to read settings or the policy file stamps
+        conservative values (enabled=False / rules=0) rather than breaking
+        tools/list — the block is diagnostic metadata, not enforcement.
+        """
+        now = time.monotonic()
+        if (
+            self._policy_cache is not None
+            and now - self._policy_cache[0] < _OVERRIDES_TTL_SECONDS
+        ):
+            return self._policy_cache[1]
+        from ._version import is_embedded, is_running_in_addon
+
+        block: dict[str, Any] = {
+            "enabled": False,
+            "live": bool(self._policy_live()) if self._policy_live else False,
+            "rules": 0,
+            "deployment": (
+                "embedded"
+                if is_embedded()
+                else ("addon" if is_running_in_addon() else "standalone")
+            ),
+        }
+        try:
+            from .config import get_global_settings
+
+            block["enabled"] = bool(get_global_settings().enable_tool_security_policies)
+        except Exception:
+            logger.debug("policy stamp: settings read failed", exc_info=True)
+        try:
+            from .policy.persistence import load_policy
+            from .utils.data_paths import get_data_dir
+
+            block["rules"] = len(load_policy(get_data_dir()).rules)
+        except Exception:
+            logger.debug("policy stamp: policy read failed", exc_info=True)
+        self._policy_cache = (now, block)
+        return block
+
     async def on_list_tools(
         self,
         context: MiddlewareContext[mt.ListToolsRequest],
@@ -200,6 +258,7 @@ class LlmExposureMiddleware(Middleware):
         """Stamp ``_meta.ha_mcp`` on every tool in the list result."""
         tools = await call_next(context)
         overrides, pinned = self._current_settings()
+        policy_block = self._policy_block()
 
         stamped: list[Tool] = []
         for tool in tools:
@@ -209,6 +268,7 @@ class LlmExposureMiddleware(Middleware):
                 tool.name, tool.tags or set(), overrides
             )
             namespace[META_PINNED_KEY] = tool.name in pinned
+            namespace[META_POLICY_KEY] = policy_block
             meta[META_NAMESPACE] = namespace
             stamped.append(tool.model_copy(update={"meta": meta}))
         return stamped

--- a/src/ha_mcp/policy/handlers.py
+++ b/src/ha_mcp/policy/handlers.py
@@ -11,7 +11,7 @@ from pydantic import ValidationError
 from starlette.requests import Request
 from starlette.responses import JSONResponse
 
-from ..utils.config_write_lock import get_config_write_lock
+from ..utils.config_write_lock import config_write_guard
 from .approval_queue import ApprovalQueue
 from .model import Policy
 from .persistence import load_policy, save_policy
@@ -88,9 +88,10 @@ async def _put_config(
     # between this caller's GET and PUT. Returns the current policy
     # so the client can rebase if it wants to retry.
     # Serialize the version-check + save against the developer tool
-    # (set_policy / set_tool) via the shared write lock so a concurrent writer
-    # can't slip between the read and the write and lose an update.
-    async with get_config_write_lock():
+    # (set_policy / set_tool) AND against other processes (the stdio
+    # sidecar runs this same handler in its own process) so a concurrent
+    # writer can't slip between the read and the write and lose an update.
+    async with config_write_guard():
         current = load_policy(data_dir)
         if new_policy.version != current.version:
             return JSONResponse(

--- a/src/ha_mcp/policy/handlers.py
+++ b/src/ha_mcp/policy/handlers.py
@@ -11,6 +11,7 @@ from pydantic import ValidationError
 from starlette.requests import Request
 from starlette.responses import JSONResponse
 
+from ..utils.config_write_lock import get_config_write_lock
 from .approval_queue import ApprovalQueue
 from .model import Policy
 from .persistence import load_policy, save_policy
@@ -86,24 +87,28 @@ async def _put_config(
     # Optimistic concurrency: reject if the on-disk version moved
     # between this caller's GET and PUT. Returns the current policy
     # so the client can rebase if it wants to retry.
-    current = load_policy(data_dir)
-    if new_policy.version != current.version:
-        return JSONResponse(
-            {
-                "error": "policy version mismatch — reload before saving",
-                "current_version": current.version,
-                "current_policy": current.model_dump(mode="json"),
-            },
-            status_code=409,
-        )
-    save_policy(data_dir, new_policy)
-    # Drop the remember-cache only when rules actually changed.
-    # Editing just wait_seconds / approval_ttl_minutes shouldn't
-    # invalidate in-flight remembered approvals; only a rule change
-    # could make a previously-approved call now want a different
-    # outcome.
-    if current.rules != new_policy.rules:
-        queue.clear_remember_cache()
+    # Serialize the version-check + save against the developer tool
+    # (set_policy / set_tool) via the shared write lock so a concurrent writer
+    # can't slip between the read and the write and lose an update.
+    async with get_config_write_lock():
+        current = load_policy(data_dir)
+        if new_policy.version != current.version:
+            return JSONResponse(
+                {
+                    "error": "policy version mismatch — reload before saving",
+                    "current_version": current.version,
+                    "current_policy": current.model_dump(mode="json"),
+                },
+                status_code=409,
+            )
+        save_policy(data_dir, new_policy)
+        # Drop the remember-cache only when rules actually changed.
+        # Editing just wait_seconds / approval_ttl_minutes shouldn't
+        # invalidate in-flight remembered approvals; only a rule change
+        # could make a previously-approved call now want a different
+        # outcome.
+        if current.rules != new_policy.rules:
+            queue.clear_remember_cache()
     return JSONResponse({"saved": True, "version": new_policy.version + 1})
 
 

--- a/src/ha_mcp/policy/middleware.py
+++ b/src/ha_mcp/policy/middleware.py
@@ -35,6 +35,29 @@ PROXY_META_TOOLS = frozenset(
     }
 )
 
+# ha_dev_manage_server actions that MANAGE the approval queue itself.
+# Gating these deadlocks by construction: with a wildcard (or
+# ha_dev_manage_server) rule in place, an MCP-only "approve" call would
+# itself require approval — creating a second pending entry instead of
+# deciding the first, so nothing can ever be approved through the tool.
+# Only the queue-management actions are exempt; update_source / restart
+# remain gateable like any other high-stakes action.
+_APPROVAL_MANAGEMENT_TOOL = "ha_dev_manage_server"
+_APPROVAL_MANAGEMENT_ACTIONS = frozenset({"list_pending", "approve", "deny"})
+
+
+def _is_approval_management(name: str, args: dict[str, Any]) -> bool:
+    """True for dev-tool calls that manage the approval queue itself."""
+    return (
+        name == _APPROVAL_MANAGEMENT_TOOL
+        and args.get("action") in _APPROVAL_MANAGEMENT_ACTIONS
+    )
+
+
+def _passes_ungated(name: str, args: dict[str, Any]) -> bool:
+    """Calls that must bypass gating: proxy meta-tools + queue management."""
+    return name in PROXY_META_TOOLS or _is_approval_management(name, args)
+
 
 class PolicyMiddleware(Middleware):
     """Gate tool calls against a Policy, blocking with progress heartbeats."""
@@ -78,7 +101,7 @@ class PolicyMiddleware(Middleware):
         name = context.message.name
         args = context.message.arguments or {}
 
-        if name in PROXY_META_TOOLS:
+        if _passes_ungated(name, args):
             return await call_next(context)
 
         if evaluate(name, args, policy) != Verdict.REQUIRE_APPROVAL:

--- a/src/ha_mcp/policy/model.py
+++ b/src/ha_mcp/policy/model.py
@@ -16,6 +16,14 @@ PredicateOp = Literal[
     "eq", "neq", "in", "not_in", "regex", "contains", "exists", "gt", "lt"
 ]
 
+# Schema generation of the persisted policy file. Version 2 = ANY-match
+# condition semantics (PR #1993): each UI condition is its own rule; a rule's
+# predicates AND together (a condition with sub-parameters). Files WITHOUT the
+# marker were written under the pre-#1993 editor, which packed every condition
+# into one AND-ed rule — ``persistence.migrate_policy_any_semantics`` splits
+# those once at startup and stamps the file.
+POLICY_SCHEMA_VERSION = 2
+
 
 class Predicate(BaseModel):
     """Single condition on a tool call's arguments (e.g. args.domain in [...])."""
@@ -103,6 +111,9 @@ class Policy(BaseModel):
     approval_ttl_minutes: int = Field(default=5, ge=1, le=60)
     rules: list[Rule] = Field(default_factory=list)
     version: int = Field(default=0, ge=0)
+    # ANY-match schema marker (see POLICY_SCHEMA_VERSION). Detection of
+    # unmigrated files reads the RAW json (this default would mask it).
+    schema_version: int = Field(default=POLICY_SCHEMA_VERSION, ge=1)
 
     @model_validator(mode="after")
     def _wait_must_be_less_than_ttl(self) -> "Policy":

--- a/src/ha_mcp/policy/persistence.py
+++ b/src/ha_mcp/policy/persistence.py
@@ -1,13 +1,16 @@
 """Atomic load/save for tool_policy.json (mirrors tool_config.json pattern in settings_ui/__init__.py)."""
 
 import json
+import logging
 import os
 import tempfile
 from pathlib import Path
 
 from pydantic import ValidationError
 
-from .model import Policy
+from .model import Policy, Rule
+
+logger = logging.getLogger(__name__)
 
 POLICY_FILENAME = "tool_policy.json"
 
@@ -24,6 +27,68 @@ def load_policy(data_dir: Path) -> Policy:
         return Policy.model_validate(raw)
     except ValidationError as e:
         raise ValueError(f"tool_policy.json failed schema validation: {e}") from e
+
+
+def migrate_policy_any_semantics(data_dir: Path) -> bool:
+    """One-time migration of a pre-ANY policy file (PR #1993). Returns True on write.
+
+    The pre-#1993 editor packed every UI condition into ONE rule with the
+    predicates AND-ed ("require approval when ALL conditions match"). The
+    editor now writes one rule per condition and the UI reads "ANY condition
+    matches" — so an untouched old file would silently enforce AND while the
+    UI claims ANY. This splits every multi-predicate rule of an UNSTAMPED
+    file into one single-predicate rule each (the explicit, documented
+    breaking change: old AND conditions become OR, the more-restrictive
+    direction) and stamps ``schema_version`` so the migration never re-runs —
+    post-upgrade multi-predicate rules (a condition with AND-ed
+    sub-parameters, hand-authored or via future UI) are left intact.
+
+    Detection reads the RAW json: the Policy model defaults
+    ``schema_version`` to current, which would mask an unstamped file.
+    Missing or corrupt files are left alone (load_policy surfaces corruption).
+    """
+    path = data_dir / POLICY_FILENAME
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return False
+    except (OSError, json.JSONDecodeError):
+        logger.warning("policy migration: cannot read %s; leaving as-is", path)
+        return False
+    if not isinstance(raw, dict) or raw.get("schema_version") is not None:
+        return False
+    try:
+        policy = Policy.model_validate(raw)
+    except ValidationError:
+        logger.warning("policy migration: %s failed validation; leaving as-is", path)
+        return False
+    new_rules: list[Rule] = []
+    split = 0
+    for rule in policy.rules:
+        if len(rule.when) > 1:
+            split += 1
+            new_rules.extend(
+                Rule(
+                    tool_name=rule.tool_name,
+                    when=[predicate],
+                    remember_minutes=rule.remember_minutes,
+                )
+                for predicate in rule.when
+            )
+        else:
+            new_rules.append(rule)
+    save_policy(data_dir, policy.model_copy(update={"rules": new_rules}))
+    logger.info(
+        "Migrated %s to ANY-match condition semantics: split %d multi-condition "
+        "rule(s) into one rule per condition (%d -> %d rules) and stamped "
+        "schema_version. Conditions that previously ALL had to match now EACH "
+        "gate on their own.",
+        path,
+        split,
+        len(policy.rules),
+        len(new_rules),
+    )
+    return True
 
 
 def save_policy(data_dir: Path, policy: Policy) -> None:

--- a/src/ha_mcp/policy/persistence.py
+++ b/src/ha_mcp/policy/persistence.py
@@ -49,8 +49,13 @@ def migrate_policy_any_semantics(data_dir: Path) -> bool:
 
     The whole read-split-save runs under ``config_file_lock()`` so a
     concurrent writer in another process (the stdio settings sidecar) can't
-    interleave with the migration's read-modify-write. Startup runs before
-    the event loop, so taking the blocking lock inline is safe here.
+    interleave with the migration's read-modify-write. The blocking lock is
+    taken inline: this runs once during server construction, before anything
+    is served. The sync entry points construct pre-loop; OAuth/OIDC construct
+    on a just-started ``asyncio.run`` loop (``_run_oauth_server`` /
+    ``_run_oidc_server``) where the sync constructor cannot await — but no
+    other task is scheduled on that loop yet, so a held lock can only delay
+    startup, never stall a served client.
     """
     from ..utils.config_write_lock import config_file_lock
 

--- a/src/ha_mcp/policy/persistence.py
+++ b/src/ha_mcp/policy/persistence.py
@@ -46,7 +46,19 @@ def migrate_policy_any_semantics(data_dir: Path) -> bool:
     Detection reads the RAW json: the Policy model defaults
     ``schema_version`` to current, which would mask an unstamped file.
     Missing or corrupt files are left alone (load_policy surfaces corruption).
+
+    The whole read-split-save runs under ``config_file_lock()`` so a
+    concurrent writer in another process (the stdio settings sidecar) can't
+    interleave with the migration's read-modify-write. Startup runs before
+    the event loop, so taking the blocking lock inline is safe here.
     """
+    from ..utils.config_write_lock import config_file_lock
+
+    with config_file_lock(data_dir):
+        return _migrate_policy_any_semantics_locked(data_dir)
+
+
+def _migrate_policy_any_semantics_locked(data_dir: Path) -> bool:
     path = data_dir / POLICY_FILENAME
     try:
         raw = json.loads(path.read_text(encoding="utf-8"))

--- a/src/ha_mcp/server.py
+++ b/src/ha_mcp/server.py
@@ -1008,6 +1008,21 @@ class HomeAssistantSmartMCPServer(EnhancedToolsMixin):
         UI take effect immediately without restart and without a stale
         in-memory cache.
         """
+        # One-time ANY-match schema migration (PR #1993) runs even when
+        # policies are disabled, so the file already matches the editor's
+        # ANY semantics whenever the user turns the feature on. Never
+        # blocks startup.
+        try:
+            from .policy.persistence import migrate_policy_any_semantics
+            from .utils.data_paths import get_data_dir as _get_data_dir
+
+            migrate_policy_any_semantics(_get_data_dir())
+        except Exception:
+            logger.warning(
+                "tool_policy.json ANY-match migration failed; continuing",
+                exc_info=True,
+            )
+
         if not self.settings.enable_tool_security_policies:
             return
 

--- a/src/ha_mcp/server.py
+++ b/src/ha_mcp/server.py
@@ -249,7 +249,14 @@ class HomeAssistantSmartMCPServer(EnhancedToolsMixin):
         # what it offers to Home Assistant conversation agents on it.
         from .llm_exposure import LlmExposureMiddleware
 
-        self.mcp.add_middleware(LlmExposureMiddleware())
+        # policy_live: whether the gating middleware/queue actually wired at
+        # startup — stamped so a client can distinguish "configured" from
+        # "enforcing" on the very connection it is using (#1990).
+        self.mcp.add_middleware(
+            LlmExposureMiddleware(
+                policy_live=lambda: getattr(self, "approval_queue", None) is not None
+            )
+        )
 
         # Read Only Mode write blocker (discussion #1569) — always
         # installed, consults the live flag per call. Before

--- a/src/ha_mcp/server.py
+++ b/src/ha_mcp/server.py
@@ -1025,8 +1025,12 @@ class HomeAssistantSmartMCPServer(EnhancedToolsMixin):
 
             migrate_policy_any_semantics(_get_data_dir())
         except Exception:
-            logger.warning(
-                "tool_policy.json ANY-match migration failed; continuing",
+            logger.error(
+                "tool_policy.json ANY-match migration failed; continuing. The "
+                "file may still carry pre-ANY semantics: multi-condition rules "
+                "will gate only when ALL conditions match, while the policy "
+                "editor presents them as ANY-match. Fix the file (or re-save "
+                "the policy in the settings UI) and restart.",
                 exc_info=True,
             )
 

--- a/src/ha_mcp/settings_ui/_handlers_backups.py
+++ b/src/ha_mcp/settings_ui/_handlers_backups.py
@@ -414,36 +414,15 @@ async def _save_backup_config_addon(
     )
 
 
-async def _save_backup_config(
-    server: HomeAssistantSmartMCPServer | None, request: Request
-) -> JSONResponse:
-    """Persist auto-backup config edits and publish to the live process.
+def _apply_backup_config_file(clean: dict[str, Any]) -> JSONResponse:
+    """Standalone/file-mode branch of ``apply_backup_config``.
 
-    Routing:
-    - Addon mode: POST ``/addons/self/options`` and return
-      ``restart_required=True`` (see ``_save_backup_config_addon``).
-    - Standalone (file) mode: refuse any field that's pinned by an env var
-      (process or ``.env``) — return 409 with the offending names so the UI
-      can refresh and show the read-only banner. Editable fields merge into
-      ``<data_dir>/backup_settings.json`` and a Settings cache reset
-      publishes them immediately, hence ``restart_required=False``.
+    Refuse any field pinned by an env var (process or ``.env``) — 409 with
+    the offending names so the UI can refresh and show the read-only banner.
+    Editable fields merge into ``<data_dir>/backup_settings.json`` and a
+    Settings cache reset publishes them immediately, hence
+    ``restart_required=False``.
     """
-    try:
-        payload = await request.json()
-    except (ValueError, json.JSONDecodeError):
-        return _bad_request("Invalid JSON body")
-    clean, err = _validate_backup_payload(payload)
-    if err is not None:
-        return _bad_request(err)
-
-    if is_running_in_addon():
-        # ``is_running_in_addon()`` checks SUPERVISOR_TOKEN — the
-        # ``_save_backup_config_addon`` helper called below also catches the
-        # missing-token ``RuntimeError`` from ``make_supervisor_httpx_client``
-        # as defense-in-depth.
-        return await _save_backup_config_addon(server, clean)
-
-    # Standalone (file) mode — refuse to override env-pinned fields.
     rejected = _filter_env_pinned_backup_fields(clean)
     if rejected:
         return JSONResponse(
@@ -481,6 +460,45 @@ async def _save_backup_config(
     return JSONResponse(
         {"success": True, "applied": clean, "mode": "file", "restart_required": False}
     )
+
+
+async def apply_backup_config(
+    server: HomeAssistantSmartMCPServer | None, clean: dict[str, Any]
+) -> JSONResponse:
+    """Route already-validated auto-backup fields to their persistence path.
+
+    Addon mode POSTs to Supervisor (``_save_backup_config_addon``);
+    standalone/file mode merges the override file (``_apply_backup_config_file``).
+    Shared core of the HTTP save handler (``_save_backup_config``) and the
+    ``ha_dev_manage_settings`` developer tool so both take identical
+    addon-vs-file routing and env-pin rejection — ``clean`` must already be
+    validated by ``_validate_backup_payload``.
+    """
+    if is_running_in_addon():
+        # ``is_running_in_addon()`` checks SUPERVISOR_TOKEN — the
+        # ``_save_backup_config_addon`` helper also catches the missing-token
+        # ``RuntimeError`` from ``make_supervisor_httpx_client`` as
+        # defense-in-depth.
+        return await _save_backup_config_addon(server, clean)
+    return _apply_backup_config_file(clean)
+
+
+async def _save_backup_config(
+    server: HomeAssistantSmartMCPServer | None, request: Request
+) -> JSONResponse:
+    """Persist auto-backup config edits and publish to the live process.
+
+    Parses and validates the request body, then delegates the addon-vs-file
+    routing to ``apply_backup_config`` (shared with the developer tool).
+    """
+    try:
+        payload = await request.json()
+    except (ValueError, json.JSONDecodeError):
+        return _bad_request("Invalid JSON body")
+    clean, err = _validate_backup_payload(payload)
+    if err is not None:
+        return _bad_request(err)
+    return await apply_backup_config(server, clean)
 
 
 def build_backups_handlers(

--- a/src/ha_mcp/settings_ui/_handlers_backups.py
+++ b/src/ha_mcp/settings_ui/_handlers_backups.py
@@ -244,32 +244,42 @@ async def _delete_backups_bulk(
     )
 
 
-async def _get_backup_config(
-    server: HomeAssistantSmartMCPServer | None, _: Request
-) -> JSONResponse:
-    """Return live auto-backup config + per-field origin + editable flag.
+def backup_config_fields() -> list[dict[str, Any]]:
+    """Auto-backup fields with per-field value/origin/editable.
 
-    Per-field origin/editable matrix (see ``config.get_backup_setting_origin``):
-    - ``addon``: editable — POST routes through Supervisor.
-    - ``env``: read-only — env var wins; user must unset to edit.
-    - ``file``/``default``: editable — POST writes the override file.
+    Shared by the HTTP ``_get_backup_config`` handler and the
+    ``ha_dev_manage_settings`` developer tool so the two never drift.
+    Origin/editable matrix (see ``config.get_backup_setting_origin``):
+    ``addon`` editable (Supervisor), ``env`` read-only, ``file``/``default``
+    editable (override file).
     """
     settings = get_global_settings()
-    addon_mode = is_running_in_addon()
-    fields = []
+    fields: list[dict[str, Any]] = []
     for field_name, env_name, _ftype in BACKUP_OVERRIDE_FIELDS:
         origin = get_backup_setting_origin(env_name)
-        editable = origin in ("addon", "file", "default")
         fields.append(
             {
                 "field": field_name,
                 "env_var": env_name,
                 "value": getattr(settings, field_name),
                 "origin": origin,
-                "editable": editable,
+                "editable": origin in ("addon", "file", "default"),
             }
         )
-    return JSONResponse({"success": True, "is_addon": addon_mode, "fields": fields})
+    return fields
+
+
+async def _get_backup_config(
+    server: HomeAssistantSmartMCPServer | None, _: Request
+) -> JSONResponse:
+    """Return live auto-backup config + per-field origin + editable flag."""
+    return JSONResponse(
+        {
+            "success": True,
+            "is_addon": is_running_in_addon(),
+            "fields": backup_config_fields(),
+        }
+    )
 
 
 # Inclusive bounds for the integer auto-backup fields; a field absent here

--- a/src/ha_mcp/settings_ui/_handlers_backups.py
+++ b/src/ha_mcp/settings_ui/_handlers_backups.py
@@ -490,7 +490,13 @@ async def apply_backup_config(
         # ``RuntimeError`` from ``make_supervisor_httpx_client`` as
         # defense-in-depth.
         return await _save_backup_config_addon(server, clean)
-    return _apply_backup_config_file(clean)
+    # Same write-guard treatment as tool_config/tool_policy: the RMW is
+    # synchronous (safe in-process), but the guard's file lock keeps a
+    # writer in another process from interleaving with it.
+    from ..utils.config_write_lock import config_write_guard
+
+    async with config_write_guard():
+        return _apply_backup_config_file(clean)
 
 
 async def _save_backup_config(

--- a/src/ha_mcp/settings_ui/_handlers_tools.py
+++ b/src/ha_mcp/settings_ui/_handlers_tools.py
@@ -18,7 +18,7 @@ from .._version import is_embedded
 from ..errors import ErrorCode, create_error_response
 from ..llm_exposure import LLM_API_CONFIG_KEY
 from ..transforms import DEFAULT_PINNED_TOOLS
-from ..utils.config_write_lock import get_config_write_lock
+from ..utils.config_write_lock import config_write_guard
 from . import _persistence
 from ._tools_meta import _VALID_STATES, BPS_MANDATORY_TOOLS, _get_tool_metadata
 
@@ -265,10 +265,11 @@ async def _save_tools(
         )
     llm_api_overrides = _coerce_llm_overrides(raw_llm_api)
 
-    # Serialize the load-modify-save against the developer tool
-    # (set_tool runs its RMW in a worker thread, in parallel with this
-    # loop) via the shared write lock so neither loses the other's update.
-    async with get_config_write_lock():
+    # Serialize the load-modify-save against the developer tool (set_tool
+    # runs its RMW in a worker thread, in parallel with this loop) AND
+    # against other processes (the stdio sidecar runs this same handler in
+    # its own process) so neither loses the other's update.
+    async with config_write_guard():
         config = _persistence.load_tool_config()
 
         # BPS-dependency guard (#1886): reject disabling a BPS-locked tool

--- a/src/ha_mcp/settings_ui/_handlers_tools.py
+++ b/src/ha_mcp/settings_ui/_handlers_tools.py
@@ -18,6 +18,7 @@ from .._version import is_embedded
 from ..errors import ErrorCode, create_error_response
 from ..llm_exposure import LLM_API_CONFIG_KEY
 from ..transforms import DEFAULT_PINNED_TOOLS
+from ..utils.config_write_lock import get_config_write_lock
 from . import _persistence
 from ._tools_meta import _VALID_STATES, BPS_MANDATORY_TOOLS, _get_tool_metadata
 
@@ -264,60 +265,65 @@ async def _save_tools(
         )
     llm_api_overrides = _coerce_llm_overrides(raw_llm_api)
 
-    config = _persistence.load_tool_config()
+    # Serialize the load-modify-save against the developer tool
+    # (set_tool runs its RMW in a worker thread, in parallel with this
+    # loop) via the shared write lock so neither loses the other's update.
+    async with get_config_write_lock():
+        config = _persistence.load_tool_config()
 
-    # BPS-dependency guard (#1886): reject disabling a BPS-locked tool
-    # while strict best-practices mode is on. Mirrors the env-pinned
-    # semantics above — only a *change to* "disabled" is rejected, so a
-    # payload echoing an already-persisted disabled state (reachable via
-    # a hand-edited tool_config.json) still saves and is handled by
-    # apply_tool_visibility's strip-and-warn at startup.
-    prior_states = config.get("tools", {})
-    bps_conflicts = sorted(
-        name
-        for name in _bps_locked_tools()
-        if states.get(name) == "disabled" and prior_states.get(name) != "disabled"
-    )
-    if bps_conflicts:
-        return JSONResponse(
-            create_error_response(
-                ErrorCode.VALIDATION_INVALID_PARAMETER,
-                f"Refusing to disable {', '.join(bps_conflicts)} while "
-                "strict best-practices mode "
-                "(enable_strict_mandatory_bps) is on — strict mode "
-                "publishes its acknowledgment key only through that "
-                "tool, so disabling it would block every gated write.",
-                suggestions=[
-                    "Turn off 'Strict best-practices mode' in the Server "
-                    "Settings tab first, then disable the tool.",
-                ],
-                context={"rejected": bps_conflicts},
-            ),
-            status_code=409,
+        # BPS-dependency guard (#1886): reject disabling a BPS-locked tool
+        # while strict best-practices mode is on. Mirrors the env-pinned
+        # semantics above — only a *change to* "disabled" is rejected, so a
+        # payload echoing an already-persisted disabled state (reachable via
+        # a hand-edited tool_config.json) still saves and is handled by
+        # apply_tool_visibility's strip-and-warn at startup.
+        prior_states = config.get("tools", {})
+        bps_conflicts = sorted(
+            name
+            for name in _bps_locked_tools()
+            if states.get(name) == "disabled" and prior_states.get(name) != "disabled"
         )
+        if bps_conflicts:
+            return JSONResponse(
+                create_error_response(
+                    ErrorCode.VALIDATION_INVALID_PARAMETER,
+                    f"Refusing to disable {', '.join(bps_conflicts)} while "
+                    "strict best-practices mode "
+                    "(enable_strict_mandatory_bps) is on — strict mode "
+                    "publishes its acknowledgment key only through that "
+                    "tool, so disabling it would block every gated write.",
+                    suggestions=[
+                        "Turn off 'Strict best-practices mode' in the Server "
+                        "Settings tab first, then disable the tool.",
+                    ],
+                    context={"rejected": bps_conflicts},
+                ),
+                status_code=409,
+            )
 
-    # The enable/disable/pin half still needs a restart to apply
-    # (visibility is wired at server build); the LLM-API exposure half
-    # applies live (stamped per tools/list). Only demand a restart when
-    # the half that needs one actually changed. Compare with the SAME
-    # default-pinned padding _get_tools applies to its response — the JS
-    # posts that padded map back verbatim, so an unpadded compare would
-    # flag every first save as a states change (live-found on #1745).
-    states_changed = _padded_pins(config.get("tools", {})) != _padded_pins(states)
-    config["tools"] = states
-    config[LLM_API_CONFIG_KEY] = llm_api_overrides
-    if not _persistence.save_tool_config(config):
-        return JSONResponse(
-            create_error_response(
-                ErrorCode.INTERNAL_ERROR,
-                "Failed to persist tool config to disk",
-                suggestions=[
-                    "Set HA_MCP_CONFIG_DIR to a writable path (read-only filesystem?)",
-                    "Check the server logs for the underlying OSError",
-                ],
-            ),
-            status_code=500,
-        )
+        # The enable/disable/pin half still needs a restart to apply
+        # (visibility is wired at server build); the LLM-API exposure half
+        # applies live (stamped per tools/list). Only demand a restart when
+        # the half that needs one actually changed. Compare with the SAME
+        # default-pinned padding _get_tools applies to its response — the JS
+        # posts that padded map back verbatim, so an unpadded compare would
+        # flag every first save as a states change (live-found on #1745).
+        states_changed = _padded_pins(config.get("tools", {})) != _padded_pins(states)
+        config["tools"] = states
+        config[LLM_API_CONFIG_KEY] = llm_api_overrides
+        if not _persistence.save_tool_config(config):
+            return JSONResponse(
+                create_error_response(
+                    ErrorCode.INTERNAL_ERROR,
+                    "Failed to persist tool config to disk",
+                    suggestions=[
+                        "Set HA_MCP_CONFIG_DIR to a writable path "
+                        + "(read-only filesystem?)",
+                        "Check the server logs for the underlying OSError",
+                    ],
+                ),
+                status_code=500,
+            )
 
     disabled_count = sum(1 for s in states.values() if s == "disabled")
     pinned_count = sum(1 for s in states.values() if s == "pinned")

--- a/src/ha_mcp/settings_ui/_persistence.py
+++ b/src/ha_mcp/settings_ui/_persistence.py
@@ -23,6 +23,7 @@ import contextlib
 import json
 import logging
 import os
+import tempfile
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -216,16 +217,22 @@ def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
 
     Raises OSError on filesystem failure — same surface as the previous
     ``path.write_text`` so caller try/except shapes don't need updating.
-    On failure, the ``.tmp`` file is cleaned up so a previous partial
-    write does not accumulate next to the real file.
+    On failure, the temp file is cleaned up so a partial write does not
+    accumulate next to the real file. The temp name is UNIQUE (``mkstemp``,
+    same pattern as ``policy.persistence.save_policy``) so two concurrent
+    writers to the same ``path`` can't collide on a shared ``.tmp`` and
+    corrupt each other's write.
     """
-    tmp = path.with_suffix(path.suffix + ".tmp")
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=f".{path.name}.", suffix=".tmp", dir=path.parent
+    )
     try:
-        tmp.write_text(json.dumps(payload, indent=2))
-        os.replace(str(tmp), str(path))
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(json.dumps(payload, indent=2))
+        os.replace(tmp_name, str(path))
     except OSError:
         with contextlib.suppress(FileNotFoundError, OSError):
-            tmp.unlink()
+            Path(tmp_name).unlink()
         raise
 
 

--- a/src/ha_mcp/settings_ui/locales/de.json
+++ b/src/ha_mcp/settings_ui/locales/de.json
@@ -312,7 +312,7 @@
     "policies.operators.lt": "ist kleiner als",
     "policies.card.no_conditions": "(keine Bedingungen, Regel stimmt mit jedem Aufruf dieses Tools überein)",
     "policies.card.remove_title": "Aus Richtlinie entfernen",
-    "policies.card.conditions_intro": "Genehmigung erfordern, wenn ALLE Bedingungen übereinstimmen (keine Bedingungen = immer Genehmigung erfordern):",
+    "policies.card.conditions_intro": "Genehmigung erfordern, wenn EINE der Bedingungen übereinstimmt (keine Bedingungen = immer Genehmigung erfordern):",
     "policies.card.add_condition": "+ Bedingung hinzufügen",
     "policies.card.argument": "Argument:",
     "policies.card.argument_placeholder": "z. B. args.color_temp",

--- a/src/ha_mcp/settings_ui/locales/de.json
+++ b/src/ha_mcp/settings_ui/locales/de.json
@@ -311,6 +311,8 @@
     "policies.operators.gt": "ist größer als",
     "policies.operators.lt": "ist kleiner als",
     "policies.card.no_conditions": "(keine Bedingungen, Regel stimmt mit jedem Aufruf dieses Tools überein)",
+    "policies.card.always_row": "(immer — jeder Aufruf dieses Tools erfordert Genehmigung)",
+    "policies.card.and_join": " UND ",
     "policies.card.remove_title": "Aus Richtlinie entfernen",
     "policies.card.conditions_intro": "Genehmigung erfordern, wenn EINE der Bedingungen übereinstimmt (keine Bedingungen = immer Genehmigung erfordern):",
     "policies.card.add_condition": "+ Bedingung hinzufügen",

--- a/src/ha_mcp/settings_ui/locales/en.json
+++ b/src/ha_mcp/settings_ui/locales/en.json
@@ -312,7 +312,7 @@
     "policies.operators.lt": "is less than",
     "policies.card.no_conditions": "(no conditions, rule matches every call to this tool)",
     "policies.card.remove_title": "Remove from policy",
-    "policies.card.conditions_intro": "Require approval when ALL conditions match (no conditions = always require approval):",
+    "policies.card.conditions_intro": "Require approval when ANY condition matches (no conditions = always require approval):",
     "policies.card.add_condition": "+ Add condition",
     "policies.card.argument": "Argument:",
     "policies.card.argument_placeholder": "e.g. args.color_temp",

--- a/src/ha_mcp/settings_ui/locales/en.json
+++ b/src/ha_mcp/settings_ui/locales/en.json
@@ -311,6 +311,8 @@
     "policies.operators.gt": "is greater than",
     "policies.operators.lt": "is less than",
     "policies.card.no_conditions": "(no conditions, rule matches every call to this tool)",
+    "policies.card.always_row": "(always — gates every call to this tool)",
+    "policies.card.and_join": " AND ",
     "policies.card.remove_title": "Remove from policy",
     "policies.card.conditions_intro": "Require approval when ANY condition matches (no conditions = always require approval):",
     "policies.card.add_condition": "+ Add condition",

--- a/src/ha_mcp/settings_ui/locales/ru.json
+++ b/src/ha_mcp/settings_ui/locales/ru.json
@@ -312,7 +312,7 @@
     "policies.operators.lt": "меньше",
     "policies.card.no_conditions": "(без условий: правило срабатывает для каждого вызова этого инструмента)",
     "policies.card.remove_title": "Удалить из политики",
-    "policies.card.conditions_intro": "Требовать подтверждение, когда все условия выполнены; без условий — требовать всегда:",
+    "policies.card.conditions_intro": "Требовать подтверждение, когда выполнено любое из условий; без условий — требовать всегда:",
     "policies.card.add_condition": "+ Добавить условие",
     "policies.card.argument": "Аргумент:",
     "policies.card.argument_placeholder": "например, args.color_temp",

--- a/src/ha_mcp/settings_ui/locales/ru.json
+++ b/src/ha_mcp/settings_ui/locales/ru.json
@@ -311,6 +311,8 @@
     "policies.operators.gt": "больше",
     "policies.operators.lt": "меньше",
     "policies.card.no_conditions": "(без условий: правило срабатывает для каждого вызова этого инструмента)",
+    "policies.card.always_row": "(всегда — каждый вызов этого инструмента требует подтверждения)",
+    "policies.card.and_join": " И ",
     "policies.card.remove_title": "Удалить из политики",
     "policies.card.conditions_intro": "Требовать подтверждение, когда выполнено любое из условий; без условий — требовать всегда:",
     "policies.card.add_condition": "+ Добавить условие",

--- a/src/ha_mcp/settings_ui/settings.js
+++ b/src/ha_mcp/settings_ui/settings.js
@@ -2518,13 +2518,16 @@ function renderPolicyCards(policy) {
   });
   order.forEach(toolName => {
     const toolRules = byTool[toolName];
-    const conditions = [];
-    toolRules.forEach(r => (r.when || []).forEach(p => conditions.push(p)));
+    // One card per tool; each RULE is one condition row. A rule's predicates
+    // stay together as a unit (a condition with AND-ed sub-parameters), so a
+    // card edit round-trips multi-predicate rules intact instead of
+    // flattening them.
+    const conditions = toolRules.map(r => r.when || []);
     // The card has a single remember-minutes input; carry the max across the
     // tool's rules so re-saving doesn't silently shorten a remembered window.
     const remember = Math.max(0, ...toolRules.map(r => r.remember_minutes || 0));
     policyRuleEdits[toolName] = JSON.parse(JSON.stringify(
-      {tool_name: toolName, when: conditions, remember_minutes: remember}
+      {tool_name: toolName, conditions: conditions, remember_minutes: remember}
     ));
     listEl.appendChild(renderPolicyCard(toolName, policyRuleEdits[toolName]));
   });
@@ -2541,15 +2544,24 @@ function renderPolicyCard(toolName, rule) {
   const card = document.createElement('div');
   card.className = 'policy-rule-card';
   card.dataset.tool = toolName;
-  rule.when = rule.when || [];
-  const predicateRows = rule.when.map((p, i) => (
+  rule.conditions = rule.conditions || [];
+  // A condition = one rule's predicate list. Multiple predicates in one
+  // condition AND together (sub-parameters); separate conditions OR. Only
+  // single-predicate conditions get the edit button — the form edits one
+  // predicate; multi-predicate conditions (hand-authored) can be removed.
+  const displayCondition = (preds) => (preds.length
+    ? preds.map(displayPredicate).join(' AND ')
+    : t('policies.card.always_row', {}, '(always — gates every call to this tool)'));
+  const predicateRows = rule.conditions.map((preds, i) => (
     '<li class="policy-predicate-row" data-idx="' + i + '">' +
-      '<code>' + escapeHtml(displayPredicate(p)) + '</code>' +
-      '<button class="policy-edit-predicate" data-idx="' + i + '">' + escapeHtml(t('actions.edit', {}, 'edit')) + '</button>' +
+      '<code>' + escapeHtml(displayCondition(preds)) + '</code>' +
+      (preds.length === 1
+        ? '<button class="policy-edit-predicate" data-idx="' + i + '">' + escapeHtml(t('actions.edit', {}, 'edit')) + '</button>'
+        : '') +
       '<button class="policy-remove-predicate" data-idx="' + i + '" aria-label="' + escapeHtml(t('actions.remove', {}, 'Remove')) + '">×</button>' +
     '</li>'
   )).join('');
-  const emptyHint = rule.when.length === 0
+  const emptyHint = rule.conditions.length === 0
     ? '<li class="policy-predicate-row"><em style="color:var(--text-secondary);font-size:0.8rem">' +
       escapeHtml(t('policies.card.no_conditions', {}, '(no conditions, rule matches every call to this tool)')) + '</em></li>'
     : '';
@@ -3008,7 +3020,8 @@ function renderPolicyCard(toolName, rule) {
     formEl.style.display = '';
     await fetchToolSchema();
     if (idx >= 0) {
-      const p = rule.when[idx];
+      // Edit is only offered for single-predicate conditions.
+      const p = rule.conditions[idx][0];
       opEl.value = p.op || 'eq';
       populatePathSelect(p.path || '');
       await renderValueControl(p.value);
@@ -3028,7 +3041,7 @@ function renderPolicyCard(toolName, rule) {
   card.querySelectorAll('.policy-remove-predicate').forEach(btn => {
     btn.addEventListener('click', async () => {
       const idx = parseInt(btn.dataset.idx, 10);
-      rule.when.splice(idx, 1);
+      rule.conditions.splice(idx, 1);
       await autoSave();
       rerenderCard();
     });
@@ -3071,9 +3084,9 @@ function renderPolicyCard(toolName, rule) {
       }
     }
     if (editingIdx >= 0) {
-      rule.when[editingIdx] = predicate;
+      rule.conditions[editingIdx] = [predicate];
     } else {
-      rule.when.push(predicate);
+      rule.conditions.push([predicate]);
     }
     await autoSave();
     rerenderCard();
@@ -3088,13 +3101,14 @@ async function savePolicyRule(toolName, ruleObj) {
   const policy = await r.json();
   policy.rules = policy.rules || [];
   // Expand the card's conditions into ONE rule each (they OR at evaluation —
-  // the tool gates if ANY condition matches). No conditions = a single bare
-  // rule that always requires approval. Replaces all of this tool's rules.
+  // the tool gates if ANY condition matches; a condition's own predicates AND
+  // together as sub-parameters). No conditions = a single bare rule that
+  // always requires approval. Replaces all of this tool's rules.
   const remember = ruleObj.remember_minutes || 0;
-  const conditions = ruleObj.when || [];
+  const conditions = ruleObj.conditions || [];
   const expanded = conditions.length === 0
     ? [{tool_name: toolName, when: [], remember_minutes: remember}]
-    : conditions.map(p => ({tool_name: toolName, when: [p], remember_minutes: remember}));
+    : conditions.map(preds => ({tool_name: toolName, when: preds, remember_minutes: remember}));
   policy.rules = policy.rules
     .filter(rule => rule.tool_name !== toolName)
     .concat(expanded);

--- a/src/ha_mcp/settings_ui/settings.js
+++ b/src/ha_mcp/settings_ui/settings.js
@@ -3109,9 +3109,22 @@ async function savePolicyRule(toolName, ruleObj) {
   const expanded = conditions.length === 0
     ? [{tool_name: toolName, when: [], remember_minutes: remember}]
     : conditions.map(preds => ({tool_name: toolName, when: preds, remember_minutes: remember}));
-  policy.rules = policy.rules
-    .filter(rule => rule.tool_name !== toolName)
-    .concat(expanded);
+  // Replace the tool's rules IN PLACE (at the position of its first rule)
+  // rather than appending at the end: rule order is behaviorally significant
+  // — find_matching_rule() takes the FIRST match's remember_minutes, so
+  // moving a tool-specific rule behind a wildcard rule would silently switch
+  // matching calls to the wildcard's approval lifetime.
+  const others = [];
+  let insertAt = -1;
+  policy.rules.forEach(rule => {
+    if (rule.tool_name === toolName) {
+      if (insertAt === -1) insertAt = others.length;
+    } else {
+      others.push(rule);
+    }
+  });
+  if (insertAt === -1) insertAt = others.length;
+  policy.rules = others.slice(0, insertAt).concat(expanded, others.slice(insertAt));
   await policyPut(policy, t('policies.operations.save_rule', {}, 'Save rule'));
 }
 

--- a/src/ha_mcp/settings_ui/settings.js
+++ b/src/ha_mcp/settings_ui/settings.js
@@ -288,7 +288,13 @@ async function loadPolicyState() {
       return;
     }
     const p = await r.json();
-    policyState.gatedTools = new Set((p.rules || []).map(rule => rule.tool_name));
+    // The Tools-tab gate toggle reflects the BARE unconditional rule only
+    // (no predicates); conditional rules are managed in the Policies tab.
+    policyState.gatedTools = new Set(
+      (p.rules || [])
+        .filter(rule => !rule.when || rule.when.length === 0)
+        .map(rule => rule.tool_name)
+    );
   } catch (e) {
     // Policy endpoint unavailable (sidecar stub) or network blip — keep the
     // prior gatedTools rather than resetting it to empty. On first load it
@@ -2500,22 +2506,27 @@ function renderPolicyCards(policy) {
     return;
   }
   emptyEl.style.display = 'none';
-  // Group rules by tool_name. The Tools-tab toggle creates exactly one
-  // rule per tool; defensively handle the case where a hand-edited file
-  // has multiple entries: each becomes its own card so the user can
-  // see/edit them all.
+  // Each condition is its own rule on disk (OR: the tool gates if ANY rule
+  // matches). Collapse all of a tool's rules into ONE card whose "conditions"
+  // are the union of the rules' predicates; the card re-expands to one rule
+  // per condition on save (savePolicyRule). Order preserved by first sight.
   const byTool = {};
-  rules.forEach((r, idx) => {
-    const key = r.tool_name + '\0' + idx;
-    byTool[key] = {tool_name: r.tool_name, rule: r, originalIndex: idx};
+  const order = [];
+  rules.forEach(r => {
+    if (!byTool[r.tool_name]) { byTool[r.tool_name] = []; order.push(r.tool_name); }
+    byTool[r.tool_name].push(r);
   });
-  Object.keys(byTool).forEach(key => {
-    const entry = byTool[key];
-    // Deep clone the rule into the edit buffer so card-local changes
-    // don't mutate the server response until "Save changes".
-    const editKey = entry.tool_name;
-    policyRuleEdits[editKey] = JSON.parse(JSON.stringify(entry.rule));
-    listEl.appendChild(renderPolicyCard(entry.tool_name, policyRuleEdits[editKey]));
+  order.forEach(toolName => {
+    const toolRules = byTool[toolName];
+    const conditions = [];
+    toolRules.forEach(r => (r.when || []).forEach(p => conditions.push(p)));
+    // The card has a single remember-minutes input; carry the max across the
+    // tool's rules so re-saving doesn't silently shorten a remembered window.
+    const remember = Math.max(0, ...toolRules.map(r => r.remember_minutes || 0));
+    policyRuleEdits[toolName] = JSON.parse(JSON.stringify(
+      {tool_name: toolName, when: conditions, remember_minutes: remember}
+    ));
+    listEl.appendChild(renderPolicyCard(toolName, policyRuleEdits[toolName]));
   });
 }
 
@@ -2549,7 +2560,7 @@ function renderPolicyCard(toolName, rule) {
     '</div>' +
     '<div class="policy-rule-predicates">' +
       '<label class="features-sub" style="display:block;margin-bottom:4px">' +
-        escapeHtml(t('policies.card.conditions_intro', {}, 'Require approval when ALL of these conditions match (no conditions = always require approval):')) +
+        escapeHtml(t('policies.card.conditions_intro', {}, 'Require approval when ANY of these conditions matches (no conditions = always require approval):')) +
       '</label>' +
       '<ul class="policy-predicate-list">' + emptyHint + predicateRows + '</ul>' +
       '<button class="policy-add-predicate">' + escapeHtml(t('policies.card.add_condition', {}, '+ Add condition')) + '</button>' +
@@ -3076,23 +3087,29 @@ async function savePolicyRule(toolName, ruleObj) {
   if (!r.ok) throw new Error(t('policies.errors.load', {status: r.status}, 'Could not load policy: ' + r.status));
   const policy = await r.json();
   policy.rules = policy.rules || [];
-  const idx = policy.rules.findIndex(rule => rule.tool_name === toolName);
-  if (idx >= 0) {
-    policy.rules[idx] = ruleObj;
-  } else {
-    // Defensive: a card exists for a tool with no server-side rule
-    // (e.g. the user removed the rule from another tab between load
-    // and save). Append rather than silently drop the edit.
-    policy.rules.push(ruleObj);
-  }
+  // Expand the card's conditions into ONE rule each (they OR at evaluation —
+  // the tool gates if ANY condition matches). No conditions = a single bare
+  // rule that always requires approval. Replaces all of this tool's rules.
+  const remember = ruleObj.remember_minutes || 0;
+  const conditions = ruleObj.when || [];
+  const expanded = conditions.length === 0
+    ? [{tool_name: toolName, when: [], remember_minutes: remember}]
+    : conditions.map(p => ({tool_name: toolName, when: [p], remember_minutes: remember}));
+  policy.rules = policy.rules
+    .filter(rule => rule.tool_name !== toolName)
+    .concat(expanded);
   await policyPut(policy, t('policies.operations.save_rule', {}, 'Save rule'));
 }
 
 async function removePolicyRule(toolName) {
-  // Mirror syncPolicyRule(toolName, false) — kept as a separate helper
-  // so the card's remove button stays self-contained, but the on-wire
-  // shape is identical.
-  await syncPolicyRule(toolName, false);
+  // The card's "Remove from policy" button removes ALL of the tool's rules
+  // (every condition), unlike the Tools-tab gate toggle which manages only
+  // the bare unconditional rule via syncPolicyRule.
+  const r = await fetch('./api/policy/config');
+  if (!r.ok) throw new Error(t('policies.errors.load', {status: r.status}, 'Could not load policy: ' + r.status));
+  const policy = await r.json();
+  policy.rules = (policy.rules || []).filter(rule => rule.tool_name !== toolName);
+  await policyPut(policy, t('policies.operations.save_rule', {}, 'Remove rule'));
 }
 
 async function saveGlobalSettings() {

--- a/src/ha_mcp/settings_ui/settings.js
+++ b/src/ha_mcp/settings_ui/settings.js
@@ -2508,8 +2508,9 @@ function renderPolicyCards(policy) {
   emptyEl.style.display = 'none';
   // Each condition is its own rule on disk (OR: the tool gates if ANY rule
   // matches). Collapse all of a tool's rules into ONE card whose "conditions"
-  // are the union of the rules' predicates; the card re-expands to one rule
-  // per condition on save (savePolicyRule). Order preserved by first sight.
+  // are the tool's rules — one condition per rule, each being that rule's
+  // whole predicate list; the card re-expands to one rule per condition on
+  // save (savePolicyRule). Order preserved by first sight.
   const byTool = {};
   const order = [];
   rules.forEach(r => {
@@ -2523,11 +2524,15 @@ function renderPolicyCards(policy) {
     // card edit round-trips multi-predicate rules intact instead of
     // flattening them.
     const conditions = toolRules.map(r => r.when || []);
-    // The card has a single remember-minutes input; carry the max across the
-    // tool's rules so re-saving doesn't silently shorten a remembered window.
-    const remember = Math.max(0, ...toolRules.map(r => r.remember_minutes || 0));
+    // The card has ONE remember-minutes input; DISPLAY the max across the
+    // tool's rules, but keep each condition's own value (remembers[i]) so a
+    // save that never touched the input can't silently rewrite heterogeneous
+    // per-condition lifetimes (rememberDirty gates which one is persisted).
+    const remembers = toolRules.map(r => r.remember_minutes || 0);
+    const remember = Math.max(0, ...remembers);
     policyRuleEdits[toolName] = JSON.parse(JSON.stringify(
-      {tool_name: toolName, conditions: conditions, remember_minutes: remember}
+      {tool_name: toolName, conditions: conditions, remembers: remembers,
+       remember_minutes: remember, rememberDirty: false}
     ));
     listEl.appendChild(renderPolicyCard(toolName, policyRuleEdits[toolName]));
   });
@@ -2550,7 +2555,7 @@ function renderPolicyCard(toolName, rule) {
   // single-predicate conditions get the edit button — the form edits one
   // predicate; multi-predicate conditions (hand-authored) can be removed.
   const displayCondition = (preds) => (preds.length
-    ? preds.map(displayPredicate).join(' AND ')
+    ? preds.map(displayPredicate).join(t('policies.card.and_join', {}, ' AND '))
     : t('policies.card.always_row', {}, '(always — gates every call to this tool)'));
   const predicateRows = rule.conditions.map((preds, i) => (
     '<li class="policy-predicate-row" data-idx="' + i + '">' +
@@ -2621,7 +2626,8 @@ function renderPolicyCard(toolName, rule) {
 
   // Auto-save: every condition add/edit/remove and every remember-minutes
   // change immediately PUTs the rule to disk. No manual "Save changes"
-  // button — the only signal is the small status text below the card.
+  // button. Returns whether the save landed so callers skip re-rendering a
+  // card that no longer reflects the server.
   let autoSaveSeq = 0;
   const autoSave = async () => {
     const status = card.querySelector('.policy-save-status');
@@ -2631,10 +2637,22 @@ function renderPolicyCard(toolName, rule) {
       await savePolicyRule(toolName, rule);
       // Skip the success label if a newer save started (rapid edits)
       if (mySeq === autoSaveSeq) status.textContent = t('status.saved', {}, 'Saved.');
+      return true;
     } catch (err) {
-      if (mySeq === autoSaveSeq) {
-        status.textContent = t('errors.save_failed_detail', {message: err.message}, 'Save failed: ' + err.message);
+      // A failed save must be LOUD and must not leave the card displaying a
+      // condition the server never persisted — a phantom SECURITY rule the
+      // user would trust (the #1990 failure shape). The tiny status text is
+      // missable, so toast like every other save surface, then resync every
+      // card from the server's actual policy.
+      const message = t('errors.save_failed_detail', {message: err.message}, 'Save failed: ' + err.message);
+      if (mySeq === autoSaveSeq) status.textContent = message;
+      showToast(message, {isError: true});
+      try {
+        await policyLoadConfig();
+      } catch (_e) {
+        // Reload failed too (e.g. network down) — the toast already fired.
       }
+      return false;
     }
   };
 
@@ -2664,6 +2682,9 @@ function renderPolicyCard(toolName, rule) {
   let rmDebounce = null;
   card.querySelector('.policy-remember-minutes').addEventListener('input', (e) => {
     rule.remember_minutes = parseInt(e.target.value, 10) || 0;
+    // Only an explicit touch of this input rewrites every condition's
+    // lifetime on save; otherwise per-condition values are preserved.
+    rule.rememberDirty = true;
     if (rmDebounce) clearTimeout(rmDebounce);
     rmDebounce = setTimeout(autoSave, 500);
   });
@@ -3042,8 +3063,10 @@ function renderPolicyCard(toolName, rule) {
     btn.addEventListener('click', async () => {
       const idx = parseInt(btn.dataset.idx, 10);
       rule.conditions.splice(idx, 1);
-      await autoSave();
-      rerenderCard();
+      if (rule.remembers) rule.remembers.splice(idx, 1);
+      // On failure autoSave toasts + rebuilds all cards from the server, so
+      // only re-render this (now stale) card when the save actually landed.
+      if (await autoSave()) rerenderCard();
     });
   });
 
@@ -3087,9 +3110,12 @@ function renderPolicyCard(toolName, rule) {
       rule.conditions[editingIdx] = [predicate];
     } else {
       rule.conditions.push([predicate]);
+      // A new condition takes the card's current lifetime value.
+      (rule.remembers = rule.remembers || []).push(rule.remember_minutes || 0);
     }
-    await autoSave();
-    rerenderCard();
+    // On failure autoSave toasts + rebuilds all cards from the server, so
+    // only re-render this (now stale) card when the save actually landed.
+    if (await autoSave()) rerenderCard();
   });
 
   return card;
@@ -3106,9 +3132,16 @@ async function savePolicyRule(toolName, ruleObj) {
   // always requires approval. Replaces all of this tool's rules.
   const remember = ruleObj.remember_minutes || 0;
   const conditions = ruleObj.conditions || [];
+  const remembers = ruleObj.remembers || [];
+  // Preserve each condition's own lifetime unless the user actually touched
+  // the card's remember input (rememberDirty) — an unrelated predicate edit
+  // must not silently rewrite heterogeneous per-condition remember values.
+  const rememberFor = (i) => (ruleObj.rememberDirty
+    ? remember
+    : (remembers[i] !== undefined ? remembers[i] : remember));
   const expanded = conditions.length === 0
     ? [{tool_name: toolName, when: [], remember_minutes: remember}]
-    : conditions.map(preds => ({tool_name: toolName, when: preds, remember_minutes: remember}));
+    : conditions.map((preds, i) => ({tool_name: toolName, when: preds, remember_minutes: rememberFor(i)}));
   // Replace the tool's rules IN PLACE (at the position of its first rule)
   // rather than appending at the end: rule order is behaviorally significant
   // — find_matching_rule() takes the FIRST match's remember_minutes, so

--- a/src/ha_mcp/settings_ui/settings.js
+++ b/src/ha_mcp/settings_ui/settings.js
@@ -326,12 +326,18 @@ async function syncPolicyRule(toolName, gated) {
   if (!r.ok) throw new Error(t('policies.errors.load', {status: r.status}, 'Could not load policy: ' + r.status));
   const policy = await r.json();
   policy.rules = policy.rules || [];
+  // The gate toggle manages ONLY the bare, unconditional rule (empty `when`)
+  // for this tool; predicate-bearing rules authored in the policy editor are
+  // preserved. A conditional rule must not be mistaken for the gate (enabling
+  // would silently no-op) nor wiped on un-gate.
+  const isBareGate = rule =>
+    rule.tool_name === toolName && (!rule.when || rule.when.length === 0);
   if (gated) {
-    if (!policy.rules.some(rule => rule.tool_name === toolName)) {
+    if (!policy.rules.some(isBareGate)) {
       policy.rules.push({tool_name: toolName, when: [], remember_minutes: 0});
     }
   } else {
-    policy.rules = policy.rules.filter(rule => rule.tool_name !== toolName);
+    policy.rules = policy.rules.filter(rule => !isBareGate(rule));
   }
   await policyPut(policy, t('policies.operations.sync_gated', {}, 'Sync gated toggle'));
 }

--- a/src/ha_mcp/settings_ui/settings.js
+++ b/src/ha_mcp/settings_ui/settings.js
@@ -327,6 +327,15 @@ async function policyPut(policy, opLabel) {
   return await w.json();
 }
 
+// Where a NEW tool's rules belong in the rule list: before the first
+// wildcard rule, else at the end. find_matching_rule() is first-match (it
+// supplies remember_minutes and the matched_rule shown to the user), so a
+// tool-specific rule appended after a `*` rule would never be the match.
+function wildcardInsertIndex(rules) {
+  const idx = rules.findIndex(rule => rule.tool_name === '*');
+  return idx === -1 ? rules.length : idx;
+}
+
 async function syncPolicyRule(toolName, gated) {
   const r = await fetch('./api/policy/config');
   if (!r.ok) throw new Error(t('policies.errors.load', {status: r.status}, 'Could not load policy: ' + r.status));
@@ -340,7 +349,8 @@ async function syncPolicyRule(toolName, gated) {
     rule.tool_name === toolName && (!rule.when || rule.when.length === 0);
   if (gated) {
     if (!policy.rules.some(isBareGate)) {
-      policy.rules.push({tool_name: toolName, when: [], remember_minutes: 0});
+      policy.rules.splice(wildcardInsertIndex(policy.rules), 0,
+        {tool_name: toolName, when: [], remember_minutes: 0});
     }
   } else {
     policy.rules = policy.rules.filter(rule => !isBareGate(rule));
@@ -3156,7 +3166,10 @@ async function savePolicyRule(toolName, ruleObj) {
       others.push(rule);
     }
   });
-  if (insertAt === -1) insertAt = others.length;
+  // A tool with no existing rule inserts before the first wildcard rule (not
+  // at the end): first-match would otherwise resolve the tool's calls to the
+  // wildcard's remember_minutes, never the new rule's.
+  if (insertAt === -1) insertAt = wildcardInsertIndex(others);
   policy.rules = others.slice(0, insertAt).concat(expanded, others.slice(insertAt));
   await policyPut(policy, t('policies.operations.save_rule', {}, 'Save rule'));
 }

--- a/src/ha_mcp/tools/registry.py
+++ b/src/ha_mcp/tools/registry.py
@@ -193,9 +193,15 @@ class ToolsRegistry:
             return
 
         # Build kwargs with all available dependencies (lazy access)
+        # ``server`` lets a register function reach the live server object
+        # (e.g. tools_dev needs server.approval_queue and the unfiltered
+        # tool registry to drive the settings-UI surfaces). Every
+        # register_*_tools takes **kwargs, so the extra key is ignored by
+        # the modules that don't need it.
         kwargs = {
             "smart_tools": self.smart_tools,
             "device_tools": self.device_tools,
+            "server": self.server,
         }
 
         # tools_*.py modules by convention, then the explicit modules (those

--- a/src/ha_mcp/tools/tools_dev.py
+++ b/src/ha_mcp/tools/tools_dev.py
@@ -40,6 +40,7 @@ from .helpers import (
     raise_tool_error,
     register_tool_methods,
 )
+from .util_helpers import JSON_STRING_COERCION
 
 logger = logging.getLogger(__name__)
 
@@ -692,6 +693,7 @@ class DevTools:
         ] = None,
         policy: Annotated[
             dict[str, Any] | None,
+            JSON_STRING_COERCION,
             Field(
                 default=None,
                 description=(
@@ -713,6 +715,7 @@ class DevTools:
         ] = None,
         backup: Annotated[
             dict[str, Any] | None,
+            JSON_STRING_COERCION,
             Field(
                 default=None,
                 description=(

--- a/src/ha_mcp/tools/tools_dev.py
+++ b/src/ha_mcp/tools/tools_dev.py
@@ -11,6 +11,7 @@ Feature Flag: Set HAMCP_ENABLE_DEV_MODE=true to enable these tools.
 """
 
 import asyncio
+import json
 import logging
 import sys
 from typing import Annotated, Any, Literal
@@ -342,8 +343,13 @@ def schedule_deferred_entry_reload(client: Any, entry_id: str) -> None:
 class DevTools:
     """Developer-mode tools for server introspection, update, and settings."""
 
-    def __init__(self, client: Any) -> None:
+    def __init__(self, client: Any, server: Any | None = None) -> None:
         self._client = client
+        # The live server object, when available (embedded / add-on / container
+        # deployments). Needed for the approval queue and the unfiltered tool
+        # registry that the Tools/Policies actions drive; ``None`` in the stdio
+        # settings sidecar, where those actions degrade to a clear error.
+        self._server = server
 
     # ----- settings management helpers -----
 
@@ -531,8 +537,6 @@ class DevTools:
         unreadable or corrupt existing file — same data-loss guard as
         the web UI save handlers.
         """
-        import json
-
         from ..config import _FEATURE_FLAG_OVERRIDE_FILENAME
         from ..settings_ui._persistence import (
             _atomic_write_json,
@@ -626,9 +630,24 @@ class DevTools:
     async def ha_dev_manage_settings(
         self,
         action: Annotated[
-            Literal["list", "set", "reset"],
+            Literal[
+                "list",
+                "set",
+                "reset",
+                "list_tools",
+                "set_tool",
+                "get_policy",
+                "set_policy",
+                "get_backup_config",
+                "set_backup_config",
+            ],
             Field(
-                description="list all settings, set one value, or reset one override"
+                description=(
+                    "Server-settings matrix: list / set / reset. Tools tab: "
+                    "list_tools / set_tool (enable-disable-pin, LLM-API, security "
+                    "gate). Security policies: get_policy / set_policy. Auto-backup "
+                    "config: get_backup_config / set_backup_config."
+                )
             ),
         ],
         setting: Annotated[
@@ -639,120 +658,735 @@ class DevTools:
             bool | int | float | str | None,
             Field(default=None, description="New value (required for set)"),
         ] = None,
+        tool: Annotated[
+            str | None,
+            Field(default=None, description="Tool name (required for set_tool)"),
+        ] = None,
+        state: Annotated[
+            Literal["enabled", "disabled", "pinned"] | None,
+            Field(
+                default=None,
+                description="set_tool: enable, disable, or pin the tool",
+            ),
+        ] = None,
+        llm_api: Annotated[
+            bool | None,
+            Field(
+                default=None,
+                description="set_tool: expose the tool to HA conversation agents",
+            ),
+        ] = None,
+        gated: Annotated[
+            bool | None,
+            Field(
+                default=None,
+                description=(
+                    "set_tool: require user approval before every call to this "
+                    "tool (adds/removes an unconditional security-policy rule)"
+                ),
+            ),
+        ] = None,
+        policy: Annotated[
+            dict[str, Any] | None,
+            Field(
+                default=None,
+                description=(
+                    "set_policy: the full policy object "
+                    "{wait_seconds, approval_ttl_minutes, rules, version}"
+                ),
+            ),
+        ] = None,
+        expected_version: Annotated[
+            int | None,
+            Field(
+                default=None,
+                description=(
+                    "set_policy: the version from your last get_policy, for "
+                    "optimistic-concurrency safety (else the policy's own "
+                    "version field is used)"
+                ),
+            ),
+        ] = None,
+        backup: Annotated[
+            dict[str, Any] | None,
+            Field(
+                default=None,
+                description=(
+                    "set_backup_config: {field: value} of auto-backup settings "
+                    "to change (see get_backup_config for field names)"
+                ),
+            ),
+        ] = None,
     ) -> dict[str, Any]:
-        """Manage ha-mcp server settings directly (developer mode).
+        """Manage ha-mcp server settings and the Tools/Policies/Backups surfaces (developer mode).
+
+        Drives everything the web settings UI can change: the Server
+        Settings matrix (list/set/reset), the Tools tab (enable/disable/pin,
+        LLM-API exposure, and the per-tool security gate), the Tool Security
+        Policies editor (get_policy/set_policy), and the auto-backup config
+        (get_backup_config/set_backup_config). Use ha_dev_manage_server for
+        the live approval queue and to restart.
 
         When NOT to use: for HA entity/automation configuration use the
-        ha_config_* tools; for enabling/disabling individual MCP tools
-        use the web settings UI (Tools tab).
+        ha_config_* tools.
 
-        When to use: reading or changing the server's own settings (the
-        same matrix as the web UI's Server Settings tab) during
-        development/testing — feature flags, advanced fields, and their
-        env/file/addon origins.
-
-        Caveats: changed values persist to the server's override file
-        (or the add-on options via Supervisor) but most settings only
-        take effect after a server restart (ha_dev_manage_server
-        action="restart").
-        Env-pinned settings are read-only until the env var is unset.
-        This can flip security-sensitive flags; treat with the same
-        care as editing the web UI.
+        Caveats: enable/disable/pin and most server settings take effect
+        only after a restart (ha_dev_manage_server action="restart");
+        LLM-API exposure, security gates, and policy edits apply live.
+        Env-pinned settings/tools are read-only until the env var is unset.
+        These actions can flip security-sensitive state — treat with the
+        same care as editing the web UI.
 
         EXAMPLES:
-        ha_dev_manage_settings("list")
-        ha_dev_manage_settings("set", setting="log_level", value="DEBUG")
-        ha_dev_manage_settings("reset", setting="log_level")
+        ha_dev_manage_settings("list_tools")
+        ha_dev_manage_settings("set_tool", tool="ha_write_file", state="disabled")
+        ha_dev_manage_settings("set_tool", tool="ha_call_service", gated=True)
+        ha_dev_manage_settings("get_policy")
+        ha_dev_manage_settings("set_backup_config", backup={"enable_auto_backup": False})
         """
         try:
-            if action == "list":
-                return {
-                    "success": True,
-                    "data": {
-                        "settings": await asyncio.to_thread(self._settings_rows),
-                        "is_addon": is_running_in_addon(),
-                        "is_embedded": is_embedded(),
-                        "note": (
-                            "Most settings need a server restart to take "
-                            "effect (ha_dev_manage_server action='restart')."
-                        ),
-                    },
-                }
-
-            if not setting:
-                raise_tool_error(
-                    create_error_response(
-                        ErrorCode.VALIDATION_MISSING_PARAMETER,
-                        f"'setting' is required for action={action!r}",
-                    )
-                )
-
-            from ..config import (
-                _ADVANCED_SETTINGS_BOUNDS,
-                _ADVANCED_SETTINGS_CHOICES,
-                _ADVANCED_SETTINGS_SENTINELS,
-                _FEATURE_FLAG_INT_BOUNDS,
-                ADVANCED_SETTINGS_FIELDS,
-                FEATURE_FLAG_FIELDS,
-                _read_feature_flag_override_file,
-                get_feature_flag_origin,
-            )
-
-            features = {f: (e, t) for f, e, t in FEATURE_FLAG_FIELDS}
-            advanced = {f: (e, t, s, ed) for f, e, t, s, ed in ADVANCED_SETTINGS_FIELDS}
-            bounds: tuple[float, float] | None
-            sentinel: int | None
-            choices: tuple[str, ...] | None
-            if setting in features:
-                env_name, ftype = features[setting]
-                origin = get_feature_flag_origin(env_name)
-                editable = origin in ("addon", "file", "default")
-                bounds = _FEATURE_FLAG_INT_BOUNDS.get(setting)
-                sentinel = None
-                choices = None
-            elif setting in advanced:
-                env_name, ftype, _section, registry_editable = advanced[setting]
-                overrides = await asyncio.to_thread(_read_feature_flag_override_file)
-                origin = self._advanced_origin(setting, env_name, overrides)
-                editable = registry_editable and origin != "env"
-                bounds = _ADVANCED_SETTINGS_BOUNDS.get(setting)
-                sentinel = _ADVANCED_SETTINGS_SENTINELS.get(setting)
-                choices = _ADVANCED_SETTINGS_CHOICES.get(setting)
-            else:
-                raise_tool_error(
-                    create_error_response(
-                        ErrorCode.VALIDATION_INVALID_PARAMETER,
-                        f"Unknown setting: {setting!r}",
-                        suggestions=[
-                            "Call ha_dev_manage_settings('list') for valid names"
-                        ],
-                    )
-                )
-
-            if action == "reset":
-                return await self._apply_setting_reset(setting, env_name, origin)
-
-            # action == "set"
-            return await self._apply_setting_set(
-                setting,
-                value,
-                env_name,
-                ftype,
-                origin,
-                editable,
-                bounds,
-                sentinel,
-                choices,
-            )
+            if action in ("list", "set", "reset"):
+                return await self._manage_server_setting(action, setting, value)
+            if action == "list_tools":
+                return await self._list_tool_states()
+            if action == "set_tool":
+                return await self._apply_set_tool(tool, state, llm_api, gated)
+            if action == "get_policy":
+                return await self._get_policy()
+            if action == "set_policy":
+                return await self._apply_set_policy(policy, expected_version)
+            if action == "get_backup_config":
+                return await self._get_backup_config()
+            return await self._apply_set_backup_config(backup)
         except ToolError:
             raise
         except Exception as e:
             exception_to_structured_error(
                 e,
-                context={"action": action, "setting": setting},
+                context={"action": action, "setting": setting, "tool": tool},
                 suggestions=["Check server logs for details"],
             )
             return None  # unreachable; explicit for CodeQL
+
+    async def _manage_server_setting(
+        self,
+        action: str,
+        setting: str | None,
+        value: bool | int | float | str | None,
+    ) -> dict[str, Any]:
+        """Handle the server-settings matrix actions (list / set / reset).
+
+        Extracted from ``ha_dev_manage_settings``'s inline body so the tool
+        method stays a thin dispatcher; the feature/advanced resolution and
+        the env/addon/file origin logic live here.
+        """
+        if action == "list":
+            return {
+                "success": True,
+                "data": {
+                    "settings": await asyncio.to_thread(self._settings_rows),
+                    "is_addon": is_running_in_addon(),
+                    "is_embedded": is_embedded(),
+                    "note": (
+                        "Most settings need a server restart to take "
+                        "effect (ha_dev_manage_server action='restart')."
+                    ),
+                },
+            }
+
+        if not setting:
+            raise_tool_error(
+                create_error_response(
+                    ErrorCode.VALIDATION_MISSING_PARAMETER,
+                    f"'setting' is required for action={action!r}",
+                )
+            )
+
+        from ..config import (
+            _ADVANCED_SETTINGS_BOUNDS,
+            _ADVANCED_SETTINGS_CHOICES,
+            _ADVANCED_SETTINGS_SENTINELS,
+            _FEATURE_FLAG_INT_BOUNDS,
+            ADVANCED_SETTINGS_FIELDS,
+            FEATURE_FLAG_FIELDS,
+            _read_feature_flag_override_file,
+            get_feature_flag_origin,
+        )
+
+        features = {f: (e, t) for f, e, t in FEATURE_FLAG_FIELDS}
+        advanced = {f: (e, t, s, ed) for f, e, t, s, ed in ADVANCED_SETTINGS_FIELDS}
+        bounds: tuple[float, float] | None
+        sentinel: int | None
+        choices: tuple[str, ...] | None
+        if setting in features:
+            env_name, ftype = features[setting]
+            origin = get_feature_flag_origin(env_name)
+            editable = origin in ("addon", "file", "default")
+            bounds = _FEATURE_FLAG_INT_BOUNDS.get(setting)
+            sentinel = None
+            choices = None
+        elif setting in advanced:
+            env_name, ftype, _section, registry_editable = advanced[setting]
+            overrides = await asyncio.to_thread(_read_feature_flag_override_file)
+            origin = self._advanced_origin(setting, env_name, overrides)
+            editable = registry_editable and origin != "env"
+            bounds = _ADVANCED_SETTINGS_BOUNDS.get(setting)
+            sentinel = _ADVANCED_SETTINGS_SENTINELS.get(setting)
+            choices = _ADVANCED_SETTINGS_CHOICES.get(setting)
+        else:
+            raise_tool_error(
+                create_error_response(
+                    ErrorCode.VALIDATION_INVALID_PARAMETER,
+                    f"Unknown setting: {setting!r}",
+                    suggestions=["Call ha_dev_manage_settings('list') for valid names"],
+                )
+            )
+
+        if action == "reset":
+            return await self._apply_setting_reset(setting, env_name, origin)
+
+        # action == "set"
+        return await self._apply_setting_set(
+            setting,
+            value,
+            env_name,
+            ftype,
+            origin,
+            editable,
+            bounds,
+            sentinel,
+            choices,
+        )
+
+    # ----- Tools tab: enable/disable/pin, LLM-API, security gate -----
+
+    async def _tool_metadata_rows(self) -> list[dict[str, Any]]:
+        """Return unfiltered tool metadata (live registry, else sidecar cache)."""
+        from ..settings_ui._persistence import load_tool_metadata_cache
+        from ..settings_ui._tools_meta import _get_tool_metadata
+
+        if self._server is not None:
+            return await _get_tool_metadata(self._server)
+        return load_tool_metadata_cache()
+
+    @staticmethod
+    def _gated_tool_names() -> set[str]:
+        """Tool names carrying at least one security-policy rule."""
+        from ..policy.persistence import load_policy
+        from ..utils.data_paths import get_data_dir
+
+        try:
+            policy = load_policy(get_data_dir())
+        except ValueError:
+            return set()
+        return {rule.tool_name for rule in policy.rules}
+
+    async def _list_tool_states(self) -> dict[str, Any]:
+        """List every tool with its state / LLM-API / gate + lock flags.
+
+        Mirrors the web Tools tab payload: enabled/disabled/pinned (from
+        tool_config.json + env overlay + default-pinned padding), effective
+        LLM-API exposure, the per-tool security gate, and the env-pinned /
+        mandatory / bps-locked flags that make a row read-only.
+        """
+        from ..config import get_global_settings
+        from ..llm_exposure import effective_llm_api_exposed, load_llm_api_overrides
+        from ..settings_ui._handlers_tools import _bps_locked_tools
+        from ..settings_ui._persistence import effective_tool_config, env_pinned_tools
+        from ..settings_ui._tools_meta import effective_mandatory_tools
+        from ..transforms import DEFAULT_PINNED_TOOLS
+
+        metadata = await self._tool_metadata_rows()
+        settings = get_global_settings()
+        states = dict(effective_tool_config().get("tools", {}))
+        for name in DEFAULT_PINNED_TOOLS:
+            states.setdefault(name, "pinned")
+        env_pinned = env_pinned_tools()
+        overrides = load_llm_api_overrides()
+        gated = self._gated_tool_names()
+        mandatory = effective_mandatory_tools(settings)
+        bps_locked = set(_bps_locked_tools())
+
+        rows = [
+            {
+                "name": t["name"],
+                "category": t.get("category"),
+                "state": states.get(t["name"], "enabled"),
+                # Feature-gated stub rows carry their primary tag but not the
+                # "beta" tag the registered tool declares; append it for
+                # disabled_by stubs so the default exposure matches what the
+                # real (beta) tool reports once enabled. Mirrors _get_tools.
+                "llm_api": effective_llm_api_exposed(
+                    t["name"],
+                    [
+                        *(t.get("tags") or []),
+                        *(["beta"] if t.get("disabled_by") else []),
+                    ],
+                    overrides,
+                ),
+                "gated": t["name"] in gated,
+                "env_pinned": t["name"] in env_pinned,
+                "mandatory": t["name"] in mandatory,
+                "bps_locked": t["name"] in bps_locked,
+            }
+            for t in metadata
+        ]
+        return {
+            "success": True,
+            "data": {
+                "tools": rows,
+                "count": len(rows),
+                "policies_enabled": settings.enable_tool_security_policies,
+                "llm_api_available": is_embedded(),
+            },
+        }
+
+    async def _apply_set_tool(
+        self,
+        tool: str | None,
+        state: str | None,
+        llm_api: bool | None,
+        gated: bool | None,
+    ) -> dict[str, Any]:
+        """Apply a Tools-tab change to one tool (state / LLM-API / gate).
+
+        All requested changes are validated (and the policy file read) BEFORE
+        anything is written, so a validation failure on one field cannot leave
+        another already persisted. ``tool='*'`` is rejected — it is a policy
+        wildcard, not a specific tool; author wildcard rules via set_policy.
+        """
+        if not tool:
+            raise_tool_error(
+                create_error_response(
+                    ErrorCode.VALIDATION_MISSING_PARAMETER,
+                    "'tool' is required for action='set_tool'",
+                )
+            )
+        if tool == "*":
+            raise_tool_error(
+                create_error_response(
+                    ErrorCode.VALIDATION_INVALID_PARAMETER,
+                    "tool='*' is a policy wildcard, not a specific tool; it "
+                    "would gate every tool. Use set_policy to author a wildcard "
+                    "rule deliberately.",
+                )
+            )
+        if not any(v is not None for v in (state, llm_api, gated)):
+            raise_tool_error(
+                create_error_response(
+                    ErrorCode.VALIDATION_MISSING_PARAMETER,
+                    "set_tool needs at least one of state / llm_api / gated",
+                )
+            )
+        return await asyncio.to_thread(
+            self._write_tool_all, tool, state, llm_api, gated
+        )
+
+    def _write_tool_all(
+        self, tool: str, state: str | None, llm_api: bool | None, gated: bool | None
+    ) -> dict[str, Any]:
+        """Preflight-validate every requested change, then write them.
+
+        Validation and the fallible policy read happen before any write, so a
+        rejected field (env-pin, mandatory/BPS lock, corrupt policy) cannot
+        leave another field already persisted (Codex #1993). Cross-file
+        atomicity across tool_config.json and tool_policy.json is still
+        best-effort on a raw disk-write failure.
+        """
+        plan = self._preflight_set_tool(tool, state, llm_api, gated)
+        return self._commit_set_tool(tool, state, plan)
+
+    def _preflight_set_tool(
+        self, tool: str, state: str | None, llm_api: bool | None, gated: bool | None
+    ) -> dict[str, Any]:
+        """Validate all requested changes without writing anything.
+
+        Returns a plan dict (persist_state / llm_val / gate_val / new_policy /
+        gate_changed); raises ToolError on the first invalid field.
+        """
+        from ..config import get_global_settings
+        from ..policy.persistence import load_policy
+        from ..settings_ui._persistence import env_pinned_tools
+        from ..utils.data_paths import get_data_dir
+
+        plan: dict[str, Any] = {
+            "persist_state": False,
+            "llm_val": None,
+            "gate_val": None,
+            "new_policy": None,
+            "gate_changed": False,
+        }
+        if state is not None:
+            plan["persist_state"] = self._validate_state_change(
+                tool, state, get_global_settings(), env_pinned_tools()
+            )
+        if llm_api is not None:
+            plan["llm_val"] = self._coerce_bool_or_raise(llm_api, "llm_api")
+        if gated is not None:
+            gate_val = self._coerce_bool_or_raise(gated, "gated")
+            try:
+                policy = load_policy(get_data_dir())
+            except ValueError as exc:
+                raise_tool_error(
+                    create_error_response(
+                        ErrorCode.CONFIG_INVALID,
+                        f"tool_policy.json is invalid: {exc}",
+                        suggestions=["Inspect or delete the file, then retry"],
+                    )
+                )
+            new_policy, changed = self._apply_gate_to_policy(policy, tool, gate_val)
+            plan["gate_val"] = gate_val
+            plan["new_policy"] = new_policy
+            plan["gate_changed"] = changed
+        return plan
+
+    def _commit_set_tool(
+        self, tool: str, state: str | None, plan: dict[str, Any]
+    ) -> dict[str, Any]:
+        """Persist a preflighted set_tool plan (validations already passed)."""
+        from ..llm_exposure import LLM_API_CONFIG_KEY
+        from ..settings_ui._persistence import load_tool_config, save_tool_config
+
+        config = load_tool_config()
+        tools_states = dict(config.get("tools", {}))
+        llm_over = dict(config.get(LLM_API_CONFIG_KEY, {}))
+        data: dict[str, Any] = {"tool": tool}
+        warnings: list[str] = []
+        restart_required = False
+        if state is not None:
+            data["state"] = state
+            if plan["persist_state"]:
+                tools_states[tool] = state
+                restart_required = True
+        if plan["llm_val"] is not None:
+            llm_over[tool] = plan["llm_val"]
+            data["llm_api"] = plan["llm_val"]
+            if not is_embedded():
+                warnings.append(
+                    "LLM-API exposure only affects the embedded custom-component "
+                    "server; it has no effect in this deployment."
+                )
+        config["tools"] = tools_states
+        config[LLM_API_CONFIG_KEY] = llm_over
+        if not save_tool_config(config):
+            raise_tool_error(
+                create_error_response(
+                    ErrorCode.INTERNAL_ERROR,
+                    "Failed to persist tool config to disk",
+                    suggestions=[
+                        "Set HA_MCP_CONFIG_DIR to a writable path",
+                        "Check the server logs for the underlying OSError",
+                    ],
+                )
+            )
+        if plan["gate_val"] is not None:
+            warnings.extend(self._commit_gate(plan, data))
+        data["restart_required"] = restart_required
+        result: dict[str, Any] = {"success": True, "data": data}
+        if warnings:
+            result["warnings"] = warnings
+        return result
+
+    def _commit_gate(self, plan: dict[str, Any], data: dict[str, Any]) -> list[str]:
+        """Persist the gate portion of a set_tool plan; returns any warnings."""
+        from ..config import get_global_settings
+        from ..policy.persistence import save_policy
+        from ..utils.data_paths import get_data_dir
+
+        data["gated"] = bool(plan["gate_val"])
+        data["policy_rules_changed"] = plan["gate_changed"]
+        if plan["gate_changed"]:
+            save_policy(get_data_dir(), plan["new_policy"])
+            self._clear_remember_cache()
+        warnings: list[str] = []
+        if not get_global_settings().enable_tool_security_policies:
+            warnings.append(
+                "Tool security policies are disabled "
+                "(enable_tool_security_policies=false); this gate is stored but "
+                "won't enforce until policies are enabled and the server restarts."
+            )
+        return warnings
+
+    @staticmethod
+    def _validate_state_change(
+        tool: str, state: str, settings: Any, env_pinned: dict[str, str]
+    ) -> bool:
+        """Validate a state change; return whether it should be persisted.
+
+        Rejects invalid states, env-pinned flips, and disabling a mandatory
+        tool (base MANDATORY_TOOLS always, plus the BPS-locked set while
+        strict best-practices mode is on) — the web Tools tab locks those
+        rows, so the headless path must refuse rather than persist a disable
+        that apply_tool_visibility silently reverts at startup. Env-pinned
+        no-op re-sends return False (nothing to persist); anything else that
+        passes returns True.
+        """
+        from ..settings_ui._tools_meta import (
+            _VALID_STATES,
+            BPS_MANDATORY_TOOLS,
+            effective_mandatory_tools,
+        )
+
+        if state not in _VALID_STATES:
+            raise_tool_error(
+                create_error_response(
+                    ErrorCode.VALIDATION_INVALID_PARAMETER,
+                    f"state must be one of {sorted(_VALID_STATES)}",
+                )
+            )
+        if tool in env_pinned:
+            if env_pinned[tool] != state:
+                raise_tool_error(
+                    create_error_response(
+                        ErrorCode.VALIDATION_INVALID_PARAMETER,
+                        f"{tool!r} is pinned by DISABLED_TOOLS / PINNED_TOOLS "
+                        f"to {env_pinned[tool]!r}; unset the env var to change it.",
+                    )
+                )
+            return False
+        if state == "disabled" and tool in effective_mandatory_tools(settings):
+            if tool in BPS_MANDATORY_TOOLS:
+                raise_tool_error(
+                    create_error_response(
+                        ErrorCode.VALIDATION_INVALID_PARAMETER,
+                        f"Refusing to disable {tool!r} while strict "
+                        "best-practices mode (enable_strict_mandatory_bps) is on.",
+                        suggestions=[
+                            "Turn off strict best-practices mode first, then retry."
+                        ],
+                    )
+                )
+            raise_tool_error(
+                create_error_response(
+                    ErrorCode.VALIDATION_INVALID_PARAMETER,
+                    f"{tool!r} is a mandatory tool and is always kept enabled; "
+                    "it cannot be disabled.",
+                )
+            )
+        return True
+
+    @staticmethod
+    def _coerce_bool_or_raise(value: Any, field: str) -> bool:
+        """Coerce ``value`` to bool or raise a ToolError naming ``field``."""
+        coerced = DevTools._coerce_bool_setting(value)
+        if coerced is _COERCE_MISS:
+            raise_tool_error(
+                create_error_response(
+                    ErrorCode.VALIDATION_INVALID_PARAMETER,
+                    f"{field} must be a boolean",
+                )
+            )
+        return bool(coerced)
+
+    @staticmethod
+    def _apply_gate_to_policy(policy: Any, tool: str, gated: bool) -> tuple[Any, bool]:
+        """Return (policy, changed) after adding/removing the bare gate rule.
+
+        Pure (no I/O): manages only the bare unconditional rule (when == [])
+        for ``tool``; predicate-bearing rules are preserved.
+        """
+        from ..policy.model import Rule
+
+        has_bare = any(r.tool_name == tool and not r.when for r in policy.rules)
+        if gated and not has_bare:
+            updated = policy.model_copy(
+                update={"rules": [*policy.rules, Rule(tool_name=tool)]}
+            )
+            return updated, True
+        if not gated and has_bare:
+            updated = policy.model_copy(
+                update={
+                    "rules": [r for r in policy.rules if r.tool_name != tool or r.when]
+                }
+            )
+            return updated, True
+        return policy, False
+
+    def _clear_remember_cache(self) -> None:
+        """Clear the approval remember-cache if a live queue exists."""
+        queue = getattr(self._server, "approval_queue", None)
+        if queue is not None:
+            queue.clear_remember_cache()
+
+    # ----- Tool security policies -----
+
+    async def _get_policy(self) -> dict[str, Any]:
+        """Return the full tool-security policy."""
+        from ..config import get_global_settings
+        from ..policy.persistence import load_policy
+        from ..utils.data_paths import get_data_dir
+
+        try:
+            policy = load_policy(get_data_dir())
+        except ValueError as exc:
+            raise_tool_error(
+                create_error_response(
+                    ErrorCode.CONFIG_INVALID,
+                    f"tool_policy.json is invalid: {exc}",
+                    suggestions=["Inspect or delete the file, then retry"],
+                )
+            )
+        return {
+            "success": True,
+            "data": {
+                "policy": policy.model_dump(mode="json"),
+                "policies_enabled": (
+                    get_global_settings().enable_tool_security_policies
+                ),
+            },
+        }
+
+    async def _apply_set_policy(
+        self, policy: dict[str, Any] | None, expected_version: int | None
+    ) -> dict[str, Any]:
+        """Write the full tool-security policy (validated, version-guarded)."""
+        from pydantic import ValidationError
+
+        from ..policy.model import Policy
+        from ..policy.persistence import load_policy, save_policy
+        from ..utils.data_paths import get_data_dir
+
+        if not isinstance(policy, dict):
+            raise_tool_error(
+                create_error_response(
+                    ErrorCode.VALIDATION_MISSING_PARAMETER,
+                    "'policy' (a policy object) is required for action='set_policy'",
+                    suggestions=[
+                        "Call ha_dev_manage_settings('get_policy') for the shape"
+                    ],
+                )
+            )
+        try:
+            new_policy = Policy.model_validate(policy)
+        except (ValidationError, ValueError) as exc:
+            raise_tool_error(
+                create_error_response(
+                    ErrorCode.VALIDATION_INVALID_PARAMETER,
+                    f"policy failed schema validation: {exc}",
+                )
+            )
+        data_dir = get_data_dir()
+        try:
+            current = load_policy(data_dir)
+        except ValueError as exc:
+            raise_tool_error(
+                create_error_response(
+                    ErrorCode.CONFIG_INVALID,
+                    f"existing tool_policy.json is invalid: {exc}",
+                    suggestions=["Inspect or delete the file, then retry"],
+                )
+            )
+        warnings: list[str] = []
+        expected = (
+            expected_version if expected_version is not None else policy.get("version")
+        )
+        if expected is not None and expected != current.version:
+            raise_tool_error(
+                create_error_response(
+                    ErrorCode.VALIDATION_INVALID_PARAMETER,
+                    "policy version mismatch — reload with get_policy before saving",
+                    context={
+                        "current_version": current.version,
+                        "current_policy": current.model_dump(mode="json"),
+                    },
+                )
+            )
+        if expected is None:
+            warnings.append(
+                "No version supplied; wrote without an optimistic-concurrency check."
+            )
+        # Rebase onto the on-disk version so save_policy bumps to current+1
+        # (matches the web PUT semantics).
+        to_save = new_policy.model_copy(update={"version": current.version})
+        save_policy(data_dir, to_save)
+        rules_changed = current.rules != new_policy.rules
+        if rules_changed:
+            self._clear_remember_cache()
+        result: dict[str, Any] = {
+            "success": True,
+            "data": {"version": current.version + 1, "rules_changed": rules_changed},
+        }
+        if warnings:
+            result["warnings"] = warnings
+        return result
+
+    # ----- Auto-backup config -----
+
+    async def _get_backup_config(self) -> dict[str, Any]:
+        """Return the auto-backup config fields with per-field origin/editable."""
+        from ..config import (
+            BACKUP_OVERRIDE_FIELDS,
+            get_backup_setting_origin,
+            get_global_settings,
+        )
+
+        settings = get_global_settings()
+        fields = [
+            {
+                "field": field_name,
+                "env_var": env_name,
+                "value": getattr(settings, field_name),
+                "origin": (origin := get_backup_setting_origin(env_name)),
+                "editable": origin in ("addon", "file", "default"),
+            }
+            for field_name, env_name, _ftype in BACKUP_OVERRIDE_FIELDS
+        ]
+        return {
+            "success": True,
+            "data": {"is_addon": is_running_in_addon(), "fields": fields},
+        }
+
+    async def _apply_set_backup_config(
+        self, backup: dict[str, Any] | None
+    ) -> dict[str, Any]:
+        """Apply auto-backup config changes (same routing as the web UI)."""
+        from ..settings_ui._handlers_backups import (
+            _validate_backup_payload,
+            apply_backup_config,
+        )
+
+        if not isinstance(backup, dict):
+            raise_tool_error(
+                create_error_response(
+                    ErrorCode.VALIDATION_MISSING_PARAMETER,
+                    "'backup' (an object of {field: value}) is required for "
+                    "action='set_backup_config'",
+                    suggestions=[
+                        "Call ha_dev_manage_settings('get_backup_config') for "
+                        "field names"
+                    ],
+                )
+            )
+        clean, err = _validate_backup_payload(backup)
+        if err is not None:
+            raise_tool_error(
+                create_error_response(ErrorCode.VALIDATION_INVALID_PARAMETER, err)
+            )
+        response = await apply_backup_config(self._server, clean)
+        # JSONResponse.body is typed bytes | memoryview; bytes() normalizes both
+        # (no-op for bytes) so json.loads accepts it.
+        body = json.loads(bytes(response.body))
+        if response.status_code >= 400:
+            raise_tool_error(
+                create_error_response(
+                    ErrorCode.SERVICE_CALL_FAILED,
+                    self._backup_error_message(body),
+                    context={"status": response.status_code, "response": body},
+                )
+            )
+        return {"success": True, "data": body}
+
+    @staticmethod
+    def _backup_error_message(body: Any) -> str:
+        """Pull a human message out of a backup-config error response body."""
+        err = body.get("error") if isinstance(body, dict) else None
+        if isinstance(err, dict):
+            return str(
+                err.get("message") or err.get("code") or "backup config update failed"
+            )
+        if isinstance(err, str):
+            return err
+        return "backup config update failed"
 
     async def _apply_setting_reset(
         self, setting: str, env_name: str, origin: str
@@ -917,14 +1551,23 @@ class DevTools:
     async def ha_dev_manage_server(
         self,
         action: Annotated[
-            Literal["info", "update_source", "restart"],
+            Literal[
+                "info",
+                "update_source",
+                "restart",
+                "list_pending",
+                "approve",
+                "deny",
+            ],
             Field(
                 description=(
                     "info: deployment/version report; update_source: point the "
                     "ha_mcp_tools component's separate in-process server at a "
                     "channel or pip spec and reinstall it (never changes the "
                     "server serving this connection, unless embedded); "
-                    "restart: restart this server"
+                    "restart: restart this server; list_pending: list tool calls "
+                    "blocked on a security-policy approval; approve / deny: decide "
+                    "one blocked call by token"
                 )
             ),
         ],
@@ -945,6 +1588,13 @@ class DevTools:
                     "https://github.com/homeassistant-ai/ha-mcp/archive/refs/"
                     "pull/<PR>/head.tar.gz. Empty string clears the override."
                 ),
+            ),
+        ] = None,
+        token: Annotated[
+            str | None,
+            Field(
+                default=None,
+                description="Approval token (required for approve/deny)",
             ),
         ] = None,
     ) -> dict[str, Any]:
@@ -981,13 +1631,19 @@ class DevTools:
         ha_dev_manage_server("update_source", channel="dev")
         ha_dev_manage_server("update_source", pip_spec="https://github.com/homeassistant-ai/ha-mcp/archive/refs/pull/1234/head.tar.gz")
         ha_dev_manage_server("restart")
+        ha_dev_manage_server("list_pending")
+        ha_dev_manage_server("approve", token="abc123")
         """
         try:
             if action == "info":
                 return await self._server_info()
             if action == "update_source":
                 return await self._update_source(channel, pip_spec)
-            return await self._restart_server()
+            if action == "restart":
+                return await self._restart_server()
+            if action == "list_pending":
+                return await self._list_pending()
+            return await self._decide_approval(token, approve=action == "approve")
         except ToolError:
             raise
         except Exception as e:
@@ -1376,6 +2032,100 @@ class DevTools:
         )
         return None  # unreachable; explicit for CodeQL
 
+    # ----- Approval queue (runtime) -----
+
+    def _require_queue(self) -> Any:
+        """Return the live approval queue or raise a clear error.
+
+        The queue only exists on a full server (embedded / add-on /
+        container) with tool security policies enabled; it is absent in the
+        stdio settings sidecar and whenever the feature flag is off.
+        """
+        queue = getattr(self._server, "approval_queue", None)
+        if queue is None:
+            raise_tool_error(
+                create_error_response(
+                    ErrorCode.VALIDATION_INVALID_PARAMETER,
+                    "No active approval queue: tool security policies are "
+                    "disabled, or this deployment has no live server (stdio "
+                    "settings sidecar).",
+                    suggestions=[
+                        "Enable enable_tool_security_policies and restart, then "
+                        "retry from a full-server (embedded/add-on/container) "
+                        "deployment."
+                    ],
+                )
+            )
+        return queue
+
+    async def _list_pending(self) -> dict[str, Any]:
+        """List tool calls currently blocked on a security-policy approval."""
+        queue = getattr(self._server, "approval_queue", None)
+        if queue is None:
+            return {
+                "success": True,
+                "data": {
+                    "pending": [],
+                    "count": 0,
+                    "note": (
+                        "No active approval queue (tool security policies "
+                        "disabled or no live server); nothing is blocked."
+                    ),
+                },
+            }
+        pending = [
+            {
+                "token": e.token,
+                "tool_name": e.tool_name,
+                "args": e.args,
+                "created_at": e.created_at.isoformat(),
+                "expires_at": e.expires_at.isoformat(),
+            }
+            for e in queue.list_pending()
+        ]
+        return {"success": True, "data": {"pending": pending, "count": len(pending)}}
+
+    async def _decide_approval(
+        self, token: str | None, *, approve: bool
+    ) -> dict[str, Any]:
+        """Approve or deny one blocked tool call by token."""
+        if not token:
+            raise_tool_error(
+                create_error_response(
+                    ErrorCode.VALIDATION_MISSING_PARAMETER,
+                    "'token' is required for approve/deny",
+                )
+            )
+        queue = self._require_queue()
+        entry = queue.get(token)
+        if entry is None:
+            raise_tool_error(
+                create_error_response(
+                    ErrorCode.VALIDATION_INVALID_PARAMETER,
+                    "Unknown or expired approval token",
+                    suggestions=[
+                        "Call ha_dev_manage_server('list_pending') for live tokens"
+                    ],
+                )
+            )
+        decided = queue.approve(token) if approve else queue.deny(token)
+        if not decided:
+            raise_tool_error(
+                create_error_response(
+                    ErrorCode.VALIDATION_INVALID_PARAMETER,
+                    f"Token already decided as {entry.decision!r}",
+                    context={"current_decision": entry.decision},
+                )
+            )
+        return {
+            "success": True,
+            "data": {
+                "token": token,
+                "tool_name": entry.tool_name,
+                "decision": "approved" if approve else "denied",
+            },
+        }
+
 
 def register_dev_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
     """Register developer-mode tools.
@@ -1390,7 +2140,7 @@ def register_dev_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
 
     logger.warning(
         "Developer mode is ON: ha_dev_manage_server / ha_dev_manage_settings "
-        "are registered. These tools can change server settings and replace "
-        "the running server version."
+        "are registered. These tools can change server settings, tool "
+        "visibility, security policies, and replace the running server version."
     )
-    register_tool_methods(mcp, DevTools(client))
+    register_tool_methods(mcp, DevTools(client, server=kwargs.get("server")))

--- a/src/ha_mcp/tools/tools_dev.py
+++ b/src/ha_mcp/tools/tools_dev.py
@@ -345,10 +345,11 @@ class DevTools:
 
     def __init__(self, client: Any, server: Any | None = None) -> None:
         self._client = client
-        # The live server object, when available (embedded / add-on / container
-        # deployments). Needed for the approval queue and the unfiltered tool
-        # registry that the Tools/Policies actions drive; ``None`` in the stdio
-        # settings sidecar, where those actions degrade to a clear error.
+        # The live server object. The registry always passes it, so it is
+        # present in every real deployment that registers these dev tools;
+        # ``None`` is only a defensive fallback (no real path constructs
+        # DevTools without a server). Used for the approval queue and the
+        # unfiltered tool registry the Tools/Policies actions drive.
         self._server = server
 
     # ----- settings management helpers -----
@@ -673,7 +674,10 @@ class DevTools:
             bool | None,
             Field(
                 default=None,
-                description="set_tool: expose the tool to HA conversation agents",
+                description=(
+                    "set_tool: expose the tool to HA conversation agents "
+                    "(effective only on the embedded custom-component server)"
+                ),
             ),
         ] = None,
         gated: Annotated[
@@ -861,7 +865,14 @@ class DevTools:
     # ----- Tools tab: enable/disable/pin, LLM-API, security gate -----
 
     async def _tool_metadata_rows(self) -> list[dict[str, Any]]:
-        """Return unfiltered tool metadata (live registry, else sidecar cache)."""
+        """Return unfiltered tool metadata from the live registry.
+
+        Every real deployment that registers these developer tools passes a
+        live server (the registry always does; the stdio settings sidecar is
+        a separate process that never builds these tools), so the metadata
+        comes from ``local_provider._list_tools()``. The on-disk cache is a
+        defensive fallback for a server-less construction only.
+        """
         from ..settings_ui._persistence import load_tool_metadata_cache
         from ..settings_ui._tools_meta import _get_tool_metadata
 
@@ -871,7 +882,13 @@ class DevTools:
 
     @staticmethod
     def _gated_tool_names() -> set[str]:
-        """Tool names carrying at least one security-policy rule."""
+        """Tool names carrying the bare unconditional gate (the Tools-tab toggle).
+
+        The Tools-tab per-tool gate toggle manages only the bare rule (no
+        predicates); conditional rules are authored in the Policies tab. Keying
+        this on the bare rule keeps the reported toggle state consistent with
+        what set_tool(gated=...) writes.
+        """
         from ..policy.persistence import load_policy
         from ..utils.data_paths import get_data_dir
 
@@ -879,7 +896,7 @@ class DevTools:
             policy = load_policy(get_data_dir())
         except ValueError:
             return set()
-        return {rule.tool_name for rule in policy.rules}
+        return {rule.tool_name for rule in policy.rules if not rule.when}
 
     async def _list_tool_states(self) -> dict[str, Any]:
         """List every tool with its state / LLM-API / gate + lock flags.
@@ -912,6 +929,12 @@ class DevTools:
                 "name": t["name"],
                 "category": t.get("category"),
                 "state": states.get(t["name"], "enabled"),
+                # Feature-gated tools appear as stubs carrying disabled_by (the
+                # flag that would register them). Surface availability so the
+                # caller doesn't read a stub's default state="enabled" as "this
+                # tool is live" — it isn't until disabled_by is turned on.
+                "available": t.get("disabled_by") is None,
+                "disabled_by": t.get("disabled_by"),
                 # Feature-gated stub rows carry their primary tag but not the
                 # "beta" tag the registered tool declares; append it for
                 # disabled_by stubs so the default exposure matches what the
@@ -936,7 +959,12 @@ class DevTools:
             "data": {
                 "tools": rows,
                 "count": len(rows),
+                # configured: the saved flag. live: whether the gating
+                # middleware/queue are actually wired (only at startup). They
+                # diverge after toggling the flag until a restart.
                 "policies_enabled": settings.enable_tool_security_policies,
+                "policies_live": getattr(self._server, "approval_queue", None)
+                is not None,
                 "llm_api_available": is_embedded(),
             },
         }
@@ -978,9 +1006,15 @@ class DevTools:
                     "set_tool needs at least one of state / llm_api / gated",
                 )
             )
-        return await asyncio.to_thread(
-            self._write_tool_all, tool, state, llm_api, gated
-        )
+        # Serialize the tool_config + policy read-modify-write against the web
+        # save handlers and other set_tool calls via the shared lock (held on
+        # the loop while the file I/O runs in the worker thread).
+        from ..utils.config_write_lock import get_config_write_lock
+
+        async with get_config_write_lock():
+            return await asyncio.to_thread(
+                self._write_tool_all, tool, state, llm_api, gated
+            )
 
     def _write_tool_all(
         self, tool: str, state: str | None, llm_api: bool | None, gated: bool | None
@@ -1080,12 +1114,41 @@ class DevTools:
                 )
             )
         if plan["gate_val"] is not None:
-            warnings.extend(self._commit_gate(plan, data))
+            partial = (state is not None and plan["persist_state"]) or plan[
+                "llm_val"
+            ] is not None
+            warnings.extend(self._commit_gate_or_flag_partial(plan, data, partial))
         data["restart_required"] = restart_required
         result: dict[str, Any] = {"success": True, "data": data}
         if warnings:
             result["warnings"] = warnings
         return result
+
+    def _commit_gate_or_flag_partial(
+        self, plan: dict[str, Any], data: dict[str, Any], partial: bool
+    ) -> list[str]:
+        """Commit the gate; on a raw policy-write failure, surface that the
+        tool_config (state/LLM-API) change already persisted so the caller
+        isn't told the whole operation failed."""
+        try:
+            return self._commit_gate(plan, data)
+        except ToolError:
+            raise
+        except Exception as exc:
+            suffix = (
+                " The state/LLM-API change WAS already saved — re-run set_tool "
+                "with only gated= to finish the gate."
+                if partial
+                else ""
+            )
+            raise_tool_error(
+                create_error_response(
+                    ErrorCode.INTERNAL_ERROR,
+                    f"The security-gate policy write failed: {exc}.{suffix}",
+                    context={"partial_commit": partial, "persisted": data},
+                )
+            )
+            return []  # unreachable; explicit for CodeQL
 
     def _commit_gate(self, plan: dict[str, Any], data: dict[str, Any]) -> list[str]:
         """Persist the gate portion of a set_tool plan; returns any warnings."""
@@ -1233,6 +1296,8 @@ class DevTools:
                 "policies_enabled": (
                     get_global_settings().enable_tool_security_policies
                 ),
+                "policies_live": getattr(self._server, "approval_queue", None)
+                is not None,
             },
         }
 
@@ -1243,8 +1308,7 @@ class DevTools:
         from pydantic import ValidationError
 
         from ..policy.model import Policy
-        from ..policy.persistence import load_policy, save_policy
-        from ..utils.data_paths import get_data_dir
+        from ..utils.config_write_lock import get_config_write_lock
 
         if not isinstance(policy, dict):
             raise_tool_error(
@@ -1265,6 +1329,28 @@ class DevTools:
                     f"policy failed schema validation: {exc}",
                 )
             )
+        # Compare against the COERCED model version so a JSON string "3" matches
+        # the on-disk int 3; ``"version" in policy`` distinguishes an omitted
+        # version (no concurrency check) from an explicit one.
+        expected = (
+            expected_version
+            if expected_version is not None
+            else (new_policy.version if "version" in policy else None)
+        )
+        # Serialize the load-check-save against the web PUT handler + set_tool.
+        async with get_config_write_lock():
+            return await asyncio.to_thread(self._commit_policy, new_policy, expected)
+
+    def _commit_policy(self, new_policy: Any, expected: int | None) -> dict[str, Any]:
+        """Load current policy, version-check against ``expected``, save, report.
+
+        MUST run while holding ``get_config_write_lock()`` (called via
+        ``asyncio.to_thread`` from ``_apply_set_policy``).
+        """
+        from ..config import get_global_settings
+        from ..policy.persistence import load_policy, save_policy
+        from ..utils.data_paths import get_data_dir
+
         data_dir = get_data_dir()
         try:
             current = load_policy(data_dir)
@@ -1277,9 +1363,6 @@ class DevTools:
                 )
             )
         warnings: list[str] = []
-        expected = (
-            expected_version if expected_version is not None else policy.get("version")
-        )
         if expected is not None and expected != current.version:
             raise_tool_error(
                 create_error_response(
@@ -1295,13 +1378,22 @@ class DevTools:
             warnings.append(
                 "No version supplied; wrote without an optimistic-concurrency check."
             )
-        # Rebase onto the on-disk version so save_policy bumps to current+1
-        # (matches the web PUT semantics).
-        to_save = new_policy.model_copy(update={"version": current.version})
-        save_policy(data_dir, to_save)
+        # Rebase onto the on-disk version so save_policy bumps to current+1.
+        save_policy(
+            data_dir, new_policy.model_copy(update={"version": current.version})
+        )
         rules_changed = current.rules != new_policy.rules
         if rules_changed:
             self._clear_remember_cache()
+        # Same "won't enforce" signal set_tool(gated=True) gives, so authoring
+        # rules while the engine is off doesn't look like a live gate.
+        if new_policy.rules and not get_global_settings().enable_tool_security_policies:
+            warnings.append(
+                "Tool security policies are disabled "
+                "(enable_tool_security_policies=false); these rules are stored "
+                "but won't enforce until policies are enabled and the server "
+                "restarts."
+            )
         result: dict[str, Any] = {
             "success": True,
             "data": {"version": current.version + 1, "rules_changed": rules_changed},
@@ -1313,27 +1405,15 @@ class DevTools:
     # ----- Auto-backup config -----
 
     async def _get_backup_config(self) -> dict[str, Any]:
-        """Return the auto-backup config fields with per-field origin/editable."""
-        from ..config import (
-            BACKUP_OVERRIDE_FIELDS,
-            get_backup_setting_origin,
-            get_global_settings,
-        )
+        """Return the auto-backup config fields (shared with the web handler)."""
+        from ..settings_ui._handlers_backups import backup_config_fields
 
-        settings = get_global_settings()
-        fields = [
-            {
-                "field": field_name,
-                "env_var": env_name,
-                "value": getattr(settings, field_name),
-                "origin": (origin := get_backup_setting_origin(env_name)),
-                "editable": origin in ("addon", "file", "default"),
-            }
-            for field_name, env_name, _ftype in BACKUP_OVERRIDE_FIELDS
-        ]
         return {
             "success": True,
-            "data": {"is_addon": is_running_in_addon(), "fields": fields},
+            "data": {
+                "is_addon": is_running_in_addon(),
+                "fields": backup_config_fields(),
+            },
         }
 
     async def _apply_set_backup_config(
@@ -2037,22 +2117,24 @@ class DevTools:
     def _require_queue(self) -> Any:
         """Return the live approval queue or raise a clear error.
 
-        The queue only exists on a full server (embedded / add-on /
-        container) with tool security policies enabled; it is absent in the
-        stdio settings sidecar and whenever the feature flag is off.
+        The queue is created at server startup only when
+        ``enable_tool_security_policies`` is on. These developer tools always
+        run with a live server, so a missing queue means policies were off at
+        startup (or were toggled on without the required restart) — not a
+        deployment without a server.
         """
         queue = getattr(self._server, "approval_queue", None)
         if queue is None:
             raise_tool_error(
                 create_error_response(
                     ErrorCode.VALIDATION_INVALID_PARAMETER,
-                    "No active approval queue: tool security policies are "
-                    "disabled, or this deployment has no live server (stdio "
-                    "settings sidecar).",
+                    "No active approval queue: tool security policies were not "
+                    "enabled when the server started, so the gating middleware "
+                    "and its queue are not wired.",
                     suggestions=[
-                        "Enable enable_tool_security_policies and restart, then "
-                        "retry from a full-server (embedded/add-on/container) "
-                        "deployment."
+                        "Enable enable_tool_security_policies "
+                        "(ha_dev_manage_settings set) and restart the server, "
+                        "then retry."
                     ],
                 )
             )
@@ -2068,8 +2150,8 @@ class DevTools:
                     "pending": [],
                     "count": 0,
                     "note": (
-                        "No active approval queue (tool security policies "
-                        "disabled or no live server); nothing is blocked."
+                        "No active approval queue — tool security policies were "
+                        "not enabled at server startup; nothing is blocked."
                     ),
                 },
             }

--- a/src/ha_mcp/tools/tools_dev.py
+++ b/src/ha_mcp/tools/tools_dev.py
@@ -1195,13 +1195,28 @@ class DevTools:
     def _commit_gate(self, plan: dict[str, Any], data: dict[str, Any]) -> list[str]:
         """Persist the gate portion of a set_tool plan; returns any warnings."""
         from ..config import get_global_settings
-        from ..policy.persistence import save_policy
+        from ..policy.persistence import load_policy, save_policy
         from ..utils.data_paths import get_data_dir
 
         data["gated"] = bool(plan["gate_val"])
         data["policy_rules_changed"] = plan["gate_changed"]
         if plan["gate_changed"]:
-            save_policy(get_data_dir(), plan["new_policy"])
+            data_dir = get_data_dir()
+            # Version re-check before the write. Under the write locks this
+            # never fires (preflight and commit share one locked section);
+            # it matters when config_file_lock degraded to no-op (exotic FS)
+            # — a concurrent cross-process save then surfaces as a loud
+            # retryable error instead of being silently clobbered.
+            current = load_policy(data_dir)
+            if current.version != plan["new_policy"].version:
+                raise_tool_error(
+                    create_error_response(
+                        ErrorCode.VALIDATION_INVALID_PARAMETER,
+                        "policy changed concurrently during set_tool; re-run the call",
+                        context={"current_version": current.version},
+                    )
+                )
+            save_policy(data_dir, plan["new_policy"])
             self._clear_remember_cache()
         warnings: list[str] = []
         if not get_global_settings().enable_tool_security_policies:
@@ -1749,7 +1764,12 @@ class DevTools:
         connection in embedded and add-on deployments (the reply
         arrives just before the server goes down) and supports those
         two deployments only (standalone processes must be restarted
-        externally).
+        externally). list_pending/approve/deny are exempt from policy
+        gating (gating queue management would deadlock approvals) —
+        and since gated-call errors include the approval token, an
+        agent can self-approve its own gated calls while dev mode is
+        on. Dev mode is a trusted-operator feature; leave it off
+        otherwise.
 
         EXAMPLES:
         ha_dev_manage_server("info")

--- a/src/ha_mcp/tools/tools_dev.py
+++ b/src/ha_mcp/tools/tools_dev.py
@@ -1009,15 +1009,54 @@ class DevTools:
                     "set_tool needs at least one of state / llm_api / gated",
                 )
             )
+        # Reject unknown tool names BEFORE persisting anything: a typo'd
+        # security gate ("ha_call_servce") would otherwise save a rule for a
+        # nonexistent tool and report success while the intended tool stays
+        # ungated. The metadata list includes feature-gated stubs, so a
+        # currently-unavailable tool is still configurable. Best-effort: a
+        # failed/empty metadata read skips validation (the guard is a typo
+        # net, not a security boundary — never brick set_tool over it).
+        try:
+            known = {t["name"] for t in await self._tool_metadata_rows()}
+        except Exception:
+            logger.debug(
+                "set_tool name validation skipped: metadata unavailable",
+                exc_info=True,
+            )
+            known = set()
+        if known and tool not in known:
+            raise_tool_error(
+                create_error_response(
+                    ErrorCode.VALIDATION_INVALID_PARAMETER,
+                    f"Unknown tool: {tool!r}",
+                    suggestions=[
+                        "Call ha_dev_manage_settings('list_tools') for valid names"
+                    ],
+                )
+            )
         # Serialize the tool_config + policy read-modify-write against the web
-        # save handlers and other set_tool calls via the shared lock (held on
-        # the loop while the file I/O runs in the worker thread).
+        # save handlers and other set_tool calls via the shared asyncio lock
+        # (held on the loop while the file I/O runs in the worker thread);
+        # the worker additionally takes the cross-process file lock so the
+        # stdio sidecar's handlers can't interleave from another process.
         from ..utils.config_write_lock import get_config_write_lock
 
         async with get_config_write_lock():
             return await asyncio.to_thread(
-                self._write_tool_all, tool, state, llm_api, gated
+                self._with_file_lock, self._write_tool_all, tool, state, llm_api, gated
             )
+
+    @staticmethod
+    def _with_file_lock(fn: Any, /, *args: Any) -> Any:
+        """Run ``fn(*args)`` holding the cross-process config file lock.
+
+        Thread-side companion of ``config_write_guard()``: callers hold the
+        asyncio lock on the loop, so the file lock never nests in-process.
+        """
+        from ..utils.config_write_lock import config_file_lock
+
+        with config_file_lock():
+            return fn(*args)
 
     def _write_tool_all(
         self, tool: str, state: str | None, llm_api: bool | None, gated: bool | None
@@ -1340,9 +1379,12 @@ class DevTools:
             if expected_version is not None
             else (new_policy.version if "version" in policy else None)
         )
-        # Serialize the load-check-save against the web PUT handler + set_tool.
+        # Serialize the load-check-save against the web PUT handler + set_tool
+        # (asyncio lock) and other processes (file lock, in the thread).
         async with get_config_write_lock():
-            return await asyncio.to_thread(self._commit_policy, new_policy, expected)
+            return await asyncio.to_thread(
+                self._with_file_lock, self._commit_policy, new_policy, expected
+            )
 
     def _commit_policy(self, new_policy: Any, expected: int | None) -> dict[str, Any]:
         """Load current policy, version-check against ``expected``, save, report.

--- a/src/ha_mcp/tools/tools_dev.py
+++ b/src/ha_mcp/tools/tools_dev.py
@@ -884,13 +884,18 @@ class DevTools:
         return load_tool_metadata_cache()
 
     @staticmethod
-    def _gated_tool_names() -> set[str]:
+    def _gated_tool_names() -> set[str] | None:
         """Tool names carrying the bare unconditional gate (the Tools-tab toggle).
 
         The Tools-tab per-tool gate toggle manages only the bare rule (no
         predicates); conditional rules are authored in the Policies tab. Keying
         this on the bare rule keeps the reported toggle state consistent with
         what set_tool(gated=...) writes.
+
+        Returns ``None`` when ``tool_policy.json`` is unreadable — the caller
+        must surface that (a silent ``set()`` would render every tool
+        ``gated=False``, indistinguishable from a clean no-gates policy, while
+        the sibling actions raise CONFIG_INVALID for the same file).
         """
         from ..policy.persistence import load_policy
         from ..utils.data_paths import get_data_dir
@@ -898,7 +903,7 @@ class DevTools:
         try:
             policy = load_policy(get_data_dir())
         except ValueError:
-            return set()
+            return None
         return {rule.tool_name for rule in policy.rules if not rule.when}
 
     async def _list_tool_states(self) -> dict[str, Any]:
@@ -924,6 +929,16 @@ class DevTools:
         env_pinned = env_pinned_tools()
         overrides = load_llm_api_overrides()
         gated = self._gated_tool_names()
+        warnings: list[str] = []
+        if gated is None:
+            # Degrade rather than fail the whole listing: states/exposure stay
+            # useful for troubleshooting, but the gate column must not read as
+            # a clean no-gates policy.
+            gated = set()
+            warnings.append(
+                "tool_policy.json is invalid; 'gated' is reported as false "
+                "for every tool. Call get_policy for the parse error."
+            )
         mandatory = effective_mandatory_tools(settings)
         bps_locked = set(_bps_locked_tools())
 
@@ -957,7 +972,7 @@ class DevTools:
             }
             for t in metadata
         ]
-        return {
+        result: dict[str, Any] = {
             "success": True,
             "data": {
                 "tools": rows,
@@ -971,6 +986,9 @@ class DevTools:
                 "llm_api_available": is_embedded(),
             },
         }
+        if warnings:
+            result["warnings"] = warnings
+        return result
 
     async def _apply_set_tool(
         self,
@@ -1309,9 +1327,16 @@ class DevTools:
 
         has_bare = any(r.tool_name == tool and not r.when for r in policy.rules)
         if gated and not has_bare:
-            updated = policy.model_copy(
-                update={"rules": [*policy.rules, Rule(tool_name=tool)]}
+            # Insert before the first wildcard rule (mirrors the web UI's
+            # wildcardInsertIndex): find_matching_rule() is first-match, so a
+            # gate appended after a `*` rule would never supply this tool's
+            # remember_minutes / matched_rule.
+            rules = list(policy.rules)
+            insert_at = next(
+                (i for i, r in enumerate(rules) if r.tool_name == "*"), len(rules)
             )
+            rules.insert(insert_at, Rule(tool_name=tool))
+            updated = policy.model_copy(update={"rules": rules})
             return updated, True
         if not gated and has_bare:
             updated = policy.model_copy(

--- a/src/ha_mcp/utils/config_write_lock.py
+++ b/src/ha_mcp/utils/config_write_lock.py
@@ -1,0 +1,30 @@
+"""Process-wide async lock serialising config/policy read-modify-write.
+
+Both the web settings handlers (async) and the developer tools (which run
+their file I/O in ``asyncio.to_thread`` while holding this lock on the event
+loop) acquire this single lock around any load-modify-save of
+``tool_config.json`` or ``tool_policy.json``, so two concurrent writers can't
+read the same on-disk state and then clobber each other's update.
+
+Lazy construction mirrors ``settings_ui._persistence._get_override_file_lock``:
+``asyncio.Lock`` binds to the running loop on first ``acquire()``, so a test
+fixture with its own loop isn't locked into an import-time loop. Assumes the
+single-uvicorn-loop deployment every ha-mcp server uses.
+
+Leaf module (only stdlib imports) so settings_ui, policy, and tools can all
+depend on it without an import cycle.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+_CONFIG_WRITE_LOCK: asyncio.Lock | None = None
+
+
+def get_config_write_lock() -> asyncio.Lock:
+    """Return the shared config/policy write lock (lazy singleton)."""
+    global _CONFIG_WRITE_LOCK
+    if _CONFIG_WRITE_LOCK is None:
+        _CONFIG_WRITE_LOCK = asyncio.Lock()
+    return _CONFIG_WRITE_LOCK

--- a/src/ha_mcp/utils/config_write_lock.py
+++ b/src/ha_mcp/utils/config_write_lock.py
@@ -18,6 +18,21 @@ depend on it without an import cycle.
 from __future__ import annotations
 
 import asyncio
+import contextlib
+import logging
+import os
+from collections.abc import AsyncIterator, Iterator
+
+try:  # POSIX
+    import fcntl
+except ImportError:  # pragma: no cover - Windows
+    fcntl = None  # type: ignore[assignment]
+try:  # Windows
+    import msvcrt
+except ImportError:  # pragma: no cover - POSIX
+    msvcrt = None  # type: ignore[assignment]
+
+logger = logging.getLogger(__name__)
 
 _CONFIG_WRITE_LOCK: asyncio.Lock | None = None
 
@@ -28,3 +43,72 @@ def get_config_write_lock() -> asyncio.Lock:
     if _CONFIG_WRITE_LOCK is None:
         _CONFIG_WRITE_LOCK = asyncio.Lock()
     return _CONFIG_WRITE_LOCK
+
+
+@contextlib.asynccontextmanager
+async def config_write_guard() -> AsyncIterator[None]:
+    """Both write locks at once: in-process (asyncio) + cross-process (file).
+
+    The one-liner for async writers: serializes against other coroutines in
+    this process AND against the sidecar / other server processes. Thread
+    writers (the dev tools' ``asyncio.to_thread`` sections) hold the asyncio
+    lock on the loop and take ``config_file_lock()`` inside the thread
+    instead.
+    """
+    async with get_config_write_lock():
+        with config_file_lock():
+            yield
+
+
+@contextlib.contextmanager
+def config_file_lock() -> Iterator[None]:
+    """Advisory CROSS-PROCESS lock over the config/policy write files.
+
+    The asyncio lock above only serializes writers within one process, but
+    stdio deployments run the settings-UI sidecar as a SEPARATE process from
+    the MCP server: a sidecar policy PUT and a dev-tool write could both read
+    the same on-disk version and silently drop each other's update. Acquire
+    this (an ``flock``/``msvcrt.locking`` on a lockfile in the data dir)
+    inside the asyncio-locked sections, so the version compare-and-swap also
+    holds across processes.
+
+    Best-effort by design: on filesystems or platforms where locking fails,
+    a warning is logged and the write proceeds (matching the previous
+    behavior) rather than bricking config saves. Never acquire twice in one
+    process (the asyncio lock already prevents that; nested flock on a second
+    fd would self-block).
+    """
+    from .data_paths import get_data_dir
+
+    fd: int | None = None
+    locked = False
+    try:
+        try:
+            fd = os.open(
+                get_data_dir() / ".config_write.lock", os.O_CREAT | os.O_RDWR, 0o600
+            )
+            if fcntl is not None:
+                fcntl.flock(fd, fcntl.LOCK_EX)
+                locked = True
+            elif msvcrt is not None:  # pragma: no cover - Windows
+                os.lseek(fd, 0, os.SEEK_SET)
+                msvcrt.locking(fd, msvcrt.LK_LOCK, 1)
+                locked = True
+        except OSError:
+            logger.warning(
+                "config write lockfile unavailable; proceeding without "
+                "cross-process lock",
+                exc_info=True,
+            )
+        yield
+    finally:
+        if fd is not None:
+            with contextlib.suppress(OSError):
+                if locked:
+                    if fcntl is not None:
+                        fcntl.flock(fd, fcntl.LOCK_UN)
+                    elif msvcrt is not None:  # pragma: no cover - Windows
+                        os.lseek(fd, 0, os.SEEK_SET)
+                        msvcrt.locking(fd, msvcrt.LK_UNLCK, 1)
+            with contextlib.suppress(OSError):
+                os.close(fd)

--- a/src/ha_mcp/utils/config_write_lock.py
+++ b/src/ha_mcp/utils/config_write_lock.py
@@ -11,8 +11,9 @@ Lazy construction mirrors ``settings_ui._persistence._get_override_file_lock``:
 fixture with its own loop isn't locked into an import-time loop. Assumes the
 single-uvicorn-loop deployment every ha-mcp server uses.
 
-Leaf module (only stdlib imports) so settings_ui, policy, and tools can all
-depend on it without an import cycle.
+Leaf at import time (stdlib-only at module scope; ``data_paths`` is imported
+lazily inside ``config_file_lock`` — keep it that way) so settings_ui, policy,
+and tools can all depend on it without an import cycle.
 """
 
 from __future__ import annotations

--- a/src/ha_mcp/utils/config_write_lock.py
+++ b/src/ha_mcp/utils/config_write_lock.py
@@ -23,6 +23,7 @@ import contextlib
 import logging
 import os
 from collections.abc import AsyncIterator, Iterator
+from pathlib import Path
 
 try:  # POSIX
     import fcntl
@@ -55,15 +56,30 @@ async def config_write_guard() -> AsyncIterator[None]:
     writers (the dev tools' ``asyncio.to_thread`` sections) hold the asyncio
     lock on the loop and take ``config_file_lock()`` inside the thread
     instead.
+
+    The file lock is acquired and released in a worker thread: ``flock`` is a
+    blocking syscall, and taking it on the event loop would stall every
+    connected client whenever another process holds the lock (or the data dir
+    sits on a filesystem where locking is slow). Cross-thread enter/exit is
+    safe — flock and msvcrt locks belong to the open file description, not
+    the acquiring thread.
     """
     async with get_config_write_lock():
-        with config_file_lock():
+        file_lock = config_file_lock()
+        await asyncio.to_thread(file_lock.__enter__)
+        try:
             yield
+        finally:
+            await asyncio.to_thread(file_lock.__exit__, None, None, None)
 
 
 @contextlib.contextmanager
-def config_file_lock() -> Iterator[None]:
+def config_file_lock(data_dir: Path | None = None) -> Iterator[None]:
     """Advisory CROSS-PROCESS lock over the config/policy write files.
+
+    ``data_dir`` overrides the lockfile directory (default: the live data
+    dir) — pass it when operating on an explicit directory, as the policy
+    migration does, so the lock lives beside the files it guards.
 
     The asyncio lock above only serializes writers within one process, but
     stdio deployments run the settings-UI sidecar as a SEPARATE process from
@@ -81,13 +97,12 @@ def config_file_lock() -> Iterator[None]:
     """
     from .data_paths import get_data_dir
 
+    lock_dir = data_dir if data_dir is not None else get_data_dir()
     fd: int | None = None
     locked = False
     try:
         try:
-            fd = os.open(
-                get_data_dir() / ".config_write.lock", os.O_CREAT | os.O_RDWR, 0o600
-            )
+            fd = os.open(lock_dir / ".config_write.lock", os.O_CREAT | os.O_RDWR, 0o600)
             if fcntl is not None:
                 fcntl.flock(fd, fcntl.LOCK_EX)
                 locked = True

--- a/tests/src/e2e/policy/test_approval_flow.py
+++ b/tests/src/e2e/policy/test_approval_flow.py
@@ -197,6 +197,54 @@ async def _install_rule(handlers, rule: dict[str, Any]) -> None:
     assert put_resp.status_code == 200, put_resp.body
 
 
+async def _install_rules(handlers, rules: list[dict[str, Any]]) -> None:
+    current_resp = await handlers["policy_get_config"](_make_request())
+    current = json.loads(current_resp.body)
+    body = {
+        "wait_seconds": 5,
+        "approval_ttl_minutes": 5,
+        "rules": rules,
+        "version": current["version"],
+    }
+    put_resp = await handlers["policy_put_config"](_make_request(body))
+    assert put_resp.status_code == 200, put_resp.body
+
+
+@pytest.mark.asyncio
+async def test_any_of_multiple_conditions_gates(policy_enabled_mcp):
+    """Each policy condition is its own rule; a call matching ANY of them is
+    gated (OR across same-tool rules) — end-to-end proof of the ALL->ANY editor
+    change (PR #1993). A call matching the SECOND condition still blocks."""
+    client, server, handlers = policy_enabled_mcp
+    await _install_rules(
+        handlers,
+        [
+            {
+                "tool_name": "ha_call_service",
+                "when": [{"path": "args.domain", "op": "eq", "value": "lock"}],
+                "remember_minutes": 0,
+            },
+            {
+                "tool_name": "ha_call_service",
+                "when": [
+                    {"path": "args.domain", "op": "eq", "value": "alarm_control_panel"}
+                ],
+                "remember_minutes": 0,
+            },
+        ],
+    )
+    # Matches the SECOND condition only → still gated (OR, not AND).
+    await _expect_blocked(
+        client,
+        {
+            "domain": "alarm_control_panel",
+            "service": "alarm_disarm",
+            "entity_id": "alarm_control_panel.home",
+        },
+    )
+    assert server.approval_queue.list_pending()
+
+
 @pytest.mark.asyncio
 async def test_wildcard_path_gates_when_any_arg_matches(policy_enabled_mcp):
     """`args.*` fans out: blocks when ANY arg equals the gated value."""

--- a/tests/src/unit/policy/test_evaluator.py
+++ b/tests/src/unit/policy/test_evaluator.py
@@ -167,6 +167,37 @@ class TestEvaluate:
         assert first is not None
         assert first.remember_minutes == 10
 
+    def test_any_of_multiple_same_tool_rules_gates(self):
+        """Each UI 'condition' persists as its own rule; the tool gates if ANY
+        of them matches (OR across rules), even when the others don't. This is
+        the semantics behind the ALL->ANY policy-editor change (PR #1993)."""
+        p = Policy(
+            rules=[
+                Rule(
+                    tool_name="ha_call_service",
+                    when=[Predicate(path="args.domain", op="eq", value="lock")],
+                ),
+                Rule(
+                    tool_name="ha_call_service",
+                    when=[
+                        Predicate(
+                            path="args.domain", op="eq", value="alarm_control_panel"
+                        )
+                    ],
+                ),
+            ],
+        )
+        assert (
+            evaluate("ha_call_service", {"domain": "lock"}, p)
+            == Verdict.REQUIRE_APPROVAL
+        )
+        assert (
+            evaluate("ha_call_service", {"domain": "alarm_control_panel"}, p)
+            == Verdict.REQUIRE_APPROVAL
+        )
+        # Neither condition matches -> allowed.
+        assert evaluate("ha_call_service", {"domain": "light"}, p) == Verdict.ALLOW
+
 
 # --- case-insensitive string comparison ---
 class TestCaseInsensitive:

--- a/tests/src/unit/policy/test_middleware.py
+++ b/tests/src/unit/policy/test_middleware.py
@@ -417,3 +417,33 @@ async def test_swept_pending_during_wait_is_reissued_with_fresh_token(queue):
         "reissue branch must create a fresh, queryable entry"
     )
     assert queue.get(original_token) is None
+
+
+class TestApprovalManagementExemption:
+    """Queue-management dev-tool actions must never themselves be gated.
+
+    With a wildcard (or ha_dev_manage_server) rule, gating "approve" would
+    create a SECOND pending entry instead of deciding the first — an
+    MCP-only approval workflow would deadlock (Codex #1993 P1).
+    """
+
+    def test_queue_management_actions_exempt(self):
+        from ha_mcp.policy.middleware import _is_approval_management
+
+        for action in ("list_pending", "approve", "deny"):
+            assert _is_approval_management(
+                "ha_dev_manage_server", {"action": action, "token": "t"}
+            )
+
+    def test_other_actions_and_tools_not_exempt(self):
+        from ha_mcp.policy.middleware import _is_approval_management
+
+        for action in ("info", "update_source", "restart"):
+            assert not _is_approval_management(
+                "ha_dev_manage_server", {"action": action}
+            )
+        assert not _is_approval_management(
+            "ha_dev_manage_settings", {"action": "approve"}
+        )
+        assert not _is_approval_management("ha_call_service", {"action": "approve"})
+        assert not _is_approval_management("ha_dev_manage_server", {})

--- a/tests/src/unit/policy/test_middleware.py
+++ b/tests/src/unit/policy/test_middleware.py
@@ -447,3 +447,38 @@ class TestApprovalManagementExemption:
         )
         assert not _is_approval_management("ha_call_service", {"action": "approve"})
         assert not _is_approval_management("ha_dev_manage_server", {})
+
+
+class TestApprovalManagementExemptionMiddleware:
+    """Drive the exemption through ``on_call_tool`` itself, not just the pure
+    ``_is_approval_management`` helper. Under a wildcard policy the queue-
+    management actions must reach ``call_next`` (so an MCP-only approval flow
+    can decide the first pending entry), while the high-stakes actions on the
+    same tool stay gated (Codex #1993 P1)."""
+
+    @pytest.mark.anyio
+    @pytest.mark.parametrize("action", ["list_pending", "approve", "deny"])
+    async def test_queue_management_action_passes_through(self, queue, action):
+        pol = Policy(rules=[Rule(tool_name="*")])
+        mw = PolicyMiddleware(policy_provider=lambda: pol, queue=queue, wait_seconds=0)
+        call_next = AsyncMock(return_value="passed")
+        result = await mw.on_call_tool(
+            make_context("ha_dev_manage_server", {"action": action, "token": "t"}),
+            call_next,
+        )
+        assert result == "passed"
+        call_next.assert_awaited_once()
+
+    @pytest.mark.anyio
+    @pytest.mark.parametrize("action", ["update_source", "restart"])
+    async def test_non_management_action_stays_gated(self, queue, action):
+        pol = Policy(rules=[Rule(tool_name="*")])
+        mw = PolicyMiddleware(policy_provider=lambda: pol, queue=queue, wait_seconds=0)
+        call_next = AsyncMock(return_value="should_not_run")
+        with pytest.raises(ToolError) as ei:
+            await mw.on_call_tool(
+                make_context("ha_dev_manage_server", {"action": action}), call_next
+            )
+        body = json.loads(ei.value.args[0])
+        assert body["error"]["code"] == "USER_APPROVAL_REQUIRED"
+        call_next.assert_not_called()

--- a/tests/src/unit/policy/test_persistence.py
+++ b/tests/src/unit/policy/test_persistence.py
@@ -83,4 +83,6 @@ def test_serialized_shape_is_stable(tmp_path: Path):
         "approval_ttl_minutes",
         "rules",
         "version",
+        # ANY-match schema marker (PR #1993) — see migrate_policy_any_semantics.
+        "schema_version",
     }

--- a/tests/src/unit/policy/test_persistence_migration.py
+++ b/tests/src/unit/policy/test_persistence_migration.py
@@ -1,0 +1,139 @@
+"""Tests for the one-time ANY-match policy schema migration (PR #1993).
+
+Pre-#1993 policy files pack every UI condition into one rule with the
+predicates AND-ed. ``migrate_policy_any_semantics`` splits those rules
+(one rule per predicate = one rule per old UI condition) exactly once,
+stamping ``schema_version`` so hand-authored multi-predicate rules created
+AFTER the upgrade (a condition with AND-ed sub-parameters) are never split.
+"""
+
+import json
+
+from ha_mcp.policy.model import POLICY_SCHEMA_VERSION, Policy, Predicate, Rule
+from ha_mcp.policy.persistence import (
+    POLICY_FILENAME,
+    load_policy,
+    migrate_policy_any_semantics,
+    save_policy,
+)
+
+
+def _write_raw(tmp_path, payload: dict) -> None:
+    (tmp_path / POLICY_FILENAME).write_text(json.dumps(payload))
+
+
+def _read_raw(tmp_path) -> dict:
+    return json.loads((tmp_path / POLICY_FILENAME).read_text())
+
+
+class TestMigration:
+    def test_unstamped_multi_predicate_rule_is_split(self, tmp_path):
+        _write_raw(
+            tmp_path,
+            {
+                "wait_seconds": 30,
+                "approval_ttl_minutes": 5,
+                "version": 4,
+                "rules": [
+                    {
+                        "tool_name": "ha_call_service",
+                        "when": [
+                            {"path": "args.domain", "op": "eq", "value": "lock"},
+                            {"path": "args.service", "op": "eq", "value": "unlock"},
+                            {"path": "args.entity_id", "op": "exists"},
+                        ],
+                        "remember_minutes": 7,
+                    },
+                    {"tool_name": "ha_restart", "when": [], "remember_minutes": 0},
+                ],
+            },
+        )
+        assert migrate_policy_any_semantics(tmp_path) is True
+        migrated = load_policy(tmp_path)
+        # 3 predicates -> 3 single-predicate rules; the bare rule untouched.
+        service_rules = [r for r in migrated.rules if r.tool_name == "ha_call_service"]
+        assert len(service_rules) == 3
+        assert all(len(r.when) == 1 for r in service_rules)
+        assert all(r.remember_minutes == 7 for r in service_rules)
+        assert [r.tool_name for r in migrated.rules].count("ha_restart") == 1
+        # Stamped + version bumped by the save.
+        assert migrated.schema_version == POLICY_SCHEMA_VERSION
+        assert migrated.version == 5
+        # Globals preserved.
+        assert migrated.wait_seconds == 30
+
+    def test_unstamped_single_predicate_file_is_stamped_without_split(self, tmp_path):
+        _write_raw(
+            tmp_path,
+            {
+                "rules": [
+                    {
+                        "tool_name": "ha_call_service",
+                        "when": [{"path": "args.domain", "op": "eq", "value": "lock"}],
+                        "remember_minutes": 0,
+                    }
+                ],
+                "version": 0,
+            },
+        )
+        assert migrate_policy_any_semantics(tmp_path) is True
+        migrated = load_policy(tmp_path)
+        assert len(migrated.rules) == 1
+        assert len(migrated.rules[0].when) == 1
+        assert _read_raw(tmp_path)["schema_version"] == POLICY_SCHEMA_VERSION
+
+    def test_stamped_multi_predicate_rule_is_preserved(self, tmp_path):
+        # Post-upgrade: a condition with AND-ed sub-parameters must survive
+        # restarts un-split.
+        save_policy(
+            tmp_path,
+            Policy(
+                rules=[
+                    Rule(
+                        tool_name="ha_call_service",
+                        when=[
+                            Predicate(path="args.domain", op="eq", value="lock"),
+                            Predicate(path="args.service", op="eq", value="unlock"),
+                        ],
+                    )
+                ]
+            ),
+        )
+        assert _read_raw(tmp_path)["schema_version"] == POLICY_SCHEMA_VERSION
+        assert migrate_policy_any_semantics(tmp_path) is False
+        kept = load_policy(tmp_path)
+        assert len(kept.rules) == 1
+        assert len(kept.rules[0].when) == 2
+
+    def test_migration_runs_once(self, tmp_path):
+        _write_raw(
+            tmp_path,
+            {
+                "rules": [
+                    {
+                        "tool_name": "t",
+                        "when": [
+                            {"path": "a", "op": "exists"},
+                            {"path": "b", "op": "exists"},
+                        ],
+                        "remember_minutes": 0,
+                    }
+                ],
+                "version": 0,
+            },
+        )
+        assert migrate_policy_any_semantics(tmp_path) is True
+        assert migrate_policy_any_semantics(tmp_path) is False  # stamped now
+
+    def test_missing_file_is_noop(self, tmp_path):
+        assert migrate_policy_any_semantics(tmp_path) is False
+        assert not (tmp_path / POLICY_FILENAME).exists()
+
+    def test_corrupt_file_left_alone(self, tmp_path):
+        (tmp_path / POLICY_FILENAME).write_text("not json {{{")
+        assert migrate_policy_any_semantics(tmp_path) is False
+        assert (tmp_path / POLICY_FILENAME).read_text() == "not json {{{"
+
+    def test_invalid_schema_left_alone(self, tmp_path):
+        _write_raw(tmp_path, {"rules": [{"tool_name": ""}], "version": 0})
+        assert migrate_policy_any_semantics(tmp_path) is False

--- a/tests/src/unit/policy/test_persistence_migration.py
+++ b/tests/src/unit/policy/test_persistence_migration.py
@@ -137,3 +137,23 @@ class TestMigration:
     def test_invalid_schema_left_alone(self, tmp_path):
         _write_raw(tmp_path, {"rules": [{"tool_name": ""}], "version": 0})
         assert migrate_policy_any_semantics(tmp_path) is False
+
+    def test_migration_holds_cross_process_lock(self, tmp_path, monkeypatch):
+        # The read-split-save must run under config_file_lock(data_dir) so a
+        # concurrent writer in another process (the stdio sidecar) can't
+        # interleave with the migration (Patch76 review).
+        import contextlib
+
+        from ha_mcp.utils import config_write_lock as cwl
+
+        entered: list = []
+
+        @contextlib.contextmanager
+        def recording_lock(data_dir=None):
+            entered.append(data_dir)
+            yield
+
+        monkeypatch.setattr(cwl, "config_file_lock", recording_lock)
+        _write_raw(tmp_path, {"rules": [], "version": 0})
+        migrate_policy_any_semantics(tmp_path)
+        assert entered == [tmp_path]

--- a/tests/src/unit/test_config_write_lock.py
+++ b/tests/src/unit/test_config_write_lock.py
@@ -1,0 +1,55 @@
+"""Tests for the cross-process config write lock (#1993 round 3)."""
+
+import threading
+
+from ha_mcp.utils.config_write_lock import config_file_lock
+from ha_mcp.utils.data_paths import get_data_dir
+
+
+class TestConfigFileLock:
+    def test_acquire_release_reacquire(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HA_MCP_CONFIG_DIR", str(tmp_path))
+        get_data_dir.cache_clear()
+        try:
+            with config_file_lock():
+                pass
+            with config_file_lock():  # released cleanly -> reacquirable
+                pass
+            assert (tmp_path / ".config_write.lock").exists()
+        finally:
+            get_data_dir.cache_clear()
+
+    def test_excludes_other_holders(self, tmp_path, monkeypatch):
+        # flock is per open-file-description, so a second holder (thread here,
+        # another PROCESS in production) blocks until release.
+        monkeypatch.setenv("HA_MCP_CONFIG_DIR", str(tmp_path))
+        get_data_dir.cache_clear()
+        order: list[str] = []
+        held = threading.Event()
+        release = threading.Event()
+
+        def holder():
+            with config_file_lock():
+                order.append("A-acquired")
+                held.set()
+                release.wait(timeout=5)
+                order.append("A-releasing")
+
+        def contender():
+            held.wait(timeout=5)
+            with config_file_lock():
+                order.append("B-acquired")
+
+        try:
+            a = threading.Thread(target=holder)
+            b = threading.Thread(target=contender)
+            a.start()
+            b.start()
+            held.wait(timeout=5)
+            release.set()
+            a.join(timeout=5)
+            b.join(timeout=5)
+            assert order == ["A-acquired", "A-releasing", "B-acquired"]
+        finally:
+            release.set()
+            get_data_dir.cache_clear()

--- a/tests/src/unit/test_config_write_lock.py
+++ b/tests/src/unit/test_config_write_lock.py
@@ -1,8 +1,12 @@
 """Tests for the cross-process config write lock (#1993 round 3)."""
 
+import asyncio
+import contextlib
 import threading
+import time
 
-from ha_mcp.utils.config_write_lock import config_file_lock
+from ha_mcp.utils import config_write_lock as cwl
+from ha_mcp.utils.config_write_lock import config_file_lock, config_write_guard
 from ha_mcp.utils.data_paths import get_data_dir
 
 
@@ -53,3 +57,36 @@ class TestConfigFileLock:
         finally:
             release.set()
             get_data_dir.cache_clear()
+
+
+class TestConfigWriteGuard:
+    async def test_event_loop_stays_live_while_file_lock_blocks(self, monkeypatch):
+        # config_write_guard must take the (blocking) file lock in a worker
+        # thread: a slow flock on the event loop would stall every connected
+        # client. Simulate a slow lock and assert other coroutines keep
+        # running during acquisition.
+        @contextlib.contextmanager
+        def slow_lock():
+            time.sleep(0.3)
+            yield
+
+        monkeypatch.setattr(cwl, "config_file_lock", slow_lock)
+        ticks = 0
+
+        async def ticker():
+            nonlocal ticks
+            while True:
+                ticks += 1
+                await asyncio.sleep(0.01)
+
+        task = asyncio.create_task(ticker())
+        try:
+            async with config_write_guard():
+                pass
+        finally:
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
+        # A blocked loop would leave the ticker at ~0; the thread hop keeps
+        # it running throughout the 0.3s acquisition (margin for slow CI).
+        assert ticks >= 5

--- a/tests/src/unit/test_config_write_lock.py
+++ b/tests/src/unit/test_config_write_lock.py
@@ -85,8 +85,9 @@ class TestConfigWriteGuard:
                 pass
         finally:
             task.cancel()
-            with contextlib.suppress(asyncio.CancelledError):
-                await task
+            # gather (not a bare `await task`) so the CodeQL quality gate
+            # doesn't flag py/ineffectual-statement on the drain.
+            await asyncio.gather(task, return_exceptions=True)
         # A blocked loop would leave the ticker at ~0; the thread hop keeps
         # it running throughout the 0.3s acquisition (margin for slow CI).
         assert ticks >= 5

--- a/tests/src/unit/test_json_string_param_coercion.py
+++ b/tests/src/unit/test_json_string_param_coercion.py
@@ -237,3 +237,96 @@ def test_list_param_rejects_json_string_of_object(
     ann = _get_param_annotation(_resolve(module, register_fn), tool_name, param_name)
     with pytest.raises(ValidationError):
         TypeAdapter(ann).validate_python('{"entity_id": "light.kitchen"}')
+
+
+# ---------------------------------------------------------------------------
+# Dev-tool dict params (ha_dev_manage_settings policy / backup)
+#
+# These carry the same JSON_STRING_COERCION as the config-tool params, but
+# register_dev_tools no-ops unless developer mode is on, so the shared
+# parametrization above can never reach them. Enable the flag, reset the
+# cached settings singleton so registration sees it, and register in a
+# dedicated class.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def dev_mode_enabled(monkeypatch):
+    from ha_mcp.config import reset_global_settings
+
+    monkeypatch.setenv("HAMCP_ENABLE_DEV_MODE", "true")
+    reset_global_settings()
+    try:
+        yield
+    finally:
+        # Drop the flag *before* re-reading so later tests see dev mode off.
+        monkeypatch.delenv("HAMCP_ENABLE_DEV_MODE", raising=False)
+        reset_global_settings()
+
+
+_DEV_DICT_PARAMS = [
+    (
+        "ha_mcp.tools.tools_dev",
+        "register_dev_tools",
+        "ha_dev_manage_settings",
+        "policy",
+    ),
+    (
+        "ha_mcp.tools.tools_dev",
+        "register_dev_tools",
+        "ha_dev_manage_settings",
+        "backup",
+    ),
+]
+
+_DEV_DICT_SAMPLES: dict[tuple[str, str], dict[str, Any]] = {
+    ("ha_dev_manage_settings", "policy"): {
+        "wait_seconds": 30,
+        "approval_ttl_minutes": 5,
+        "rules": [],
+        "version": 0,
+    },
+    ("ha_dev_manage_settings", "backup"): {"enable_auto_backup": False},
+}
+
+
+class TestDevToolDictParamCoercion:
+    """The dev-mode set_policy/set_backup dict params round-trip a JSON string
+    just like the config-tool dict params — a stringified object is coerced,
+    a native dict passes through, and genuinely-malformed input still fails."""
+
+    @pytest.mark.parametrize(
+        ("module", "register_fn", "tool_name", "param_name"), _DEV_DICT_PARAMS
+    )
+    def test_dev_dict_param_coerces_json_string(
+        self, dev_mode_enabled, module, register_fn, tool_name, param_name
+    ):
+        sample = _DEV_DICT_SAMPLES[(tool_name, param_name)]
+        ann = _get_param_annotation(
+            _resolve(module, register_fn), tool_name, param_name
+        )
+        assert TypeAdapter(ann).validate_python(json.dumps(sample)) == sample
+
+    @pytest.mark.parametrize(
+        ("module", "register_fn", "tool_name", "param_name"), _DEV_DICT_PARAMS
+    )
+    def test_dev_dict_param_passes_native_dict_through(
+        self, dev_mode_enabled, module, register_fn, tool_name, param_name
+    ):
+        sample = _DEV_DICT_SAMPLES[(tool_name, param_name)]
+        ann = _get_param_annotation(
+            _resolve(module, register_fn), tool_name, param_name
+        )
+        assert TypeAdapter(ann).validate_python(sample) == sample
+
+    @pytest.mark.parametrize(
+        ("module", "register_fn", "tool_name", "param_name"), _DEV_DICT_PARAMS
+    )
+    def test_dev_dict_param_rejects_unparseable_string(
+        self, dev_mode_enabled, module, register_fn, tool_name, param_name
+    ):
+        ann = _get_param_annotation(
+            _resolve(module, register_fn), tool_name, param_name
+        )
+        with pytest.raises(ValidationError):
+            TypeAdapter(ann).validate_python("definitely not json {")

--- a/tests/src/unit/test_llm_exposure.py
+++ b/tests/src/unit/test_llm_exposure.py
@@ -138,7 +138,10 @@ class TestMiddleware:
         result = await mw.on_list_tools(_context(), AsyncMock(return_value=tools))
 
         by_name = {t.name: t.meta[META_NAMESPACE] for t in result}
-        assert by_name["ha_search"] == {META_EXPOSED_KEY: True, META_PINNED_KEY: True}
+        assert by_name["ha_search"][META_EXPOSED_KEY] is True
+        assert by_name["ha_search"][META_PINNED_KEY] is True
+        # The serving-server policy block rides the same namespace (#1990).
+        assert llm_exposure.META_POLICY_KEY in by_name["ha_search"]
         # Override exposes the default-hidden restart tool.
         assert by_name["ha_restart"][META_EXPOSED_KEY] is True
         assert by_name["ha_restart"][META_PINNED_KEY] is False
@@ -227,3 +230,55 @@ class TestMiddleware:
         )
         # The user-hidden tool STAYS hidden on the stale data.
         assert second[0].meta[META_NAMESPACE][META_EXPOSED_KEY] is False
+
+
+class TestPolicyStamp:
+    """The serving-server policy/identity block in _meta.ha_mcp (#1990).
+
+    A client pointed at a different server than the one the user configured
+    rules on previously failed SILENTLY — calls executed ungated with nothing
+    on the wire saying "this server has zero rules". The stamp makes the
+    serving server's actual gating state visible on every tools/list.
+    """
+
+    async def test_policy_block_reflects_rules_and_live_state(
+        self, monkeypatch, tmp_path
+    ):
+        from ha_mcp.policy.model import Policy, Rule
+        from ha_mcp.policy.persistence import save_policy
+        from ha_mcp.utils.data_paths import get_data_dir
+
+        monkeypatch.setenv("HA_MCP_CONFIG_DIR", str(tmp_path))
+        get_data_dir.cache_clear()
+        save_policy(tmp_path, Policy(rules=[Rule(tool_name="ha_call_service")]))
+        monkeypatch.setattr(llm_exposure, "load_llm_api_overrides", dict)
+        monkeypatch.setattr(llm_exposure, "_pinned_tool_names", set)
+
+        mw = LlmExposureMiddleware(policy_live=lambda: True)
+        result = await mw.on_list_tools(
+            _context(), AsyncMock(return_value=[_tool("ha_get_state")])
+        )
+        block = result[0].meta[META_NAMESPACE][llm_exposure.META_POLICY_KEY]
+        assert block["rules"] == 1
+        assert block["live"] is True
+        assert block["deployment"] in ("embedded", "addon", "standalone")
+        get_data_dir.cache_clear()
+
+    async def test_policy_block_defaults_without_queue_or_file(
+        self, monkeypatch, tmp_path
+    ):
+        from ha_mcp.utils.data_paths import get_data_dir
+
+        monkeypatch.setenv("HA_MCP_CONFIG_DIR", str(tmp_path))
+        get_data_dir.cache_clear()
+        monkeypatch.setattr(llm_exposure, "load_llm_api_overrides", dict)
+        monkeypatch.setattr(llm_exposure, "_pinned_tool_names", set)
+
+        mw = LlmExposureMiddleware()  # no policy_live callable
+        result = await mw.on_list_tools(
+            _context(), AsyncMock(return_value=[_tool("ha_get_state")])
+        )
+        block = result[0].meta[META_NAMESPACE][llm_exposure.META_POLICY_KEY]
+        assert block["live"] is False
+        assert block["rules"] == 0
+        get_data_dir.cache_clear()

--- a/tests/src/unit/test_server_policy_wiring.py
+++ b/tests/src/unit/test_server_policy_wiring.py
@@ -65,3 +65,45 @@ def test_policy_middleware_not_attached_when_disabled():
     assert getattr(stub, "approval_queue", None) is None
     # No middleware registered on the FastMCP instance
     assert stub.mcp.add_middleware.call_count == 0
+
+
+def test_migration_runs_even_when_policies_disabled():
+    """The ANY-match schema migration must run at startup regardless of the
+    enable flag, so the file already matches the editor's semantics whenever
+    the user later turns the feature on. The method imports
+    ``migrate_policy_any_semantics`` from ``ha_mcp.policy.persistence`` at call
+    time, so patching the source module intercepts it."""
+    from unittest.mock import patch
+
+    from ha_mcp.server import HomeAssistantSmartMCPServer
+    from ha_mcp.utils.data_paths import get_data_dir
+
+    stub = _make_server_stub(enable_policies=False)
+    with patch(
+        "ha_mcp.policy.persistence.migrate_policy_any_semantics"
+    ) as mock_migrate:
+        HomeAssistantSmartMCPServer._apply_tool_security_policies(stub)
+
+    mock_migrate.assert_called_once_with(get_data_dir())
+    # Disabled path is otherwise a clean no-op: no queue, no middleware.
+    assert getattr(stub, "approval_queue", None) is None
+    assert stub.mcp.add_middleware.call_count == 0
+
+
+def test_raising_migration_does_not_block_startup():
+    """A migration that raises must be swallowed — startup continues. A
+    crash here would take down every server boot over a one-time data fixup."""
+    from unittest.mock import patch
+
+    from ha_mcp.server import HomeAssistantSmartMCPServer
+
+    stub = _make_server_stub(enable_policies=False)
+    with patch(
+        "ha_mcp.policy.persistence.migrate_policy_any_semantics",
+        side_effect=RuntimeError("migration boom"),
+    ):
+        # Must not propagate out of _apply_tool_security_policies.
+        HomeAssistantSmartMCPServer._apply_tool_security_policies(stub)
+
+    assert getattr(stub, "approval_queue", None) is None
+    assert stub.mcp.add_middleware.call_count == 0

--- a/tests/src/unit/test_settings_ui_js_behavior.py
+++ b/tests/src/unit/test_settings_ui_js_behavior.py
@@ -1375,6 +1375,56 @@ class TestPolicyTabFlow:
         assert len(rules) == 1, f"multi-predicate condition was split: {rules}"
         assert len(rules[0]["when"]) == 2
 
+    def test_save_rule_preserves_rule_order(self, settings_script: str) -> None:
+        """Saving a card must replace the tool's rules IN PLACE — rule order
+        is behaviorally significant (find_matching_rule takes the FIRST
+        match's remember_minutes), so a tool rule must not slide behind a
+        wildcard rule on edit (Codex #1993 round 3)."""
+        fetches = {
+            **DEFAULT_FETCHES,
+            "/api/policy/config": {
+                "status": 200,
+                "json": {
+                    "wait_seconds": 60,
+                    "approval_ttl_minutes": 5,
+                    "version": 1,
+                    "rules": [
+                        {
+                            "tool_name": "ha_call_service",
+                            "when": [
+                                {"path": "args.domain", "op": "eq", "value": "lock"}
+                            ],
+                            "remember_minutes": 5,
+                        },
+                        {"tool_name": "*", "when": [], "remember_minutes": 60},
+                    ],
+                },
+            },
+        }
+        result = run_script(
+            settings_script,
+            initial_html=_policy_panel_dom(),
+            fetch_map=fetches,
+            invoke="""
+              await window.savePolicyRule('ha_call_service', {
+                tool_name: 'ha_call_service',
+                conditions: [[{path: 'args.domain', op: 'eq', value: 'lock'}]],
+                remember_minutes: 5
+              });
+            """,
+        )
+        _assert_clean_init(result)
+        puts = [
+            f
+            for f in result.fetches
+            if f["method"] == "PUT" and "/api/policy/config" in f["url"]
+        ]
+        assert len(puts) == 1
+        rules = json.loads(puts[0]["body"])["rules"]
+        assert [r["tool_name"] for r in rules] == ["ha_call_service", "*"], (
+            f"tool rule moved behind the wildcard: {rules}"
+        )
+
     def test_pending_list_shows_off_message_when_feature_disabled(
         self, settings_script: str
     ) -> None:

--- a/tests/src/unit/test_settings_ui_js_behavior.py
+++ b/tests/src/unit/test_settings_ui_js_behavior.py
@@ -1241,6 +1241,95 @@ class TestPolicyTabFlow:
         assert len(rules) == 1, f"conditional rule was wrongly removed: {rules}"
         assert rules[0]["when"], "expected the predicate-bearing rule to remain"
 
+    def test_gate_toggle_on_adds_bare_rule_beside_conditional(
+        self, settings_script: str
+    ) -> None:
+        """Enable direction: turning the Tools-tab gate ON when a conditional
+        rule already exists must ADD the bare unconditional rule (not silently
+        no-op), so the tool is gated for every call."""
+        fetches = {
+            **DEFAULT_FETCHES,
+            "/api/policy/config": {
+                "status": 200,
+                "json": {
+                    "wait_seconds": 60,
+                    "approval_ttl_minutes": 5,
+                    "version": 2,
+                    "rules": [
+                        {
+                            "tool_name": "ha_call_service",
+                            "when": [
+                                {"path": "args.domain", "op": "eq", "value": "lock"}
+                            ],
+                            "remember_minutes": 0,
+                        }
+                    ],
+                },
+            },
+        }
+        result = run_script(
+            settings_script,
+            initial_html=_policy_panel_dom(),
+            fetch_map=fetches,
+            invoke="await window.syncPolicyRule('ha_call_service', true);",
+        )
+        _assert_clean_init(result)
+        puts = [
+            f
+            for f in result.fetches
+            if f["method"] == "PUT" and "/api/policy/config" in f["url"]
+        ]
+        assert len(puts) == 1
+        rules = json.loads(puts[0]["body"])["rules"]
+        assert len(rules) == 2
+        assert any(r["tool_name"] == "ha_call_service" and not r["when"] for r in rules)
+        assert any(r["when"] for r in rules)  # conditional rule preserved
+
+    def test_save_rule_expands_conditions_into_separate_rules(
+        self, settings_script: str
+    ) -> None:
+        """Each condition on a card persists as its OWN rule so they OR at
+        evaluation (gate if ANY matches), not one AND-ed rule."""
+        fetches = {
+            **DEFAULT_FETCHES,
+            "/api/policy/config": {
+                "status": 200,
+                "json": {
+                    "wait_seconds": 60,
+                    "approval_ttl_minutes": 5,
+                    "version": 0,
+                    "rules": [],
+                },
+            },
+        }
+        result = run_script(
+            settings_script,
+            initial_html=_policy_panel_dom(),
+            fetch_map=fetches,
+            invoke="""
+              await window.savePolicyRule('ha_call_service', {
+                tool_name: 'ha_call_service',
+                when: [
+                  {path: 'args.domain', op: 'eq', value: 'lock'},
+                  {path: 'args.domain', op: 'eq', value: 'alarm_control_panel'}
+                ],
+                remember_minutes: 0
+              });
+            """,
+        )
+        _assert_clean_init(result)
+        puts = [
+            f
+            for f in result.fetches
+            if f["method"] == "PUT" and "/api/policy/config" in f["url"]
+        ]
+        assert len(puts) == 1
+        rules = json.loads(puts[0]["body"])["rules"]
+        assert len(rules) == 2, f"expected one rule per condition; got {rules}"
+        assert all(
+            r["tool_name"] == "ha_call_service" and len(r["when"]) == 1 for r in rules
+        )
+
     def test_pending_list_shows_off_message_when_feature_disabled(
         self, settings_script: str
     ) -> None:

--- a/tests/src/unit/test_settings_ui_js_behavior.py
+++ b/tests/src/unit/test_settings_ui_js_behavior.py
@@ -1194,6 +1194,53 @@ class TestPolicyTabFlow:
             f"got {[f.get('body') for f in flag_posts]}"
         )
 
+    def test_gate_toggle_preserves_conditional_rules(
+        self, settings_script: str
+    ) -> None:
+        """Un-gating a tool must remove only the bare unconditional rule, not
+        a predicate-bearing rule the user authored in the policy editor. The
+        gate toggle keys on the ``when == []`` rule; conditional rules survive."""
+        fetches = {
+            **DEFAULT_FETCHES,
+            "/api/policy/config": {
+                "status": 200,
+                "json": {
+                    "wait_seconds": 60,
+                    "approval_ttl_minutes": 5,
+                    "version": 3,
+                    "rules": [
+                        {
+                            "tool_name": "ha_call_service",
+                            "when": [
+                                {"path": "args.domain", "op": "eq", "value": "lock"}
+                            ],
+                            "remember_minutes": 0,
+                        }
+                    ],
+                },
+            },
+        }
+        result = run_script(
+            settings_script,
+            initial_html=_policy_panel_dom(),
+            fetch_map=fetches,
+            invoke="await window.syncPolicyRule('ha_call_service', false);",
+        )
+        _assert_clean_init(result)
+        puts = [
+            f
+            for f in result.fetches
+            if f["method"] == "PUT" and "/api/policy/config" in f["url"]
+        ]
+        assert len(puts) == 1, (
+            f"expected one PUT to policy config; got {result.fetches}"
+        )
+        body = json.loads(puts[0]["body"])
+        rules = body.get("rules", [])
+        # The conditional rule survives un-gating; nothing was wiped.
+        assert len(rules) == 1, f"conditional rule was wrongly removed: {rules}"
+        assert rules[0]["when"], "expected the predicate-bearing rule to remain"
+
     def test_pending_list_shows_off_message_when_feature_disabled(
         self, settings_script: str
     ) -> None:

--- a/tests/src/unit/test_settings_ui_js_behavior.py
+++ b/tests/src/unit/test_settings_ui_js_behavior.py
@@ -1309,9 +1309,9 @@ class TestPolicyTabFlow:
             invoke="""
               await window.savePolicyRule('ha_call_service', {
                 tool_name: 'ha_call_service',
-                when: [
-                  {path: 'args.domain', op: 'eq', value: 'lock'},
-                  {path: 'args.domain', op: 'eq', value: 'alarm_control_panel'}
+                conditions: [
+                  [{path: 'args.domain', op: 'eq', value: 'lock'}],
+                  [{path: 'args.domain', op: 'eq', value: 'alarm_control_panel'}]
                 ],
                 remember_minutes: 0
               });
@@ -1329,6 +1329,51 @@ class TestPolicyTabFlow:
         assert all(
             r["tool_name"] == "ha_call_service" and len(r["when"]) == 1 for r in rules
         )
+
+    def test_save_rule_preserves_multi_predicate_condition(
+        self, settings_script: str
+    ) -> None:
+        """A condition with AND-ed sub-parameters (multi-predicate rule) must
+        round-trip as ONE rule — not be flattened into separate OR rules."""
+        fetches = {
+            **DEFAULT_FETCHES,
+            "/api/policy/config": {
+                "status": 200,
+                "json": {
+                    "wait_seconds": 60,
+                    "approval_ttl_minutes": 5,
+                    "version": 0,
+                    "rules": [],
+                },
+            },
+        }
+        result = run_script(
+            settings_script,
+            initial_html=_policy_panel_dom(),
+            fetch_map=fetches,
+            invoke="""
+              await window.savePolicyRule('ha_call_service', {
+                tool_name: 'ha_call_service',
+                conditions: [
+                  [
+                    {path: 'args.domain', op: 'eq', value: 'lock'},
+                    {path: 'args.service', op: 'eq', value: 'unlock'}
+                  ]
+                ],
+                remember_minutes: 0
+              });
+            """,
+        )
+        _assert_clean_init(result)
+        puts = [
+            f
+            for f in result.fetches
+            if f["method"] == "PUT" and "/api/policy/config" in f["url"]
+        ]
+        assert len(puts) == 1
+        rules = json.loads(puts[0]["body"])["rules"]
+        assert len(rules) == 1, f"multi-predicate condition was split: {rules}"
+        assert len(rules[0]["when"]) == 2
 
     def test_pending_list_shows_off_message_when_feature_disabled(
         self, settings_script: str

--- a/tests/src/unit/test_settings_ui_js_behavior.py
+++ b/tests/src/unit/test_settings_ui_js_behavior.py
@@ -1425,6 +1425,93 @@ class TestPolicyTabFlow:
             f"tool rule moved behind the wildcard: {rules}"
         )
 
+    def test_load_collapses_tool_rules_into_one_card(
+        self, settings_script: str
+    ) -> None:
+        """Read side of renderPolicyCards: a tool's on-disk rules collapse into
+        ONE card, one condition row per rule in order. Only single-predicate
+        rows get the edit button; the hand-authored multi-predicate row joins
+        its predicates with ' AND ' and offers no edit. The single remember
+        input shows the MAX across the rules (60), so a save that never touches
+        it can't silently shorten a longer window."""
+        fetches = {
+            **DEFAULT_FETCHES,
+            "/api/policy/config": {
+                "status": 200,
+                "json": {
+                    "wait_seconds": 60,
+                    "approval_ttl_minutes": 5,
+                    "version": 4,
+                    "rules": [
+                        {
+                            "tool_name": "ha_call_service",
+                            "when": [
+                                {"path": "args.domain", "op": "eq", "value": "lock"}
+                            ],
+                            "remember_minutes": 1,
+                        },
+                        {
+                            "tool_name": "ha_call_service",
+                            "when": [
+                                {"path": "args.service", "op": "eq", "value": "unlock"}
+                            ],
+                            "remember_minutes": 60,
+                        },
+                        {
+                            "tool_name": "ha_call_service",
+                            "when": [
+                                {"path": "args.domain", "op": "eq", "value": "lock"},
+                                {"path": "args.service", "op": "eq", "value": "unlock"},
+                            ],
+                            "remember_minutes": 0,
+                        },
+                    ],
+                },
+            },
+        }
+        result = run_script(
+            settings_script,
+            initial_html=_policy_panel_dom(),
+            fetch_map=fetches,
+            invoke="""
+              await window.policyLoadConfig();
+              const cards = document.querySelectorAll('.policy-rule-card');
+              document.body.setAttribute('data-card-count', String(cards.length));
+              const card = cards[0];
+              const rows = card
+                ? Array.from(card.querySelectorAll('.policy-predicate-row'))
+                : [];
+              document.body.setAttribute('data-row-count', String(rows.length));
+              const codeText = (r) =>
+                (r && r.querySelector('code')) ? r.querySelector('code').textContent : '';
+              const hasEdit = (r) =>
+                String(!!(r && r.querySelector('.policy-edit-predicate')));
+              document.body.setAttribute(
+                'data-multi-has-and', String(codeText(rows[2]).includes(' AND ')));
+              document.body.setAttribute('data-multi-has-edit', hasEdit(rows[2]));
+              document.body.setAttribute('data-single0-has-edit', hasEdit(rows[0]));
+              document.body.setAttribute('data-single1-has-edit', hasEdit(rows[1]));
+              const rem = card ? card.querySelector('.policy-remember-minutes') : null;
+              document.body.setAttribute('data-remember', rem ? String(rem.value) : '');
+            """,
+        )
+        _assert_clean_init(result)
+        assert _probe(result, "card-count") == "1", (
+            "tool rules did not collapse to one card"
+        )
+        assert _probe(result, "row-count") == "3", "expected one condition row per rule"
+        assert _probe(result, "multi-has-and") == "true", (
+            "multi-predicate row missing ' AND ' join"
+        )
+        assert _probe(result, "multi-has-edit") == "false", (
+            "multi-predicate row should not be editable"
+        )
+        assert _probe(result, "single0-has-edit") == "true"
+        assert _probe(result, "single1-has-edit") == "true"
+        assert _probe(result, "remember") == "60", (
+            "remember input should show the max across rules"
+        )
+
     def test_pending_list_shows_off_message_when_feature_disabled(
         self, settings_script: str
     ) -> None:

--- a/tests/src/unit/test_settings_ui_js_behavior.py
+++ b/tests/src/unit/test_settings_ui_js_behavior.py
@@ -1425,6 +1425,87 @@ class TestPolicyTabFlow:
             f"tool rule moved behind the wildcard: {rules}"
         )
 
+    def test_new_tool_rule_inserts_before_wildcard(self, settings_script: str) -> None:
+        """A tool with NO existing rule must insert BEFORE a wildcard rule,
+        not append after it — first-match would otherwise resolve the tool's
+        calls to the wildcard's remember_minutes (Patch76 review: the branch
+        the in-place reorder fix doesn't cover)."""
+        fetches = {
+            **DEFAULT_FETCHES,
+            "/api/policy/config": {
+                "status": 200,
+                "json": {
+                    "wait_seconds": 60,
+                    "approval_ttl_minutes": 5,
+                    "version": 1,
+                    "rules": [
+                        {"tool_name": "ha_restart", "when": [], "remember_minutes": 0},
+                        {"tool_name": "*", "when": [], "remember_minutes": 60},
+                    ],
+                },
+            },
+        }
+        result = run_script(
+            settings_script,
+            initial_html=_policy_panel_dom(),
+            fetch_map=fetches,
+            invoke="""
+              await window.savePolicyRule('ha_call_service', {
+                tool_name: 'ha_call_service',
+                conditions: [[{path: 'args.domain', op: 'eq', value: 'lock'}]],
+                remember_minutes: 5
+              });
+            """,
+        )
+        _assert_clean_init(result)
+        puts = [
+            f
+            for f in result.fetches
+            if f["method"] == "PUT" and "/api/policy/config" in f["url"]
+        ]
+        assert len(puts) == 1
+        rules = json.loads(puts[0]["body"])["rules"]
+        assert [r["tool_name"] for r in rules] == [
+            "ha_restart",
+            "ha_call_service",
+            "*",
+        ], f"new tool rule appended after the wildcard: {rules}"
+
+    def test_gate_toggle_on_inserts_before_wildcard(self, settings_script: str) -> None:
+        """The Tools-tab gate toggle has the same new-rule case: a fresh bare
+        gate must land before an existing wildcard rule."""
+        fetches = {
+            **DEFAULT_FETCHES,
+            "/api/policy/config": {
+                "status": 200,
+                "json": {
+                    "wait_seconds": 60,
+                    "approval_ttl_minutes": 5,
+                    "version": 1,
+                    "rules": [
+                        {"tool_name": "*", "when": [], "remember_minutes": 60},
+                    ],
+                },
+            },
+        }
+        result = run_script(
+            settings_script,
+            initial_html=_policy_panel_dom(),
+            fetch_map=fetches,
+            invoke="await window.syncPolicyRule('ha_call_service', true);",
+        )
+        _assert_clean_init(result)
+        puts = [
+            f
+            for f in result.fetches
+            if f["method"] == "PUT" and "/api/policy/config" in f["url"]
+        ]
+        assert len(puts) == 1
+        rules = json.loads(puts[0]["body"])["rules"]
+        assert [r["tool_name"] for r in rules] == ["ha_call_service", "*"], (
+            f"bare gate appended after the wildcard: {rules}"
+        )
+
     def test_load_collapses_tool_rules_into_one_card(
         self, settings_script: str
     ) -> None:

--- a/tests/src/unit/test_tools_dev.py
+++ b/tests/src/unit/test_tools_dev.py
@@ -669,3 +669,429 @@ class TestConcurrentSettingsWrites:
         )
         persisted = json.loads(_override_file_path().read_text())
         assert persisted == {"log_level": "DEBUG", "debug": True}
+
+
+def _tool_config() -> dict:
+    """Read the persisted tool_config.json (or {} if absent)."""
+    path = get_data_dir() / "tool_config.json"
+    return json.loads(path.read_text()) if path.exists() else {}
+
+
+def _seed_metadata(rows: list[dict]) -> None:
+    """Seed the sidecar tool-metadata cache so server-less list_tools works."""
+    from ha_mcp.settings_ui._persistence import dump_tool_metadata_cache
+
+    dump_tool_metadata_cache(rows)
+
+
+class TestManageToolsState:
+    """set_tool drives the Tools-tab enable/disable/pin + LLM-API toggles."""
+
+    @pytest.fixture
+    def dev_tools(self):
+        return DevTools(MagicMock())
+
+    async def test_set_state_disabled_writes_config(self, dev_tools):
+        result = await dev_tools.ha_dev_manage_settings(
+            action="set_tool", tool="ha_write_file", state="disabled"
+        )
+        assert result["data"]["state"] == "disabled"
+        assert result["data"]["restart_required"] is True
+        assert _tool_config()["tools"]["ha_write_file"] == "disabled"
+
+    async def test_set_state_pinned_writes_config(self, dev_tools):
+        await dev_tools.ha_dev_manage_settings(
+            action="set_tool", tool="ha_get_history", state="pinned"
+        )
+        assert _tool_config()["tools"]["ha_get_history"] == "pinned"
+
+    async def test_set_state_rejects_invalid_state(self, dev_tools):
+        with pytest.raises(ToolError, match="state must be one of"):
+            await dev_tools.ha_dev_manage_settings(
+                action="set_tool", tool="ha_get_history", state="bogus"
+            )
+
+    async def test_set_state_rejects_env_pinned_flip(self, dev_tools, monkeypatch):
+        monkeypatch.setenv("DISABLED_TOOLS", "ha_foo")
+        reset_global_settings()
+        with pytest.raises(ToolError, match="unset the env var"):
+            await dev_tools.ha_dev_manage_settings(
+                action="set_tool", tool="ha_foo", state="pinned"
+            )
+
+    async def test_set_state_rejects_bps_locked_disable(self, dev_tools):
+        # enable_mandatory_bps + enable_strict_mandatory_bps default on, so
+        # ha_get_skill_guide is locked enabled.
+        with pytest.raises(ToolError, match="strict best-practices"):
+            await dev_tools.ha_dev_manage_settings(
+                action="set_tool", tool="ha_get_skill_guide", state="disabled"
+            )
+
+    async def test_set_state_rejects_mandatory_disable(self, dev_tools):
+        # ha_search is an unconditional MANDATORY_TOOLS member; the headless
+        # path must refuse (the web UI locks the row, and apply_tool_visibility
+        # would silently re-enable it at startup — a misleading "success").
+        with pytest.raises(ToolError, match="mandatory"):
+            await dev_tools.ha_dev_manage_settings(
+                action="set_tool", tool="ha_search", state="disabled"
+            )
+
+    async def test_set_tool_rejects_wildcard(self, dev_tools):
+        # tool='*' is a policy wildcard; gating it would gate every tool,
+        # including the developer recovery actions.
+        with pytest.raises(ToolError, match="wildcard"):
+            await dev_tools.ha_dev_manage_settings(
+                action="set_tool", tool="*", gated=True
+            )
+
+    async def test_set_llm_api_writes_override(self, dev_tools):
+        result = await dev_tools.ha_dev_manage_settings(
+            action="set_tool", tool="ha_search", llm_api=False
+        )
+        assert result["data"]["llm_api"] is False
+        assert _tool_config()["llm_api"]["ha_search"] is False
+        # Not embedded in the test env → a no-effect warning is surfaced.
+        assert any("embedded" in w for w in result["warnings"])
+
+    async def test_set_state_and_llm_api_together(self, dev_tools):
+        await dev_tools.ha_dev_manage_settings(
+            action="set_tool", tool="ha_search", state="pinned", llm_api=True
+        )
+        config = _tool_config()
+        assert config["tools"]["ha_search"] == "pinned"
+        assert config["llm_api"]["ha_search"] is True
+
+    async def test_set_tool_requires_tool(self, dev_tools):
+        with pytest.raises(ToolError, match="'tool' is required"):
+            await dev_tools.ha_dev_manage_settings(action="set_tool", state="disabled")
+
+    async def test_set_tool_requires_a_field(self, dev_tools):
+        with pytest.raises(ToolError, match="at least one"):
+            await dev_tools.ha_dev_manage_settings(action="set_tool", tool="ha_search")
+
+
+class TestManageToolsGate:
+    """The per-tool security gate adds/removes an unconditional policy rule."""
+
+    @pytest.fixture
+    def dev_tools(self):
+        return DevTools(MagicMock())
+
+    def _rules(self):
+        from ha_mcp.policy.persistence import load_policy
+
+        return load_policy(get_data_dir()).rules
+
+    async def test_gate_on_adds_rule(self, dev_tools):
+        result = await dev_tools.ha_dev_manage_settings(
+            action="set_tool", tool="ha_call_service", gated=True
+        )
+        assert result["data"]["gated"] is True
+        assert result["data"]["policy_rules_changed"] is True
+        rules = self._rules()
+        assert [r.tool_name for r in rules] == ["ha_call_service"]
+        assert rules[0].when == []
+        # Policies default OFF → warning that the gate won't enforce yet.
+        assert any("enable_tool_security_policies" in w for w in result["warnings"])
+
+    async def test_gate_off_removes_rule(self, dev_tools):
+        await dev_tools.ha_dev_manage_settings(
+            action="set_tool", tool="ha_call_service", gated=True
+        )
+        result = await dev_tools.ha_dev_manage_settings(
+            action="set_tool", tool="ha_call_service", gated=False
+        )
+        assert result["data"]["policy_rules_changed"] is True
+        assert self._rules() == []
+
+    async def test_gate_on_is_idempotent(self, dev_tools):
+        await dev_tools.ha_dev_manage_settings(
+            action="set_tool", tool="ha_call_service", gated=True
+        )
+        result = await dev_tools.ha_dev_manage_settings(
+            action="set_tool", tool="ha_call_service", gated=True
+        )
+        assert result["data"]["policy_rules_changed"] is False
+        assert len(self._rules()) == 1
+
+    async def test_gate_preserves_conditional_rules(self, dev_tools):
+        # A predicate-bearing rule the user authored must survive gate toggles:
+        # gated=True adds the bare gate alongside it; gated=False removes ONLY
+        # the bare gate, never the conditional rule (Codex #1993 P1).
+        from ha_mcp.policy.model import Policy, Predicate, Rule
+        from ha_mcp.policy.persistence import save_policy
+
+        save_policy(
+            get_data_dir(),
+            Policy(
+                rules=[
+                    Rule(
+                        tool_name="ha_call_service",
+                        when=[Predicate(path="args.domain", op="eq", value="lock")],
+                    )
+                ]
+            ),
+        )
+        await dev_tools.ha_dev_manage_settings(
+            action="set_tool", tool="ha_call_service", gated=True
+        )
+        rules = self._rules()
+        assert len(rules) == 2
+        assert any(r.tool_name == "ha_call_service" and not r.when for r in rules)
+        assert any(r.when for r in rules)  # conditional preserved
+
+        await dev_tools.ha_dev_manage_settings(
+            action="set_tool", tool="ha_call_service", gated=False
+        )
+        rules = self._rules()
+        assert len(rules) == 1
+        assert rules[0].when  # the conditional rule remains
+
+    async def test_combined_set_tool_is_atomic_on_validation_failure(self, dev_tools):
+        # A combined state+gate request whose state fails validation must NOT
+        # have persisted the gate rule — preflight validates before any write.
+        with pytest.raises(ToolError, match="strict best-practices"):
+            await dev_tools.ha_dev_manage_settings(
+                action="set_tool",
+                tool="ha_get_skill_guide",
+                state="disabled",
+                gated=True,
+            )
+        assert self._rules() == []  # the gate was never written
+
+
+class TestListToolStates:
+    async def test_list_reflects_state_llm_and_gate(self):
+        _seed_metadata(
+            [
+                {"name": "ha_search", "tags": ["Search"], "category": "read"},
+                {"name": "ha_call_service", "tags": ["Control"], "category": "write"},
+            ]
+        )
+        dev = DevTools(MagicMock())
+        await dev.ha_dev_manage_settings(
+            action="set_tool", tool="ha_call_service", state="disabled", gated=True
+        )
+        result = await dev.ha_dev_manage_settings(action="list_tools")
+        rows = {r["name"]: r for r in result["data"]["tools"]}
+        assert rows["ha_call_service"]["state"] == "disabled"
+        assert rows["ha_call_service"]["gated"] is True
+        assert rows["ha_search"]["gated"] is False
+        assert result["data"]["policies_enabled"] is False
+        assert result["data"]["count"] == 2
+
+    async def test_list_marks_mandatory_and_bps(self):
+        _seed_metadata(
+            [
+                {"name": "ha_search", "tags": ["Search"]},
+                {"name": "ha_get_skill_guide", "tags": ["System"]},
+            ]
+        )
+        result = await DevTools(MagicMock()).ha_dev_manage_settings(action="list_tools")
+        rows = {r["name"]: r for r in result["data"]["tools"]}
+        assert rows["ha_search"]["mandatory"] is True
+        assert rows["ha_get_skill_guide"]["bps_locked"] is True
+
+
+class TestManagePolicy:
+    @pytest.fixture
+    def dev_tools(self):
+        return DevTools(MagicMock())
+
+    async def test_get_policy_default(self, dev_tools):
+        result = await dev_tools.ha_dev_manage_settings(action="get_policy")
+        policy = result["data"]["policy"]
+        assert policy["wait_seconds"] == 60
+        assert policy["rules"] == []
+        assert policy["version"] == 0
+        assert result["data"]["policies_enabled"] is False
+
+    async def test_set_policy_roundtrip_bumps_version(self, dev_tools):
+        result = await dev_tools.ha_dev_manage_settings(
+            action="set_policy",
+            policy={
+                "wait_seconds": 30,
+                "approval_ttl_minutes": 5,
+                "rules": [{"tool_name": "ha_call_service"}],
+                "version": 0,
+            },
+        )
+        assert result["data"]["version"] == 1
+        assert result["data"]["rules_changed"] is True
+        got = await dev_tools.ha_dev_manage_settings(action="get_policy")
+        assert got["data"]["policy"]["version"] == 1
+        assert got["data"]["policy"]["rules"][0]["tool_name"] == "ha_call_service"
+
+    async def test_set_policy_version_mismatch_rejected(self, dev_tools):
+        await dev_tools.ha_dev_manage_settings(
+            action="set_policy", policy={"rules": [], "version": 0}
+        )
+        # On-disk version is now 1; a stale expected_version=0 must be rejected.
+        with pytest.raises(ToolError, match="version mismatch"):
+            await dev_tools.ha_dev_manage_settings(
+                action="set_policy",
+                policy={"rules": []},
+                expected_version=0,
+            )
+
+    async def test_set_policy_invalid_schema_rejected(self, dev_tools):
+        # wait_seconds must be < approval_ttl_minutes * 60.
+        with pytest.raises(ToolError, match="schema validation"):
+            await dev_tools.ha_dev_manage_settings(
+                action="set_policy",
+                policy={"wait_seconds": 599, "approval_ttl_minutes": 1},
+            )
+
+    async def test_set_policy_requires_object(self, dev_tools):
+        with pytest.raises(ToolError, match="'policy'"):
+            await dev_tools.ha_dev_manage_settings(action="set_policy")
+
+    async def test_set_policy_without_version_warns(self, dev_tools):
+        result = await dev_tools.ha_dev_manage_settings(
+            action="set_policy", policy={"rules": []}
+        )
+        assert any("without an optimistic-concurrency" in w for w in result["warnings"])
+
+
+class TestBackupConfig:
+    @pytest.fixture(autouse=True)
+    def _clean_backup_env(self, monkeypatch):
+        """Neutralize ambient auto-backup env vars (e.g. from tests/.env.test)
+        so file-mode edits aren't spuriously rejected as env-pinned."""
+        from ha_mcp.config import BACKUP_OVERRIDE_FIELDS
+
+        for _field, env_name, _ftype in BACKUP_OVERRIDE_FIELDS:
+            monkeypatch.delenv(env_name, raising=False)
+        reset_global_settings()
+
+    @pytest.fixture
+    def dev_tools(self):
+        return DevTools(MagicMock())
+
+    async def test_get_backup_config_lists_fields(self, dev_tools):
+        result = await dev_tools.ha_dev_manage_settings(action="get_backup_config")
+        fields = {f["field"]: f for f in result["data"]["fields"]}
+        assert "enable_auto_backup" in fields
+        assert fields["enable_auto_backup"]["editable"] is True
+
+    async def test_set_backup_config_file_mode_persists(self, dev_tools):
+        result = await dev_tools.ha_dev_manage_settings(
+            action="set_backup_config", backup={"enable_auto_backup": False}
+        )
+        assert result["data"]["applied"] == {"enable_auto_backup": False}
+        assert result["data"]["restart_required"] is False
+        assert get_global_settings().enable_auto_backup is False
+
+    async def test_set_backup_config_rejects_env_pinned(self, dev_tools, monkeypatch):
+        monkeypatch.setenv("ENABLE_AUTO_BACKUP", "true")
+        reset_global_settings()
+        with pytest.raises(ToolError, match="environment variable"):
+            await dev_tools.ha_dev_manage_settings(
+                action="set_backup_config", backup={"enable_auto_backup": False}
+            )
+
+    async def test_set_backup_config_rejects_out_of_bounds(self, dev_tools):
+        with pytest.raises(ToolError, match="must be"):
+            await dev_tools.ha_dev_manage_settings(
+                action="set_backup_config",
+                backup={"auto_backup_throttle_minutes": 99999},
+            )
+
+    async def test_set_backup_config_requires_object(self, dev_tools):
+        with pytest.raises(ToolError, match="'backup'"):
+            await dev_tools.ha_dev_manage_settings(action="set_backup_config")
+
+
+def _queue_with_entry(**args):
+    """A real ApprovalQueue holding one pending entry; returns (server, token)."""
+    from types import SimpleNamespace
+
+    from ha_mcp.policy.approval_queue import ApprovalQueue, compute_args_hash
+
+    queue = ApprovalQueue()
+    entry = queue.create(
+        "ha_call_service",
+        compute_args_hash(args),
+        args,
+        ttl_minutes=5,
+    )
+    return SimpleNamespace(approval_queue=queue), entry.token, queue
+
+
+class TestManageServerApprovals:
+    async def test_list_pending_reports_entries(self):
+        server, token, _queue = _queue_with_entry(domain="light")
+        result = await DevTools(MagicMock(), server=server).ha_dev_manage_server(
+            action="list_pending"
+        )
+        assert result["data"]["count"] == 1
+        assert result["data"]["pending"][0]["token"] == token
+        assert result["data"]["pending"][0]["tool_name"] == "ha_call_service"
+
+    async def test_list_pending_without_queue_is_empty(self):
+        result = await DevTools(MagicMock(), server=None).ha_dev_manage_server(
+            action="list_pending"
+        )
+        assert result["data"]["pending"] == []
+        assert "No active approval queue" in result["data"]["note"]
+
+    async def test_approve_marks_entry_approved(self):
+        server, token, queue = _queue_with_entry(domain="light")
+        result = await DevTools(MagicMock(), server=server).ha_dev_manage_server(
+            action="approve", token=token
+        )
+        assert result["data"]["decision"] == "approved"
+        assert queue.get(token).decision == "approved"
+
+    async def test_deny_marks_entry_denied(self):
+        server, token, queue = _queue_with_entry(domain="light")
+        await DevTools(MagicMock(), server=server).ha_dev_manage_server(
+            action="deny", token=token
+        )
+        assert queue.get(token).decision == "denied"
+
+    async def test_approve_unknown_token_errors(self):
+        server, _token, _queue = _queue_with_entry(domain="light")
+        with pytest.raises(ToolError, match="Unknown or expired"):
+            await DevTools(MagicMock(), server=server).ha_dev_manage_server(
+                action="approve", token="not-a-real-token"
+            )
+
+    async def test_approve_already_decided_errors(self):
+        server, token, _queue = _queue_with_entry(domain="light")
+        dev = DevTools(MagicMock(), server=server)
+        await dev.ha_dev_manage_server(action="approve", token=token)
+        with pytest.raises(ToolError, match="already decided"):
+            await dev.ha_dev_manage_server(action="approve", token=token)
+
+    async def test_approve_requires_token(self):
+        server, _token, _queue = _queue_with_entry(domain="light")
+        with pytest.raises(ToolError, match="'token' is required"):
+            await DevTools(MagicMock(), server=server).ha_dev_manage_server(
+                action="approve"
+            )
+
+    async def test_approve_without_queue_errors(self):
+        with pytest.raises(ToolError, match="No active approval queue"):
+            await DevTools(MagicMock(), server=None).ha_dev_manage_server(
+                action="approve", token="x"
+            )
+
+
+class TestDevToolsServerPlumbing:
+    def test_init_stores_server(self):
+        sentinel = object()
+        assert DevTools(MagicMock(), server=sentinel)._server is sentinel
+
+    def test_register_passes_server_through(self, monkeypatch):
+        monkeypatch.setenv(FEATURE_FLAG, "true")
+        reset_global_settings()
+        captured = {}
+
+        def _capture(_mcp, dev_tools):
+            captured["server"] = dev_tools._server
+
+        monkeypatch.setattr(tools_dev, "register_tool_methods", _capture)
+        sentinel = object()
+        register_dev_tools(MagicMock(), MagicMock(), server=sentinel)
+        assert captured["server"] is sentinel

--- a/tests/src/unit/test_tools_dev.py
+++ b/tests/src/unit/test_tools_dev.py
@@ -1237,3 +1237,42 @@ class TestCoerceBoolBranch:
     def test_coerce_bool_or_raise_rejects_non_bool(self):
         with pytest.raises(ToolError, match="must be a boolean"):
             DevTools._coerce_bool_or_raise("not-a-bool", "llm_api")
+
+
+class TestSetToolNameValidation:
+    """set_tool rejects unknown tool names before persisting any guard.
+
+    A typo'd gate ("ha_call_servce") previously saved a rule for a
+    nonexistent tool and reported success while the intended tool stayed
+    ungated (Codex #1993 round 3).
+    """
+
+    async def test_unknown_tool_rejected(self):
+        _seed_metadata([{"name": "ha_call_service", "tags": ["Control"]}])
+        with pytest.raises(ToolError, match="Unknown tool"):
+            await DevTools(MagicMock()).ha_dev_manage_settings(
+                action="set_tool", tool="ha_call_servce", gated=True
+            )
+
+    async def test_feature_gated_stub_accepted(self):
+        # Currently-unavailable (flag-off) tools are still configurable.
+        _seed_metadata(
+            [
+                {
+                    "name": "ha_write_file",
+                    "tags": ["Files"],
+                    "disabled_by": "enable_filesystem_tools",
+                }
+            ]
+        )
+        result = await DevTools(MagicMock()).ha_dev_manage_settings(
+            action="set_tool", tool="ha_write_file", state="disabled"
+        )
+        assert result["data"]["state"] == "disabled"
+
+    async def test_validation_skipped_without_metadata(self):
+        # Defensive server-less path with an empty cache: don't brick set_tool.
+        result = await DevTools(MagicMock()).ha_dev_manage_settings(
+            action="set_tool", tool="ha_anything", state="pinned"
+        )
+        assert result["data"]["state"] == "pinned"

--- a/tests/src/unit/test_tools_dev.py
+++ b/tests/src/unit/test_tools_dev.py
@@ -1095,3 +1095,145 @@ class TestDevToolsServerPlumbing:
         sentinel = object()
         register_dev_tools(MagicMock(), MagicMock(), server=sentinel)
         assert captured["server"] is sentinel
+
+
+def _fake_server_with_tools(tools, *, approval_queue=None):
+    """A server whose mcp.local_provider._list_tools() returns fake tool objs,
+    exercising the live-registry list_tools path (not the cache fallback)."""
+    from types import SimpleNamespace
+
+    fake_tools = [
+        SimpleNamespace(
+            name=name,
+            tags=set(tags),
+            description="desc",
+            title=None,
+            annotations=SimpleNamespace(
+                readOnlyHint=None, destructiveHint=None, title=None
+            ),
+        )
+        for name, tags in tools
+    ]
+    provider = SimpleNamespace(_list_tools=AsyncMock(return_value=fake_tools))
+    return SimpleNamespace(
+        mcp=SimpleNamespace(local_provider=provider),
+        approval_queue=approval_queue,
+    )
+
+
+class TestListToolsLiveRegistry:
+    """The live-registry path every real deployment uses (server present)."""
+
+    async def test_uses_live_registry_and_marks_feature_gated(self):
+        server = _fake_server_with_tools(
+            [("ha_search", ["Search"]), ("ha_call_service", ["Control"])]
+        )
+        result = await DevTools(MagicMock(), server=server).ha_dev_manage_settings(
+            action="list_tools"
+        )
+        rows = {r["name"]: r for r in result["data"]["tools"]}
+        assert rows["ha_search"]["available"] is True
+        assert rows["ha_search"]["disabled_by"] is None
+        # Feature-gated stub injected by _get_tool_metadata (flag off).
+        assert rows["ha_write_file"]["available"] is False
+        assert rows["ha_write_file"]["disabled_by"] == "enable_filesystem_tools"
+
+    async def test_policies_live_reflects_queue_presence(self):
+        from ha_mcp.policy.approval_queue import ApprovalQueue
+
+        with_q = _fake_server_with_tools(
+            [("ha_search", ["Search"])], approval_queue=ApprovalQueue()
+        )
+        res_live = await DevTools(MagicMock(), server=with_q).ha_dev_manage_settings(
+            action="list_tools"
+        )
+        assert res_live["data"]["policies_live"] is True
+
+        without_q = _fake_server_with_tools([("ha_search", ["Search"])])
+        res_off = await DevTools(MagicMock(), server=without_q).ha_dev_manage_settings(
+            action="list_tools"
+        )
+        assert res_off["data"]["policies_live"] is False
+
+
+class TestRememberCacheCleared:
+    """clear_remember_cache must actually fire on a rule change (security)."""
+
+    def _server_with_remembered(self):
+        from types import SimpleNamespace
+
+        from ha_mcp.policy.approval_queue import ApprovalQueue
+
+        queue = ApprovalQueue()
+        queue.remember("ha_call_service", "argshash", minutes=10)
+        assert queue.is_remembered("ha_call_service", "argshash")
+        return SimpleNamespace(approval_queue=queue), queue
+
+    async def test_set_tool_gate_clears_cache(self):
+        server, queue = self._server_with_remembered()
+        await DevTools(MagicMock(), server=server).ha_dev_manage_settings(
+            action="set_tool", tool="ha_call_service", gated=True
+        )
+        assert not queue.is_remembered("ha_call_service", "argshash")
+
+    async def test_set_policy_clears_cache_on_rule_change(self):
+        server, queue = self._server_with_remembered()
+        await DevTools(MagicMock(), server=server).ha_dev_manage_settings(
+            action="set_policy",
+            policy={"rules": [{"tool_name": "ha_call_service"}]},
+        )
+        assert not queue.is_remembered("ha_call_service", "argshash")
+
+
+class TestSetToolPartialCommit:
+    async def test_partial_commit_surfaced_when_gate_write_fails(self, monkeypatch):
+        # tool_config saves first; force the policy save to fail and assert the
+        # error tells the caller the state change already persisted.
+        def _boom(*_a, **_k):
+            raise OSError("disk full")
+
+        monkeypatch.setattr("ha_mcp.policy.persistence.save_policy", _boom)
+        with pytest.raises(ToolError, match="already saved"):
+            await DevTools(MagicMock()).ha_dev_manage_settings(
+                action="set_tool", tool="ha_get_history", state="pinned", gated=True
+            )
+        assert _tool_config()["tools"]["ha_get_history"] == "pinned"
+
+
+class TestBackupConfigAddon:
+    @pytest.fixture(autouse=True)
+    def _addon(self, monkeypatch):
+        from ha_mcp.config import BACKUP_OVERRIDE_FIELDS
+
+        monkeypatch.setenv("SUPERVISOR_TOKEN", "t")
+        for _field, env_name, _ftype in BACKUP_OVERRIDE_FIELDS:
+            monkeypatch.delenv(env_name, raising=False)
+        reset_global_settings()
+
+    async def test_addon_routes_through_supervisor(self, monkeypatch):
+        from types import SimpleNamespace
+
+        from ha_mcp import settings_ui
+
+        calls: list[dict] = []
+
+        async def _fake_merge(verify_ssl, clean):
+            calls.append(clean)
+            return True, None
+
+        monkeypatch.setattr(
+            settings_ui._supervisor, "_supervisor_merge_and_post_options", _fake_merge
+        )
+        server = SimpleNamespace(settings=get_global_settings())
+        result = await DevTools(MagicMock(), server=server).ha_dev_manage_settings(
+            action="set_backup_config", backup={"enable_auto_backup": False}
+        )
+        assert calls == [{"enable_auto_backup": False}]
+        assert result["data"]["mode"] == "addon"
+        assert result["data"]["restart_required"] is True
+
+
+class TestCoerceBoolBranch:
+    def test_coerce_bool_or_raise_rejects_non_bool(self):
+        with pytest.raises(ToolError, match="must be a boolean"):
+            DevTools._coerce_bool_or_raise("not-a-bool", "llm_api")

--- a/tests/src/unit/test_tools_dev.py
+++ b/tests/src/unit/test_tools_dev.py
@@ -847,6 +847,22 @@ class TestManageToolsGate:
         assert len(rules) == 1
         assert rules[0].when  # the conditional rule remains
 
+    async def test_gate_on_inserts_before_wildcard(self, dev_tools):
+        # A NEW bare gate lands BEFORE an existing wildcard rule, mirroring
+        # the web UI's wildcardInsertIndex: find_matching_rule() is
+        # first-match, so a gate appended after `*` would resolve this tool's
+        # calls to the wildcard's remember_minutes/matched_rule (Patch76).
+        from ha_mcp.policy.model import Policy, Rule
+        from ha_mcp.policy.persistence import save_policy
+
+        save_policy(
+            get_data_dir(), Policy(rules=[Rule(tool_name="*", remember_minutes=60)])
+        )
+        await dev_tools.ha_dev_manage_settings(
+            action="set_tool", tool="ha_call_service", gated=True
+        )
+        assert [r.tool_name for r in self._rules()] == ["ha_call_service", "*"]
+
     async def test_combined_set_tool_is_atomic_on_validation_failure(self, dev_tools):
         # A combined state+gate request whose state fails validation must NOT
         # have persisted the gate rule — preflight validates before any write.
@@ -891,6 +907,17 @@ class TestListToolStates:
         rows = {r["name"]: r for r in result["data"]["tools"]}
         assert rows["ha_search"]["mandatory"] is True
         assert rows["ha_get_skill_guide"]["bps_locked"] is True
+
+    async def test_list_warns_on_corrupt_policy(self):
+        # A corrupt tool_policy.json must not read as a clean no-gates
+        # policy: the listing degrades (gated=False everywhere) but carries
+        # a warning, where get_policy/set_tool raise CONFIG_INVALID.
+        _seed_metadata([{"name": "ha_search", "tags": ["Search"]}])
+        (get_data_dir() / "tool_policy.json").write_text("{not json", encoding="utf-8")
+        result = await DevTools(MagicMock()).ha_dev_manage_settings(action="list_tools")
+        rows = {r["name"]: r for r in result["data"]["tools"]}
+        assert rows["ha_search"]["gated"] is False
+        assert any("tool_policy.json is invalid" in w for w in result["warnings"])
 
 
 class TestManagePolicy:


### PR DESCRIPTION
## What does this PR do?

Reworks the tool-security-policy condition semantics to ANY-match, and extends the two existing developer-mode tools to drive every toggle in the web settings UI.

### Policy semantics — each condition is its own rule (ANY-match)

The policy editor packed every condition into one rule with the predicates AND-ed ("Require approval when ALL conditions match"). Now each condition persists as its own rule under the same `tool_name`, and a tool gates when **ANY** of its conditions matches (the evaluator already OR's across rules; a single condition's own predicates still AND together as sub-parameters). No conditions = one bare rule (always require approval). Copy updated to "ANY" (en/de/ru). The policy card renders one row per rule: single-predicate rows are editable; multi-predicate rows display `p1 AND p2` and round-trip intact. The Tools-tab gate toggle manages only the bare unconditional rule.

### 💥 Breaking change — existing multi-condition rules are migrated AND → OR

A one-time startup migration splits every multi-predicate rule of a pre-upgrade `tool_policy.json` into one rule per predicate: **conditions that previously ALL had to match now EACH gate on their own.** Gating triggers more than before — the fail-safe direction — and enforcement matches what the editor displays instead of silently diverging. The file is stamped (`schema_version`) so the migration runs exactly once; users who want an AND condition can author a multi-predicate rule afterward and it is preserved. The migration runs even when policies are disabled and never blocks startup. This major also formally marks the in-process custom-component era (the component + embedded server introduced over the recent release cycle), which warranted a major bump on its own.

### Developer tools — full settings-UI parity

`ha_dev_manage_settings` gains `list_tools` (state, LLM-API, gate, availability/`disabled_by`, env-pin/mandatory locks, live-vs-configured enforcement), `set_tool` (state / `llm_api` / `gated`, preflight-validated, wildcard and mandatory-disable rejected), `get_policy` / `set_policy` (full rule editing, version-CAS, "won't enforce" warning), and `get_backup_config` / `set_backup_config`. `ha_dev_manage_server` gains `list_pending` / `approve` / `deny` for the live approval queue. Every action reuses the web handlers' persistence and guards. Dict params accept JSON-string encoding (`JSON_STRING_COERCION`) — found live when an MCP client stringified object args.

### Concurrency

A shared write lock serialises every `tool_config.json` / `tool_policy.json` read-modify-write across the web save handlers and the developer tool; `_atomic_write_json` uses unique temp files. Concurrent writers can no longer lose updates or collide on a shared `.tmp`.

### #1990 — silent policy bypass made visible

Live testing shows enforcement itself is sound: stable 7.14.1 with the reporter's exact rule (`args.domain in [alarm_control_panel, lock]`) gates correctly, both directly and through the tool-search proxies (verified to re-enter the middleware chain). The reporter's posted log excerpt shows only settings-UI polling and no tool-call requests in the window — consistent with the calls being served by a different endpoint than the configured one (unconfirmed pending complete logs), a failure mode that was previously invisible on the wire. Fix: every `tools/list` entry now carries `_meta.ha_mcp.policy = {enabled, live, rules, deployment}` — the actual gating state of the server answering the connection — so a client talking to an unconfigured endpoint is visible at a glance instead of failing silently. `live` also distinguishes "configured" from "enforcing" when the flag was flipped without the required restart.

### Review hardening (post-review rounds)

Codex round 3 + a full pr-review-toolkit pass produced further fixes, all with regression tests: queue-management actions (`list_pending`/`approve`/`deny`) are exempt from policy gating (gating them deadlocks approvals by construction; `update_source`/`restart` remain gateable — and the docstring now notes a token-holding agent can self-approve while dev mode is on, a trusted-operator feature); `set_tool` validates tool names against the registry so a typo'd gate can't silently guard a nonexistent tool; the policy card replaces rules in place (order is significant — first match supplies `remember_minutes`) and preserves each condition's own `remember_minutes` unless the input is actually touched; a failed card auto-save now toasts loudly and resyncs from the server instead of displaying a phantom rule; config/policy/backup writes hold a cross-process file lock (stdio sidecar vs server process) with a version re-check on the gate write so a degraded lock fails loud instead of clobbering; i18n catch-up (en/de/ru).

### Verification

Unit (policy 191, dev-tools 98+, settings-UI), jsdom behavior tests for the editor semantics (expand, enable-direction, multi-predicate preservation), e2e ANY-match approval-flow, and live testing on an embedded deployment: PR deployed via `update_source`, ANY-match gating/deny/pass-through verified against a real HA instance, then re-verified after downgrading the same instance to stable for the #1990 repro attempt.

## Type of change
- [x] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [x] 💥 Breaking change

## Testing
- [x] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

## Checklist
- [x] I have updated documentation if needed
