### PR TITLE
fix: keep the WebSocket pool usable after an event-loop change

### DIFF
--- a/src/ha_mcp/client/websocket_client.py
+++ b/src/ha_mcp/client/websocket_client.py
@@ -8,6 +8,7 @@ This module handles WebSocket connections to Home Assistant for:
 """
 
 import asyncio
+import concurrent.futures
 import hashlib
 import json
 import logging
@@ -1036,6 +1037,21 @@ class HomeAssistantWebSocketClient:
 MAX_POOL_SIZE = 50
 
 
+def _log_stale_disconnect(future: "concurrent.futures.Future[None]") -> None:
+    """Report how a disconnect scheduled on a stale event loop ended.
+
+    Nothing awaits that future, so without this the outcome would be invisible
+    at every log level: a ``concurrent.futures.Future`` never warns about an
+    exception no one retrieved.
+    """
+    if future.cancelled():
+        logger.debug("Stale WebSocket disconnect was cancelled with its loop")
+        return
+    error = future.exception()
+    if error is not None:
+        logger.debug("Stale WebSocket disconnect failed: %s", error)
+
+
 class WebSocketManager:
     """Singleton manager for Home Assistant WebSocket connections.
 
@@ -1123,12 +1139,14 @@ class WebSocketManager:
 
         Never awaits: the connections belong to ``loop``, and awaiting them
         from the loop that replaced it is exactly the cross-loop failure this
-        avoids. When ``loop`` is still running (two live loops in one
-        process) each disconnect is scheduled on it and deliberately not
-        waited for. When it is closed or no longer running there is nothing to
-        schedule on, so the connection is abandoned and its socket is released
-        with the loop's own resources. Either way the caller has already
-        detached the pool, so a failure here cannot make it stale again.
+        avoids. When ``loop`` is still running (two live loops in one process)
+        each disconnect is scheduled on it and deliberately not waited for.
+        When it is closed or stopped there is nothing left to schedule on, so
+        the connection is abandoned: its socket is closed when the orphaned
+        transport is garbage-collected (with a ``ResourceWarning``), because
+        closing a loop does not close the transports it carried. Either way
+        the caller has already detached the pool, so a failure here cannot
+        make it stale again.
         """
         if not clients:
             return
@@ -1142,15 +1160,22 @@ class WebSocketManager:
         for client in clients:
             coro = client.disconnect()
             try:
-                asyncio.run_coroutine_threadsafe(coro, loop)
+                future = asyncio.run_coroutine_threadsafe(coro, loop)
             except RuntimeError:
-                # The loop stopped between the check above and now; close the
-                # coroutine so it does not surface as "never awaited".
+                # The loop closed between the check above and now. Closing the
+                # coroutine keeps it from surfacing as "never awaited". The
+                # narrower window stays open by construction: a loop that
+                # accepts the callback and then stops before draining it never
+                # runs the coroutine at all, and ``run_coroutine_threadsafe``
+                # needs the coroutine object up front, so there is nothing left
+                # to reclaim from this side.
                 coro.close()
                 logger.debug(
                     "Could not schedule disconnect of a stale WebSocket client",
                     exc_info=True,
                 )
+                continue
+            future.add_done_callback(_log_stale_disconnect)
 
     async def get_client(
         self,

--- a/src/ha_mcp/client/websocket_client.py
+++ b/src/ha_mcp/client/websocket_client.py
@@ -1139,10 +1139,13 @@ class WebSocketManager:
 
         Never awaits: the connections belong to ``loop``, and awaiting them
         from the loop that replaced it is exactly the cross-loop failure this
-        avoids. When ``loop`` is still running (two live loops in one process)
-        each disconnect is scheduled on it and deliberately not waited for.
-        When it is closed or stopped there is nothing left to schedule on, so
-        the connection is abandoned: its socket is closed when the orphaned
+        avoids. Each disconnect is scheduled on the owning loop and
+        deliberately not waited for. A merely stopped loop is scheduled too:
+        it still owns live transports and still accepts callbacks, so the
+        disconnect runs once that loop is resumed, and otherwise stays an
+        unrun callback like any other the abandoned loop still holds. Only a
+        closed or unknown loop has nothing left to schedule on; its
+        connection is abandoned and the socket closes when the orphaned
         transport is garbage-collected (with a ``ResourceWarning``), because
         closing a loop does not close the transports it carried. Either way
         the caller has already detached the pool, so a failure here cannot
@@ -1150,7 +1153,7 @@ class WebSocketManager:
         """
         if not clients:
             return
