### PR TITLE
fix: report Hue/YAML scenes as CONFIG_NOT_FOUND, not ENTITY_NOT_FOUND

### DIFF
--- a/src/ha_mcp/client/rest_client.py
+++ b/src/ha_mcp/client/rest_client.py
@@ -8,7 +8,8 @@ import logging
 import os
 import ssl
 import time
-from typing import Any
+from dataclasses import dataclass
+from typing import Any, NoReturn
 
 import httpx
 from websockets.exceptions import WebSocketException
@@ -95,6 +96,54 @@ class HomeAssistantAPIError(HomeAssistantError):
         super().__init__(message)
         self.status_code = status_code
         self.response_data = response_data
+
+
+@dataclass(frozen=True)
+class SceneResolution:
+    """Outcome of resolving a scene identifier via the entity registry.
+
+    ``registry_hit`` records whether ``config/entity_registry/get`` returned a
+    usable ``unique_id`` - i.e. the entity actually EXISTS. It is the signal that
+    separates a genuinely-missing scene from one that exists but is not editable
+    through HA's scene config API (a Hue/vendor scene, or a raw-YAML scene): both
+    resolve fine yet 404 on ``config/scene/config/{id}``, because that endpoint is
+    backed only by the managed ``scenes.yaml`` (issue #1971). ``platform`` carries
+    the registry entry's integration domain (``"hue"``, ``"homeassistant"``, …)
+    for error-message enrichment only - it never drives the classification, since
+    a raw-YAML scene is ``platform="homeassistant"`` yet still 404s.
+    """
+
+    storage_key: str
+    registry_hit: bool
+    platform: str | None
+
+
+class SceneStorageConfigNotFoundError(HomeAssistantAPIError):
+    """A scene entity resolved in the registry, but ``config/scene/config/{id}``
+    (backed by ``scenes.yaml``) has no matching entry.
+
+    The entity EXISTS; it is simply not an editable Home Assistant storage scene
+    (Hue/vendor scene, or a raw-YAML scene). Raised instead of a bare 404 so the
+    tools layer can surface ``CONFIG_NOT_FOUND`` rather than the misleading
+    ``ENTITY_NOT_FOUND``/``RESOURCE_NOT_FOUND`` (issue #1971). Subclasses
+    ``HomeAssistantAPIError`` so existing ``except HomeAssistantAPIError`` sites
+    keep treating it as the 404 it is.
+    """
+
+    def __init__(
+        self,
+        scene_id: str,
+        *,
+        platform: str | None = None,
+        storage_key: str | None = None,
+    ):
+        self.scene_id = scene_id
+        self.platform = platform
+        self.storage_key = storage_key
+        msg = f"Scene not found in editable storage: {scene_id}"
+        if storage_key and storage_key != scene_id:
+            msg += f" (resolved storage key: {storage_key})"
+        super().__init__(msg, status_code=404)
 
 
 class HomeAssistantCommandError(HomeAssistantError):
@@ -1773,20 +1822,23 @@ class HomeAssistantClient:
                 ) from e
             raise
 
-    async def resolve_scene_id(self, identifier: str) -> str:
-        """
-        Resolve a scene identifier to its storage key via the entity registry.
+    async def _resolve_scene(self, identifier: str) -> SceneResolution:
+        """Resolve a scene identifier to its storage key AND registry metadata.
 
