### PR TITLE
fix: honor view_path scoping in ha_config_get_dashboard get mode

### DIFF
--- a/src/ha_mcp/dashboard_screenshot/paths.py
+++ b/src/ha_mcp/dashboard_screenshot/paths.py
@@ -347,6 +347,77 @@ async def fetch_dashboard_render_config(
     return cast(dict[str, Any], config)
 
 
+def match_dashboard_view(
+    dashboard_url_path: str,
+    config: dict[str, Any],
+    view_path: str,
+    *,
+    strategy_suggestions: tuple[str, ...] = (
+        "Use dashboard_path with the frontend route instead",
+    ),
+) -> tuple[int, dict[str, Any]]:
+    """Match one named Lovelace view by its configured ``views[].path``.
+
+    Shared by screenshot view resolution and get-mode view scoping so both
+    honour identical semantics: exact match on the configured path, with
+    structured errors for an empty path, a strategy dashboard (no static
+    views to match), and a missing/ambiguous path (the not-found error lists
+    the available paths). Returns ``(view_index, view)``.
+
+    ``strategy_suggestions`` lets each caller phrase the strategy-dashboard
+    remediation in its own vocabulary (the screenshot tools have a
+    ``dashboard_path`` route parameter; config scoping does not).
+    """
+    if not view_path.strip():
+        raise_tool_error(
+            create_error_response(
+                ErrorCode.VALIDATION_INVALID_PARAMETER,
+                "view_path cannot be empty.",
+                context={"view_path": view_path},
+            )
+        )
+    if "strategy" in config:
+        raise_tool_error(
+            create_error_response(
+                ErrorCode.VALIDATION_INVALID_PARAMETER,
+                "Strategy dashboards do not expose static named view paths.",
+                context={
+                    "dashboard_url_path": dashboard_url_path,
+                    "view_path": view_path,
+                },
+                suggestions=list(strategy_suggestions),
+            )
+        )
+    views = config.get("views")
+    if not isinstance(views, list):
+        views = []
+    matches = [
+        (index, view)
+        for index, view in enumerate(views)
+        if _configured_view_path(view) == view_path
+    ]
+    if len(matches) != 1:
+        available = [
+            view.get("path")
+            for view in views
+            if isinstance(view, dict) and isinstance(view.get("path"), str)
+        ]
+        reason = "not found" if not matches else "ambiguous"
+        raise_tool_error(
+            create_error_response(
+                ErrorCode.RESOURCE_NOT_FOUND,
+                f"Dashboard view path '{view_path}' is {reason}.",
+                context={
+                    "dashboard_url_path": dashboard_url_path,
+                    "view_path": view_path,
+                    "available_view_paths": available,
+                },
+                suggestions=["Use a view_path returned by ha_config_get_dashboard"],
+            )
+        )
+    return matches[0]
+
+
 def resolve_dashboard_view(
     dashboard_url_path: str,
     config: dict[str, Any],
@@ -381,56 +452,11 @@ def resolve_dashboard_view(
             warnings=(warning,),
         )
 
+    view_index, _ = match_dashboard_view(dashboard_url_path, config, view_path)
     cleaned_view_path = view_path
-    if not cleaned_view_path.strip():
-        raise_tool_error(
-            create_error_response(
-                ErrorCode.VALIDATION_INVALID_PARAMETER,
-                "view_path cannot be empty.",
-                context={"view_path": view_path},
-            )
-        )
-    if "strategy" in config:
-        raise_tool_error(
-            create_error_response(
-                ErrorCode.VALIDATION_INVALID_PARAMETER,
-                "Strategy dashboards do not expose static named view paths.",
-                context={
-                    "dashboard_url_path": dashboard_url_path,
-                    "view_path": cleaned_view_path,
-                },
-                suggestions=["Use dashboard_path with the frontend route instead"],
-            )
-        )
     views = config.get("views")
     if not isinstance(views, list):
         views = []
-    matches = [
-        (index, view)
-        for index, view in enumerate(views)
-        if _configured_view_path(view) == cleaned_view_path
-    ]
-    if len(matches) != 1:
-        available = [
-            view.get("path")
-            for view in views
-            if isinstance(view, dict) and isinstance(view.get("path"), str)
-        ]
-        reason = "not found" if not matches else "ambiguous"
-        raise_tool_error(
-            create_error_response(
-                ErrorCode.RESOURCE_NOT_FOUND,
-                f"Dashboard view path '{cleaned_view_path}' is {reason}.",
-                context={
-                    "dashboard_url_path": dashboard_url_path,
-                    "view_path": cleaned_view_path,
-                    "available_view_paths": available,
-                },
-                suggestions=["Use a view_path returned by ha_config_get_dashboard"],
-            )
-        )
-
-    view_index, _ = matches[0]
     render_path = _safe_named_render_path(base_path, cleaned_view_path)
     if render_path is None:
         return _fallback_view_target(

--- a/src/ha_mcp/tools/tools_bug_report.py
+++ b/src/ha_mcp/tools/tools_bug_report.py
@@ -34,7 +34,7 @@ from ..utils.usage_logger import (
 )
 from .component_api import get_component_caps
 from .helpers import log_tool_usage, register_tool_methods
-from .util_helpers import ANSI_ESCAPE_RE
+from .util_helpers import ANSI_ESCAPE_RE, JSON_STRING_COERCION, project_fields
 
 logger = logging.getLogger(__name__)
 
@@ -676,6 +676,27 @@ class BugReportTools:
                 ),
             ),
         ] = 10,
