### PR TITLE
fix: create all-day calendar events from date-only values

### DIFF
--- a/src/ha_mcp/tools/tools_calendar.py
+++ b/src/ha_mcp/tools/tools_calendar.py
@@ -232,12 +232,16 @@ class CalendarTools:
         location: str | None,
     ) -> Any:
         """Create a one-off calendar event via the calendar.create_event service."""
+        start_is_date = self._is_date_only(start)
+
         service_data: dict[str, Any] = {
             "entity_id": entity_id,
             "summary": summary,
-            "start_date_time": start,
-            "end_date_time": end,
         }
+        if start_is_date:
+            service_data.update({"start_date": start, "end_date": end})
+        else:
+            service_data.update({"start_date_time": start, "end_date_time": end})
 
         if description is not None:
             service_data["description"] = description
@@ -245,6 +249,17 @@ class CalendarTools:
             service_data["location"] = location
 
         return await self._client.call_service("calendar", "create_event", service_data)
+
+    @staticmethod
+    def _is_date_only(value: str) -> bool:
+        """Return whether value is a valid date in strict YYYY-MM-DD form."""
+        try:
+            return (
+                len(value) == 10
+                and datetime.strptime(value, "%Y-%m-%d").date().isoformat() == value
+            )
+        except ValueError:
+            return False
 
     def _build_set_calendar_event_error_suggestions(
         self, entity_id: str, rrule: str | None, error: Exception
@@ -276,6 +291,16 @@ class CalendarTools:
             suggestions.insert(0, f"Calendar entity '{entity_id}' not found")
         if "not supported" in error_str.lower():
             suggestions.insert(0, "This calendar does not support event creation")
+        # HA enforces MIN_NEW_EVENT_DURATION (1 second): for all-day events the
+        # end date is exclusive, so start == end has zero duration and is
+        # rejected. Steer the agent to bump the end date by a day.
+        if "duration" in error_str.lower():
+            suggestions.insert(
+                0,
+                "For an all-day event the end date is exclusive — set end to "
+                "start + 1 day (a single-day all-day event cannot have "
+                "start == end)",
+            )
 
         return suggestions
 
@@ -305,8 +330,19 @@ class CalendarTools:
             str, Field(description="Calendar entity ID (e.g., 'calendar.family')")
         ],
         summary: Annotated[str, Field(description="Event title/summary")],
-        start: Annotated[str, Field(description="Event start datetime in ISO format")],
-        end: Annotated[str, Field(description="Event end datetime in ISO format")],
+        start: Annotated[
+            str, Field(description="Event start date or datetime in ISO format")
+        ],
+        end: Annotated[
+            str,
+            Field(
+                description=(
+                    "Event end date or datetime in ISO format. For all-day "
+                    "events (date-only) the end date is exclusive; a "
+                    "single-day all-day event needs end = start + 1 day."
+                )
+            ),
+        ],
         description: Annotated[
             str | None,
             Field(description="Optional event description", default=None),
@@ -334,11 +370,15 @@ class CalendarTools:
         when ``rrule`` is provided (the REST service schema does not accept
         recurrence rules).
 
+        **When NOT to use:**
+        - To retrieve calendar events, use ``ha_config_get_calendar_events``.
+        - To delete an event, use ``ha_config_remove_calendar_event``.
+
         **Parameters:**
         - entity_id: Calendar entity ID (e.g., 'calendar.family')
         - summary: Event title/summary
-        - start: Event start datetime in ISO format
-        - end: Event end datetime in ISO format
+        - start: Event start date or datetime in ISO format
+        - end: Event end date or datetime in ISO format
         - description: Optional event description
         - location: Optional event location
         - rrule: Optional RFC 5545 recurrence rule (creates a recurring series)
@@ -361,9 +401,25 @@ class CalendarTools:
             end="2024-01-15T11:00:00",
             rrule="FREQ=WEEKLY;BYDAY=MO;COUNT=10"
         )
