### PR TITLE
test: gate inaddon setup on the addon's Home Assistant link

### DIFF
--- a/tests/src/e2e/conftest.py
+++ b/tests/src/e2e/conftest.py
@@ -183,6 +183,11 @@ _EMBEDDED_READY_POLL_S = 5
 # _READY_TIMEOUT_S). pytest.ini's timeout_func_only exempts this session-fixture
 # wait from the 300s per-test timeout.
 _HAOS_EMBEDDED_BRINGUP_TIMEOUT = 600
+# Inaddon: budget for the addon's Home Assistant link after its own HTTP
+# listener answers. Core is usually accepting within a few seconds of the
+# listener, so this is only consumed when something is genuinely wrong.
+_ADDON_HA_LINK_TIMEOUT_S = 180.0
+_ADDON_HA_LINK_POLL_S = 3.0
 
 
 def _is_embedded_backend_selected() -> bool:
@@ -979,6 +984,50 @@ def _wait_for_embedded_webhook_ready(webhook_url: str, timeout: int) -> bool:
             # Bring-up still in flight (pip force-install, thread start): retry.
             pass
         time.sleep(_EMBEDDED_READY_POLL_S)
+    return False
+
+
+def _wait_for_addon_ha_link_ready(addon_mcp_url: str, timeout: float) -> bool:
+    """Poll the dev addon until a tool call that needs Home Assistant answers.
+
+    ``wait_for_addon_mcp_ready`` gates on the addon's own HTTP listener, which
+    is a different layer from the one tools actually depend on: the addon
+    reaches Core over the Supervisor WebSocket proxy, and that proxy answers
+    HTTP 502 for a beat after boot while Core comes up behind it. Gating only
+    on the listener leaves the session's first HA-backed tool call to race that
+    window and fail with ``CONNECTION_FAILED``, which reads as a product bug
+    rather than a setup that returned half-ready.
+
+    ``ha_get_addon`` is the probe because it needs both legs of that path (the
+    Core WebSocket and the Supervisor API) — the same call that surfaced the
+    race. Returns False on timeout so the caller can fail with context.
+    Transient errors follow the suite's canonical ``_POLLING_TRANSIENT_ERRORS``
+    discipline; bugs propagate.
+    """
+    import httpx
+    from fastmcp.client.transports import StreamableHttpTransport
+
+    from .utilities.wait_helpers import _POLLING_TRANSIENT_ERRORS
+
+    async def _probe() -> None:
+        # Fresh client per attempt: the server is stateless, and a long-lived
+        # session would not survive the addon restarting mid-poll.
+        async with Client(StreamableHttpTransport(url=addon_mcp_url)) as client:
+            await client.call_tool("ha_get_addon", {})
+
+    deadline = time.monotonic() + timeout
+    last_err: BaseException | None = None
+    while time.monotonic() < deadline:
+        try:
+            asyncio.run(_probe())
+            elapsed = int(time.monotonic() - (deadline - timeout))
+            logger.info("✅ Addon → Home Assistant link ready after ~%ds", elapsed)
+            return True
+        except (*_POLLING_TRANSIENT_ERRORS, httpx.HTTPError) as e:
+            last_err = e
+            logger.debug("Addon → Home Assistant link not ready yet: %r", e)
+        time.sleep(_ADDON_HA_LINK_POLL_S)
+    logger.error("Addon → Home Assistant link never came up (last error: %r)", last_err)
     return False
 
 
@@ -1904,6 +1953,19 @@ def _bringup_haos_out_of_process_server(
             "violation. Downstream mcp_client fixture would fail "
             "with an obscure TypeError on transport construction."
         )
+        # The listener answering HTTP does not mean its Home Assistant link is
+        # up, so gate on that too — otherwise the session's first HA-backed
+        # tool call can land while the Supervisor proxy is still 502ing.
+        if not _wait_for_addon_ha_link_ready(
+            addon_mcp_url, timeout=_ADDON_HA_LINK_TIMEOUT_S
+        ):
+            raise AssertionError(
+                "The dev addon's MCP listener answered HTTP but no Home "
+                "Assistant-backed tool call succeeded within "
+                f"{_ADDON_HA_LINK_TIMEOUT_S:.0f}s of it. The addon reaches "
+                "Core through the Supervisor WebSocket proxy — see the "
+                "Supervisor and HA Core logs in the HAOS diagnostics artifact."
+            )
     elif haos_embedded:
         # Enable the baked-disabled in-process server entry ONCE for the
         # whole session (the per-test smoke module is skipped on this

