### PR TITLE
fix: prevent overlapping overview pages

### DIFF
--- a/src/ha_mcp/tools/smart_search/_overview.py
+++ b/src/ha_mcp/tools/smart_search/_overview.py
@@ -433,65 +433,38 @@ class SystemOverviewMixin(_SearchBase):
         return formatted_domain_stats
 
     @staticmethod
-    def _allocate_page_one(
-        formatted_domain_stats: dict[str, dict[str, Any]],
-        effective_limit: int,
-        total_entity_count: int,
-    ) -> int:
-        """Distribute the page-1 budget: a min allocation per domain, rest proportional.
-
-        Gives each domain a minimum slice so the LLM sees entities from every
-        domain, then distributes the remaining budget proportionally. Mutates
-        ``formatted_domain_stats`` in place; returns the count included.
-        """
-        min_per_domain = 3
-        num_domains = len(formatted_domain_stats)
-        reserved = min(min_per_domain * num_domains, effective_limit)
-        remaining_budget = effective_limit - reserved
-
-        entities_included = 0
-        for domain_data in formatted_domain_stats.values():
-            domain_entities = domain_data["entities"]
-            domain_len = len(domain_entities)
-            base = min(min_per_domain, domain_len)
-            if total_entity_count > 0 and remaining_budget > 0:
-                extra = int(remaining_budget * domain_len / total_entity_count)
-            else:
-                extra = 0
-            take = min(base + extra, domain_len)
-            if take < domain_len:
-                domain_data["entities"] = domain_entities[:take]
-                domain_data["truncated"] = True
-            entities_included += len(domain_data["entities"])
-        return entities_included
-
-    @staticmethod
-    def _allocate_subsequent_pages(
+    def _allocate_page(
         formatted_domain_stats: dict[str, dict[str, Any]],
         effective_limit: int,
         offset: int,
     ) -> int:
-        """Apply pages-2+ sequential skip/take across domains. Mutates in place."""
-        entities_skipped = 0
-        entities_included = 0
-        for domain_data in formatted_domain_stats.values():
-            domain_entities = domain_data["entities"]
-            domain_len = len(domain_entities)
+        """Take one stable round-robin page across domains.
 
-            skip_from_domain = max(0, min(domain_len, offset - entities_skipped))
-            budget_left = effective_limit - entities_included
-            take_from_domain = max(0, min(domain_len - skip_from_domain, budget_left))
+        A single ordering must drive every page. Otherwise a specially balanced
+        first page followed by sequential offset pages can repeat entities.
+        """
+        ordered: list[tuple[str, dict[str, Any]]] = []
+        max_domain_size = max(
+            (len(data["entities"]) for data in formatted_domain_stats.values()),
+            default=0,
+        )
+        for index in range(max_domain_size):
+            for domain, data in formatted_domain_stats.items():
+                if index < len(data["entities"]):
+                    ordered.append((domain, data["entities"][index]))
 
-            if skip_from_domain > 0 or take_from_domain < domain_len:
-                domain_data["entities"] = domain_entities[
-                    skip_from_domain : skip_from_domain + take_from_domain
-                ]
-                if take_from_domain < domain_len:
-                    domain_data["truncated"] = True
+        selected: dict[str, list[dict[str, Any]]] = {
+            domain: [] for domain in formatted_domain_stats
+        }
+        for domain, entity in ordered[offset : offset + effective_limit]:
+            selected[domain].append(entity)
 
-            entities_skipped += skip_from_domain
-            entities_included += take_from_domain
-        return entities_included
+        for domain, data in formatted_domain_stats.items():
+            original_count = len(data["entities"])
+            data["entities"] = selected[domain]
+            if len(data["entities"]) < original_count:
+                data["truncated"] = True
+        return sum(len(entities) for entities in selected.values())
 
     def _paginate_overview_entities(
         self,
@@ -514,14 +487,9 @@ class SystemOverviewMixin(_SearchBase):
         total_entity_count = sum(
             len(ds["entities"]) for ds in formatted_domain_stats.values()
         )
-        if offset == 0:
-            entities_included = self._allocate_page_one(
-                formatted_domain_stats, effective_limit, total_entity_count
-            )
-        else:
-            entities_included = self._allocate_subsequent_pages(
-                formatted_domain_stats, effective_limit, offset
-            )
+        entities_included = self._allocate_page(
+            formatted_domain_stats, effective_limit, offset
+        )
 
         has_more = (offset + entities_included) < total_entity_count
         return {

--- a/src/ha_mcp/tools/smart_search/_overview.py
+++ b/src/ha_mcp/tools/smart_search/_overview.py
@@ -3,6 +3,7 @@
 import asyncio
 import logging
 import random
+from itertools import islice
 from typing import Any
 
 from ...visibility.resolver import load_hidden_set
@@ -442,21 +443,24 @@ class SystemOverviewMixin(_SearchBase):
 
         A single ordering must drive every page. Otherwise a specially balanced
         first page followed by sequential offset pages can repeat entities.
+
+        Mutates ``formatted_domain_stats`` in place; returns the count included.
         """
-        ordered: list[tuple[str, dict[str, Any]]] = []
         max_domain_size = max(
             (len(data["entities"]) for data in formatted_domain_stats.values()),
             default=0,
         )
-        for index in range(max_domain_size):
-            for domain, data in formatted_domain_stats.items():
-                if index < len(data["entities"]):
-                    ordered.append((domain, data["entities"][index]))
+        ordered = (
+            (domain, data["entities"][index])
+            for index in range(max_domain_size)
+            for domain, data in formatted_domain_stats.items()
+            if index < len(data["entities"])
+        )
 
         selected: dict[str, list[dict[str, Any]]] = {
             domain: [] for domain in formatted_domain_stats
         }
-        for domain, entity in ordered[offset : offset + effective_limit]:
+        for domain, entity in islice(ordered, offset, offset + effective_limit):
             selected[domain].append(entity)
 
         for domain, data in formatted_domain_stats.items():

--- a/tests/src/unit/test_performance_parallelization.py
+++ b/tests/src/unit/test_performance_parallelization.py
@@ -595,7 +595,7 @@ class TestGetSystemOverview:
 
     @pytest.mark.asyncio
     async def test_pagination_across_multiple_domains(self):
-        """Pagination distributes budget fairly across domains on page 1."""
+        """Pagination interleaves entities across domains in round-robin order."""
         entities = (
             [
                 {
@@ -631,7 +631,7 @@ class TestGetSystemOverview:
         assert result["domain_stats"]["sensor"]["count"] == 150
         assert result["domain_stats"]["light"]["count"] == 50
         assert result["domain_stats"]["switch"]["count"] == 50
-        # Every domain gets at least some entities (fair distribution)
+        # Round-robin interleaving includes entities from every domain
         assert len(result["domain_stats"]["sensor"]["entities"]) >= 3
         assert len(result["domain_stats"]["light"]["entities"]) >= 3
         assert len(result["domain_stats"]["switch"]["entities"]) >= 3
@@ -641,6 +641,50 @@ class TestGetSystemOverview:
         )
         assert total_returned <= 100
         assert result["pagination"]["has_more"] is True
+
+    @pytest.mark.asyncio
+    async def test_pagination_walks_multiple_domains_without_overlap(self):
+        """Following next_offset tiles a multi-domain round-robin ordering."""
+        entities = [
+            {
+                "entity_id": f"{domain}.{domain[0]}{index}",
+                "attributes": {"friendly_name": f"{domain.title()} {index}"},
+                "state": "on",
+            }
+            for domain in ("sensor", "light", "switch")
+            for index in range(3)
+        ]
+        tools = _make_tools(MockClient(entities=entities))
+
+        pages = []
+        offset = 0
+        while True:
+            page = await tools.get_system_overview(
+                detail_level="standard", limit=3, offset=offset
+            )
+            pages.append(page)
+            next_offset = page["pagination"]["next_offset"]
+            if next_offset is None:
+                break
+            offset = next_offset
+
+        returned_names = [
+            entity["friendly_name"]
+            for page in pages
+            for domain in page["domain_stats"].values()
+            for entity in domain["entities"]
+        ]
+        expected_names = {entity["attributes"]["friendly_name"] for entity in entities}
+
+        assert len(pages) == 3
+        assert all(page["pagination"]["entities_returned"] == 3 for page in pages)
+        assert all(
+            len(domain["entities"]) == 1
+            for page in pages
+            for domain in page["domain_stats"].values()
+        )
+        assert len(returned_names) == len(set(returned_names))
+        assert set(returned_names) == expected_names
 
     @pytest.mark.asyncio
     async def test_pagination_explicit_limit_overrides_default(self):

--- a/tests/src/unit/test_performance_parallelization.py
+++ b/tests/src/unit/test_performance_parallelization.py
@@ -540,6 +540,40 @@ class TestGetSystemOverview:
         assert result["pagination"]["next_offset"] is None
 
     @pytest.mark.asyncio
+    async def test_pagination_pages_respect_limit_without_overlap(self):
+        """Following next_offset returns disjoint pages of the requested size."""
+        entities = [
+            {
+                "entity_id": f"light.l{i}",
+                "attributes": {"friendly_name": f"Light {i}"},
+                "state": "on",
+            }
+            for i in range(4)
+        ]
+        tools = _make_tools(MockClient(entities=entities))
+
+        first = await tools.get_system_overview(
+            detail_level="standard", limit=2, offset=0
+        )
+        second = await tools.get_system_overview(
+            detail_level="standard",
+            limit=2,
+            offset=first["pagination"]["next_offset"],
+        )
+
+        first_names = {
+            entity["friendly_name"]
+            for entity in first["domain_stats"]["light"]["entities"]
+        }
+        second_names = {
+            entity["friendly_name"]
+            for entity in second["domain_stats"]["light"]["entities"]
+        }
+        assert first["pagination"]["entities_returned"] == 2
+        assert second["pagination"]["entities_returned"] == 2
+        assert first_names.isdisjoint(second_names)
+
+    @pytest.mark.asyncio
     async def test_pagination_not_applied_to_minimal(self):
         """Minimal mode does not apply global pagination (already capped per-domain)."""
         entities = [


### PR DESCRIPTION
Closes #2007

## What does this PR do?

Uses the same stable round-robin entity ordering for every overview page. This keeps each page within `limit` and prevents `next_offset` from returning entities that appeared on an earlier page.

## Type of change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [ ] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

Regression proof: the two-page test fails with 3 entities on a `limit=2` page before the fix, then passes with two disjoint two-entity pages. All 84 focused overview/unit tests pass; Ruff and mypy pass for the changed implementation.

## Checklist
- [x] I have updated documentation if needed