+
+        # Create an all-day event (date-only, no time component). The end
+        # date is EXCLUSIVE, so this spans 2026-07-04 through 2026-07-10.
+        result = ha_config_set_calendar_event(
+            "calendar.family",
+            summary="Vacation",
+            start="2026-07-04",
+            end="2026-07-11"
+        )
         ```
 
         **Note:**
+        Passing date-only values (``YYYY-MM-DD``) for both ``start`` and
+        ``end`` creates an all-day event; passing full ISO datetimes creates
+        a timed event. The two forms cannot be mixed — a date-only ``start``
+        with a datetime ``end`` (or vice versa) is rejected. Because the
+        all-day ``end`` date is exclusive, a single-day all-day event must
+        set ``end`` to ``start + 1 day``.
+
         Not every calendar integration supports event creation; recurring
         events additionally require the integration to support recurrence
         (the built-in Local Calendar does).
@@ -382,6 +438,23 @@ class CalendarTools:
                         suggestions=[
                             "Use ha_search(query='calendar', domain_filter='calendar') to find calendar entities",
                             "Calendar entity IDs start with 'calendar.' prefix",
+                        ],
+                    )
+                )
+
+            # Reject mixed date/datetime up front so both the simple and the
+            # recurring (rrule) paths give the same clear validation error —
+            # the rrule branch does not route through
+            # ``_create_simple_calendar_event`` where this used to live.
+            if self._is_date_only(start) != self._is_date_only(end):
+                raise_tool_error(
+                    create_error_response(
+                        ErrorCode.VALIDATION_INVALID_PARAMETER,
+                        "Calendar event start and end must both be dates or both be datetimes",
+                        context={"start": start, "end": end},
+                        suggestions=[
+                            "Use YYYY-MM-DD for both values to create an all-day event",
+                            "Use ISO 8601 datetimes for both values to create a timed event",
                         ],
                     )
                 )

--- a/src/ha_mcp/tools/tools_calendar.py
+++ b/src/ha_mcp/tools/tools_calendar.py
@@ -262,7 +262,7 @@ class CalendarTools:
             return False
 
     def _build_set_calendar_event_error_suggestions(
-        self, entity_id: str, rrule: str | None, error: Exception, date_only: bool
+        self, entity_id: str, rrule: str | None, error: Exception, start: str, end: str
     ) -> list[str]:
         """Build suggestions for a failed ha_config_set_calendar_event call."""
         if isinstance(error, HomeAssistantConnectionError):
@@ -291,12 +291,15 @@ class CalendarTools:
             suggestions.insert(0, f"Calendar entity '{entity_id}' not found")
         if "not supported" in error_str.lower():
             suggestions.insert(0, "This calendar does not support event creation")
-        # HA enforces MIN_NEW_EVENT_DURATION (1 second): for all-day events the
-        # end date is exclusive, so start == end has zero duration and is
-        # rejected. Steer the agent to bump the end date by a day. Gate on
-        # date-only input — the same min-duration error fires for timed events
-        # with too-close boundaries, where the fix is a later time, not +1 day.
-        if date_only and "duration" in error_str.lower():
+        # HA treats the all-day end date as exclusive and enforces
+        # MIN_NEW_EVENT_DURATION (1 second), so an all-day range with
+        # end <= start is rejected. Key this on the boundaries we already hold
+        # rather than on HA's wording: the REST service path raises a bare
+        # HTTPBadRequest, so voluptuous' "Expected minimum event duration"
+        # text never reaches the client (only the WebSocket rrule path keeps
+        # it). Strict YYYY-MM-DD sorts lexicographically, so comparing the
+        # strings is an exact date comparison here.
+        if self._is_date_only(start) and self._is_date_only(end) and end <= start:
             suggestions.insert(
                 0,
                 "For an all-day event the end date is exclusive — set end to "
@@ -482,10 +485,7 @@ class CalendarTools:
             logger.error(f"Failed to create calendar event in {entity_id}: {error}")
 
             suggestions = self._build_set_calendar_event_error_suggestions(
-                entity_id,
-                rrule,
-                error,
-                self._is_date_only(start) and self._is_date_only(end),
+                entity_id, rrule, error, start, end
             )
 
             exception_to_structured_error(

--- a/src/ha_mcp/tools/tools_calendar.py
+++ b/src/ha_mcp/tools/tools_calendar.py
@@ -262,7 +262,7 @@ class CalendarTools:
             return False
 
     def _build_set_calendar_event_error_suggestions(
-        self, entity_id: str, rrule: str | None, error: Exception
+        self, entity_id: str, rrule: str | None, error: Exception, date_only: bool
     ) -> list[str]:
         """Build suggestions for a failed ha_config_set_calendar_event call."""
         if isinstance(error, HomeAssistantConnectionError):
@@ -293,8 +293,10 @@ class CalendarTools:
             suggestions.insert(0, "This calendar does not support event creation")
         # HA enforces MIN_NEW_EVENT_DURATION (1 second): for all-day events the
         # end date is exclusive, so start == end has zero duration and is
-        # rejected. Steer the agent to bump the end date by a day.
-        if "duration" in error_str.lower():
+        # rejected. Steer the agent to bump the end date by a day. Gate on
+        # date-only input — the same min-duration error fires for timed events
+        # with too-close boundaries, where the fix is a later time, not +1 day.
+        if date_only and "duration" in error_str.lower():
             suggestions.insert(
                 0,
                 "For an all-day event the end date is exclusive — set end to "
@@ -373,15 +375,6 @@ class CalendarTools:
         **When NOT to use:**
         - To retrieve calendar events, use ``ha_config_get_calendar_events``.
         - To delete an event, use ``ha_config_remove_calendar_event``.
-
-        **Parameters:**
-        - entity_id: Calendar entity ID (e.g., 'calendar.family')
-        - summary: Event title/summary
-        - start: Event start date or datetime in ISO format
-        - end: Event end date or datetime in ISO format
-        - description: Optional event description
-        - location: Optional event location
-        - rrule: Optional RFC 5545 recurrence rule (creates a recurring series)
 
         **Example Usage:**
         ```python