-        if loop is None or loop.is_closed() or not loop.is_running():
+        if loop is None or loop.is_closed():
             logger.debug(
                 "Abandoning %d stale WebSocket client(s): the owning event "
                 "loop is gone",

--- a/src/ha_mcp/client/websocket_client.py
+++ b/src/ha_mcp/client/websocket_client.py
@@ -1304,10 +1304,16 @@ class WebSocketManager:
         if not self._lock:
             raise Exception("Lock not initialized")
         async with self._lock:
-            # Detach before disconnecting, for the same reason as the
-            # loop-change branch in ``get_client``: a disconnect that raises
-            # (a cross-loop ``RuntimeError`` when this runs on a loop other
-            # than the pool's) must not leave the pool populated.
+            # Detach the pool before disconnecting so a raising disconnect
+            # cannot leave it populated (the bookkeeping half of the
+            # loop-change branch in ``get_client``). The only caller,
+            # ``__main__``'s shutdown, runs on the pool's own loop, so each
+            # ``disconnect()`` is awaited to completion here. ``RuntimeError``
+            # is caught purely defensively: were this ever driven from a
+            # different loop, the cross-loop future would raise instead of
+            # hanging the shutdown. Unlike ``get_client`` it does not
+            # reschedule onto the owning loop, because the process is going
+            # away and there is nothing left to resume it.
             clients = list(self._clients.values())
             self._clients.clear()
             self._last_used.clear()

--- a/src/ha_mcp/client/websocket_client.py
+++ b/src/ha_mcp/client/websocket_client.py
@@ -1114,6 +1114,44 @@ class WebSocketManager:
             )
             return True
 