--- a/tests/src/e2e/conftest.py
+++ b/tests/src/e2e/conftest.py
@@ -67,6 +67,7 @@ from haos_runtime import (
     stage_embedded_server_feature_flags_in_qcow2,
     stage_embedded_server_wheel_in_qcow2,
     trigger_dev_addon_update,
+    wait_for_addon_ha_link_ready,
     wait_for_addon_mcp_ready,
 )
 
@@ -183,11 +184,6 @@ _EMBEDDED_READY_POLL_S = 5
 # _READY_TIMEOUT_S). pytest.ini's timeout_func_only exempts this session-fixture
 # wait from the 300s per-test timeout.
 _HAOS_EMBEDDED_BRINGUP_TIMEOUT = 600
-# Inaddon: budget for the addon's Home Assistant link after its own HTTP
-# listener answers. Core is usually accepting within a few seconds of the
-# listener, so this is only consumed when something is genuinely wrong.
-_ADDON_HA_LINK_TIMEOUT_S = 180.0
-_ADDON_HA_LINK_POLL_S = 3.0
 
 
 def _is_embedded_backend_selected() -> bool:
@@ -984,50 +980,6 @@ def _wait_for_embedded_webhook_ready(webhook_url: str, timeout: int) -> bool:
             # Bring-up still in flight (pip force-install, thread start): retry.
             pass
         time.sleep(_EMBEDDED_READY_POLL_S)
-    return False
-
-
-def _wait_for_addon_ha_link_ready(addon_mcp_url: str, timeout: float) -> bool:
-    """Poll the dev addon until a tool call that needs Home Assistant answers.
-
-    ``wait_for_addon_mcp_ready`` gates on the addon's own HTTP listener, which
-    is a different layer from the one tools actually depend on: the addon
-    reaches Core over the Supervisor WebSocket proxy, and that proxy answers
-    HTTP 502 for a beat after boot while Core comes up behind it. Gating only
-    on the listener leaves the session's first HA-backed tool call to race that
-    window and fail with ``CONNECTION_FAILED``, which reads as a product bug
-    rather than a setup that returned half-ready.
-
-    ``ha_get_addon`` is the probe because it needs both legs of that path (the
-    Core WebSocket and the Supervisor API) — the same call that surfaced the
-    race. Returns False on timeout so the caller can fail with context.
-    Transient errors follow the suite's canonical ``_POLLING_TRANSIENT_ERRORS``
-    discipline; bugs propagate.
-    """
-    import httpx
-    from fastmcp.client.transports import StreamableHttpTransport
-
-    from .utilities.wait_helpers import _POLLING_TRANSIENT_ERRORS
-
-    async def _probe() -> None:
-        # Fresh client per attempt: the server is stateless, and a long-lived
-        # session would not survive the addon restarting mid-poll.
-        async with Client(StreamableHttpTransport(url=addon_mcp_url)) as client:
-            await client.call_tool("ha_get_addon", {})
-
-    deadline = time.monotonic() + timeout
-    last_err: BaseException | None = None
-    while time.monotonic() < deadline:
-        try:
-            asyncio.run(_probe())
-            elapsed = int(time.monotonic() - (deadline - timeout))
-            logger.info("✅ Addon → Home Assistant link ready after ~%ds", elapsed)
-            return True
-        except (*_POLLING_TRANSIENT_ERRORS, httpx.HTTPError) as e:
-            last_err = e
-            logger.debug("Addon → Home Assistant link not ready yet: %r", e)
-        time.sleep(_ADDON_HA_LINK_POLL_S)
-    logger.error("Addon → Home Assistant link never came up (last error: %r)", last_err)
     return False
 
 