@@ -489,7 +482,10 @@ class CalendarTools:
             logger.error(f"Failed to create calendar event in {entity_id}: {error}")
 
             suggestions = self._build_set_calendar_event_error_suggestions(
-                entity_id, rrule, error
+                entity_id,
+                rrule,
+                error,
+                self._is_date_only(start) and self._is_date_only(end),
             )
 
             exception_to_structured_error(

--- a/src/ha_mcp/tools/tools_calendar.py
+++ b/src/ha_mcp/tools/tools_calendar.py
@@ -289,6 +289,15 @@ class CalendarTools:
         error_str = str(error)
         if "404" in error_str or "not found" in error_str.lower():
             suggestions.insert(0, f"Calendar entity '{entity_id}' not found")
+        # Only reachable on the WebSocket (rrule) path, which preserves HA's
+        # humanized message. The REST service path loses it: a read-only
+        # calendar raises ServiceNotSupported, which HA's handler does not map
+        # (see homeassistant/helpers/http.py — only vol.Invalid, ServiceNotFound
+        # and Unauthorized are), so the client sees a bodyless status line. Do
+        # NOT broaden this to match that generic shape: it would promote
+        # "does not support event creation" onto every validation failure. The
+        # REST path keeps the read-only hint via the unconditional
+        # "Some calendar integrations may be read-only" suggestion above.
         if "not supported" in error_str.lower():
             suggestions.insert(0, "This calendar does not support event creation")
         # HA treats the all-day end date as exclusive and enforces

--- a/tests/src/e2e/workflows/calendar/test_calendar.py
+++ b/tests/src/e2e/workflows/calendar/test_calendar.py
@@ -277,6 +277,104 @@ class TestCalendarEventLifecycle:
 
         logger.info("ha_config_set_calendar_event test completed")
 
+    async def test_create_all_day_calendar_event(self, mcp_client):
+        """
+        Test: Create an all-day event from date-only values and read it back.
+
+        Passing ``YYYY-MM-DD`` (no time component) for both start and end
+        must produce an all-day event. This proves the round-trip: HA should
+        return the occurrence with a date-only ``{"date": ...}`` start, NOT a
+        ``{"dateTime": ...}`` start. The all-day ``end`` date is exclusive, so
+        a single-day event spans start .. start + 1 day.
+        """
+        calendar_entity = await self._find_writable_calendar(mcp_client)
+        if not calendar_entity:
+            pytest.skip("No calendar entities available for testing")
+
+        summary = f"E2E All-Day Test Event {uuid.uuid4().hex[:8]}"
+        # Date-only, well into the future to avoid colliding with the default
+        # get-events window used elsewhere. end is exclusive -> single day.
+        start_date = (datetime.now(UTC) + timedelta(days=2)).date()
+        end_date = start_date + timedelta(days=1)
+        list_args = {
+            "entity_id": calendar_entity,
+            "start": datetime.combine(
+                start_date, datetime.min.time(), tzinfo=UTC
+            ).isoformat(),
+            "end": datetime.combine(
+                end_date + timedelta(days=1), datetime.min.time(), tzinfo=UTC
+            ).isoformat(),
+        }
+
+        def _match(data: dict) -> list[dict]:
+            return [e for e in data.get("events", []) if e.get("summary") == summary]
+
+        create_data = await safe_call_tool(
+            mcp_client,
+            "ha_config_set_calendar_event",
+            {
+                "entity_id": calendar_entity,
+                "summary": summary,
+                "start": start_date.isoformat(),
+                "end": end_date.isoformat(),
+            },
+        )
+        if not create_data.get("success"):
+            pytest.skip(
+                f"Calendar {calendar_entity} does not support event creation: "
+                f"{extract_error_message(create_data) or 'Unknown'}"
+            )
+
+        event_uid: str | None = None
+        try:
+            events_data = await wait_for_tool_result(
+                mcp_client,
+                "ha_config_get_calendar_events",
+                list_args,
+                predicate=lambda d: bool(_match(d)),
+                timeout=15,
+                description=f"read-back of all-day event '{summary}'",
+            )
+            matches = _match(events_data)
+            assert matches, f"created all-day event '{summary}' did not surface"
+            event = matches[0]
+            event_uid = event.get("uid")
+
+            # Core assertion: an all-day event round-trips as a date-only
+            # start ({"date": ...}), never a timed start ({"dateTime": ...}).
+            start_field = event.get("start")
+            if isinstance(start_field, dict):
+                assert "date" in start_field, (
+                    f"all-day event start should be date-only, got {start_field}"
+                )
+                assert "dateTime" not in start_field, (
+                    f"all-day event start must not be a datetime, got {start_field}"
+                )
+                assert start_field["date"] == start_date.isoformat(), (
+                    f"expected start date {start_date.isoformat()}, got {start_field}"
+                )
+            else:
+                # Some backends flatten to a bare string; it must still be the
+                # date-only form with no time component.
+                assert str(start_field) == start_date.isoformat(), (
+                    f"all-day event start should be date-only "
+                    f"{start_date.isoformat()}, got {start_field!r}"
+                )
+        finally:
+            if event_uid:
+                try:
+                    await mcp_client.call_tool(
+                        "ha_config_remove_calendar_event",
+                        {"entity_id": calendar_entity, "uid": event_uid},
+                    )
+                except Exception as cleanup_error:
+                    logger.warning(
+                        f"Cleanup of all-day test event {event_uid} on "
+                        f"{calendar_entity}: {cleanup_error}"
+                    )
+
+        logger.info("All-day calendar event round-trip test completed")
+
     async def test_create_calendar_event_invalid_entity(self, mcp_client):
         """
         Test: Create event with invalid calendar entity

--- a/tests/src/e2e/workflows/calendar/test_calendar.py
+++ b/tests/src/e2e/workflows/calendar/test_calendar.py
@@ -319,11 +319,14 @@ class TestCalendarEventLifecycle:
                 "end": end_date.isoformat(),
             },
         )
-        if not create_data.get("success"):
-            pytest.skip(
-                f"Calendar {calendar_entity} does not support event creation: "
-                f"{extract_error_message(create_data) or 'Unknown'}"
-            )
+        # The testcontainer seeds a writable local_calendar (preferred by
+        # _find_writable_calendar), so all-day creation must succeed here.
+        # Skipping on failure would let the exact regression this test guards
+        # against slip through with CI still green.
+        assert create_data.get("success"), (
+            f"all-day event creation failed on writable calendar "
+            f"{calendar_entity}: {extract_error_message(create_data) or create_data}"
+        )
 
         event_uid: str | None = None
         try:

--- a/tests/src/e2e/workflows/calendar/test_calendar.py
+++ b/tests/src/e2e/workflows/calendar/test_calendar.py
@@ -18,6 +18,7 @@ from datetime import UTC, datetime, timedelta
 import pytest
 
 from ...utilities.assertions import (
+    MCPAssertions,
     assert_mcp_success,
     extract_error_message,
     parse_mcp_result,
@@ -309,8 +310,12 @@ class TestCalendarEventLifecycle:
         def _match(data: dict) -> list[dict]:
             return [e for e in data.get("events", []) if e.get("summary") == summary]
 
-        create_data = await safe_call_tool(
-            mcp_client,
+        # The testcontainer seeds a writable local_calendar (preferred by
+        # _find_writable_calendar), so all-day creation must succeed here. Use
+        # the success-assertion helper so a failure fails CI loudly instead of
+        # slipping past the regression this test guards against.
+        mcp = MCPAssertions(mcp_client)
+        await mcp.call_tool_success(
             "ha_config_set_calendar_event",
             {
                 "entity_id": calendar_entity,
@@ -318,14 +323,6 @@ class TestCalendarEventLifecycle:
                 "start": start_date.isoformat(),
                 "end": end_date.isoformat(),
             },
-        )
-        # The testcontainer seeds a writable local_calendar (preferred by
-        # _find_writable_calendar), so all-day creation must succeed here.
-        # Skipping on failure would let the exact regression this test guards
-        # against slip through with CI still green.
-        assert create_data.get("success"), (
-            f"all-day event creation failed on writable calendar "
-            f"{calendar_entity}: {extract_error_message(create_data) or create_data}"
         )
 
         event_uid: str | None = None

--- a/tests/src/unit/test_tools_calendar_rrule.py
+++ b/tests/src/unit/test_tools_calendar_rrule.py
@@ -7,8 +7,8 @@ Since issue #1813 that WS command routes through the shared pooled client
 
 These tests pin the transport routing: ``rrule`` present → pooled WS command
 carrying an RFC 5545 event payload (``dtstart``/``dtend`` keys); ``rrule``
-absent → the pre-existing REST service call (``start_date_time``/
-``end_date_time`` keys), unchanged.
+absent → the REST service call. Datetime values use ``start_date_time``/
+``end_date_time`` while date-only values use ``start_date``/``end_date``.
 
 They also cover the rrule-branch failure path: a failed WS command comes back
 from the pooled client as ``{"success": False, ...}`` and is re-raised so the
@@ -147,6 +147,50 @@ async def test_no_rrule_keeps_rest_service_path():
     client.send_websocket_message.assert_not_awaited()
     assert result["success"] is True
     assert result["event"]["rrule"] is None
+
+
+@pytest.mark.asyncio
+async def test_no_rrule_date_only_values_create_all_day_event():
+    """Date-only values must use HA's all-day service fields."""
+    client = _make_mock_client()
+
+    tools = CalendarTools(client)
+    await tools.ha_config_set_calendar_event(
+        entity_id="calendar.test",
+        summary="School holidays",
+        start="2026-07-04",
+        end="2026-08-10",
+    )
+
+    client.call_service.assert_awaited_once_with(
+        "calendar",
+        "create_event",
+        {
+            "entity_id": "calendar.test",
+            "summary": "School holidays",
+            "start_date": "2026-07-04",
+            "end_date": "2026-08-10",
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_no_rrule_rejects_mixed_date_and_datetime_values():
+    """Mixed all-day and timed boundaries are ambiguous and invalid."""
+    client = _make_mock_client()
+
+    tools = CalendarTools(client)
+    with pytest.raises(ToolError) as exc_info:
+        await tools.ha_config_set_calendar_event(
+            entity_id="calendar.test",
+            summary="Mixed event",
+            start="2026-07-04",
+            end="2026-07-04T12:00:00",
+        )
+
+    error = _structured_error(exc_info.value)["error"]
+    assert error["code"] == "VALIDATION_INVALID_PARAMETER"
+    client.call_service.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/src/unit/test_tools_calendar_rrule.py
+++ b/tests/src/unit/test_tools_calendar_rrule.py
@@ -282,6 +282,80 @@ async def test_non_rrule_failure_omits_rrule_suggestion():
 
 
 @pytest.mark.asyncio
+async def test_all_day_zero_duration_failure_prepends_exclusive_end_suggestion():
+    """An all-day range with end <= start surfaces the exclusive-end hint first.
+
+    The hint is keyed on the supplied boundaries, not on HA's error text: the
+    REST service path raises a bare ``HTTPBadRequest``, so voluptuous'
+    "Expected minimum event duration" message never reaches the client.
+    """
+    client = _make_mock_client()
+    client.call_service = AsyncMock(
+        side_effect=HomeAssistantCommandError("API error: 400 - 400: Bad Request")
+    )
+
+    tools = CalendarTools(client)
+    with pytest.raises(ToolError) as exc_info:
+        await tools.ha_config_set_calendar_event(
+            entity_id="calendar.test",
+            summary="Single day off",
+            start="2026-07-04",
+            end="2026-07-04",
+        )
+
+    suggestions = _structured_error(exc_info.value)["error"]["suggestions"]
+    assert suggestions[0].startswith("For an all-day event the end date is exclusive")
+
+
+@pytest.mark.asyncio
+async def test_all_day_valid_range_failure_omits_exclusive_end_suggestion():
+    """The exclusive-end hint must not appear when the all-day range is valid."""
+    client = _make_mock_client()
+    client.call_service = AsyncMock(
+        side_effect=HomeAssistantCommandError("API error: 400 - 400: Bad Request")
+    )
+
+    tools = CalendarTools(client)
+    with pytest.raises(ToolError) as exc_info:
+        await tools.ha_config_set_calendar_event(
+            entity_id="calendar.test",
+            summary="Vacation",
+            start="2026-07-04",
+            end="2026-07-11",
+        )
+
+    suggestions = _structured_error(exc_info.value)["error"]["suggestions"]
+    assert all(
+        not s.startswith("For an all-day event the end date is exclusive")
+        for s in suggestions
+    )
+
+
+@pytest.mark.asyncio
+async def test_timed_event_too_close_boundaries_omits_exclusive_end_suggestion():
+    """Timed events hit the same min-duration rule but need a later time, not +1 day."""
+    client = _make_mock_client()
+    client.call_service = AsyncMock(
+        side_effect=HomeAssistantCommandError("API error: 400 - 400: Bad Request")
+    )
+
+    tools = CalendarTools(client)
+    with pytest.raises(ToolError) as exc_info:
+        await tools.ha_config_set_calendar_event(
+            entity_id="calendar.test",
+            summary="Instant meeting",
+            start="2026-06-15T10:00:00",
+            end="2026-06-15T10:00:00",
+        )
+
+    suggestions = _structured_error(exc_info.value)["error"]["suggestions"]
+    assert all(
+        not s.startswith("For an all-day event the end date is exclusive")
+        for s in suggestions
+    )
+
+
+@pytest.mark.asyncio
 async def test_rrule_transport_failure_maps_to_connection_error():
     """A connection-shaped pooled-WS failure surfaces as CONNECTION_FAILED with
     connectivity guidance — not rrule/calendar suggestions (issue #1832 review)."""

--- a/tests/src/unit/test_tools_calendar_rrule.py
+++ b/tests/src/unit/test_tools_calendar_rrule.py
@@ -23,7 +23,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 from fastmcp.exceptions import ToolError
 
-from ha_mcp.client.rest_client import HomeAssistantCommandError
+from ha_mcp.client.rest_client import HomeAssistantAPIError
 from ha_mcp.tools import tools_calendar
 from ha_mcp.tools.tools_calendar import CalendarTools
 
@@ -264,7 +264,9 @@ async def test_non_rrule_failure_omits_rrule_suggestion():
     """The RRULE-syntax hint must not appear when no rrule was supplied."""
     client = _make_mock_client()
     client.call_service = AsyncMock(
-        side_effect=HomeAssistantCommandError("Command failed: backend boom")
+        side_effect=HomeAssistantAPIError(
+            "API error: 500 - 500: Internal Server Error", status_code=500
+        )
     )
 
     tools = CalendarTools(client)
@@ -291,7 +293,9 @@ async def test_all_day_zero_duration_failure_prepends_exclusive_end_suggestion()
     """
     client = _make_mock_client()
     client.call_service = AsyncMock(
-        side_effect=HomeAssistantCommandError("API error: 400 - 400: Bad Request")
+        side_effect=HomeAssistantAPIError(
+            "API error: 400 - 400: Bad Request", status_code=400
+        )
     )
 
     tools = CalendarTools(client)
@@ -312,7 +316,9 @@ async def test_all_day_valid_range_failure_omits_exclusive_end_suggestion():
     """The exclusive-end hint must not appear when the all-day range is valid."""
     client = _make_mock_client()
     client.call_service = AsyncMock(
-        side_effect=HomeAssistantCommandError("API error: 400 - 400: Bad Request")
+        side_effect=HomeAssistantAPIError(
+            "API error: 400 - 400: Bad Request", status_code=400
+        )
     )
 
     tools = CalendarTools(client)
@@ -336,7 +342,9 @@ async def test_timed_event_too_close_boundaries_omits_exclusive_end_suggestion()
     """Timed events hit the same min-duration rule but need a later time, not +1 day."""
     client = _make_mock_client()
     client.call_service = AsyncMock(
-        side_effect=HomeAssistantCommandError("API error: 400 - 400: Bad Request")
+        side_effect=HomeAssistantAPIError(
+            "API error: 400 - 400: Bad Request", status_code=400
+        )
     )
 
     tools = CalendarTools(client)


### PR DESCRIPTION
Closes #1972

## What does this PR do?

Date-only calendar boundaries (`YYYY-MM-DD`) now create true all-day events via Home Assistant's `start_date` / `end_date` service fields instead of midnight timed events. Datetime boundaries still use `start_date_time` / `end_date_time`. Mixed date/datetime boundaries are rejected up front with a clear validation error on both the one-off and recurring paths. The docstring and `end` parameter document that the all-day end date is exclusive (a single-day all-day event needs `end = start + 1 day`), and a new e2e test asserts the created event reads back as a date-only value rather than a datetime.

This reconstructs a prior contributor PR for the same issue that was lost when its fork was deleted, and folds in the final review-requested change (narrowing the all-day error suggestion trigger).

## Type of change
- [x] 🐛 Bug fix

## Testing
- [x] Code follows style guidelines (`uv run ruff check`)

Unit regression tests (date-only all-day payload, mixed-boundary rejection) plus a new e2e round-trip test cover the change; full suite runs in CI.

## Checklist
- [x] I have updated documentation if needed
