### PR TITLE
docs: add auth/ package to the architecture tree

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -424,6 +424,9 @@ src/ha_mcp/
 │   ├── rest_client.py       # HTTP REST API client
 │   ├── websocket_client.py  # Real-time state monitoring
 │   └── websocket_listener.py
+├── auth/
+│   ├── provider.py          # OAuth provider (HTTP mode)
+│   └── consent_form.py      # OAuth consent screen
 ├── tools/             # 36 modules, auto-discovered
 │   ├── registry.py          # Lazy auto-discovery
 │   ├── smart_search.py      # Fuzzy entity search


### PR DESCRIPTION
The `src/ha_mcp/auth/` package - the OAuth provider used in HTTP mode (`provider.py`, `consent_form.py`) - is missing from the Architecture tree in `AGENTS.md`. This adds it between `client/` and `tools/`.

Docs-only, no code changes.