### PR TITLE
fix: force-exit the stdio entry point to avoid SIGABRT at shutdown

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -266,7 +266,10 @@ jobs:
     container:
       # renovate: datasource=docker depName=ghcr.io/astral-sh/uv
       image: ghcr.io/astral-sh/uv:0.11.28-python3.13-trixie-slim
-    timeout-minutes: 5
+    # 8 (was 5, with ~1 min headroom): the issue #2027 regression tests
+    # spawn real subprocesses — including one full stdio server session —
+    # which costs tens of seconds on a slow runner.
+    timeout-minutes: 8
 
     steps:
     - name: Restore apt download cache

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -266,9 +266,9 @@ jobs:
     container:
       # renovate: datasource=docker depName=ghcr.io/astral-sh/uv
       image: ghcr.io/astral-sh/uv:0.11.28-python3.13-trixie-slim
-    # 8 (was 5, with ~1 min headroom): the issue #2027 regression tests
-    # spawn real subprocesses — including one full stdio server session —
-    # which costs tens of seconds on a slow runner.
+    # Bumped 5 → 8 for the issue #2027 regression tests, which spawn real
+    # subprocesses — including a full stdio server session — costing tens
+    # of seconds on a slow runner.
     timeout-minutes: 8
 
     steps:

--- a/scripts/codeql_quality_gate.py
+++ b/scripts/codeql_quality_gate.py
@@ -148,6 +148,16 @@ ALLOWLIST: tuple[tuple[str, str, str, str], ...] = (
         "a clean add-on exit code; KeyboardInterrupt is handled by the clause "
         "above. Matches how the codebase suppresses other deliberate catches.",
     ),
+    (
+        "py/catch-base-exception",
+        "src/ha_mcp/__main__.py",
+        "BaseException",
+        "Intentional: the stdio exit routing must see BaseExceptions (e.g. the "
+        "re-raised CancelledError from the #1544 hard-stop path) so they leave "
+        "via _force_exit — reaching interpreter finalization with the SDK's "
+        "stdin reader parked is the issue #2027 SIGABRT. The exception is "
+        "logged before the forced exit.",
+    ),
     # NOTE: CodeQL emits the same generic message for every py/mixed-returns
     # finding, so this entry is PATH-WIDE for server.py (a future genuinely
     # mixed-returns function in this file would be suppressed too). Accepted:

--- a/src/ha_mcp/__main__.py
+++ b/src/ha_mcp/__main__.py
@@ -31,7 +31,7 @@ import stat  # noqa: E402
 import sys  # noqa: E402
 import threading  # noqa: E402
 from collections.abc import Coroutine  # noqa: E402
-from typing import TYPE_CHECKING, Any  # noqa: E402
+from typing import TYPE_CHECKING, Any, NoReturn  # noqa: E402
 
 from fastmcp.exceptions import ToolError  # noqa: E402
 from pydantic import ValidationError as PydanticValidationError  # noqa: E402
@@ -720,6 +720,29 @@ async def _run_with_graceful_shutdown() -> None:
     await _run_with_shutdown(_get_mcp().run_async(show_banner=_get_show_banner()))
 
 
+def _force_exit(code: int) -> NoReturn:
+    """Exit the stdio process without interpreter finalization (issue #2027).
+
+    The MCP SDK's stdio transport reads stdin through anyio's worker-thread
+    pool, so a daemon thread is parked in ``readline()`` holding the
+    ``BufferedReader`` lock whenever no message is in flight. If the process
+    exits while that read is pending — SIGTERM, or the client vanishing
+    mid-read — interpreter finalization tries to close stdin, cannot acquire
+    the lock, and CPython aborts: ``Fatal Python error: _enter_buffered_busy``
+    → SIGABRT (a crash dialog on macOS). The reader lives in the SDK, so the
+    entry point neutralizes it instead: flush what matters, then skip
+    finalization entirely. By this point ``_run_with_shutdown`` has already
+    run resource cleanup, and a stdio server persists nothing at exit.
+    """
+    logging.shutdown()
+    for stream in (sys.stdout, sys.stderr):
+        try:
+            stream.flush()
+        except Exception:  # nothing actionable at exit
+            pass
+    os._exit(code)
+
+
 # CLI entry point (for pyproject.toml) - use FastMCP's built-in runner
 def main() -> None:
     """Run server via CLI using FastMCP's stdio transport."""
@@ -758,7 +781,18 @@ def main() -> None:
     # Best-effort: failure logs a warning but doesn't block MCP startup.
     _maybe_spawn_settings_sidecar()
 