+        fields: Annotated[
+            str | list[str] | None,
+            JSON_STRING_COERCION,
+            Field(
+                default=None,
+                description=(
+                    "Return only the specified top-level response keys — the "
+                    "full response (both templates + logs + diagnostics, with "
+                    "the same log content repeated in each) is very large. "
+                    "None = full response. Typical for a runtime bug: "
+                    "'runtime_bug_template,suggested_title,"
+                    "runtime_bug_submit_url,duplicate_check_urls,"
+                    "anonymization_guide,instructions'; for agent feedback "
+                    "swap in agent_behavior_template/agent_behavior_submit_url. "
+                    "The templates already embed the relevant logs, so the raw "
+                    "recent_logs/startup_logs/addon_logs/core_error_log/"
+                    "formatted_report keys are only needed for your own "
+                    "analysis."
+                ),
+            ),
+        ] = None,
         ctx: Context | None = None,
     ) -> dict[str, Any]:
         """
@@ -709,7 +730,10 @@ class BugReportTools:
         - "That was inefficient"
 
         **OUTPUT:**
-        Returns both templates plus diagnostic data. Key fields:
+        Returns both templates plus diagnostic data. The full response is
+        LARGE (the captured logs appear in the raw log keys AND inside each
+        template) — pass fields=... to fetch only the keys you need once you
+        know which template applies. Key fields:
         - `runtime_bug_template`, `agent_behavior_template` — pick based on context
         - `recent_logs`, `startup_logs` — captured ha-mcp tool/server log entries
         - `addon_logs` — addon container stdout/stderr (HA add-on installs only;
@@ -843,7 +867,7 @@ class BugReportTools:
             for keyword in search_keywords[:3]  # Limit to top 3 keywords
         ]
 
-        return {
+        result: dict[str, Any] = {
             "success": True,
             "diagnostic_info": diagnostic_info,
             "recent_logs": recent_logs,
@@ -934,6 +958,7 @@ class BugReportTools:
                 "CRITICAL: Always ANONYMIZE the report BEFORE presenting it in markdown code blocks!"
             ),
         }
+        return project_fields(result, fields)
 
 
 def register_bug_report_tools(mcp: Any, client: Any, **kwargs: Any) -> None:

--- a/src/ha_mcp/tools/tools_bug_report.py
+++ b/src/ha_mcp/tools/tools_bug_report.py
@@ -684,23 +684,30 @@ class BugReportTools:
                 description=(
                     "Return only the specified top-level response keys — the "
                     "full response (both templates + logs + diagnostics, with "
-                    "the same log content repeated in each) is very large. "
+                    "log content repeated across the raw keys and templates) "
+                    "is very large. "
                     "None = full response. Typical for a runtime bug: "
                     "'runtime_bug_template,suggested_title,"
                     "runtime_bug_submit_url,duplicate_check_urls,"
                     "anonymization_guide,instructions'; for agent feedback "
-                    "swap in agent_behavior_template/agent_behavior_submit_url. "
-                    "The templates already embed the relevant logs, so the raw "
-                    "recent_logs/startup_logs/addon_logs/core_error_log/"
-                    "formatted_report keys are only needed for your own "
-                    "analysis."
+                    "swap in agent_behavior_template and "
+                    "agent_behavior_submit_url. The templates already embed "
+                    "the relevant logs, so the raw log keys are only needed "
+                    "for your own analysis. "
+                    "Available keys: diagnostic_info, recent_logs, "
+                    "startup_logs, addon_logs, core_error_log, log_count, "
+                    "startup_log_count, formatted_report, "
+                    "runtime_bug_template, agent_behavior_template, "
+                    "anonymization_guide, suggested_title, "
+                    "runtime_bug_submit_url, agent_behavior_submit_url, "
+                    "duplicate_check_urls, missing_tool_hint, instructions."
                 ),
             ),
         ] = None,
         ctx: Context | None = None,
     ) -> dict[str, Any]:
         """
-        Collect diagnostic information for filing issue reports or feedback.
+        Get diagnostic information and templates for filing issue reports or feedback.
 
         This tool generates templates for TWO types of reports:
         1. **Runtime Bug Report** - For ha-mcp errors, failures, unexpected behavior

