### PR TITLE
feat: include RFC 9207 iss parameter in OAuth authorization responses

### DIFF
--- a/custom_components/ha_mcp_tools/mcp_webhook.py
+++ b/custom_components/ha_mcp_tools/mcp_webhook.py
@@ -291,11 +291,28 @@ def _protected_resource_document(webhook_id: str, base: str) -> dict[str, Any]:
     }
 
 
+def oauth_issuer(base: str) -> str:
+    """Issuer identifier this component's OWN authorization servers advertise.
+
+    Single source for the ``issuer`` field of the legacy and none-mode documents
+    below and for the RFC 9207 ``iss`` authorization-response parameter that
+    :mod:`oauth_legacy` / :mod:`oauth_autoapprove` put on their redirects — RFC
+    9207 §2 requires the redirect's ``iss`` to equal the advertised issuer
+    exactly.
+    """
+    return f"{base}{OAUTH_BASE}"
+
+
+def issuer_for_request(request: web.Request) -> str:
+    """:func:`oauth_issuer` for the public base URL ``request`` resolves to."""
+    return oauth_issuer(_build_base_url(request))
+
+
 def _legacy_authorization_server_document(base: str) -> dict[str, Any]:
     """RFC 8414 authorization-server metadata for legacy mode's own root
     ``/authorize`` + ``/token`` views (see :mod:`oauth_legacy`)."""
     return {
-        "issuer": f"{base}{OAUTH_BASE}",
+        "issuer": oauth_issuer(base),
         "authorization_endpoint": f"{base}{AUTHORIZE_PATH}",
         "token_endpoint": f"{base}{TOKEN_PATH}",
         "response_types_supported": ["code"],
@@ -323,7 +340,7 @@ def _none_mode_authorization_server_document(base: str) -> dict[str, Any]:
     ``authorization_code`` is advertised.
     """
     return {
-        "issuer": f"{base}{OAUTH_BASE}",
+        "issuer": oauth_issuer(base),
         "authorization_endpoint": f"{base}{OAUTH_BASE}/authorize",
         "token_endpoint": f"{base}{OAUTH_BASE}/token",
         "response_types_supported": ["code"],

--- a/custom_components/ha_mcp_tools/mcp_webhook.py
+++ b/custom_components/ha_mcp_tools/mcp_webhook.py
@@ -313,6 +313,9 @@ def _legacy_authorization_server_document(base: str) -> dict[str, Any]:
     ``/authorize`` + ``/token`` views (see :mod:`oauth_legacy`)."""
     return {
         "issuer": oauth_issuer(base),
+        # RFC 9207 §3: authorization responses carry ``iss`` (oauth_legacy's
+        # redirects); omission reads as "not supported" to discovery clients.
+        "authorization_response_iss_parameter_supported": True,
         "authorization_endpoint": f"{base}{AUTHORIZE_PATH}",
         "token_endpoint": f"{base}{TOKEN_PATH}",
         "response_types_supported": ["code"],
@@ -341,6 +344,9 @@ def _none_mode_authorization_server_document(base: str) -> dict[str, Any]:
     """
     return {
         "issuer": oauth_issuer(base),
+        # RFC 9207 §3: authorization responses carry ``iss`` (the auto-approve
+        # redirects); omission reads as "not supported" to discovery clients.
+        "authorization_response_iss_parameter_supported": True,
         "authorization_endpoint": f"{base}{OAUTH_BASE}/authorize",
         "token_endpoint": f"{base}{OAUTH_BASE}/token",
         "response_types_supported": ["code"],

--- a/custom_components/ha_mcp_tools/oauth_autoapprove.py
+++ b/custom_components/ha_mcp_tools/oauth_autoapprove.py
@@ -59,6 +59,7 @@ from .oauth_legacy import (
     ACCESS_TOKEN_TTL,
     PKCECodeStore,
     _is_valid_redirect_uri,
+    _issuer_for,
 )
 
 if TYPE_CHECKING:
@@ -238,14 +239,19 @@ class AutoApproveAuthorizeView(HomeAssistantView):
         if not _is_valid_autoapprove_redirect(redirect_uri):
             return _json_error("invalid_request", 400, "invalid redirect_uri")
 
+        # RFC 9207: every authorization response — success or error — names the
+        # issuer that produced it, so a client registered with several
+        # authorization servers cannot be fed a response minted by another one.
+        iss = _issuer_for(request)
+
         code = provider.issue_code(redirect_uri, code_challenge)
         if code is None:
             # Pending-code store at capacity (abuse guard) — surface per
             # RFC 6749 §4.1.2.1 instead of a silent failure.
             return _redirect_with(
-                redirect_uri, error="temporarily_unavailable", state=state
+                redirect_uri, error="temporarily_unavailable", state=state, iss=iss
             )
-        redirect_params = {"code": code}
+        redirect_params = {"code": code, "iss": iss}
         if state:
             redirect_params["state"] = state
         return _redirect_with(redirect_uri, **redirect_params)

--- a/custom_components/ha_mcp_tools/oauth_legacy.py
+++ b/custom_components/ha_mcp_tools/oauth_legacy.py
@@ -292,6 +292,19 @@ def _live_auth_mode(hass: HomeAssistant) -> str | None:
     return active_auth_mode(hass)
 
 
+def _issuer_for(request: web.Request) -> str:
+    """The issuer identifier this mode advertises for ``request``.
+
+    RFC 9207 §2 requires the ``iss`` authorization-response parameter to equal
+    the advertised ``issuer`` exactly, so it comes from the same helper that
+    fills the discovery document's field. Deferred import for the module-cycle
+    reason documented on :func:`_live_auth_mode`.
+    """
+    from .mcp_webhook import issuer_for_request
+
+    return issuer_for_request(request)
+
+
 # ---------------------------------------------------------------------------
 # Small helpers (ported from the add-on's oauth.py)
 # ---------------------------------------------------------------------------
@@ -713,8 +726,15 @@ class AuthorizeView(HomeAssistantView):
         if err is not None:
             return err
 
+        # RFC 9207: every authorization response — success or error — names the
+        # issuer that produced it, so a client registered with several
+        # authorization servers cannot be fed a response minted by another one.
+        iss = _issuer_for(request)
+
         if action == "deny":
-            return self._redirect_with(redirect_uri, error="access_denied", state=state)
+            return self._redirect_with(
+                redirect_uri, error="access_denied", state=state, iss=iss
+            )
         if action != "approve":
             return _text_error(400, "invalid action")
 
@@ -723,9 +743,9 @@ class AuthorizeView(HomeAssistantView):
             # Pending-code store at cap → signal back per RFC 6749 §4.1.2.1
             # instead of silently failing.
             return self._redirect_with(
-                redirect_uri, error="temporarily_unavailable", state=state
+                redirect_uri, error="temporarily_unavailable", state=state, iss=iss
             )
-        return self._redirect_with(redirect_uri, code=code, state=state)
+        return self._redirect_with(redirect_uri, code=code, state=state, iss=iss)
 
     def _validate_authorize_params(
         self,

--- a/homeassistant-addon-webhook-proxy-dev/CHANGELOG.md
+++ b/homeassistant-addon-webhook-proxy-dev/CHANGELOG.md
@@ -9,6 +9,19 @@ history from before the fork.
 -->
 
 
+## v2.0.5.dev2 (2026-07-25)
+
+### Features
+
+- Authorization responses from the add-on's own OAuth servers (the legacy
+  `/authorize` view and the none-mode auto-approve `/authorize` view) now carry
+  the RFC 9207 `iss` parameter naming the issuer that produced them, on both the
+  success redirect and the error redirects. The value is the same issuer the
+  add-on's RFC 8414 metadata document advertises. Clients that do not implement
+  RFC 9207 ignore the extra query parameter, so existing connectors are
+  unaffected.
+
+
 ## v2.0.5.dev1 (2026-07-20)
 
 ### Bug Fixes

--- a/homeassistant-addon-webhook-proxy-dev/config.yaml
+++ b/homeassistant-addon-webhook-proxy-dev/config.yaml
@@ -1,6 +1,6 @@
 name: "Nabu Casa - Webhook Proxy for HA MCP (Dev)"
 description: "DEV CHANNEL (unstable) — remote access proxy via Nabu Casa or any reverse proxy. Cannot run alongside the stable Webhook Proxy add-on."
-version: "2.0.5.dev1"
+version: "2.0.5.dev2"
 slug: "ha_mcp_webhook_proxy_dev"
 url: "https://github.com/homeassistant-ai/ha-mcp"
 stage: experimental

--- a/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/manifest.json
+++ b/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/manifest.json
@@ -7,5 +7,5 @@
   "dependencies": ["webhook"],
   "documentation": "https://github.com/homeassistant-ai/ha-mcp",
   "iot_class": "local_push",
-  "version": "2.0.5.dev1"
+  "version": "2.0.5.dev2"
 }

--- a/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/oauth.py
+++ b/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/oauth.py
@@ -935,8 +935,18 @@ class AuthorizeView(HomeAssistantView):
         if err is not None:
             return err
 
+        # RFC 9207: every authorization response — success or error — names the
+        # issuer that produced it, so a client registered with several
+        # authorization servers cannot be fed a response minted by another one.
+        # Resolved through the ACTIVE mode's provider, exactly as
+        # AuthorizationServerMetadataView builds the `issuer` this must match.
+        provider = _active_provider(self._provider)
+        iss = provider.authorization_server_url(provider.base_url_for(request))
+
         if action == "deny":
-            return self._redirect_with(redirect_uri, error="access_denied", state=state)
+            return self._redirect_with(
+                redirect_uri, error="access_denied", state=state, iss=iss
+            )
         if action != "approve":
             return _text_error(400, "invalid action")
 
@@ -945,9 +955,9 @@ class AuthorizeView(HomeAssistantView):
             # Pending-code store at cap → signal back to the client per
             # RFC 6749 §4.1.2.1 instead of silently failing.
             return self._redirect_with(
-                redirect_uri, error="temporarily_unavailable", state=state
+                redirect_uri, error="temporarily_unavailable", state=state, iss=iss
             )
-        return self._redirect_with(redirect_uri, code=code, state=state)
+        return self._redirect_with(redirect_uri, code=code, state=state, iss=iss)
 
     def _validate_authorize_params(
         self,

--- a/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/oauth.py
+++ b/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/oauth.py
@@ -751,6 +751,10 @@ class AuthorizationServerMetadataView(HomeAssistantView):
         return web.json_response(
             {
                 "issuer": as_url,
+                # RFC 9207 §3: authorization responses carry ``iss`` (the
+                # AuthorizeView redirects); omission reads as "not supported"
+                # to discovery clients.
+                "authorization_response_iss_parameter_supported": True,
                 "authorization_endpoint": f"{base}{AUTHORIZE_PATH}",
                 "token_endpoint": f"{base}{TOKEN_PATH}",
                 "response_types_supported": ["code"],

--- a/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/oauth_autoapprove.py
+++ b/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/oauth_autoapprove.py
@@ -95,6 +95,17 @@ _AUTOAPPROVE_REDIRECT_ALLOWLIST = frozenset(
 )
 
 
+def _issuer(base: str) -> str:
+    """Issuer identifier none-mode auto-approve advertises under ``base``.
+
+    Single source for the document's ``issuer`` below, the provider's
+    ``authorization_server_url``, and the RFC 9207 ``iss`` authorization-response
+    parameter — RFC 9207 §2 requires the redirect's ``iss`` to equal the
+    advertised issuer exactly.
+    """
+    return f"{base}{OAUTH_BASE}"
+
+
 def authorization_server_document(base: str) -> dict:
     """RFC 8414 authorization-server metadata for none-mode auto-approve.
 
@@ -109,7 +120,7 @@ def authorization_server_document(base: str) -> dict:
     so only ``authorization_code`` is advertised.
     """
     return {
-        "issuer": f"{base}{OAUTH_BASE}",
+        "issuer": _issuer(base),
         "authorization_endpoint": f"{base}{OAUTH_BASE}/authorize",
         "token_endpoint": f"{base}{OAUTH_BASE}/token",
         "response_types_supported": ["code"],
@@ -193,7 +204,7 @@ class AutoApproveProvider:
         return f"{base_url}/api/webhook/{self._webhook_id}"
 
     def authorization_server_url(self, base_url: str) -> str:
-        return f"{base_url}{OAUTH_BASE}"
+        return _issuer(base_url)
 
     def base_url_for(self, request: web.Request) -> str:
         return _build_base_url(request, self._public_base_url)
@@ -291,14 +302,19 @@ class AutoApproveAuthorizeView(HomeAssistantView):
         if not _is_valid_autoapprove_redirect(redirect_uri):
             return _json_error("invalid_request", 400, "invalid redirect_uri")
 
+        # RFC 9207: every authorization response — success or error — names the
+        # issuer that produced it, so a client registered with several
+        # authorization servers cannot be fed a response minted by another one.
+        iss = _issuer(provider.base_url_for(request))
+
         code = provider.issue_code(redirect_uri, code_challenge)
         if code is None:
             # Pending-code store at capacity (abuse guard) — surface per
             # RFC 6749 §4.1.2.1 instead of a silent failure.
             return _redirect_with(
-                redirect_uri, error="temporarily_unavailable", state=state
+                redirect_uri, error="temporarily_unavailable", state=state, iss=iss
             )
-        redirect_params = {"code": code}
+        redirect_params = {"code": code, "iss": iss}
         if state:
             redirect_params["state"] = state
         return _redirect_with(redirect_uri, **redirect_params)

--- a/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/oauth_autoapprove.py
+++ b/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/oauth_autoapprove.py
@@ -121,6 +121,9 @@ def authorization_server_document(base: str) -> dict:
     """
     return {
         "issuer": _issuer(base),
+        # RFC 9207 §3: authorization responses carry ``iss`` (the auto-approve
+        # redirects); omission reads as "not supported" to discovery clients.
+        "authorization_response_iss_parameter_supported": True,
         "authorization_endpoint": f"{base}{OAUTH_BASE}/authorize",
         "token_endpoint": f"{base}{OAUTH_BASE}/token",
         "response_types_supported": ["code"],

--- a/src/ha_mcp/auth/provider.py
+++ b/src/ha_mcp/auth/provider.py
@@ -370,6 +370,15 @@ class HomeAssistantOAuthProvider(OAuthProvider):
             logger.debug(f"Failed to decode token: {e}")
             return None
 
+    def _issuer(self) -> str:
+        """The issuer identifier this authorization server advertises.
+
+        Single source for the ``issuer`` field of the metadata document served
+        below and for the RFC 9207 ``iss`` authorization-response parameter,
+        which RFC 9207 §2 requires to equal the advertised issuer exactly.
+        """
+        return str(AnyHttpUrl(str(self.base_url).rstrip("/")))
+
     def get_routes(self, mcp_path: str | None = None) -> list[Route]:
         """
         Get OAuth routes including custom consent form routes.
@@ -391,12 +400,9 @@ class HomeAssistantOAuthProvider(OAuthProvider):
             """Enhanced OAuth metadata handler with Claude.ai compatibility."""
             from mcp.server.auth.routes import build_metadata
 
-            # Get base URL
-            base = str(self.base_url).rstrip("/")
-
             # Get base metadata from MCP SDK
             metadata = build_metadata(
-                issuer_url=AnyHttpUrl(base),
+                issuer_url=AnyHttpUrl(self._issuer()),
                 service_documentation_url=AnyHttpUrl(
                     "https://github.com/homeassistant-ai/ha-mcp"
                 ),
@@ -697,11 +703,15 @@ class HomeAssistantOAuthProvider(OAuthProvider):
         # Clean up pending authorization
         del self.pending_authorizations[str(txn_id)]
 
-        # Redirect back to client with auth code
+        # Redirect back to client with auth code. RFC 9207: the authorization
+        # response carries the issuer that produced it, so a client registered
+        # with several authorization servers cannot be fed a code minted by a
+        # different one.
         redirect_uri = construct_redirect_uri(
             pending["redirect_uri"],
             code=auth_code_value,
             state=pending.get("state"),
+            iss=self._issuer(),
         )
 
         logger.info(f"Authorization successful for client {client_id}")

--- a/src/ha_mcp/auth/provider.py
+++ b/src/ha_mcp/auth/provider.py
@@ -18,7 +18,7 @@ import time
 from base64 import urlsafe_b64decode, urlsafe_b64encode
 from pathlib import Path
 from typing import Any
-from urllib.parse import urlencode
+from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
 
 from fastmcp.server.auth.auth import (
     AccessToken,  # FastMCP version has claims field
@@ -379,6 +379,47 @@ class HomeAssistantOAuthProvider(OAuthProvider):
         """
         return str(AnyHttpUrl(str(self.base_url).rstrip("/")))
 
+    def _ensure_single_iss(self, url: str) -> str:
+        """Return ``url`` carrying the RFC 9207 ``iss`` parameter exactly once.
+
+        A registered redirect URI may itself carry an ``iss`` query parameter;
+        blindly appending ours would produce an ambiguous double-``iss``
+        response — and common parsers take the FIRST value, which is precisely
+        the issuer mix-up RFC 9207 exists to prevent. Any pre-existing ``iss``
+        is dropped so the one this server stamps is authoritative.
+        """
+        parsed = urlparse(url)
+        params = [
+            (k, v) for k, vs in parse_qs(parsed.query).items() for v in vs if k != "iss"
+        ]
+        params.append(("iss", self._issuer()))
+        return urlunparse(parsed._replace(query=urlencode(params)))
+
+    def _wrap_authorize_with_iss(self, endpoint: Any) -> Any:
+        """Wrap the SDK's ``/authorize`` endpoint to stamp ``iss`` on its
+        error redirects.
+
+        The SDK's ``AuthorizationHandler`` builds OAuth error authorization
+        responses (invalid scope, ``authorize()`` raising after redirect-URI
+        validation) itself, without the RFC 9207 ``iss`` parameter — only our
+        consent-form success path carries it otherwise. Success on this route
+        is a same-origin redirect to the consent form (no ``error``), which is
+        not an authorization response and stays untouched.
+        """
+
+        async def authorize_with_iss(request: Request) -> Response:
+            response = await endpoint(request)
+            location = response.headers.get("location", "")
+            if (
+                response.status_code in (302, 303, 307)
+                and location
+                and "error" in parse_qs(urlparse(location).query)
+            ):
+                response.headers["location"] = self._ensure_single_iss(location)
+            return response
+
+        return authorize_with_iss
+
     def get_routes(self, mcp_path: str | None = None) -> list[Route]:
         """
         Get OAuth routes including custom consent form routes.
@@ -417,6 +458,11 @@ class HomeAssistantOAuthProvider(OAuthProvider):
             # Add response_modes_supported (required by some OAuth clients)
             metadata_dict["response_modes_supported"] = ["query"]
 
+            # RFC 9207 §3: advertise that authorization responses carry the
+            # ``iss`` parameter — omission means "not supported" to
+            # discovery-driven clients even though redirects now include it.
+            metadata_dict["authorization_response_iss_parameter_supported"] = True
+
             # Add "none" auth method for public clients with PKCE (used by Claude.ai)
             if "token_endpoint_auth_methods_supported" in metadata_dict:
                 if "none" not in metadata_dict["token_endpoint_auth_methods_supported"]:
@@ -452,6 +498,16 @@ class HomeAssistantOAuthProvider(OAuthProvider):
                             enhanced_metadata_handler, ["GET", "OPTIONS"]
                         ),
                         methods=["GET", "OPTIONS"],
+                    )
+                )
+            elif isinstance(route, Route) and route.path == "/authorize":
+                # RFC 9207: the SDK handler's own error redirects must carry
+                # ``iss`` too — see _wrap_authorize_with_iss.
+                enhanced_routes.append(
+                    Route(
+                        path=route.path,
+                        endpoint=self._wrap_authorize_with_iss(route.endpoint),
+                        methods=list(route.methods or []),
                     )
                 )
             else:
@@ -706,12 +762,16 @@ class HomeAssistantOAuthProvider(OAuthProvider):
         # Redirect back to client with auth code. RFC 9207: the authorization
         # response carries the issuer that produced it, so a client registered
         # with several authorization servers cannot be fed a code minted by a
-        # different one.
-        redirect_uri = construct_redirect_uri(
-            pending["redirect_uri"],
-            code=auth_code_value,
-            state=pending.get("state"),
-            iss=self._issuer(),
+        # different one. _ensure_single_iss (rather than an ``iss=`` kwarg
+        # here) collapses any ``iss`` baked into the registered redirect URI —
+        # construct_redirect_uri appends blindly, and a double ``iss`` is
+        # ambiguous to strict clients.
+        redirect_uri = self._ensure_single_iss(
+            construct_redirect_uri(
+                pending["redirect_uri"],
+                code=auth_code_value,
+                state=pending.get("state"),
+            )
         )
 
         logger.info(f"Authorization successful for client {client_id}")

--- a/src/ha_mcp/auth/provider.py
+++ b/src/ha_mcp/auth/provider.py
@@ -16,6 +16,7 @@ import os
 import secrets
 import time
 from base64 import urlsafe_b64decode, urlsafe_b64encode
+from collections.abc import Awaitable, Callable
 from pathlib import Path
 from typing import Any
 from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
@@ -395,7 +396,9 @@ class HomeAssistantOAuthProvider(OAuthProvider):
         params.append(("iss", self._issuer()))
         return urlunparse(parsed._replace(query=urlencode(params)))
 
-    def _wrap_authorize_with_iss(self, endpoint: Any) -> Any:
+    def _wrap_authorize_with_iss(
+        self, endpoint: "Callable[[Request], Awaitable[Response]]"
+    ) -> "Callable[[Request], Awaitable[Response]]":
         """Wrap the SDK's ``/authorize`` endpoint to stamp ``iss`` on its
         error redirects.
 
@@ -408,7 +411,7 @@ class HomeAssistantOAuthProvider(OAuthProvider):
         """
 
         async def authorize_with_iss(request: Request) -> Response:
-            response = await endpoint(request)
+            response: Response = await endpoint(request)
             location = response.headers.get("location", "")
             if (
                 response.status_code in (302, 303, 307)

--- a/tests/addon/test_webhook_proxy.py
+++ b/tests/addon/test_webhook_proxy.py
@@ -306,6 +306,20 @@ def _none_autoapprove_supported() -> bool:
     )
 
 
+def _rfc9207_iss_supported() -> bool:
+    """Feature-detect whether the CURRENT flavor stamps the RFC 9207 ``iss``
+    parameter on its authorization responses. Both of the add-on's own OAuth
+    servers gained it in one dev change, whose marker is the single-source
+    ``_issuer`` helper that change introduced in ``oauth_autoapprove.py``; the
+    stable flavor skips these assertions until it is promoted — same
+    lockstep-with-code approach as `_ha_auth_supported`."""
+    path = os.path.join(PROXY_ADDON_DIR, CURRENT["component"], "oauth_autoapprove.py")
+    if not os.path.exists(path):
+        return False
+    with open(path, encoding="utf-8") as fh:
+        return "def _issuer(" in fh.read()
+
+
 def _import_none_autoapprove_stack():
     """Import the integration wired so none-mode auto-approve resolves.
 
@@ -3621,6 +3635,37 @@ class TestAuthorizeViewPost:
         assert "code=" in loc
         assert "state=abc123" in loc
 
+    @pytest.mark.parametrize(
+        "action,expected", [("approve", "code"), ("deny", "error")]
+    )
+    async def test_redirects_carry_the_advertised_rfc9207_iss(
+        self, tmp_path, action, expected
+    ):
+        """RFC 9207 §2: success AND error authorization responses name the
+        issuer that produced them, using the exact identifier the add-on's
+        RFC 8414 metadata document advertises (`authorization_server_url`)."""
+        if not _rfc9207_iss_supported():
+            pytest.skip("RFC 9207 `iss` rides the dev flavor until promote")
+        from urllib.parse import parse_qs, urlparse
+
+        oauth, provider = _provider_for_view_tests(
+            tmp_path, public_base_url="https://legit.example"
+        )
+        view = oauth.AuthorizeView(provider)
+        # Pinned base URL, so the issuer does not depend on request headers.
+        advertised = provider.authorization_server_url("https://legit.example")
+        assert advertised == f"https://legit.example{CURRENT['oauth_base']}"
+
+        request = _make_view_request(
+            method="POST", post_data=self._good_form(action=action)
+        )
+        resp = await view.post(request)
+
+        assert resp.status == 302
+        params = parse_qs(urlparse(resp.headers["Location"]).query)
+        assert expected in params
+        assert params["iss"] == [advertised]
+
     async def test_post_re_validates_hidden_client_id(self, setup):
         """POST must not trust hidden form fields — re-validate them."""
         oauth, provider, view = setup
@@ -6109,6 +6154,46 @@ class TestNoneAutoApproveMode:
         assert q["state"][0] == "st-1"
         # The issued code is real: it consumes with the matching verifier.
         assert provider.consume_code(q["code"][0], self.CLAUDE_REDIRECT, verifier)
+
+    @pytest.mark.parametrize("at_capacity,expected", [(False, "code"), (True, "error")])
+    async def test_authorize_redirects_carry_the_advertised_rfc9207_iss(
+        self, at_capacity, expected
+    ):
+        """RFC 9207 §2: success AND error authorization responses name the
+        issuer that produced them, byte-identical to the ``issuer`` the
+        none-mode metadata document advertises for the same request."""
+        if not _rfc9207_iss_supported():
+            pytest.skip("RFC 9207 `iss` rides the dev flavor until promote")
+        from urllib.parse import parse_qs, urlparse
+
+        _mod, oauth, autoapprove, _an = _import_none_autoapprove_stack()
+        hass, provider = self._none_live_hass(oauth, autoapprove)
+        if at_capacity:
+            # Store at cap → the temporarily_unavailable error redirect.
+            provider.issue_code = lambda *a, **k: None
+        view = autoapprove.AutoApproveAuthorizeView(hass)
+        _v, challenge = self._pkce_pair()
+        request = _make_view_request(
+            headers={"Host": "ha.example.com"},
+            query={
+                "response_type": "code",
+                "client_id": "https://claude.ai/whatever",
+                "redirect_uri": self.CLAUDE_REDIRECT,
+                "code_challenge": challenge,
+                "code_challenge_method": "S256",
+                "state": "st-1",
+            },
+        )
+        with patch.object(autoapprove.web, "Response") as resp:
+            await view.get(request)
+
+        advertised = autoapprove.authorization_server_document(
+            provider.base_url_for(request)
+        )["issuer"]
+        assert advertised == f"https://ha.example.com{CURRENT['oauth_base']}"
+        q = parse_qs(urlparse(resp.call_args.kwargs["headers"]["Location"]).query)
+        assert expected in q
+        assert q["iss"] == [advertised]
 
     async def test_authorize_rejects_non_allowlisted_redirect_with_400(self):
         _mod, oauth, autoapprove, _an = _import_none_autoapprove_stack()

--- a/tests/addon/test_webhook_proxy.py
+++ b/tests/addon/test_webhook_proxy.py
@@ -3255,6 +3255,10 @@ class TestAuthorizationServerView:
         assert "S256" in body["code_challenge_methods_supported"]
         assert "client_secret_basic" in body["token_endpoint_auth_methods_supported"]
         assert "client_secret_post" in body["token_endpoint_auth_methods_supported"]
+        # RFC 9207 §3 advertisement — gated like the redirect assertions: the
+        # stable flavor skips until promoted.
+        if _rfc9207_iss_supported():
+            assert body["authorization_response_iss_parameter_supported"] is True
 
 
 class TestWellKnownMetadataViews:
@@ -6018,6 +6022,10 @@ class TestNoneAutoApproveMode:
         assert doc["response_types_supported"] == ["code"]
         assert doc["grant_types_supported"] == ["authorization_code"]
         assert doc["code_challenge_methods_supported"] == ["S256"]
+        # RFC 9207 §3 advertisement — gated like the redirect assertions: the
+        # stable flavor skips until promoted.
+        if _rfc9207_iss_supported():
+            assert doc["authorization_response_iss_parameter_supported"] is True
         # The two fields HA core's root doc lacks — the whole reason for #1969.
         assert doc["token_endpoint_auth_methods_supported"] == ["none"]
         assert doc["client_id_metadata_document_supported"] is True

--- a/tests/src/e2e/conftest.py
+++ b/tests/src/e2e/conftest.py
@@ -408,11 +408,15 @@ def pytest_terminal_summary(terminalreporter, exitstatus, config):
         and p.get("entries_loaded", 0) < p.get("entries_total", 0)
     ]
     if drift_samples:
+        culprits = sorted(
+            {p.get("unloaded") for p in drift_samples if p.get("unloaded")}
+        )
         terminalreporter.write_line(
             f"⚠️ [READINESS_GATE_DRIFT] {len(drift_samples)} core_state sample(s) "
             f"with entries_loaded < entries_total — a slow integration "
             f"finished async_setup_entry after CoreState.RUNNING; "
             f"follow-up gate justified."
+            + (f" Not loaded: {'; '.join(culprits)}" if culprits else "")
         )
 
 
@@ -1179,9 +1183,14 @@ def _snapshot_config_entries(
     headers: dict[str, str],
     *,
     timeout: float = 5.0,
-) -> tuple[int, int, bool]:
-    """Return ``(loaded_count, total_count, snapshot_ok)`` from
+) -> tuple[int, int, bool, str]:
+    """Return ``(loaded_count, total_count, snapshot_ok, unloaded)`` from
     ``/api/config/config_entries/entry``.
+
+    ``unloaded`` names the entries that are NOT ``state == "loaded"`` as a
+    comma-joined ``domain:state`` string (capped at 5), so a drift sample
+    identifies the culprit directly — count-only telemetry left the
+    2033-arm ``11/12`` incidents unattributable without container logs.
 
     Used by ``_wait_for_core_state_running`` to capture the entry-state
     snapshot at the trip moment (and on timeout) so post-merge data can
@@ -1205,33 +1214,40 @@ def _snapshot_config_entries(
         )
         if resp.status_code != 200:
             logger.debug(f"snapshot_config_entries: HTTP {resp.status_code}")
-            return 0, 0, False
+            return 0, 0, False, ""
         entries = resp.json()
         if not isinstance(entries, list):
             logger.debug(
                 f"snapshot_config_entries: unexpected body type {type(entries).__name__}"
             )
-            return 0, 0, False
+            return 0, 0, False, ""
         total = len(entries)
         loaded = sum(
             1 for e in entries if isinstance(e, dict) and e.get("state") == "loaded"
         )
-        return loaded, total, True
+        unloaded = ",".join(
+            f"{e.get('domain', '?')}:{e.get('state', '?')}"
+            for e in entries
+            if isinstance(e, dict) and e.get("state") != "loaded"
+        )[:200]
+        return loaded, total, True, unloaded
     except (requests.exceptions.RequestException, json.JSONDecodeError) as exc:
         logger.debug(f"snapshot_config_entries: {type(exc).__name__}: {exc}")
-        return 0, 0, False
+        return 0, 0, False, ""
 
 
 def _wait_for_core_state_running(
     base_url: str,
     headers: dict[str, str],
     timeout: int,
-) -> tuple[bool, float, str, int, int, bool]:
+) -> tuple[bool, float, str, int, int, bool, str]:
     """Poll ``/api/core/state`` until ``state == "RUNNING"``.
 
     Returns ``(success, elapsed_s, last_state, entries_loaded,
-    entries_total, snapshot_ok)``. ``snapshot_ok=False`` flags that the
-    entries fields are sentinel zeros rather than real data.
+    entries_total, snapshot_ok, entries_unloaded)``. ``snapshot_ok=False``
+    flags that the entries fields are sentinel zeros rather than real
+    data; ``entries_unloaded`` names the not-loaded entries as
+    ``domain:state`` pairs (empty when all loaded).
 
     HA Core's ``APICoreStateView`` (``homeassistant/components/api/__init__.py``)
     is the documented Supervisor-facing readiness endpoint: it reports the
@@ -1278,12 +1294,13 @@ def _wait_for_core_state_running(
                 last_state = state_value
                 if state_value == "RUNNING":
                     elapsed = time.monotonic() - start_time
-                    entries_loaded, entries_total, snapshot_ok = (
+                    entries_loaded, entries_total, snapshot_ok, entries_unloaded = (
                         _snapshot_config_entries(base_url, headers)
                     )
                     logger.info(
                         f"🏃 CoreState.RUNNING after {elapsed:.1f}s "
                         f"(entries loaded: {entries_loaded}/{entries_total}"
+                        f"{f', not loaded: {entries_unloaded}' if entries_unloaded else ''}"
                         f"{'' if snapshot_ok else ', snapshot unavailable'})"
                     )
                     return (
@@ -1293,6 +1310,7 @@ def _wait_for_core_state_running(
                         entries_loaded,
                         entries_total,
                         snapshot_ok,
+                        entries_unloaded,
                     )
             else:
                 # Surface HTTP status as a fallback ``last_state`` so a
@@ -1308,8 +1326,8 @@ def _wait_for_core_state_running(
     # Final snapshot for the failure-diagnostics path — HA is known-bad
     # by this point, so use a tight 2s timeout rather than the default 5s
     # to keep teardown responsive.
-    entries_loaded, entries_total, snapshot_ok = _snapshot_config_entries(
-        base_url, headers, timeout=2.0
+    entries_loaded, entries_total, snapshot_ok, entries_unloaded = (
+        _snapshot_config_entries(base_url, headers, timeout=2.0)
     )
     return (
         False,
@@ -1318,6 +1336,7 @@ def _wait_for_core_state_running(
         entries_loaded,
         entries_total,
         snapshot_ok,
+        entries_unloaded,
     )
 
 
@@ -2338,6 +2357,7 @@ def _wait_for_testcontainer_ready(
         entries_loaded,
         entries_total,
         snapshot_ok,
+        entries_unloaded,
     ) = _wait_for_core_state_running(base_url, headers, CORE_STATE_TIMEOUT)
     if not core_state_ok:
         _dump_ha_readiness_diagnostics(
@@ -2359,6 +2379,9 @@ def _wait_for_testcontainer_ready(
         entries_loaded=entries_loaded,
         entries_total=entries_total,
         snapshot_ok=snapshot_ok,
+        # Only stamped when something is actually unloaded, so the common
+        # all-loaded line stays compact.
+        **({"unloaded": entries_unloaded} if entries_unloaded else {}),
     )
 
     _wait_for_testcontainer_sun(base_url, headers, container, SUN_WAIT)

--- a/tests/src/unit/test_oauth.py
+++ b/tests/src/unit/test_oauth.py
@@ -1807,3 +1807,52 @@ class TestRunOAuthServerSettingsUI:
         paths = [c.args[0] for c in mock_mcp.custom_route.call_args_list]
 
         assert not any("settings" in p for p in paths)
+
+
+class TestRfc9207ResponseHygiene:
+    """RFC 9207 hardening beyond the consent-path ``iss`` stamp: the SDK
+    handler's own error redirects carry ``iss`` too, and a redirect URI with a
+    baked-in ``iss`` cannot produce an ambiguous double-``iss`` response."""
+
+    @pytest.fixture
+    def provider(self):
+        return HomeAssistantOAuthProvider(base_url="http://localhost:8086")
+
+    def test_ensure_single_iss_collapses_preexisting_iss(self, provider):
+        url = provider._ensure_single_iss(
+            "https://client.example/cb?iss=evil&code=abc&state=s"
+        )
+        params = parse_qs(urlparse(url).query)
+        assert params["iss"] == [provider._issuer()]
+        assert params["code"] == ["abc"]
+        assert params["state"] == ["s"]
+
+    @pytest.mark.asyncio
+    async def test_authorize_wrap_stamps_iss_on_error_redirect(self, provider):
+        from starlette.responses import RedirectResponse
+
+        async def sdk_endpoint(request):
+            return RedirectResponse(
+                "https://client.example/cb?error=invalid_scope&state=s",
+                status_code=302,
+            )
+
+        wrapped = provider._wrap_authorize_with_iss(sdk_endpoint)
+        response = await wrapped(MagicMock())
+        params = parse_qs(urlparse(response.headers["location"]).query)
+        assert params["iss"] == [provider._issuer()]
+        assert params["error"] == ["invalid_scope"]
+        assert params["state"] == ["s"]
+
+    @pytest.mark.asyncio
+    async def test_authorize_wrap_leaves_consent_redirect_untouched(self, provider):
+        from starlette.responses import RedirectResponse
+
+        consent_url = "http://localhost:8086/consent?txn_id=t1"
+
+        async def sdk_endpoint(request):
+            return RedirectResponse(consent_url, status_code=302)
+
+        wrapped = provider._wrap_authorize_with_iss(sdk_endpoint)
+        response = await wrapped(MagicMock())
+        assert response.headers["location"] == consent_url

--- a/tests/src/unit/test_oauth.py
+++ b/tests/src/unit/test_oauth.py
@@ -4,6 +4,7 @@ import json
 import stat
 import time
 from unittest.mock import AsyncMock, MagicMock, patch
+from urllib.parse import parse_qs, urlparse
 
 import pytest
 
@@ -636,8 +637,13 @@ class TestOAuthRoutes:
 
         # Should redirect with auth code
         assert response.status_code == 303
-        assert "code=" in response.headers["location"]
-        assert "state=test-state" in response.headers["location"]
+        params = parse_qs(urlparse(response.headers["location"]).query)
+        assert params["code"]
+        assert params["state"] == ["test-state"]
+        # RFC 9207 §2: the authorization response names the issuer that minted
+        # the code, using the identifier the metadata document advertises.
+        assert params["iss"] == [provider._issuer()]
+        assert provider._issuer() == "http://localhost:8086/"
 
     @pytest.mark.asyncio
     async def test_consent_post_missing_token(self, provider, mock_request):

--- a/tests/src/unit/test_oauth_autoapprove.py
+++ b/tests/src/unit/test_oauth_autoapprove.py
@@ -51,10 +51,13 @@ import custom_components.ha_mcp_tools.oauth_autoapprove as aa  # noqa: E402
 from custom_components.ha_mcp_tools.const import (  # noqa: E402
     DATA_WEBHOOK,
     DOMAIN,
+    OAUTH_BASE,
 )
 
 CLAUDE_CLIENT_ID = "https://claude.ai/api/mcp/client_metadata"
 CLAUDE_REDIRECT = "https://claude.ai/api/mcp/auth_callback"
+HOST = "ha.example.com"
+EXPECTED_ISSUER = f"https://{HOST}{OAUTH_BASE}"
 
 
 def _pkce_pair() -> tuple[str, str]:
@@ -89,6 +92,10 @@ def _live_hass(provider: aa.AutoApproveProvider | None = None) -> MagicMock:
 def _get_request(query: dict[str, str]) -> MagicMock:
     request = MagicMock(name="Request")
     request.query = query
+    # Host/scheme are what ``mcp_webhook._build_base_url`` reads to derive the
+    # RFC 9207 ``iss`` this server stamps on its authorization responses.
+    request.headers = {"Host": HOST}
+    request.scheme = "https"
     return request
 
 
@@ -209,8 +216,28 @@ class TestAuthorizeView:
         base, params = _parse_location(resp.headers["Location"])
         assert base == CLAUDE_REDIRECT
         assert params["state"] == "st-1"
+        # RFC 9207 §2: the success response names the issuer that minted it.
+        assert params["iss"] == EXPECTED_ISSUER
         # The issued code is real: it consumes with the matching verifier.
         assert provider.consume_code(params["code"], CLAUDE_REDIRECT, verifier) is True
+
+    async def test_iss_equals_the_advertised_none_mode_issuer(self):
+        """The redirect's ``iss`` is byte-identical to the ``issuer`` the
+        none-mode discovery document advertises for the same request — RFC 9207
+        §2 rejects anything else, and the two are built in different modules."""
+        from custom_components.ha_mcp_tools import mcp_webhook
+
+        hass = _live_hass()
+        view = aa.AutoApproveAuthorizeView(hass)
+        request = _get_request(_authorize_query())
+        resp = await view.get(request)
+
+        advertised = mcp_webhook._none_mode_authorization_server_document(
+            mcp_webhook._build_base_url(request)
+        )["issuer"]
+        assert advertised == EXPECTED_ISSUER
+        _, params = _parse_location(resp.headers["Location"])
+        assert params["iss"] == advertised
 
     async def test_allowlisted_claude_redirect_is_approved(self):
         hass = _live_hass()
@@ -261,6 +288,8 @@ class TestAuthorizeView:
         _, params = _parse_location(resp.headers["Location"])
         assert params["error"] == "temporarily_unavailable"
         assert params["state"] == "st-1"
+        # RFC 9207 §2 covers error responses too, not just the success redirect.
+        assert params["iss"] == EXPECTED_ISSUER
 
 
 # ---------------------------------------------------------------------------

--- a/tests/src/unit/test_oauth_autoapprove.py
+++ b/tests/src/unit/test_oauth_autoapprove.py
@@ -457,3 +457,13 @@ class TestFullFlow:
         )
         assert token_resp.status == 200
         assert token_resp.json_body["access_token"]
+
+
+class TestRfc9207MetadataAdvertisement:
+    """RFC 9207 §3: the none-mode document advertises response issuer support."""
+
+    def test_none_mode_document_advertises_iss_support(self):
+        from custom_components.ha_mcp_tools import mcp_webhook
+
+        doc = mcp_webhook._none_mode_authorization_server_document("https://ha.example")
+        assert doc["authorization_response_iss_parameter_supported"] is True

--- a/tests/src/unit/test_oauth_legacy_component.py
+++ b/tests/src/unit/test_oauth_legacy_component.py
@@ -59,6 +59,7 @@ from custom_components.ha_mcp_tools.const import (  # noqa: E402
     DATA_OAUTH_CLIENT_ID,
     DATA_OAUTH_CLIENT_SECRET,
     DATA_OAUTH_SIGNING_KEY,
+    OAUTH_BASE,
     OPT_OAUTH_CLIENT_ID,
     OPT_OAUTH_CLIENT_SECRET,
     OPT_OAUTH_REGENERATE,
@@ -68,6 +69,8 @@ from custom_components.ha_mcp_tools.const import (  # noqa: E402
 CLIENT_ID = "test-client-id"
 CLIENT_SECRET = "test-client-secret"
 REDIRECT_URI = "https://client.example.com/cb"
+HOST = "ha.example.com"
+EXPECTED_ISSUER = f"https://{HOST}{OAUTH_BASE}"
 
 
 def _make_provider(
@@ -114,6 +117,28 @@ def _make_get_request(query: dict[str, str]) -> MagicMock:
     request = MagicMock(name="Request")
     request.query = query
     return request
+
+
+def _make_post_request(form: dict[str, str]) -> MagicMock:
+    """A POST /authorize request carrying the Host header that
+    ``mcp_webhook._build_base_url`` reads to derive the RFC 9207 ``iss``."""
+    request = MagicMock(name="Request")
+    request.headers = {"Host": HOST}
+    request.scheme = "https"
+    request.post = AsyncMock(return_value=form)
+    return request
+
+
+def _approve_form(challenge: str, **overrides: str) -> dict[str, str]:
+    form = {
+        "action": "approve",
+        "client_id": CLIENT_ID,
+        "redirect_uri": REDIRECT_URI,
+        "state": "xyz",
+        "code_challenge": challenge,
+    }
+    form.update(overrides)
+    return form
 
 
 def _extract_query_param(url: str, key: str) -> str:
@@ -548,21 +573,14 @@ class TestAuthorizeViewPost:
         provider = _make_provider()
         view = oauth_legacy.AuthorizeView(provider)
         verifier, challenge = _pkce_pair()
-        request = MagicMock()
-        request.post = AsyncMock(
-            return_value={
-                "action": "approve",
-                "client_id": CLIENT_ID,
-                "redirect_uri": REDIRECT_URI,
-                "state": "xyz",
-                "code_challenge": challenge,
-            }
-        )
+        request = _make_post_request(_approve_form(challenge))
         response = await view.post(request)
         assert response.status == 302
         location = response.headers["Location"]
         assert location.startswith(f"{REDIRECT_URI}?")
         assert _extract_query_param(location, "state") == "xyz"
+        # RFC 9207 §2: the success response names the issuer that minted it.
+        assert _extract_query_param(location, "iss") == EXPECTED_ISSUER
         code = _extract_query_param(location, "code")
         assert provider.consume_code(code, REDIRECT_URI, verifier) is True
 
@@ -570,20 +588,31 @@ class TestAuthorizeViewPost:
         provider = _make_provider()
         view = oauth_legacy.AuthorizeView(provider)
         _, challenge = _pkce_pair()
-        request = MagicMock()
-        request.post = AsyncMock(
-            return_value={
-                "action": "deny",
-                "client_id": CLIENT_ID,
-                "redirect_uri": REDIRECT_URI,
-                "state": "xyz",
-                "code_challenge": challenge,
-            }
-        )
+        request = _make_post_request(_approve_form(challenge, action="deny"))
         response = await view.post(request)
         assert response.status == 302
         location = response.headers["Location"]
         assert _extract_query_param(location, "error") == "access_denied"
+        # RFC 9207 §2 covers error responses too, not just the success redirect.
+        assert _extract_query_param(location, "iss") == EXPECTED_ISSUER
+
+    async def test_iss_equals_the_advertised_legacy_issuer(self):
+        """The redirect's ``iss`` is byte-identical to the ``issuer`` the legacy
+        discovery document advertises for the same request — RFC 9207 §2 rejects
+        anything else, and the two are built in different modules."""
+        from custom_components.ha_mcp_tools import mcp_webhook
+
+        provider = _make_provider()
+        view = oauth_legacy.AuthorizeView(provider)
+        _, challenge = _pkce_pair()
+        request = _make_post_request(_approve_form(challenge))
+        response = await view.post(request)
+
+        advertised = mcp_webhook._legacy_authorization_server_document(
+            mcp_webhook._build_base_url(request)
+        )["issuer"]
+        assert advertised == EXPECTED_ISSUER
+        assert _extract_query_param(response.headers["Location"], "iss") == advertised
 
     async def test_inactive_provider_returns_404(self):
         provider = _make_provider(active=False)
@@ -599,15 +628,10 @@ class TestAuthorizeViewPost:
         provider = _make_provider()
         view = oauth_legacy.AuthorizeView(provider)
         _, challenge = _pkce_pair()
-        request = MagicMock()
-        request.post = AsyncMock(
-            return_value={
-                "action": "approve",
-                "client_id": CLIENT_ID,
-                "redirect_uri": "https://client.example.com:999999/cb",
-                "state": "xyz",
-                "code_challenge": challenge,
-            }
+        request = _make_post_request(
+            _approve_form(
+                challenge, redirect_uri="https://client.example.com:999999/cb"
+            )
         )
         response = await view.post(request)
         assert response.status == 400
@@ -616,16 +640,7 @@ class TestAuthorizeViewPost:
         provider = _make_provider()
         view = oauth_legacy.AuthorizeView(provider)
         _, challenge = _pkce_pair()
-        request = MagicMock()
-        request.post = AsyncMock(
-            return_value={
-                "action": "bogus",
-                "client_id": CLIENT_ID,
-                "redirect_uri": REDIRECT_URI,
-                "state": "xyz",
-                "code_challenge": challenge,
-            }
-        )
+        request = _make_post_request(_approve_form(challenge, action="bogus"))
         response = await view.post(request)
         assert response.status == 400
 
@@ -637,21 +652,13 @@ class TestAuthorizeViewPost:
         for _ in range(oauth_legacy.MAX_PENDING_CODES):
             provider.issue_code(REDIRECT_URI, challenge)
         view = oauth_legacy.AuthorizeView(provider)
-        request = MagicMock()
-        request.post = AsyncMock(
-            return_value={
-                "action": "approve",
-                "client_id": CLIENT_ID,
-                "redirect_uri": REDIRECT_URI,
-                "state": "xyz",
-                "code_challenge": challenge,
-            }
-        )
+        request = _make_post_request(_approve_form(challenge))
         response = await view.post(request)
         assert response.status == 302
         location = response.headers["Location"]
         assert _extract_query_param(location, "error") == "temporarily_unavailable"
         assert _extract_query_param(location, "state") == "xyz"
+        assert _extract_query_param(location, "iss") == EXPECTED_ISSUER
 
 
 # ---------------------------------------------------------------------------

--- a/tests/src/unit/test_oauth_legacy_component.py
+++ b/tests/src/unit/test_oauth_legacy_component.py
@@ -1133,3 +1133,13 @@ class TestEnsureLegacyOAuthSecrets:
         assert data[DATA_OAUTH_CLIENT_ID] == "already-set"
         assert data[DATA_OAUTH_SIGNING_KEY] == "ee" * 32  # unchanged
         assert options[OPT_OAUTH_CLIENT_ID] == ""
+
+
+class TestRfc9207MetadataAdvertisement:
+    """RFC 9207 §3: the legacy document advertises response issuer support."""
+
+    def test_legacy_document_advertises_iss_support(self):
+        from custom_components.ha_mcp_tools import mcp_webhook
+
+        doc = mcp_webhook._legacy_authorization_server_document("https://ha.example")
+        assert doc["authorization_response_iss_parameter_supported"] is True

--- a/tests/src/unit/test_oauth_metadata_http.py
+++ b/tests/src/unit/test_oauth_metadata_http.py
@@ -18,6 +18,10 @@ under Starlette's first-match-wins routing, would not change the served body) is
 also caught.
 """
 
+import time
+from unittest.mock import AsyncMock, MagicMock
+from urllib.parse import parse_qs, urlparse
+
 import httpx
 import pytest
 from fastmcp import FastMCP
@@ -69,7 +73,11 @@ def oauth_app(tmp_path, monkeypatch):
 
     server = FastMCP("test")
     server.auth = HomeAssistantOAuthProvider(base_url=BASE_URL)
-    return server.http_app(path="/mcp", stateless_http=True)
+    app = server.http_app(path="/mcp", stateless_http=True)
+    # Expose the provider that served the document so a test can cross-check it
+    # against what that same instance puts on an authorization response.
+    app.state.ha_mcp_oauth_provider = server.auth
+    return app
 
 
 @pytest.mark.asyncio
@@ -130,6 +138,45 @@ async def test_discovery_endpoints_serve_identical_metadata(oauth_app):
         assert body == canonical, (
             f"{path} metadata diverged from the canonical document"
         )
+
+
+@pytest.mark.asyncio
+async def test_authorization_redirect_iss_matches_served_issuer(oauth_app):
+    """RFC 9207 §2: the ``iss`` on an authorization response equals the issuer
+    the metadata document advertises, byte for byte.
+
+    Cross-checks both ends against each other — the document is read back over
+    HTTP and the redirect comes from the same provider instance that served it —
+    so a change to either side that drifts them apart fails here. The two are
+    easy to drift because pydantic's ``AnyHttpUrl`` normalisation restores a
+    trailing slash that ``base_url`` alone does not carry.
+    """
+    provider = oauth_app.state.ha_mcp_oauth_provider
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=oauth_app), base_url="http://test"
+    ) as client:
+        resp = await client.get("/.well-known/oauth-authorization-server")
+    assert resp.status_code == 200
+    served_issuer = resp.json()["issuer"]
+
+    txn_id = "iss-parity-txn"
+    provider.pending_authorizations[txn_id] = {
+        "client_id": "test-client",
+        "redirect_uri": "https://claude.ai/api/mcp/auth_callback",
+        "state": "st-1",
+        "scopes": ["homeassistant"],
+        "code_challenge": "X" * 43,
+        "created_at": time.time(),
+    }
+    request = MagicMock()
+    request.form = AsyncMock(return_value={"txn_id": txn_id, "ha_token": "llat"})
+    redirect = await provider._consent_post(request)
+
+    params = parse_qs(urlparse(redirect.headers["location"]).query)
+    assert params["iss"] == [served_issuer]
+    # Non-vacuous: pin the normalised form, so a hand-built `iss` that dropped
+    # the trailing slash would fail even if both sides were changed together.
+    assert served_issuer == f"{BASE_URL}/"
 
 
 def _iter_route_paths(routes):