@@ -1956,15 +1908,13 @@ def _bringup_haos_out_of_process_server(
         # The listener answering HTTP does not mean its Home Assistant link is
         # up, so gate on that too — otherwise the session's first HA-backed
         # tool call can land while the Supervisor proxy is still 502ing.
-        if not _wait_for_addon_ha_link_ready(
-            addon_mcp_url, timeout=_ADDON_HA_LINK_TIMEOUT_S
-        ):
+        if not wait_for_addon_ha_link_ready(addon_mcp_url):
             raise AssertionError(
                 "The dev addon's MCP listener answered HTTP but no Home "
-                "Assistant-backed tool call succeeded within "
-                f"{_ADDON_HA_LINK_TIMEOUT_S:.0f}s of it. The addon reaches "
-                "Core through the Supervisor WebSocket proxy — see the "
-                "Supervisor and HA Core logs in the HAOS diagnostics artifact."
+                "Assistant-backed tool call succeeded before the link "
+                "deadline. The addon reaches Core through the Supervisor "
+                "WebSocket proxy — see the Supervisor and HA Core logs in "
+                "the HAOS diagnostics artifact."
             )
     elif haos_embedded:
         # Enable the baked-disabled in-process server entry ONCE for the

--- a/tests/src/haos_runtime.py
+++ b/tests/src/haos_runtime.py
@@ -1374,6 +1374,96 @@ def wait_for_addon_mcp_ready(*, timeout: float = 300.0) -> str:
     )
 
 
