### PR TITLE
docs: add mcpindex screened badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![mcpindex](https://mcpindex.ai/api/v1/badge/io-github-homeassistant-ai-ha-mcp)](https://mcpindex.ai/server/io-github-homeassistant-ai-ha-mcp)
+
 > **Breaking change (v7.3.0):** `ha_config_set_yaml` has been moved to [beta](docs/beta.md).
 
 <div align="center">


### PR DESCRIPTION
Hey, ha-mcp's registered server came back clean on mcpindex's description-level screen (injection/manipulation check on the tool description). Added the badge to your README in case it's useful. Advisory only, not a security cert. Feel free to close if not.