-        Scenes may be renamed in the HA UI, changing the entity_id but keeping
-        the original storage key. Mirrors :meth:`_resolve_script_id` — scenes
-        likewise need a WebSocket entity registry lookup; their state attributes
-        do not surface the storage key.
+        Backs :meth:`resolve_scene_id`. Returns the storage key together with
+        ``registry_hit`` (did the entity actually resolve?) and ``platform`` - the
+        two signals a bare storage key throws away. Callers that hit a config-API
+        404 need ``registry_hit`` to tell "entity missing" from "entity exists but
+        has no editable storage config", and ``platform`` to name the owning
+        integration in the resulting error (issue #1971).
 
         Args:
             identifier: Scene ID (with or without ``scene.`` prefix)
 
         Returns:
-            The storage key for the configuration API
+            A :class:`SceneResolution`. On any lookup failure it falls back to the
+            bare id with ``registry_hit=False`` - a write path must not treat the
+            guessed bare id as a confirmed resolve.
         """
         bare_id = identifier.removeprefix("scene.")
         entity_id = f"scene.{bare_id}"
@@ -1795,13 +1847,18 @@ class HomeAssistantClient:
                 {"type": "config/entity_registry/get", "entity_id": entity_id}
             )
             if result.get("success") is not False:
-                unique_id = result.get("result", {}).get("unique_id")
+                entry = result.get("result") or {}
+                unique_id = entry.get("unique_id")
                 if unique_id:
                     if unique_id != bare_id:
                         logger.debug(
                             f"Resolved scene entity_id {entity_id} to storage key {unique_id}"
                         )
-                    return str(unique_id)
+                    return SceneResolution(
+                        storage_key=str(unique_id),
+                        registry_hit=True,
+                        platform=entry.get("platform"),
+                    )
         except HomeAssistantConnectionError:
             # A dead transport must not become a silent guess: the fallback
             # below assumes the storage key equals the bare entity_id, which is
@@ -1814,7 +1871,50 @@ class HomeAssistantClient:
                 f"Entity registry lookup failed for {entity_id}, using bare id: {bare_id}",
                 exc_info=True,
             )
-        return bare_id
+        return SceneResolution(storage_key=bare_id, registry_hit=False, platform=None)
+
+    async def resolve_scene_id(self, identifier: str) -> str:
+        """
+        Resolve a scene identifier to its storage key via the entity registry.
+
+        Scenes may be renamed in the HA UI, changing the entity_id but keeping
+        the original storage key. Mirrors :meth:`_resolve_script_id` - scenes
+        likewise need a WebSocket entity registry lookup; their state attributes
+        do not surface the storage key.
+
+        Thin wrapper over :meth:`_resolve_scene` for callers that only need the
+        storage key (e.g. the write path); the read/delete paths use the richer
+        :class:`SceneResolution` directly.
+
+        Args:
+            identifier: Scene ID (with or without ``scene.`` prefix)
+
+        Returns:
+            The storage key for the configuration API
+        """
+        return (await self._resolve_scene(identifier)).storage_key
+
+    def _raise_scene_config_404(
+        self,
+        scene_id: str,
+        resolved_id: str,
+        resolution: SceneResolution | None,
+    ) -> NoReturn:
+        """Translate a scene config-API 404 into the right exception.
+
+        When the registry resolve succeeded (``registry_hit``), the entity exists
+        and the 404 means "no editable storage config" → raise
+        :class:`SceneStorageConfigNotFoundError`. Otherwise the entity is genuinely
+        absent → the historic bare 404 (issue #1971). Always raises.
+        """
+        if resolution is not None and resolution.registry_hit:
+            raise SceneStorageConfigNotFoundError(
+                scene_id, platform=resolution.platform, storage_key=resolved_id
+            )
+        msg = f"Scene not found: {scene_id}"
+        if resolved_id != scene_id:
+            msg += f" (resolved storage key: {resolved_id})"
+        raise HomeAssistantAPIError(msg, status_code=404)
 
     async def get_scene_config(
         self, scene_id: str, *, _resolved: bool = False
@@ -1824,9 +1924,17 @@ class HomeAssistantClient:
         ``_resolved=True`` signals ``scene_id`` is already the resolved storage
         key (the caller ran :meth:`resolve_scene_id`), skipping the redundant
         registry lookup. ``resolve_scene_id`` is idempotent, so the result is
-        identical either way.
+        identical either way. The ``registry_hit``/``platform`` signals a config
+        404 needs (issue #1971) are unavailable on the ``_resolved`` fast path -
+        that path is the internal re-fetch of an already-resolved scene, where a
+        subsequent 404 is a genuine disappearance, not the not-storage-scene case.
         """
-        resolved_id = scene_id if _resolved else await self.resolve_scene_id(scene_id)
+        if _resolved:
+            resolved_id = scene_id
+            resolution: SceneResolution | None = None
+        else:
+            resolution = await self._resolve_scene(scene_id)
+            resolved_id = resolution.storage_key
         try:
             endpoint = f"config/scene/config/{resolved_id}"
             response = await self._request("GET", endpoint)
@@ -1834,10 +1942,7 @@ class HomeAssistantClient:
             return {"success": True, "scene_id": resolved_id, "config": response}
         except HomeAssistantAPIError as e:
             if e.status_code == 404:
-                msg = f"Scene not found: {scene_id}"
-                if resolved_id != scene_id:
-                    msg += f" (resolved storage key: {resolved_id})"
-                raise HomeAssistantAPIError(msg, status_code=404) from e
+                self._raise_scene_config_404(scene_id, resolved_id, resolution)
             raise
         except Exception as e:
             logger.error(f"Failed to get scene config for {scene_id}: {e}")
@@ -1904,15 +2009,30 @@ class HomeAssistantClient:
             raise
 
     async def delete_scene_config(
-        self, scene_id: str, *, _resolved: bool = False
+        self,
+        scene_id: str,
+        *,
+        _resolved: bool = False,
+        resolution: SceneResolution | None = None,
     ) -> dict[str, Any]:
         """Delete Home Assistant scene configuration.
 
         ``_resolved=True`` signals ``scene_id`` is already the resolved storage
         key, skipping the redundant registry lookup (``resolve_scene_id`` is
         idempotent, so the endpoint id is unchanged).
+
+        ``resolution`` lets a caller that already ran :meth:`_resolve_scene` pass
+        the full outcome through - the endpoint uses its ``storage_key`` while
+        ``scene_id`` stays the caller's slug for messages, and its ``registry_hit``
+        drives the config-404 classification (issue #1971) with no extra lookup.
         """
-        resolved_id = scene_id if _resolved else await self.resolve_scene_id(scene_id)
+        if resolution is not None:
+            resolved_id = resolution.storage_key
+        elif _resolved:
+            resolved_id = scene_id
+        else:
+            resolution = await self._resolve_scene(scene_id)
+            resolved_id = resolution.storage_key
         try:
             endpoint = f"config/scene/config/{resolved_id}"
             response = await self._request("DELETE", endpoint)
@@ -1925,10 +2045,7 @@ class HomeAssistantClient:
             }
         except HomeAssistantAPIError as e:
             if e.status_code == 404:
-                msg = f"Scene not found: {scene_id}"
-                if resolved_id != scene_id:
-                    msg += f" (resolved storage key: {resolved_id})"
-                raise HomeAssistantAPIError(msg, status_code=404) from e
+                self._raise_scene_config_404(scene_id, resolved_id, resolution)
             elif e.status_code == 405:
                 raise HomeAssistantAPIError(
                     f"Cannot delete scene '{scene_id}': The HTTP DELETE method is blocked. "

--- a/src/ha_mcp/client/rest_client.py
+++ b/src/ha_mcp/client/rest_client.py
@@ -1878,9 +1878,11 @@ class HomeAssistantClient:
         Resolve a scene identifier to its storage key via the entity registry.
 
         Scenes may be renamed in the HA UI, changing the entity_id but keeping
-        the original storage key. Mirrors :meth:`_resolve_script_id` - scenes
-        likewise need a WebSocket entity registry lookup; their state attributes
-        do not surface the storage key.
+        the original storage key. Like :meth:`_resolve_script_id`, this returns
+        the bare storage key and needs a WebSocket entity registry lookup because
+        the state attributes do not surface it; the parity ends there, since the
+        underlying :meth:`_resolve_scene` additionally carries registry metadata
+        (``registry_hit``/``platform``) that the script resolver has no analogue for.
 
         Thin wrapper over :meth:`_resolve_scene` for callers that only need the
         storage key (e.g. the write path); the read/delete paths use the richer
@@ -1894,7 +1896,24 @@ class HomeAssistantClient:
         """
         return (await self._resolve_scene(identifier)).storage_key
 
-    def _raise_scene_config_404(
+    async def _scene_state_exists(self, storage_key: str) -> bool:
+        """Return True if ``scene.<storage_key>`` exists in the state machine.
+
+        An ``id``-less YAML scene has no registry ``unique_id`` (so
+        ``registry_hit`` is False) yet still registers a state-machine entity.
+        This one-shot existence check separates that real-but-not-storage scene
+        from a genuinely-absent one after a config-API 404 (issue #1971). A 404
+        here is a clean "absent"; a transport failure propagates (fail loud).
+        """
+        try:
+            await self.get_entity_state(f"scene.{storage_key}")
+            return True
+        except HomeAssistantAPIError as e:
+            if e.status_code == 404:
+                return False
+            raise
+
+    async def _raise_scene_config_404(
         self,
         scene_id: str,
         resolved_id: str,
@@ -1904,34 +1923,56 @@ class HomeAssistantClient:
 
         When the registry resolve succeeded (``registry_hit``), the entity exists
         and the 404 means "no editable storage config" → raise
-        :class:`SceneStorageConfigNotFoundError`. Otherwise the entity is genuinely
-        absent → the historic bare 404 (issue #1971). Always raises.
+        :class:`SceneStorageConfigNotFoundError` carrying the platform. On a
+        registry miss the entity may still be an ``id``-less YAML scene, which has
+        no registry ``unique_id`` yet exists in the state machine: a state hit
+        upgrades the 404 to the same not-storage-scene case with ``platform=None``
+        (issue #1971). Only a state miss too is the historic genuinely-absent bare
+        404. The state check is skipped when ``resolution`` is None (the internal
+        ``_resolved`` re-fetch fast path, where a 404 is a genuine disappearance).
+        Always raises.
         """
-        if resolution is not None and resolution.registry_hit:
-            raise SceneStorageConfigNotFoundError(
-                scene_id, platform=resolution.platform, storage_key=resolved_id
-            )
+        if resolution is not None:
+            if resolution.registry_hit:
+                raise SceneStorageConfigNotFoundError(
+                    scene_id, platform=resolution.platform, storage_key=resolved_id
+                )
+            if await self._scene_state_exists(resolved_id):
+                raise SceneStorageConfigNotFoundError(
+                    scene_id, platform=None, storage_key=resolved_id
+                )
         msg = f"Scene not found: {scene_id}"
         if resolved_id != scene_id:
             msg += f" (resolved storage key: {resolved_id})"
         raise HomeAssistantAPIError(msg, status_code=404)
 
     async def get_scene_config(
-        self, scene_id: str, *, _resolved: bool = False
+        self,
+        scene_id: str,
+        *,
+        _resolved: bool = False,
+        resolution: SceneResolution | None = None,
     ) -> dict[str, Any]:
         """Get Home Assistant scene configuration by scene_id.
+
+        ``resolution`` lets a caller that already ran :meth:`_resolve_scene` pass
+        the full outcome through: the endpoint uses its ``storage_key`` and its
+        ``registry_hit``/``platform`` drive the config-404 classification (issue
+        #1971) with no extra lookup. It takes precedence over ``_resolved``.
 
         ``_resolved=True`` signals ``scene_id`` is already the resolved storage
         key (the caller ran :meth:`resolve_scene_id`), skipping the redundant
         registry lookup. ``resolve_scene_id`` is idempotent, so the result is
-        identical either way. The ``registry_hit``/``platform`` signals a config
-        404 needs (issue #1971) are unavailable on the ``_resolved`` fast path -
-        that path is the internal re-fetch of an already-resolved scene, where a
-        subsequent 404 is a genuine disappearance, not the not-storage-scene case.
+        identical either way. This fast path is the internal re-fetch of an
+        already-resolved scene (its sole caller is the post-write re-fetch), where
+        a subsequent 404 is a genuine disappearance, not the not-storage-scene
+        case; the ``registry_hit``/``platform`` signals a config 404 needs are
+        deliberately unavailable there.
         """
-        if _resolved:
+        if resolution is not None:
+            resolved_id = resolution.storage_key
+        elif _resolved:
             resolved_id = scene_id
-            resolution: SceneResolution | None = None
         else:
             resolution = await self._resolve_scene(scene_id)
             resolved_id = resolution.storage_key
@@ -1942,7 +1983,7 @@ class HomeAssistantClient:
             return {"success": True, "scene_id": resolved_id, "config": response}
         except HomeAssistantAPIError as e:
             if e.status_code == 404:
-                self._raise_scene_config_404(scene_id, resolved_id, resolution)
+                await self._raise_scene_config_404(scene_id, resolved_id, resolution)
             raise
         except Exception as e:
             logger.error(f"Failed to get scene config for {scene_id}: {e}")
@@ -2012,24 +2053,18 @@ class HomeAssistantClient:
         self,
         scene_id: str,
         *,
-        _resolved: bool = False,
         resolution: SceneResolution | None = None,
     ) -> dict[str, Any]:
         """Delete Home Assistant scene configuration.
-
-        ``_resolved=True`` signals ``scene_id`` is already the resolved storage
-        key, skipping the redundant registry lookup (``resolve_scene_id`` is
-        idempotent, so the endpoint id is unchanged).
 
         ``resolution`` lets a caller that already ran :meth:`_resolve_scene` pass
         the full outcome through - the endpoint uses its ``storage_key`` while
         ``scene_id`` stays the caller's slug for messages, and its ``registry_hit``
         drives the config-404 classification (issue #1971) with no extra lookup.
+        Otherwise the id is resolved here.
         """
         if resolution is not None:
             resolved_id = resolution.storage_key
-        elif _resolved:
-            resolved_id = scene_id
         else:
             resolution = await self._resolve_scene(scene_id)
             resolved_id = resolution.storage_key
@@ -2045,7 +2080,7 @@ class HomeAssistantClient:
             }
         except HomeAssistantAPIError as e:
             if e.status_code == 404:
-                self._raise_scene_config_404(scene_id, resolved_id, resolution)
+                await self._raise_scene_config_404(scene_id, resolved_id, resolution)
             elif e.status_code == 405:
                 raise HomeAssistantAPIError(
                     f"Cannot delete scene '{scene_id}': The HTTP DELETE method is blocked. "

--- a/src/ha_mcp/tools/tools_config_scenes.py
+++ b/src/ha_mcp/tools/tools_config_scenes.py
@@ -795,6 +795,12 @@ class ConfigSceneTools:
 
         except ToolError as te:
             raise augment_tool_error_with_skill_content(te, bp_warnings=None) from None
+        except SceneStorageConfigNotFoundError as e:
+            # Set on a non-storage scene: the hash-verify / python_transform
+            # pre-fetch read 404s because the entity has no editable scenes.yaml
+            # config (Hue/vendor or raw-YAML). Same CONFIG_NOT_FOUND
+            # classification as get/delete (#1971), not a generic write failure.
+            _raise_scene_not_storage_error(e.scene_id, e.platform)
         except Exception as e:
             error = exception_to_structured_error(
                 e,

--- a/src/ha_mcp/tools/tools_config_scenes.py
+++ b/src/ha_mcp/tools/tools_config_scenes.py
@@ -9,7 +9,7 @@ keyed by entity_id (not a list).
 
 import asyncio
 import logging
-from typing import Annotated, Any, cast
+from typing import Annotated, Any, NoReturn, cast
 
 from fastmcp.exceptions import ToolError
 from fastmcp.tools import tool
@@ -19,6 +19,7 @@ from ..client.rest_client import (
     HomeAssistantAPIError,
     HomeAssistantAuthError,
     HomeAssistantConnectionError,
+    SceneStorageConfigNotFoundError,
 )
 from ..errors import ErrorCode, create_error_response
 from ..strict_bps import BestPracticeKeyParam
@@ -61,6 +62,49 @@ from .util_helpers import (
 _SCENE_SKILL_FILES: tuple[str, ...] = ("SKILL.md",)
 
 logger = logging.getLogger(__name__)
+
+
+def _raise_scene_not_storage_error(scene_id: str, platform: str | None) -> NoReturn:
+    """Raise ``CONFIG_NOT_FOUND`` for a scene that exists but has no editable config.
+
+    The scene entity resolved in the registry, but ``config/scene/config/{id}`` -
+    backed only by the managed ``scenes.yaml`` - has no entry for it. That is the
+    not-a-storage-scene case (a Hue/vendor scene, or a scene defined directly in
+    YAML): the entity EXISTS, so ``ENTITY_NOT_FOUND`` would be wrong (issue #1971).
+    ``platform`` names the owning integration when the registry exposed it; the
+    message stays generic otherwise.
+    """
+    entity_id = f"scene.{scene_id.removeprefix('scene.')}"
+    suggestions = [
+        "Activate it with the scene.turn_on service: "
+        f"ha_call_service('scene', 'turn_on', {{'entity_id': '{entity_id}'}}).",
+    ]
+    if platform and platform != "homeassistant":
+        platform_note = (
+            f" It is provided by the '{platform}' integration, which manages its "
+            "own scenes outside Home Assistant's editable scene storage."
+        )
+        suggestions.append(
+            f"Edit this scene in the '{platform}' integration or its companion app; "
+            "ha_config_get_scene / ha_config_set_scene only edit Home Assistant "
+            "UI/storage scenes."
+        )
+    else:
+        platform_note = ""
+        suggestions.append(
+            "ha_config_get_scene / ha_config_set_scene only read and edit Home "
+            "Assistant UI/storage scenes (Settings > Automations & Scenes > Scenes). "
+            "Scenes defined directly in YAML are not editable through this API."
+        )
+    raise_tool_error(
+        create_error_response(
+            ErrorCode.CONFIG_NOT_FOUND,
+            f"Scene '{entity_id}' exists but has no editable Home Assistant "
+            f"storage configuration.{platform_note}",
+            suggestions=suggestions,
+            context={"scene_id": scene_id, "platform": platform},
+        )
+    )
 
 
 class ConfigSceneTools:
@@ -352,6 +396,11 @@ class ConfigSceneTools:
             return await self._legacy_get_scene(scene_id)
         except ToolError:
             raise
+        except SceneStorageConfigNotFoundError as e:
+            # The entity resolved but scenes.yaml has no config for it - a Hue/
+            # vendor or raw-YAML scene. Surface CONFIG_NOT_FOUND, not the
+            # ENTITY_NOT_FOUND the generic handler below would emit (#1971).
+            _raise_scene_not_storage_error(e.scene_id, e.platform)
         except Exception as e:
             # Pass `entity_id` so a 404 from rest_client surfaces as
             # ENTITY_NOT_FOUND (not the generic RESOURCE_NOT_FOUND fallback).
@@ -1229,8 +1278,12 @@ class ConfigSceneTools:
             # callsite (entity_id resolver, delete call, response) uses the
             # storage key consistently — outer ``scene_id`` matches the
             # inner body regardless of whether the caller passed the
-            # entity_id slug or the storage key.
-            resolved_id = await self._client.resolve_scene_id(scene_id)
+            # entity_id slug or the storage key. The rich resolution also
+            # carries ``registry_hit``/``platform`` so a config-API 404 on a
+            # non-storage scene (Hue/vendor, raw-YAML) classifies as
+            # CONFIG_NOT_FOUND rather than the misleading generic 404 (#1971).
+            resolution = await self._client._resolve_scene(scene_id)
+            resolved_id = resolution.storage_key
 
             # Resolve actual entity_id BEFORE delete — once the registry
             # entry is gone, the unique_id lookup can no longer find it.
@@ -1240,9 +1293,11 @@ class ConfigSceneTools:
                 resolved_id, allow_component=True
             )
 
-            # ``resolved_id`` is already the storage key (resolved above), so
-            # skip the redundant re-resolve inside delete_scene_config.
-            result = await self._client.delete_scene_config(resolved_id, _resolved=True)
+            # Thread the resolution through so delete_scene_config reuses the
+            # storage key (no redundant re-resolve) and can classify a 404.
+            result = await self._client.delete_scene_config(
+                scene_id, resolution=resolution
+            )
 
             if wait:
                 try:
@@ -1264,6 +1319,10 @@ class ConfigSceneTools:
             }
         except ToolError:
             raise
+        except SceneStorageConfigNotFoundError as e:
+            # Entity resolved but scenes.yaml has no config for it - a Hue/
+            # vendor or raw-YAML scene, not a genuinely missing entity (#1971).
+            _raise_scene_not_storage_error(e.scene_id, e.platform)
         except Exception as e:
             exception_to_structured_error(
                 e,

--- a/src/ha_mcp/tools/tools_config_scenes.py
+++ b/src/ha_mcp/tools/tools_config_scenes.py
@@ -67,12 +67,13 @@ logger = logging.getLogger(__name__)
 def _raise_scene_not_storage_error(scene_id: str, platform: str | None) -> NoReturn:
     """Raise ``CONFIG_NOT_FOUND`` for a scene that exists but has no editable config.
 
-    The scene entity resolved in the registry, but ``config/scene/config/{id}`` -
-    backed only by the managed ``scenes.yaml`` - has no entry for it. That is the
-    not-a-storage-scene case (a Hue/vendor scene, or a scene defined directly in
-    YAML): the entity EXISTS, so ``ENTITY_NOT_FOUND`` would be wrong (issue #1971).
-    ``platform`` names the owning integration when the registry exposed it; the
-    message stays generic otherwise.
+    The scene entity was confirmed to exist - in the entity registry, or, for an
+    ``id``-less YAML scene that has no registry entry, in the state machine - but
+    ``config/scene/config/{id}``, backed only by the managed ``scenes.yaml``, has
+    no entry for it. That is the not-a-storage-scene case (a Hue/vendor scene, or
+    a scene defined directly in YAML): the entity EXISTS, so ``ENTITY_NOT_FOUND``
+    would be wrong (issue #1971). ``platform`` names the owning integration when
+    the registry exposed it; the message stays generic otherwise.
     """
     entity_id = f"scene.{scene_id.removeprefix('scene.')}"
     suggestions = [
@@ -1149,16 +1150,20 @@ class ConfigSceneTools:
         else:
             resolution = await self._client._resolve_scene(scene_id)
             resolved_id = resolution.storage_key
-            if resolution.registry_hit:
-                # The entity already exists, so this is an EDIT. Without a
-                # hash there is no prior read, and a POST to
-                # ``config/scene/config/<unique_id>`` for a Hue/vendor or
-                # raw-YAML scene would CREATE a brand-new managed
-                # ``scenes.yaml`` entry keyed by that id – a shadow
-                # duplicate – instead of erroring. Pre-check the config
-                # API: a 404 raises SceneStorageConfigNotFoundError, which
-                # the outer handler maps to CONFIG_NOT_FOUND. A registry
-                # miss (registry_hit False) stays a normal create, unchanged.
+            # If the scene already exists this is an EDIT, and without a hash
+            # there is no prior read: a POST to ``config/scene/config/<key>``
+            # for a Hue/vendor or YAML scene would CREATE a duplicate managed
+            # ``scenes.yaml`` entry instead of erroring. Pre-check the config
+            # API first – its 404 raises SceneStorageConfigNotFoundError, which
+            # the outer handler maps to CONFIG_NOT_FOUND.
+            #
+            # Existence takes both signals: an ``id``-less YAML scene has no
+            # registry unique_id yet still holds a state-machine entity, and
+            # shadow-creates just the same. Only a scene missing from both is a
+            # real create, at the price of one extra ``/states/`` GET there.
+            if resolution.registry_hit or await self._client._scene_state_exists(
+                resolved_id
+            ):
                 await self._client.get_scene_config(scene_id, resolution=resolution)
 
         # Cross-check literal service and entity references against the

--- a/src/ha_mcp/tools/tools_config_scenes.py
+++ b/src/ha_mcp/tools/tools_config_scenes.py
@@ -1134,18 +1134,32 @@ class ConfigSceneTools:
         # so subsequent upsert/response builders use the storage key
         # consistently (issue #1168 R3 blocker 6).
         #
-        # Path branching: if a hash is supplied for a non-existent
-        # scene, the inner fetch raises 404 and surfaces as
-        # ENTITY_NOT_FOUND via the outer except — which is the right
-        # caller-facing semantics ("you can't lock against a scene
-        # that doesn't exist"). The no-hash branch resolves separately
-        # so a fresh create still threads the resolved id correctly.
+        # Path branching: the hash arm's inner fetch reads the config
+        # first, so a non-storage scene (Hue/vendor, raw-YAML) surfaces
+        # as CONFIG_NOT_FOUND and a genuinely-missing scene as the bare
+        # 404 – you cannot lock against a config that isn't there. The
+        # no-hash arm has no such read, so it resolves richly and, when
+        # the entity already exists, pre-checks the config API below
+        # before the upsert (issue #1971) so a plain ``set`` on a
+        # non-storage scene cannot silently shadow-create a duplicate.
         if config_hash:
             _, resolved_id = await self._fetch_and_verify_hash(
                 scene_id, config_hash, "set"
             )
         else:
-            resolved_id = await self._client.resolve_scene_id(scene_id)
+            resolution = await self._client._resolve_scene(scene_id)
+            resolved_id = resolution.storage_key
+            if resolution.registry_hit:
+                # The entity already exists, so this is an EDIT. Without a
+                # hash there is no prior read, and a POST to
+                # ``config/scene/config/<unique_id>`` for a Hue/vendor or
+                # raw-YAML scene would CREATE a brand-new managed
+                # ``scenes.yaml`` entry keyed by that id – a shadow
+                # duplicate – instead of erroring. Pre-check the config
+                # API: a 404 raises SceneStorageConfigNotFoundError, which
+                # the outer handler maps to CONFIG_NOT_FOUND. A registry
+                # miss (registry_hit False) stays a normal create, unchanged.
+                await self._client.get_scene_config(scene_id, resolution=resolution)
 
         # Cross-check literal service and entity references against the
         # live registries. Soft warnings only.

--- a/tests/src/e2e/conftest.py
+++ b/tests/src/e2e/conftest.py
@@ -1034,6 +1034,12 @@ E2E_YAML_PACKAGE_SCENE_ENTITY_ID = (
 E2E_YAML_PACKAGE_SCENE_UID = (
     "e2e_yaml_scene_1971_storage_uid"  # declared id / storage key
 )
+# Sibling scene declaring NO ``id``. HA core makes ``id`` optional and maps it
+# straight to the entity's unique_id (homeassistant/components/homeassistant/
+# scene.py: ``unique_id`` -> ``scene_config.id``), so this one gets no registry
+# entry at all while still living in the state machine under its name slug -
+# the registry-MISS arm of the same not-storage-scene case.
+E2E_YAML_PACKAGE_SCENE_IDLESS_ENTITY_ID = "e2e_yaml_scene_1971_idless"
 
 
 def _seed_yaml_package_scene(config_path: Path) -> None:
@@ -1059,6 +1065,12 @@ def _seed_yaml_package_scene(config_path: Path) -> None:
     e2e. That makes the test pin the registry-hit path, not just the state-check
     fallback.
 
+    A second scene in the same package declares NO ``id``. It therefore has no
+    registry entry at all (registry MISS) yet still exists in the state machine,
+    which is the other arm the classification has to cover: on the read path via
+    the state check, and on the no-hash write path so a plain ``set`` cannot
+    shadow-create over it either.
+
     The filename must NOT start with an underscore: ``!include_dir_named`` uses
     the file stem as the package name, and ``PACKAGES_CONFIG_SCHEMA`` validates
     each package name with ``cv.slug``, which rejects a leading underscore
@@ -1071,6 +1083,10 @@ def _seed_yaml_package_scene(config_path: Path) -> None:
         "scene:\n"
         f"  - id: {E2E_YAML_PACKAGE_SCENE_UID}\n"
         "    name: E2E YAML Scene 1971\n"
+        "    entities:\n"
+        "      light.bed_light:\n"
+        '        state: "on"\n'
+        "  - name: E2E YAML Scene 1971 Idless\n"
         "    entities:\n"
         "      light.bed_light:\n"
         '        state: "on"\n'

--- a/tests/src/e2e/conftest.py
+++ b/tests/src/e2e/conftest.py
@@ -1024,6 +1024,59 @@ def _seed_non_yaml_package_file(config_path: Path) -> None:
     )
 
 
+# scene_id / entity_id the YAML-package scene below lands at. HA slugifies the
+# ``name`` into the entity_id while the declared ``id`` becomes the registry
+# unique_id / storage key. They are deliberately DIFFERENT here so the e2e can
+# discriminate the registry-hit classification branch (see the helper below).
+E2E_YAML_PACKAGE_SCENE_ENTITY_ID = (
+    "e2e_yaml_scene_1971"  # HA slugifies the name to this
+)
+E2E_YAML_PACKAGE_SCENE_UID = (
+    "e2e_yaml_scene_1971_storage_uid"  # declared id / storage key
+)
+
+
+def _seed_yaml_package_scene(config_path: Path) -> None:
+    """Stage a YAML-package scene declaring an ``id`` pre-boot (#1971).
+
+    A scene defined in a YAML package with an ``id`` registers in the entity
+    registry (unique_id = that ``id``) yet has NO entry in the managed
+    ``scenes.yaml`` store, so ``config/scene/config/{id}`` 404s. That is the
+    exact registry-hit not-storage-scene case #1971 classifies as
+    CONFIG_NOT_FOUND. It is also the only arm of that case that can run
+    in-container (the Hue/vendor arm needs a real integration). No tool can
+    create it: scene writes go through the managed store, and a post-boot host
+    write to the bind-mounted config dir doesn't propagate in CI, so it is
+    staged here like the legacy backups above. The folder name matches the one
+    initial_test_state/configuration.yaml binds via ``!include_dir_named``.
+
+    The declared ``id`` is deliberately NOT the slug of ``name``: the caller
+    references the scene by its name-derived entity slug, which resolves in the
+    registry to this distinct ``id`` (registry_hit). So a regression that
+    dropped the registry-hit classification branch would fall through to the
+    state-machine check on the storage key ``id`` (which is NOT a real entity,
+    since the entity is the name slug), yielding the generic 404 and failing the
+    e2e. That makes the test pin the registry-hit path, not just the state-check
+    fallback.
+
+    The filename must NOT start with an underscore: ``!include_dir_named`` uses
+    the file stem as the package name, and ``PACKAGES_CONFIG_SCHEMA`` validates
+    each package name with ``cv.slug``, which rejects a leading underscore
+    (slugify strips it, so ``value != slugify(value)`` raises). A ``_``-prefixed
+    name makes HA discard the whole package and the scene silently never loads.
+    """
+    packages_dir = config_path / "custom_packages"
+    packages_dir.mkdir(parents=True, exist_ok=True)
+    (packages_dir / "e2e_yaml_scene.yaml").write_text(
+        "scene:\n"
+        f"  - id: {E2E_YAML_PACKAGE_SCENE_UID}\n"
+        "    name: E2E YAML Scene 1971\n"
+        "    entities:\n"
+        "      light.bed_light:\n"
+        '        state: "on"\n'
+    )
+
+
 def _collect_manifest_requirements(config_path: Path) -> list[str]:
     """Aggregate ``requirements`` from every installed custom-component manifest.
 
@@ -2004,6 +2057,10 @@ def _prepare_testcontainer_config(
     # A non-YAML file in the bound packages folder for the glob warn-and-continue
     # e2e (#1788): same pre-boot reason, and no tool can write it there.
     _seed_non_yaml_package_file(config_path)
+
+    # A YAML-package scene with an ``id`` for the not-storage-scene e2e (#1971):
+    # registers in the registry yet 404s on the config API. Same pre-boot reason.
+    _seed_yaml_package_scene(config_path)
 
     # Shift the pre-baked recorder timestamps forward so the seeded rows
     # look "recent" to history queries with a 24h window. The recorder DB in

--- a/tests/src/e2e/workflows/scenes/test_yaml_scene_not_storage.py
+++ b/tests/src/e2e/workflows/scenes/test_yaml_scene_not_storage.py
@@ -6,6 +6,11 @@ registry (unique_id = that ``id``) yet has NO entry in the managed
 registry-hit case #1971 must classify as ``CONFIG_NOT_FOUND`` rather than the
 misleading ``ENTITY_NOT_FOUND``, because the entity plainly exists.
 
+Its ``id``-less sibling is the same case reached the other way: HA core makes
+``id`` optional and maps it straight to the entity's unique_id, so without one
+there is no registry entry to resolve, only a state-machine entity. Both arms
+run here because the classification takes a different route for each.
+
 Why an e2e test earns its keep here: the tool-layer unit tests inject
 ``SceneStorageConfigNotFoundError`` directly, so a wiring break between the
 resolver, the config-API GET and the tool handler would pass the unit suite
@@ -13,7 +18,7 @@ while shipping the old error. This spans the whole chain through the real
 component. The Hue/vendor arm and the platform-named message can't run
 in-container (they need a real integration); the YAML-package arm can.
 
-The scene is staged pre-boot by ``conftest._seed_yaml_package_scene`` (a
+Both scenes are staged pre-boot by ``conftest._seed_yaml_package_scene`` (a
 post-boot host write to the bind-mounted config dir doesn't propagate in CI),
 which only runs on the testcontainer backends, so these tests skip elsewhere.
 """
@@ -22,21 +27,18 @@ import logging
 
 import pytest
 
+from ...conftest import (
+    E2E_YAML_PACKAGE_SCENE_ENTITY_ID,
+    E2E_YAML_PACKAGE_SCENE_IDLESS_ENTITY_ID,
+)
 from ...utilities.assertions import safe_call_tool
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
-# The entity slug HA derives from the staged scene's ``name`` (what a caller
-# references it by). It is intentionally distinct from the scene's declared
-# ``id`` / storage key (conftest.E2E_YAML_PACKAGE_SCENE_UID) so this test pins
-# the registry-hit classification branch, not just the state-check fallback.
-# Matches conftest.E2E_YAML_PACKAGE_SCENE_ENTITY_ID.
-_YAML_PACKAGE_SCENE_ID = "e2e_yaml_scene_1971"
-
 
 def _require_seeded_backend(container_info: dict) -> None:
-    """Skip unless the YAML-package scene was staged into the container config_path.
+    """Skip unless the YAML-package scenes were staged into the container config_path.
 
     ``_seed_yaml_package_scene`` runs on the shared testcontainer setup path,
     which both the ``container`` and ``embedded`` backends use. The HAOS
@@ -49,18 +51,29 @@ def _require_seeded_backend(container_info: dict) -> None:
         )
 
 
-class TestYamlPackageSceneNotStorage:
-    """A registry-resolved YAML-package scene surfaces CONFIG_NOT_FOUND, not a 404."""
+# The two YAML-package scenes staged by the conftest helper, each reaching the
+# not-storage-scene classification by a different route: the ``id``-bearing one
+# resolves in the entity registry (registry hit), the ``id``-less one is invisible
+# there and is only found in the state machine (registry miss).
+_SCENE_ARMS = [
+    pytest.param(E2E_YAML_PACKAGE_SCENE_ENTITY_ID, id="registry-hit"),
+    pytest.param(E2E_YAML_PACKAGE_SCENE_IDLESS_ENTITY_ID, id="registry-miss-idless"),
+]
 
+
+class TestYamlPackageSceneNotStorage:
+    """A YAML-package scene surfaces CONFIG_NOT_FOUND, not a missing-entity 404."""
+
+    @pytest.mark.parametrize("scene_id", _SCENE_ARMS)
     async def test_get_yaml_package_scene_maps_to_config_not_found(
-        self, ha_container_with_fresh_config, mcp_client
+        self, ha_container_with_fresh_config, mcp_client, scene_id
     ):
         _require_seeded_backend(ha_container_with_fresh_config)
 
         data = await safe_call_tool(
             mcp_client,
             "ha_config_get_scene",
-            {"scene_id": _YAML_PACKAGE_SCENE_ID},
+            {"scene_id": scene_id},
         )
 
         assert data.get("success") is False, (
@@ -74,22 +87,24 @@ class TestYamlPackageSceneNotStorage:
         assert "editable" in (err.get("message") or "").lower(), err
         assert any("turn_on" in s for s in err.get("suggestions", [])), err
 
+    @pytest.mark.parametrize("scene_id", _SCENE_ARMS)
     async def test_set_no_hash_yaml_package_scene_does_not_shadow_create(
-        self, ha_container_with_fresh_config, mcp_client
+        self, ha_container_with_fresh_config, mcp_client, scene_id
     ):
-        """#1971 P1 end-to-end: a plain ``set`` (no config_hash) on the existing
+        """#1971 P1 end-to-end: a plain ``set`` (no config_hash) on an existing
         YAML-package scene pre-checks the config API and surfaces
         CONFIG_NOT_FOUND instead of POSTing a duplicate managed ``scenes.yaml``
-        entry keyed by the package scene's id."""
+        entry. Both arms matter: the pre-check opens on a registry hit OR on a
+        state-machine hit, and only the latter covers the ``id``-less scene."""
         _require_seeded_backend(ha_container_with_fresh_config)
 
         data = await safe_call_tool(
             mcp_client,
             "ha_config_set_scene",
             {
-                "scene_id": _YAML_PACKAGE_SCENE_ID,
+                "scene_id": scene_id,
                 "config": {
-                    "name": "E2E YAML Scene 1971",
+                    "name": "Shadow Copy 1971",
                     "entities": {"light.bed_light": {"state": "off"}},
                 },
                 "wait": False,
@@ -102,3 +117,16 @@ class TestYamlPackageSceneNotStorage:
         )
         err = data.get("error") or {}
         assert err.get("code") == "CONFIG_NOT_FOUND", err
+
+        # The error alone does not prove nothing was written: read back through
+        # the config API. A shadow entry in the managed store would make this
+        # succeed, so the same CONFIG_NOT_FOUND is the actual no-write evidence.
+        after = await safe_call_tool(
+            mcp_client,
+            "ha_config_get_scene",
+            {"scene_id": scene_id},
+        )
+        assert after.get("success") is False, (
+            f"the rejected set still created a managed scenes.yaml entry: {after}"
+        )
+        assert (after.get("error") or {}).get("code") == "CONFIG_NOT_FOUND", after

--- a/tests/src/e2e/workflows/scenes/test_yaml_scene_not_storage.py
+++ b/tests/src/e2e/workflows/scenes/test_yaml_scene_not_storage.py
@@ -1,0 +1,104 @@
+"""End-to-end coverage for the not-storage-scene classification (issue #1971).
+
+A scene defined in a YAML package with an ``id`` registers in the entity
+registry (unique_id = that ``id``) yet has NO entry in the managed
+``scenes.yaml`` store, so ``config/scene/config/{id}`` 404s. That is the exact
+registry-hit case #1971 must classify as ``CONFIG_NOT_FOUND`` rather than the
+misleading ``ENTITY_NOT_FOUND``, because the entity plainly exists.
+
+Why an e2e test earns its keep here: the tool-layer unit tests inject
+``SceneStorageConfigNotFoundError`` directly, so a wiring break between the
+resolver, the config-API GET and the tool handler would pass the unit suite
+while shipping the old error. This spans the whole chain through the real
+component. The Hue/vendor arm and the platform-named message can't run
+in-container (they need a real integration); the YAML-package arm can.
+
+The scene is staged pre-boot by ``conftest._seed_yaml_package_scene`` (a
+post-boot host write to the bind-mounted config dir doesn't propagate in CI),
+which only runs on the testcontainer backends, so these tests skip elsewhere.
+"""
+
+import logging
+
+import pytest
+
+from ...utilities.assertions import safe_call_tool
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+# The entity slug HA derives from the staged scene's ``name`` (what a caller
+# references it by). It is intentionally distinct from the scene's declared
+# ``id`` / storage key (conftest.E2E_YAML_PACKAGE_SCENE_UID) so this test pins
+# the registry-hit classification branch, not just the state-check fallback.
+# Matches conftest.E2E_YAML_PACKAGE_SCENE_ENTITY_ID.
+_YAML_PACKAGE_SCENE_ID = "e2e_yaml_scene_1971"
+
+
+def _require_seeded_backend(container_info: dict) -> None:
+    """Skip unless the YAML-package scene was staged into the container config_path.
+
+    ``_seed_yaml_package_scene`` runs on the shared testcontainer setup path,
+    which both the ``container`` and ``embedded`` backends use. The HAOS
+    backends boot a pre-baked qcow2 with no such seed.
+    """
+    if container_info.get("backend") not in ("container", "embedded"):
+        pytest.skip(
+            "not-storage-scene e2e relies on the pre-boot YAML-package scene "
+            "seeded in the container config_path (testcontainer / embedded only)"
+        )
+
+
+class TestYamlPackageSceneNotStorage:
+    """A registry-resolved YAML-package scene surfaces CONFIG_NOT_FOUND, not a 404."""
+
+    async def test_get_yaml_package_scene_maps_to_config_not_found(
+        self, ha_container_with_fresh_config, mcp_client
+    ):
+        _require_seeded_backend(ha_container_with_fresh_config)
+
+        data = await safe_call_tool(
+            mcp_client,
+            "ha_config_get_scene",
+            {"scene_id": _YAML_PACKAGE_SCENE_ID},
+        )
+
+        assert data.get("success") is False, (
+            f"a YAML-package scene has no editable storage config; get should "
+            f"fail with CONFIG_NOT_FOUND, got: {data}"
+        )
+        err = data.get("error") or {}
+        assert err.get("code") == "CONFIG_NOT_FOUND", err
+        assert err.get("code") != "ENTITY_NOT_FOUND", err
+        # The entity exists, so the message must not read as a missing entity.
+        assert "editable" in (err.get("message") or "").lower(), err
+        assert any("turn_on" in s for s in err.get("suggestions", [])), err
+
+    async def test_set_no_hash_yaml_package_scene_does_not_shadow_create(
+        self, ha_container_with_fresh_config, mcp_client
+    ):
+        """#1971 P1 end-to-end: a plain ``set`` (no config_hash) on the existing
+        YAML-package scene pre-checks the config API and surfaces
+        CONFIG_NOT_FOUND instead of POSTing a duplicate managed ``scenes.yaml``
+        entry keyed by the package scene's id."""
+        _require_seeded_backend(ha_container_with_fresh_config)
+
+        data = await safe_call_tool(
+            mcp_client,
+            "ha_config_set_scene",
+            {
+                "scene_id": _YAML_PACKAGE_SCENE_ID,
+                "config": {
+                    "name": "E2E YAML Scene 1971",
+                    "entities": {"light.bed_light": {"state": "off"}},
+                },
+                "wait": False,
+            },
+        )
+
+        assert data.get("success") is False, (
+            f"a plain set on a non-storage scene must not shadow-create; "
+            f"expected CONFIG_NOT_FOUND, got: {data}"
+        )
+        err = data.get("error") or {}
+        assert err.get("code") == "CONFIG_NOT_FOUND", err

--- a/tests/src/unit/test_helper_response_shape.py
+++ b/tests/src/unit/test_helper_response_shape.py
@@ -18,6 +18,7 @@ import pytest
 from ha_mcp.client.rest_client import (
     HomeAssistantAuthError,
     HomeAssistantConnectionError,
+    SceneResolution,
 )
 
 
@@ -743,6 +744,14 @@ class TestLifecycleWriteWarningsShape:
         client.delete_scene_config = AsyncMock(return_value={"scene_id": "test_scene"})
         client.resolve_scene_id = AsyncMock(
             side_effect=lambda sid: sid.removeprefix("scene.")
+        )
+        # The remove path resolves via ``_resolve_scene`` (issue #1971).
+        client._resolve_scene = AsyncMock(
+            side_effect=lambda sid: SceneResolution(
+                storage_key=sid.removeprefix("scene."),
+                registry_hit=False,
+                platform=None,
+            )
         )
         client.get_entity_state = AsyncMock(
             return_value={

--- a/tests/src/unit/test_helper_response_shape.py
+++ b/tests/src/unit/test_helper_response_shape.py
@@ -753,6 +753,10 @@ class TestLifecycleWriteWarningsShape:
                 platform=None,
             )
         )
+        # On that registry miss the no-hash set path also asks the state machine,
+        # to tell an ``id``-less YAML scene from a genuine create (#1971). False
+        # keeps these fixtures on the create path whose warnings they assert.
+        client._scene_state_exists = AsyncMock(return_value=False)
         client.get_entity_state = AsyncMock(
             return_value={
                 "state": "2026-05-18T00:00:00+00:00",

--- a/tests/src/unit/test_rest_client_scenes.py
+++ b/tests/src/unit/test_rest_client_scenes.py
@@ -13,6 +13,8 @@ import pytest
 from ha_mcp.client.rest_client import (
     HomeAssistantAPIError,
     HomeAssistantClient,
+    SceneResolution,
+    SceneStorageConfigNotFoundError,
 )
 
 
@@ -351,6 +353,114 @@ class TestSceneResolvedShortCircuit:
         mock_client.send_websocket_message.assert_not_called()
         mock_client._request.assert_called_once_with(
             "DELETE", "config/scene/config/storage_key"
+        )
+
+
+class TestSceneStorageConfigNotFound:
+    """Issue #1971: a scene entity that resolves in the registry but 404s on the
+    scenes.yaml-backed config API (a Hue/vendor scene, or a raw-YAML scene) must
+    surface as the not-storage-scene case, not a bare missing-entity 404.
+
+    ``config/scene/config/{id}`` is backed ONLY by the managed ``scenes.yaml``
+    (verified against HA-core), so it 404s for any scene not in that file even
+    though the entity exists - the registry resolve is what tells the two apart.
+    """
+
+    @pytest.fixture
+    def mock_client(self):
+        return _make_mock_client()
+
+    @pytest.mark.asyncio
+    async def test_resolve_scene_returns_platform_and_hit(self, mock_client):
+        """``_resolve_scene`` threads out the registry ``platform`` and a
+        ``registry_hit`` flag - the two signals a bare storage key drops."""
+        mock_client.send_websocket_message = AsyncMock(
+            return_value={"result": {"unique_id": "hue-uuid-123", "platform": "hue"}}
+        )
+
+        resolution = await mock_client._resolve_scene("bedroom_sleepy")
+
+        assert resolution == SceneResolution(
+            storage_key="hue-uuid-123", registry_hit=True, platform="hue"
+        )
+
+    @pytest.mark.asyncio
+    async def test_resolve_scene_miss_reports_no_hit(self, mock_client):
+        """A failed registry lookup falls back to the bare id with
+        ``registry_hit=False`` - a write path must not treat the guess as real."""
+        # _make_mock_client's send_websocket_message raises → lookup miss.
+        resolution = await mock_client._resolve_scene("ghost_scene")
+
+        assert resolution == SceneResolution(
+            storage_key="ghost_scene", registry_hit=False, platform=None
+        )
+
+    @pytest.mark.asyncio
+    async def test_get_scene_404_after_registry_hit_raises_storage_config_error(
+        self, mock_client
+    ):
+        """Entity resolves (Hue) but the config API 404s → the distinct
+        SceneStorageConfigNotFoundError carrying the platform, NOT a bare 404."""
+        mock_client.send_websocket_message = AsyncMock(
+            return_value={"result": {"unique_id": "hue-uuid-123", "platform": "hue"}}
+        )
+        mock_client._request = AsyncMock(
+            side_effect=HomeAssistantAPIError(
+                "API error: 404 - Not found", status_code=404
+            )
+        )
+
+        with pytest.raises(SceneStorageConfigNotFoundError) as exc_info:
+            await mock_client.get_scene_config("bedroom_sleepy")
+
+        err = exc_info.value
+        assert err.status_code == 404
+        assert err.platform == "hue"
+        assert err.scene_id == "bedroom_sleepy"
+        assert err.storage_key == "hue-uuid-123"
+
+    @pytest.mark.asyncio
+    async def test_get_scene_404_registry_miss_stays_generic(self, mock_client):
+        """No registry hit → a genuinely missing entity → the historic bare
+        404, NOT the not-storage-scene subclass."""
+        # send_websocket_message raises (miss) via _make_mock_client.
+        mock_client._request = AsyncMock(
+            side_effect=HomeAssistantAPIError(
+                "API error: 404 - Not found", status_code=404
+            )
+        )
+
+        with pytest.raises(HomeAssistantAPIError) as exc_info:
+            await mock_client.get_scene_config("truly_missing")
+
+        assert not isinstance(exc_info.value, SceneStorageConfigNotFoundError)
+        assert exc_info.value.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_delete_scene_404_after_registry_hit_raises_storage_config_error(
+        self, mock_client
+    ):
+        """The delete read-path 404 classifies identically when the caller
+        threads a registry-hit resolution through (#1971 delete parity)."""
+        mock_client._request = AsyncMock(
+            side_effect=HomeAssistantAPIError(
+                "API error: 404 - Not found", status_code=404
+            )
+        )
+        resolution = SceneResolution(
+            storage_key="hue-uuid-123", registry_hit=True, platform="hue"
+        )
+
+        with pytest.raises(SceneStorageConfigNotFoundError) as exc_info:
+            await mock_client.delete_scene_config(
+                "bedroom_sleepy", resolution=resolution
+            )
+
+        assert exc_info.value.platform == "hue"
+        assert exc_info.value.scene_id == "bedroom_sleepy"
+        # Endpoint used the resolved storage key, not the caller slug.
+        mock_client._request.assert_called_once_with(
+            "DELETE", "config/scene/config/hue-uuid-123"
         )
 
     @pytest.mark.asyncio

--- a/tests/src/unit/test_rest_client_scenes.py
+++ b/tests/src/unit/test_rest_client_scenes.py
@@ -270,12 +270,12 @@ class TestResolveSceneId:
 
 class TestSceneResolvedShortCircuit:
     """Skipping the redundant ``resolve_scene_id`` lookup on get/upsert/delete
-    scene methods (issue #1813 P5 item 3). ``get``/``delete`` take
-    ``_resolved=True``; ``upsert`` takes a separate ``resolved_id`` write-target
-    (so ``scene_id`` stays the caller's id for the missing-``name`` default —
-    #1935). ``_make_mock_client`` makes ``send_websocket_message`` raise, so
-    ``assert_not_called`` proves the resolver was skipped rather than merely
-    falling back."""
+    scene methods (issue #1813 P5 item 3). ``get`` takes ``_resolved=True``;
+    ``delete`` takes a pre-computed ``resolution``; ``upsert`` takes a separate
+    ``resolved_id`` write-target (so ``scene_id`` stays the caller's id for the
+    missing-``name`` default, #1935). ``_make_mock_client`` makes
+    ``send_websocket_message`` raise, so ``assert_not_called`` proves the resolver
+    was skipped rather than merely falling back."""
 
     @pytest.fixture
     def mock_client(self):
@@ -344,10 +344,15 @@ class TestSceneResolvedShortCircuit:
         assert mock_client._request.call_args.kwargs["json"]["name"] == "movie_night"
 
     @pytest.mark.asyncio
-    async def test_delete_scene_resolved_skips_lookup(self, mock_client):
+    async def test_delete_scene_resolution_skips_lookup(self, mock_client):
         mock_client._request = AsyncMock(return_value={"result": "ok"})
 
-        result = await mock_client.delete_scene_config("storage_key", _resolved=True)
+        result = await mock_client.delete_scene_config(
+            "storage_key",
+            resolution=SceneResolution(
+                storage_key="storage_key", registry_hit=False, platform=None
+            ),
+        )
 
         assert result["scene_id"] == "storage_key"
         mock_client.send_websocket_message.assert_not_called()
@@ -435,6 +440,31 @@ class TestSceneStorageConfigNotFound:
 
         assert not isinstance(exc_info.value, SceneStorageConfigNotFoundError)
         assert exc_info.value.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_get_scene_404_registry_miss_but_state_exists_maps_to_config_not_found(
+        self, mock_client
+    ):
+        """An ``id``-less YAML scene has no registry ``unique_id`` (registry miss)
+        yet still exists in the state machine. A config-API 404 there upgrades to
+        the not-storage-scene case with ``platform=None`` (#1971), not the generic
+        missing-entity 404."""
+
+        # send_websocket_message raises (registry miss) via _make_mock_client.
+        async def _req(method, endpoint, **kwargs):
+            if endpoint.startswith("/states/"):
+                return {"entity_id": "scene.yaml_only", "state": "unknown"}
+            raise HomeAssistantAPIError("API error: 404 - Not found", status_code=404)
+
+        mock_client._request = AsyncMock(side_effect=_req)
+
+        with pytest.raises(SceneStorageConfigNotFoundError) as exc_info:
+            await mock_client.get_scene_config("yaml_only")
+
+        err = exc_info.value
+        assert err.status_code == 404
+        assert err.platform is None
+        assert err.scene_id == "yaml_only"
 
     @pytest.mark.asyncio
     async def test_delete_scene_404_after_registry_hit_raises_storage_config_error(

--- a/tests/src/unit/test_tools_config_scenes.py
+++ b/tests/src/unit/test_tools_config_scenes.py
@@ -15,6 +15,8 @@ from ha_mcp.client.rest_client import (
     HomeAssistantAPIError,
     HomeAssistantAuthError,
     HomeAssistantConnectionError,
+    SceneResolution,
+    SceneStorageConfigNotFoundError,
 )
 from ha_mcp.tools.tools_config_scenes import ConfigSceneTools
 
@@ -61,6 +63,17 @@ def mock_client():
     # storage-key remapping override per-test.
     client.resolve_scene_id = AsyncMock(
         side_effect=lambda sid: sid.removeprefix("scene.")
+    )
+    # The remove path resolves via ``_resolve_scene`` (richer than
+    # ``resolve_scene_id``) so a config-API 404 can be classified (#1971).
+    # Default identity mapping mirrors ``resolve_scene_id`` above; tests
+    # needing a slug↔storage-key remap or the not-storage-scene case override.
+    client._resolve_scene = AsyncMock(
+        side_effect=lambda sid: SceneResolution(
+            storage_key=sid.removeprefix("scene."),
+            registry_hit=False,
+            platform=None,
+        )
     )
     return client
 
@@ -846,8 +859,12 @@ class TestSceneResponseShape:
     async def test_remove_scene_response_uses_storage_key(self, tools, mock_client):
         """Issue #1168 R3 blocker 6: remove-scene response surfaces the
         storage key, even when the caller passed the entity_id slug."""
-        mock_client.resolve_scene_id = AsyncMock(
-            return_value="night_light_led_desk_strip"
+        mock_client._resolve_scene = AsyncMock(
+            return_value=SceneResolution(
+                storage_key="night_light_led_desk_strip",
+                registry_hit=True,
+                platform=None,
+            )
         )
         mock_client.delete_scene_config = AsyncMock(
             return_value={
@@ -976,6 +993,15 @@ class TestSceneResolutionDedup:
         resolve = AsyncMock(side_effect=lambda sid: sid.removeprefix("scene."))
         client.resolve_scene_id = resolve
 
+        async def _resolve_rich(sid):
+            return SceneResolution(
+                storage_key=sid.removeprefix("scene."),
+                registry_hit=True,
+                platform=None,
+            )
+
+        client._resolve_scene = AsyncMock(side_effect=_resolve_rich)
+
         async def _get(scene_id, *, _resolved=False):
             rid = scene_id if _resolved else await resolve(scene_id)
             return {
@@ -991,8 +1017,13 @@ class TestSceneResolutionDedup:
             rid = resolved_id if resolved_id is not None else await resolve(scene_id)
             return {"success": True, "scene_id": rid, "result": "ok"}
 
-        async def _delete(scene_id, *, _resolved=False):
-            rid = scene_id if _resolved else await resolve(scene_id)
+        async def _delete(scene_id, *, _resolved=False, resolution=None):
+            if resolution is not None:
+                rid = resolution.storage_key
+            elif _resolved:
+                rid = scene_id
+            else:
+                rid = await resolve(scene_id)
             return {"success": True, "scene_id": rid, "operation": "deleted"}
 
         client.get_scene_config = AsyncMock(side_effect=_get)
@@ -1047,9 +1078,13 @@ class TestSceneResolutionDedup:
 
         assert result["success"] is True
         assert result["scene_id"] == "test_scene"
-        assert client.resolve_scene_id.await_count == 1
+        # Remove resolves via the richer ``_resolve_scene`` (carries
+        # ``registry_hit``/``platform`` for #1971) exactly once, and threads
+        # that resolution into delete so it does not re-resolve.
+        assert client._resolve_scene.await_count == 1
+        assert client.resolve_scene_id.await_count == 0
         _, kwargs = client.delete_scene_config.call_args
-        assert kwargs.get("_resolved") is True
+        assert kwargs.get("resolution") is not None
 
     async def test_python_transform_resolves_once(self, monkeypatch):
         from ha_mcp.utils.config_hash import compute_config_hash
@@ -2541,3 +2576,71 @@ class TestSceneVerificationFailureWarnings:
             f"expected scene-remove verbiage; got {warnings!r}"
         )
         assert any("forced for test" in w for w in warnings)
+
+
+class TestSceneNotStorageScene:
+    """Issue #1971: get/remove of a scene entity that exists in the registry but
+    has no editable ``scenes.yaml`` config (a Hue/vendor scene, or a raw-YAML
+    scene) surfaces ``CONFIG_NOT_FOUND`` - never the misleading
+    ``ENTITY_NOT_FOUND``, since the entity is present. When the registry exposed
+    the owning ``platform`` the message names it and points at ``scene.turn_on``.
+    """
+
+    async def test_get_scene_not_storage_scene_maps_to_config_not_found(
+        self, tools, mock_client
+    ):
+        mock_client.get_scene_config = AsyncMock(
+            side_effect=SceneStorageConfigNotFoundError(
+                "bedroom_sleepy", platform="hue", storage_key="hue-uuid-123"
+            )
+        )
+
+        with pytest.raises(ToolError) as exc_info:
+            await tools.ha_config_get_scene(scene_id="bedroom_sleepy")
+
+        error = json.loads(str(exc_info.value))["error"]
+        assert error["code"] == "CONFIG_NOT_FOUND"
+        assert error["code"] != "ENTITY_NOT_FOUND"
+        msg = error["message"].lower()
+        assert "exists" in msg and "hue" in msg
+        assert any("turn_on" in s for s in error["suggestions"])
+
+    async def test_get_scene_not_storage_scene_unknown_platform_stays_generic(
+        self, tools, mock_client
+    ):
+        """No platform exposed → still CONFIG_NOT_FOUND, generic message (no
+        fabricated integration name), still points at scene.turn_on."""
+        mock_client.get_scene_config = AsyncMock(
+            side_effect=SceneStorageConfigNotFoundError(
+                "yaml_scene", platform=None, storage_key="yaml_scene"
+            )
+        )
+
+        with pytest.raises(ToolError) as exc_info:
+            await tools.ha_config_get_scene(scene_id="yaml_scene")
+
+        error = json.loads(str(exc_info.value))["error"]
+        assert error["code"] == "CONFIG_NOT_FOUND"
+        assert any("turn_on" in s for s in error["suggestions"])
+
+    async def test_remove_scene_not_storage_scene_maps_to_config_not_found(
+        self, tools, mock_client
+    ):
+        mock_client._resolve_scene = AsyncMock(
+            return_value=SceneResolution(
+                storage_key="hue-uuid-123", registry_hit=True, platform="hue"
+            )
+        )
+        mock_client.delete_scene_config = AsyncMock(
+            side_effect=SceneStorageConfigNotFoundError(
+                "bedroom_sleepy", platform="hue", storage_key="hue-uuid-123"
+            )
+        )
+
+        with pytest.raises(ToolError) as exc_info:
+            await tools.ha_config_remove_scene(scene_id="bedroom_sleepy", wait=False)
+
+        error = json.loads(str(exc_info.value))["error"]
+        assert error["code"] == "CONFIG_NOT_FOUND"
+        assert error["code"] != "ENTITY_NOT_FOUND"
+        assert "hue" in error["message"].lower()

--- a/tests/src/unit/test_tools_config_scenes.py
+++ b/tests/src/unit/test_tools_config_scenes.py
@@ -2644,3 +2644,27 @@ class TestSceneNotStorageScene:
         assert error["code"] == "CONFIG_NOT_FOUND"
         assert error["code"] != "ENTITY_NOT_FOUND"
         assert "hue" in error["message"].lower()
+
+    async def test_set_scene_not_storage_scene_maps_to_config_not_found(
+        self, tools, mock_client
+    ):
+        """The hash-verify / python_transform set path pre-fetches the scene;
+        on a non-storage scene that read raises SceneStorageConfigNotFoundError,
+        which must surface as CONFIG_NOT_FOUND (not a generic write failure)."""
+        mock_client.get_scene_config = AsyncMock(
+            side_effect=SceneStorageConfigNotFoundError(
+                "bedroom_sleepy", platform="hue", storage_key="hue-uuid-123"
+            )
+        )
+
+        with pytest.raises(ToolError) as exc_info:
+            await tools.ha_config_set_scene(
+                scene_id="bedroom_sleepy",
+                python_transform="config['name'] = 'x'",
+                config_hash="deadbeef",
+                wait=False,
+            )
+
+        error = json.loads(str(exc_info.value))["error"]
+        assert error["code"] == "CONFIG_NOT_FOUND"
+        assert "hue" in error["message"].lower()

--- a/tests/src/unit/test_tools_config_scenes.py
+++ b/tests/src/unit/test_tools_config_scenes.py
@@ -75,6 +75,11 @@ def mock_client():
             platform=None,
         )
     )
+    # On a registry miss the no-hash set path falls back to the state machine to
+    # tell an ``id``-less YAML scene (exists, shadow-creatable) from a genuine
+    # create (#1971). Default False = "not there", matching the create-shaped
+    # default above; the tests pinning the YAML arm override it.
+    client._scene_state_exists = AsyncMock(return_value=False)
     return client
 
 
@@ -2730,3 +2735,53 @@ class TestSceneNotStorageScene:
         assert "hue" in error["message"].lower()
         # The shadow-create is exactly what the pre-check prevents.
         mock_client.upsert_scene_config.assert_not_called()
+
+    async def test_set_scene_no_hash_idless_yaml_scene_maps_to_config_not_found(
+        self, tools, mock_client
+    ):
+        """#1971 P1, registry-miss arm: an ``id``-less YAML scene has no registry
+        unique_id, so ``registry_hit`` is False, yet it exists in the state
+        machine and a plain no-hash ``set`` would shadow-create over it. The state
+        check must open the same pre-check the registry hit does."""
+        # Fixture default already yields registry_hit=False; the scene is real.
+        mock_client._scene_state_exists = AsyncMock(return_value=True)
+        mock_client.get_scene_config = AsyncMock(
+            side_effect=SceneStorageConfigNotFoundError(
+                "movie_night", platform=None, storage_key="movie_night"
+            )
+        )
+
+        with pytest.raises(ToolError) as exc_info:
+            await tools.ha_config_set_scene(
+                scene_id="movie_night",
+                config={"name": "x", "entities": {"light.kitchen": {"state": "on"}}},
+                wait=False,
+            )
+
+        error = json.loads(str(exc_info.value))["error"]
+        assert error["code"] == "CONFIG_NOT_FOUND"
+        mock_client._scene_state_exists.assert_awaited_once_with("movie_night")
+        mock_client.upsert_scene_config.assert_not_called()
+
+    async def test_set_scene_no_hash_absent_scene_still_creates(
+        self, tools, mock_client
+    ):
+        """Contrast to the two arms above: a scene in neither the registry nor the
+        state machine is a genuine create, so the pre-check is skipped entirely
+        and the upsert runs unchanged (#1971 must not turn creates into errors)."""
+        mock_client._scene_state_exists = AsyncMock(return_value=False)
+
+        result = await tools.ha_config_set_scene(
+            scene_id="brand_new_scene",
+            config={
+                "name": "Brand New",
+                "entities": {"light.kitchen": {"state": "on"}},
+            },
+            wait=False,
+        )
+
+        assert result["success"] is True
+        mock_client._scene_state_exists.assert_awaited_once_with("brand_new_scene")
+        # No pre-check read on the create path - that is the whole point of gating.
+        mock_client.get_scene_config.assert_not_called()
+        mock_client.upsert_scene_config.assert_called_once()

--- a/tests/src/unit/test_tools_config_scenes.py
+++ b/tests/src/unit/test_tools_config_scenes.py
@@ -1002,8 +1002,13 @@ class TestSceneResolutionDedup:
 
         client._resolve_scene = AsyncMock(side_effect=_resolve_rich)
 
-        async def _get(scene_id, *, _resolved=False):
-            rid = scene_id if _resolved else await resolve(scene_id)
+        async def _get(scene_id, *, _resolved=False, resolution=None):
+            if resolution is not None:
+                rid = resolution.storage_key
+            elif _resolved:
+                rid = scene_id
+            else:
+                rid = await resolve(scene_id)
             return {
                 "success": True,
                 "scene_id": rid,
@@ -1017,13 +1022,12 @@ class TestSceneResolutionDedup:
             rid = resolved_id if resolved_id is not None else await resolve(scene_id)
             return {"success": True, "scene_id": rid, "result": "ok"}
 
-        async def _delete(scene_id, *, _resolved=False, resolution=None):
-            if resolution is not None:
-                rid = resolution.storage_key
-            elif _resolved:
-                rid = scene_id
-            else:
-                rid = await resolve(scene_id)
+        async def _delete(scene_id, *, resolution=None):
+            rid = (
+                resolution.storage_key
+                if resolution is not None
+                else await resolve(scene_id)
+            )
             return {"success": True, "scene_id": rid, "operation": "deleted"}
 
         client.get_scene_config = AsyncMock(side_effect=_get)
@@ -1064,7 +1068,11 @@ class TestSceneResolutionDedup:
 
         assert result["success"] is True
         assert result["scene_id"] == "test_scene"
-        assert client.resolve_scene_id.await_count == 1
+        # The no-hash set arm resolves via the richer ``_resolve_scene`` exactly
+        # once (it needs ``registry_hit`` to guard the shadow-create pre-check for
+        # #1971) and never falls back to ``resolve_scene_id``.
+        assert client._resolve_scene.await_count == 1
+        assert client.resolve_scene_id.await_count == 0
         args, kwargs = client.upsert_scene_config.call_args
         # Caller id passed as scene_id; resolved storage key as resolved_id.
         assert args[1] == "test_scene"
@@ -2626,16 +2634,26 @@ class TestSceneNotStorageScene:
     async def test_remove_scene_not_storage_scene_maps_to_config_not_found(
         self, tools, mock_client
     ):
-        mock_client._resolve_scene = AsyncMock(
-            return_value=SceneResolution(
-                storage_key="hue-uuid-123", registry_hit=True, platform="hue"
-            )
+        # The registry hit and the config-404 classification are threaded through
+        # the SAME resolution: the delete mock raises only because that resolution
+        # says ``registry_hit`` – exercising the real threading rather than a
+        # hardcoded raise (a resolution-insensitive mock would leave the override
+        # dead).
+        resolution = SceneResolution(
+            storage_key="hue-uuid-123", registry_hit=True, platform="hue"
         )
-        mock_client.delete_scene_config = AsyncMock(
-            side_effect=SceneStorageConfigNotFoundError(
-                "bedroom_sleepy", platform="hue", storage_key="hue-uuid-123"
-            )
-        )
+        mock_client._resolve_scene = AsyncMock(return_value=resolution)
+
+        async def _delete(scene_id, *, resolution=None):
+            if resolution is not None and resolution.registry_hit:
+                raise SceneStorageConfigNotFoundError(
+                    scene_id,
+                    platform=resolution.platform,
+                    storage_key=resolution.storage_key,
+                )
+            return {"success": True, "scene_id": scene_id, "operation": "deleted"}
+
+        mock_client.delete_scene_config = AsyncMock(side_effect=_delete)
 
         with pytest.raises(ToolError) as exc_info:
             await tools.ha_config_remove_scene(scene_id="bedroom_sleepy", wait=False)
@@ -2645,12 +2663,55 @@ class TestSceneNotStorageScene:
         assert error["code"] != "ENTITY_NOT_FOUND"
         assert "hue" in error["message"].lower()
 
+    @pytest.mark.parametrize("mode", ["python_transform", "config_hash"])
     async def test_set_scene_not_storage_scene_maps_to_config_not_found(
+        self, tools, mock_client, mode
+    ):
+        """Both hash-bearing set arms (python_transform and a plain config with a
+        config_hash) pre-fetch the scene; on a non-storage scene that read raises
+        SceneStorageConfigNotFoundError, which must surface as CONFIG_NOT_FOUND
+        (not a generic write failure); same handler, both arms."""
+        mock_client.get_scene_config = AsyncMock(
+            side_effect=SceneStorageConfigNotFoundError(
+                "bedroom_sleepy", platform="hue", storage_key="hue-uuid-123"
+            )
+        )
+
+        with pytest.raises(ToolError) as exc_info:
+            if mode == "python_transform":
+                await tools.ha_config_set_scene(
+                    scene_id="bedroom_sleepy",
+                    python_transform="config['name'] = 'x'",
+                    config_hash="deadbeef",
+                    wait=False,
+                )
+            else:
+                await tools.ha_config_set_scene(
+                    scene_id="bedroom_sleepy",
+                    config={
+                        "name": "x",
+                        "entities": {"light.kitchen": {"state": "on"}},
+                    },
+                    config_hash="deadbeef",
+                    wait=False,
+                )
+
+        error = json.loads(str(exc_info.value))["error"]
+        assert error["code"] == "CONFIG_NOT_FOUND"
+        assert "hue" in error["message"].lower()
+
+    async def test_set_scene_no_hash_non_storage_scene_maps_to_config_not_found(
         self, tools, mock_client
     ):
-        """The hash-verify / python_transform set path pre-fetches the scene;
-        on a non-storage scene that read raises SceneStorageConfigNotFoundError,
-        which must surface as CONFIG_NOT_FOUND (not a generic write failure)."""
+        """#1971 P1: a plain ``set`` with NO config_hash on an already-existing
+        non-storage scene pre-checks the config API and surfaces CONFIG_NOT_FOUND
+        instead of silently shadow-creating a duplicate scenes.yaml entry. The
+        upsert must never run."""
+        mock_client._resolve_scene = AsyncMock(
+            return_value=SceneResolution(
+                storage_key="hue-uuid-123", registry_hit=True, platform="hue"
+            )
+        )
         mock_client.get_scene_config = AsyncMock(
             side_effect=SceneStorageConfigNotFoundError(
                 "bedroom_sleepy", platform="hue", storage_key="hue-uuid-123"
@@ -2660,11 +2721,12 @@ class TestSceneNotStorageScene:
         with pytest.raises(ToolError) as exc_info:
             await tools.ha_config_set_scene(
                 scene_id="bedroom_sleepy",
-                python_transform="config['name'] = 'x'",
-                config_hash="deadbeef",
+                config={"name": "x", "entities": {"light.kitchen": {"state": "on"}}},
                 wait=False,
             )
 
         error = json.loads(str(exc_info.value))["error"]
         assert error["code"] == "CONFIG_NOT_FOUND"
         assert "hue" in error["message"].lower()
+        # The shadow-create is exactly what the pre-check prevents.
+        mock_client.upsert_scene_config.assert_not_called()


### PR DESCRIPTION
## What does this PR do?

Closes #1971. `ha_config_get_scene` reported `ENTITY_NOT_FOUND` (and `ha_config_remove_scene` reported `RESOURCE_NOT_FOUND`) for scenes that exist as entities but have no editable storage config – Philips Hue / other vendor scenes, and scenes defined directly in YAML. The entity resolves cleanly, so labelling it "not found" is misleading and pushes agent harnesses into retry loops.

**Root cause.** The scene config API (`GET`/`DELETE config/scene/config/{id}`) is backed only by the managed `scenes.yaml`, so it 404s any scene not written to that file even though the entity exists. `resolve_scene_id` returned only the storage key, discarding whether the registry lookup even succeeded, so the 404 site could not tell a genuinely-missing entity from one that simply has no storage config.

**Fix.**
- `_resolve_scene` now returns a `SceneResolution(storage_key, registry_hit, platform)`; `resolve_scene_id` stays a thin `str` wrapper, so the write path is unchanged.
- On a config-API 404 after a successful registry resolve, a dedicated `SceneStorageConfigNotFoundError` is raised.
- A registry miss does not by itself mean "absent". HA core makes a YAML scene's `id` optional and maps it straight to the entity's unique_id, so an `id`-less YAML scene has no registry entry yet still holds a state-machine entity. On a registry miss the classifier therefore runs one `/api/states/scene.<slug>` existence check and upgrades a state hit to the same case with `platform=None`; only a miss on both stays the historic bare 404.
- The tool layer maps the error to `CONFIG_NOT_FOUND` with a message that names the owning platform when the registry exposes it, and points at `scene.turn_on` or the vendor app. This covers the get and remove read paths and the set hash-verify / `python_transform` pre-fetch.
- A plain `set` with no `config_hash` has no prior read, so it would POST over a non-storage scene and create a duplicate managed entry keyed by its storage key. That arm now pre-checks the config API whenever the scene already exists – by registry hit or by state hit – so the shadow-create surfaces as `CONFIG_NOT_FOUND` instead. A scene present in neither proceeds as a normal create, unchanged.

A `platform == "homeassistant"` gate would be insufficient: scenes defined in raw YAML are also `platform: homeassistant` yet still 404, so the classification keys off the resolve outcome rather than the platform (platform only enriches the message). No new error code – `CONFIG_NOT_FOUND` already exists, and genuinely-missing scenes still report `ENTITY_NOT_FOUND` unchanged.

## Type of change
- [x] 🐛 Bug fix

## Testing
- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

Unit regression tests cover the REST-client seam (resolve metadata; a config 404 after a registry hit raises `SceneStorageConfigNotFoundError`; a registry miss whose entity is still in the state machine raises it with `platform=None`; a miss on both stays a bare 404) and the tool boundary (get / remove / set all map to `CONFIG_NOT_FOUND`, with both platform-named and generic messages, and the no-hash set arm pinned on the registry-hit path, the `id`-less path, and a contrast case asserting an absent scene still creates). Both classification gates were verified by inject-and-revert: dropping the `registry_hit` condition and dropping the state-existence condition each turn the corresponding tests red.

`tests/src/e2e/workflows/scenes/test_yaml_scene_not_storage.py` drives the whole chain through the real component. The fixture stages two YAML-package scenes pre-boot: one declaring an `id` deliberately distinct from its name slug, so the test pins the registry-hit branch rather than the state-check fallback, and one with no `id` at all, which is the registry-miss arm. Both `ha_config_get_scene` and a no-hash `ha_config_set_scene` run over both arms, and the set case reads back through the config API afterwards, since the error alone does not prove that nothing was written. These tests skip on the HAOS backends, which have no host `config_path`; the Hue arm and the platform-named message need a real integration and cannot run in-container.

## Checklist
- [x] I have updated documentation if needed
