### PR TITLE
fix: clarify missing "File & YAML Tools" entry in error text and options UI

### DIFF
--- a/custom_components/ha_mcp_tools/config_flow.py
+++ b/custom_components/ha_mcp_tools/config_flow.py
@@ -577,11 +577,11 @@ class HaMcpServerOptionsFlow(OptionsFlow):
             return (
                 "Beta/advanced file & YAML tools module (optional): Installed "
                 'but not loaded — enable or reload the "HA-MCP File & YAML '
-                'Tools" entry on the HA-MCP integration page'
+                "Tools\" entry on this integration's page"
             )
         return (
             "Beta/advanced file & YAML tools module (optional): Not installed — "
-            'press "Add entry" on the HA-MCP integration page and choose '
+            'press "Add entry" on this integration\'s page and choose '
             '"HA-MCP File & YAML Tools" to add it'
         )
 

--- a/custom_components/ha_mcp_tools/config_flow.py
+++ b/custom_components/ha_mcp_tools/config_flow.py
@@ -442,11 +442,18 @@ class HaMcpServerOptionsFlow(OptionsFlow):
             if bool(opts.get(OPT_ENABLE_SIDEBAR_PANEL, True))
             else ""
         )
+        # The tools-module status renders as its own paragraph directly under
+        # the version line, sharing the {versions} placeholder so every
+        # translation shows it without a strings change.
+        versions = await self._versions_hint()
+        tools_hint = self._tools_module_hint()
+        if tools_hint:
+            versions = f"{versions}\n\n{tools_hint}"
         return self.async_show_form(
             step_id="init",
             data_schema=schema,
             description_placeholders={
-                "versions": await self._versions_hint(),
+                "versions": versions,
                 "connect_url": await self._connect_url_hint(),
                 "oauth_creds": self._oauth_creds_hint(),
                 "llm_api_docs_url": LLM_API_DOCS_URL,
@@ -533,6 +540,36 @@ class HaMcpServerOptionsFlow(OptionsFlow):
         return (
             f"Component {component_version} - "
             f"Server ha-mcp {server_version} ({channel} channel)"
+        )
+
+    def _tools_module_hint(self) -> str | None:
+        """Return the File & YAML tools entry status line, or None if unreadable.
+
+        Shown directly under the version line (#1996): users routinely add the
+        server entry only and never learn the file / YAML tools need the second
+        "HA-MCP File & YAML Tools" entry until a tool call fails. Failure-proof
+        like the other hints: any read error drops the line rather than
+        breaking the options form.
+        """
+        hass = getattr(self, "hass", None)
+        if hass is None:
+            return None
+        try:
+            # A missing entry_type means tools (pre-#1527 entries never carried
+            # the discriminator) — same default async_setup_entry dispatches on.
+            installed = any(
+                entry.data.get(CONF_ENTRY_TYPE, ENTRY_TYPE_TOOLS) == ENTRY_TYPE_TOOLS
+                for entry in hass.config_entries.async_entries(DOMAIN)
+            )
+        except Exception as err:
+            _LOGGER.debug("Could not read the tools-entry state for the hint: %s", err)
+            return None
+        if installed:
+            return "Beta/advanced file & YAML tools module (optional): Installed"
+        return (
+            "Beta/advanced file & YAML tools module (optional): Not installed — "
+            'press "Add entry" on the HA-MCP integration page and choose '
+            '"HA-MCP File & YAML Tools" to add it'
         )
 
     async def _connect_url_hint(self) -> str:

--- a/custom_components/ha_mcp_tools/config_flow.py
+++ b/custom_components/ha_mcp_tools/config_flow.py
@@ -25,6 +25,7 @@ from typing import Any
 import voluptuous as vol
 from homeassistant.config_entries import (
     ConfigEntry,
+    ConfigEntryState,
     ConfigFlow,
     ConfigFlowResult,
     OptionsFlow,
@@ -547,9 +548,11 @@ class HaMcpServerOptionsFlow(OptionsFlow):
 
         Shown directly under the version line (#1996): users routinely add the
         server entry only and never learn the file / YAML tools need the second
-        "HA-MCP File & YAML Tools" entry until a tool call fails. Failure-proof
-        like the other hints: any read error drops the line rather than
-        breaking the options form.
+        "HA-MCP File & YAML Tools" entry until a tool call fails. An entry
+        that exists but is not loaded (disabled, or setup failed) serves no
+        services either, so it reports "not loaded" rather than Installed.
+        Failure-proof like the other hints: any read error drops the line
+        rather than breaking the options form.
         """
         hass = getattr(self, "hass", None)
         if hass is None:
@@ -557,15 +560,25 @@ class HaMcpServerOptionsFlow(OptionsFlow):
         try:
             # A missing entry_type means tools (pre-#1527 entries never carried
             # the discriminator) — same default async_setup_entry dispatches on.
-            installed = any(
-                entry.data.get(CONF_ENTRY_TYPE, ENTRY_TYPE_TOOLS) == ENTRY_TYPE_TOOLS
+            tools_entries = [
+                entry
                 for entry in hass.config_entries.async_entries(DOMAIN)
+                if entry.data.get(CONF_ENTRY_TYPE, ENTRY_TYPE_TOOLS) == ENTRY_TYPE_TOOLS
+            ]
+            loaded = any(
+                entry.state is ConfigEntryState.LOADED for entry in tools_entries
             )
         except Exception as err:
             _LOGGER.debug("Could not read the tools-entry state for the hint: %s", err)
             return None
-        if installed:
+        if loaded:
             return "Beta/advanced file & YAML tools module (optional): Installed"
+        if tools_entries:
+            return (
+                "Beta/advanced file & YAML tools module (optional): Installed "
+                'but not loaded — enable or reload the "HA-MCP File & YAML '
+                'Tools" entry on the HA-MCP integration page'
+            )
         return (
             "Beta/advanced file & YAML tools module (optional): Not installed — "
             'press "Add entry" on the HA-MCP integration page and choose '

--- a/custom_components/ha_mcp_tools/const.py
+++ b/custom_components/ha_mcp_tools/const.py
@@ -24,7 +24,7 @@ DOMAIN = "ha_mcp_tools"
 # manifest bump that forgets this constant (or vice-versa) fails in CI. The
 # capability negotiation — not this version — gates each WS command (see
 # ``websocket_api.CAPABILITIES``).
-COMPONENT_VERSION = "1.2.3"
+COMPONENT_VERSION = "1.2.4"
 
 # Config-entry discriminator (``entry.data[CONF_ENTRY_TYPE]``). A missing value
 # means "tools" so the pre-existing services entry keeps working across the

--- a/custom_components/ha_mcp_tools/manifest.json
+++ b/custom_components/ha_mcp_tools/manifest.json
@@ -22,5 +22,5 @@
     "requirements": [
         "ruamel.yaml>=0.18.0"
     ],
-    "version": "1.2.3"
+    "version": "1.2.4"
 }

--- a/src/ha_mcp/backup_manager.py
+++ b/src/ha_mcp/backup_manager.py
@@ -2178,16 +2178,18 @@ async def _list_legacy_backups(client: Any) -> list[dict[str, Any]]:
     service.
 
     Returns ``[]`` (logged at debug) when the component predates the service —
-    a service-unavailable rejection surfaces either as a ``success: False``
-    response or a ``HomeAssistantError`` — so the edits ``list`` still works
-    against an older standalone component. Genuine programming errors propagate.
+    a service-unavailable rejection surfaces as a ``success: False`` response,
+    a ``HomeAssistantError``, or a ``ToolError`` from the caller-token gates
+    (tools entry not set up / component too old) — so the edits ``list`` still
+    works against an older or component-less install. Genuine programming
+    errors propagate.
     """
     from .tools.tools_filesystem import call_mcp_tools_service
     from .tools.util_helpers import unwrap_service_response
 
     try:
         result = await call_mcp_tools_service(client, "list_legacy_backups", {})
-    except HomeAssistantError as err:
+    except (HomeAssistantError, ToolError) as err:
         logger.debug("legacy backup list unavailable: %s", err)
         return []
     if not isinstance(result, dict):
@@ -2204,8 +2206,9 @@ async def _read_legacy_backup(client: Any, filename: str) -> dict[str, Any]:
 
     Returns the unwrapped service response (carries ``success`` / ``content`` /
     ``file_path`` / ``path_ambiguous`` / ``timestamp``). A service-unavailable
-    ``HomeAssistantError`` is mapped to a ``success: False`` dict so the caller
-    surfaces a not-found rather than crashing.
+    ``HomeAssistantError`` — or a ``ToolError`` from the caller-token gates —
+    is mapped to a ``success: False`` dict so the caller surfaces a not-found
+    rather than crashing.
     """
     from .tools.tools_filesystem import call_mcp_tools_service
     from .tools.util_helpers import unwrap_service_response
@@ -2214,7 +2217,7 @@ async def _read_legacy_backup(client: Any, filename: str) -> dict[str, Any]:
         result = await call_mcp_tools_service(
             client, "read_legacy_backup", {"filename": filename}
         )
-    except HomeAssistantError as err:
+    except (HomeAssistantError, ToolError) as err:
         return {"success": False, "error": str(err)}
     if not isinstance(result, dict):
         return {"success": False, "error": f"no response for {filename!r}"}

--- a/src/ha_mcp/backup_manager.py
+++ b/src/ha_mcp/backup_manager.py
@@ -766,16 +766,18 @@ class BackupManager:
 
     # ----- legacy store (pre-#1579 .ha_mcp_tools_backups/) ---------------
 
-    async def list_legacy(self) -> list[dict[str, Any]]:
+    async def list_legacy(self) -> tuple[list[dict[str, Any]], str | None]:
         """List pre-#1579 ``.bak`` backups via the component service.
 
         Each entry is normalized to a synthetic ``name`` (``legacy:<file>``)
         plus ``source="legacy"`` and the decode hints (``file_path`` /
         ``path_ambiguous``) so the caller can route view/diff/restore and warn
-        on un-restorable (ambiguous) names. Returns ``[]`` when the component
-        is too old to expose the service, so ``list`` still works.
+        on un-restorable (ambiguous) names. Returns ``(entries,
+        unavailable_reason)``: entries is ``[]`` when the component is too
+        old, unconfigured, or absent — ``list`` still works — and the reason
+        (when set) lets the caller flag the omission.
         """
-        backups = await _list_legacy_backups(self._client)
+        backups, unavailable_reason = await _list_legacy_backups(self._client)
         out: list[dict[str, Any]] = []
         for b in backups:
             filename = b.get("filename")
@@ -792,7 +794,7 @@ class BackupManager:
                     "path_ambiguous": b.get("path_ambiguous", True),
                 }
             )
-        return out
+        return out, unavailable_reason
 
     async def read_legacy(self, filename: str) -> dict[str, Any]:
         """Read one legacy ``.bak`` (raw content + decode hints).
@@ -815,7 +817,7 @@ class BackupManager:
         domain: str | None = None,
         entity_id: str | None = None,
         limit: int | None = None,
-    ) -> list[dict[str, Any]]:
+    ) -> tuple[list[dict[str, Any]], list[str]]:
         """Edits-store snapshots plus pre-#1579 legacy ``.bak`` entries (#1579).
 
         ``list_snapshots`` is sync (dir glob, run off-thread); the legacy store
@@ -828,9 +830,22 @@ class BackupManager:
         Legacy entries get reserved room within ``limit`` so a full edits store
         (>= ``limit`` snapshots) can't truncate the few historical legacy
         entries out of the listing — surfacing them is the whole point.
+
+        Returns ``(entries, warnings)``: when the legacy sub-fetch was
+        suppressed (tools entry not set up / component too old), ``warnings``
+        says so, so the tool response doesn't read as a clean, complete list
+        with the ``.bak`` history silently missing (#1996).
         """
         want_legacy = domain in (None, "yaml_file") and entity_id is None
-        legacy = await self.list_legacy() if want_legacy else []
+        legacy: list[dict[str, Any]] = []
+        warnings: list[str] = []
+        if want_legacy:
+            legacy, unavailable_reason = await self.list_legacy()
+            if unavailable_reason:
+                warnings.append(
+                    "Legacy .bak backups could not be listed and are omitted: "
+                    f"{unavailable_reason}"
+                )
         edits_limit = max(1, limit - len(legacy)) if limit and legacy else limit
         entries = await asyncio.to_thread(
             self.list_snapshots, domain=domain, entity_id=entity_id, limit=edits_limit
@@ -838,7 +853,7 @@ class BackupManager:
         entries.extend(legacy)
         if limit:
             entries = entries[:limit]
-        return entries
+        return entries, warnings
 
     async def _diff_legacy(self, filename: str) -> DiffResponseText:
         info = await self.read_legacy(filename)
@@ -2173,17 +2188,22 @@ async def _restore_yaml_file(client: Any, entity_id: str, config: Any) -> Any:
     return result
 
 
-async def _list_legacy_backups(client: Any) -> list[dict[str, Any]]:
+async def _list_legacy_backups(client: Any) -> tuple[list[dict[str, Any]], str | None]:
     """Fetch pre-#1579 ``.bak`` backups via the component list_legacy_backups
     service.
 
-    Returns ``[]`` (logged at debug) when the component predates the service —
-    a service-unavailable rejection surfaces as a ``success: False`` response,
-    a ``HomeAssistantError``, or a ``ToolError`` from the caller-token gates
-    (tools entry not set up / component too old) — so the edits ``list`` still
-    works against an older or component-less install. Genuine programming
-    errors propagate.
+    Returns ``(backups, unavailable_reason)``. The legacy store is
+    best-effort: when the component predates the service, isn't configured
+    (tools entry not set up), or is missing entirely, the entry list is ``[]``
+    and ``unavailable_reason`` carries the human-readable cause — a
+    ``HomeAssistantError`` or any ``ToolError`` out of
+    ``call_mcp_tools_service`` (all its caller-token gates included) lands
+    here (also logged at debug), so the edits ``list`` still works and the
+    caller can surface the degradation as a warning. A ``success: False``
+    service response degrades silently as before. Genuine programming errors
+    propagate.
     """
+    from .tools.helpers import extract_structured_error_reason
     from .tools.tools_filesystem import call_mcp_tools_service
     from .tools.util_helpers import unwrap_service_response
 
@@ -2191,14 +2211,14 @@ async def _list_legacy_backups(client: Any) -> list[dict[str, Any]]:
         result = await call_mcp_tools_service(client, "list_legacy_backups", {})
     except (HomeAssistantError, ToolError) as err:
         logger.debug("legacy backup list unavailable: %s", err)
-        return []
+        return [], extract_structured_error_reason(err) or str(err)
     if not isinstance(result, dict):
-        return []
+        return [], None
     result = unwrap_service_response(result)
     if not result.get("success", False):
-        return []
+        return [], None
     backups = result.get("backups")
-    return backups if isinstance(backups, list) else []
+    return (backups, None) if isinstance(backups, list) else ([], None)
 
 
 async def _read_legacy_backup(client: Any, filename: str) -> dict[str, Any]:
@@ -2210,6 +2230,7 @@ async def _read_legacy_backup(client: Any, filename: str) -> dict[str, Any]:
     is mapped to a ``success: False`` dict so the caller surfaces a not-found
     rather than crashing.
     """
+    from .tools.helpers import extract_structured_error_reason
     from .tools.tools_filesystem import call_mcp_tools_service
     from .tools.util_helpers import unwrap_service_response
 
@@ -2218,7 +2239,13 @@ async def _read_legacy_backup(client: Any, filename: str) -> dict[str, Any]:
             client, "read_legacy_backup", {"filename": filename}
         )
     except (HomeAssistantError, ToolError) as err:
-        return {"success": False, "error": str(err)}
+        # The human reason, not str(err) verbatim: a ToolError's string is
+        # the whole JSON envelope, which would reach the tool layer as an
+        # unreadable JSON-in-JSON message (#1996's original symptom).
+        return {
+            "success": False,
+            "error": extract_structured_error_reason(err) or str(err),
+        }
     if not isinstance(result, dict):
         return {"success": False, "error": f"no response for {filename!r}"}
     return unwrap_service_response(result)

--- a/src/ha_mcp/backup_manager.py
+++ b/src/ha_mcp/backup_manager.py
@@ -2242,6 +2242,7 @@ async def _read_legacy_backup(client: Any, filename: str) -> dict[str, Any]:
         # The human reason, not str(err) verbatim: a ToolError's string is
         # the whole JSON envelope, which would reach the tool layer as an
         # unreadable JSON-in-JSON message (#1996's original symptom).
+        logger.debug("legacy backup read unavailable: %s", err)
         return {
             "success": False,
             "error": extract_structured_error_reason(err) or str(err),

--- a/src/ha_mcp/settings_ui/_handlers_fs.py
+++ b/src/ha_mcp/settings_ui/_handlers_fs.py
@@ -11,6 +11,7 @@ into thin request-only wrappers for the route table.
 from __future__ import annotations
 
 import contextlib
+import json
 import logging
 from typing import TYPE_CHECKING, Any
 
@@ -23,6 +24,38 @@ if TYPE_CHECKING:
     from ..server import HomeAssistantSmartMCPServer
 
 logger = logging.getLogger(__name__)
+
+
+def _component_error_reason(exc: Exception) -> str | None:
+    """Extract the human-readable message from a structured ``ToolError``.
+
+    ``raise_tool_error`` serializes the whole error envelope into the
+    exception string, so rendering ``str(exc)`` verbatim shows the settings
+    UI a raw JSON blob behind a misleading "could not reach" prefix — the
+    hard-to-read surface from #1996. Returns the message plus the first
+    suggestion (which carries the actionable step), or None for anything
+    that is not a structured error payload.
+    """
+    try:
+        payload = json.loads(str(exc))
+    except (TypeError, ValueError):
+        return None
+    if not isinstance(payload, dict):
+        return None
+    error = payload.get("error")
+    if not isinstance(error, dict):
+        return None
+    message = error.get("message")
+    if not isinstance(message, str) or not message:
+        return None
+    suggestions = error.get("suggestions")
+    if (
+        isinstance(suggestions, list)
+        and suggestions
+        and isinstance(suggestions[0], str)
+    ):
+        return f"{message} {suggestions[0]}"
+    return message
 
 
 async def _fs_custom_paths_call(
@@ -90,7 +123,10 @@ async def _get_fs_custom_paths(
         result = await _fs_custom_paths_call(server, "get_allowed_paths", {})
     except Exception as exc:
         logger.warning("fs-custom-paths GET could not reach ha_mcp_tools: %s", exc)
-        return _unavailable(f"Could not reach the ha_mcp_tools component: {exc}")
+        return _unavailable(
+            _component_error_reason(exc)
+            or f"Could not reach the ha_mcp_tools component: {exc}"
+        )
 
     data = unwrap_service_response(result) if isinstance(result, dict) else {}
     if not isinstance(data, dict) or not data.get("success", False):
@@ -163,7 +199,8 @@ async def _save_fs_custom_paths(
         return JSONResponse(
             create_error_response(
                 ErrorCode.SERVICE_CALL_FAILED,
-                f"Could not reach the ha_mcp_tools component: {exc}",
+                _component_error_reason(exc)
+                or f"Could not reach the ha_mcp_tools component: {exc}",
             ),
             status_code=502,
         )

--- a/src/ha_mcp/settings_ui/_handlers_fs.py
+++ b/src/ha_mcp/settings_ui/_handlers_fs.py
@@ -11,7 +11,6 @@ into thin request-only wrappers for the route table.
 from __future__ import annotations
 
 import contextlib
-import json
 import logging
 from typing import TYPE_CHECKING, Any
 
@@ -27,35 +26,17 @@ logger = logging.getLogger(__name__)
 
 
 def _component_error_reason(exc: Exception) -> str | None:
-    """Extract the human-readable message from a structured ``ToolError``.
+    """Extract the human message from a structured ``ToolError``, else None.
 
     ``raise_tool_error`` serializes the whole error envelope into the
     exception string, so rendering ``str(exc)`` verbatim shows the settings
     UI a raw JSON blob behind a misleading "could not reach" prefix — the
-    hard-to-read surface from #1996. Returns the message plus the first
-    suggestion (which carries the actionable step), or None for anything
-    that is not a structured error payload.
+    hard-to-read surface from #1996. Thin seam over the shared extractor
+    (imported lazily like the other tools imports in this module).
     """
-    try:
-        payload = json.loads(str(exc))
-    except (TypeError, ValueError):
-        return None
-    if not isinstance(payload, dict):
-        return None
-    error = payload.get("error")
-    if not isinstance(error, dict):
-        return None
-    message = error.get("message")
-    if not isinstance(message, str) or not message:
-        return None
-    suggestions = error.get("suggestions")
-    if (
-        isinstance(suggestions, list)
-        and suggestions
-        and isinstance(suggestions[0], str)
-    ):
-        return f"{message} {suggestions[0]}"
-    return message
+    from ..tools.helpers import extract_structured_error_reason
+
+    return extract_structured_error_reason(exc)
 
 
 async def _fs_custom_paths_call(

--- a/src/ha_mcp/tools/backup.py
+++ b/src/ha_mcp/tools/backup.py
@@ -1908,12 +1908,12 @@ async def _edits_list(
     # Edits-store snapshots + pre-#1579 legacy .bak entries (#1579).
     # The manager owns the merge (sync dir-glob off-thread + async
     # legacy service call) so this layer stays source-agnostic.
-    entries = await mgr.list_edits_and_legacy(
+    entries, warnings = await mgr.list_edits_and_legacy(
         domain=domain,
         entity_id=entity_id,
         limit=limit,
     )
-    return {
+    response: dict[str, Any] = {
         "success": True,
         "data": {
             "backups": entries,
@@ -1924,6 +1924,9 @@ async def _edits_list(
             "retain_per_entity": settings.auto_backup_retain_per_entity,
         },
     }
+    if warnings:
+        response["warnings"] = warnings
+    return response
 
 
 async def _edits_view(

--- a/src/ha_mcp/tools/helpers.py
+++ b/src/ha_mcp/tools/helpers.py
@@ -78,6 +78,41 @@ def extract_tool_error_message(te: ToolError) -> str:
         return str(te)
 
 
+def extract_structured_error_reason(exc: BaseException) -> str | None:
+    """Extract "message" + first actionable suggestion from a structured error.
+
+    Like ``extract_tool_error_message`` but for surfaces that show the reason
+    to a human (settings UI, degraded-result warnings): it appends the first
+    suggestion when one exists, and returns ``None`` — instead of the raw
+    ``str(exc)`` JSON envelope — when the payload is not a structured error
+    or carries no usable message, so callers pick their own fallback.
+    ``create_error_response`` emits only the singular ``suggestion`` key for
+    one-suggestion errors (the plural ``suggestions`` list needs two or
+    more), so both keys are honored.
+    """
+    try:
+        payload = json.loads(str(exc))
+    except (TypeError, ValueError):
+        return None
+    if not isinstance(payload, dict):
+        return None
+    error = payload.get("error")
+    if not isinstance(error, dict):
+        return None
+    message = error.get("message")
+    if not isinstance(message, str) or not message:
+        return None
+    suggestions = error.get("suggestions")
+    first = (
+        suggestions[0]
+        if isinstance(suggestions, list) and suggestions
+        else error.get("suggestion")
+    )
+    if isinstance(first, str) and first:
+        return f"{message} {first}"
+    return message
+
+
 def validate_identifier_not_empty(
     value: str | None,
     param_name: str,

--- a/src/ha_mcp/tools/tools_bug_report.py
+++ b/src/ha_mcp/tools/tools_bug_report.py
@@ -561,6 +561,44 @@ def _format_tools_entry_value(diagnostic_info: dict[str, Any]) -> str:
     return diagnostic_info.get("tools_entry_status") or "unknown (probe failed)"
 
 
+def _format_server_entry_value(diagnostic_info: dict[str, Any]) -> str:
+    """Render the in-process server entry status for the report templates."""
+    return diagnostic_info.get("server_entry_status") or "unknown (probe failed)"
+
+
+# Entry titles assigned by the component's config flow (config_flow.py /
+# const.py in custom_components/ha_mcp_tools) — the server code cannot import
+# the separately-shipped component package, so the defaults are mirrored here.
+# "HA MCP Tools" is the pre-#1853 tools-entry title an unloaded legacy entry
+# may still carry. A user-renamed entry lands in the "unrecognized" bucket
+# rather than being misclassified.
+_SERVER_ENTRY_TITLE = "HA-MCP Server"
+_TOOLS_ENTRY_TITLES = frozenset({"HA-MCP File & YAML Tools", "HA MCP Tools"})
+
+
+def _classify_component_entries(
+    entries: list[Any],
+) -> tuple[list[str], list[str]]:
+    """Split ha_mcp_tools config entries into server-entry and unrecognized.
+
+    Tools-entry titles are dropped: their functional state comes from the
+    services probe (``_detect_tools_entry_status``), which sees whether the
+    entry actually serves, not just whether it exists.
+    """
+    server: list[str] = []
+    unrecognized: list[str] = []
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        title = str(entry.get("title") or "untitled")
+        state = str(entry.get("state") or "unknown state")
+        if title == _SERVER_ENTRY_TITLE:
+            server.append(f"added ({state})")
+        elif title not in _TOOLS_ENTRY_TITLES:
+            unrecognized.append(f'"{title}" ({state})')
+    return server, unrecognized
+
+
 def _build_formatted_report(
     diagnostic_info: dict[str, Any],
     mcp_transport: str,
@@ -580,6 +618,7 @@ def _build_formatted_report(
         f"ha-mcp Version: {_format_version_value(diagnostic_info)}",
         f"Custom Component: {diagnostic_info.get('component_version') or 'not detected (not installed, or probe failed)'}",
         f"File & YAML Tools entry: {_format_tools_entry_value(diagnostic_info)}",
+        f"In-process Server entry: {_format_server_entry_value(diagnostic_info)}",
         f"Installation Method: {diagnostic_info['installation_method']}",
         f"MCP Transport: {mcp_transport}",
         f"MCP Client: {_format_client_info_for_template(client_info)}",
@@ -684,6 +723,41 @@ class BugReportTools:
             return "set up, but the component is pre-0.5.0 (update via HACS)"
         return "set up (ha_mcp_tools services registered)"
 
+    async def _detect_server_entry_status(self) -> str | None:
+        """Describe the in-process "HA-MCP Server" entry state, best-effort.
+
+        Both parts of the custom component ship under the single
+        ``ha_mcp_tools`` domain, so "the component is installed" says nothing
+        about WHICH part is set up. The File & YAML tools part is covered by
+        the services probe; this one classifies the domain's config entries by
+        their flow-assigned titles to show whether the in-process server entry
+        exists — e.g. an add-on install that erroneously also added it (a
+        second, redundant server) becomes visible next to Installation Method.
+        Returns None when the probe fails; the report must never break on it.
+        """
+        try:
+            response = await self._client.send_websocket_message(
+                {"type": "config_entries/get", "domain": "ha_mcp_tools"}
+            )
+            if not isinstance(response, dict) or not response.get("success"):
+                return None
+            result = response.get("result")
+            if not isinstance(result, list):
+                return None
+        except Exception as e:
+            logger.info("Server-entry status probe failed: %s", e)
+            return None
+        server, unrecognized = _classify_component_entries(result)
+        if server:
+            return ", ".join(server)
+        if unrecognized:
+            # A renamed entry cannot be classified by title — report it
+            # rather than claiming the server entry is absent.
+            return "not identified — unrecognized ha_mcp_tools entries: " + ", ".join(
+                unrecognized
+            )
+        return "not added"
+
     @tool(
         name="ha_report_issue",
         tags={"Utilities"},
@@ -765,6 +839,7 @@ class BugReportTools:
         installed_version = await asyncio.to_thread(_detect_installed_version)
         component_version = await self._detect_component_version()
         tools_entry_status = await self._detect_tools_entry_status()
+        server_entry_status = await self._detect_server_entry_status()
 
         diagnostic_info: dict[str, Any] = {
             "ha_mcp_version": __version__,
@@ -774,6 +849,7 @@ class BugReportTools:
             ),
             "component_version": component_version,
             "tools_entry_status": tools_entry_status,
+            "server_entry_status": server_entry_status,
             "instance": _instance_identity(),
             "installation_method": install_method,
             "platform": platform_info,
@@ -1284,6 +1360,7 @@ ha_call_service(domain="light", service="turn_on", entity_id="light.example")
 - **ha-mcp Version:** {_format_version_value(diagnostic_info)}
 - **Custom Component:** {diagnostic_info.get("component_version") or "not detected (not installed, or probe failed)"}
 - **File & YAML Tools entry:** {_format_tools_entry_value(diagnostic_info)}
+- **In-process Server entry:** {_format_server_entry_value(diagnostic_info)}
 - **Installation Method:** {diagnostic_info.get("installation_method", "Unknown")}
 - **MCP Transport:** {mcp_transport} _(auto-detected — correct if wrong)_
 - **MCP Client:** {_format_client_info_for_template(client_info)} _(auto-detected from the MCP `initialize` handshake)_
@@ -1450,6 +1527,7 @@ def _generate_agent_behavior_template(
 - **ha-mcp Version:** {_format_version_value(diagnostic_info)}
 - **Custom Component:** {diagnostic_info.get("component_version") or "not detected (not installed, or probe failed)"}
 - **File & YAML Tools entry:** {_format_tools_entry_value(diagnostic_info)}
+- **In-process Server entry:** {_format_server_entry_value(diagnostic_info)}
 - **Installation Method:** {diagnostic_info.get("installation_method", "Unknown")}
 - **MCP Transport:** {mcp_transport} _(auto-detected — correct if wrong)_
 - **MCP Client:** {_format_client_info_for_template(client_info)} _(auto-detected from the MCP `initialize` handshake)_

--- a/src/ha_mcp/tools/tools_bug_report.py
+++ b/src/ha_mcp/tools/tools_bug_report.py
@@ -556,6 +556,11 @@ async def _fetch_core_error_log(client: Any) -> str:
     return sanitized
 
 
+def _format_tools_entry_value(diagnostic_info: dict[str, Any]) -> str:
+    """Render the File & YAML Tools entry status for the report templates."""
+    return diagnostic_info.get("tools_entry_status") or "unknown (probe failed)"
+
+
 def _build_formatted_report(
     diagnostic_info: dict[str, Any],
     mcp_transport: str,
@@ -574,6 +579,7 @@ def _build_formatted_report(
         "",
         f"ha-mcp Version: {_format_version_value(diagnostic_info)}",
         f"Custom Component: {diagnostic_info.get('component_version') or 'not detected (not installed, or probe failed)'}",
+        f"File & YAML Tools entry: {_format_tools_entry_value(diagnostic_info)}",
         f"Installation Method: {diagnostic_info['installation_method']}",
         f"MCP Transport: {mcp_transport}",
         f"MCP Client: {_format_client_info_for_template(client_info)}",
@@ -648,6 +654,35 @@ class BugReportTools:
         except Exception as e:
             logger.info("Component version probe failed: %s", e)
             return None
+
+    async def _detect_tools_entry_status(self) -> str | None:
+        """Describe the File & YAML Tools entry state for the report, best-effort.
+
+        The ``ha_mcp_tools`` services register only in that entry's setup, so
+        the service registry distinguishes "entry set up" from the #1996
+        state — integration installed but the second entry never added —
+        which the component version alone cannot show. Returns None when the
+        probe fails; the report path must never break on it.
+        """
+        from .tools_filesystem import _bootstrap_service_state
+
+        try:
+            domain_registered, bootstrap_registered = await _bootstrap_service_state(
+                self._client
+            )
+        except Exception as e:
+            logger.info("Tools-entry status probe failed: %s", e)
+            return None
+        if not domain_registered:
+            return (
+                "not set up — no ha_mcp_tools services registered; add the "
+                '"HA-MCP File & YAML Tools" entry via "Add entry" on the '
+                "HA-MCP Custom Component integration (or install the "
+                "component first)"
+            )
+        if not bootstrap_registered:
+            return "set up, but the component is pre-0.5.0 (update via HACS)"
+        return "set up (ha_mcp_tools services registered)"
 
     @tool(
         name="ha_report_issue",
@@ -729,6 +764,7 @@ class BugReportTools:
         client_info = _extract_client_info(ctx)
         installed_version = await asyncio.to_thread(_detect_installed_version)
         component_version = await self._detect_component_version()
+        tools_entry_status = await self._detect_tools_entry_status()
 
         diagnostic_info: dict[str, Any] = {
             "ha_mcp_version": __version__,
@@ -737,6 +773,7 @@ class BugReportTools:
                 installed_version and installed_version != __version__
             ),
             "component_version": component_version,
+            "tools_entry_status": tools_entry_status,
             "instance": _instance_identity(),
             "installation_method": install_method,
             "platform": platform_info,
@@ -1246,6 +1283,7 @@ ha_call_service(domain="light", service="turn_on", entity_id="light.example")
 
 - **ha-mcp Version:** {_format_version_value(diagnostic_info)}
 - **Custom Component:** {diagnostic_info.get("component_version") or "not detected (not installed, or probe failed)"}
+- **File & YAML Tools entry:** {_format_tools_entry_value(diagnostic_info)}
 - **Installation Method:** {diagnostic_info.get("installation_method", "Unknown")}
 - **MCP Transport:** {mcp_transport} _(auto-detected — correct if wrong)_
 - **MCP Client:** {_format_client_info_for_template(client_info)} _(auto-detected from the MCP `initialize` handshake)_
@@ -1411,6 +1449,7 @@ def _generate_agent_behavior_template(
 
 - **ha-mcp Version:** {_format_version_value(diagnostic_info)}
 - **Custom Component:** {diagnostic_info.get("component_version") or "not detected (not installed, or probe failed)"}
+- **File & YAML Tools entry:** {_format_tools_entry_value(diagnostic_info)}
 - **Installation Method:** {diagnostic_info.get("installation_method", "Unknown")}
 - **MCP Transport:** {mcp_transport} _(auto-detected — correct if wrong)_
 - **MCP Client:** {_format_client_info_for_template(client_info)} _(auto-detected from the MCP `initialize` handshake)_

--- a/src/ha_mcp/tools/tools_filesystem.py
+++ b/src/ha_mcp/tools/tools_filesystem.py
@@ -137,8 +137,8 @@ async def _bootstrap_service_state(client: Any) -> tuple[bool, bool]:
       (<0.5.0) component that pre-dates the bootstrap service; the call would
       otherwise fail with an opaque 400 from HA. This one IS fixed by updating.
     """
-    # HA /api/services returns a list of {"domain": str, "services": {...}} objects.
-    # This format has been stable since before HA 0.7 (the first public release).
+    # HA /api/services returns a list of {"domain": str, "services": {...}}
+    # objects — stable across all supported HA versions.
     services = await client.get_services()
     for entry in services:
         if not isinstance(entry, dict):

--- a/src/ha_mcp/tools/tools_filesystem.py
+++ b/src/ha_mcp/tools/tools_filesystem.py
@@ -122,11 +122,21 @@ def _get_token_lock(client: Any) -> asyncio.Lock:
     return lock
 
 
-async def _is_bootstrap_service_registered(client: Any) -> bool:
-    """Returns True if ha_mcp_tools.get_caller_token is present in HA's
-    service registry. Old (<0.5.0) versions of the custom component
-    didn't ship this service; the bootstrap call would otherwise fail
-    with an opaque 400 from HA."""
+async def _bootstrap_service_state(client: Any) -> tuple[bool, bool]:
+    """Return ``(domain_registered, bootstrap_registered)`` from HA's service
+    registry.
+
+    The two flags distinguish the two very different ways the
+    ``get_caller_token`` bootstrap can be missing (#1996):
+
+    - No ``ha_mcp_tools`` services at all — the component's "HA-MCP File &
+      YAML Tools" config entry was never added (the services register only in
+      that entry's setup), or the component isn't installed. A HACS update
+      cannot fix this.
+    - Domain services present but no ``get_caller_token`` — a genuinely old
+      (<0.5.0) component that pre-dates the bootstrap service; the call would
+      otherwise fail with an opaque 400 from HA. This one IS fixed by updating.
+    """
     services = await client.get_services()
     for entry in services:
         if not isinstance(entry, dict):
@@ -134,8 +144,41 @@ async def _is_bootstrap_service_registered(client: Any) -> bool:
         if entry.get("domain") != MCP_TOOLS_DOMAIN:
             continue
         domain_services = entry.get("services") or {}
-        return CALLER_TOKEN_BOOTSTRAP_SERVICE in domain_services
-    return False
+        return True, CALLER_TOKEN_BOOTSTRAP_SERVICE in domain_services
+    return False, False
+
+
+def _raise_tools_entry_not_set_up() -> NoReturn:
+    """Actionable error for the no-services state (#1996).
+
+    Installing the HA-MCP integration is not enough for the file / YAML
+    tools: they need the separate "HA-MCP File & YAML Tools" config entry,
+    which users routinely miss. Lead with the "Add entry" step; the full
+    HACS install is the fallback for a component that isn't there at all.
+    """
+    raise_tool_error(
+        create_error_response(
+            ErrorCode.COMPONENT_NOT_INSTALLED,
+            'The optional "HA-MCP File & YAML Tools" entry is not set up in '
+            "Home Assistant, so the file and YAML tools are unavailable. "
+            "Installing the HA-MCP integration alone is not enough — this "
+            "second entry must be added to it.",
+            suggestions=[
+                "In Home Assistant: Settings → Devices & Services → HA-MCP → "
+                + '"Add entry" → choose "HA-MCP File & YAML Tools" (NOT '
+                + '"HA-MCP Server", which starts a second in-process server '
+                + "this ha-mcp server does not need)",
+                "If the HA-MCP integration is not listed there, install it "
+                + 'first: ha_manage_hacs(action="add_repository", '
+                + 'repository="homeassistant-ai/ha-mcp-integration", '
+                + 'category="integration"), then ha_manage_hacs('
+                + 'action="download", '
+                + 'repository_id="homeassistant-ai/ha-mcp-integration"), '
+                + "then restart Home Assistant (ha_restart)",
+                "Then retry the operation",
+            ],
+        )
+    )
 
 
 def _raise_component_too_old(detail: str) -> NoReturn:
@@ -158,12 +201,17 @@ def _raise_component_too_old(detail: str) -> NoReturn:
 async def _fetch_caller_token(client: Any) -> str:
     """Call the bootstrap service and cache the returned token.
 
-    Two version gates:
+    Three gates, pre-flighted via ``_bootstrap_service_state``:
 
-    1. ``_is_bootstrap_service_registered`` — pre-0.5.0 components don't
-       ship ``get_caller_token`` at all. Surface an actionable "update"
+    1. No ``ha_mcp_tools`` services registered at all — the "HA-MCP File &
+       YAML Tools" config entry was never added (or the component isn't
+       installed). Surface the "add the entry" error, NOT an update prompt:
+       a current component in this state misled users into fruitless HACS
+       updates when the old code lumped it in with "too old" (#1996).
+    2. Domain present but no ``get_caller_token`` — pre-0.5.0 components
+       don't ship the bootstrap service. Surface an actionable "update"
        error instead of letting HA return an opaque 400 to the caller.
-    2. ``MIN_COMPONENT_VERSION`` — even when the bootstrap service is
+    3. ``MIN_COMPONENT_VERSION`` — even when the bootstrap service is
        present, the response now carries the component's manifest
        version. ha-mcp releases that depend on newer custom-component
        behavior (e.g. a new accepted yaml_path key, a new schema field)
@@ -176,7 +224,10 @@ async def _fetch_caller_token(client: Any) -> str:
     reason: the absence of the field IS the signal that the component
     doesn't yet know how to report its capabilities to ha-mcp.
     """
-    if not await _is_bootstrap_service_registered(client):
+    domain_registered, bootstrap_registered = await _bootstrap_service_state(client)
+    if not domain_registered:
+        _raise_tools_entry_not_set_up()
+    if not bootstrap_registered:
         _raise_component_too_old(
             "the get_caller_token bootstrap service is not registered (pre-0.5.0)"
         )
@@ -319,10 +370,8 @@ async def _is_mcp_tools_available(client: Any) -> bool:
     """
     # HA /api/services returns a list of {"domain": str, "services": {...}} objects.
     # This format has been stable since before HA 0.7 (the first public release).
-    services = await client.get_services()
-    return any(
-        isinstance(s, dict) and s.get("domain") == MCP_TOOLS_DOMAIN for s in services
-    )
+    domain_registered, _ = await _bootstrap_service_state(client)
+    return domain_registered
 
 
 def _assert_caps_version_ok(caps: ComponentCaps) -> None:
@@ -365,22 +414,7 @@ async def _assert_mcp_tools_available(client: Any) -> None:
         _assert_caps_version_ok(caps)
         return
     if not await _is_mcp_tools_available(client):
-        raise_tool_error(
-            create_error_response(
-                ErrorCode.COMPONENT_NOT_INSTALLED,
-                f"The {MCP_TOOLS_DOMAIN} custom component is not installed.",
-                suggestions=[
-                    'Add the repository to HACS: ha_manage_hacs(action="add_repository",'
-                    + ' repository="homeassistant-ai/ha-mcp-integration", category="integration")',
-                    'Download the component: ha_manage_hacs(action="download",'
-                    + ' repository_id="homeassistant-ai/ha-mcp-integration")',
-                    "Restart Home Assistant (ha_restart) so the integration loads",
-                    'In HA, add the "HA-MCP Custom Component" integration and choose the'
-                    + ' "HA-MCP File & YAML Tools" entry — NOT "HA-MCP Server", which starts'
-                    + " a second in-process server this ha-mcp server does not need",
-                ],
-            )
-        )
+        _raise_tools_entry_not_set_up()
 
 
 class FilesystemTools:

--- a/src/ha_mcp/tools/tools_filesystem.py
+++ b/src/ha_mcp/tools/tools_filesystem.py
@@ -137,6 +137,8 @@ async def _bootstrap_service_state(client: Any) -> tuple[bool, bool]:
       (<0.5.0) component that pre-dates the bootstrap service; the call would
       otherwise fail with an opaque 400 from HA. This one IS fixed by updating.
     """
+    # HA /api/services returns a list of {"domain": str, "services": {...}} objects.
+    # This format has been stable since before HA 0.7 (the first public release).
     services = await client.get_services()
     for entry in services:
         if not isinstance(entry, dict):
@@ -164,8 +166,9 @@ def _raise_tools_entry_not_set_up() -> NoReturn:
             "Installing the HA-MCP integration alone is not enough — this "
             "second entry must be added to it.",
             suggestions=[
-                "In Home Assistant: Settings → Devices & Services → HA-MCP → "
-                + '"Add entry" → choose "HA-MCP File & YAML Tools" (NOT '
+                "In Home Assistant: Settings → Devices & Services → "
+                + 'HA-MCP Custom Component → "Add entry" → choose '
+                + '"HA-MCP File & YAML Tools" (NOT '
                 + '"HA-MCP Server", which starts a second in-process server '
                 + "this ha-mcp server does not need)",
                 "If the HA-MCP integration is not listed there, install it "
@@ -368,8 +371,6 @@ async def _is_mcp_tools_available(client: Any) -> bool:
     Raises if the services API call fails — callers handle API errors via
     their own exception_to_structured_error blocks.
     """
-    # HA /api/services returns a list of {"domain": str, "services": {...}} objects.
-    # This format has been stable since before HA 0.7 (the first public release).
     domain_registered, _ = await _bootstrap_service_state(client)
     return domain_registered
 

--- a/src/ha_mcp/tools/tools_filesystem.py
+++ b/src/ha_mcp/tools/tools_filesystem.py
@@ -366,10 +366,13 @@ def is_filesystem_tools_enabled() -> bool:
 
 
 async def _is_mcp_tools_available(client: Any) -> bool:
-    """Return True if the ha_mcp_tools custom component is registered in HA services.
+    """Return True if any ha_mcp_tools services are registered in HA.
 
-    Raises if the services API call fails — callers handle API errors via
-    their own exception_to_structured_error blocks.
+    No services means the File & YAML Tools entry is not set up (or the
+    component is absent entirely — indistinguishable from here, see
+    ``_bootstrap_service_state``). Raises if the services API call fails —
+    callers handle API errors via their own exception_to_structured_error
+    blocks.
     """
     domain_registered, _ = await _bootstrap_service_state(client)
     return domain_registered
@@ -402,7 +405,10 @@ async def _assert_mcp_tools_available(client: Any) -> None:
     ``caps.component_version`` (info shipped in 1.1.0, already past the floor).
     Legacy fallback: caps is None for a component in the 0.11.0-1.1.0 band
     (services, no info command) or an absent one, so fall back to the per-call
-    ``get_services()`` existence probe.
+    ``get_services()`` existence probe. A no-services verdict raises the
+    "File & YAML Tools entry not set up" error
+    (``_raise_tools_entry_not_set_up``), not an install-the-component prompt —
+    the entry-not-added state is the common cause (#1996).
 
     Must be called within a try block that handles API errors via
     exception_to_structured_error, so connection failures are classified

--- a/tests/src/unit/test_backup_manager.py
+++ b/tests/src/unit/test_backup_manager.py
@@ -12,6 +12,7 @@ the client and handler fetch/restore coroutines.
 from __future__ import annotations
 
 import asyncio
+import json
 import time
 from dataclasses import dataclass
 from pathlib import Path
@@ -2010,32 +2011,48 @@ class TestLegacyList:
         monkeypatch.setattr(
             "ha_mcp.tools.tools_filesystem.call_mcp_tools_service", boom
         )
-        assert await bm._list_legacy_backups(_StubClient()) == []
+        backups, reason = await bm._list_legacy_backups(_StubClient())
+        assert backups == []
+        assert reason == "service not found"
 
     async def test_tool_error_from_token_gates_degrades_to_empty(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         # The caller-token gates (tools entry not set up / component too old)
-        # raise ToolError, not HomeAssistantError — the edits list must still
-        # degrade to [] instead of failing wholesale (#1996 exercise path).
+        # raise ToolError, not HomeAssistantError — both the edits list and the
+        # legacy read must still degrade instead of failing wholesale, and the
+        # surfaced reason must be the human message, not the raw JSON envelope
+        # (#1996 exercise path).
         from fastmcp.exceptions import ToolError
 
+        from ha_mcp.errors import ErrorCode, create_error_response
+
+        payload = json.dumps(
+            create_error_response(
+                ErrorCode.COMPONENT_NOT_INSTALLED,
+                "Entry not set up.",
+                suggestions=["Add the entry."],
+            )
+        )
+
         async def boom(_c: Any, _s: str, _d: dict[str, Any]) -> Any:
-            raise ToolError('{"success": false, "error": {"code": "X"}}')
+            raise ToolError(payload)
 
         monkeypatch.setattr(
             "ha_mcp.tools.tools_filesystem.call_mcp_tools_service", boom
         )
-        assert await bm._list_legacy_backups(_StubClient()) == []
-        assert (await bm._read_legacy_backup(_StubClient(), "x.bak"))[
-            "success"
-        ] is False
+        backups, reason = await bm._list_legacy_backups(_StubClient())
+        assert backups == []
+        assert reason == "Entry not set up. Add the entry."
+        read = await bm._read_legacy_backup(_StubClient(), "x.bak")
+        assert read["success"] is False
+        assert read["error"] == "Entry not set up. Add the entry."
 
     async def test_unsuccessful_response_degrades_to_empty(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         _patch_services(monkeypatch, {"list_legacy_backups": {"success": False}}, [])
-        assert await bm._list_legacy_backups(_StubClient()) == []
+        assert await bm._list_legacy_backups(_StubClient()) == ([], None)
 
     async def test_manager_normalizes_entries(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -2059,7 +2076,8 @@ class TestLegacyList:
             [],
         )
         mgr = _mk_manager(tmp_path)
-        out = await mgr.list_legacy()
+        out, reason = await mgr.list_legacy()
+        assert reason is None
         assert out[0]["name"] == "legacy:configuration.yaml.20260101_120000.bak"
         assert out[0]["domain"] == "yaml_file"
         assert out[0]["source"] == "legacy"
@@ -2296,13 +2314,15 @@ class TestListEditsAndLegacy:
             lambda **_kw: [{"name": "file.x.20260101_000000.yaml", "domain": "file"}],
         )
 
-        async def _legacy() -> list[Any]:
-            return [{"name": "legacy:configuration.yaml.20200101_000000.bak"}]
+        async def _legacy() -> tuple[list[Any], str | None]:
+            return [{"name": "legacy:configuration.yaml.20200101_000000.bak"}], None
 
         monkeypatch.setattr(mgr, "list_legacy", _legacy)
-        names = [e["name"] for e in await mgr.list_edits_and_legacy()]
+        entries, warnings = await mgr.list_edits_and_legacy()
+        names = [e["name"] for e in entries]
         assert "file.x.20260101_000000.yaml" in names
         assert "legacy:configuration.yaml.20200101_000000.bak" in names
+        assert warnings == []
 
     async def test_legacy_skipped_when_filtered(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -2310,18 +2330,18 @@ class TestListEditsAndLegacy:
         mgr = _mk_manager(tmp_path)
         monkeypatch.setattr(mgr, "list_snapshots", lambda **_kw: [])
 
-        async def _legacy() -> list[Any]:
-            return [{"name": "legacy:x.bak"}]
+        async def _legacy() -> tuple[list[Any], str | None]:
+            return [{"name": "legacy:x.bak"}], None
 
         monkeypatch.setattr(mgr, "list_legacy", _legacy)
         # A non-yaml_file domain filter excludes legacy (legacy maps to yaml_file).
-        assert await mgr.list_edits_and_legacy(domain="automation") == []
+        assert await mgr.list_edits_and_legacy(domain="automation") == ([], [])
         # An entity_id filter excludes legacy (decoded path != sanitized filter).
-        assert await mgr.list_edits_and_legacy(entity_id="foo") == []
+        assert await mgr.list_edits_and_legacy(entity_id="foo") == ([], [])
         # Unfiltered (or explicit yaml_file) surfaces it.
-        out = await mgr.list_edits_and_legacy()
+        out, _ = await mgr.list_edits_and_legacy()
         assert any(e["name"] == "legacy:x.bak" for e in out)
-        out2 = await mgr.list_edits_and_legacy(domain="yaml_file")
+        out2, _ = await mgr.list_edits_and_legacy(domain="yaml_file")
         assert any(e["name"] == "legacy:x.bak" for e in out2)
 
     async def test_limit_reserves_room_for_legacy(
@@ -2337,12 +2357,56 @@ class TestListEditsAndLegacy:
 
         monkeypatch.setattr(mgr, "list_snapshots", _snaps)
 
-        async def _legacy() -> list[Any]:
-            return [{"name": "legacy:a.bak"}, {"name": "legacy:b.bak"}]
+        async def _legacy() -> tuple[list[Any], str | None]:
+            return [{"name": "legacy:a.bak"}, {"name": "legacy:b.bak"}], None
 
         monkeypatch.setattr(mgr, "list_legacy", _legacy)
-        out = await mgr.list_edits_and_legacy(limit=4)
+        out, _ = await mgr.list_edits_and_legacy(limit=4)
         assert len(out) == 4
         names = {e["name"] for e in out}
         # Legacy survives the cap (room reserved): 2 edits + 2 legacy.
         assert "legacy:a.bak" in names and "legacy:b.bak" in names
+
+    async def test_suppressed_legacy_fetch_surfaces_warning(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # When the legacy sub-fetch is unavailable (tools entry not set up /
+        # component too old), the merged list must carry a warning instead of
+        # reading as a clean, complete listing (#1996).
+        mgr = _mk_manager(tmp_path)
+        monkeypatch.setattr(mgr, "list_snapshots", lambda **_kw: [])
+
+        async def _legacy() -> tuple[list[Any], str | None]:
+            return [], "Entry not set up. Add the entry."
+
+        monkeypatch.setattr(mgr, "list_legacy", _legacy)
+        entries, warnings = await mgr.list_edits_and_legacy()
+        assert entries == []
+        assert len(warnings) == 1
+        assert "omitted" in warnings[0]
+        assert "Entry not set up. Add the entry." in warnings[0]
+
+    async def test_warnings_reach_the_tool_response(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Top-level warnings contract (AGENTS.md Return Values): present when
+        # the legacy fetch was suppressed, omitted entirely when clean.
+        from ha_mcp.tools.backup import _edits_list
+
+        mgr = _mk_manager(tmp_path)
+        monkeypatch.setattr(mgr, "list_snapshots", lambda **_kw: [])
+
+        async def _legacy_down() -> tuple[list[Any], str | None]:
+            return [], "Entry not set up."
+
+        monkeypatch.setattr(mgr, "list_legacy", _legacy_down)
+        out = await _edits_list(mgr, _StubSettings(), None, None, 50)
+        assert out["success"] is True
+        assert "Entry not set up." in out["warnings"][0]
+
+        async def _legacy_ok() -> tuple[list[Any], str | None]:
+            return [], None
+
+        monkeypatch.setattr(mgr, "list_legacy", _legacy_ok)
+        out = await _edits_list(mgr, _StubSettings(), None, None, 50)
+        assert "warnings" not in out

--- a/tests/src/unit/test_backup_manager.py
+++ b/tests/src/unit/test_backup_manager.py
@@ -2012,6 +2012,25 @@ class TestLegacyList:
         )
         assert await bm._list_legacy_backups(_StubClient()) == []
 
+    async def test_tool_error_from_token_gates_degrades_to_empty(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # The caller-token gates (tools entry not set up / component too old)
+        # raise ToolError, not HomeAssistantError — the edits list must still
+        # degrade to [] instead of failing wholesale (#1996 exercise path).
+        from fastmcp.exceptions import ToolError
+
+        async def boom(_c: Any, _s: str, _d: dict[str, Any]) -> Any:
+            raise ToolError('{"success": false, "error": {"code": "X"}}')
+
+        monkeypatch.setattr(
+            "ha_mcp.tools.tools_filesystem.call_mcp_tools_service", boom
+        )
+        assert await bm._list_legacy_backups(_StubClient()) == []
+        assert (await bm._read_legacy_backup(_StubClient(), "x.bak"))[
+            "success"
+        ] is False
+
     async def test_unsuccessful_response_degrades_to_empty(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/src/unit/test_backup_manager.py
+++ b/tests/src/unit/test_backup_manager.py
@@ -1814,8 +1814,6 @@ class TestMandatoryGate:
 
     @staticmethod
     def _error_code(exc: ToolError) -> str:
-        import json
-
         return str(json.loads(str(exc))["error"]["code"])
 
     async def test_refuses_when_disabled(self, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/src/unit/test_caller_token_auth.py
+++ b/tests/src/unit/test_caller_token_auth.py
@@ -469,6 +469,28 @@ class TestCallMcpToolsServiceInjectsToken:
         client.call_service.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_raises_entry_not_set_up_when_no_domain_services(self):
+        """No ha_mcp_tools services at all → the "add the File & YAML Tools
+        entry" error, NOT the "too old / update via HACS" prompt (#1996).
+
+        This is the state a fully-current component is in when only the
+        "HA-MCP Server" entry was added: the services register in the tools
+        entry's setup, so a HACS update can never fix it — the old message
+        sent users on exactly that goose chase.
+        """
+        client = AsyncMock()
+        client.get_services.return_value = [
+            {"domain": "light", "services": {"turn_on": {}}},
+        ]
+        with pytest.raises(ToolError) as exc_info:
+            await call_mcp_tools_service(client, "list_files", {"path": "www"})
+        msg = str(exc_info.value)
+        assert "HA-MCP File & YAML Tools" in msg
+        assert "Add entry" in msg
+        assert "too old" not in msg
+        client.call_service.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_raises_component_too_old_when_response_missing_version(self):
         """Bootstrap registered but response has no ``version`` field → still
         rejected as "too old" with the same actionable update prompt.

--- a/tests/src/unit/test_caller_token_auth.py
+++ b/tests/src/unit/test_caller_token_auth.py
@@ -479,7 +479,9 @@ class TestCallMcpToolsServiceInjectsToken:
         sent users on exactly that goose chase.
         """
         client = AsyncMock()
+        # The non-dict item exercises the probe's malformed-entry guard.
         client.get_services.return_value = [
+            "bogus-non-dict-entry",
             {"domain": "light", "services": {"turn_on": {}}},
         ]
         with pytest.raises(ToolError) as exc_info:
@@ -488,6 +490,8 @@ class TestCallMcpToolsServiceInjectsToken:
         assert "HA-MCP File & YAML Tools" in msg
         assert "Add entry" in msg
         assert "too old" not in msg
+        # The Add-entry step leads; the HACS install is the fallback.
+        assert msg.index("Add entry") < msg.index("add_repository")
         client.call_service.assert_not_called()
 
     @pytest.mark.asyncio

--- a/tests/src/unit/test_component_ws_phase2_async.py
+++ b/tests/src/unit/test_component_ws_phase2_async.py
@@ -140,11 +140,11 @@ class TestCapabilityPresence:
             assert cap in wsapi.CAPABILITIES
 
     def test_component_version(self):
-        # Pending 1.2.3 (1.2.2 is the released stable). Capabilities are
+        # Pending 1.2.4 (1.2.3 is the released stable). Capabilities are
         # advertised by name, never version-inferred, so new caps ride any
         # pending version without a bump; this assertion just pins the
         # declared version (the write caps shipped in 1.2.1).
-        assert wsapi.COMPONENT_VERSION == "1.2.3"
+        assert wsapi.COMPONENT_VERSION == "1.2.4"
 
 
 # =============================================================================

--- a/tests/src/unit/test_component_ws_search.py
+++ b/tests/src/unit/test_component_ws_search.py
@@ -768,7 +768,7 @@ class TestInfo:
                 _REPO_ROOT / "custom_components" / "ha_mcp_tools" / "manifest.json"
             ).read_text(encoding="utf-8")
         )
-        assert manifest["version"] == COMPONENT_VERSION == "1.2.3"
+        assert manifest["version"] == COMPONENT_VERSION == "1.2.4"
 
 
 # =============================================================================

--- a/tests/src/unit/test_config_flow.py
+++ b/tests/src/unit/test_config_flow.py
@@ -501,6 +501,33 @@ class TestServerOptionsFlow:
         assert "not loaded" in versions
         assert "enable or reload" in versions
 
+    def test_tools_module_hint_mixed_entry_states_reads_installed(self, monkeypatch):
+        # With several tools entries, one loaded entry is enough for Installed
+        # (the any() semantics) — the unloaded sibling must not downgrade it.
+        monkeypatch.setattr(
+            cf,
+            "async_get_integration",
+            AsyncMock(return_value=SimpleNamespace(version="1.2.4")),
+        )
+        monkeypatch.setattr(cf, "_installed_server_version", lambda: "7.14.1")
+        flow = _make_options_flow(data={const.DATA_WEBHOOK_ID: "mcp_abc"})
+        flow.hass = self._hass_with_entries(
+            [
+                SimpleNamespace(
+                    data={const.CONF_ENTRY_TYPE: const.ENTRY_TYPE_TOOLS},
+                    state=cf.ConfigEntryState.NOT_LOADED,
+                ),
+                SimpleNamespace(
+                    data={const.CONF_ENTRY_TYPE: const.ENTRY_TYPE_TOOLS},
+                    state=cf.ConfigEntryState.LOADED,
+                ),
+            ]
+        )
+        form = asyncio.run(flow.async_step_init(None))
+        versions = form["description_placeholders"]["versions"]
+        assert "tools module (optional): Installed" in versions
+        assert "not loaded" not in versions
+
     def test_tools_module_hint_read_error_drops_line(self, monkeypatch):
         # Failure-proof like the sibling hints: a raising entry-registry read
         # drops the status line rather than breaking the options form.

--- a/tests/src/unit/test_config_flow.py
+++ b/tests/src/unit/test_config_flow.py
@@ -447,9 +447,10 @@ class TestServerOptionsFlow:
         assert "Add entry" in versions
 
     def test_versions_placeholder_shows_tools_entry_installed(self, monkeypatch):
-        # Both entries present → the status line reads Installed. A legacy tools
-        # entry without the entry_type discriminator counts as installed too
-        # (missing entry_type means tools, mirroring async_setup_entry).
+        # Both entries present and the tools entry loaded → the status line
+        # reads Installed. A legacy tools entry without the entry_type
+        # discriminator counts too (missing entry_type means tools, mirroring
+        # async_setup_entry).
         monkeypatch.setattr(
             cf,
             "async_get_integration",
@@ -466,13 +467,39 @@ class TestServerOptionsFlow:
                     SimpleNamespace(
                         data={const.CONF_ENTRY_TYPE: const.ENTRY_TYPE_SERVER}
                     ),
-                    SimpleNamespace(data=tools_data),
+                    SimpleNamespace(data=tools_data, state=cf.ConfigEntryState.LOADED),
                 ]
             )
             form = asyncio.run(flow.async_step_init(None))
             versions = form["description_placeholders"]["versions"]
             assert "tools module (optional): Installed" in versions
             assert "Not installed" not in versions
+            assert "not loaded" not in versions
+
+    def test_versions_placeholder_flags_unloaded_tools_entry(self, monkeypatch):
+        # A tools entry that exists but is not loaded (disabled / setup failed)
+        # serves no services, so it must not read as plain Installed — the line
+        # points at enabling/reloading the existing entry instead.
+        monkeypatch.setattr(
+            cf,
+            "async_get_integration",
+            AsyncMock(return_value=SimpleNamespace(version="1.2.4")),
+        )
+        monkeypatch.setattr(cf, "_installed_server_version", lambda: "7.14.1")
+        flow = _make_options_flow(data={const.DATA_WEBHOOK_ID: "mcp_abc"})
+        flow.hass = self._hass_with_entries(
+            [
+                SimpleNamespace(data={const.CONF_ENTRY_TYPE: const.ENTRY_TYPE_SERVER}),
+                SimpleNamespace(
+                    data={const.CONF_ENTRY_TYPE: const.ENTRY_TYPE_TOOLS},
+                    state=cf.ConfigEntryState.NOT_LOADED,
+                ),
+            ]
+        )
+        form = asyncio.run(flow.async_step_init(None))
+        versions = form["description_placeholders"]["versions"]
+        assert "not loaded" in versions
+        assert "enable or reload" in versions
 
     def test_webhook_auth_is_first_option_field(self):
         # #1875: Authentication mode sits at the top of the options form,

--- a/tests/src/unit/test_config_flow.py
+++ b/tests/src/unit/test_config_flow.py
@@ -377,7 +377,11 @@ class TestServerOptionsFlow:
 
         form = asyncio.run(flow.async_step_init(None))
         versions = form["description_placeholders"]["versions"]
-        assert versions == "Component 0.14.0 - Server ha-mcp 7.9.0 (dev channel)"
+        # startswith, not equality: the tools-module status line (#1996) rides
+        # the same placeholder below the version line.
+        assert versions.startswith(
+            "Component 0.14.0 - Server ha-mcp 7.9.0 (dev channel)"
+        )
 
     def test_versions_placeholder_is_failure_proof(self, monkeypatch):
         # A broken version read must not break the form: the component read
@@ -396,9 +400,8 @@ class TestServerOptionsFlow:
 
         form = asyncio.run(flow.async_step_init(None))  # must not raise
         versions = form["description_placeholders"]["versions"]
-        assert (
-            versions
-            == "Component unknown - Server ha-mcp not installed yet (stable channel)"
+        assert versions.startswith(
+            "Component unknown - Server ha-mcp not installed yet (stable channel)"
         )
 
     def test_versions_placeholder_server_not_installed_yet(self, monkeypatch):
@@ -411,6 +414,65 @@ class TestServerOptionsFlow:
         # No hass on the flow ⇒ component "unknown"; server not installed yet.
         assert "not installed yet" in versions
         assert versions.startswith("Component unknown")
+
+    @staticmethod
+    def _hass_with_entries(entries):
+        """hass whose config-entry registry returns ``entries`` for the domain."""
+        hass = MagicMock()
+        hass.async_add_executor_job = AsyncMock(side_effect=lambda fn, *a: fn(*a))
+        hass.config_entries.async_entries = MagicMock(return_value=entries)
+        return hass
+
+    def test_versions_placeholder_flags_missing_tools_entry(self, monkeypatch):
+        # #1996: a server-entry-only install shows a status line directly under
+        # the version line pointing at the missing File & YAML Tools entry —
+        # users otherwise never learn about the second entry until a tool fails.
+        flow = _make_options_flow(data={const.DATA_WEBHOOK_ID: "mcp_abc"})
+        flow.hass = self._hass_with_entries(
+            [SimpleNamespace(data={const.CONF_ENTRY_TYPE: const.ENTRY_TYPE_SERVER})]
+        )
+        monkeypatch.setattr(
+            cf,
+            "async_get_integration",
+            AsyncMock(return_value=SimpleNamespace(version="1.2.4")),
+        )
+        monkeypatch.setattr(cf, "_installed_server_version", lambda: "7.14.1")
+
+        form = asyncio.run(flow.async_step_init(None))
+        versions = form["description_placeholders"]["versions"]
+        assert versions.startswith(
+            "Component 1.2.4 - Server ha-mcp 7.14.1 (stable channel)"
+        )
+        assert "Not installed" in versions
+        assert "Add entry" in versions
+
+    def test_versions_placeholder_shows_tools_entry_installed(self, monkeypatch):
+        # Both entries present → the status line reads Installed. A legacy tools
+        # entry without the entry_type discriminator counts as installed too
+        # (missing entry_type means tools, mirroring async_setup_entry).
+        monkeypatch.setattr(
+            cf,
+            "async_get_integration",
+            AsyncMock(return_value=SimpleNamespace(version="1.2.4")),
+        )
+        monkeypatch.setattr(cf, "_installed_server_version", lambda: "7.14.1")
+        for tools_data in (
+            {const.CONF_ENTRY_TYPE: const.ENTRY_TYPE_TOOLS},
+            {},  # legacy pre-#1527 entry
+        ):
+            flow = _make_options_flow(data={const.DATA_WEBHOOK_ID: "mcp_abc"})
+            flow.hass = self._hass_with_entries(
+                [
+                    SimpleNamespace(
+                        data={const.CONF_ENTRY_TYPE: const.ENTRY_TYPE_SERVER}
+                    ),
+                    SimpleNamespace(data=tools_data),
+                ]
+            )
+            form = asyncio.run(flow.async_step_init(None))
+            versions = form["description_placeholders"]["versions"]
+            assert "tools module (optional): Installed" in versions
+            assert "Not installed" not in versions
 
     def test_webhook_auth_is_first_option_field(self):
         # #1875: Authentication mode sits at the top of the options form,

--- a/tests/src/unit/test_config_flow.py
+++ b/tests/src/unit/test_config_flow.py
@@ -501,6 +501,28 @@ class TestServerOptionsFlow:
         assert "not loaded" in versions
         assert "enable or reload" in versions
 
+    def test_tools_module_hint_read_error_drops_line(self, monkeypatch):
+        # Failure-proof like the sibling hints: a raising entry-registry read
+        # drops the status line rather than breaking the options form.
+        flow = _make_options_flow(data={const.DATA_WEBHOOK_ID: "mcp_abc"})
+        hass = MagicMock()
+        hass.async_add_executor_job = AsyncMock(side_effect=lambda fn, *a: fn(*a))
+        hass.config_entries.async_entries = MagicMock(side_effect=RuntimeError("boom"))
+        flow.hass = hass
+        monkeypatch.setattr(
+            cf,
+            "async_get_integration",
+            AsyncMock(return_value=SimpleNamespace(version="1.2.4")),
+        )
+        monkeypatch.setattr(cf, "_installed_server_version", lambda: "7.14.1")
+
+        form = asyncio.run(flow.async_step_init(None))  # must not raise
+        versions = form["description_placeholders"]["versions"]
+        assert versions.startswith(
+            "Component 1.2.4 - Server ha-mcp 7.14.1 (stable channel)"
+        )
+        assert "tools module" not in versions
+
     def test_webhook_auth_is_first_option_field(self):
         # #1875: Authentication mode sits at the top of the options form,
         # directly under the connect URLs, so users find it without scrolling.

--- a/tests/src/unit/test_error_reason_extraction.py
+++ b/tests/src/unit/test_error_reason_extraction.py
@@ -1,0 +1,74 @@
+"""Unit tests for extract_structured_error_reason (tools/helpers.py).
+
+The helper is the single extraction seam behind the settings UI's beta panel,
+the legacy-backup degradation warnings, and the legacy read error mapping
+(#1996): its branches decide whether a human message + actionable step is
+surfaced or the caller falls back to its own generic prefix.
+"""
+
+import json
+
+import pytest
+from fastmcp.exceptions import ToolError
+
+from ha_mcp.errors import ErrorCode, create_error_response
+from ha_mcp.tools.helpers import extract_structured_error_reason
+
+
+class TestExtractStructuredErrorReason:
+    @pytest.mark.parametrize(
+        ("payload", "expected"),
+        [
+            # Message + no suggestions at all → bare message.
+            ({"error": {"message": "Broken."}}, "Broken."),
+            # Singular "suggestion" key (what create_error_response emits for
+            # exactly one suggestion) → appended.
+            (
+                {"error": {"message": "Broken.", "suggestion": "Fix it."}},
+                "Broken. Fix it.",
+            ),
+            # Plural list wins when present.
+            (
+                {
+                    "error": {
+                        "message": "Broken.",
+                        "suggestion": "Fix it.",
+                        "suggestions": ["First.", "Second."],
+                    }
+                },
+                "Broken. First.",
+            ),
+            # "error" present but not a dict → not a structured envelope.
+            ({"error": "oops"}, None),
+            # Missing / empty / non-str message → no usable reason.
+            ({"error": {"suggestions": ["x"]}}, None),
+            ({"error": {"message": ""}}, None),
+            ({"error": {"message": 42}}, None),
+        ],
+    )
+    def test_payload_shapes(self, payload, expected):
+        assert extract_structured_error_reason(ToolError(json.dumps(payload))) == (
+            expected
+        )
+
+    def test_non_json_and_non_dict_json_return_none(self):
+        assert extract_structured_error_reason(ToolError("plain text")) is None
+        assert extract_structured_error_reason(ToolError("[1, 2]")) is None
+
+    def test_real_serializations_round_trip(self):
+        # Built via create_error_response so the singular/plural key emission
+        # is the real one: one suggestion → singular key only, two → plural.
+        single = json.dumps(
+            create_error_response(
+                ErrorCode.COMPONENT_NOT_INSTALLED, "Entry missing.", suggestions=["A."]
+            )
+        )
+        assert extract_structured_error_reason(ToolError(single)) == "Entry missing. A."
+        double = json.dumps(
+            create_error_response(
+                ErrorCode.COMPONENT_NOT_INSTALLED,
+                "Entry missing.",
+                suggestions=["A.", "B."],
+            )
+        )
+        assert extract_structured_error_reason(ToolError(double)) == "Entry missing. A."

--- a/tests/src/unit/test_settings_ui.py
+++ b/tests/src/unit/test_settings_ui.py
@@ -4501,20 +4501,21 @@ class TestFsCustomPathsEndpoints:
         # #1996: a structured ToolError (e.g. the File & YAML Tools entry is
         # not set up) must surface its human message plus the actionable first
         # suggestion — not a "could not reach" prefix wrapping a raw JSON blob.
+        # The payload is built via create_error_response so the test exercises
+        # the REAL serialization: a single suggestion lands under the singular
+        # "suggestion" key only (the plural list needs two or more).
         from fastmcp.exceptions import ToolError
 
         import ha_mcp.tools.tools_filesystem as tf
+        from ha_mcp.errors import ErrorCode, create_error_response
         from ha_mcp.settings_ui import build_settings_handlers
 
         payload = json.dumps(
-            {
-                "success": False,
-                "error": {
-                    "code": "COMPONENT_NOT_INSTALLED",
-                    "message": "The optional entry is not set up.",
-                    "suggestions": ["Press Add entry to add it."],
-                },
-            }
+            create_error_response(
+                ErrorCode.COMPONENT_NOT_INSTALLED,
+                "The optional entry is not set up.",
+                suggestions=["Press Add entry to add it."],
+            )
         )
 
         monkeypatch.setattr(tf, "is_filesystem_tools_enabled", lambda: True)
@@ -4533,6 +4534,61 @@ class TestFsCustomPathsEndpoints:
             == "The optional entry is not set up. Press Add entry to add it."
         )
         assert "Could not reach" not in body["reason"]
+
+    @pytest.mark.asyncio
+    async def test_get_falls_back_on_json_that_is_not_an_envelope(self, monkeypatch):
+        # A ToolError whose string parses as JSON but is not the structured
+        # error envelope must NOT be embedded bare — the generic prefix applies.
+        from fastmcp.exceptions import ToolError
+
+        import ha_mcp.tools.tools_filesystem as tf
+        from ha_mcp.settings_ui import build_settings_handlers
+
+        monkeypatch.setattr(tf, "is_filesystem_tools_enabled", lambda: True)
+
+        async def boom(client, service, data):
+            raise ToolError("[1, 2]")
+
+        monkeypatch.setattr(tf, "call_mcp_tools_service", boom)
+        handlers = build_settings_handlers(server=MagicMock())
+        resp = await handlers["get_fs_custom_paths"](MagicMock())
+        body = json.loads(resp.body)
+        assert body["available"] is False
+        assert body["reason"].startswith("Could not reach the ha_mcp_tools component:")
+
+    @pytest.mark.asyncio
+    async def test_save_surfaces_structured_tool_error_message(self, monkeypatch):
+        # The save path carries the same extraction: a user fixing custom paths
+        # while the entry is missing hits POST, not GET (#1996).
+        from fastmcp.exceptions import ToolError
+
+        import ha_mcp.tools.tools_filesystem as tf
+        from ha_mcp.errors import ErrorCode, create_error_response
+        from ha_mcp.settings_ui import build_settings_handlers
+
+        payload = json.dumps(
+            create_error_response(
+                ErrorCode.COMPONENT_NOT_INSTALLED,
+                "The optional entry is not set up.",
+                suggestions=["Press Add entry to add it.", "Then retry."],
+            )
+        )
+
+        monkeypatch.setattr(tf, "is_filesystem_tools_enabled", lambda: True)
+
+        async def boom(client, service, data):
+            raise ToolError(payload)
+
+        monkeypatch.setattr(tf, "call_mcp_tools_service", boom)
+        handlers = build_settings_handlers(server=MagicMock())
+        req = MagicMock()
+        req.json = AsyncMock(return_value={"paths": ["pyscript"]})
+        resp = await handlers["save_fs_custom_paths"](req)
+        assert resp.status_code == 502
+        body = json.loads(resp.body)
+        message = body["error"]["message"]
+        assert message == "The optional entry is not set up. Press Add entry to add it."
+        assert "Could not reach" not in message
 
     @pytest.mark.asyncio
     async def test_save_disabled_returns_409(self, monkeypatch):

--- a/tests/src/unit/test_settings_ui.py
+++ b/tests/src/unit/test_settings_ui.py
@@ -4497,6 +4497,44 @@ class TestFsCustomPathsEndpoints:
         assert "connection refused" in body["reason"]
 
     @pytest.mark.asyncio
+    async def test_get_surfaces_structured_tool_error_message(self, monkeypatch):
+        # #1996: a structured ToolError (e.g. the File & YAML Tools entry is
+        # not set up) must surface its human message plus the actionable first
+        # suggestion — not a "could not reach" prefix wrapping a raw JSON blob.
+        from fastmcp.exceptions import ToolError
+
+        import ha_mcp.tools.tools_filesystem as tf
+        from ha_mcp.settings_ui import build_settings_handlers
+
+        payload = json.dumps(
+            {
+                "success": False,
+                "error": {
+                    "code": "COMPONENT_NOT_INSTALLED",
+                    "message": "The optional entry is not set up.",
+                    "suggestions": ["Press Add entry to add it."],
+                },
+            }
+        )
+
+        monkeypatch.setattr(tf, "is_filesystem_tools_enabled", lambda: True)
+
+        async def boom(client, service, data):
+            raise ToolError(payload)
+
+        monkeypatch.setattr(tf, "call_mcp_tools_service", boom)
+        handlers = build_settings_handlers(server=MagicMock())
+        resp = await handlers["get_fs_custom_paths"](MagicMock())
+        assert resp.status_code == 200
+        body = json.loads(resp.body)
+        assert body["available"] is False
+        assert (
+            body["reason"]
+            == "The optional entry is not set up. Press Add entry to add it."
+        )
+        assert "Could not reach" not in body["reason"]
+
+    @pytest.mark.asyncio
     async def test_save_disabled_returns_409(self, monkeypatch):
         import ha_mcp.tools.tools_filesystem as tf
         from ha_mcp.settings_ui import build_settings_handlers

--- a/tests/src/unit/test_tools_bug_report.py
+++ b/tests/src/unit/test_tools_bug_report.py
@@ -214,14 +214,33 @@ class TestBugReportTool:
         )
 
     @pytest.mark.asyncio
+    async def test_tools_entry_status_pre_050_component(
+        self, ha_report_issue_func, mock_client
+    ):
+        """Domain services present but no get_caller_token → the report names
+        the pre-0.5.0 state distinctly from entry-not-set-up."""
+        mock_client.get_config.return_value = {"version": "2024.12.0"}
+        mock_client.get_states.return_value = []
+        mock_client.get_services = AsyncMock(
+            return_value=[{"domain": "ha_mcp_tools", "services": {"list_files": {}}}]
+        )
+
+        result = await ha_report_issue_func()
+
+        status = result["diagnostic_info"]["tools_entry_status"]
+        assert status == "set up, but the component is pre-0.5.0 (update via HACS)"
+
+    @pytest.mark.asyncio
     async def test_tools_entry_status_probe_failure_degrades(
         self, ha_report_issue_func, mock_client
     ):
-        """Failing probes must not break the report — the lines read unknown.
-        (The fixture's MagicMock get_services / send_websocket_message are not
-        awaitable, which is exactly a probe failure.)"""
+        """Failing probes must not break the report — the lines read unknown."""
         mock_client.get_config.return_value = {"version": "2024.12.0"}
         mock_client.get_states.return_value = []
+        mock_client.get_services = AsyncMock(side_effect=RuntimeError("probe boom"))
+        mock_client.send_websocket_message = AsyncMock(
+            side_effect=RuntimeError("probe boom")
+        )
 
         result = await ha_report_issue_func()
 
@@ -268,8 +287,9 @@ class TestBugReportTool:
     async def test_server_entry_status_not_added(
         self, ha_report_issue_func, mock_client
     ):
-        """Only the tools entry exists → the server entry reads not added
-        (the tools entry's own state comes from the services probe, not here)."""
+        """Only tools entries exist (current or pre-#1853 legacy title) → the
+        server entry reads not added (the tools entry's own state comes from
+        the services probe, not here)."""
         mock_client.get_config.return_value = {"version": "2024.12.0"}
         mock_client.get_states.return_value = []
         mock_client.send_websocket_message = AsyncMock(
@@ -280,7 +300,8 @@ class TestBugReportTool:
                         "entry_id": "b2",
                         "title": "HA-MCP File & YAML Tools",
                         "state": "loaded",
-                    }
+                    },
+                    {"entry_id": "c3", "title": "HA MCP Tools", "state": "not_loaded"},
                 ],
             }
         )
@@ -289,6 +310,25 @@ class TestBugReportTool:
 
         assert result["diagnostic_info"]["server_entry_status"] == "not added"
         assert "In-process Server entry: not added" in result["formatted_report"]
+
+    @pytest.mark.asyncio
+    async def test_server_entry_status_unknown_on_ws_rejection(
+        self, ha_report_issue_func, mock_client
+    ):
+        """A rejected config_entries/get (success False) degrades to unknown."""
+        mock_client.get_config.return_value = {"version": "2024.12.0"}
+        mock_client.get_states.return_value = []
+        mock_client.send_websocket_message = AsyncMock(
+            return_value={"success": False, "error": "nope"}
+        )
+
+        result = await ha_report_issue_func()
+
+        assert result["diagnostic_info"]["server_entry_status"] is None
+        assert (
+            "In-process Server entry: unknown (probe failed)"
+            in result["formatted_report"]
+        )
 
     @pytest.mark.asyncio
     async def test_server_entry_status_renamed_entry_reported_unrecognized(

--- a/tests/src/unit/test_tools_bug_report.py
+++ b/tests/src/unit/test_tools_bug_report.py
@@ -217,9 +217,9 @@ class TestBugReportTool:
     async def test_tools_entry_status_probe_failure_degrades(
         self, ha_report_issue_func, mock_client
     ):
-        """A failing services probe must not break the report — the line reads
-        unknown. (The fixture's MagicMock get_services is not awaitable, which
-        is exactly a probe failure.)"""
+        """Failing probes must not break the report — the lines read unknown.
+        (The fixture's MagicMock get_services / send_websocket_message are not
+        awaitable, which is exactly a probe failure.)"""
         mock_client.get_config.return_value = {"version": "2024.12.0"}
         mock_client.get_states.return_value = []
 
@@ -227,10 +227,91 @@ class TestBugReportTool:
 
         assert result["success"] is True
         assert result["diagnostic_info"]["tools_entry_status"] is None
+        assert result["diagnostic_info"]["server_entry_status"] is None
         assert (
             "File & YAML Tools entry: unknown (probe failed)"
             in (result["formatted_report"])
         )
+        assert (
+            "In-process Server entry: unknown (probe failed)"
+            in (result["formatted_report"])
+        )
+
+    @pytest.mark.asyncio
+    async def test_server_entry_status_added(self, ha_report_issue_func, mock_client):
+        """The report names the in-process server entry distinctly — so e.g.
+        an add-on install that also (erroneously) added the "HA-MCP Server"
+        entry shows both parts of the component next to Installation Method."""
+        mock_client.get_config.return_value = {"version": "2024.12.0"}
+        mock_client.get_states.return_value = []
+        mock_client.send_websocket_message = AsyncMock(
+            return_value={
+                "success": True,
+                "result": [
+                    {"entry_id": "a1", "title": "HA-MCP Server", "state": "loaded"},
+                    {
+                        "entry_id": "b2",
+                        "title": "HA-MCP File & YAML Tools",
+                        "state": "loaded",
+                    },
+                ],
+            }
+        )
+
+        result = await ha_report_issue_func()
+
+        assert result["diagnostic_info"]["server_entry_status"] == "added (loaded)"
+        assert "In-process Server entry: added (loaded)" in result["formatted_report"]
+        assert "In-process Server entry:" in result["runtime_bug_template"]
+
+    @pytest.mark.asyncio
+    async def test_server_entry_status_not_added(
+        self, ha_report_issue_func, mock_client
+    ):
+        """Only the tools entry exists → the server entry reads not added
+        (the tools entry's own state comes from the services probe, not here)."""
+        mock_client.get_config.return_value = {"version": "2024.12.0"}
+        mock_client.get_states.return_value = []
+        mock_client.send_websocket_message = AsyncMock(
+            return_value={
+                "success": True,
+                "result": [
+                    {
+                        "entry_id": "b2",
+                        "title": "HA-MCP File & YAML Tools",
+                        "state": "loaded",
+                    }
+                ],
+            }
+        )
+
+        result = await ha_report_issue_func()
+
+        assert result["diagnostic_info"]["server_entry_status"] == "not added"
+        assert "In-process Server entry: not added" in result["formatted_report"]
+
+    @pytest.mark.asyncio
+    async def test_server_entry_status_renamed_entry_reported_unrecognized(
+        self, ha_report_issue_func, mock_client
+    ):
+        """A user-renamed entry cannot be classified by title — the report
+        lists it as unrecognized instead of wrongly claiming not added."""
+        mock_client.get_config.return_value = {"version": "2024.12.0"}
+        mock_client.get_states.return_value = []
+        mock_client.send_websocket_message = AsyncMock(
+            return_value={
+                "success": True,
+                "result": [
+                    {"entry_id": "a1", "title": "My Renamed Entry", "state": "loaded"}
+                ],
+            }
+        )
+
+        result = await ha_report_issue_func()
+
+        status = result["diagnostic_info"]["server_entry_status"]
+        assert status.startswith("not identified — unrecognized")
+        assert '"My Renamed Entry" (loaded)' in status
 
     @pytest.mark.asyncio
     async def test_bug_report_connection_error(self, registered_tools, mock_client):

--- a/tests/src/unit/test_tools_bug_report.py
+++ b/tests/src/unit/test_tools_bug_report.py
@@ -168,6 +168,71 @@ class TestBugReportTool:
         assert "KEEP AS-IS" in anon_guide
 
     @pytest.mark.asyncio
+    async def test_tools_entry_status_not_set_up(
+        self, ha_report_issue_func, mock_client
+    ):
+        """No ha_mcp_tools services → the report flags the missing File & YAML
+        Tools entry with the Add-entry pointer instead of conflating it with
+        "component not installed" (#1996)."""
+        mock_client.get_config.return_value = {"version": "2024.12.0"}
+        mock_client.get_states.return_value = []
+        mock_client.get_services = AsyncMock(
+            return_value=[{"domain": "light", "services": {"turn_on": {}}}]
+        )
+
+        result = await ha_report_issue_func()
+
+        status = result["diagnostic_info"]["tools_entry_status"]
+        assert "not set up" in status
+        assert "Add entry" in status
+        report = result["formatted_report"]
+        assert "File & YAML Tools entry: not set up" in report
+        assert "File & YAML Tools entry:" in result["runtime_bug_template"]
+
+    @pytest.mark.asyncio
+    async def test_tools_entry_status_set_up(self, ha_report_issue_func, mock_client):
+        """ha_mcp_tools services present (incl. get_caller_token) → the report
+        shows the entry as set up."""
+        mock_client.get_config.return_value = {"version": "2024.12.0"}
+        mock_client.get_states.return_value = []
+        mock_client.get_services = AsyncMock(
+            return_value=[
+                {
+                    "domain": "ha_mcp_tools",
+                    "services": {"get_caller_token": {}, "list_files": {}},
+                }
+            ]
+        )
+
+        result = await ha_report_issue_func()
+
+        status = result["diagnostic_info"]["tools_entry_status"]
+        assert status == "set up (ha_mcp_tools services registered)"
+        assert (
+            "File & YAML Tools entry: set up (ha_mcp_tools services registered)"
+            in result["formatted_report"]
+        )
+
+    @pytest.mark.asyncio
+    async def test_tools_entry_status_probe_failure_degrades(
+        self, ha_report_issue_func, mock_client
+    ):
+        """A failing services probe must not break the report — the line reads
+        unknown. (The fixture's MagicMock get_services is not awaitable, which
+        is exactly a probe failure.)"""
+        mock_client.get_config.return_value = {"version": "2024.12.0"}
+        mock_client.get_states.return_value = []
+
+        result = await ha_report_issue_func()
+
+        assert result["success"] is True
+        assert result["diagnostic_info"]["tools_entry_status"] is None
+        assert (
+            "File & YAML Tools entry: unknown (probe failed)"
+            in (result["formatted_report"])
+        )
+
+    @pytest.mark.asyncio
     async def test_bug_report_connection_error(self, registered_tools, mock_client):
         """Test bug report when connection fails."""
         # Setup mock to raise exception

--- a/tests/src/unit/test_tools_filesystem.py
+++ b/tests/src/unit/test_tools_filesystem.py
@@ -260,11 +260,14 @@ class TestAssertMcpToolsAvailableCapsFirst:
                 "ha_mcp.tools.tools_filesystem.get_component_caps",
                 AsyncMock(return_value=None),
             ),
-            pytest.raises(ToolError),
+            pytest.raises(ToolError) as exc_info,
         ):
             await _assert_mcp_tools_available(client)
 
         client.get_services.assert_awaited_once()
+        # Routes to the "add the entry" error (#1996), not "too old".
+        assert "HA-MCP File & YAML Tools" in str(exc_info.value)
+        assert "too old" not in str(exc_info.value)
 
 
 class TestRegisterFilesystemTools:


### PR DESCRIPTION
## What does this PR do?

Closes #1996.

Users who install the HA-MCP integration but never add the second "HA-MCP File & YAML Tools" entry hit a misleading error: the caller-token pre-flight found no `get_caller_token` service and reported the component as "too old (pre-0.5.0), update via HACS" — even on a fully current component. Updating via HACS can never fix that state, and the reporter in #1996 was stuck on exactly that loop until pointed at "Add entry".

Two changes:

1. **The server error now distinguishes the two states.** The pre-flight checks whether any `ha_mcp_tools` services are registered at all:
   - No services at all → new actionable error: the optional "HA-MCP File & YAML Tools" entry is not set up — add it via Settings → Devices & Services → HA-MCP → "Add entry" (HACS install steps as fallback when the integration is missing entirely). `_assert_mcp_tools_available` raises the same error for consistency.
   - Services present but no `get_caller_token` → unchanged "too old, update via HACS" prompt (genuine pre-0.5.0 component).
2. **The server entry's Configure dialog surfaces the entry state.** A status line renders directly under the version line: `Beta/advanced file & YAML tools module (optional): Installed` / `Not installed — press "Add entry" on the HA-MCP integration page and choose "HA-MCP File & YAML Tools" to add it`. It rides the existing `{versions}` placeholder so every translation shows it without strings changes, and it is dropped (rather than breaking the form) if the entry registry cannot be read — same failure-proofing as the other hints.

Component version: 1.2.4 (level with stable 1.2.3, so this opens the pending version; no new services or arguments, so `MIN_COMPONENT_VERSION` is unchanged).

Review round (multi-agent + Codex, all addressed in-branch):

- Guidance strings now name the real Devices & Services tile ("HA-MCP Custom Component"); the options-form hint says "this integration's page" since the reader is already on it.
- The settings UI's beta custom-paths panel extracts the human message + first actionable suggestion from a structured `ToolError` instead of rendering a "could not reach" prefix around a raw JSON blob.
- `backup_manager`'s legacy-backup catches now include `ToolError`, restoring the documented graceful degradation of the edits list when the tools entry is absent.
- The Configure status line reports an existing-but-unloaded tools entry as "Installed but not loaded" (Codex finding) rather than plain Installed.
- Added tests: hint failure-proof path, `_assert_mcp_tools_available` message routing, malformed services entry, suggestion ordering, structured-reason extraction, ToolError degrade for legacy backups.
- Round two (clean-prompt agent run): shared `extract_structured_error_reason` helper (honors the singular `suggestion` key) reused by the settings UI and the legacy-backup read; a suppressed legacy-backup fetch now surfaces as top-level `warnings` on the edits list instead of a silently incomplete listing; settings-UI tests build payloads via `create_error_response` so they exercise the real serialization; save-path, non-envelope-JSON, and mixed-entry-state tests added.


- `ha_report_issue` now separates the two component parts in the plain report and both issue templates: a "File & YAML Tools entry" line (set up / set up but pre-0.5.0 / not set up with the Add-entry pointer / unknown) and an "In-process Server entry" line (added with state / not added / not identified for renamed entries) — so support reports show exactly which part of `ha_mcp_tools` is installed, e.g. an add-on install that erroneously also added the in-process server.

## Type of change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

Ran locally: `test_caller_token_auth.py` (38 passed, including the new no-domain-services regression test), `test_config_flow.py` (51 passed, including the new Installed / Not installed status-line tests), `mypy src/` (clean), ruff check + format. Full e2e suite rides CI.

## Checklist
- [x] I have updated documentation if needed