-    _run_entrypoint(_run_with_graceful_shutdown(), "Server")
+    # Route the final exit through _force_exit: _run_entrypoint always leaves
+    # via sys.exit, and letting that SystemExit reach interpreter finalization
+    # aborts when the SDK's stdin reader thread still holds the stdin lock.
+    code = 0
+    try:
+        _run_entrypoint(_run_with_graceful_shutdown(), "Server")
+    except SystemExit as exc:
+        if isinstance(exc.code, int):
+            code = exc.code
+        elif exc.code is not None:
+            code = 1
+    _force_exit(code)
 
 
 def _maybe_spawn_settings_sidecar() -> None:

--- a/src/ha_mcp/__main__.py
+++ b/src/ha_mcp/__main__.py
@@ -727,7 +727,6 @@ def _signal_handler(signum: int, frame: Any) -> None:
         sys.exit(1)
 
     _shutdown_in_progress = True
-    logger.info(f"Received {sig_name}, initiating graceful shutdown...")
 
     if _force_exit_on_shutdown:
         # The SDK's stdio teardown hangs if a stdin read is in flight when
@@ -736,9 +735,13 @@ def _signal_handler(signum: int, frame: Any) -> None:
         # parked in a blocking stdin read, so asyncio.run never returns
         # (issue #2027 — leftover stdio instances that never exit).
         # Guarantee the process dies even if the graceful path is stuck.
+        # Armed BEFORE the log line below: logging writes to stderr, and a
+        # full stderr pipe would block this handler before it armed anything.
         watchdog = threading.Timer(_SHUTDOWN_WATCHDOG_SECONDS, _shutdown_watchdog_fire)
         watchdog.daemon = True
         watchdog.start()
+
+    logger.info(f"Received {sig_name}, initiating graceful shutdown...")
 
     # Signal the shutdown event if we have an event loop
     if _shutdown_event is not None:
@@ -776,27 +779,44 @@ def _force_exit(code: int) -> NoReturn:
     finalization entirely. By this point ``_run_with_shutdown`` has already
     run resource cleanup, and a stdio server persists nothing at exit.
 