--- a/src/ha_mcp/tools/tools_config_dashboards.py
+++ b/src/ha_mcp/tools/tools_config_dashboards.py
@@ -1508,12 +1508,14 @@ def _note_screenshot_ignored(
     options: _DashboardScreenshotOptions | None = None,
     mode: str,
 ) -> None:
-    """Warn when a screenshot was requested in a mode that can't render one.
+    """Warn when get-mode-only options are passed to a mode that ignores them.
 
-    Screenshot options are only honoured in get mode. In list and search mode
-    they are accepted but inapplicable, so surface a
-    ``warnings`` entry rather than dropping the request as a silent no-op
-    (matches the warn-don't-fail contract the params document)."""
+    Screenshot options — and ``view_path``, which is a get-mode scoping
+    parameter that merely travels inside the options dataclass — are only
+    honoured in get mode. In list and search mode they are accepted but
+    inapplicable, so surface a ``warnings`` entry rather than dropping the
+    request as a silent no-op (matches the warn-don't-fail contract the
+    params document)."""
     capture_options = options or _DashboardScreenshotOptions(full_page=full_page)
     if include_screenshot or capture_options != _DashboardScreenshotOptions():
         result.setdefault("warnings", []).append(
@@ -1833,7 +1835,7 @@ class DashboardConfigTools:
         view_path: Annotated[
             str | None,
             Field(
-                description="Get mode: return ONLY the view whose stable "
+                description="Get mode: return ONLY the view whose "
                 "Lovelace views[].path matches (response carries 'view' + "
                 "'view_index' instead of the full 'config') — use this to keep "
                 "multi-view dashboards from blowing up the response when you "
@@ -1943,7 +1945,11 @@ class DashboardConfigTools:
         try:
             if mode == "search":
                 # Cross-dashboard search takes precedence over every other mode.
-                return await self._get_dashboard_search_all_mode(query)
+                return await self._get_dashboard_search_all_mode(
+                    query,
+                    include_screenshot=include_screenshot,
+                    screenshot_options=screenshot_options,
+                )
 
             if list_only:
                 return await self._get_dashboard_list_mode(
@@ -2298,7 +2304,13 @@ class DashboardConfigTools:
         )
         return search_result
 
-    async def _get_dashboard_search_all_mode(self, query: str | None) -> dict[str, Any]:
+    async def _get_dashboard_search_all_mode(
+        self,
+        query: str | None,
+        *,
+        include_screenshot: bool,
+        screenshot_options: _DashboardScreenshotOptions,
+    ) -> dict[str, Any]:
         """mode='search': find which storage dashboards contain ``query``.
 
         The component ``search`` walks every storage dashboard in one in-process
@@ -2340,6 +2352,12 @@ class DashboardConfigTools:
                 f"Results capped at {_SEARCH_ALL_MATCH_CAP} matches; "
                 "refine the query for a complete list."
             ]
