### PR TITLE
feat: allow state_filter-only ha_search to enumerate entities by state

### DIFF
--- a/custom_components/ha_mcp_tools/const.py
+++ b/custom_components/ha_mcp_tools/const.py
@@ -24,7 +24,7 @@ DOMAIN = "ha_mcp_tools"
 # manifest bump that forgets this constant (or vice-versa) fails in CI. The
 # capability negotiation — not this version — gates each WS command (see
 # ``websocket_api.CAPABILITIES``).
-COMPONENT_VERSION = "1.2.3"
+COMPONENT_VERSION = "1.2.4"
 
 # Config-entry discriminator (``entry.data[CONF_ENTRY_TYPE]``). A missing value
 # means "tools" so the pre-existing services entry keeps working across the

--- a/custom_components/ha_mcp_tools/manifest.json
+++ b/custom_components/ha_mcp_tools/manifest.json
@@ -22,5 +22,5 @@
     "requirements": [
         "ruamel.yaml>=0.18.0"
     ],
-    "version": "1.2.3"
+    "version": "1.2.4"
 }

--- a/custom_components/ha_mcp_tools/websocket_api.py
+++ b/custom_components/ha_mcp_tools/websocket_api.py
@@ -1274,13 +1274,20 @@ def _search_entities(
     """Score every state against the query over the joined registry view."""
     results: list[dict[str, Any]] = []
     area_filter_lower = area_filter.lower() if area_filter else None
+    # Lower the state filter once; the entity state is lowered per record so the
+    # compare is case-insensitive (e.g. an input_select holding "Vacation"
+    # matches state_filter="vacation").
+    state_filter_lower = state_filter.lower() if state_filter is not None else None
     for state in _iter_states(hass):
         rec = _entity_record(state, view)
         if domain_filter and rec["domain"] != domain_filter:
             continue
         if rec["_hidden"] and not include_hidden:
             continue
-        if state_filter is not None and rec["state"] != state_filter:
+        if (
+            state_filter_lower is not None
+            and (rec["state"] or "").lower() != state_filter_lower
+        ):
             continue
         if area_filter_lower is not None and not _entity_matches_area(
             rec, area_filter_lower

--- a/src/ha_mcp/tools/tools_search.py
+++ b/src/ha_mcp/tools/tools_search.py
@@ -181,7 +181,8 @@ _ALWAYS_KEEP_PROJECTION: frozenset[str] = frozenset(
         # search actually scanned — caller value beyond the input echo.
         "area_names",
         # Entity-branch internal mode label ("exact_match", "fuzzy_search",
-        # "area_only", "area_filtered_query", "domain_listing"). E2E tests
+        # "area_only", "area_filtered_query", "domain_listing",
+        # "state_listing"). E2E tests
         # pin its presence at 17+ assertion sites — callers verifiably
         # rely on it to disambiguate which entity-search path produced
         # the result, so retained at the envelope top instead of stripped.
@@ -335,8 +336,10 @@ def _compute_eligibility(
     Returns ``(registry_eligible, body_eligible, body_skipped_by_intent_gate)``:
 
     - ``registry_eligible``: the entity-registry branch runs whenever any of
-      ``query`` / ``domain_filter`` / ``area_filter`` is set, except when the
-      caller pinned config-only via an explicit ``search_types``.
+      ``query`` / ``domain_filter`` / ``area_filter`` / ``state_filter`` is set,
+      except when the caller pinned config-only via an explicit ``search_types``.
+      ``state_filter`` alone is sufficient — it enumerates every entity in that
+      state (issue #2002), mirroring the ``domain_filter``-only listing mode.
     - ``body_eligible``: the config-body branch runs only when a ``query``
       term is set AND the caller's inputs do not signal entity-only intent.
       "Entity-only intent" = any of ``domain_filter`` / ``area_filter`` /
@@ -348,7 +351,9 @@ def _compute_eligibility(
       ``query`` + entity-filter without explicit pin). The orchestrator
       surfaces a warning in this case so callers can opt back in.
     """
-    any_registry_input = bool(query_text or domain_filter_text or area_filter_text)
+    any_registry_input = bool(
+        query_text or domain_filter_text or area_filter_text or state_filter_text
+    )
     registry_eligible = any_registry_input and not explicit_config_only
     entity_intent_signal = bool(
         domain_filter_text or area_filter_text or state_filter_text
@@ -1253,8 +1258,14 @@ def _validate_entity_search_params(
     domain_filter: str | None,
     area_filter: str | None,
     result_fields: Any,
+    state_filter: str | None = None,
 ) -> tuple[str, str | None, str | None, list[str] | None]:
-    """Validate and normalise inputs for entity search; returns (query, domain_filter, area_filter, parsed_result_fields)."""
+    """Validate and normalise inputs for entity search; returns (query, domain_filter, area_filter, parsed_result_fields).
+
+    ``state_filter`` is not returned (the caller normalises it separately via
+    ``_normalize_state_filter``); it participates here only in the
+    at-least-one-criterion check so a ``state_filter``-only call is accepted and
+    enumerates every entity in that state (issue #2002)."""
     parsed_result_fields: list[str] | None = None
     if result_fields is not None:
         try:
@@ -1278,10 +1289,16 @@ def _validate_entity_search_params(
         domain_filter = domain_filter.strip().lower()
     if area_filter:
         area_filter = area_filter.strip()
-    if not query.strip() and not domain_filter and not area_filter:
+    if (
+        not query.strip()
+        and not domain_filter
+        and not area_filter
+        and not _normalize_state_filter(state_filter)
+    ):
         raise_tool_error(
             create_validation_error(
-                "At least one of 'query', 'domain_filter', or 'area_filter' must be set.",
+                "At least one of 'query', 'domain_filter', 'area_filter', or "
+                "'state_filter' must be set.",
                 parameter="query",
             )
         )
@@ -1575,10 +1592,11 @@ class SearchTools:
                     "script sequences, scene contents, helper bodies, "
                     "dashboard cards) in one call. Use this for any "
                     "find-something-in-HA question — entity OR config. "
-                    "Omit `query` to enumerate by `domain_filter` and/or "
-                    "`area_filter` alone (registry-listing mode); "
-                    "configuration-body search is skipped in that mode "
-                    "because there is no term to match against."
+                    "Omit `query` to enumerate by `domain_filter`, "
+                    "`area_filter`, and/or `state_filter` alone "
+                    "(registry-listing mode); configuration-body search is "
+                    "skipped in that mode because there is no term to match "
+                    "against."
                 ),
             ),
         ] = None,
@@ -1691,7 +1709,10 @@ class SearchTools:
                 default=None,
                 description=(
                     "Filter entity-registry results to a specific state "
-                    '(e.g. "on", "off", "unavailable"). Case-insensitive.'
+                    '(e.g. "on", "off", "unavailable"). Case-insensitive. '
+                    "Can be used standalone (no query/domain/area) to enumerate "
+                    "every entity in that state; total_matches reflects the "
+                    "filtered count."
                 ),
             ),
         ] = None,
@@ -1757,8 +1778,8 @@ class SearchTools:
 
         Two surfaces run in parallel and return tagged results:
           - **entities**: entity-registry matches (entity_id, friendly name,
-            area). Filter with `domain_filter`/`area_filter`; omit `query` to
-            enumerate a domain/area.
+            area). Filter with `domain_filter`/`area_filter`/`state_filter`;
+            omit `query` to enumerate a domain, area, or state.
           - **automations / scripts / scenes / helpers / dashboards**: matches
             *inside* config definitions — triggers, actions, sequences, scene
             entity-sets, helper bodies, dashboard cards. Driven by `query`;
@@ -1800,6 +1821,7 @@ class SearchTools:
             - Which automations use an entity: ha_search("light.bed_light")
             - Scenes touching a light: ha_search("light.kitchen", search_types=["scene"])
             - Narrow the response to the entity bucket: ha_search("kitchen", fields=["entities"])
+            - All unavailable entities: ha_search(state_filter="unavailable")
         """
         try:
             parsed_search_types = parse_string_list_param(search_types, "search_types")
@@ -1848,7 +1870,7 @@ class SearchTools:
             raise_tool_error(
                 create_validation_error(
                     "ha_search requires a non-empty query, or one of "
-                    "domain_filter / area_filter to enumerate.",
+                    "domain_filter / area_filter / state_filter to enumerate.",
                     parameter="query",
                 )
             )
@@ -2128,8 +2150,8 @@ class SearchTools:
                 default=None,
                 description=(
                     "Entity name to search for (fuzzy or exact match). "
-                    "Omit to list entities; `domain_filter` or `area_filter` "
-                    "must be set in that mode."
+                    "Omit to list entities; `domain_filter`, `area_filter`, "
+                    "or `state_filter` must be set in that mode."
                 ),
             ),
         ] = None,
@@ -2215,8 +2237,10 @@ class SearchTools:
                     "Filter results to entities in a specific state "
                     '(e.g. "on", "off", "unavailable"). Case-insensitive — '
                     "input is lowercased before matching. Applied server-side after "
-                    "search results are collected. For exact-match and domain-listing "
-                    "searches, total_matches reflects the filtered count. For fuzzy "
+                    "search results are collected. Can be used standalone (no "
+                    "query/domain/area) to enumerate every entity in that state. "
+                    "For exact-match, domain-listing, and state-listing searches, "
+                    "total_matches reflects the filtered count. For fuzzy "
                     "searches, state_filter is page-only and total_matches remains "
                     "unfiltered (see state_filter_note in the response). "
                     "None = no state filter (default)."
@@ -2248,8 +2272,10 @@ class SearchTools:
         use `ha_deep_search`.
 
         To enumerate all entities of a domain, omit `query` and pass `domain_filter`. For
-        example, `ha_search_entities(domain_filter="calendar")` lists all calendars. At
-        least one of `query`, `domain_filter`, or `area_filter` must be set.
+        example, `ha_search_entities(domain_filter="calendar")` lists all calendars. To
+        enumerate every entity in a state, omit `query` and pass `state_filter` (e.g.
+        `state_filter="unavailable"`). At least one of `query`, `domain_filter`,
+        `area_filter`, or `state_filter` must be set.
 
         ``prefetched_states`` / ``prefetched_registry`` are the orchestrator's
         shared snapshots; they only reach the regular (non-area, non-domain-only)
@@ -2257,7 +2283,7 @@ class SearchTools:
         """
         query, domain_filter, area_filter, parsed_result_fields = (
             _validate_entity_search_params(
-                query, domain_filter, area_filter, result_fields
+                query, domain_filter, area_filter, result_fields, state_filter
             )
         )
         group_by_domain_bool = group_by_domain
@@ -2319,6 +2345,17 @@ class SearchTools:
                 return await self._search_domain_only(
                     query,
                     domain_filter,
+                    state_filter,
+                    limit,
+                    offset,
+                    include_hidden_bool,
+                    group_by_domain_bool,
+                    per_domain_limit_int,
+                    parsed_result_fields,
+                )
+
+            if state_filter and not domain_filter and (not query or not query.strip()):
+                return await self._search_state_only(
                     state_filter,
                     limit,
                     offset,
@@ -2807,24 +2844,22 @@ class SearchTools:
         # No add_timezone_metadata — see _search_area_with_query.
         return empty_area_data
 
-    async def _search_domain_only(
+    async def _fetch_listing_snapshot(
         self,
-        query: str | None,
-        domain_filter: str,
-        state_filter: str | None,
-        limit: int,
-        offset: int,
-        include_hidden_bool: bool,
-        group_by_domain_bool: bool,
-        per_domain_limit_int: int | None,
-        parsed_result_fields: list[str] | None,
-    ) -> dict[str, Any]:
-        """List all entities of a single domain (empty query + domain_filter)."""
-        # Fetch states + registry list in parallel. Registry-list failure is
-        # tolerated (we just lose the hidden filter); states-fetch failure is
-        # fatal — auth/connection errors must propagate. The device registry is
-        # gated: it only feeds the visibility area/label dimensions, so a
-        # default/area-free config skips the fetch entirely.
+    ) -> tuple[list[dict[str, Any]], set[str], set[str], list[str]]:
+        """Fetch states + registries and resolve hidden/visibility sets for listing modes.
+
+        Shared by ``_search_domain_only`` and ``_search_state_only``: both
+        enumerate the full state machine and need the same ``/api/states``
+        snapshot, registry-derived hidden ids, and visibility-excluded set.
+        Returns ``(states, hidden_ids, visibility_hidden, visibility_warnings)``.
+
+        Fetches states + the entity registry in parallel. Registry-list failure is
+        tolerated (we just lose the hidden filter); states-fetch failure is fatal —
+        auth/connection errors must propagate. The device registry is gated: it
+        only feeds the visibility area/label dimensions, so a default/area-free
+        config skips the fetch entirely.
+        """
         need_device = await device_registry_needed_for_visibility()
         fetch_coros: list[Any] = [
             self._client.get_states(),
@@ -2860,6 +2895,27 @@ class SearchTools:
         visibility_hidden, visibility_warnings = await load_hidden_set(
             registry_result, states_result, self._client, device_result
         )
+        return states_result, hidden_ids, visibility_hidden, visibility_warnings
+
+    async def _search_domain_only(
+        self,
+        query: str | None,
+        domain_filter: str,
+        state_filter: str | None,
+        limit: int,
+        offset: int,
+        include_hidden_bool: bool,
+        group_by_domain_bool: bool,
+        per_domain_limit_int: int | None,
+        parsed_result_fields: list[str] | None,
+    ) -> dict[str, Any]:
+        """List all entities of a single domain (empty query + domain_filter)."""
+        (
+            states_result,
+            hidden_ids,
+            visibility_hidden,
+            visibility_warnings,
+        ) = await self._fetch_listing_snapshot()
 
         # Filter by domain. Hidden entities are kept by default (with score
         # penalty applied below); ``include_hidden=False`` filters them out.
@@ -2923,6 +2979,96 @@ class SearchTools:
         # No add_timezone_metadata — see _search_area_with_query.
         return merge_visibility_warnings(
             domain_list_data, [*visibility_warnings, *enrich_warnings]
+        )
+
+    async def _search_state_only(
+        self,
+        state_filter: str,
+        limit: int,
+        offset: int,
+        include_hidden_bool: bool,
+        group_by_domain_bool: bool,
+        per_domain_limit_int: int | None,
+        parsed_result_fields: list[str] | None,
+    ) -> dict[str, Any]:
+        """List all entities in a given state (state_filter with no query/domain/area).
+
+        Mirrors ``_search_domain_only`` but enumerates across every domain,
+        filtering on exact state equality (``state_filter`` is already lowercased
+        by ``_normalize_state_filter``) so a single call answers "all unavailable
+        entities" (issue #2002). The state filter is applied before pagination so
+        ``total_matches`` reflects the filtered count.
+        """
+        (
+            states_result,
+            hidden_ids,
+            visibility_hidden,
+            visibility_warnings,
+        ) = await self._fetch_listing_snapshot()
+
+        # Exact state match — identical semantics to the exact/domain paths.
+        # Hidden entities are kept by default (score-penalised below);
+        # ``include_hidden=False`` filters them out. The visibility exclude is
+        # applied before pagination so the counts below stay coherent.
+        filtered_entities = [
+            e
+            for e in states_result
+            if (eid := e.get("entity_id", "")) not in visibility_hidden
+            and e.get("state") == state_filter
+            and (include_hidden_bool or eid not in hidden_ids)
+        ]
+
+        # Score: 100 baseline for state membership (exact, not fuzzy); penalised
+        # for hidden entries so they sort below visible peers. ``domain`` is
+        # derived per record since results span every domain.
+        scored_entities = []
+        for entity in filtered_entities:
+            entity_id = entity.get("entity_id", "")
+            attributes = entity.get("attributes", {})
+            score = apply_hidden_penalty(
+                100, "_hidden" if entity_id in hidden_ids else None
+            )
+            scored_entities.append(
+                {
+                    "entity_id": entity_id,
+                    "friendly_name": attributes.get("friendly_name", entity_id),
+                    "domain": entity_id.split(".")[0],
+                    "state": entity.get("state", "unknown"),
+                    "score": score,
+                    "match_type": "state_listing",
+                }
+            )
+        scored_entities.sort(key=lambda x: (-x["score"], x["entity_id"]))
+        results = scored_entities[offset : offset + limit]
+
+        state_list_data: dict[str, Any] = {
+            "success": True,
+            "query": None,
+            "state_filter": state_filter,
+            **_build_pagination_metadata(len(scored_entities), offset, limit, results),
+            "results": results,
+            "search_type": "state_listing",
+            "note": (
+                f"Listing all entities in state '{state_filter}' "
+                "(state_filter with no query/domain/area)"
+            ),
+        }
+
+        enrich_warnings = await self._maybe_enrich_entity_records(
+            results, parsed_result_fields
+        )
+        _apply_result_fields_to_response(state_list_data, parsed_result_fields)
+        _apply_by_domain_grouping(
+            state_list_data,
+            results,
+            group_by_domain_bool,
+            per_domain_limit_int,
+            parsed_result_fields,
+        )
+
+        # No add_timezone_metadata — see _search_area_with_query.
+        return merge_visibility_warnings(
+            state_list_data, [*visibility_warnings, *enrich_warnings]
         )
 
     async def _search_regular(

--- a/src/ha_mcp/tools/tools_search.py
+++ b/src/ha_mcp/tools/tools_search.py
@@ -1253,6 +1253,17 @@ def _normalize_state_filter(state_filter: str | None) -> str | None:
     return state_filter
 
 
+def _state_matches(record: dict[str, Any], state_filter: str) -> bool:
+    """True when ``record``'s state equals ``state_filter``, case-insensitively.
+
+    ``state_filter`` is already lowercased by ``_normalize_state_filter``; the
+    record side is lowered here so an uppercase entity state (e.g. an
+    input_select holding "Vacation") still matches the documented
+    case-insensitive contract.
+    """
+    return (record.get("state") or "").lower() == state_filter
+
+
 def _validate_entity_search_params(
     query: str | None,
     domain_filter: str | None,
@@ -1541,7 +1552,7 @@ async def _exact_match_search(
             results.append(match)
 
     if state_filter:
-        results = [r for r in results if r.get("state") == state_filter]
+        results = [r for r in results if _state_matches(r, state_filter)]
 
     # Sort by score descending, tie-break on entity_id for stable
     # pagination when many results share a score (visible substring
@@ -1711,8 +1722,8 @@ class SearchTools:
                     "Filter entity-registry results to a specific state "
                     '(e.g. "on", "off", "unavailable"). Case-insensitive. '
                     "Can be used standalone (no query/domain/area) to enumerate "
-                    "every entity in that state; total_matches reflects the "
-                    "filtered count."
+                    "every entity in that state; entity_total_matches reflects "
+                    "the filtered count."
                 ),
             ),
         ] = None,
@@ -2267,15 +2278,18 @@ class SearchTools:
     ) -> dict[str, Any]:
         """Search for entities (lights, sensors, switches, etc.) by name, domain, or area.
 
+        Internal helper reached through the `ha_search` tool; the examples below
+        use that tool as the entry point.
+
         When NOT to use: for searching inside automation, script, helper, or dashboard
         *configurations* (e.g. which automations call a service or reference an entity),
-        use `ha_deep_search`.
+        search config bodies via `ha_search(query=...)`.
 
-        To enumerate all entities of a domain, omit `query` and pass `domain_filter`. For
-        example, `ha_search_entities(domain_filter="calendar")` lists all calendars. To
-        enumerate every entity in a state, omit `query` and pass `state_filter` (e.g.
-        `state_filter="unavailable"`). At least one of `query`, `domain_filter`,
-        `area_filter`, or `state_filter` must be set.
+        To enumerate all entities of a domain, omit `query` and pass `domain_filter` —
+        e.g. `ha_search(domain_filter="calendar")` lists all calendars. To enumerate
+        every entity in a state, omit `query` and pass `state_filter` — e.g.
+        `ha_search(state_filter="unavailable")`. At least one of `query`,
+        `domain_filter`, `area_filter`, or `state_filter` must be set.
 
         ``prefetched_states`` / ``prefetched_registry`` are the orchestrator's
         shared snapshots; they only reach the regular (non-area, non-domain-only)
@@ -2395,6 +2409,7 @@ class SearchTools:
                         "query": query,
                         "domain_filter": domain_filter,
                         "area_filter": area_filter,
+                        "state_filter": state_filter,
                     },
                 )
             )
@@ -2406,11 +2421,12 @@ class SearchTools:
                     "query": query,
                     "domain_filter": domain_filter,
                     "area_filter": area_filter,
+                    "state_filter": state_filter,
                 },
                 suggestions=[
                     "Check Home Assistant connection",
                     "Try simpler search terms",
-                    "Check area/domain filter spelling",
+                    "Check area/domain/state filter spelling",
                 ],
             )
             return None  # unreachable: error helpers above always raise
@@ -2676,7 +2692,7 @@ class SearchTools:
         ]
 
         if state_filter:
-            results = [r for r in results if r.get("state") == state_filter]
+            results = [r for r in results if _state_matches(r, state_filter)]
 
         pagination = _build_pagination_metadata(total_matches, offset, limit, results)
 
@@ -2757,7 +2773,7 @@ class SearchTools:
 
         all_results.sort(key=lambda x: (-x["score"], x["entity_id"]))
         if state_filter:
-            all_results = [r for r in all_results if r.get("state") == state_filter]
+            all_results = [r for r in all_results if _state_matches(r, state_filter)]
         paginated = all_results[offset : offset + limit]
 
         area_search_data: dict[str, Any] = {
@@ -2951,7 +2967,7 @@ class SearchTools:
         scored_entities.sort(key=lambda x: (-x["score"], x["entity_id"]))
         if state_filter:
             scored_entities = [
-                e for e in scored_entities if e.get("state") == state_filter
+                e for e in scored_entities if _state_matches(e, state_filter)
             ]
         results = scored_entities[offset : offset + limit]
 
@@ -3014,7 +3030,7 @@ class SearchTools:
             e
             for e in states_result
             if (eid := e.get("entity_id", "")) not in visibility_hidden
-            and e.get("state") == state_filter
+            and _state_matches(e, state_filter)
             and (include_hidden_bool or eid not in hidden_ids)
         ]
 
@@ -3159,7 +3175,7 @@ class SearchTools:
         # page-only — smart_entity_search already paginated internally, so
         # total_matches/has_more reflect the unfiltered dataset.
         if state_filter and "results" in result and search_type == "fuzzy_search":
-            filtered = [r for r in result["results"] if r.get("state") == state_filter]
+            filtered = [r for r in result["results"] if _state_matches(r, state_filter)]
             result["results"] = filtered
             result["count"] = len(filtered)
             result["state_filter_note"] = (

--- a/tests/src/e2e/tools/test_search_entities.py
+++ b/tests/src/e2e/tools/test_search_entities.py
@@ -120,6 +120,78 @@ async def test_search_entities_all_filters_empty_rejected(mcp_client, params):
 
 
 @pytest.mark.asyncio
+async def test_search_entities_state_filter_only(mcp_client):
+    """state_filter alone enumerates every entity in that state (issue #2002).
+
+    Observe a real state from a domain listing first (fixture states are not
+    pinned here), then enumerate by that state and assert the state_listing
+    contract: search_type, per-result state match, and filtered pagination.
+    """
+    logger.info("Testing state_filter-only listing (issue #2002)")
+
+    # Observe an actual state from the light domain (reliably present).
+    listing = await mcp_client.call_tool(
+        "ha_search",
+        {"domain_filter": "light", "limit": 50},
+    )
+    lights = assert_mcp_success(listing, "Light domain listing")
+    light_entities = lights.get("entities", [])
+    assert light_entities, "Expected at least one light entity in the test env"
+    observed_state = light_entities[0].get("state")
+    assert isinstance(observed_state, str) and observed_state, (
+        f"Expected a non-empty state on the first light, got {observed_state!r}"
+    )
+
+    # Enumerate every entity in that state with ONLY state_filter set.
+    limit = 5
+    result = await mcp_client.call_tool(
+        "ha_search",
+        {"state_filter": observed_state, "limit": limit},
+    )
+    data = assert_mcp_success(result, f"state_filter-only ({observed_state})")
+
+    assert data.get("success") is True
+    assert data.get("search_type") == "state_listing", (
+        f"Expected search_type 'state_listing', got '{data.get('search_type')}'"
+    )
+
+    results = data.get("entities", [])
+    assert results, f"Expected at least one entity in state '{observed_state}'"
+    assert len(results) <= limit, f"limit={limit} not honored: got {len(results)}"
+
+    # Every returned record is in the requested state (exact match) and tagged.
+    for entity in results:
+        assert entity.get("state") == observed_state, (
+            f"{entity.get('entity_id')} state {entity.get('state')!r} "
+            f"!= filter {observed_state!r}"
+        )
+        assert entity.get("match_type") == "state_listing"
+
+    # Pagination reflects the FILTERED total, not the whole state machine.
+    total = data.get("entity_total_matches")
+    assert isinstance(total, int) and total >= len(results), (
+        f"entity_total_matches ({total}) should be >= returned count ({len(results)})"
+    )
+    assert "has_more" in data and isinstance(data["has_more"], bool)
+    assert data.get("count") == len(results), (
+        f"count ({data.get('count')}) should equal returned entities ({len(results)})"
+    )
+    if total > len(results):
+        assert data["has_more"] is True
+        assert data.get("next_offset") is not None
+
+    # A call with NO usable criterion at all still fails validation.
+    empty = await safe_call_tool(mcp_client, "ha_search", {})
+    inner = empty.get("data", empty)
+    assert inner.get("success") is False, f"No-param call must fail: {inner}"
+    assert inner.get("error", {}).get("code") == "VALIDATION_FAILED", inner
+
+    logger.info(
+        f"state_listing: {len(results)}/{total} entities in state '{observed_state}'"
+    )
+
+
+@pytest.mark.asyncio
 async def test_search_entities_area_filter_only(mcp_client):
     """area_filter alone (no query, no domain_filter) returns entities in that area.
 
@@ -348,6 +420,7 @@ async def test_search_entities_response_structure_issue_214(mcp_client):
         "fuzzy_search",
         "exact_match",
         "domain_listing",
+        "state_listing",
         "area_only",
         "area_filtered_query",
     ]
@@ -1307,6 +1380,7 @@ async def test_result_shape_consistent_across_branches(mcp_client):
     forbidden = {"essential_attributes"}
     calls = [
         ({"domain_filter": "light", "limit": 1}, "domain_listing"),
+        ({"state_filter": "unknown", "limit": 1}, "state_listing"),
         ({"query": "light", "exact_match": True, "limit": 1}, "exact_match"),
         ({"query": "light", "exact_match": False, "limit": 1}, "fuzzy_search"),
         ({"area_filter": "kitchen", "limit": 1}, "area_only"),

--- a/tests/src/unit/test_component_ws_phase2_async.py
+++ b/tests/src/unit/test_component_ws_phase2_async.py
@@ -140,11 +140,11 @@ class TestCapabilityPresence:
             assert cap in wsapi.CAPABILITIES
 
     def test_component_version(self):
-        # Pending 1.2.3 (1.2.2 is the released stable). Capabilities are
+        # Pending 1.2.4 (1.2.3 is the released stable). Capabilities are
         # advertised by name, never version-inferred, so new caps ride any
         # pending version without a bump; this assertion just pins the
         # declared version (the write caps shipped in 1.2.1).
-        assert wsapi.COMPONENT_VERSION == "1.2.3"
+        assert wsapi.COMPONENT_VERSION == "1.2.4"
 
 
 # =============================================================================

--- a/tests/src/unit/test_component_ws_search.py
+++ b/tests/src/unit/test_component_ws_search.py
@@ -768,7 +768,7 @@ class TestInfo:
                 _REPO_ROOT / "custom_components" / "ha_mcp_tools" / "manifest.json"
             ).read_text(encoding="utf-8")
         )
-        assert manifest["version"] == COMPONENT_VERSION == "1.2.3"
+        assert manifest["version"] == COMPONENT_VERSION == "1.2.4"
 
 
 # =============================================================================
@@ -862,6 +862,7 @@ class TestEntityJoins:
         states = [
             FakeState("light.a", "on", "Lamp A"),
             FakeState("light.b", "off", "Lamp B"),
+            FakeState("light.c", "Vacation", "Lamp C"),
         ]
         monkeypatch.setattr(
             wsapi, "_resolve_registries", lambda hass: wsapi._RegistryView()
@@ -870,6 +871,13 @@ class TestEntityJoins:
             FakeHass(states=states), {"query": "lamp", "state_filter": "off"}
         )
         assert {e["entity_id"] for e in res["entities"]} == {"light.b"}
+
+        # Case-insensitive compare: a mixed-case entity state ("Vacation")
+        # matches a differently-cased state_filter ("vacation").
+        res_ci = wsapi._do_search(
+            FakeHass(states=states), {"query": "lamp", "state_filter": "vacation"}
+        )
+        assert {e["entity_id"] for e in res_ci["entities"]} == {"light.c"}
 
     def test_area_filter_by_name_or_id(self, monkeypatch):
         states = [FakeState("light.lamp", "on", "Lamp")]

--- a/tests/src/unit/test_ha_search_component_routing.py
+++ b/tests/src/unit/test_ha_search_component_routing.py
@@ -582,7 +582,7 @@ class TestResultFieldsEnrichment:
 
 
 class TestListingModesBypassComponent:
-    """The three legacy listing modes must NEVER route through the component.
+    """The legacy listing modes must NEVER route through the component.
 
     Regression for the first live e2e run of the component path
     (test_search_entities.py::test_search_entities_{empty,whitespace}_query_
@@ -590,7 +590,9 @@ class TestListingModesBypassComponent:
     component path stamped ``search_type: exact_match`` onto responses the
     legacy path labels ``domain_listing`` / ``area_only`` — and those modes
     carry mode-specific response shapes the component does not replicate.
-    Only query-driven, non-area searches may route through the component.
+    Only query-driven, non-area searches may route through the component — the
+    state_filter-only listing (issue #2002) has an empty query, so it stays on
+    the legacy path too.
     """
 
     @pytest.mark.asyncio
@@ -649,6 +651,21 @@ class TestListingModesBypassComponent:
         assert data.get("search_type") == "area_filtered_query", data
         assert not ws.send_command.await_count, (
             "component must not be consulted for area-scoped queries"
+        )
+
+    @pytest.mark.asyncio
+    async def test_state_filter_only_bypasses_component(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        _setup_visibility_disabled(tmp_path, monkeypatch)
+        client = ListingModeClient()
+        ha_search = _build_ha_search(client)
+        ws = make_ws("ha_mcp_tools/search", info_result=_CAPS_SEARCH, cmd_result={})
+        with patch_ws(ws, tools_search):
+            data = await ha_search(state_filter="on")
+        assert data.get("search_type") == "state_listing", data
+        assert not ws.send_command.await_count, (
+            "component must not be consulted for state listings"
         )
 
 

--- a/tests/src/unit/test_ha_search_merge.py
+++ b/tests/src/unit/test_ha_search_merge.py
@@ -24,6 +24,7 @@ from ha_mcp.tools.tools_search import (
     _mirror_partial_to_warnings,
     _project_response_fields,
     _synthesize_combined_pagination,
+    _validate_entity_search_params,
     _validate_search_types,
 )
 
@@ -268,10 +269,18 @@ def test_gate_area_only_runs_entity_only() -> None:
     assert _gate(area="Living Room") == (True, False, False)
 
 
-def test_gate_state_only_is_rejected() -> None:
-    """``state_filter`` alone doesn't unlock registry (unchanged from
-    pre-NEW1 behavior); body has no query either. Caller hits validation."""
-    assert _gate(state="on") == (False, False, False)
+def test_gate_state_only_runs_entity_only() -> None:
+    """``state_filter`` alone now unlocks the registry branch (issue #2002):
+    it enumerates every entity in that state, mirroring the domain-only
+    listing mode. Body stays ineligible (no query term)."""
+    assert _gate(state="on") == (True, False, False)
+
+
+def test_gate_state_only_plus_pin_is_rejected() -> None:
+    """An explicit ``search_types`` pin scopes the call to config-only, so the
+    state-only registry listing is suppressed and body has no query to match.
+    Caller hits validation."""
+    assert _gate(state="on", pin=True) == (False, False, False)
 
 
 def test_gate_query_plus_domain_skips_body_NEW() -> None:
@@ -329,6 +338,31 @@ def test_gate_query_plus_all_filters_plus_pin_runs_body() -> None:
         True,
         False,
     )
+
+
+# ``_validate_entity_search_params`` is the entity-branch input gate. It must
+# accept a state_filter-only call (issue #2002) and still reject a call with no
+# usable criterion at all.
+
+
+def test_validate_entity_params_state_only_accepted() -> None:
+    """state_filter alone satisfies the at-least-one-criterion check; the
+    return tuple is unchanged (state_filter is normalised by the caller)."""
+    result = _validate_entity_search_params(None, None, None, None, "unavailable")
+    assert result == ("", None, None, None)
+
+
+def test_validate_entity_params_whitespace_state_only_rejected() -> None:
+    """A whitespace-only state_filter collapses to nothing, so an otherwise
+    empty call is still rejected."""
+    with pytest.raises(ToolError):
+        _validate_entity_search_params(None, None, None, None, "   ")
+
+
+def test_validate_entity_params_all_empty_rejected() -> None:
+    """No query, domain, area, or state — validation error."""
+    with pytest.raises(ToolError):
+        _validate_entity_search_params(None, None, None, None)
 
 
 def test_empty_payload_is_noop() -> None:

--- a/tests/src/unit/test_search_fields_projection.py
+++ b/tests/src/unit/test_search_fields_projection.py
@@ -605,6 +605,25 @@ class TestHaSearchEntitiesStateFilter(_SearchToolFixture):
         # Both should return the same number of results (no filtering applied)
         assert ws_filter_count == no_filter_count
 
+    @pytest.mark.asyncio
+    async def test_state_only_group_by_domain_spans_domains(self, search_tool):
+        """state_filter-only + group_by_domain groups matches across domains.
+
+        _MULTI_ENTITY_STATES has light.kitchen=on and switch.fan=on, so a
+        state_filter="on" listing with group_by_domain=True must produce a
+        by_domain map keyed by BOTH domains (the cross-domain grouping helper,
+        not the single-domain one).
+        """
+        result = await search_tool(state_filter="on", group_by_domain=True, limit=20)
+        assert result.get("search_type") == "state_listing"
+        by_domain = result.get("by_domain", {})
+        assert "light" in by_domain and "switch" in by_domain, (
+            f"expected both 'light' and 'switch' domains, got {sorted(by_domain)}"
+        )
+        for entities in by_domain.values():
+            for entity in entities:
+                assert entity["state"] == "on"
+
 
 class TestHaSearchEntitiesResultFields(_SearchToolFixture):
     """Tests for result_fields= per-record projection (issue #1199)."""

--- a/tests/src/unit/visibility/test_search_filter.py
+++ b/tests/src/unit/visibility/test_search_filter.py
@@ -138,6 +138,81 @@ def test_domain_only_search_excludes_denied_and_counts_stay_coherent(
     assert res["total_matches"] == 1  # count reflects post-filter set, not raw 2
 
 
+def test_state_only_search_excludes_denied_and_counts_stay_coherent(
+    tmp_path, monkeypatch
+):
+    """_search_state_only applies the filter before pagination, so a denied
+    entity in the target state is gone AND total_matches reflects the
+    post-filter set (not the raw count of entities in that state)."""
+    states = [
+        {"entity_id": "sensor.on_keep", "state": "on", "attributes": {}},
+        {"entity_id": "sensor.on_keep2", "state": "on", "attributes": {}},
+        {"entity_id": "sensor.on_drop", "state": "on", "attributes": {}},
+        {"entity_id": "sensor.off_ignore", "state": "off", "attributes": {}},
+    ]
+    registry = {
+        "success": True,
+        "result": [
+            {"entity_id": "sensor.on_keep", "entity_category": None},
+            {"entity_id": "sensor.on_keep2", "entity_category": None},
+            {"entity_id": "sensor.on_drop", "entity_category": "diagnostic"},
+            {"entity_id": "sensor.off_ignore", "entity_category": None},
+        ],
+    }
+    save_visibility_config(
+        tmp_path,
+        VisibilityConfig(enabled=True, exclude_categories=["diagnostic"]),
+    )
+    monkeypatch.setattr(resolver, "get_data_dir", lambda: tmp_path)
+    tools = tools_search.SearchTools(_DomainClient(states, registry), smart_tools=None)
+    res = asyncio.run(
+        tools._search_state_only(
+            "on",
+            limit=10,
+            offset=0,
+            include_hidden_bool=True,
+            group_by_domain_bool=False,
+            per_domain_limit_int=None,
+            parsed_result_fields=None,
+        )
+    )
+    ids = sorted(r["entity_id"] for r in res["results"])
+    assert ids == ["sensor.on_keep", "sensor.on_keep2"]  # diagnostic on_drop excluded
+    assert res["total_matches"] == 2  # post-filter count (2 "on"), not raw 4
+
+
+def test_state_only_search_is_case_insensitive(tmp_path, monkeypatch):
+    """A mixed-case entity state matches a (lowercased) state_filter."""
+    states = [
+        {"entity_id": "input_select.mode", "state": "Vacation", "attributes": {}},
+        {"entity_id": "input_select.other", "state": "Home", "attributes": {}},
+    ]
+    registry = {
+        "success": True,
+        "result": [
+            {"entity_id": "input_select.mode", "entity_category": None},
+            {"entity_id": "input_select.other", "entity_category": None},
+        ],
+    }
+    save_visibility_config(tmp_path, VisibilityConfig(enabled=False))
+    monkeypatch.setattr(resolver, "get_data_dir", lambda: tmp_path)
+    tools = tools_search.SearchTools(_DomainClient(states, registry), smart_tools=None)
+    res = asyncio.run(
+        tools._search_state_only(
+            "vacation",
+            limit=10,
+            offset=0,
+            include_hidden_bool=True,
+            group_by_domain_bool=False,
+            per_domain_limit_int=None,
+            parsed_result_fields=None,
+        )
+    )
+    ids = [r["entity_id"] for r in res["results"]]
+    assert ids == ["input_select.mode"]  # "Vacation" matches "vacation"
+    assert res["total_matches"] == 1
+
+
 class _GetStateClient:
     """Minimal client for the targeted single-entity read path."""
 


### PR DESCRIPTION
## What does this PR do?

Implements #2002: `state_filter` is now a sufficient standalone criterion for `ha_search`. A single call like `ha_search(state_filter="unavailable")` enumerates every entity in that state — previously this failed with `VALIDATION_FAILED` and required a `query`, `domain_filter`, or `area_filter` alongside it.

- `_compute_eligibility` now counts `state_filter` as a registry input. The config-body branch and its intent-gate logic are unchanged: with no query term the body surface stays ineligible, exactly as before.
- New `state_listing` mode mirrors the existing `domain_listing` mode: same states + registry snapshot, same hidden/visibility handling and hidden-score penalty, exact state match applied before pagination so `entity_total_matches` reflects the filtered count, with `result_fields` projection and `group_by_domain` support.
- The shared fetch/visibility preamble of the two listing modes is extracted into `_fetch_listing_snapshot`; the `domain_listing` response contract is unchanged.
- The component fast path is untouched: state-only calls have no query text, so they stay on the legacy path on both install methods (matches the reporter's observation that the embedded server behaves identically).
- Validation messages, docstrings, and parameter descriptions updated, including a new usage example.

Tests: unit coverage for the eligibility gate and the entity-params validator, a component-routing regression asserting state-only calls never route through the component, and e2e coverage of the `state_listing` contract (per-result state match, filtered pagination, shape parity with the other branches).

Closes #2002

## Type of change
- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [ ] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

## Checklist
- [x] I have updated documentation if needed