+# Budget for the addon's Home Assistant link once its own listener answers.
+# Core is normally accepting within seconds of it, so this is only consumed
+# when something is genuinely wrong.
+_ADDON_HA_LINK_TIMEOUT_S = 180.0
+_ADDON_HA_LINK_POLL_S = 3.0
+
+
+def _addon_link_transient_errors() -> tuple[type[BaseException], ...]:
+    """Return the errors that mean "not linked yet" rather than "broken".
+
+    Mirrors the suite's canonical MCP-polling set
+    (``e2e/utilities/wait_helpers._POLLING_TRANSIENT_ERRORS``) plus httpx
+    transport errors — the same combination ``test_addon_debug_log_level``
+    uses for this exact target. Copied by value rather than imported because
+    this module is also imported bare (``from haos_runtime import ...``), so a
+    package-relative import of the e2e tree would not resolve;
+    ``test_haos_addon_ha_link_wait`` pins that it stays a superset of the
+    canonical tuple.
+    """
+    import httpx
+    from fastmcp.exceptions import ClientError, FastMCPError
+    from mcp import McpError
+
+    return (
+        McpError,
+        FastMCPError,
+        ClientError,
+        RuntimeError,
+        OSError,
+        TimeoutError,
+        httpx.HTTPError,
+    )
+
+
+def _probe_addon_ha_link(addon_mcp_url: str) -> None:
+    """Make one MCP call that needs Home Assistant; raise if it does not work."""
+    import asyncio
+
+    from fastmcp import Client
+    from fastmcp.client.transports import StreamableHttpTransport
+
+    async def _call() -> None:
+        # Fresh client per attempt: the server is stateless, and a long-lived
+        # session would not survive the addon restarting mid-poll.
+        async with Client(StreamableHttpTransport(url=addon_mcp_url)) as client:
+            await client.call_tool("ha_get_addon", {})
+
+    asyncio.run(_call())
+
+
+def wait_for_addon_ha_link_ready(
+    addon_mcp_url: str, *, timeout: float = _ADDON_HA_LINK_TIMEOUT_S
+) -> bool:
+    """Poll the addon until a tool call that needs Home Assistant answers.
+
+    ``wait_for_addon_mcp_ready`` gates on the addon's own HTTP listener, which
+    is a different layer from the one tools depend on: the addon reaches Core
+    over the Supervisor WebSocket proxy, and that proxy answers HTTP 502 for a
+    beat after boot while Core comes up behind it. Gating only on the listener
+    lets setup return half-ready, so the session's first HA-backed tool call
+    can land in that window and fail with ``CONNECTION_FAILED`` — which reads
+    as a product bug rather than a setup race.
+
+    ``ha_get_addon`` is the probe because it needs both legs of that path (the
+    Core WebSocket and the Supervisor API) and is the call that surfaced the
+    race. Returns False on timeout so the caller can fail with context.
+    Transient errors are retried; bugs propagate.
+    """
+    deadline = time.monotonic() + timeout
+    transient = _addon_link_transient_errors()
+    last_err: BaseException | None = None
+    while time.monotonic() < deadline:
+        try:
+            _probe_addon_ha_link(addon_mcp_url)
+        except transient as e:
+            last_err = e
+            LOG.debug("Addon -> Home Assistant link not ready yet: %r", e)
+        else:
+            elapsed = int(time.monotonic() - (deadline - timeout))
+            LOG.info("Addon -> Home Assistant link ready after ~%ds", elapsed)
+            return True
+        time.sleep(_ADDON_HA_LINK_POLL_S)
+    LOG.error(
+        "Addon -> Home Assistant link never came up within %.0fs (last_exc=%r)",
+        timeout,
+        last_err,
+    )
+    return False
+
+
 def _http(
     method: str,
     url: str,

--- a/tests/src/unit/test_haos_addon_ha_link_wait.py
+++ b/tests/src/unit/test_haos_addon_ha_link_wait.py
@@ -1,0 +1,137 @@
+"""Unit tests for ``haos_runtime.wait_for_addon_ha_link_ready``.
+
+The inaddon lane used to gate setup on ``wait_for_addon_mcp_ready`` alone,
+which proves the addon's own HTTP listener is up. Tools depend on a different
+layer: the addon reaches Core over the Supervisor WebSocket proxy, and that
+proxy answers HTTP 502 for a beat after boot. Setup therefore returned while
+the addon was half-ready and the session's first HA-backed tool call could
+fail with ``CONNECTION_FAILED`` (observed on #1997:
+``test_web_ui_debug_log_level_reaches_addon_log`` died on its first
+``ha_get_addon`` while the same job's main suite passed 1037 tests).
+
+These drive the probe through a stub, so they need no booted HAOS. The clock
+is faked so the poll loop is deterministic and instant.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from tests.src.haos_runtime import (
+    _ADDON_HA_LINK_POLL_S,
+    _addon_link_transient_errors,
+    wait_for_addon_ha_link_ready,
+)
+
+_URL = "http://127.0.0.1:9583/mcp_e2e_test_path"
+
+
+class _Clock:
+    """Stand-in for the ``time`` module that only advances when slept on.
+
+    Substituted for ``haos_runtime.time`` rather than patching attributes on
+    the stdlib module, so a faked clock cannot leak into pytest's own timing.
+    """
+
+    def __init__(self) -> None:
+        self.now = 0.0
+
+    def monotonic(self) -> float:
+        return self.now
+
+    def sleep(self, seconds: float) -> None:
+        self.now += seconds
+
+
+def _run(probe: Any, *, timeout: float = 10.0) -> tuple[bool, _Clock]:
+    clock = _Clock()
+    with (
+        patch("tests.src.haos_runtime._probe_addon_ha_link", probe),
+        patch("tests.src.haos_runtime.time", clock),
+    ):
+        return wait_for_addon_ha_link_ready(_URL, timeout=timeout), clock
+
+
+def test_returns_immediately_when_link_is_up() -> None:
+    """A link that already works costs one probe and no sleep."""
+    calls: list[str] = []
+    ready, clock = _run(lambda url: calls.append(url))
+    assert ready is True
+    assert calls == [_URL]
+    assert clock.now == 0.0
+
+
+def test_retries_until_the_link_comes_up() -> None:
+    """The 502 window is ridden out rather than surfaced to the first test.
+
+    This is the regression: before the gate existed, the very first HA-backed
+    call took this failure and the test carrying it had no reason to retry.
+    """
+    from fastmcp.exceptions import ToolError
+
+    attempts: list[int] = []
+
+    def probe(url: str) -> None:
+        attempts.append(len(attempts))
+        if len(attempts) < 3:
+            # Shape of the observed failure: the tool call raises with the
+            # Supervisor proxy's 502 wrapped in a structured CONNECTION_FAILED.
+            raise ToolError(
+                '{"error": {"code": "CONNECTION_FAILED", "message": '
+                '"server rejected WebSocket connection: HTTP 502"}}'
+            )
+
+    ready, clock = _run(probe)
+    assert ready is True
+    assert len(attempts) == 3
+    # Slept between attempts — a paced loop, not a tight spin.
+    assert clock.now == pytest.approx(2 * _ADDON_HA_LINK_POLL_S)
+
+
+def test_gives_up_at_the_deadline() -> None:
+    """A link that never comes up returns False for the caller to report."""
+    attempts: list[int] = []
+
+    def probe(url: str) -> None:
+        attempts.append(len(attempts))
+        raise OSError("connection refused")
+
+    ready, clock = _run(probe, timeout=10.0)
+    assert ready is False
+    # timeout 10s / poll 3s: probes at t=0,3,6,9 then the deadline stops it.
+    assert len(attempts) == 4
+    assert clock.now >= 10.0
+
+
+def test_bugs_propagate_instead_of_being_retried() -> None:
+    """A bug in the probe must fail loudly, not burn the whole budget.
+
+    Mirrors .gemini/styleguide.md's polling-loop rule: only genuinely
+    transient classes are retried.
+    """
+
+    def probe(url: str) -> None:
+        raise TypeError("probe called with the wrong shape")
+
+    with pytest.raises(TypeError):
+        _run(probe)
+
+
+def test_transient_set_covers_the_canonical_polling_errors() -> None:
+    """The copied set must not drift from the suite's canonical tuple.
+
+    ``haos_runtime`` is imported bare by the e2e tests, so it cannot import
+    the e2e package to reuse the tuple directly — this pins the copy instead.
+    """
+    from fastmcp.exceptions import ToolError
+
+    from tests.src.e2e.utilities.wait_helpers import _POLLING_TRANSIENT_ERRORS
+
+    transient = _addon_link_transient_errors()
+    missing = set(_POLLING_TRANSIENT_ERRORS) - set(transient)
+    assert not missing, f"drifted from the canonical polling set: {missing}"
+    # The failure this gate exists for arrives as a ToolError.
+    assert issubclass(ToolError, transient)


### PR DESCRIPTION
## What does this PR do?

The HAOS inaddon lane gated setup on `wait_for_addon_mcp_ready`, which probes the dev addon's own MCP port (TCP accept, then HTTP OPTIONS). That proves the addon's listener is up, but tools depend on a different layer: the addon reaches Core over the Supervisor WebSocket proxy, and that proxy answers HTTP 502 for a beat after boot while Core comes up behind it. Setup returned while the addon was half-ready, so the session's first HA-backed tool call could land in that window and fail with `CONNECTION_FAILED` — presenting as a product bug rather than a setup race.

Seen on #1997, where a fresh single-test invocation of `test_web_ui_debug_log_level_reaches_addon_log` died on its first call (`ha_get_addon`) with `server rejected WebSocket connection: HTTP 502` on `/addons`, while the same job's main suite passed 1037 tests and a rerun went green.

- Adds `wait_for_addon_ha_link_ready` next to `wait_for_addon_mcp_ready` in `haos_runtime.py` and calls it from the inaddon bring-up: poll `ha_get_addon` until it answers, then let setup proceed. That tool is the probe because it needs both legs of the racing path (the Core WebSocket and the Supervisor API) and is the call that surfaced it.
- On timeout, setup fails pointing at the Supervisor and Core logs in the HAOS diagnostics artifact, instead of leaving the first test to absorb it.
- Mirrors the `haos_embedded` branch a few lines below, which already gates on its webhook answering a real MCP `initialize` rather than on a port being open. Transient errors mirror the suite's canonical `_POLLING_TRANSIENT_ERRORS` set plus `httpx.HTTPError` — the same combination `test_addon_debug_log_level.py` uses — so bugs still propagate per the styleguide's polling-loop rule.

The gate is in shared inaddon bring-up, so it covers every test on that lane, not only the one that flaked.

## Type of change
- [x] 🐛 Bug fix

## Testing
- [ ] I have tested these changes with a LLM agent
- [ ] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

## Checklist
- [x] I have updated documentation if needed
