### PR TITLE
fix: restore read-only annotations on the dashboard get and screenshot tools

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -560,6 +560,12 @@ Every tool needs `tags={"Category Name"}` (native FastMCP parameter). Drives the
 | `idempotentHint: True` | `False` | Repeated calls with same args have no additional effect (only meaningful when `readOnlyHint` is false) |
 | `openWorldHint: True` | `True` | Tool reaches an external, third-party-authored world (HACS store, add-on repositories, GitHub release feeds, arbitrary import URLs). Set to `False` when the tool's domain is the local Home Assistant instance. A tool is also open-world if its output carries externally-authored content back to the client, even when a local integration (HACS, Supervisor, HA Core) makes the actual network call on its behalf — `ha_get_overview` and `ha_get_system_health` embed the update-check field that reaches PyPI / the Supervisor store, while `ha_get_blueprint` and `ha_config_list_dashboard_resources` return externally-authored content from purely local reads. Required on every tool — the default is `true`, so an omitted value silently marks a local tool as open-world |
 
+**Version baseline:** annotations describe a tool's behavior against current
+upstream versions of any external engine or component it drives; a side effect
+that exists only in outdated external builds does not demote the tool to
+write-classified — document the update requirement in the tool's docs instead
+(e.g. the screenshot engine's old `settheme` write, #1991).
+
 ### Error Handling
 
 **Always use the dedicated error functions** from `errors.py` and `helpers.py`. Never construct raw error dicts manually — the helpers ensure consistent structure, error codes, and suggestions across all tools.

--- a/docs/beta.md
+++ b/docs/beta.md
@@ -174,20 +174,18 @@ token grants. If the token is missing or invalid, Puppet lands on the login
 page and (by its design) restarts; ha-mcp surfaces this as a clear "set the
 engine's access token" error rather than a silent failure.
 
-Puppet's theme and dark-mode renderer controls dispatch Home Assistant's
-`settheme` event, which Home Assistant persists on the frontend profile of
-the user whose token the engine runs with — and syncs to that user's real
-web and mobile sessions. Even a fresh Puppet browser's first default render
-saves a "light" selection, which used to flip a dark-mode user's whole UI to
-light on every screenshot. ha-mcp now brackets every capture: it reads that
-user's saved theme before rendering and writes it back afterwards if the
-render changed it (in add-on mode it authenticates with the Puppet add-on's
-own configured token; in sidecar / self-hosted non-add-on mode with ha-mcp's
-own HA credentials, which protects the user whenever both tokens belong to the
-same account). The restore is best-effort — a failed restore surfaces as a
-`warnings` entry on the tool response. A dedicated Puppet account remains a
-sound belt-and-suspenders setup. Language selection is local to Puppet's
-browser session.
+Puppet's theme and dark-mode renderer controls used to dispatch Home
+Assistant's `settheme` event on every cold render, which Home Assistant
+persisted on the frontend profile of the user whose token the engine runs with
+— and synced to that user's real web and mobile sessions, flipping a dark-mode
+user's whole UI to light on every screenshot (#1909). Recent Puppet versions
+fixed that cold-render dispatch, so ha-mcp's snapshot/restore bracket around
+each capture is now disabled (#1991); the guard code is retained so it can be
+switched back on if a future engine regression reintroduces the write. If you
+run an older Puppet build, update the add-on (or your self-hosted sidecar
+image) — older engines still persist the theme selection and will keep
+flipping it. A dedicated Puppet account remains a sound belt-and-suspenders
+setup. Language selection is local to Puppet's browser session.
 
 To change the Puppet engine add-on's own options (such as `keep_browser_open`)
 or to restart it, use `ha_manage_addon`; the screenshot tools only render and

--- a/src/ha_mcp/dashboard_screenshot/capture.py
+++ b/src/ha_mcp/dashboard_screenshot/capture.py
@@ -855,11 +855,15 @@ async def capture_dashboard_images(
     preset's native orientation. ``full_page`` is a compatibility alias for
     requesting the engine's native ``WIDTHxauto`` viewport.
 
-    The batch is bracketed by a :class:`ThemeGuard` that restores the engine
-    user's saved frontend theme if rendering changed it (issue #1909).
-    ``client`` supplies the guard's non-add-on credential fallback and
-    ``capture_warnings`` collects the guard's non-fatal warnings; both are
-    optional and never affect the captures themselves.
+    The batch used to be bracketed by a :class:`ThemeGuard` that restored the
+    engine user's saved frontend theme when a cold render changed it (issue
+    #1909). That bracket is currently disabled (#1991): upstream Puppet no
+    longer dispatches ``settheme`` on cold renders, so there is nothing to undo.
+    The guard construction and the ``client`` / ``capture_warnings`` plumbing
+    are retained so the bracket can be re-enabled by uncommenting the
+    snapshot/restore calls if a future engine regression reintroduces the write;
+    while disabled ``capture_warnings`` simply stays empty and never affects the
+    captures themselves.
     """
     path = _validate_dashboard_path(dashboard_path)
     options = validate_capture_parameters(
@@ -884,13 +888,16 @@ async def capture_dashboard_images(
     mime_type = _MIME_TYPES[options.image_format]
     captures: list[DashboardImageCapture] = []
 
-    # The engine dispatches a theme write into the authenticated frontend on
-    # cold renders, which Home Assistant persists to the engine user's real
-    # profile (issue #1909). Snapshot before, restore after — including when
-    # the batch fails, since the engine may already have rendered (and
-    # written) before the failure.
+    # ThemeGuard bracket — currently DISABLED (#1991). Stock Puppet used to
+    # dispatch a theme write into the authenticated frontend on cold renders,
+    # which Home Assistant persisted to the engine user's real profile (#1909);
+    # ha-mcp snapshotted before and restored after to undo it. Upstream Puppet
+    # has since fixed the cold-render settheme dispatch, so the bracket is no
+    # longer needed. The guard is still constructed (and the snapshot/restore
+    # calls kept below, commented out) so it can be re-enabled by uncommenting
+    # if a future engine regression reintroduces the write.
     guard = ThemeGuard.for_capture(engine_target.addon_credential, client)
-    await guard.take_snapshot()
+    # await guard.take_snapshot()
     batch_error: ToolError | None = None
     try:
         async with httpx.AsyncClient(
@@ -970,7 +977,7 @@ async def capture_dashboard_images(
         # and its outcome can be attached to the error payload below.
         batch_error = exc
     finally:
-        await guard.restore()
+        # await guard.restore()  # ThemeGuard bracket disabled (#1991) — see above.
         if capture_warnings is not None:
             capture_warnings.extend(guard.warnings)
 

--- a/src/ha_mcp/dashboard_screenshot/theme_guard.py
+++ b/src/ha_mcp/dashboard_screenshot/theme_guard.py
@@ -1,5 +1,11 @@
 """Snapshot and restore the engine user's saved frontend theme (issue #1909).
 
+NOTE: This guard is currently disabled at its call site (``capture.py``)
+because upstream Puppet fixed the cold-render ``settheme`` dispatch that made
+the bracket necessary (#1991). The code here is retained unchanged so the
+bracket can be re-enabled by uncommenting the snapshot/restore calls in
+``capture.py`` if a future engine regression reintroduces the write.
+
 Stock Puppet dispatches Home Assistant's ``settheme`` event on every
 cold-browser render — its ``dark`` query flag is presence-based, so "not
 requested" reaches the frontend as an explicit "light". Home Assistant

--- a/src/ha_mcp/read_only.py
+++ b/src/ha_mcp/read_only.py
@@ -143,14 +143,6 @@ def _updates_write(args: dict[str, Any]) -> str | None:
     return f"action={action!r}"
 
 
-def _dashboard_get_write(args: dict[str, Any]) -> str | None:
-    """Allow config/list/search reads; fail closed on a screenshot render."""
-    include_screenshot = args.get("include_screenshot")
-    if include_screenshot is None or include_screenshot is False:
-        return None
-    return "dashboard screenshot render (Puppet persists theme/dark preferences)"
-
-
 def _radio_write(args: dict[str, Any]) -> str | None:
     action = args.get("action")
     # Reads (allowed): per-node diagnostics, the integration/network summary,
@@ -191,10 +183,6 @@ def _radio_write(args: dict[str, Any]) -> str | None:
 # against the real registered catalog at PR time, so the two sets
 # cannot drift apart silently.
 READ_ONLY_EXEMPT_TOOLS: dict[str, ReadOnlyExemption] = {
-    "ha_config_get_dashboard": ReadOnlyExemption(
-        _dashboard_get_write,
-        "dashboard config, list, and search reads with include_screenshot=false",
-    ),
     "ha_manage_backup": ReadOnlyExemption(
         _backup_write,
         "listing, viewing, and diffing per-edit backups (scope='edits', "

--- a/src/ha_mcp/tools/tools_config_dashboards.py
+++ b/src/ha_mcp/tools/tools_config_dashboards.py
@@ -1749,7 +1749,7 @@ class DashboardConfigTools:
         tags={"Dashboards"},
         annotations={
             "openWorldHint": False,
-            "destructiveHint": False,
+            "readOnlyHint": True,
             "idempotentHint": True,
             "title": "Get Dashboard",
         },

--- a/src/ha_mcp/tools/tools_dashboard_screenshot.py
+++ b/src/ha_mcp/tools/tools_dashboard_screenshot.py
@@ -109,7 +109,7 @@ class DashboardScreenshotTools:
         tags={"Dashboard", "beta"},
         annotations={
             "openWorldHint": False,
-            "destructiveHint": False,
+            "readOnlyHint": True,
             "title": "Get Dashboard Screenshot",
         },
     )

--- a/tests/src/unit/test_dashboard_readonly_hints_1991.py
+++ b/tests/src/unit/test_dashboard_readonly_hints_1991.py
@@ -1,0 +1,51 @@
+"""Regression tests for #1991 — dashboard read tools carry readOnlyHint.
+
+``ha_config_get_dashboard`` and ``ha_get_dashboard_screenshot`` both render
+screenshots via the Puppet engine, which used to persist a ``settheme`` write
+per user (#1909). PR #1837 dropped their ``readOnlyHint`` for that reason. With
+upstream Puppet fixed and ha-mcp's theme-guard bracket disabled (#1991), both
+tools are honestly read-only again. These tests pin the restored annotation so
+a regression back to the #1837 state (``destructiveHint`` instead of
+``readOnlyHint``) fails loudly.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from ha_mcp.tools.tools_config_dashboards import DashboardConfigTools
+from ha_mcp.tools.tools_dashboard_screenshot import DashboardScreenshotTools
+from ha_mcp.transforms.categorized_search import _categorize_tool
+
+
+def _annotations(method):
+    """The ToolAnnotations the @tool decorator attached via __fastmcp__."""
+    return method.__fastmcp__.annotations
+
+
+class TestDashboardReadOnlyHints:
+    def test_config_get_dashboard_is_read_only(self):
+        annotations = _annotations(
+            DashboardConfigTools(MagicMock()).ha_config_get_dashboard
+        )
+        assert annotations.readOnlyHint is True
+        # Guard against re-regression to the #1837 state, which marked the
+        # tool destructiveHint=False instead of read-only.
+        assert annotations.destructiveHint is None
+
+    def test_get_dashboard_screenshot_is_read_only(self):
+        annotations = _annotations(
+            DashboardScreenshotTools(MagicMock()).ha_get_dashboard_screenshot
+        )
+        assert annotations.readOnlyHint is True
+        assert annotations.destructiveHint is None
+
+    def test_both_tools_categorize_as_read(self):
+        """The categorized tool-search bucketing must classify both as read so
+        a ``ha_call_read_tool`` invocation no longer hard-fails (#1991)."""
+        get_dashboard = DashboardConfigTools(MagicMock()).ha_config_get_dashboard
+        get_screenshot = DashboardScreenshotTools(
+            MagicMock()
+        ).ha_get_dashboard_screenshot
+        assert _categorize_tool(get_dashboard.__fastmcp__) == "read"
+        assert _categorize_tool(get_screenshot.__fastmcp__) == "read"

--- a/tests/src/unit/test_dashboard_screenshot_theme_guard.py
+++ b/tests/src/unit/test_dashboard_screenshot_theme_guard.py
@@ -1,14 +1,17 @@
 """Unit tests for the dashboard-screenshot theme guard (issue #1909).
 
-Stock Puppet dispatches a ``settheme`` event on cold renders, and Home
-Assistant persists it server-side on the engine token user's profile —
+Stock Puppet dispatched a ``settheme`` event on cold renders, and Home
+Assistant persisted it server-side on the engine token user's profile —
 flipping that user's real sessions to light mode. The guard snapshots the
 saved theme before a capture batch and restores it afterwards.
 
-Covers credential resolution (add-on options vs ha-mcp's own credentials),
-snapshot/restore semantics against a fake WebSocket client, non-fatal
-failure handling, and the restore bracket around ``capture_dashboard_images``
-— including the regression scenario itself.
+The capture-time bracket is currently DISABLED (#1991): upstream Puppet fixed
+the cold-render dispatch, so ``capture.py`` no longer calls the guard's
+snapshot/restore. The guard code itself is retained (and unchanged), so the
+unit tests below still cover its credential resolution and snapshot/restore
+semantics against a fake WebSocket client. ``TestCaptureBracketDisabled``
+asserts the bracket stays off — capture opens no guard sessions and adds no
+warnings — guarding against a silent re-enable.
 """
 
 from __future__ import annotations
@@ -363,10 +366,13 @@ def _patch_engine(monkeypatch: Any, addon_credential: EngineCredential | None) -
     _ClobberingEngineClient.status_code = 200
 
 
-class TestCaptureBracket:
-    """The guard brackets capture_dashboard_images end to end."""
+class TestCaptureBracketDisabled:
+    """The ThemeGuard bracket around capture_dashboard_images is DISABLED
+    (#1991). Upstream Puppet no longer clobbers the theme on cold renders, so
+    ha-mcp opens no snapshot/restore sessions and adds no guard warnings. These
+    guard against the bracket being silently re-enabled."""
 
-    async def test_default_render_clobber_is_restored_issue_1909(
+    async def test_capture_opens_no_guard_sessions_and_leaves_theme(
         self, monkeypatch: Any
     ) -> None:
         from ha_mcp.dashboard_screenshot import capture
@@ -380,13 +386,19 @@ class TestCaptureBracket:
         )
 
         assert captures[0].data == _PNG
-        assert _FakeWsClient.user_data[THEME_USER_DATA_KEY] == _DARK_THEME
+        # No snapshot/restore WebSocket sessions were opened.
+        assert _FakeWsClient.instances == []
+        # The bracket did not run: the fake engine still simulates the old
+        # clobber, and ha-mcp no longer undoes it (real Puppet no longer
+        # causes it).
+        assert _FakeWsClient.user_data[THEME_USER_DATA_KEY] == _CLOBBERED_THEME
         assert capture_warnings == []
 
-    async def test_client_credential_fallback_restores_via_client(
+    async def test_client_credential_fallback_opens_no_guard_sessions(
         self, monkeypatch: Any
     ) -> None:
-        """Sidecar/standalone mode: no add-on credential, own HA creds used."""
+        """Sidecar/standalone mode: even with a usable client credential the
+        disabled bracket opens no guard sessions."""
         from ha_mcp.dashboard_screenshot import capture
 
         _patch_engine(monkeypatch, None)
@@ -397,49 +409,11 @@ class TestCaptureBracket:
         )
 
         assert captures[0].data == _PNG
-        assert _FakeWsClient.user_data[THEME_USER_DATA_KEY] == _DARK_THEME
-        assert {(ws.url, ws.token) for ws in _FakeWsClient.instances} == {
-            ("http://ha.local:8123", "own-token")
-        }
+        assert _FakeWsClient.instances == []
 
-    async def test_restore_runs_even_when_capture_fails(self, monkeypatch: Any) -> None:
-        from ha_mcp.dashboard_screenshot import capture
-
-        _patch_engine(monkeypatch, _PUPPET_CREDENTIAL)
-        _FakeWsClient.user_data[THEME_USER_DATA_KEY] = dict(_DARK_THEME)
-        _ClobberingEngineClient.status_code = 500
-
-        with pytest.raises(ToolError):
-            await capture.capture_dashboard_images("lovelace/0")
-
-        assert _FakeWsClient.user_data[THEME_USER_DATA_KEY] == _DARK_THEME
-
-    async def test_restore_failure_surfaces_as_capture_warning(
+    async def test_capture_failure_raises_without_guard_warnings(
         self, monkeypatch: Any
     ) -> None:
-        from ha_mcp.dashboard_screenshot import capture
-
-        _patch_engine(monkeypatch, _PUPPET_CREDENTIAL)
-        _FakeWsClient.user_data[THEME_USER_DATA_KEY] = dict(_DARK_THEME)
-        _FakeWsClient.fail_set = True
-        capture_warnings: list[str] = []
-
-        captures = await capture.capture_dashboard_images(
-            "lovelace/0", capture_warnings=capture_warnings
-        )
-
-        assert captures[0].data == _PNG
-        assert len(capture_warnings) == 1
-        assert "restoring it failed" in capture_warnings[0]
-
-    async def test_restore_failure_rides_on_the_raised_capture_error(
-        self, monkeypatch: Any
-    ) -> None:
-        """Failed render + failed restore: the warning must reach the caller.
-
-        The theme is most likely left flipped exactly when both fail, so the
-        raised ToolError payload has to carry the guard warning.
-        """
         import json
 
         from ha_mcp.dashboard_screenshot import capture
@@ -447,10 +421,13 @@ class TestCaptureBracket:
         _patch_engine(monkeypatch, _PUPPET_CREDENTIAL)
         _FakeWsClient.user_data[THEME_USER_DATA_KEY] = dict(_DARK_THEME)
         _ClobberingEngineClient.status_code = 500
-        _FakeWsClient.fail_set = True
 
         with pytest.raises(ToolError) as exc_info:
             await capture.capture_dashboard_images("lovelace/0")
 
+        # No guard sessions opened, and no guard warning on the error payload.
+        assert _FakeWsClient.instances == []
         payload = json.loads(str(exc_info.value))
-        assert any("restoring it failed" in warning for warning in payload["warnings"])
+        assert not any(
+            "restoring it failed" in warning for warning in payload.get("warnings", [])
+        )

--- a/tests/src/unit/test_read_only.py
+++ b/tests/src/unit/test_read_only.py
@@ -47,7 +47,10 @@ CATALOG = [
     make_tool("ha_unannotated", None),
     make_tool("ha_manage_backup", False),
     make_tool("ha_manage_addon", False),
-    make_tool("ha_config_get_dashboard", False),
+    # #1991: ha_config_get_dashboard is now annotated readOnlyHint=True — it is
+    # honestly read-only (the theme-guard bracket is disabled), so it is a plain
+    # read tool, no longer a mixed read/write exemption.
+    make_tool("ha_config_get_dashboard", True),
 ]
 
 
@@ -97,21 +100,6 @@ class TestHelpers:
 
 class TestExemptionRules:
     """Argument-level write detection for the exempt mixed tools."""
-
-    @pytest.mark.parametrize(
-        ("args", "allowed"),
-        [
-            ({}, True),
-            ({"list_only": True}, True),
-            ({"include_screenshot": False}, True),
-            ({"include_screenshot": True}, False),
-            ({"include_screenshot": "false"}, False),
-            ({"include_screenshot": 1}, False),
-        ],
-    )
-    def test_get_dashboard(self, args, allowed):
-        rule = READ_ONLY_EXEMPT_TOOLS["ha_config_get_dashboard"].blocked_write
-        assert (rule(args) is None) is allowed
 
     @pytest.mark.parametrize(
         ("args", "allowed"),
@@ -443,42 +431,42 @@ class TestMiddleware:
 
         assert result == "dashboard"
 
-    async def test_dashboard_config_screenshot_is_blocked(self, read_only_on):
+    async def test_dashboard_config_screenshot_now_passes(self, read_only_on):
+        """#1991 regression: ha_config_get_dashboard is now readOnlyHint=True,
+        so an include_screenshot render is a plain read and must pass through in
+        read-only mode (it was blocked by the now-removed exemption)."""
         mw = make_middleware()
-        call_next = AsyncMock()
+        call_next = AsyncMock(return_value="dashboard-with-screenshot")
 
-        with pytest.raises(ToolError) as excinfo:
-            await mw.on_call_tool(
-                make_context(
-                    "ha_config_get_dashboard",
-                    {"url_path": "wall-panel", "include_screenshot": True},
-                ),
-                call_next,
-            )
+        result = await mw.on_call_tool(
+            make_context(
+                "ha_config_get_dashboard",
+                {"url_path": "wall-panel", "include_screenshot": True},
+            ),
+            call_next,
+        )
 
-        body = expect_read_only_error(excinfo)
-        assert body["tool_name"] == "ha_config_get_dashboard"
-        call_next.assert_not_called()
+        assert result == "dashboard-with-screenshot"
 
-    async def test_proxied_dashboard_screenshot_is_blocked(self, read_only_on):
+    async def test_proxied_dashboard_screenshot_now_passes(self, read_only_on):
+        """#1991 regression: the same screenshot render routed through the call
+        proxy must also pass — the read classification means ha_call_read_tool
+        no longer hard-fails on it."""
         mw = make_middleware()
-        call_next = AsyncMock()
+        call_next = AsyncMock(return_value="proxied-dashboard-with-screenshot")
 
-        with pytest.raises(ToolError) as excinfo:
-            await mw.on_call_tool(
-                make_context(
-                    "ha_call_write_tool",
-                    {
-                        "name": "ha_config_get_dashboard",
-                        "arguments": {"include_screenshot": True},
-                    },
-                ),
-                call_next,
-            )
+        result = await mw.on_call_tool(
+            make_context(
+                "ha_call_read_tool",
+                {
+                    "name": "ha_config_get_dashboard",
+                    "arguments": {"include_screenshot": True},
+                },
+            ),
+            call_next,
+        )
 
-        body = expect_read_only_error(excinfo)
-        assert body["tool_name"] == "ha_config_get_dashboard"
-        call_next.assert_not_called()
+        assert result == "proxied-dashboard-with-screenshot"
 
     async def test_exempt_tool_write_action_blocked(self, read_only_on):
         mw = make_middleware()
@@ -539,7 +527,7 @@ class TestTransform:
         for tool in (
             make_tool("ha_get_state", True),
             make_tool("ha_manage_backup", False),
-            make_tool("ha_config_get_dashboard", False),
+            make_tool("ha_config_get_dashboard", True),
         ):
             call_next = AsyncMock(return_value=tool)
             assert await transform.get_tool(tool.name, call_next) is tool
@@ -557,7 +545,6 @@ class TestExemptTableContract:
         must be deliberate (each entry means 'this tool stays callable
         in read-only mode')."""
         assert set(READ_ONLY_EXEMPT_TOOLS) == {
-            "ha_config_get_dashboard",
             "ha_manage_backup",
             "ha_manage_addon",
             "ha_manage_energy_prefs",
@@ -580,7 +567,6 @@ _SRC_TOOLS_DIR = Path(__file__).resolve().parents[3] / "src" / "ha_mcp" / "tools
 
 # Module that defines each exempt tool's ``@tool`` / ``@mcp.tool`` method.
 _EXEMPT_TOOL_MODULES = {
-    "ha_config_get_dashboard": "tools_config_dashboards.py",
     "ha_manage_backup": "backup.py",
     "ha_manage_addon": "tools_addons.py",
     "ha_manage_energy_prefs": "tools_energy.py",
@@ -599,7 +585,6 @@ _EXEMPT_TOOL_MODULES = {
 # tool likewise fails this test, telling the maintainer to re-review the
 # read-only predicate.
 _EXEMPT_INSPECTED_ARGS = {
-    "ha_config_get_dashboard": {"include_screenshot"},
     "ha_manage_backup": {"scope", "action"},
     "ha_manage_addon": {
         "action",
@@ -641,20 +626,6 @@ _ADDON_CONFIG_WRITE_PARAMS_MANIFEST = (
 # dispatch fields the predicate inspects) would silently classify as a
 # read in Read Only Mode.
 _EXEMPT_GATED_OR_READ_ARGS = {
-    "ha_config_get_dashboard": {
-        "url_path",
-        "list_only",
-        "force_reload",
-        "entity_id",
-        "card_type",
-        "heading",
-        "include_config",
-        "view_path",
-        # Cross-dashboard search selectors: mode='search' + query are pure reads
-        # (walk storage dashboards for a substring), no mutation capability.
-        "mode",
-        "query",
-    },
     "ha_manage_backup": {
         # Consumed only under the (scope, action) dispatch the predicate
         # inspects: snapshot create/restore payloads...


### PR DESCRIPTION
## What does this PR do?

Restores `readOnlyHint: True` on `ha_config_get_dashboard` and `ha_get_dashboard_screenshot`, and disables the dashboard-screenshot theme guard (code retained, calls commented out) now that upstream Puppet no longer dispatches `settheme` on cold renders.

PR #1837 dropped the getter's `readOnlyHint` because the `include_screenshot` render used to trigger a persisted theme write in Home Assistant (#1909), mitigated by the ThemeGuard snapshot/restore bracket. Consequences tracked in #1991: clients show "Get Dashboard" with a write badge, categorized tool search buckets both tools as write (`ha_call_read_tool` hard-fails on them), and the policy handlers treat them as write. With the engine-side write fixed upstream and nothing on the capture path persisting anything (verified in the issue thread), both tools are honestly read-only again.

Changes:
- `dashboard_screenshot/capture.py`: the theme-guard `take_snapshot()`/`restore()` calls are commented out; the guard construction and warnings plumbing are retained so the bracket can be re-enabled by uncommenting if a future engine regression reintroduces the write
- `dashboard_screenshot/theme_guard.py`: module docstring note that the guard is currently disabled at its call site; no code changes
- `tools_config_dashboards.py` / `tools_dashboard_screenshot.py`: `destructiveHint: False` -> `readOnlyHint: True` on both tools
- `read_only.py`: removed the now-stale `ha_config_get_dashboard` exemption — `include_screenshot=true` is a plain read now, and the middleware checks the exemption table before annotations, so leaving the entry would keep blocking a read-only-annotated tool in Read Only Mode
- `docs/beta.md`: theme paragraph rewritten for the new state; users on older Puppet builds should update the add-on/sidecar
- Tests: read-only suite updated to the new classification; #1991 regression tests added (both tools pinned `readOnlyHint: True` with no `destructiveHint`, both categorize as `read` for tool search, `include_screenshot=true` passes Read Only Mode directly and via `ha_call_read_tool`, and capture opens no guard sessions)

Full unit suite passes locally; e2e runs in CI.

Closes #1991

## Type of change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

## Checklist
- [x] I have updated documentation if needed