-    The ``finally`` is load-bearing: ``os._exit`` must run even if flushing
-    raises, or the escaping exception reaches interpreter finalization and
-    reintroduces the exact abort this function exists to prevent.
+    The flush is best-effort and time-bounded in a daemon thread: if the
+    client stopped draining stdout/stderr, the SDK's writer thread can be
+    blocked on the full pipe holding the buffered-writer lock, and flushing
+    inline would wait on that same lock forever — turning the hard-exit
+    path (including the shutdown watchdog) back into a hang. ``os._exit``
+    runs unconditionally once the bounded wait elapses.
     """
-    try:
+
+    def _best_effort_flush() -> None:
         logging.shutdown()
         for stream in (sys.stdout, sys.stderr):
             try:
                 stream.flush()
             except Exception:  # nothing actionable at exit
                 pass
+
+    try:
+        flusher = threading.Thread(target=_best_effort_flush, daemon=True)
+        flusher.start()
+        flusher.join(timeout=1.0)
     finally:
         os._exit(code)
 
 
 def _shutdown_watchdog_fire() -> None:
-    """Hard-deadline fallback for a stuck graceful shutdown (issue #2027)."""
-    logger.warning(
-        "Graceful shutdown did not complete within %.0fs; forcing exit",
-        _SHUTDOWN_WATCHDOG_SECONDS,
-    )
+    """Hard-deadline fallback for a stuck graceful shutdown (issue #2027).
+
+    The warning is fire-and-forget in a daemon thread: logging writes to
+    stderr, and a full stderr pipe blocking the warning would block the
+    watchdog itself — the very condition it exists to escape.
+    """
+    threading.Thread(
+        target=lambda: logger.warning(
+            "Graceful shutdown did not complete within %.0fs; forcing exit",
+            _SHUTDOWN_WATCHDOG_SECONDS,
+        ),
+        daemon=True,
+    ).start()
     _force_exit(0)
 
 

--- a/src/ha_mcp/__main__.py
+++ b/src/ha_mcp/__main__.py
@@ -131,6 +131,16 @@ SHUTDOWN_TIMEOUT_SECONDS = 2.0
 _shutdown_event: asyncio.Event | None = None
 _shutdown_in_progress = False
 
+# Set by the stdio entry point (main) so signal-initiated shutdown arms a
+# hard-deadline watchdog. HTTP entry points leave this False.
+_force_exit_on_shutdown = False
+
+# Hard deadline for a signal-initiated stdio shutdown. Must exceed the sum
+# of the graceful phases (server-stop wait + resource cleanup + task
+# cancellation, SHUTDOWN_TIMEOUT_SECONDS each) so it only fires when the
+# graceful path is truly stuck (issue #2027).
+_SHUTDOWN_WATCHDOG_SECONDS = 10.0
+
 # Stdin error message for Docker without -i flag
 _STDIN_ERROR_MESSAGE = """
 ==============================================================================
@@ -589,16 +599,29 @@ async def _cleanup_resources() -> None:
 
 
 async def _cancel_tasks(*tasks: asyncio.Task) -> None:
-    """Cancel tasks and wait for completion, swallowing CancelledError."""
-    for task in tasks:
-        if not task.done():
-            task.cancel()
-            try:
-                await task
-            except asyncio.CancelledError:
-                # Expected: we just cancelled this task, swallow its
-                # CancelledError so remaining tasks still get awaited.
-                pass
+    """Cancel tasks and wait for completion, bounding the wait.
+
+    A task can ignore cancellation indefinitely — the stdio transport does
+    when a blocking stdin read is in flight (issue #2027) — so the wait is
+    bounded instead of awaiting each task unboundedly. Stragglers are
+    logged and abandoned; the stdio entry point force-exits anyway.
+    """
+    pending = [task for task in tasks if not task.done()]
+    if not pending:
+        return
+    for task in pending:
+        task.cancel()
+    done, still_pending = await asyncio.wait(pending, timeout=SHUTDOWN_TIMEOUT_SECONDS)
+    if still_pending:
+        logger.warning(
+            "%d task(s) ignored cancellation during shutdown", len(still_pending)
+        )
+    for task in done:
+        if task.cancelled():
+            continue
+        exc = task.exception()
+        if exc is not None:
+            logger.warning(f"Task raised during shutdown: {exc!r}")
 
 
 async def _run_with_shutdown(server_coro: Coroutine[Any, Any, Any]) -> None:
@@ -622,14 +645,22 @@ async def _run_with_shutdown(server_coro: Coroutine[Any, Any, Any]) -> None:
         if shutdown_task in done:
             logger.info("Shutdown signal received, stopping server...")
             server_task.cancel()
-            try:
-                await asyncio.wait_for(server_task, timeout=SHUTDOWN_TIMEOUT_SECONDS)
-            except TimeoutError:
+            # asyncio.wait, not wait_for: wait_for's timeout path awaits the
+            # cancellation completing, which hangs when the stdio transport
+            # ignores cancellation mid-stdin-read (issue #2027). wait simply
+            # returns after the timeout, leaving the straggler abandoned.
+            stopped, _ = await asyncio.wait(
+                {server_task}, timeout=SHUTDOWN_TIMEOUT_SECONDS
+            )
+            if server_task in stopped:
+                try:
+                    server_task.result()
+                except asyncio.CancelledError:
+                    # Expected: we just cancelled server_task above; swallow
+                    # its CancelledError so shutdown can proceed to cleanup.
+                    pass
+            else:
                 logger.warning("Server did not stop within timeout")
-            except asyncio.CancelledError:
-                # Expected: we just cancelled server_task above; swallow its
-                # CancelledError so shutdown can proceed to cleanup.
-                pass
         elif server_task in done:
             # Server task finished on its own (no shutdown signal). Re-raise any
             # exception it captured so a hard startup failure surfaces as a
@@ -698,6 +729,17 @@ def _signal_handler(signum: int, frame: Any) -> None:
     _shutdown_in_progress = True
     logger.info(f"Received {sig_name}, initiating graceful shutdown...")
 
+    if _force_exit_on_shutdown:
+        # The SDK's stdio teardown hangs if a stdin read is in flight when
+        # the server task is cancelled: the CancelledError gets stuck being
+        # thrown into stdio_server's task group while the reader thread is
+        # parked in a blocking stdin read, so asyncio.run never returns
+        # (issue #2027 — leftover stdio instances that never exit).
+        # Guarantee the process dies even if the graceful path is stuck.
+        watchdog = threading.Timer(_SHUTDOWN_WATCHDOG_SECONDS, _shutdown_watchdog_fire)
+        watchdog.daemon = True
+        watchdog.start()
+
     # Signal the shutdown event if we have an event loop
     if _shutdown_event is not None:
         try:
@@ -724,7 +766,7 @@ def _force_exit(code: int) -> NoReturn:
     """Exit the stdio process without interpreter finalization (issue #2027).
 
     The MCP SDK's stdio transport reads stdin through anyio's worker-thread
-    pool, so a daemon thread is parked in ``readline()`` holding the
+    pool, so a daemon thread is parked in a blocking stdin read holding the
     ``BufferedReader`` lock whenever no message is in flight. If the process
     exits while that read is pending — SIGTERM, or the client vanishing
     mid-read — interpreter finalization tries to close stdin, cannot acquire
@@ -733,14 +775,29 @@ def _force_exit(code: int) -> NoReturn:
     entry point neutralizes it instead: flush what matters, then skip
     finalization entirely. By this point ``_run_with_shutdown`` has already
     run resource cleanup, and a stdio server persists nothing at exit.
+
+    The ``finally`` is load-bearing: ``os._exit`` must run even if flushing
+    raises, or the escaping exception reaches interpreter finalization and
+    reintroduces the exact abort this function exists to prevent.
     """
-    logging.shutdown()
-    for stream in (sys.stdout, sys.stderr):
-        try:
-            stream.flush()
-        except Exception:  # nothing actionable at exit
-            pass
-    os._exit(code)
+    try:
+        logging.shutdown()
+        for stream in (sys.stdout, sys.stderr):
+            try:
+                stream.flush()
+            except Exception:  # nothing actionable at exit
+                pass
+    finally:
+        os._exit(code)
+
+
+def _shutdown_watchdog_fire() -> None:
+    """Hard-deadline fallback for a stuck graceful shutdown (issue #2027)."""
+    logger.warning(
+        "Graceful shutdown did not complete within %.0fs; forcing exit",
+        _SHUTDOWN_WATCHDOG_SECONDS,
+    )
+    _force_exit(0)
 
 
 # CLI entry point (for pyproject.toml) - use FastMCP's built-in runner
@@ -781,18 +838,28 @@ def main() -> None:
     # Best-effort: failure logs a warning but doesn't block MCP startup.
     _maybe_spawn_settings_sidecar()
 
-    # Route the final exit through _force_exit: _run_entrypoint always leaves
-    # via sys.exit, and letting that SystemExit reach interpreter finalization
-    # aborts when the SDK's stdin reader thread still holds the stdin lock.
-    code = 0
+    # Route every exit through _force_exit: letting interpreter finalization
+    # run aborts when the SDK's stdin reader thread still holds the stdin
+    # lock. _run_entrypoint always leaves via sys.exit; the BaseException
+    # arm covers hard-stop paths (e.g. the re-raised CancelledError from the
+    # #1544 handling) that would otherwise bypass the force-exit. It also
+    # lets the signal handler arm the shutdown watchdog (stdio only).
+    global _force_exit_on_shutdown
+    _force_exit_on_shutdown = True
+    code = 1  # abnormal termination unless an exit says otherwise
     try:
         _run_entrypoint(_run_with_graceful_shutdown(), "Server")
+        code = 0
     except SystemExit as exc:
         if isinstance(exc.code, int):
             code = exc.code
-        elif exc.code is not None:
-            code = 1
-    _force_exit(code)
+        elif exc.code is None:
+            code = 0
+        # any other code (an error-message string) keeps the default 1
+    except BaseException:
+        logger.error("Server terminated abnormally", exc_info=True)
+    finally:
+        _force_exit(code)
 
 
 def _maybe_spawn_settings_sidecar() -> None:

--- a/tests/src/unit/test_graceful_shutdown.py
+++ b/tests/src/unit/test_graceful_shutdown.py
@@ -467,11 +467,18 @@ class TestMainEntryPoint:
             patch.object(
                 main_module, "_run_with_graceful_shutdown", new_callable=AsyncMock
             ),
+            # main() ends in _force_exit → os._exit(), which would kill this
+            # pytest worker (issue #2027). Substitute a SystemExit so the
+            # in-process call still terminates the normal way.
+            patch.object(
+                main_module, "_force_exit", side_effect=SystemExit(0)
+            ) as mock_force_exit,
             pytest.raises(SystemExit),
         ):
             main_module.main()
 
         assert setup_called, "Signal handlers were not set up"
+        mock_force_exit.assert_called_once_with(0)
 
 
 class TestHTTPEntryPoints:

--- a/tests/src/unit/test_graceful_shutdown.py
+++ b/tests/src/unit/test_graceful_shutdown.py
@@ -480,6 +480,83 @@ class TestMainEntryPoint:
         assert setup_called, "Signal handlers were not set up"
         mock_force_exit.assert_called_once_with(0)
 
+    def _assert_exit_routed(self, raised: BaseException, expected: int) -> None:
+        """Run main() with _run_entrypoint raising, assert _force_exit code."""
+        import ha_mcp.__main__ as main_module
+
+        with (
+            patch.dict(
+                os.environ,
+                {
+                    "HOMEASSISTANT_URL": "http://test.local:8123",
+                    "HOMEASSISTANT_TOKEN": "test_token",
+                },
+            ),
+            patch.object(sys, "argv", ["ha-mcp"]),
+            patch.object(main_module, "_check_stdin_available", return_value=True),
+            patch.object(main_module, "_maybe_spawn_settings_sidecar"),
+            # Plain MagicMock: an auto-created AsyncMock would return a
+            # never-awaited coroutine and trip pytest's unraisable check.
+            patch.object(main_module, "_run_with_graceful_shutdown", new=MagicMock()),
+            patch.object(main_module, "_run_entrypoint", side_effect=raised),
+            patch.object(
+                main_module, "_force_exit", side_effect=SystemExit
+            ) as force_exit,
+            pytest.raises(SystemExit),
+        ):
+            main_module.main()
+
+        force_exit.assert_called_once_with(expected)
+
+    def test_main_routes_nonzero_exit_code_through_force_exit(self):
+        """A failed server exit (sys.exit(1) etc.) must not collapse to 0."""
+        self._assert_exit_routed(SystemExit(3), 3)
+
+    def test_main_routes_string_exit_code_as_failure(self):
+        """SystemExit with a message string is an abnormal exit → code 1."""
+        self._assert_exit_routed(SystemExit("config error"), 1)
+
+    def test_main_routes_cancelled_error_through_force_exit(self):
+        """BaseExceptions like CancelledError (the #1544 hard-stop path) must
+        still exit via _force_exit — reaching interpreter finalization with a
+        parked stdin reader is the issue #2027 abort."""
+        self._assert_exit_routed(asyncio.CancelledError(), 1)
+
+
+class TestShutdownWatchdog:
+    """Tests for the stdio shutdown watchdog (issue #2027 hang variant)."""
+
+    def _fire_first_signal(self, stdio_mode: bool) -> MagicMock:
+        import ha_mcp.__main__ as main_module
+
+        main_module._shutdown_in_progress = False
+        main_module._shutdown_event = None  # handler returns after arming
+        try:
+            with (
+                patch.object(main_module.threading, "Timer") as timer_cls,
+                patch.object(main_module, "_force_exit_on_shutdown", stdio_mode),
+            ):
+                main_module._signal_handler(signal.SIGTERM, None)
+        finally:
+            main_module._shutdown_in_progress = False
+        return timer_cls
+
+    def test_first_signal_arms_watchdog_in_stdio_mode(self):
+        timer_cls = self._fire_first_signal(stdio_mode=True)
+
+        import ha_mcp.__main__ as main_module
+
+        timer_cls.assert_called_once_with(
+            main_module._SHUTDOWN_WATCHDOG_SECONDS,
+            main_module._shutdown_watchdog_fire,
+        )
+        assert timer_cls.return_value.daemon is True
+        timer_cls.return_value.start.assert_called_once()
+
+    def test_first_signal_does_not_arm_watchdog_for_http(self):
+        timer_cls = self._fire_first_signal(stdio_mode=False)
+        timer_cls.assert_not_called()
+
 
 class TestHTTPEntryPoints:
     """Tests for HTTP entry points (main_web, main_sse)."""

--- a/tests/src/unit/test_stdio_shutdown_abort.py
+++ b/tests/src/unit/test_stdio_shutdown_abort.py
@@ -1,12 +1,13 @@
 """Regression tests for the stdio shutdown abort (issue #2027).
 
 The MCP SDK's stdio transport reads stdin through anyio's worker-thread
-pool, so a daemon thread parked in ``readline()`` holds the
+pool, so a daemon thread parked in a blocking stdin read holds the
 ``BufferedReader`` lock whenever no message is in flight. If the process
 reaches interpreter finalization in that state, CPython aborts with
 ``Fatal Python error: _enter_buffered_busy`` — SIGABRT, which macOS turns
 into a user-visible crash dialog. ``ha_mcp.__main__._force_exit`` skips
-finalization to neutralize this.
+finalization to neutralize this; a shutdown watchdog bounds the related
+hang where the SDK's stdio teardown never completes at all.
 
 Everything here spawns real subprocesses: the abort happens inside
 interpreter teardown, which cannot be reproduced in-process.
@@ -73,10 +74,13 @@ class TestForceExitMechanism:
     def test_plain_exit_with_parked_reader_aborts(self) -> None:
         """Control: sys.exit() in the parked-reader state aborts the process.
 
-        This is the bug being guarded against. If a future CPython or anyio
-        release makes this pass cleanly (returncode 0, no fatal error), the
-        _force_exit workaround in ha_mcp.__main__ can likely be removed —
-        that is the only situation in which this test should ever fail.
+        This is the bug being guarded against (no anyio involved — the abort
+        is CPython finalization behavior). If a future CPython release
+        changes buffered-IO finalization so this passes cleanly (returncode
+        0, no fatal error), the _force_exit workaround in ha_mcp.__main__
+        can likely be removed. It can also fail if the reader thread loses
+        the startup race and is not yet inside read() at exit — treat that
+        as a race to investigate, not as the upstream fix having landed.
         """
         code, stderr = _run_with_open_stdin(_PARKED_READER_PREAMBLE + "sys.exit(0)")
         assert code != 0
@@ -113,13 +117,16 @@ def _drain(stream: BufferedReader, sink: bytearray) -> None:
 )
 @pytest.mark.timeout(180)
 def test_stdio_server_sigterm_exits_cleanly(tmp_path: Path) -> None:
-    """Full-server regression test: SIGTERM mid-session must not SIGABRT.
+    """Full-server regression test: SIGTERM mid-session must exit cleanly.
 
     Reproduces the issue #2027 session-end sequence: the server is up, has
     answered ``initialize``, and its stdin reader is parked awaiting the next
-    message; the client then goes away (SIGTERM). Without _force_exit the
-    graceful-shutdown path ends in ``sys.exit`` → finalization → SIGABRT
-    (returncode -6) and a macOS crash dialog.
+    message; the client then goes away (SIGTERM). Without the fixes this
+    fails two ways: ``sys.exit`` reaching finalization aborts (returncode
+    -6, the macOS crash-dialog variant), or the SDK's stdio teardown never
+    completes while the stdin read is in flight and the process never exits
+    (the leftover-instances variant). The shutdown watchdog bounds the
+    latter, so the process must exit 0 well inside the wait below.
     """
     env = os.environ.copy()
     env.update(

--- a/tests/src/unit/test_stdio_shutdown_abort.py
+++ b/tests/src/unit/test_stdio_shutdown_abort.py
@@ -45,17 +45,21 @@ time.sleep(0.5)
 """
 
 
-def _run_with_open_stdin(script: str, timeout: float = 60) -> tuple[int, str]:
+def _run_with_open_stdin(
+    script: str, timeout: float = 60, stdout: int = subprocess.DEVNULL
+) -> tuple[int, str]:
     """Run ``script`` in a subprocess whose stdin stays open until it exits.
 
     Returns (returncode, stderr). Crucially does NOT use ``communicate()``
     while the child is alive — that closes stdin, which delivers EOF, wakes
-    the parked reader thread, and destroys the scenario under test.
+    the parked reader thread, and destroys the scenario under test. Pass
+    ``stdout=subprocess.PIPE`` to leave stdout undrained so the child can
+    block on a full pipe (the blocked-writer scenario).
     """
     proc = subprocess.Popen(
         [sys.executable, "-c", script],
         stdin=subprocess.PIPE,
-        stdout=subprocess.DEVNULL,
+        stdout=stdout,
         stderr=subprocess.PIPE,
     )
     try:
@@ -102,6 +106,26 @@ class TestForceExitMechanism:
         )
         code, stderr = _run_with_open_stdin(script)
         assert code == 7, f"stderr:\n{stderr}"
+        assert _FATAL not in stderr
+
+    def test_force_exit_with_blocked_stdout_writer_still_exits(self) -> None:
+        """A writer thread blocked on a full stdout pipe (the client stopped
+        draining) holds the buffered-writer lock; _force_exit's flush must
+        not deadlock on that lock or the hard-exit path — watchdog included
+        — turns back into a hang. The parent deliberately never reads
+        stdout so the 16 MiB write fills the pipe and blocks."""
+        script = (
+            "import sys, threading, time\n"
+            "from ha_mcp.__main__ import _force_exit\n"
+            "threading.Thread(\n"
+            "    target=lambda: sys.stdout.buffer.write(b'x' * (16 * 1024 * 1024)),\n"
+            "    daemon=True,\n"
+            ").start()\n"
+            "time.sleep(1.0)  # let the pipe fill and the writer block\n"
+            "_force_exit(5)\n"
+        )
+        code, stderr = _run_with_open_stdin(script, stdout=subprocess.PIPE)
+        assert code == 5, f"stderr:\n{stderr}"
         assert _FATAL not in stderr
 
 

--- a/tests/src/unit/test_stdio_shutdown_abort.py
+++ b/tests/src/unit/test_stdio_shutdown_abort.py
@@ -1,0 +1,193 @@
+"""Regression tests for the stdio shutdown abort (issue #2027).
+
+The MCP SDK's stdio transport reads stdin through anyio's worker-thread
+pool, so a daemon thread parked in ``readline()`` holds the
+``BufferedReader`` lock whenever no message is in flight. If the process
+reaches interpreter finalization in that state, CPython aborts with
+``Fatal Python error: _enter_buffered_busy`` — SIGABRT, which macOS turns
+into a user-visible crash dialog. ``ha_mcp.__main__._force_exit`` skips
+finalization to neutralize this.
+
+Everything here spawns real subprocesses: the abort happens inside
+interpreter teardown, which cannot be reproduced in-process.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import signal
+import subprocess
+import sys
+import threading
+import time
+from io import BufferedReader
+from pathlib import Path
+
+import pytest
+
+_FATAL = "Fatal Python error"
+
+# Parks a daemon thread in a blocking stdin read — the exact state the MCP
+# SDK's stdio transport is in between client messages. The Event narrows
+# the start-up race; the sleep afterwards lets the thread enter read() and
+# take the BufferedReader lock before the main thread exits.
+_PARKED_READER_PREAMBLE = """\
+import sys, threading, time
+ready = threading.Event()
+def _park():
+    ready.set()
+    sys.stdin.buffer.read()
+threading.Thread(target=_park, daemon=True).start()
+ready.wait(5)
+time.sleep(0.5)
+"""
+
+
+def _run_with_open_stdin(script: str, timeout: float = 60) -> tuple[int, str]:
+    """Run ``script`` in a subprocess whose stdin stays open until it exits.
+
+    Returns (returncode, stderr). Crucially does NOT use ``communicate()``
+    while the child is alive — that closes stdin, which delivers EOF, wakes
+    the parked reader thread, and destroys the scenario under test.
+    """
+    proc = subprocess.Popen(
+        [sys.executable, "-c", script],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.PIPE,
+    )
+    try:
+        proc.wait(timeout=timeout)
+    finally:
+        if proc.poll() is None:
+            proc.kill()
+    _, stderr = proc.communicate(timeout=10)
+    return proc.returncode, stderr.decode(errors="replace")
+
+
+@pytest.mark.timeout(120)
+class TestForceExitMechanism:
+    """The finalization abort is real, and _force_exit sidesteps it."""
+
+    def test_plain_exit_with_parked_reader_aborts(self) -> None:
+        """Control: sys.exit() in the parked-reader state aborts the process.
+
+        This is the bug being guarded against. If a future CPython or anyio
+        release makes this pass cleanly (returncode 0, no fatal error), the
+        _force_exit workaround in ha_mcp.__main__ can likely be removed —
+        that is the only situation in which this test should ever fail.
+        """
+        code, stderr = _run_with_open_stdin(_PARKED_READER_PREAMBLE + "sys.exit(0)")
+        assert code != 0
+        assert "_enter_buffered_busy" in stderr
+
+    def test_force_exit_with_parked_reader_is_clean(self) -> None:
+        script = (
+            _PARKED_READER_PREAMBLE
+            + "from ha_mcp.__main__ import _force_exit\n_force_exit(0)"
+        )
+        code, stderr = _run_with_open_stdin(script)
+        assert code == 0, f"stderr:\n{stderr}"
+        assert _FATAL not in stderr
+
+    def test_force_exit_propagates_exit_code(self) -> None:
+        script = (
+            _PARKED_READER_PREAMBLE
+            + "from ha_mcp.__main__ import _force_exit\n_force_exit(7)"
+        )
+        code, stderr = _run_with_open_stdin(script)
+        assert code == 7, f"stderr:\n{stderr}"
+        assert _FATAL not in stderr
+
+
+def _drain(stream: BufferedReader, sink: bytearray) -> None:
+    """Continuously read a pipe so the child never blocks on a full buffer."""
+    while chunk := stream.read(4096):
+        sink.extend(chunk)
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="POSIX signal semantics required (SIGTERM); CI runs this on Linux",
+)
+@pytest.mark.timeout(180)
+def test_stdio_server_sigterm_exits_cleanly(tmp_path: Path) -> None:
+    """Full-server regression test: SIGTERM mid-session must not SIGABRT.
+
+    Reproduces the issue #2027 session-end sequence: the server is up, has
+    answered ``initialize``, and its stdin reader is parked awaiting the next
+    message; the client then goes away (SIGTERM). Without _force_exit the
+    graceful-shutdown path ends in ``sys.exit`` → finalization → SIGABRT
+    (returncode -6) and a macOS crash dialog.
+    """
+    env = os.environ.copy()
+    env.update(
+        {
+            # Unreachable on purpose: startup must not depend on a live HA.
+            "HOMEASSISTANT_URL": "http://127.0.0.1:1",
+            "HOMEASSISTANT_TOKEN": "test-token",
+            "HA_MCP_CONFIG_DIR": str(tmp_path),
+            # No detached sidecar process and no PyPI call from CI.
+            "HA_MCP_DISABLE_SETTINGS_UI": "1",
+            "HA_MCP_DISABLE_UPDATE_CHECK": "1",
+        }
+    )
+    proc = subprocess.Popen(
+        [sys.executable, "-m", "ha_mcp"],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        env=env,
+    )
+    assert proc.stdin is not None and proc.stdout is not None
+    assert proc.stderr is not None
+    stdout = proc.stdout
+    stderr_sink = bytearray()
+    threading.Thread(
+        target=_drain, args=(proc.stderr, stderr_sink), daemon=True
+    ).start()
+
+    try:
+        initialize = {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2025-06-18",
+                "capabilities": {},
+                "clientInfo": {"name": "pytest-2027", "version": "0"},
+            },
+        }
+        proc.stdin.write(json.dumps(initialize).encode() + b"\n")
+        proc.stdin.flush()
+
+        # First stdout line is the initialize response (stdout is
+        # protocol-only in stdio transport; logs go to stderr). Reading it
+        # proves the server is fully up with the stdin reader active.
+        response: list[bytes] = []
+        reader = threading.Thread(
+            target=lambda: response.append(stdout.readline()), daemon=True
+        )
+        reader.start()
+        reader.join(timeout=90)
+        assert response and response[0], "no initialize response before timeout"
+        assert b'"serverInfo"' in response[0]
+
+        # Let the transport dispatch the next readline so the reader thread
+        # is parked holding the stdin lock — the crash-triggering state.
+        time.sleep(1.0)
+
+        proc.send_signal(signal.SIGTERM)
+        returncode = proc.wait(timeout=60)
+    finally:
+        if proc.poll() is None:
+            proc.kill()
+            proc.wait(timeout=10)
+
+    stderr_text = stderr_sink.decode(errors="replace")
+    assert returncode == 0, (
+        f"expected clean exit after SIGTERM, got {returncode}\nstderr:\n{stderr_text}"
+    )
+    assert _FATAL not in stderr_text
+    assert "_enter_buffered_busy" not in stderr_text


### PR DESCRIPTION
## What does this PR do?

Fixes the stdio shutdown abort from #2027: when the stdio process exits while the MCP SDK's stdin reader thread is parked in a blocking stdin read (SIGTERM, or the client vanishing mid-read), interpreter finalization cannot close stdin and CPython aborts — `Fatal Python error: _enter_buffered_busy` → SIGABRT, which macOS surfaces as a "Python quit unexpectedly" crash dialog at session end.

The reader thread lives in the MCP SDK's stdio transport, so this neutralizes the abort in our entry point (option 3 from the issue): `main()` now routes its final exit through `os._exit()` after flushing logging, stdout and stderr, skipping interpreter finalization entirely. By that point `_run_with_shutdown` has already run resource cleanup, and a stdio process persists nothing at exit. HTTP entry points (`ha-mcp-web`/`-sse`/`-oauth`/`-oidc`) are unchanged — they have no stdin reader and no abort. The embedded/in-process server never imports `ha_mcp.__main__` and is unaffected.

CI then exposed the issue's second symptom (stdio instances that never exit): with a stdin read in flight, cancelling the server task hangs inside the SDK's `stdio_server` teardown, so `asyncio.run` never returns. The shutdown path now bounds its waits with `asyncio.wait`, and the signal handler arms a 10-second watchdog (stdio only) that force-exits if the graceful path is stuck. Both symptoms — the SIGABRT and the leftover processes — are covered by the SIGTERM regression test.

Closes #2027

## Type of change
- [x] 🐛 Bug fix

## Testing
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

New regression tests in `tests/src/unit/test_stdio_shutdown_abort.py`:
- **Mechanism control**: a subprocess with a daemon thread parked in a stdin read plus plain `sys.exit(0)` must abort with `_enter_buffered_busy` — proves the bug class is real on the CI platform. If a future CPython release changes finalization so this passes cleanly, that failure is the signal the workaround can be removed.
- **Helper tests**: the same parked-reader state exiting via `_force_exit` exits cleanly, including exit-code propagation.
- **Full-server test (Linux)**: spawns `python -m ha_mcp`, completes a real `initialize` handshake over stdio, then sends SIGTERM — asserts exit code 0 with no fatal error on stderr. Covers both the SIGABRT and the never-exits variants.

Plus unit tests for exit-code routing through `main()` (non-zero, string, and `CancelledError` cases) and watchdog arming in `tests/src/unit/test_graceful_shutdown.py`.

## Checklist
- [x] I have updated documentation if needed