+        _note_screenshot_ignored(
+            result,
+            include_screenshot=include_screenshot,
+            options=screenshot_options,
+            mode="search",
+        )
         return result
 
     async def _search_all_dashboards(

--- a/src/ha_mcp/tools/tools_config_dashboards.py
+++ b/src/ha_mcp/tools/tools_config_dashboards.py
@@ -37,6 +37,7 @@ from ..dashboard_screenshot.content import (
 from ..dashboard_screenshot.paths import (
     dashboard_frontend_path,
     dashboard_render_paths,
+    match_dashboard_view,
     resolve_dashboard_view,
 )
 from ..errors import ErrorCode, create_error_response
@@ -1516,10 +1517,10 @@ def _note_screenshot_ignored(
     capture_options = options or _DashboardScreenshotOptions(full_page=full_page)
     if include_screenshot or capture_options != _DashboardScreenshotOptions():
         result.setdefault("warnings", []).append(
-            f"include_screenshot and screenshot render options are ignored in {mode} "
-            "mode; call "
+            f"include_screenshot, view_path, and screenshot render options are "
+            f"ignored in {mode} mode; call "
             "ha_config_get_dashboard with a url_path (and no search criteria) "
-            "to get a screenshot."
+            "to scope to a view or get a screenshot."
         )
 
 
@@ -1832,8 +1833,13 @@ class DashboardConfigTools:
         view_path: Annotated[
             str | None,
             Field(
-                description="With include_screenshot: stable Lovelace "
-                "views[].path to render. Omit to render the dashboard base route."
+                description="Get mode: return ONLY the view whose stable "
+                "Lovelace views[].path matches (response carries 'view' + "
+                "'view_index' instead of the full 'config') — use this to keep "
+                "multi-view dashboards from blowing up the response when you "
+                "only need one view. Does not require any beta feature. With "
+                "include_screenshot, also selects the view to render. Ignored "
+                "in list/search mode. Omit for the full config."
             ),
         ] = None,
         mode: Annotated[
@@ -1880,6 +1886,13 @@ class DashboardConfigTools:
         MODE 3 — Get: Active when list_only=False and no search parameters are provided.
           Returns the full Lovelace dashboard config, defaulting to the
           main dashboard if url_path is omitted.
+          Pass view_path=<views[].path> to return ONLY that view: the response
+          then carries `view` + `view_index` instead of `config`, keeping the
+          payload small on multi-view dashboards. `config_hash` still covers
+          the FULL config, so a follow-up
+          ha_config_set_dashboard(python_transform=...) addressing
+          config['views'][view_index] validates unchanged. An unknown
+          view_path errors and lists the available view paths.
 
         MODE 4 — Search all: mode="search" with query=<entity_id or text>
           Answers "which dashboards contain this entity/card" by walking every
@@ -1900,6 +1913,7 @@ class DashboardConfigTools:
         - List all dashboards: ha_config_get_dashboard(list_only=True)
         - Get default dashboard: ha_config_get_dashboard(url_path="default")
         - Get custom dashboard: ha_config_get_dashboard(url_path="lovelace-mobile")
+        - Get one view only: ha_config_get_dashboard(url_path="lovelace-mobile", view_path="office")
         - Force reload: ha_config_get_dashboard(url_path="lovelace-home", force_reload=True)
         - Find cards by entity: ha_config_get_dashboard(url_path="my-dash", entity_id="light.living_room")
         - Find by wildcard: ha_config_get_dashboard(url_path="my-dash", entity_id="sensor.temperature_*")
@@ -1972,6 +1986,7 @@ class DashboardConfigTools:
                 url_path,
                 resolved_url_path=resolved_url_path,
                 force_reload=force_reload,
+                view_path=view_path,
                 include_screenshot=include_screenshot,
                 screenshot_options=screenshot_options,
             )
@@ -2434,6 +2449,7 @@ class DashboardConfigTools:
         *,
         resolved_url_path: list[str | None],
         force_reload: bool,
+        view_path: str | None,
         include_screenshot: bool,
         screenshot_options: _DashboardScreenshotOptions,
     ) -> "dict[str, Any] | ToolResult":
@@ -2468,6 +2484,7 @@ class DashboardConfigTools:
                 url_path,
                 component_config,
                 original_url_path=url_path,
+                view_path=view_path,
                 include_screenshot=include_screenshot,
                 screenshot_options=screenshot_options,
             )
@@ -2518,6 +2535,7 @@ class DashboardConfigTools:
             url_path,
             config,
             original_url_path=original_url_path,
+            view_path=view_path,
             include_screenshot=include_screenshot,
             screenshot_options=screenshot_options,
         )
@@ -2528,6 +2546,7 @@ class DashboardConfigTools:
         config: Any,
         *,
         original_url_path: str | None,
+        view_path: str | None,
         include_screenshot: bool,
         screenshot_options: _DashboardScreenshotOptions,
     ) -> "dict[str, Any] | ToolResult":
@@ -2538,6 +2557,14 @@ class DashboardConfigTools:
         render paths, ``resolved_from`` (when the legacy lazy resolver
         canonicalised an internal id), the large-config disclosure hint, and an
         optional screenshot.