+    @staticmethod
+    def _release_stale_clients(
+        clients: list[HomeAssistantWebSocketClient],
+        loop: asyncio.AbstractEventLoop | None,
+    ) -> None:
+        """Best-effort cleanup of clients orphaned by an event-loop change.
+
+        Never awaits: the connections belong to ``loop``, and awaiting them
+        from the loop that replaced it is exactly the cross-loop failure this
+        avoids. When ``loop`` is still running (two live loops in one
+        process) each disconnect is scheduled on it and deliberately not
+        waited for. When it is closed or no longer running there is nothing to
+        schedule on, so the connection is abandoned and its socket is released
+        with the loop's own resources. Either way the caller has already
+        detached the pool, so a failure here cannot make it stale again.
+        """
+        if not clients:
+            return
+        if loop is None or loop.is_closed() or not loop.is_running():
+            logger.debug(
+                "Abandoning %d stale WebSocket client(s): the owning event "
+                "loop is gone",
+                len(clients),
+            )
+            return
+        for client in clients:
+            coro = client.disconnect()
+            try:
+                asyncio.run_coroutine_threadsafe(coro, loop)
+            except RuntimeError:
+                # The loop stopped between the check above and now; close the
+                # coroutine so it does not surface as "never awaited".
+                coro.close()
+                logger.debug(
+                    "Could not schedule disconnect of a stale WebSocket client",
+                    exc_info=True,
+                )
+
     async def get_client(
         self,
         url: str | None = None,
@@ -1143,22 +1181,21 @@ class WebSocketManager:
         if not self._lock:
             raise Exception("Lock not initialized")
         async with self._lock:
-            if self._current_loop is not None and self._current_loop != current_loop:
-                # Event loop changed — disconnect all clients
-                for client in self._clients.values():
-                    try:
-                        await client.disconnect()
-                    except (OSError, asyncio.CancelledError):
-                        # Best-effort cleanup — failure is expected when the
-                        # event loop changed and connections are stale.
-                        logger.debug(
-                            "Ignoring error disconnecting stale WebSocket client",
-                            exc_info=True,
-                        )
+            previous_loop = self._current_loop
+            stale_clients: list[HomeAssistantWebSocketClient] = []
+            if previous_loop is not None and previous_loop is not current_loop:
+                # Event loop changed: detach the pool BEFORE cleaning it up.
+                # The pooled clients' futures belong to ``previous_loop``, so
+                # awaiting their ``disconnect()`` here raises ``RuntimeError:
+                # ... attached to a different loop``, which used to escape the
+                # best-effort catch and leave both the pool and the loop
+                # reference stale for every later call (issue #1994).
+                stale_clients = list(self._clients.values())
                 self._clients.clear()
                 self._last_used.clear()
 
             self._current_loop = current_loop
+            self._release_stale_clients(stale_clients, previous_loop)
 
             # Determine credentials to use
             if url and token:
@@ -1226,7 +1263,7 @@ class WebSocketManager:
         if stale:
             try:
                 await stale.disconnect()
-            except (OSError, asyncio.CancelledError):
+            except (OSError, RuntimeError, asyncio.CancelledError):
                 logger.warning(
                     "Error disconnecting evicted WebSocket client",
                     exc_info=True,
@@ -1239,16 +1276,21 @@ class WebSocketManager:
         if not self._lock:
             raise Exception("Lock not initialized")
         async with self._lock:
-            for client in self._clients.values():
-                try:
-                    await client.disconnect()
-                except (OSError, asyncio.CancelledError):
-                    logger.warning(
-                        "Error disconnecting WebSocket client", exc_info=True
-                    )
+            # Detach before disconnecting, for the same reason as the
+            # loop-change branch in ``get_client``: a disconnect that raises
+            # (a cross-loop ``RuntimeError`` when this runs on a loop other
+            # than the pool's) must not leave the pool populated.
+            clients = list(self._clients.values())
             self._clients.clear()
             self._last_used.clear()
             self._current_loop = None
+            for client in clients:
+                try:
+                    await client.disconnect()
+                except (OSError, RuntimeError, asyncio.CancelledError):
+                    logger.warning(
+                        "Error disconnecting WebSocket client", exc_info=True
+                    )
 
 
 # Global WebSocket manager instance

--- a/tests/src/unit/test_tools_utility_supervisor_logs.py
+++ b/tests/src/unit/test_tools_utility_supervisor_logs.py
@@ -1502,7 +1502,9 @@ class TestJournaldWindowLinesParam:
         assert kwargs["params"] is None
 
     @pytest.mark.asyncio
-    async def test_addon_proxy_branch_sends_lines_query(self, mock_client):
+    async def test_addon_proxy_branch_sends_lines_query(
+        self, mock_client, non_addon_install
+    ):
         mock_response = MagicMock()
         mock_response.status_code = 200
         mock_response.text = "x\n"
@@ -1514,7 +1516,9 @@ class TestJournaldWindowLinesParam:
         assert kwargs["params"] == {"lines": 2000}
 
     @pytest.mark.asyncio
-    async def test_system_service_proxy_branch_sends_lines_query(self, mock_client):
+    async def test_system_service_proxy_branch_sends_lines_query(
+        self, mock_client, non_addon_install
+    ):
         mock_response = MagicMock()
         mock_response.status_code = 200
         mock_response.text = "x\n"

--- a/tests/src/unit/test_ws_pool_loop_change_1994.py
+++ b/tests/src/unit/test_ws_pool_loop_change_1994.py
@@ -1,0 +1,164 @@
+"""Regression tests for issue #1994: pooled clients after an event-loop change.
+
+``WebSocketManager`` is a process-wide singleton, but its pooled connections
+belong to the event loop they were created on. The embedded custom component
+runs the server in a worker thread with its own loop and closes that loop on
+teardown, so an integration reload hands the surviving manager a pool of
+clients whose transports and futures belong to a loop that is already gone.
+
+Awaiting ``client.disconnect()`` for such a client from the new loop raises
+``RuntimeError: Task ... got Future ... attached to a different loop``. That is
+neither ``OSError`` nor ``CancelledError``, so before the fix it escaped the
+best-effort catch, the pool was never cleared, ``_current_loop`` was never
+updated, and every subsequent WebSocket-backed call re-entered the same branch
+and failed identically until Home Assistant was restarted.
+
+The tests below pin the two halves of the fix: the pool is detached before any
+cleanup runs, and cleanup for a still-running owning loop happens on that loop
+instead of being awaited from the new one.
+"""
+
+import asyncio
+import threading
+
+import pytest
+
+from ha_mcp.client.websocket_client import (
+    HomeAssistantWebSocketClient,
+    WebSocketManager,
+)
+
+CROSS_LOOP_MESSAGE = (
+    "Task <Task pending name='Task-1'> got Future <Future pending> "
+    "attached to a different loop"
+)
+
+
+class StubWebSocketClient:
+    """Minimal pooled-client stand-in that records its disconnect calls."""
+
+    def __init__(self, *, disconnect_error: BaseException | None = None) -> None:
+        self.is_connected = True
+        self.disconnect_error = disconnect_error
+        self.disconnect_calls = 0
+        self.disconnected = threading.Event()
+        self.disconnect_loop: asyncio.AbstractEventLoop | None = None
+        self.last_connect_error: str | None = None
+
+    async def connect(self) -> bool:
+        return True
+
+    async def disconnect(self) -> None:
+        self.disconnect_calls += 1
+        self.disconnect_loop = asyncio.get_running_loop()
+        self.disconnected.set()
+        if self.disconnect_error is not None:
+            raise self.disconnect_error
+
+
+@pytest.fixture
+def manager():
+    """Yield the singleton manager with isolated, restored pool state."""
+    mgr = WebSocketManager()
+    saved = (
+        dict(mgr._clients),
+        dict(mgr._last_used),
+        mgr._current_loop,
+        mgr._lock,
+        mgr._lock_loop,
+        mgr._client_factory,
+    )
+    mgr._clients.clear()
+    mgr._last_used.clear()
+    mgr._current_loop = None
+    mgr._lock = None
+    mgr._lock_loop = None
+    try:
+        yield mgr
+    finally:
+        mgr._clients.clear()
+        mgr._clients.update(saved[0])
+        mgr._last_used.clear()
+        mgr._last_used.update(saved[1])
+        mgr._current_loop = saved[2]
+        mgr._lock = saved[3]
+        mgr._lock_loop = saved[4]
+        mgr.configure(client_factory=saved[5] or HomeAssistantWebSocketClient)
+
+
+def test_get_client_recovers_after_the_owning_loop_was_closed(manager):
+    """A second loop gets a fresh client instead of the cross-loop failure.
+
+    Both halves matter: ``get_client`` must return normally, and the stale
+    client must never be awaited, because its loop is closed by then.
+    """
+    stale = StubWebSocketClient(disconnect_error=RuntimeError(CROSS_LOOP_MESSAGE))
+    fresh = StubWebSocketClient()
+    handed_out = iter((stale, fresh))
+    manager.configure(client_factory=lambda url, token: next(handed_out))
+
+    first = asyncio.run(manager.get_client(url="http://ha.local", token="t"))
+    assert first is stale
+
+    # A different loop: this is the call that used to raise and leave the pool
+    # permanently stale.
+    second = asyncio.run(manager.get_client(url="http://ha.local", token="t"))
+
+    assert second is fresh
+    assert stale.disconnect_calls == 0
+    assert list(manager._clients.values()) == [fresh]
+    assert len(manager._last_used) == 1
+
+
+async def test_stale_disconnect_runs_on_a_still_running_owning_loop(manager):
+    """Two live loops: cleanup runs on the loop that owns the client.
+
+    The discriminating assertion is which loop executed the disconnect. Simply
+    awaiting it from the new loop also sets the call counter, so the counter
+    alone would pass against the unfixed code.
+    """
+    stale = StubWebSocketClient()
+    fresh = StubWebSocketClient()
+    handed_out = iter((stale, fresh))
+    manager.configure(client_factory=lambda url, token: next(handed_out))
+
+    owning_loop = asyncio.new_event_loop()
+    worker = threading.Thread(target=owning_loop.run_forever, daemon=True)
+    worker.start()
+    try:
+        first = asyncio.run_coroutine_threadsafe(
+            manager.get_client(url="http://ha.local", token="t"), owning_loop
+        ).result(timeout=10)
+        assert first is stale
+
+        second = await manager.get_client(url="http://ha.local", token="t")
+
+        assert second is fresh
+        assert stale.disconnected.wait(timeout=10)
+        assert stale.disconnect_calls == 1
+        assert stale.disconnect_loop is owning_loop
+        assert list(manager._clients.values()) == [fresh]
+    finally:
+        owning_loop.call_soon_threadsafe(owning_loop.stop)
+        worker.join(timeout=10)
+        owning_loop.close()
+
+
+async def test_disconnect_clears_the_pool_even_when_a_client_raises(manager):
+    """``WebSocketManager.disconnect`` leaves no pooled state behind.
+
+    A raising client used to abort the loop before ``_clients.clear()``, which
+    is the same permanently-stale-pool failure on the shutdown path.
+    """
+    failing = StubWebSocketClient(disconnect_error=RuntimeError(CROSS_LOOP_MESSAGE))
+    manager.configure(client_factory=lambda url, token: failing)
+
+    await manager.get_client(url="http://ha.local", token="t")
+    assert manager._clients
+
+    await manager.disconnect()
+
+    assert failing.disconnect_calls == 1
+    assert manager._clients == {}
+    assert manager._last_used == {}
+    assert manager._current_loop is None

--- a/tests/src/unit/test_ws_pool_loop_change_1994.py
+++ b/tests/src/unit/test_ws_pool_loop_change_1994.py
@@ -20,6 +20,7 @@ instead of being awaited from the new one.
 
 import asyncio
 import threading
+from collections.abc import Callable
 
 import pytest
 
@@ -44,6 +45,10 @@ class StubWebSocketClient:
         self.disconnected = threading.Event()
         self.disconnect_loop: asyncio.AbstractEventLoop | None = None
         self.last_connect_error: str | None = None
+        # Set by a test that needs to observe manager state from inside the
+        # disconnect call, i.e. mid-cleanup.
+        self.observe_pool: Callable[[], dict[str, object]] | None = None
+        self.pool_at_disconnect: dict[str, object] | None = None
 
     async def connect(self) -> bool:
         return True
@@ -51,6 +56,8 @@ class StubWebSocketClient:
     async def disconnect(self) -> None:
         self.disconnect_calls += 1
         self.disconnect_loop = asyncio.get_running_loop()
+        if self.observe_pool is not None:
+            self.pool_at_disconnect = self.observe_pool()
         self.disconnected.set()
         if self.disconnect_error is not None:
             raise self.disconnect_error
@@ -147,18 +154,23 @@ async def test_stale_disconnect_runs_on_a_still_running_owning_loop(manager):
 async def test_disconnect_clears_the_pool_even_when_a_client_raises(manager):
     """``WebSocketManager.disconnect`` leaves no pooled state behind.
 
-    A raising client used to abort the loop before ``_clients.clear()``, which
-    is the same permanently-stale-pool failure on the shutdown path.
+    Two independent properties, so both are asserted: the pool is already
+    detached while a client is being disconnected (``pool_at_disconnect``),
+    and a raising client does not abort the shutdown. Asserting only the final
+    state would pass against the old order, where the raise was merely caught
+    and the trailing ``clear()`` still ran.
     """
     failing = StubWebSocketClient(disconnect_error=RuntimeError(CROSS_LOOP_MESSAGE))
     manager.configure(client_factory=lambda url, token: failing)
 
     await manager.get_client(url="http://ha.local", token="t")
     assert manager._clients
+    failing.observe_pool = lambda: dict(manager._clients)
 
     await manager.disconnect()
 
     assert failing.disconnect_calls == 1
+    assert failing.pool_at_disconnect == {}
     assert manager._clients == {}
     assert manager._last_used == {}
     assert manager._current_loop is None

--- a/tests/src/unit/test_ws_pool_loop_change_1994.py
+++ b/tests/src/unit/test_ws_pool_loop_change_1994.py
@@ -19,14 +19,18 @@ instead of being awaited from the new one.
 """
 
 import asyncio
+import concurrent.futures
+import logging
 import threading
 from collections.abc import Callable
 
 import pytest
 
+from ha_mcp.client import websocket_client
 from ha_mcp.client.websocket_client import (
     HomeAssistantWebSocketClient,
     WebSocketManager,
+    _log_stale_disconnect,
 )
 
 CROSS_LOOP_MESSAGE = (
@@ -218,3 +222,84 @@ async def test_disconnect_clears_the_pool_even_when_a_client_raises(manager):
     assert manager._clients == {}
     assert manager._last_used == {}
     assert manager._current_loop is None
+
+
+def test_log_stale_disconnect_handles_a_cancelled_future(caplog):
+    """A cancelled fire-and-forget disconnect logs, and never calls exception().
+
+    ``_log_stale_disconnect`` is the only signal for a disconnect nobody
+    awaits. Its ``cancelled()`` guard must precede ``exception()``: on a
+    cancelled ``concurrent.futures.Future`` calling ``.exception()`` raises
+    ``CancelledError``, so dropping or reordering the guard would turn this
+    callback into a raiser. Cancel while PENDING so ``cancelled()`` is True.
+    """
+    future: concurrent.futures.Future[None] = concurrent.futures.Future()
+    assert future.cancel()
+
+    with caplog.at_level(logging.DEBUG, logger=websocket_client.logger.name):
+        _log_stale_disconnect(future)
+
+    assert "cancelled with its loop" in caplog.text
+
+
+def test_log_stale_disconnect_reports_a_failed_future(caplog):
+    """A scheduled disconnect that raised is surfaced at debug, not swallowed.
+
+    The future finished with an exception no one retrieved; without this
+    callback a ``concurrent.futures.Future`` stays silent about it.
+    """
+    future: concurrent.futures.Future[None] = concurrent.futures.Future()
+    future.set_exception(RuntimeError(CROSS_LOOP_MESSAGE))
+
+    with caplog.at_level(logging.DEBUG, logger=websocket_client.logger.name):
+        _log_stale_disconnect(future)
+
+    assert "Stale WebSocket disconnect failed" in caplog.text
+    assert CROSS_LOOP_MESSAGE in caplog.text
+
+
+def test_release_stale_clients_survives_a_loop_closing_mid_schedule(
+    monkeypatch, caplog
+):
+    """The race where the owning loop closes between the is_closed() check and
+    ``run_coroutine_threadsafe`` is caught, and cleanup moves to the next
+    client instead of propagating.
+
+    A running loop clears the abandon guard so the scheduling branch is
+    reached; ``run_coroutine_threadsafe`` is then forced to raise
+    ``RuntimeError`` (what a loop closing in that window actually raises).
+    Two clients pin the ``continue``: both are attempted, the disconnect
+    coroutines are closed (no "never awaited" warning), and nothing escapes.
+    """
+    first = StubWebSocketClient()
+    second = StubWebSocketClient()
+
+    calls = 0
+
+    def raise_runtime(_coro, _loop):
+        # Model the loop closing in the check->schedule window; the real
+        # except branch is what must close the orphaned coroutine, not this.
+        nonlocal calls
+        calls += 1
+        raise RuntimeError("Event loop is closed")
+
+    monkeypatch.setattr(
+        websocket_client.asyncio, "run_coroutine_threadsafe", raise_runtime
+    )
+
+    owning_loop = asyncio.new_event_loop()
+    worker = threading.Thread(target=owning_loop.run_forever, daemon=True)
+    worker.start()
+    try:
+        with caplog.at_level(logging.DEBUG, logger=websocket_client.logger.name):
+            # Does not raise despite both schedule attempts failing.
+            WebSocketManager._release_stale_clients([first, second], owning_loop)
+    finally:
+        owning_loop.call_soon_threadsafe(owning_loop.stop)
+        worker.join(timeout=10)
+        owning_loop.close()
+
+    assert calls == 2
+    assert caplog.text.count("Could not schedule disconnect") == 2
+    assert first.disconnect_calls == 0
+    assert second.disconnect_calls == 0

--- a/tests/src/unit/test_ws_pool_loop_change_1994.py
+++ b/tests/src/unit/test_ws_pool_loop_change_1994.py
@@ -151,6 +151,50 @@ async def test_stale_disconnect_runs_on_a_still_running_owning_loop(manager):
         owning_loop.close()
 
 
+def test_stale_disconnect_is_deferred_to_a_stopped_owning_loop(manager):
+    """A stopped, not closed loop still gets the cleanup when it resumes.
+
+    Such a loop owns live transports and can be restarted, so abandoning its
+    clients would leak a connection and its background task on every loop
+    swap. The discriminating assertion is that the disconnect runs on the
+    owning loop only after that loop is resumed, not that it runs at all.
+    """
+    stale = StubWebSocketClient()
+    fresh = StubWebSocketClient()
+    handed_out = iter((stale, fresh))
+    manager.configure(client_factory=lambda url, token: next(handed_out))
+
+    owning_loop = asyncio.new_event_loop()
+    try:
+        first = owning_loop.run_until_complete(
+            manager.get_client(url="http://ha.local", token="t")
+        )
+        assert first is stale
+        assert not owning_loop.is_running()
+        assert not owning_loop.is_closed()
+
+        # A second loop takes over while the first one is merely stopped.
+        second = asyncio.run(manager.get_client(url="http://ha.local", token="t"))
+
+        assert second is fresh
+        # Still queued: a stopped loop runs nothing until it is resumed.
+        assert stale.disconnect_calls == 0
+
+        async def drain() -> None:
+            for _ in range(100):
+                if stale.disconnected.is_set():
+                    return
+                await asyncio.sleep(0.01)
+
+        owning_loop.run_until_complete(drain())
+
+        assert stale.disconnect_calls == 1
+        assert stale.disconnect_loop is owning_loop
+        assert list(manager._clients.values()) == [fresh]
+    finally:
+        owning_loop.close()
+
+
 async def test_disconnect_clears_the_pool_even_when_a_client_raises(manager):
     """``WebSocketManager.disconnect`` leaves no pooled state behind.
 


### PR DESCRIPTION
Closes #1994
Closes #2000

## What does this PR do?

`WebSocketManager` is a process-wide singleton, but its pooled connections belong to the event loop they were created on. When the loop changed, `get_client()` awaited `client.disconnect()` for every pooled client from the new loop. That raises `RuntimeError: Task ... got Future ... attached to a different loop`, which is neither `OSError` nor `CancelledError`, so it escaped the best-effort catch before `_clients.clear()` and before `self._current_loop` was updated. The pool and the loop reference stayed stale, every later call re-entered the same branch, and WebSocket-backed tools (history, statistics) failed with `CONNECTION_FAILED` until the process restarted, while REST-backed reads kept working.

The embedded custom component is where this shows up: it runs the server in a worker thread on its own loop (`custom_components/ha_mcp_tools/embedded_server.py:1164`) and closes that loop on teardown, so an integration reload hands the surviving manager a pool bound to a loop that is already gone.

Changes:

- `get_client()` detaches the pool and updates `_current_loop` **before** any cleanup runs, so a failure during cleanup can no longer leave the pool stale.
- Cleanup of orphaned clients never awaits across loops. Each disconnect is scheduled on the owning loop via `run_coroutine_threadsafe` and its outcome reported through a done-callback. A merely stopped loop is scheduled too, since it still owns live transports and runs the callback once resumed; only a closed or unknown loop has nothing left to schedule on, so its connection is abandoned and the socket is closed when the orphaned transport is garbage-collected.
- `WebSocketManager.disconnect()` uses the same detach-first order for the shutdown path, and both remaining best-effort catches in `WebSocketManager` (shutdown and LRU eviction) now include `RuntimeError`.

## Type of change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [ ] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

Seven regression tests in `tests/src/unit/test_ws_pool_loop_change_1994.py`. Three drive the loop-change branch with a real second loop, which had no such coverage before: recovery after the owning loop was closed, cleanup executing on a still-running owning loop (asserted by which loop ran the disconnect, since the call counter alone passes either way), and the disconnect deferred onto a stopped-but-not-closed loop until it resumes. One pins the detach order in `disconnect()`. The last three cover the fire-and-forget cleanup itself: the done-callback on a cancelled and on a failed future, and the schedule-race branch where the owning loop closes between the `is_closed()` check and `run_coroutine_threadsafe`. Each was checked against the unpatched source and fails there.

No LLM-agent run: the trigger is a second event loop inside the server process, which is not reachable from a test that drives the server from outside. That is also why there is no e2e test for it.

While validating locally I also folded in a Boy-Scout fix for #2000: the two `TestJournaldWindowLinesParam` proxy cases in `tests/src/unit/test_tools_utility_supervisor_logs.py` selected their branch off an ambient `SUPERVISOR_TOKEN`, so they took the Supervisor-direct path and issued a real request when the variable happened to be set. They now take the existing `non_addon_install` fixture, making the branch explicit on every machine.

Local unit run: 8241 passed, 9 failed, 194 skipped. The 9 failures are pre-existing on master and reproduce with this branch's source change reverted: the skills-vendor submodule is not initialized in my worktree (four `TestUniformResponseShape` cases and five `TestResourcesAccessibility` cases), unrelated to the files this PR touches. E2E was not run locally (no Docker available in this environment), so the full suite is left to CI. `ruff check` and `ruff format --check` are clean on the changed files.

## Checklist
- [x] I have updated documentation if needed

