### PR TITLE
Fix required section defaults in config flows

### DIFF
--- a/src/ha_mcp/tools/config_entry_flow.py
+++ b/src/ha_mcp/tools/config_entry_flow.py
@@ -177,9 +177,9 @@ def _record_ignored_section_keys(
 def _field_default_value(field: dict[str, Any]) -> Any:
     """Return a serialized schema field's default/suggested value, if present."""
     description = field.get("description")
-    if isinstance(description, dict) and "suggested_value" in description:
+    if isinstance(description, dict) and description.get("suggested_value") is not None:
         return copy.deepcopy(description["suggested_value"])
-    if "suggested_value" in field:
+    if field.get("suggested_value") is not None:
         return copy.deepcopy(field["suggested_value"])
     if "default" in field:
         return copy.deepcopy(field["default"])
@@ -207,11 +207,10 @@ def _schema_default_values(data_schema: list[Any]) -> dict[str, Any]:
     return defaults
 
 
-def _required_section_defaults(
-    field: dict[str, Any], nested_schema: list[Any]
-) -> dict[str, Any]:
+def _required_section_defaults(field: dict[str, Any]) -> dict[str, Any]:
     """Return default data for a required section, otherwise an empty dict."""
-    if not field.get("required"):
+    nested_schema = field.get("schema")
+    if not field.get("required") or not isinstance(nested_schema, list):
         return {}
     return _schema_default_values(nested_schema)
 
@@ -240,32 +239,29 @@ def _ignored_keys_warnings(
 
 def _consume_section_schema(
     field: dict[str, Any],
-    nested_schema: list[Any],
+    explicit_section: dict[str, Any] | None,
     remaining_config: dict[str, Any],
     ignored_config_keys: set[str] | None,
+    consumed_config_keys: set[str] | None,
     path_prefix: str,
-    missing: object,
-) -> tuple[str | None, dict[str, Any] | Any]:
+) -> dict[str, Any]:
     """Consume config values for a nested flow section."""
-    name = field.get("name")
-    section_name = name if isinstance(name, str) else None
-    section_path = _section_path(path_prefix, name)
-    explicit_section = (
-        remaining_config.pop(section_name, missing)
-        if section_name is not None
-        else missing
-    )
-    if explicit_section is not missing and not isinstance(explicit_section, dict):
-        return section_name, explicit_section
+    nested_schema = field.get("schema")
+    if not isinstance(nested_schema, list):
+        return {}
 
-    nested_data = _required_section_defaults(field, nested_schema)
-    if isinstance(explicit_section, dict):
+    name = field.get("name")
+    section_path = _section_path(path_prefix, name)
+    nested_data = _required_section_defaults(field)
+
+    if explicit_section is not None:
         explicit_remaining = dict(explicit_section)
         nested_data.update(
             _consume_form_schema(
                 nested_schema,
                 explicit_remaining,
                 ignored_config_keys,
+                consumed_config_keys,
                 section_path,
             )
         )
@@ -274,21 +270,56 @@ def _consume_section_schema(
             explicit_remaining,
             section_path,
         )
+
     nested_data.update(
         _consume_form_schema(
             nested_schema,
             remaining_config,
             ignored_config_keys,
+            consumed_config_keys,
             section_path,
         )
     )
-    return section_name, nested_data
+    return nested_data
+
+
+def _mark_consumed(
+    consumed_config_keys: set[str] | None,
+    path_prefix: str,
+    name: str,
+) -> None:
+    """Record that a caller-supplied form key, not an injected default, was used."""
+    if consumed_config_keys is not None:
+        consumed_config_keys.add(_section_path(path_prefix, name))
+
+
+def _auto_confirm_form_payload(current_step: dict[str, Any]) -> dict[str, Any] | None:
+    """Return payload for HA preview/confirmation-only forms we can safely advance."""
+    if "preview" not in current_step:
+        return None
+    data_schema = current_step.get("data_schema")
+    if not isinstance(data_schema, list) or len(data_schema) != 1:
+        return None
+    field = data_schema[0]
+    if not isinstance(field, dict) or not field.get("required"):
+        return None
+    name = field.get("name")
+    if not isinstance(name, str) or name in _MENU_SELECTION_KEYS:
+        return None
+    default = _field_default_value(field)
+    if default is not False:
+        return None
+    selector = field.get("selector")
+    if isinstance(selector, dict) and selector and "boolean" not in selector:
+        return None
+    return {name: True}
 
 
 def _consume_form_schema(
     data_schema: list[Any],
     remaining_config: dict[str, Any],
     ignored_config_keys: set[str] | None = None,
+    consumed_config_keys: set[str] | None = None,
     path_prefix: str = "",
 ) -> dict[str, Any]:
     """Consume matching config values and shape nested flow sections.
@@ -299,7 +330,6 @@ def _consume_form_schema(
     ``ignored_config_keys`` with their dotted section path.
     """
     form_data: dict[str, Any] = {}
-    missing = object()
 
     for field in data_schema:
         if not isinstance(field, dict):
@@ -308,13 +338,23 @@ def _consume_form_schema(
         name = field.get("name")
         nested_schema = field.get("schema")
         if isinstance(nested_schema, list):
-            section_name, nested_data = _consume_section_schema(
+            section_name = name if isinstance(name, str) else None
+            explicit_section = None
+            if section_name is not None and section_name in remaining_config:
+                explicit_value = remaining_config.pop(section_name)
+                if not isinstance(explicit_value, dict):
+                    form_data[section_name] = explicit_value
+                    _mark_consumed(consumed_config_keys, path_prefix, section_name)
+                    continue
+                explicit_section = explicit_value
+
+            nested_data = _consume_section_schema(
                 field,
-                nested_schema,
+                explicit_section,
                 remaining_config,
                 ignored_config_keys,
+                consumed_config_keys,
                 path_prefix,
-                missing,
             )
             if nested_data:
                 if section_name is not None:
@@ -329,6 +369,7 @@ def _consume_form_schema(
             and name in remaining_config
         ):
             form_data[name] = remaining_config.pop(name)
+            _mark_consumed(consumed_config_keys, path_prefix, name)
 
     return form_data
 
@@ -357,6 +398,7 @@ def _handle_form_step(
     current_step: dict[str, Any],
     remaining_config: dict[str, Any],
     ignored_config_keys: set[str] | None = None,
+    consumed_config_keys: set[str] | None = None,
 ) -> dict[str, Any]:
     """Validate a form step and return form data to submit.
 
@@ -398,9 +440,10 @@ def _handle_form_step(
             if key in _MENU_SELECTION_KEYS:
                 continue
             form_data[key] = remaining_config.pop(key)
+            _mark_consumed(consumed_config_keys, "", key)
     else:
         form_data = _consume_form_schema(
-            data_schema, remaining_config, ignored_config_keys
+            data_schema, remaining_config, ignored_config_keys, consumed_config_keys
         )
 
     return form_data
@@ -844,13 +887,17 @@ async def _handle_flow_steps(
             # for subsequent steps (HA can present multi-step forms, e.g.
             # statistics: user step then pick-characteristic step).
             saw_form_step = True
-            form_data = _handle_form_step(
-                flow_id,
-                current_step,
-                remaining_config,
-                ignored_config_keys,
-            )
-            if form_data:
+            consumed_form_keys: set[str] = set()
+            form_data = _auto_confirm_form_payload(current_step)
+            if form_data is None:
+                form_data = _handle_form_step(
+                    flow_id,
+                    current_step,
+                    remaining_config,
+                    ignored_config_keys,
+                    consumed_form_keys,
+                )
+            if consumed_form_keys:
                 any_form_key_consumed = True
             logger.debug(
                 f"Flow step {step_num}: form submit "

--- a/src/ha_mcp/tools/config_entry_flow.py
+++ b/src/ha_mcp/tools/config_entry_flow.py
@@ -11,6 +11,7 @@ for the 15 helper types listed in FLOW_HELPER_TYPES.
 """
 
 import asyncio
+import copy
 import logging
 from collections.abc import Iterator
 from enum import StrEnum
@@ -78,6 +79,7 @@ _RECONFIGURE_SUCCESS_REASONS = frozenset(
         "reconfigure_successful",
     }
 )
+_MISSING_DEFAULT = object()
 
 
 class _FlowType(StrEnum):
@@ -172,6 +174,48 @@ def _record_ignored_section_keys(
     )
 
 
+def _field_default_value(field: dict[str, Any]) -> Any:
+    """Return a serialized schema field's default/suggested value, if present."""
+    description = field.get("description")
+    if isinstance(description, dict) and "suggested_value" in description:
+        return copy.deepcopy(description["suggested_value"])
+    if "suggested_value" in field:
+        return copy.deepcopy(field["suggested_value"])
+    if "default" in field:
+        return copy.deepcopy(field["default"])
+    return _MISSING_DEFAULT
+
+
+def _schema_default_values(data_schema: list[Any]) -> dict[str, Any]:
+    """Build default form data from serialized schema suggestions/defaults."""
+    defaults: dict[str, Any] = {}
+    for field in data_schema:
+        if not isinstance(field, dict):
+            continue
+        name = field.get("name")
+        nested_schema = field.get("schema")
+        if not isinstance(name, str):
+            continue
+        if isinstance(nested_schema, list):
+            nested_defaults = _schema_default_values(nested_schema)
+            if nested_defaults:
+                defaults[name] = nested_defaults
+            continue
+        default = _field_default_value(field)
+        if default is not _MISSING_DEFAULT:
+            defaults[name] = default
+    return defaults
+
+
+def _required_section_defaults(
+    field: dict[str, Any], nested_schema: list[Any]
+) -> dict[str, Any]:
+    """Return default data for a required section, otherwise an empty dict."""
+    if not field.get("required"):
+        return {}
+    return _schema_default_values(nested_schema)
+
+
 def _ignored_keys_warnings(
     ignored_config_keys: set[str], remaining_config: dict[str, Any]
 ) -> list[str]:
@@ -192,6 +236,53 @@ def _ignored_keys_warnings(
             f"{', '.join(sorted(leftover_menu_keys))}"
         )
     return warnings
+
+
+def _consume_section_schema(
+    field: dict[str, Any],
+    nested_schema: list[Any],
+    remaining_config: dict[str, Any],
+    ignored_config_keys: set[str] | None,
+    path_prefix: str,
+    missing: object,
+) -> tuple[str | None, dict[str, Any] | Any]:
+    """Consume config values for a nested flow section."""
+    name = field.get("name")
+    section_name = name if isinstance(name, str) else None
+    section_path = _section_path(path_prefix, name)
+    explicit_section = (
+        remaining_config.pop(section_name, missing)
+        if section_name is not None
+        else missing
+    )
+    if explicit_section is not missing and not isinstance(explicit_section, dict):
+        return section_name, explicit_section
+
+    nested_data = _required_section_defaults(field, nested_schema)
+    if isinstance(explicit_section, dict):
+        explicit_remaining = dict(explicit_section)
+        nested_data.update(
+            _consume_form_schema(
+                nested_schema,
+                explicit_remaining,
+                ignored_config_keys,
+                section_path,
+            )
+        )
+        _record_ignored_section_keys(
+            ignored_config_keys,
+            explicit_remaining,
+            section_path,
+        )
+    nested_data.update(
+        _consume_form_schema(
+            nested_schema,
+            remaining_config,
+            ignored_config_keys,
+            section_path,
+        )
+    )
+    return section_name, nested_data
 
 
 def _consume_form_schema(
@@ -217,47 +308,17 @@ def _consume_form_schema(
         name = field.get("name")
         nested_schema = field.get("schema")
         if isinstance(nested_schema, list):
-            section_path = _section_path(path_prefix, name)
-            explicit_section = (
-                remaining_config.pop(name, missing)
-                if isinstance(name, str)
-                else missing
+            section_name, nested_data = _consume_section_schema(
+                field,
+                nested_schema,
+                remaining_config,
+                ignored_config_keys,
+                path_prefix,
+                missing,
             )
-            if explicit_section is not missing and not isinstance(
-                explicit_section, dict
-            ):
-                if isinstance(name, str):
-                    form_data[name] = explicit_section
-                continue
-
-            nested_data: dict[str, Any] = {}
-            if isinstance(explicit_section, dict):
-                explicit_remaining = dict(explicit_section)
-                nested_data.update(
-                    _consume_form_schema(
-                        nested_schema,
-                        explicit_remaining,
-                        ignored_config_keys,
-                        section_path,
-                    )
-                )
-                _record_ignored_section_keys(
-                    ignored_config_keys,
-                    explicit_remaining,
-                    section_path,
-                )
-            nested_data.update(
-                _consume_form_schema(
-                    nested_schema,
-                    remaining_config,
-                    ignored_config_keys,
-                    section_path,
-                )
-            )
-
             if nested_data:
-                if isinstance(name, str):
-                    form_data[name] = nested_data
+                if section_name is not None:
+                    form_data[section_name] = nested_data
                 else:
                     form_data.update(nested_data)
             continue

--- a/tests/src/unit/test_flow_multistep.py
+++ b/tests/src/unit/test_flow_multistep.py
@@ -234,6 +234,98 @@ class TestHandleFormStepFiltering:
         }
         assert remaining == {}
 
+    def test_required_section_uses_all_schema_default_sources(self) -> None:
+        remaining: dict[str, Any] = {}
+        step = {
+            "type": "form",
+            "step_id": "user",
+            "data_schema": [
+                {
+                    "type": "expandable",
+                    "name": "advanced",
+                    "required": True,
+                    "schema": [
+                        {
+                            "name": "from_description",
+                            "description": {"suggested_value": 2},
+                        },
+                        {"name": "from_top_level", "suggested_value": "tcp"},
+                        {"name": "from_default", "default": True},
+                    ],
+                },
+            ],
+        }
+
+        form_data = _handle_form_step("flow-1", step, remaining)
+
+        assert form_data == {
+            "advanced": {
+                "from_description": 2,
+                "from_top_level": "tcp",
+                "from_default": True,
+            }
+        }
+        assert remaining == {}
+
+    def test_null_suggested_values_fall_back_to_defaults(self) -> None:
+        remaining: dict[str, Any] = {}
+        step = {
+            "type": "form",
+            "step_id": "user",
+            "data_schema": [
+                {
+                    "type": "expandable",
+                    "name": "advanced",
+                    "required": True,
+                    "schema": [
+                        {
+                            "name": "description_null",
+                            "description": {"suggested_value": None},
+                            "default": "fallback-a",
+                        },
+                        {
+                            "name": "top_level_null",
+                            "suggested_value": None,
+                            "default": "fallback-b",
+                        },
+                    ],
+                },
+            ],
+        }
+
+        form_data = _handle_form_step("flow-1", step, remaining)
+
+        assert form_data == {
+            "advanced": {
+                "description_null": "fallback-a",
+                "top_level_null": "fallback-b",
+            }
+        }
+        assert remaining == {}
+
+    def test_optional_expandable_section_does_not_seed_suggestions(self) -> None:
+        remaining = {"stream_source": "rtsp://camera.example/stream"}
+        step = {
+            "type": "form",
+            "step_id": "user",
+            "data_schema": [
+                {"name": "stream_source", "required": False},
+                {
+                    "type": "expandable",
+                    "name": "advanced",
+                    "required": False,
+                    "schema": [
+                        {"name": "framerate", "description": {"suggested_value": 2}},
+                    ],
+                },
+            ],
+        }
+
+        form_data = _handle_form_step("flow-1", step, remaining)
+
+        assert form_data == {"stream_source": "rtsp://camera.example/stream"}
+        assert remaining == {}
+
     def test_omits_section_when_only_top_level_field_is_updated(self) -> None:
         remaining = {"state": "{{ 2 }}"}
         step = {
@@ -341,6 +433,24 @@ class TestHandleFormStepFiltering:
 
         assert form_data == {"advanced_options": "invalid"}
         assert remaining == {}
+
+    def test_passes_through_falsy_non_dict_explicit_section_values(self) -> None:
+        step = {
+            "type": "form",
+            "step_id": "sensor",
+            "data_schema": [
+                {
+                    "type": "expandable",
+                    "name": "advanced_options",
+                    "schema": [{"name": "availability"}],
+                }
+            ],
+        }
+        for value in (0, False, "", []):
+            remaining = {"advanced_options": value}
+            form_data = _handle_form_step("flow-1", step, remaining)
+            assert form_data == {"advanced_options": value}
+            assert remaining == {}
 
     def test_flattens_children_when_section_name_is_missing(self) -> None:
         remaining = {"availability": "{{ true }}"}
@@ -733,6 +843,79 @@ class TestAllKeysIgnoredIsAnError:
 
         assert result["success"] is True
         assert "warnings" not in result
+
+    async def test_seeded_section_defaults_do_not_count_as_consumed_keys(self) -> None:
+        import json
+
+        from fastmcp.exceptions import ToolError
+
+        final_entry = {"type": "create_entry", "result": {"entry_id": "e1"}}
+        submit_fn = AsyncMock(side_effect=[final_entry])
+        initial_step = {
+            "type": "form",
+            "flow_id": "flow-defaults",
+            "step_id": "user",
+            "data_schema": [
+                {
+                    "type": "expandable",
+                    "name": "advanced",
+                    "required": True,
+                    "schema": [{"name": "framerate", "default": 2}],
+                }
+            ],
+        }
+
+        with pytest.raises(ToolError) as exc_info:
+            await _handle_flow_steps(
+                client=None,
+                flow_id="flow-defaults",
+                initial_step=initial_step,
+                config={"typo_key": 5},
+                submit_fn=submit_fn,
+            )
+
+        body = json.loads(str(exc_info.value))
+        assert body["error"]["code"] == "VALIDATION_INVALID_PARAMETER"
+        assert "without consuming any" in body["error"]["message"]
+        assert submit_fn.await_args.args[1] == {"advanced": {"framerate": 2}}
+
+    async def test_preview_confirm_form_is_auto_advanced(self) -> None:
+        confirm_step = {
+            "type": "form",
+            "flow_id": "flow-generic",
+            "step_id": "user_confirm",
+            "preview": "Camera preview",
+            "data_schema": [
+                {
+                    "name": "confirmed_ok",
+                    "required": True,
+                    "default": False,
+                    "selector": {"boolean": {}},
+                }
+            ],
+        }
+        final_entry = {"type": "create_entry", "result": {"entry_id": "camera-1"}}
+        submit_fn = AsyncMock(side_effect=[confirm_step, final_entry])
+        initial_step = {
+            "type": "form",
+            "flow_id": "flow-generic",
+            "step_id": "user",
+            "data_schema": [{"name": "stream_source"}],
+        }
+
+        result = await _handle_flow_steps(
+            client=None,
+            flow_id="flow-generic",
+            initial_step=initial_step,
+            config={"stream_source": "rtsp://camera.example/stream"},
+            submit_fn=submit_fn,
+        )
+
+        assert result["success"] is True
+        assert submit_fn.await_args_list[0].args[1] == {
+            "stream_source": "rtsp://camera.example/stream"
+        }
+        assert submit_fn.await_args_list[1].args[1] == {"confirmed_ok": True}
 
     async def test_menu_only_selection_still_succeeds(self) -> None:
         # A caller whose config is JUST a menu selection consumed by a menu

--- a/tests/src/unit/test_flow_multistep.py
+++ b/tests/src/unit/test_flow_multistep.py
@@ -149,6 +149,91 @@ class TestHandleFormStepFiltering:
         }
         assert remaining == {}
 
+    def test_required_expandable_section_uses_schema_suggestions(self) -> None:
+        """Generic Camera's required advanced section has HA-suggested defaults."""
+        remaining = {"stream_source": "rtsp://camera.example/stream"}
+        step = {
+            "type": "form",
+            "step_id": "user",
+            "data_schema": [
+                {"name": "stream_source", "required": False},
+                {
+                    "type": "expandable",
+                    "name": "advanced",
+                    "required": True,
+                    "expanded": False,
+                    "schema": [
+                        {
+                            "name": "framerate",
+                            "required": True,
+                            "description": {"suggested_value": 2},
+                        },
+                        {
+                            "name": "verify_ssl",
+                            "required": True,
+                            "description": {"suggested_value": True},
+                        },
+                        {
+                            "name": "rtsp_transport",
+                            "required": False,
+                            "description": {"suggested_value": "tcp"},
+                        },
+                    ],
+                },
+            ],
+        }
+
+        form_data = _handle_form_step("flow-1", step, remaining)
+
+        assert form_data == {
+            "stream_source": "rtsp://camera.example/stream",
+            "advanced": {
+                "framerate": 2,
+                "verify_ssl": True,
+                "rtsp_transport": "tcp",
+            },
+        }
+        assert remaining == {}
+
+    def test_required_expandable_section_config_overrides_suggestions(self) -> None:
+        remaining = {
+            "stream_source": "rtsp://camera.example/stream",
+            "advanced": {"framerate": 5},
+            "verify_ssl": False,
+        }
+        step = {
+            "type": "form",
+            "step_id": "user",
+            "data_schema": [
+                {"name": "stream_source", "required": False},
+                {
+                    "type": "expandable",
+                    "name": "advanced",
+                    "required": True,
+                    "schema": [
+                        {
+                            "name": "framerate",
+                            "required": True,
+                            "description": {"suggested_value": 2},
+                        },
+                        {
+                            "name": "verify_ssl",
+                            "required": True,
+                            "description": {"suggested_value": True},
+                        },
+                    ],
+                },
+            ],
+        }
+
+        form_data = _handle_form_step("flow-1", step, remaining)
+
+        assert form_data == {
+            "stream_source": "rtsp://camera.example/stream",
+            "advanced": {"framerate": 5, "verify_ssl": False},
+        }
+        assert remaining == {}
+
     def test_omits_section_when_only_top_level_field_is_updated(self) -> None:
         remaining = {"state": "{{ 2 }}"}
         step = {


### PR DESCRIPTION
## What does this PR do?

Fixes #2011.

When Home Assistant returns a required expandable section with suggested/default values, `ha_set_integration` now includes those defaults in the submitted form data. This lets Generic Camera flows submit the required `advanced` section even when the caller only provides fields like `stream_source`, while still allowing explicit caller overrides.

AI assistance was used to implement and test this change.

## Type of change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [x] I have tested these changes with a LLM agent
- [ ] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

Targeted tests run:
- `uv run pytest tests/src/unit/test_flow_multistep.py -q`
- `uv run pytest tests/src/unit/test_flow_error_parsing.py tests/src/unit/test_flow_name_injection.py tests/src/unit/test_identifier_validation_family.py -q`
- `uv run ruff format --check src/ha_mcp/tools/config_entry_flow.py tests/src/unit/test_flow_multistep.py`
- `uv run ruff check src/ha_mcp/tools/config_entry_flow.py tests/src/unit/test_flow_multistep.py`
- `git diff --check`

## Checklist
- [x] I have updated documentation if needed