+
+        ``view_path`` scopes the payload to one view: the response carries
+        ``view`` + ``view_index`` instead of ``config``. The scoped envelope
+        deliberately has NO ``config`` key so the view object cannot be
+        mistaken for a full config and pushed back through
+        ``ha_config_set_dashboard(config=...)``, which would drop every other
+        view; ``config_hash``/``config_size_bytes`` still describe the full
+        config so ``python_transform`` optimistic locking works unchanged.
         """
         # Compute hash for optimistic locking in subsequent operations
         config_hash = compute_config_hash(config) if isinstance(config, dict) else None
@@ -2545,19 +2572,37 @@ class DashboardConfigTools:
         # Calculate config size for progressive disclosure hint
         config_size = len(json.dumps(config)) if isinstance(config, dict) else 0
 
-        get_result: dict[str, Any] = {
-            "success": True,
-            "action": "get",
-            "url_path": url_path,
-            "config": config,
-            "config_hash": config_hash,
-            "config_size_bytes": config_size,
-        }
-        _attach_dashboard_render_paths(
-            get_result,
-            url_path,
-            config if isinstance(config, dict) else None,
-        )
+        if view_path is not None:
+            get_result = self._scoped_view_get_result(
+                url_path,
+                config,
+                view_path=view_path,
+                config_hash=config_hash,
+                config_size=config_size,
+            )
+        else:
+            get_result = {
+                "success": True,
+                "action": "get",
+                "url_path": url_path,
+                "config": config,
+                "config_hash": config_hash,
+                "config_size_bytes": config_size,
+            }
+            _attach_dashboard_render_paths(
+                get_result,
+                url_path,
+                config if isinstance(config, dict) else None,
+            )
+            # Add hint for large configs (progressive disclosure) - 10KB ≈ 2-3k tokens
+            if config_size >= 10000:
+                get_result["hint"] = (
+                    f"Large config ({config_size:,} bytes). Pass view_path=... "
+                    "to fetch a single view, or use "
+                    "ha_config_get_dashboard(entity_id=...) to find card positions, "
+                    "then ha_config_set_dashboard(python_transform=...) "
+                    "instead of full config replacement."
+                )
         # Surface the original caller-passed identifier when the lazy
         # resolver canonicalised it (parity with delete_dashboard's
         # resolved_id field). Caller can use this to detect that their
@@ -2565,24 +2610,90 @@ class DashboardConfigTools:
         if original_url_path is not None and original_url_path != url_path:
             get_result["resolved_from"] = original_url_path
 
-        # Add hint for large configs (progressive disclosure) - 10KB ≈ 2-3k tokens
-        if config_size >= 10000:
-            get_result["hint"] = (
-                f"Large config ({config_size:,} bytes). For edits, use "
-                "ha_config_get_dashboard(entity_id=...) to find card positions, "
-                "then ha_config_set_dashboard(python_transform=...) "
-                "instead of full config replacement."
-            )
-
         return await _maybe_attach_screenshot(
             get_result,
             url_path,
             include_screenshot,
             client=self._client,
             config=config if isinstance(config, dict) else None,
-            options=screenshot_options,
+            # view_path doubles as the get-mode scoping parameter now, so a
+            # scoped read without a screenshot request must not trip the
+            # "screenshot render options are ignored" warning.
+            options=(
+                screenshot_options
+                if include_screenshot
+                else replace(screenshot_options, view_path=None)
+            ),
             raise_on_failure=True,
         )
+
+    def _scoped_view_get_result(
+        self,
+        url_path: str | None,
+        config: Any,
+        *,
+        view_path: str,
+        config_hash: str | None,
+        config_size: int,
+    ) -> dict[str, Any]:
+        """Build the view-scoped get-mode envelope (issue #2010).
+
+        Raises the shared matcher's structured errors for an empty, unknown,
+        or ambiguous ``view_path`` and for strategy dashboards (no static
+        views). Pure config walking — works whether or not the dashboard
+        screenshot beta feature is enabled.
+        """
+        if not isinstance(config, dict):
+            raise_tool_error(
+                create_error_response(
+                    ErrorCode.RESOURCE_NOT_FOUND,
+                    "Dashboard config is unavailable, so view_path cannot be resolved.",
+                    context={"url_path": url_path, "view_path": view_path},
+                    suggestions=["Retry without view_path to inspect the raw response"],
+                )
+            )
+        view_index, view = match_dashboard_view(
+            url_path or "default",
+            config,
+            view_path,
+            strategy_suggestions=(
+                "Omit view_path — strategy dashboards generate their views at "
+                "runtime, so there is no static view config to return",
+            ),
+        )
+        views = config.get("views")
+        view_count = len(views) if isinstance(views, list) else 0
+        get_result: dict[str, Any] = {
+            "success": True,
+            "action": "get",
+            "url_path": url_path,
+            "view_path": view_path,
+            "view_index": view_index,
+            "view_count": view_count,
+            "view": view,
+            "config_hash": config_hash,
+            "config_size_bytes": config_size,
+            "view_size_bytes": len(json.dumps(view)),
+            "hint": (
+                f"Scoped to view '{view_path}' — config['views'][{view_index}] "
+                f"of {view_count} views. config_hash and config_size_bytes "
+                "cover the FULL dashboard config, so "
+                "ha_config_set_dashboard(python_transform=...) edits addressed "
+                f"via config['views'][{view_index}] validate as-is. Do NOT "
+                "pass this view object as the config parameter — that would "
+                "replace the entire dashboard. Omit view_path for the full "
+                "config."
+            ),
+        }
+        _attach_dashboard_render_paths(get_result, url_path, config)
+        render_paths = get_result.get("render_paths")
+        if isinstance(render_paths, list):
+            get_result["render_paths"] = [
+                row
+                for row in render_paths
+                if isinstance(row, dict) and row.get("view_index") == view_index
+            ]
+        return get_result
 
     @tool(
         name="ha_config_set_dashboard",

--- a/tests/src/unit/test_fields_projection_docstring_completeness.py
+++ b/tests/src/unit/test_fields_projection_docstring_completeness.py
@@ -189,6 +189,14 @@ TOOL_SPECS: list[dict[str, Any]] = [
             ("tools/util_helpers.py", "build_pagination_metadata"),
         ],
     },
+    {
+        "tool": "ha_report_issue",
+        "docstring": ("tools/tools_bug_report.py", "ha_report_issue"),
+        "var_harvest": [
+            ("tools/tools_bug_report.py", "ha_report_issue", "result"),
+        ],
+        "return_harvest": [],
+    },
 ]
 
 

--- a/tests/src/unit/test_get_dashboard_view_scoping.py
+++ b/tests/src/unit/test_get_dashboard_view_scoping.py
@@ -130,6 +130,54 @@ async def test_strategy_dashboard_view_path_errors_with_get_suggestion(mock_clie
 
 
 @pytest.mark.asyncio
+async def test_non_dict_config_with_view_path_errors(mock_client):
+    """A malformed (non-dict) HA config cannot be scoped — structured error,
+    not an AttributeError from walking a list."""
+    mock_client.send_websocket_message = AsyncMock(return_value={"result": ["nope"]})
+    tool = DashboardConfigTools(mock_client).ha_config_get_dashboard
+
+    with pytest.raises(ToolError) as exc_info:
+        await tool(url_path="default", view_path="office")
+
+    error = json.loads(str(exc_info.value))
+    assert error["error"]["code"] == "RESOURCE_NOT_FOUND"
+    assert "view_path cannot be resolved" in error["error"]["message"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "include_screenshot,expected_view_path",
+    [(True, "office"), (False, None)],
+)
+async def test_screenshot_options_view_path_follows_request(
+    mock_client, monkeypatch, include_screenshot, expected_view_path
+):
+    """view_path drives BOTH scoping and the render target: it stays in the
+    screenshot options when a screenshot is requested, and is stripped when
+    not (so the ignored-options warning can't fire on a plain scoped read)."""
+    captured = {}
+
+    async def fake_attach(result, url_path, requested, **kwargs):
+        captured["requested"] = requested
+        captured["options"] = kwargs["options"]
+        return result
+
+    monkeypatch.setattr(
+        "ha_mcp.tools.tools_config_dashboards._maybe_attach_screenshot",
+        fake_attach,
+    )
+    tool = DashboardConfigTools(mock_client).ha_config_get_dashboard
+
+    result = await tool(
+        url_path="default", view_path="office", include_screenshot=include_screenshot
+    )
+
+    assert result["view"] == _CONFIG["views"][1]
+    assert captured["requested"] is include_screenshot
+    assert captured["options"].view_path == expected_view_path
+
+
+@pytest.mark.asyncio
 async def test_full_get_unchanged_without_view_path(get_dashboard_tool):
     result = await get_dashboard_tool(url_path="default")
 
@@ -175,4 +223,18 @@ async def test_view_path_in_search_mode_warns_ignored(get_dashboard_tool):
     )
 
     assert result["match_count"] == 1
+    assert any("view_path" in w and "ignored" in w for w in result["warnings"])
+
+
+@pytest.mark.asyncio
+async def test_view_path_in_search_all_mode_warns_ignored(mock_client):
+    """MODE 4 (mode='search') must warn like the other non-get modes instead
+    of silently dropping view_path."""
+    mock_client.send_websocket_message = AsyncMock(return_value={"result": []})
+    tool = DashboardConfigTools(mock_client).ha_config_get_dashboard
+
+    result = await tool(mode="search", query="light.desk", view_path="office")
+
+    assert result["success"] is True
+    assert result["action"] == "search_all"
     assert any("view_path" in w and "ignored" in w for w in result["warnings"])

--- a/tests/src/unit/test_get_dashboard_view_scoping.py
+++ b/tests/src/unit/test_get_dashboard_view_scoping.py
@@ -1,0 +1,178 @@
+"""Unit tests for ha_config_get_dashboard get-mode view_path scoping (issue #2010).
+
+``view_path`` used to be a screenshot-only render selector: get mode accepted
+it but returned the full multi-view config regardless, so a single-view read
+on a large dashboard blew up the response. These tests pin the scoped
+envelope: ``view`` + ``view_index`` instead of ``config`` (so the view object
+can't be pushed back as a full-config replacement), ``config_hash`` still
+covering the FULL config (python_transform optimistic locking unchanged),
+structured errors for unknown/empty/strategy paths, and the explicit
+ignored-parameter warning in list/search mode. Scoping is pure config
+walking — no screenshot beta feature involved.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastmcp.exceptions import ToolError
+
+from ha_mcp.tools.tools_config_dashboards import DashboardConfigTools
+from ha_mcp.utils.config_hash import compute_config_hash
+
+_CONFIG = {
+    "title": "Multi",
+    "views": [
+        {"title": "Home", "path": "home", "cards": [{"type": "tile", "entity": "a.b"}]},
+        {
+            "title": "Office",
+            "path": "office",
+            "cards": [
+                {"type": "tile", "entity": "light.desk"},
+                {"type": "button", "entity": "switch.fan"},
+            ],
+        },
+        {"title": "Pathless", "cards": []},
+    ],
+}
+
+
+@pytest.fixture
+def mock_client():
+    client = MagicMock()
+    # url_path="default" sends a single lovelace/config read (no lazy-resolve
+    # retry); the component fast path falls back to this legacy read in the
+    # unit environment (no websocket client), matching the sibling test files.
+    client.send_websocket_message = AsyncMock(return_value={"result": _CONFIG})
+    return client
+
+
+@pytest.fixture
+def get_dashboard_tool(mock_client):
+    return DashboardConfigTools(mock_client).ha_config_get_dashboard
+
+
+@pytest.mark.asyncio
+async def test_view_path_scopes_response_to_single_view(get_dashboard_tool):
+    result = await get_dashboard_tool(url_path="default", view_path="office")
+
+    assert result["success"] is True
+    assert result["action"] == "get"
+    assert result["view"] == _CONFIG["views"][1]
+    assert result["view_path"] == "office"
+    assert result["view_index"] == 1
+    assert result["view_count"] == 3
+    # The scoped envelope must NOT carry a config key: the view object must
+    # not be mistakable for a full config and pushed back through
+    # ha_config_set_dashboard(config=...), which would drop the other views.
+    assert "config" not in result
+    # Optimistic locking stays anchored to the FULL config.
+    assert result["config_hash"] == compute_config_hash(_CONFIG)
+    assert result["config_size_bytes"] == len(json.dumps(_CONFIG))
+    assert result["view_size_bytes"] == len(json.dumps(_CONFIG["views"][1]))
+    assert "config['views'][1]" in result["hint"]
+
+
+@pytest.mark.asyncio
+async def test_scoped_render_paths_limited_to_matched_view(get_dashboard_tool):
+    result = await get_dashboard_tool(url_path="default", view_path="office")
+
+    assert [row["view_index"] for row in result["render_paths"]] == [1]
+    assert result["render_paths"][0]["view_path"] == "office"
+
+
+@pytest.mark.asyncio
+async def test_scoped_get_without_screenshot_emits_no_ignored_warning(
+    get_dashboard_tool,
+):
+    """view_path is a first-class get-mode parameter now — consuming it for
+    scoping must not trip the 'screenshot render options are ignored' warning."""
+    result = await get_dashboard_tool(url_path="default", view_path="office")
+
+    for warning in result.get("warnings", []):
+        assert "ignored" not in warning, warning
+
+
+@pytest.mark.asyncio
+async def test_unknown_view_path_errors_and_lists_available(get_dashboard_tool):
+    with pytest.raises(ToolError) as exc_info:
+        await get_dashboard_tool(url_path="default", view_path="garage")
+
+    error = json.loads(str(exc_info.value))
+    assert error["error"]["code"] == "RESOURCE_NOT_FOUND"
+    assert error["available_view_paths"] == ["home", "office"]
+
+
+@pytest.mark.asyncio
+async def test_empty_view_path_errors(get_dashboard_tool):
+    with pytest.raises(ToolError) as exc_info:
+        await get_dashboard_tool(url_path="default", view_path="   ")
+
+    error = json.loads(str(exc_info.value))
+    assert error["error"]["code"] == "VALIDATION_INVALID_PARAMETER"
+
+
+@pytest.mark.asyncio
+async def test_strategy_dashboard_view_path_errors_with_get_suggestion(mock_client):
+    mock_client.send_websocket_message = AsyncMock(
+        return_value={"result": {"strategy": {"type": "original-states"}}}
+    )
+    tool = DashboardConfigTools(mock_client).ha_config_get_dashboard
+
+    with pytest.raises(ToolError) as exc_info:
+        await tool(url_path="default", view_path="home")
+
+    error = json.loads(str(exc_info.value))
+    assert error["error"]["code"] == "VALIDATION_INVALID_PARAMETER"
+    assert "Omit view_path" in error["error"]["suggestion"]
+
+
+@pytest.mark.asyncio
+async def test_full_get_unchanged_without_view_path(get_dashboard_tool):
+    result = await get_dashboard_tool(url_path="default")
+
+    assert result["config"] == _CONFIG
+    assert "view" not in result
+    assert "view_index" not in result
+
+
+@pytest.mark.asyncio
+async def test_large_config_hint_mentions_view_path(mock_client):
+    big_config = {
+        "views": [
+            {
+                "title": "Big",
+                "path": "big",
+                "cards": [{"type": "markdown", "content": "x" * 12000}],
+            }
+        ]
+    }
+    mock_client.send_websocket_message = AsyncMock(return_value={"result": big_config})
+    tool = DashboardConfigTools(mock_client).ha_config_get_dashboard
+
+    result = await tool(url_path="default")
+
+    assert "view_path" in result["hint"]
+
+
+@pytest.mark.asyncio
+async def test_view_path_in_list_mode_warns_ignored(mock_client):
+    mock_client.send_websocket_message = AsyncMock(return_value={"result": []})
+    tool = DashboardConfigTools(mock_client).ha_config_get_dashboard
+
+    result = await tool(list_only=True, view_path="office")
+
+    assert result["success"] is True
+    assert any("view_path" in w and "ignored" in w for w in result["warnings"])
+
+
+@pytest.mark.asyncio
+async def test_view_path_in_search_mode_warns_ignored(get_dashboard_tool):
+    result = await get_dashboard_tool(
+        url_path="default", entity_id="light.desk", view_path="office"
+    )
+
+    assert result["match_count"] == 1
+    assert any("view_path" in w and "ignored" in w for w in result["warnings"])

--- a/tests/src/unit/test_tools_bug_report.py
+++ b/tests/src/unit/test_tools_bug_report.py
@@ -763,6 +763,58 @@ class TestBugReportTool:
         assert "Add-on Container Logs" not in result["formatted_report"]
         assert "Add-on Container Logs" not in result["runtime_bug_template"]
 
+    @pytest.mark.asyncio
+    async def test_fields_projection_returns_only_requested_keys(
+        self, ha_report_issue_func, mock_client
+    ):
+        """fields=... trims the very large full response down to the keys the
+        agent actually needs (issue #2010's ha_report_issue note)."""
+        mock_client.get_config.return_value = {"version": "2024.12.0"}
+        mock_client.get_states.return_value = []
+
+        result = await ha_report_issue_func(
+            fields=["runtime_bug_template", "suggested_title"]
+        )
+
+        assert result["success"] is True
+        assert set(result) <= {
+            "success",
+            "warnings",
+            "runtime_bug_template",
+            "suggested_title",
+        }
+        assert "recent_logs" not in result
+        assert "agent_behavior_template" not in result
+
+    @pytest.mark.asyncio
+    async def test_fields_projection_unknown_key_warns(
+        self, ha_report_issue_func, mock_client
+    ):
+        mock_client.get_config.return_value = {"version": "2024.12.0"}
+        mock_client.get_states.return_value = []
+
+        result = await ha_report_issue_func(fields=["no_such_key"])
+
+        assert any("no_such_key" in w for w in result["warnings"])
+
+    @pytest.mark.asyncio
+    async def test_fields_none_returns_full_response(
+        self, ha_report_issue_func, mock_client
+    ):
+        mock_client.get_config.return_value = {"version": "2024.12.0"}
+        mock_client.get_states.return_value = []
+
+        result = await ha_report_issue_func()
+
+        for key in (
+            "runtime_bug_template",
+            "agent_behavior_template",
+            "formatted_report",
+            "recent_logs",
+            "instructions",
+        ):
+            assert key in result
+
 
 class TestDetectComponentVersion:
     """``_detect_component_version`` prefers the shared cached caps probe and

--- a/tests/src/unit/test_tools_bug_report.py
+++ b/tests/src/unit/test_tools_bug_report.py
@@ -787,6 +787,26 @@ class TestBugReportTool:
         assert "agent_behavior_template" not in result
 
     @pytest.mark.asyncio
+    async def test_fields_projection_accepts_csv_string(
+        self, ha_report_issue_func, mock_client
+    ):
+        """The docstring's recommended usage is a CSV string — pin that form."""
+        mock_client.get_config.return_value = {"version": "2024.12.0"}
+        mock_client.get_states.return_value = []
+
+        result = await ha_report_issue_func(
+            fields="suggested_title,runtime_bug_submit_url"
+        )
+
+        assert set(result) <= {
+            "success",
+            "warnings",
+            "suggested_title",
+            "runtime_bug_submit_url",
+        }
+        assert result["suggested_title"]
+
+    @pytest.mark.asyncio
     async def test_fields_projection_unknown_key_warns(
         self, ha_report_issue_func, mock_client
     ):


### PR DESCRIPTION
## What does this PR do?

`ha_config_get_dashboard` accepted `view_path` in get mode but returned the full multi-view config regardless — the parameter only selected the screenshot render view, so a single-view read on a 13-view dashboard returned the entire ~74KB config (#2010).

- Get mode now scopes to the matched view: the response carries `view` + `view_index` + `view_count` instead of `config`. The scoped envelope deliberately has no `config` key so the view object cannot be pushed back through `ha_config_set_dashboard(config=...)` and silently drop the other views; `config_hash`/`config_size_bytes` still cover the full config, so `python_transform` optimistic locking works unchanged (the response hint documents both).
- View matching is extracted into `match_dashboard_view()`, shared with screenshot view resolution — identical semantics and structured errors (unknown path lists `available_view_paths`; empty path; strategy dashboards). Scoping is pure config walking and works without the dashboard-screenshot beta feature.
- `view_path` passed in list/search mode now warns explicitly; a scoped get no longer emits the misleading "screenshot render options are ignored" warning; the large-config hint suggests `view_path` first.
- `ha_report_issue` gains the standard `fields=` projection (the issue's additional note): its full response repeats the captured logs in the raw log keys and inside each template, so agents can now fetch just the template they need.

Closes #2010

## Type of change
- [x] 🐛 Bug fix

## Testing
- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

## Checklist
- [x] I have updated documentation if needed