--- a/tests/src/unit/test_oauth_metadata_http.py
+++ b/tests/src/unit/test_oauth_metadata_http.py
@@ -108,6 +108,9 @@ async def test_metadata_endpoint_serves_enhanced_metadata(oauth_app, discovery_p
     assert "none" in data["token_endpoint_auth_methods_supported"], (
         "public-client PKCE 'none' auth method missing — handler was not applied"
     )
+    # RFC 9207 §3: redirects carry ``iss``, so the document must advertise it —
+    # omission reads as "not supported" to discovery-driven clients.
+    assert data["authorization_response_iss_parameter_supported"] is True
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What does this PR do?

Adds the RFC 9207 `iss` parameter to OAuth authorization responses (success and error
redirects) in all five authorization servers that build redirects in our own code: the
standalone OAuth provider (`src/ha_mcp/auth/provider.py`), the component's legacy and
none-mode auto-approve views, and the webhook proxy's dev-flavor twins. Each redirect sources
`iss` from the same expression that fills that mode's metadata document `issuer` field, so the
two cannot drift (tests assert redirect-vs-document equality, not literals).

Strictly additive — clients without RFC 9207 support ignore the extra query parameter.
Untouched: ha_auth mode everywhere (HA core IndieAuth builds those responses), token/refresh/
registration/PKCE/scope logic, and the stable webhook-proxy directory (dev bumped to
2.0.5.dev2; stable picks it up on promote).

Note: shares the webhook-proxy-dev version bump with #2034 — whichever merges second rebases
onto 2.0.5.dev3.

Part of #2031.

## Type of change
- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

## Checklist
- [x] I have updated documentation if needed
