### PR TITLE
fix: resolve a bracketed YAML path as both pattern and literal

### DIFF
--- a/src/ha_mcp/tools/tools_yaml_read.py
+++ b/src/ha_mcp/tools/tools_yaml_read.py
@@ -45,9 +45,14 @@ logger = logging.getLogger(__name__)
 _GLOB_METACHARS = ("*", "?", "[")
 
 
-def _has_glob(file: str) -> bool:
-    """True if ``file`` carries an fnmatch wildcard and must be expanded."""
-    return any(char in file for char in _GLOB_METACHARS)
+def _has_glob(name: str) -> bool:
+    """True if ``name`` carries an fnmatch wildcard and must be expanded.
+
+    Takes the file name rather than the whole path: the component resolves
+    directories literally, so a metacharacter in a folder name belongs to that
+    folder's name and is not a pattern.
+    """
+    return any(char in name for char in _GLOB_METACHARS)
 
 
 def _call_failed(service: str, context: dict[str, Any]) -> None:
@@ -84,18 +89,18 @@ def _failure_text(payload: dict[str, Any]) -> str:
 
 
 def _parse_error_result(
-    target: str, yaml_path: str, parse_error: str, *, expanded: bool
+    target: str, yaml_path: str, parse_error: str, *, is_expanded: bool
 ) -> tuple[None, str]:
     """Decide a file the component could not parse: raise for a named target.
 
     The explicitly named target raises rather than soft-degrading to a warning
-    that reads as "key absent" – it raises even when expansion turned up
+    that reads as "key absent" - it raises even when expansion turned up
     siblings alongside it, discarding their results, because a named file that
     cannot be parsed is the caller's question, not a stray unreadable neighbour.
     An expanded target stays a per-file warning so one broken file does not
     sink the whole search.
     """
-    if not expanded:
+    if not is_expanded:
         raise_tool_error(
             create_error_response(
                 ErrorCode.CONFIG_INVALID,
@@ -108,17 +113,21 @@ def _parse_error_result(
 
 
 def _read_exception_result(
-    target: str, error: BaseException, *, expanded: bool
+    target: str, error: BaseException, *, is_expanded: bool
 ) -> tuple[None, str]:
     """Decide a read that blew up outright.
 
     An expanded target degrades to a warning so one unreadable file cannot sink
     the search; the explicitly named target re-raises, matching every other
     failure class in :func:`_evaluate_read`.
+
+    ``str()`` is empty on a bare ``TimeoutError()`` or ``CancelledError()``, so
+    the class name stands in - a warning reading "was not searched: ." names no
+    reason at all.
     """
-    if not expanded:
+    if not is_expanded:
         raise error
-    return None, f"{target} was not searched: {error}."
+    return None, f"{target} was not searched: {str(error) or type(error).__name__}."
 
 
 def _evaluate_read(
@@ -126,7 +135,7 @@ def _evaluate_read(
     target: str,
     yaml_path: str,
     *,
-    expanded: bool,
+    is_expanded: bool,
     include_content: bool,
     include_parsed: bool,
 ) -> tuple[dict[str, Any] | None, str | None]:
@@ -147,23 +156,23 @@ def _evaluate_read(
     * **match** — the key is there.
     """
     if isinstance(response, BaseException):
-        return _read_exception_result(target, response, expanded=expanded)
+        return _read_exception_result(target, response, is_expanded=is_expanded)
 
     if not isinstance(response, dict):
-        if expanded:
+        if is_expanded:
             return None, f"{target} was not searched: unexpected read_file response."
         _call_failed("read_file", {"file": target, "yaml_path": yaml_path})
     unwrapped = unwrap_service_response(response)
 
     if not unwrapped.get("success", True):
-        if not expanded:
+        if not is_expanded:
             raise_tool_error(unwrapped)
         return None, f"{target} was not searched: {_failure_text(unwrapped)}."
 
     parse_error = unwrapped.get("parse_error")
     if parse_error:
         return _parse_error_result(
-            target, yaml_path, str(parse_error), expanded=expanded
+            target, yaml_path, str(parse_error), is_expanded=is_expanded
         )
 
     if unwrapped.get("subtree") is None:
@@ -201,15 +210,17 @@ async def _list_files_matching(
     )
 
 
-async def _resolve_target_files(client: Any, file: str) -> list[tuple[str, bool]]:
-    """Expand ``file`` into ``(path, expanded)`` pairs to read.
+async def _resolve_target_files(
+    client: Any, file: str
+) -> tuple[list[tuple[str, bool]], list[str]]:
+    """Expand ``file`` into ``(path, is_expanded)`` pairs plus any warnings.
 
-    ``expanded`` records where the path came from, and it is decided here
+    ``is_expanded`` records where the path came from, and it is decided here
     because only here is it known: a path produced by the pattern lookup is an
     expansion, while the requested path itself and anything the escaped-literal
     lookup returns were named explicitly. Recovering that downstream by
     comparing the path against the requested string would be wrong for ``*``
-    and ``?``, which match their own literal names – a file genuinely called
+    and ``?``, which match their own literal names - a file genuinely called
     ``*.yaml`` would then be mistaken for the name the caller typed and its
     read failure would sink the whole search.
 
@@ -232,19 +243,43 @@ async def _resolve_target_files(client: Any, file: str) -> list[tuple[str, bool]
     otherwise mask the file the caller named exactly. Only bracketed names pay
     the second round-trip. The component likewise treats package folder names
     carrying metacharacters as literal names (#1854).
+
+    The guard is any bracket, not a closed class: an unclosed or empty bracket
+    is literal to ``fnmatch`` and so matches its own name, which means both
+    lookups return it and the deduplication below is what keeps it a single
+    target. A listing failure on either lookup raises rather than degrading -
+    the directory is the same one in both calls, so a failure there is a broken
+    request, not one unreadable file among several.
+
+    When the literal lookup comes back empty the caller named a file that does
+    not exist, and the pattern's siblings would otherwise be reported as if the
+    named file had been searched; a warning says so.
     """
     directory, _, pattern = file.rpartition("/")
     if not _has_glob(pattern):
-        return [(file, False)]
+        return [(file, False)], []
 
-    matches = await _list_files_matching(client, file, directory, pattern)
-    named: set[str] = set()
-    if "[" in pattern:
-        named = set(
-            await _list_files_matching(client, file, directory, glob.escape(pattern))
-        )
-        matches = sorted(set(matches) | named)
-    return [(target, target not in named) for target in matches]
+    if "[" not in pattern:
+        matched = await _list_files_matching(client, file, directory, pattern)
+        return [(target, True) for target in matched], []
+
+    # The two lookups are independent, so run them together rather than paying
+    # two sequential round-trips; the reads below fan out for the same reason.
+    matched, literal = await asyncio.gather(
+        _list_files_matching(client, file, directory, pattern),
+        _list_files_matching(client, file, directory, glob.escape(pattern)),
+    )
+    named = set(literal)
+    targets = sorted(set(matched) | named)
+    warnings = (
+        []
+        if named
+        else [
+            f"No file is literally named {file}; searched the {len(targets)} "
+            f"file(s) matching it as a pattern."
+        ]
+    )
+    return [(target, target not in named) for target in targets], warnings
 
 
 class YamlReadTools:
@@ -332,7 +367,7 @@ class YamlReadTools:
 
             # Strictness is a property of each target, not of the request, so
             # the resolver reports which targets were named rather than expanded.
-            targets = await _resolve_target_files(self._client, file)
+            targets, resolve_warnings = await _resolve_target_files(self._client, file)
 
             extra: dict[str, Any] = {"include_parsed": True} if include_parsed else {}
             # The reads are independent, so fan them out rather than paying N
@@ -355,13 +390,13 @@ class YamlReadTools:
             )
 
             matches: list[dict[str, Any]] = []
-            warnings: list[str] = []
-            for (target, expanded), response in zip(targets, responses, strict=True):
+            warnings: list[str] = list(resolve_warnings)
+            for (target, is_expanded), response in zip(targets, responses, strict=True):
                 match, warning = _evaluate_read(
                     response,
                     target,
                     yaml_path,
-                    expanded=expanded,
+                    is_expanded=is_expanded,
                     include_content=include_content,
                     include_parsed=include_parsed,
                 )

--- a/src/ha_mcp/tools/tools_yaml_read.py
+++ b/src/ha_mcp/tools/tools_yaml_read.py
@@ -16,8 +16,8 @@ back door.
 """
 
 import asyncio
-import glob
 import logging
+import re
 from typing import Annotated, Any
 
 from fastmcp.exceptions import ToolError
@@ -43,6 +43,17 @@ logger = logging.getLogger(__name__)
 # fnmatch metacharacters. Matching itself happens component-side (list_files
 # fnmatches on the file name); this only decides single-file vs. glob.
 _GLOB_METACHARS = ("*", "?", "[")
+
+# The metacharacters that match their own literal names, and so are pattern
+# syntax rather than a plausible spelling of a file name the caller means
+# exactly. A bracket class is the ambiguous one and is deliberately absent.
+_PATTERN_ONLY_METACHARS = ("*", "?")
+
+# Wraps each metacharacter in a bracket class so fnmatch reads it literally.
+# Deliberately not glob.escape: that splits a drive letter off first, which is
+# ntpath on a Windows-hosted server - the one host-dependent step in a path
+# that is otherwise POSIX and config-relative.
+_METACHAR_RE = re.compile(r"([*?\[])")
 
 
 def _has_glob(name: str) -> bool:
@@ -121,11 +132,17 @@ def _read_exception_result(
     the search; the explicitly named target re-raises, matching every other
     failure class in :func:`_evaluate_read`.
 
-    ``str()`` is empty on a bare ``TimeoutError()`` or ``CancelledError()``, so
-    the class name stands in - a warning reading "was not searched: ." names no
-    reason at all.
+    Anything that is not an ``Exception`` propagates whatever the target's
+    provenance. Cancellation and shutdown are not one file being unreadable,
+    and absorbing them into a warning next to ``success: true`` would report a
+    search that was called off as one that ran and found nothing. The codebase
+    draws the same line wherever it fans out per item (``tools_entities``,
+    ``tools_search``, ``smart_search``).
+
+    ``str()`` is empty on a bare ``TimeoutError()``, so the class name stands
+    in - a warning reading "was not searched: ." names no reason at all.
     """
-    if not is_expanded:
+    if not is_expanded or not isinstance(error, Exception):
         raise error
     return None, f"{target} was not searched: {str(error) or type(error).__name__}."
 
@@ -143,9 +160,9 @@ def _evaluate_read(
 
     Three outcomes, in the order they are decided:
 
-    * **warning** — the file could not be searched at all. Under a glob that
+    * **warning** — the file could not be searched at all. An expanded target
       must not sink the whole search and discard the matches already found:
-      the glob is not restricted to ``*.yaml``, so ``packages/*`` can turn up
+      expansion is not restricted to ``*.yaml``, so ``packages/*`` can turn up
       a README the component refuses to read, and a permission-denied or
       non-UTF-8 ``.yaml`` lands here too. A syntactically broken file is the
       same class — reporting it as "key absent" would claim a file was
@@ -210,6 +227,36 @@ async def _list_files_matching(
     )
 
 
+def _absent_literal_warnings(
+    file: str, pattern: str, *, literal_found: bool, target_count: int
+) -> list[str]:
+    """Say so when nothing is literally named the way a bracketed request was.
+
+    Silence is what the caller reads as "your file was searched": the siblings
+    the class matched arrive as ``files_searched`` with nothing marking the
+    named file as never opened.
+
+    Two cases stay silent. A literal that was found needs no warning, and
+    neither does a name also carrying ``*`` or ``?`` - that is pattern syntax,
+    so a missing file of exactly that name is no thwarted expectation. The
+    literal lookup still runs for those names, because a file can genuinely be
+    called ``[ab]*.yaml``; only the complaint is dropped.
+    """
+    if literal_found or any(char in pattern for char in _PATTERN_ONLY_METACHARS):
+        return []
+    if not target_count:
+        # Phrased for the degenerate case rather than reporting "the 0 file(s)
+        # matching it as a pattern", which reads as a search that happened.
+        return [
+            f"No file is literally named {file}, and nothing matched it as a "
+            f"pattern either."
+        ]
+    return [
+        f"No file is literally named {file}; searched the {target_count} "
+        f"file(s) matching it as a pattern."
+    ]
+
+
 async def _resolve_target_files(
     client: Any, file: str
 ) -> tuple[list[tuple[str, bool]], list[str]]:
@@ -241,8 +288,9 @@ async def _resolve_target_files(
     would drop the siblings a deliberate class like ``svc[12].yaml`` is meant
     to find. Both lookups run because a sibling that satisfies the class would
     otherwise mask the file the caller named exactly. Only bracketed names pay
-    the second round-trip. The component likewise treats package folder names
-    carrying metacharacters as literal names (#1854).
+    the second lookup, and it is issued concurrently with the first rather than
+    after it. The component likewise treats package folder names carrying
+    metacharacters as literal names (#1854).
 
     The guard is any bracket, not a closed class: an unclosed or empty bracket
     is literal to ``fnmatch`` and so matches its own name, which means both
@@ -253,7 +301,8 @@ async def _resolve_target_files(
 
     When the literal lookup comes back empty the caller named a file that does
     not exist, and the pattern's siblings would otherwise be reported as if the
-    named file had been searched; a warning says so.
+    named file had been searched; :func:`_absent_literal_warnings` decides what
+    to say about that.
     """
     directory, _, pattern = file.rpartition("/")
     if not _has_glob(pattern):
@@ -267,17 +316,14 @@ async def _resolve_target_files(
     # two sequential round-trips; the reads below fan out for the same reason.
     matched, literal = await asyncio.gather(
         _list_files_matching(client, file, directory, pattern),
-        _list_files_matching(client, file, directory, glob.escape(pattern)),
+        _list_files_matching(
+            client, file, directory, _METACHAR_RE.sub(r"[\1]", pattern)
+        ),
     )
     named = set(literal)
     targets = sorted(set(matched) | named)
-    warnings = (
-        []
-        if named
-        else [
-            f"No file is literally named {file}; searched the {len(targets)} "
-            f"file(s) matching it as a pattern."
-        ]
+    warnings = _absent_literal_warnings(
+        file, pattern, literal_found=bool(named), target_count=len(targets)
     )
     return [(target, target not in named) for target in targets], warnings
 
@@ -316,9 +362,7 @@ class YamlReadTools:
                     "Config-relative file to read. Accepts an fnmatch glob to "
                     "search several files at once — 'packages/*.yaml' matches one "
                     "directory level, not a nested tree. Use the glob to find "
-                    "which file defines a key. A name carrying a bracket class "
-                    "is read both ways, as the pattern and as that literal "
-                    "filename."
+                    "which file defines a key."
                 ),
             ),
         ] = "configuration.yaml",
@@ -391,6 +435,7 @@ class YamlReadTools:
 
             matches: list[dict[str, Any]] = []
             warnings: list[str] = list(resolve_warnings)
+            files_unreadable = 0
             for (target, is_expanded), response in zip(targets, responses, strict=True):
                 match, warning = _evaluate_read(
                     response,
@@ -402,6 +447,7 @@ class YamlReadTools:
                 )
                 if warning:
                     warnings.append(warning)
+                    files_unreadable += 1
                 elif match:
                     matches.append(match)
 
@@ -413,6 +459,10 @@ class YamlReadTools:
                 # Separates "the glob matched no files" from "no file defines
                 # the key" — same empty matches[], different fix.
                 "files_searched": len(targets),
+                # Keeps `count: 0` beside a non-zero files_searched from reading
+                # as "searched them, found nothing". Counted in the loop, not as
+                # len(warnings): those also carry resolver-level entries.
+                "files_unreadable": files_unreadable,
             }
             if warnings:
                 result["warnings"] = warnings

--- a/src/ha_mcp/tools/tools_yaml_read.py
+++ b/src/ha_mcp/tools/tools_yaml_read.py
@@ -18,7 +18,6 @@ back door.
 import asyncio
 import glob
 import logging
-import posixpath
 from typing import Annotated, Any
 
 from fastmcp.exceptions import ToolError
@@ -85,16 +84,18 @@ def _failure_text(payload: dict[str, Any]) -> str:
 
 
 def _parse_error_result(
-    target: str, yaml_path: str, parse_error: str, *, is_glob: bool
+    target: str, yaml_path: str, parse_error: str, *, expanded: bool
 ) -> tuple[None, str]:
-    """Decide a file the component could not parse: raise for a single target.
+    """Decide a file the component could not parse: raise for a named target.
 
-    A single explicit target has no siblings to salvage, so a parse failure
-    raises rather than soft-degrading to a warning that reads as "key absent".
-    Under a glob it stays a per-file warning so one broken file does not sink
-    the whole search.
+    The explicitly named target raises rather than soft-degrading to a warning
+    that reads as "key absent" – it raises even when expansion turned up
+    siblings alongside it, discarding their results, because a named file that
+    cannot be parsed is the caller's question, not a stray unreadable neighbour.
+    An expanded target stays a per-file warning so one broken file does not
+    sink the whole search.
     """
-    if not is_glob:
+    if not expanded:
         raise_tool_error(
             create_error_response(
                 ErrorCode.CONFIG_INVALID,
@@ -107,7 +108,7 @@ def _parse_error_result(
 
 
 def _read_exception_result(
-    target: str, error: BaseException, *, is_glob: bool
+    target: str, error: BaseException, *, expanded: bool
 ) -> tuple[None, str]:
     """Decide a read that blew up outright.
 
@@ -115,7 +116,7 @@ def _read_exception_result(
     the search; the explicitly named target re-raises, matching every other
     failure class in :func:`_evaluate_read`.
     """
-    if not is_glob:
+    if not expanded:
         raise error
     return None, f"{target} was not searched: {error}."
 
@@ -125,7 +126,7 @@ def _evaluate_read(
     target: str,
     yaml_path: str,
     *,
-    is_glob: bool,
+    expanded: bool,
     include_content: bool,
     include_parsed: bool,
 ) -> tuple[dict[str, Any] | None, str | None]:
@@ -139,29 +140,31 @@ def _evaluate_read(
       a README the component refuses to read, and a permission-denied or
       non-UTF-8 ``.yaml`` lands here too. A syntactically broken file is the
       same class — reporting it as "key absent" would claim a file was
-      inspected when it never was. A single explicit target has no siblings
-      to salvage, so it raises instead.
+      inspected when it never was. The explicitly named target raises
+      instead, even when expansion turned up siblings alongside it.
     * **neither** — the file parsed and simply has no such key. The real
       non-match, and the whole point of a glob search.
     * **match** — the key is there.
     """
     if isinstance(response, BaseException):
-        return _read_exception_result(target, response, is_glob=is_glob)
+        return _read_exception_result(target, response, expanded=expanded)
 
     if not isinstance(response, dict):
-        if is_glob:
+        if expanded:
             return None, f"{target} was not searched: unexpected read_file response."
         _call_failed("read_file", {"file": target, "yaml_path": yaml_path})
     unwrapped = unwrap_service_response(response)
 
     if not unwrapped.get("success", True):
-        if not is_glob:
+        if not expanded:
             raise_tool_error(unwrapped)
         return None, f"{target} was not searched: {_failure_text(unwrapped)}."
 
     parse_error = unwrapped.get("parse_error")
     if parse_error:
-        return _parse_error_result(target, yaml_path, str(parse_error), is_glob=is_glob)
+        return _parse_error_result(
+            target, yaml_path, str(parse_error), expanded=expanded
+        )
 
     if unwrapped.get("subtree") is None:
         return None, None
@@ -198,8 +201,17 @@ async def _list_files_matching(
     )
 
 
-async def _resolve_target_files(client: Any, file: str) -> list[str]:
-    """Expand ``file`` into the concrete config-relative paths to read.
+async def _resolve_target_files(client: Any, file: str) -> list[tuple[str, bool]]:
+    """Expand ``file`` into ``(path, expanded)`` pairs to read.
+
+    ``expanded`` records where the path came from, and it is decided here
+    because only here is it known: a path produced by the pattern lookup is an
+    expansion, while the requested path itself and anything the escaped-literal
+    lookup returns were named explicitly. Recovering that downstream by
+    comparing the path against the requested string would be wrong for ``*``
+    and ``?``, which match their own literal names – a file genuinely called
+    ``*.yaml`` would then be mistaken for the name the caller typed and its
+    read failure would sink the whole search.
 
     A plain path is returned as-is (the read itself reports a missing file). A
     glob is expanded through the component's ``list_files``, which matches the
@@ -223,15 +235,16 @@ async def _resolve_target_files(client: Any, file: str) -> list[str]:
     """
     directory, _, pattern = file.rpartition("/")
     if not _has_glob(pattern):
-        return [file]
+        return [(file, False)]
 
     matches = await _list_files_matching(client, file, directory, pattern)
+    named: set[str] = set()
     if "[" in pattern:
-        literal = await _list_files_matching(
-            client, file, directory, glob.escape(pattern)
+        named = set(
+            await _list_files_matching(client, file, directory, glob.escape(pattern))
         )
-        matches = sorted(set(matches) | set(literal))
-    return matches
+        matches = sorted(set(matches) | named)
+    return [(target, target not in named) for target in matches]
 
 
 class YamlReadTools:
@@ -317,16 +330,9 @@ class YamlReadTools:
         try:
             await _assert_mcp_tools_available(self._client)
 
+            # Strictness is a property of each target, not of the request, so
+            # the resolver reports which targets were named rather than expanded.
             targets = await _resolve_target_files(self._client, file)
-            # Strictness is a property of each target, not of the request: the
-            # target that IS the requested path was named explicitly and keeps
-            # the strict contract (raise, don't degrade) even when expansion
-            # turned up siblings alongside it. Compared normalized, since the
-            # component reports what it walked rather than what was asked for.
-            requested = posixpath.normpath(file)
-            expanded = {
-                target: posixpath.normpath(target) != requested for target in targets
-            }
 
             extra: dict[str, Any] = {"include_parsed": True} if include_parsed else {}
             # The reads are independent, so fan them out rather than paying N
@@ -343,19 +349,19 @@ class YamlReadTools:
                         "read_file",
                         {"path": target, "yaml_path": yaml_path, **extra},
                     )
-                    for target in targets
+                    for target, _ in targets
                 ),
                 return_exceptions=True,
             )
 
             matches: list[dict[str, Any]] = []
             warnings: list[str] = []
-            for target, response in zip(targets, responses, strict=True):
+            for (target, expanded), response in zip(targets, responses, strict=True):
                 match, warning = _evaluate_read(
                     response,
                     target,
                     yaml_path,
-                    is_glob=expanded[target],
+                    expanded=expanded,
                     include_content=include_content,
                     include_parsed=include_parsed,
                 )

--- a/src/ha_mcp/tools/tools_yaml_read.py
+++ b/src/ha_mcp/tools/tools_yaml_read.py
@@ -50,9 +50,11 @@ _GLOB_METACHARS = ("*", "?", "[")
 _PATTERN_ONLY_METACHARS = ("*", "?")
 
 # Wraps each metacharacter in a bracket class so fnmatch reads it literally.
-# Deliberately not glob.escape: that splits a drive letter off first, which is
-# ntpath on a Windows-hosted server - the one host-dependent step in a path
-# that is otherwise POSIX and config-relative.
+# Deliberately not glob.escape: it splits a drive off first and returns that
+# part UNESCAPED, and the split is ntpath on a Windows-hosted server - where a
+# name like \\weird[a].yaml is taken for a drive in its entirety and comes back
+# with its bracket intact. The one host-dependent step in a path that is
+# otherwise POSIX and config-relative.
 _METACHAR_RE = re.compile(r"([*?\[])")
 
 
@@ -64,6 +66,24 @@ def _has_glob(name: str) -> bool:
     folder's name and is not a pattern.
     """
     return any(char in name for char in _GLOB_METACHARS)
+
+
+def _names_a_file(pattern: str) -> bool:
+    """True if the request can be read as naming one file rather than a class.
+
+    ``*`` and ``?`` are pattern syntax: they match their own literal names, so
+    a caller who wrote one wrote a pattern. A bracket class alone is ambiguous,
+    since such a name is legal on the filesystem and cannot match itself.
+
+    One predicate for two decisions that must not diverge - whether a path the
+    literal lookup returned counts as explicitly named, and whether the absence
+    of such a path is worth a warning. Honouring it in the warning alone would
+    leave a file genuinely called ``[ab]*.yaml`` strict, so one failed read of
+    it would discard every match the pattern half had already found: the shape
+    removed for ``*.yaml`` when provenance moved into the resolver, reachable
+    again through the other lookup.
+    """
+    return not any(char in pattern for char in _PATTERN_ONLY_METACHARS)
 
 
 def _call_failed(service: str, context: dict[str, Any]) -> None:
@@ -129,15 +149,18 @@ def _read_exception_result(
     """Decide a read that blew up outright.
 
     An expanded target degrades to a warning so one unreadable file cannot sink
-    the search; the explicitly named target re-raises, matching every other
-    failure class in :func:`_evaluate_read`.
+    the search; the explicitly named target raises, as it does for every other
+    failure class in :func:`_evaluate_read`. The error is re-raised as it came
+    rather than wrapped, so the tool's own handler classifies it by type - the
+    other classes have no live exception to preserve and build a structured
+    :class:`ToolError` instead.
 
     Anything that is not an ``Exception`` propagates whatever the target's
-    provenance. Cancellation and shutdown are not one file being unreadable,
+    provenance - this is the one failure class here that raises for an expanded
+    target too. Cancellation and shutdown are not one file being unreadable,
     and absorbing them into a warning next to ``success: true`` would report a
-    search that was called off as one that ran and found nothing. The codebase
-    draws the same line wherever it fans out per item (``tools_entities``,
-    ``tools_search``, ``smart_search``).
+    search that was called off as one that ran and found nothing. The per-item
+    fan-outs in ``tools_entities`` and ``tools_search`` draw the same line.
 
     ``str()`` is empty on a bare ``TimeoutError()``, so the class name stands
     in - a warning reading "was not searched: ." names no reason at all.
@@ -237,12 +260,12 @@ def _absent_literal_warnings(
     named file as never opened.
 
     Two cases stay silent. A literal that was found needs no warning, and
-    neither does a name also carrying ``*`` or ``?`` - that is pattern syntax,
-    so a missing file of exactly that name is no thwarted expectation. The
-    literal lookup still runs for those names, because a file can genuinely be
-    called ``[ab]*.yaml``; only the complaint is dropped.
+    neither does a request that :func:`_names_a_file` rejects - nobody named a
+    file, so nothing is missing. The literal lookup still runs for those, since
+    its results are merged as ordinary expansion matches; only the complaint is
+    dropped.
     """
-    if literal_found or any(char in pattern for char in _PATTERN_ONLY_METACHARS):
+    if literal_found or not _names_a_file(pattern):
         return []
     if not target_count:
         # Phrased for the degenerate case rather than reporting "the 0 file(s)
@@ -264,12 +287,13 @@ async def _resolve_target_files(
 
     ``is_expanded`` records where the path came from, and it is decided here
     because only here is it known: a path produced by the pattern lookup is an
-    expansion, while the requested path itself and anything the escaped-literal
-    lookup returns were named explicitly. Recovering that downstream by
-    comparing the path against the requested string would be wrong for ``*``
-    and ``?``, which match their own literal names - a file genuinely called
-    ``*.yaml`` would then be mistaken for the name the caller typed and its
-    read failure would sink the whole search.
+    expansion, while the requested path itself, and what the escaped-literal
+    lookup returns for a request :func:`_names_a_file` accepts, were named
+    explicitly. Recovering that downstream by comparing the path against the
+    requested string would be wrong for ``*`` and ``?``, which match their own
+    literal names - a file genuinely called ``*.yaml`` would then be mistaken
+    for the name the caller typed and its read failure would sink the whole
+    search.
 
     A plain path is returned as-is (the read itself reports a missing file). A
     glob is expanded through the component's ``list_files``, which matches the
@@ -320,8 +344,13 @@ async def _resolve_target_files(
             client, file, directory, _METACHAR_RE.sub(r"[\1]", pattern)
         ),
     )
-    named = set(literal)
-    targets = sorted(set(matched) | named)
+    # Both lookups always contribute targets; only whether a literal hit counts
+    # as *named* depends on the request. Under a pattern it is merged as an
+    # ordinary expansion match, so nobody named it and a bad read stays a
+    # warning.
+    literal_paths = set(literal)
+    named = literal_paths if _names_a_file(pattern) else set()
+    targets = sorted(set(matched) | literal_paths)
     warnings = _absent_literal_warnings(
         file, pattern, literal_found=bool(named), target_count=len(targets)
     )

--- a/src/ha_mcp/tools/tools_yaml_read.py
+++ b/src/ha_mcp/tools/tools_yaml_read.py
@@ -16,7 +16,9 @@ back door.
 """
 
 import asyncio
+import glob
 import logging
+import posixpath
 from typing import Annotated, Any
 
 from fastmcp.exceptions import ToolError
@@ -104,6 +106,20 @@ def _parse_error_result(
     return None, f"{target} was not searched: {parse_error}."
 
 
+def _read_exception_result(
+    target: str, error: BaseException, *, is_glob: bool
+) -> tuple[None, str]:
+    """Decide a read that blew up outright.
+
+    An expanded target degrades to a warning so one unreadable file cannot sink
+    the search; the explicitly named target re-raises, matching every other
+    failure class in :func:`_evaluate_read`.
+    """
+    if not is_glob:
+        raise error
+    return None, f"{target} was not searched: {error}."
+
+
 def _evaluate_read(
     response: Any,
     target: str,
@@ -129,10 +145,8 @@ def _evaluate_read(
       non-match, and the whole point of a glob search.
     * **match** — the key is there.
     """
-    # Only reachable under a glob: with a single target return_exceptions is
-    # False, so gather itself raised.
     if isinstance(response, BaseException):
-        return None, f"{target} was not searched: {response}."
+        return _read_exception_result(target, response, is_glob=is_glob)
 
     if not isinstance(response, dict):
         if is_glob:
@@ -160,18 +174,10 @@ def _evaluate_read(
     return match, None
 
 
-async def _resolve_target_files(client: Any, file: str) -> list[str]:
-    """Expand ``file`` into the concrete config-relative paths to read.
-
-    A plain path is returned as-is (the read itself reports a missing file). A
-    glob is expanded through the component's ``list_files``, which matches the
-    file name only — so ``packages/*.yaml`` covers one directory level, not a
-    nested tree.
-    """
-    if not _has_glob(file):
-        return [file]
-
-    directory, _, pattern = file.rpartition("/")
+async def _list_files_matching(
+    client: Any, file: str, directory: str, pattern: str
+) -> list[str]:
+    """Return the non-directory paths in ``directory`` matching ``pattern``."""
     unwrapped = _unwrap_or_raise(
         await call_mcp_tools_service(
             client,
@@ -190,6 +196,42 @@ async def _resolve_target_files(client: Any, file: str) -> list[str]:
         for entry in entries
         if isinstance(entry, dict) and entry.get("path") and not entry.get("is_dir")
     )
+
+
+async def _resolve_target_files(client: Any, file: str) -> list[str]:
+    """Expand ``file`` into the concrete config-relative paths to read.
+
+    A plain path is returned as-is (the read itself reports a missing file). A
+    glob is expanded through the component's ``list_files``, which matches the
+    file name only, so ``packages/*.yaml`` covers one directory level rather
+    than a nested tree. Only the name is inspected for metacharacters: the
+    component resolves the directory literally, so ``pack[a]ges/svc.yaml``
+    names one file and is read as one rather than expanded.
+
+    A bracketed name is ambiguous: ``packages/svc[a].yaml`` is both a valid
+    pattern and a valid filename, and a closed bracket class is the one
+    metacharacter form whose pattern cannot match its own name (``fnmatch``
+    reads ``[a]`` as the single character ``a``, while ``*`` and ``?`` do match
+    themselves). Such a name is therefore looked up twice, as the pattern and
+    as the escaped literal, and the results are merged: the pattern alone would
+    report ``files_searched: 0`` for a file that exists, and the literal alone
+    would drop the siblings a deliberate class like ``svc[12].yaml`` is meant
+    to find. Both lookups run because a sibling that satisfies the class would
+    otherwise mask the file the caller named exactly. Only bracketed names pay
+    the second round-trip. The component likewise treats package folder names
+    carrying metacharacters as literal names (#1854).
+    """
+    directory, _, pattern = file.rpartition("/")
+    if not _has_glob(pattern):
+        return [file]
+
+    matches = await _list_files_matching(client, file, directory, pattern)
+    if "[" in pattern:
+        literal = await _list_files_matching(
+            client, file, directory, glob.escape(pattern)
+        )
+        matches = sorted(set(matches) | set(literal))
+    return matches
 
 
 class YamlReadTools:
@@ -226,7 +268,9 @@ class YamlReadTools:
                     "Config-relative file to read. Accepts an fnmatch glob to "
                     "search several files at once — 'packages/*.yaml' matches one "
                     "directory level, not a nested tree. Use the glob to find "
-                    "which file defines a key."
+                    "which file defines a key. A name carrying a bracket class "
+                    "is read both ways, as the pattern and as that literal "
+                    "filename."
                 ),
             ),
         ] = "configuration.yaml",
@@ -273,15 +317,25 @@ class YamlReadTools:
         try:
             await _assert_mcp_tools_available(self._client)
 
-            is_glob = _has_glob(file)
             targets = await _resolve_target_files(self._client, file)
+            # Strictness is a property of each target, not of the request: the
+            # target that IS the requested path was named explicitly and keeps
+            # the strict contract (raise, don't degrade) even when expansion
+            # turned up siblings alongside it. Compared normalized, since the
+            # component reports what it walked rather than what was asked for.
+            requested = posixpath.normpath(file)
+            expanded = {
+                target: posixpath.normpath(target) != requested for target in targets
+            }
 
             extra: dict[str, Any] = {"include_parsed": True} if include_parsed else {}
             # The reads are independent, so fan them out rather than paying N
             # sequential round-trips to HA — a packages glob is routinely 10+
             # files. gather preserves order, so matches stay sorted by file.
-            # Under a glob a single read blowing up must not sink its siblings,
-            # so exceptions come back as values to be warned about below.
+            # An expanded target blowing up must not sink the search, so every
+            # exception comes back as a value; whether it degrades to a warning
+            # or is re-raised is then decided per target, like every other
+            # failure class.
             responses = await asyncio.gather(
                 *(
                     call_mcp_tools_service(
@@ -291,7 +345,7 @@ class YamlReadTools:
                     )
                     for target in targets
                 ),
-                return_exceptions=is_glob,
+                return_exceptions=True,
             )
 
             matches: list[dict[str, Any]] = []
@@ -301,7 +355,7 @@ class YamlReadTools:
                     response,
                     target,
                     yaml_path,
-                    is_glob=is_glob,
+                    is_glob=expanded[target],
                     include_content=include_content,
                     include_parsed=include_parsed,
                 )

--- a/tests/src/e2e/workflows/filesystem/test_yaml_read.py
+++ b/tests/src/e2e/workflows/filesystem/test_yaml_read.py
@@ -387,6 +387,10 @@ class TestYamlReadGlobDiscovery:
         assert data["files_searched"] == 1
         assert data["matches"][0]["file"] == target
         assert "e2e_bracket_probe" in data["matches"][0]["content"]
+        # The other half, on the real instance: the literal lookup found the
+        # file, so nothing degraded and no warning was manufactured.
+        assert data["files_unreadable"] == 0
+        assert "warnings" not in data
 
     async def test_glob_returns_every_defining_file(
         self, mcp_client, yaml_editing_enabled

--- a/tests/src/e2e/workflows/filesystem/test_yaml_read.py
+++ b/tests/src/e2e/workflows/filesystem/test_yaml_read.py
@@ -357,6 +357,37 @@ class TestYamlReadGlobDiscovery:
         # file + yaml_path address the same fragment for ha_config_set_yaml.
         assert match["yaml_path"] == "command_line"
 
+    async def test_bracketed_filename_is_read_by_its_exact_name(
+        self, mcp_client, yaml_editing_enabled
+    ):
+        """The behavioural half of the unit coverage, on a real instance.
+
+        The unit tests resolve against a replica of the component's matcher;
+        this seeds a file whose name carries a bracket class and reads it back
+        by that exact name, so the two halves are pinned against the same
+        behaviour rather than against each other.
+        """
+        target = f"{PACKAGES_DIR}/_e2e_bracket[a].yaml"
+        async with MCPAssertions(mcp_client) as mcp:
+            await _set_yaml_confirmed(
+                mcp,
+                {
+                    "yaml_path": "shell_command",
+                    "action": "add",
+                    "file": target,
+                    "content": "e2e_bracket_probe: echo 1\n",
+                },
+            )
+
+            data = await mcp.call_tool_success(
+                TOOL_NAME, {"yaml_path": "shell_command", "file": target}
+            )
+
+        assert data["count"] == 1
+        assert data["files_searched"] == 1
+        assert data["matches"][0]["file"] == target
+        assert "e2e_bracket_probe" in data["matches"][0]["content"]
+
     async def test_glob_returns_every_defining_file(
         self, mcp_client, yaml_editing_enabled
     ):

--- a/tests/src/unit/test_custom_component_filesystem.py
+++ b/tests/src/unit/test_custom_component_filesystem.py
@@ -4,6 +4,7 @@ These tests focus on the pure Python utility functions that don't require
 Home Assistant dependencies.
 """
 
+import glob
 import json
 import os
 import shutil
@@ -547,6 +548,23 @@ class TestListFilesSync:
 
         names = sorted(f["name"] for f in result["files"])
         assert names == ["a.yaml", "b.yaml"]
+
+    def test_bracketed_name_is_absent_from_its_own_expansion(self, tmp_path):
+        """The premise ha_config_get_yaml's double lookup rests on.
+
+        A bracket class never matches the literal name it is written as, so a
+        file called ``svc[a].yaml`` is invisible to its own name used as a
+        pattern; the escaped form finds it. Asserted here against the real
+        filter rather than against a replica in the caller's tests.
+        """
+        (tmp_path / "svc[a].yaml").write_text("a")
+        (tmp_path / "svca.yaml").write_text("b")
+
+        as_pattern = _list_files_sync(tmp_path, tmp_path, "svc[a].yaml")
+        as_literal = _list_files_sync(tmp_path, tmp_path, glob.escape("svc[a].yaml"))
+
+        assert [f["name"] for f in as_pattern["files"]] == ["svca.yaml"]
+        assert [f["name"] for f in as_literal["files"]] == ["svc[a].yaml"]
 
 
 class TestReadFileSync:

--- a/tests/src/unit/test_yaml_read_tool.py
+++ b/tests/src/unit/test_yaml_read_tool.py
@@ -1,5 +1,6 @@
 """Unit tests for the ha_config_get_yaml MCP tool wrapper (#1788)."""
 
+import asyncio
 import fnmatch
 import posixpath
 from unittest.mock import AsyncMock, MagicMock
@@ -392,7 +393,7 @@ async def test_glob_malformed_response_warns_instead_of_aborting():
 
 
 async def test_single_file_malformed_response_still_raises():
-    """With one target there is nothing to salvage, so it stays an error."""
+    """A named target has no expansion to salvage, so it stays an error."""
     fn, _ = await _make_tool({"read_file": _Raw("not a dict at all")})
 
     with pytest.raises(ToolError):
@@ -459,7 +460,9 @@ async def test_bracketed_name_is_read_as_a_literal_file():
 
     assert out["files_searched"] == 1
     assert [m["file"] for m in out["matches"]] == ["packages/svc[a].yaml"]
-    assert patterns == ["svc[a].yaml", "svc[[]a].yaml"]
+    # Sorted: the two lookups are gathered, so their arrival order is a
+    # scheduling detail and asserting it would be a latent flake.
+    assert sorted(patterns) == ["svc[[]a].yaml", "svc[a].yaml"]
 
 
 async def test_bracketed_name_is_not_masked_by_a_sibling():
@@ -482,7 +485,9 @@ async def test_bracketed_name_is_not_masked_by_a_sibling():
         "packages/svc[a].yaml",
         "packages/svca.yaml",
     ]
-    assert patterns == ["svc[a].yaml", "svc[[]a].yaml"]
+    # Sorted: the two lookups are gathered, so their arrival order is a
+    # scheduling detail and asserting it would be a latent flake.
+    assert sorted(patterns) == ["svc[[]a].yaml", "svc[a].yaml"]
 
 
 async def test_bracketed_literal_keeps_the_single_target_error_contract():
@@ -597,7 +602,7 @@ async def test_bracketed_directory_with_a_plain_name_is_read_directly():
     """Only the name is a pattern. The component resolves directories
     literally, so a bracketed folder must not send the request through
     expansion - which would answer a typo with a silent empty result instead of
-    'file not found'."""
+    the component's "File does not exist"."""
 
     def list_files(payload):
         raise AssertionError(f"expansion must not run: {payload}")
@@ -761,13 +766,13 @@ async def test_root_level_glob_lists_config_root():
 
 
 async def test_named_file_read_exception_raises_instead_of_warning():
-    """The strict half of the exception path, which nothing else reaches.
+    """The strict half of the exception path, in its simplest shape.
 
-    Every other strict-target test raises through a different door (parse
-    error, ``success: False``, non-dict). Since ``return_exceptions`` is
-    unconditional, a named target whose read blows up now reaches an explicit
-    re-raise, and without this test dropping that re-raise would hand the
-    caller ``success: true, count: 0`` for a file that was never opened.
+    Since ``return_exceptions`` is unconditional, a named target whose read
+    blows up reaches an explicit re-raise rather than aborting the gather.
+    Dropping that re-raise would hand the caller ``success: true, count: 0``
+    for a file that was never opened; the mixed case below covers the same
+    door with an expanded sibling alongside.
     """
     fn, _ = await _make_tool(
         {"read_file": MagicMock(side_effect=ConnectionResetError("connection reset"))}
@@ -836,6 +841,9 @@ async def test_absent_bracketed_literal_is_reported_not_implied():
         "No file is literally named packages/svc[a].yaml; searched the 1 "
         "file(s) matching it as a pattern."
     ]
+    # The counterexample to counting unreadable files off the warnings list:
+    # this warning comes from the resolver, and the one read succeeded.
+    assert out["files_unreadable"] == 0
 
 
 async def test_bracket_class_searches_its_siblings():
@@ -865,9 +873,9 @@ async def test_bracket_class_searches_its_siblings():
 
 
 async def test_literal_lookup_failure_raises():
-    """Both lookups walk the same directory, so a listing failure on the second
-    is a broken request, not one unreadable file - it raises rather than
-    silently returning only what the pattern pass found."""
+    """Both lookups walk the same directory, so a listing failure on the
+    literal one is a broken request, not one unreadable file - it raises rather
+    than silently returning only what the pattern pass found."""
 
     def list_files(payload):
         if payload["pattern"] == "svc[[]a].yaml":
@@ -897,5 +905,174 @@ async def test_unclosed_bracket_resolves_to_one_target():
 
     assert out["files_searched"] == 1
     assert [m["file"] for m in out["matches"]] == ["packages/svc[a.yaml"]
-    assert patterns == ["svc[a.yaml", "svc[[]a.yaml"]
+    assert sorted(patterns) == ["svc[[]a.yaml", "svc[a.yaml"]
     assert "warnings" not in out
+
+
+async def test_unclosed_bracket_read_failure_raises():
+    """An unclosed bracket names a file, so its failed read is not a warning.
+
+    Both lookups return it - it is literal to ``fnmatch``, so it matches its
+    own name - and provenance has to come from the literal one. Reading it off
+    the pattern lookup instead would make this file expanded, degrade the
+    failure to a warning, and answer ``success: true, count: 0`` for the file
+    the caller named exactly.
+    """
+    list_files, _ = _bracket_dir("svc[a.yaml")
+
+    fn, _ = await _make_tool(
+        {
+            "list_files": list_files,
+            "read_file": MagicMock(
+                side_effect=ConnectionResetError("connection reset")
+            ),
+        }
+    )
+
+    with pytest.raises(ToolError):
+        await fn(yaml_path="rest", file="packages/svc[a.yaml")
+
+
+async def test_cancellation_propagates_even_on_an_expanded_target():
+    """Leniency covers unreadable files, not a cancelled search.
+
+    ``CancelledError`` is not one file being unreadable: absorbing it into a
+    warning beside ``success: true`` would report a search that was called off
+    as one that ran and found nothing. It propagates whatever the target's
+    provenance, which is what every other per-item fan-out in the codebase
+    does.
+    """
+    fn, _ = await _make_tool(
+        {
+            "list_files": {
+                "success": True,
+                "files": [{"path": "packages/only.yaml", "is_dir": False}],
+            },
+            "read_file": MagicMock(side_effect=asyncio.CancelledError()),
+        }
+    )
+
+    with pytest.raises(asyncio.CancelledError):
+        await fn(yaml_path="rest", file="packages/*.yaml")
+
+
+async def test_files_unreadable_counts_the_reads_that_failed():
+    """The summary fields must not read as a completed search.
+
+    ``count: 0`` beside ``files_searched: 3`` is the affirmative "I looked"
+    this tool exists to stop making, so the count of files that could not be
+    opened travels with them rather than only in prose.
+    """
+    fn, _ = await _make_tool(
+        {
+            "list_files": {
+                "success": True,
+                "files": [
+                    {"path": f"packages/{name}.yaml", "is_dir": False}
+                    for name in ("a", "b", "c")
+                ],
+            },
+            "read_file": MagicMock(
+                side_effect=ConnectionResetError("connection reset")
+            ),
+        }
+    )
+
+    out = await fn(yaml_path="rest", file="packages/*.yaml")
+
+    assert out["count"] == 0
+    assert out["files_searched"] == 3
+    assert out["files_unreadable"] == 3
+    assert len(out["warnings"]) == 3
+
+
+async def test_resolver_warning_and_read_warning_both_survive():
+    """The two warning sources are independent and both reach the caller.
+
+    The resolver's "nothing is literally named that" and a per-file read
+    failure describe different things, so one must not stand in for the other -
+    and only the read counts as an unreadable file.
+    """
+    list_files, _ = _bracket_dir("svca.yaml", "svcb.yaml")
+
+    def read(payload):
+        if payload["path"] == "packages/svca.yaml":
+            raise ConnectionResetError("connection reset")
+        return _read_ok("- name: sibling\n")
+
+    fn, _ = await _make_tool({"list_files": list_files, "read_file": read})
+
+    out = await fn(yaml_path="rest", file="packages/svc[ab].yaml")
+
+    assert out["count"] == 1
+    assert out["files_searched"] == 2
+    assert out["files_unreadable"] == 1
+    assert out["warnings"] == [
+        "No file is literally named packages/svc[ab].yaml; searched the 2 "
+        "file(s) matching it as a pattern.",
+        "packages/svca.yaml was not searched: connection reset.",
+    ]
+
+
+async def test_nothing_matches_either_reading_says_so_directly():
+    """Neither reading found anything, and the warning says that plainly.
+
+    Reporting "searched the 0 file(s) matching it as a pattern" describes a
+    search that did not happen. The result stays a success because a bracketed
+    name is a glob spelling too, and an empty glob is not an error here - but
+    silence would make a typo'd bracketed name look like a key that is simply
+    not defined.
+    """
+    list_files, _ = _bracket_dir("other.yaml")
+
+    fn, _ = await _make_tool({"list_files": list_files, "read_file": _read_ok("x\n")})
+
+    out = await fn(yaml_path="rest", file="packages/svc[a].yaml")
+
+    assert out["success"] is True
+    assert out["files_searched"] == 0
+    assert out["count"] == 0
+    assert out["files_unreadable"] == 0
+    assert out["warnings"] == [
+        "No file is literally named packages/svc[a].yaml, and nothing matched "
+        "it as a pattern either."
+    ]
+
+
+async def test_mixed_pattern_keeps_its_literal_lookup_but_not_the_warning():
+    """``*`` alongside the bracket is pattern syntax, so nothing was named.
+
+    A caller writing ``[ab]*.yaml`` is not naming a file, and telling them no
+    file is called that would hang a ``warnings`` key on an ordinary,
+    completely successful glob. The literal lookup still runs, because a file
+    can genuinely carry that name.
+    """
+    list_files, patterns = _bracket_dir("a1.yaml", "b1.yaml")
+
+    fn, _ = await _make_tool(
+        {"list_files": list_files, "read_file": _read_ok("- name: probe\n")}
+    )
+
+    out = await fn(yaml_path="rest", file="packages/[ab]*.yaml")
+
+    assert out["files_searched"] == 2
+    assert "warnings" not in out
+    assert sorted(patterns) == ["[[]ab][*].yaml", "[ab]*.yaml"]
+
+
+async def test_both_lookups_failing_raises():
+    """The realistic component failure is path-based and hits both lookups.
+
+    Whichever of the two concurrent calls reports first, the request is broken
+    in the same way, so it raises rather than returning a half-resolved
+    expansion.
+    """
+    fn, _ = await _make_tool(
+        {
+            "list_files": {"success": False, "error": "Path not allowed.", "files": []},
+            "read_file": _read_ok("x\n"),
+        }
+    )
+
+    with pytest.raises(ToolError):
+        await fn(yaml_path="rest", file="packages/svc[a].yaml")

--- a/tests/src/unit/test_yaml_read_tool.py
+++ b/tests/src/unit/test_yaml_read_tool.py
@@ -837,10 +837,11 @@ async def test_absent_bracketed_literal_is_reported_not_implied():
 
     assert out["files_searched"] == 1
     assert out["count"] == 1
-    assert out["warnings"] == [
+    expected_warning = (
         "No file is literally named packages/svc[a].yaml; searched the 1 "
         "file(s) matching it as a pattern."
-    ]
+    )
+    assert out["warnings"] == [expected_warning]
     # The counterexample to counting unreadable files off the warnings list:
     # this warning comes from the resolver, and the one read succeeded.
     assert out["files_unreadable"] == 0
@@ -866,10 +867,11 @@ async def test_bracket_class_searches_its_siblings():
         "packages/svc1.yaml",
         "packages/svc2.yaml",
     ]
-    assert out["warnings"] == [
+    expected_warning = (
         "No file is literally named packages/svc[12].yaml; searched the 2 "
         "file(s) matching it as a pattern."
-    ]
+    )
+    assert out["warnings"] == [expected_warning]
 
 
 async def test_literal_lookup_failure_raises():
@@ -1007,9 +1009,12 @@ async def test_resolver_warning_and_read_warning_both_survive():
     assert out["count"] == 1
     assert out["files_searched"] == 2
     assert out["files_unreadable"] == 1
-    assert out["warnings"] == [
+    resolver_warning = (
         "No file is literally named packages/svc[ab].yaml; searched the 2 "
-        "file(s) matching it as a pattern.",
+        "file(s) matching it as a pattern."
+    )
+    assert out["warnings"] == [
+        resolver_warning,
         "packages/svca.yaml was not searched: connection reset.",
     ]
 
@@ -1033,10 +1038,11 @@ async def test_nothing_matches_either_reading_says_so_directly():
     assert out["files_searched"] == 0
     assert out["count"] == 0
     assert out["files_unreadable"] == 0
-    assert out["warnings"] == [
+    expected_warning = (
         "No file is literally named packages/svc[a].yaml, and nothing matched "
         "it as a pattern either."
-    ]
+    )
+    assert out["warnings"] == [expected_warning]
 
 
 async def test_mixed_pattern_keeps_its_literal_lookup_but_not_the_warning():

--- a/tests/src/unit/test_yaml_read_tool.py
+++ b/tests/src/unit/test_yaml_read_tool.py
@@ -1,5 +1,7 @@
 """Unit tests for the ha_config_get_yaml MCP tool wrapper (#1788)."""
 
+import fnmatch
+import posixpath
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -416,6 +418,204 @@ async def test_empty_glob_matches_nothing_without_raising():
     assert out["count"] == 0
     assert out["files_searched"] == 0
     assert "warnings" not in out
+
+
+def _bracket_dir(*names):
+    """A ``list_files`` mock over ``names``, matching the way the component does.
+
+    The component filters with ``fnmatch.fnmatch(item.name, pattern)``, which is
+    why a file called ``svc[a].yaml`` never appears in its own expansion.
+    """
+    recorded: list[str] = []
+
+    def list_files(payload):
+        recorded.append(payload["pattern"])
+        # The component normalizes the directory it walks and reports paths
+        # relative to the config dir, so ``./packages`` and ``packages`` are
+        # the same request and both answer with the normalized form.
+        assert posixpath.normpath(payload["path"]) == "packages"
+        return {
+            "success": True,
+            "files": [
+                {"path": f"packages/{n}", "is_dir": False}
+                for n in names
+                if fnmatch.fnmatch(n, payload["pattern"])
+            ],
+        }
+
+    return list_files, recorded
+
+
+async def test_bracketed_name_is_read_as_a_literal_file():
+    """A bracket class cannot match its own name, so the pattern pass alone
+    reports files_searched 0 for a file that is right there."""
+    list_files, patterns = _bracket_dir("svc[a].yaml")
+
+    fn, _ = await _make_tool(
+        {"list_files": list_files, "read_file": _read_ok("- name: probe\n")}
+    )
+
+    out = await fn(yaml_path="rest", file="packages/svc[a].yaml")
+
+    assert out["files_searched"] == 1
+    assert [m["file"] for m in out["matches"]] == ["packages/svc[a].yaml"]
+    assert patterns == ["svc[a].yaml", "svc[[]a].yaml"]
+
+
+async def test_bracketed_name_is_not_masked_by_a_sibling():
+    """The sibling the class matches must not stand in for the exact name.
+
+    Both are legitimate readings of the same string, so both are searched -
+    stopping at the pattern hit would return a match from another file while
+    the file the caller named stayed closed.
+    """
+    list_files, patterns = _bracket_dir("svc[a].yaml", "svca.yaml")
+
+    fn, _ = await _make_tool(
+        {"list_files": list_files, "read_file": _read_ok("- name: probe\n")}
+    )
+
+    out = await fn(yaml_path="rest", file="packages/svc[a].yaml")
+
+    assert out["files_searched"] == 2
+    assert [m["file"] for m in out["matches"]] == [
+        "packages/svc[a].yaml",
+        "packages/svca.yaml",
+    ]
+    assert patterns == ["svc[a].yaml", "svc[[]a].yaml"]
+
+
+async def test_bracketed_literal_keeps_the_single_target_error_contract():
+    """Resolving to exactly the requested file makes it a single explicit
+    target, so a parse failure raises instead of degrading to a warning - the
+    same contract a path without metacharacters gets."""
+    list_files, _ = _bracket_dir("svc[a].yaml")
+
+    fn, _ = await _make_tool(
+        {
+            "list_files": list_files,
+            "read_file": {
+                "success": True,
+                "path": "packages/svc[a].yaml",
+                "content": "...",
+                "subtree": None,
+                "parse_error": "not valid YAML at line 3, column 5",
+            },
+        }
+    )
+
+    with pytest.raises(ToolError):
+        await fn(yaml_path="rest", file="packages/svc[a].yaml")
+
+
+async def test_named_file_keeps_its_contract_when_a_sibling_tags_along():
+    """Strictness belongs to the target, not to the request.
+
+    The sibling arrives because the class matched it, and it must not turn the
+    explicitly named file's parse failure into a warning - otherwise whether a
+    broken file is diagnosed depends on what else happens to sit next to it.
+    """
+    list_files, _ = _bracket_dir("svc[a].yaml", "svca.yaml")
+
+    def read(payload):
+        if payload["path"] == "packages/svc[a].yaml":
+            return {
+                "success": True,
+                "path": payload["path"],
+                "content": "...",
+                "subtree": None,
+                "parse_error": "not valid YAML at line 3, column 5",
+            }
+        return _read_ok("- name: sibling\n")
+
+    fn, _ = await _make_tool({"list_files": list_files, "read_file": read})
+
+    with pytest.raises(ToolError):
+        await fn(yaml_path="rest", file="packages/svc[a].yaml")
+
+
+async def test_equivalent_spelling_is_still_the_named_target():
+    """The component answers with the path it walked, so a caller-side spelling
+    like ``./packages/...`` would never compare equal as a raw string."""
+    list_files, _ = _bracket_dir("svc[a].yaml")
+
+    fn, _ = await _make_tool(
+        {
+            "list_files": list_files,
+            "read_file": {
+                "success": True,
+                "path": "packages/svc[a].yaml",
+                "content": "...",
+                "subtree": None,
+                "parse_error": "not valid YAML at line 3, column 5",
+            },
+        }
+    )
+
+    with pytest.raises(ToolError):
+        await fn(yaml_path="rest", file="./packages/svc[a].yaml")
+
+
+async def test_bracketed_directory_with_a_plain_name_is_read_directly():
+    """Only the name is a pattern. The component resolves directories
+    literally, so a bracketed folder must not send the request through
+    expansion - which would answer a typo with a silent empty result instead of
+    'file not found'."""
+
+    def list_files(payload):
+        raise AssertionError(f"expansion must not run: {payload}")
+
+    read_paths: list[str] = []
+
+    def read(payload):
+        read_paths.append(payload["path"])
+        return _read_ok("- name: probe\n")
+
+    fn, _ = await _make_tool({"list_files": list_files, "read_file": read})
+
+    out = await fn(yaml_path="rest", file="pack[a]ges/svc.yaml")
+
+    assert read_paths == ["pack[a]ges/svc.yaml"]
+    assert out["files_searched"] == 1
+
+
+async def test_single_match_glob_still_warns_when_its_read_blows_up():
+    """A glob is lenient however many files it happens to match.
+
+    The count is an accident of the directory, so a one-file expansion must
+    still degrade a failed read to a warning rather than aborting the search,
+    exactly as a two-file one does.
+    """
+    fn, _ = await _make_tool(
+        {
+            "list_files": {
+                "success": True,
+                "files": [{"path": "packages/only.yaml", "is_dir": False}],
+            },
+            "read_file": MagicMock(
+                side_effect=ConnectionResetError("connection reset")
+            ),
+        }
+    )
+
+    out = await fn(yaml_path="rest", file="packages/*.yaml")
+
+    assert out["success"] is True
+    assert out["files_searched"] == 1
+    assert out["warnings"] == ["packages/only.yaml was not searched: connection reset."]
+
+
+async def test_glob_without_brackets_is_resolved_in_one_call():
+    """The second lookup is scoped to bracketed names; ``*.yaml`` matching
+    nothing is a genuinely empty glob, not an ambiguous literal."""
+    list_files, patterns = _bracket_dir("lights.yaml")
+
+    fn, _ = await _make_tool({"list_files": list_files, "read_file": _read_ok("x\n")})
+
+    out = await fn(yaml_path="alert2", file="packages/nothing*.yaml")
+
+    assert out["files_searched"] == 0
+    assert patterns == ["nothing*.yaml"]
 
 
 async def test_list_failure_raises_tool_error():

--- a/tests/src/unit/test_yaml_read_tool.py
+++ b/tests/src/unit/test_yaml_read_tool.py
@@ -962,8 +962,10 @@ async def test_files_unreadable_counts_the_reads_that_failed():
     """The summary fields must not read as a completed search.
 
     ``count: 0`` beside ``files_searched: 3`` is the affirmative "I looked"
-    this tool exists to stop making, so the count of files that could not be
-    opened travels with them rather than only in prose.
+    this tool exists to stop making, so the count of files that were not
+    searched travels with them rather than only in prose. Not searched is the
+    wider class the warnings already name: a file that was opened and read but
+    would not parse counts here too, because its key was never inspected.
     """
     fn, _ = await _make_tool(
         {
@@ -985,7 +987,13 @@ async def test_files_unreadable_counts_the_reads_that_failed():
     assert out["count"] == 0
     assert out["files_searched"] == 3
     assert out["files_unreadable"] == 3
-    assert len(out["warnings"]) == 3
+    # Contents, not just the length: three copies of one file's warning would
+    # satisfy a count while describing a different failure.
+    assert out["warnings"] == [
+        "packages/a.yaml was not searched: connection reset.",
+        "packages/b.yaml was not searched: connection reset.",
+        "packages/c.yaml was not searched: connection reset.",
+    ]
 
 
 async def test_resolver_warning_and_read_warning_both_survive():
@@ -1064,6 +1072,35 @@ async def test_mixed_pattern_keeps_its_literal_lookup_but_not_the_warning():
     assert out["files_searched"] == 2
     assert "warnings" not in out
     assert sorted(patterns) == ["[[]ab][*].yaml", "[ab]*.yaml"]
+
+
+async def test_mixed_pattern_literal_hit_is_still_an_expansion():
+    """Under a pattern, even an exact hit is an expansion match.
+
+    The caller wrote ``*``, so nothing was named - and a file that happens to
+    be called ``[ab]*.yaml`` must not become the strict target, or one failed
+    read of it would discard the matches the pattern half already found. Same
+    shape the resolver removed for ``*.yaml``, reachable through the literal
+    lookup instead, so one predicate has to drive both halves.
+    """
+    list_files, _ = _bracket_dir("[ab]*.yaml", "a1.yaml")
+
+    def read(payload):
+        if payload["path"] == "packages/[ab]*.yaml":
+            raise ConnectionResetError("connection reset")
+        return _read_ok("- name: probe\n")
+
+    fn, _ = await _make_tool({"list_files": list_files, "read_file": read})
+
+    out = await fn(yaml_path="rest", file="packages/[ab]*.yaml")
+
+    assert out["count"] == 1
+    assert out["matches"][0]["file"] == "packages/a1.yaml"
+    assert out["files_searched"] == 2
+    assert out["files_unreadable"] == 1
+    assert out["warnings"] == [
+        "packages/[ab]*.yaml was not searched: connection reset."
+    ]
 
 
 async def test_both_lookups_failing_raises():

--- a/tests/src/unit/test_yaml_read_tool.py
+++ b/tests/src/unit/test_yaml_read_tool.py
@@ -534,9 +534,46 @@ async def test_named_file_keeps_its_contract_when_a_sibling_tags_along():
         await fn(yaml_path="rest", file="packages/svc[a].yaml")
 
 
+async def test_file_named_like_the_glob_is_still_an_expansion():
+    """A pattern is not a name, even when a file happens to be called that.
+
+    ``*`` and ``?`` match their own literal names, so a file genuinely called
+    ``*.yaml`` comes back out of its own expansion. Nobody named it, so its
+    read failure stays a warning. Deciding provenance by comparing the target
+    against the requested string instead would read it as the named file and
+    let one unreadable oddity discard every match already found.
+    """
+
+    def list_files(payload):
+        return {
+            "success": True,
+            "files": [
+                {"path": f"packages/{n}", "is_dir": False}
+                for n in ("*.yaml", "a.yaml", "b.yaml")
+                if fnmatch.fnmatch(n, payload["pattern"])
+            ],
+        }
+
+    def read(payload):
+        if payload["path"] == "packages/*.yaml":
+            return {"success": False, "error": "Path not allowed: packages/*.yaml"}
+        return _read_ok("- name: found\n")
+
+    fn, _ = await _make_tool({"list_files": list_files, "read_file": read})
+
+    out = await fn(yaml_path="found", file="packages/*.yaml")
+
+    assert out["count"] == 2
+    assert out["files_searched"] == 3
+    assert out["warnings"] == [
+        "packages/*.yaml was not searched: Path not allowed: packages/*.yaml."
+    ]
+
+
 async def test_equivalent_spelling_is_still_the_named_target():
-    """The component answers with the path it walked, so a caller-side spelling
-    like ``./packages/...`` would never compare equal as a raw string."""
+    """The literal lookup reports the path the component walked, so an
+    equivalent caller-side spelling like ``./packages/...`` still resolves to
+    the same named target."""
     list_files, _ = _bracket_dir("svc[a].yaml")
 
     fn, _ = await _make_tool(

--- a/tests/src/unit/test_yaml_read_tool.py
+++ b/tests/src/unit/test_yaml_read_tool.py
@@ -283,7 +283,7 @@ async def test_include_parsed_not_sent_by_default():
 
 
 async def test_read_failure_raises_tool_error():
-    """A single explicit target has no siblings to salvage, so it still raises."""
+    """A named target raises, whether or not anything else was resolved."""
     fn, _ = await _make_tool(
         {"read_file": {"success": False, "error": "File does not exist: nope.yaml"}}
     )
@@ -486,9 +486,9 @@ async def test_bracketed_name_is_not_masked_by_a_sibling():
 
 
 async def test_bracketed_literal_keeps_the_single_target_error_contract():
-    """Resolving to exactly the requested file makes it a single explicit
-    target, so a parse failure raises instead of degrading to a warning - the
-    same contract a path without metacharacters gets."""
+    """The literal lookup returns the requested file, so it is a named target
+    and a parse failure raises instead of degrading to a warning - the same
+    contract a path without metacharacters gets."""
     list_files, _ = _bracket_dir("svc[a].yaml")
 
     fn, _ = await _make_tool(
@@ -617,11 +617,12 @@ async def test_bracketed_directory_with_a_plain_name_is_read_directly():
 
 
 async def test_single_match_glob_still_warns_when_its_read_blows_up():
-    """A glob is lenient however many files it happens to match.
+    """An expanded target is lenient however few of them there are.
 
     The count is an accident of the directory, so a one-file expansion must
     still degrade a failed read to a warning rather than aborting the search,
-    exactly as a two-file one does.
+    exactly as a two-file one does. Leniency follows from the target having
+    come out of an expansion, not from how many did.
     """
     fn, _ = await _make_tool(
         {
@@ -708,7 +709,7 @@ async def test_parse_error_warns_instead_of_reading_as_a_non_match():
 
 
 async def test_single_file_parse_error_raises_instead_of_reporting_no_match():
-    """A single explicit target that will not parse has no siblings to salvage.
+    """A named target that will not parse raises rather than degrading.
 
     Soft-degrading to a warning would make a real parse failure indistinguishable
     from "key absent" at the success/count level, so it raises instead.
@@ -757,3 +758,144 @@ async def test_root_level_glob_lists_config_root():
     with pytest.raises(ToolError):
         await fn(yaml_path="rest", file="*.yaml")
     assert seen["path"] == "."
+
+
+async def test_named_file_read_exception_raises_instead_of_warning():
+    """The strict half of the exception path, which nothing else reaches.
+
+    Every other strict-target test raises through a different door (parse
+    error, ``success: False``, non-dict). Since ``return_exceptions`` is
+    unconditional, a named target whose read blows up now reaches an explicit
+    re-raise, and without this test dropping that re-raise would hand the
+    caller ``success: true, count: 0`` for a file that was never opened.
+    """
+    fn, _ = await _make_tool(
+        {"read_file": MagicMock(side_effect=ConnectionResetError("connection reset"))}
+    )
+
+    with pytest.raises(ToolError):
+        await fn(yaml_path="rest", file="configuration.yaml")
+
+
+async def test_named_bracketed_target_read_exception_raises_despite_sibling():
+    """A tagging-along sibling does not soften the named file's contract.
+
+    The mixed case: the class turns up a sibling that reads fine while the file
+    the caller actually named blows up. Reporting the sibling's result with a
+    warning would answer a question nobody asked.
+    """
+    list_files, _ = _bracket_dir("svc[a].yaml", "svca.yaml")
+
+    def read(payload):
+        if payload["path"] == "packages/svc[a].yaml":
+            raise ConnectionResetError("connection reset")
+        return _read_ok("- name: sibling\n")
+
+    fn, _ = await _make_tool({"list_files": list_files, "read_file": read})
+
+    with pytest.raises(ToolError):
+        await fn(yaml_path="rest", file="packages/svc[a].yaml")
+
+
+async def test_message_less_read_exception_still_names_a_reason():
+    """``str()`` is empty on a bare ``TimeoutError()``, so the class name stands
+    in - otherwise the warning reads "was not searched: ." and names nothing."""
+    fn, _ = await _make_tool(
+        {
+            "list_files": {
+                "success": True,
+                "files": [{"path": "packages/only.yaml", "is_dir": False}],
+            },
+            "read_file": MagicMock(side_effect=TimeoutError()),
+        }
+    )
+
+    out = await fn(yaml_path="rest", file="packages/*.yaml")
+
+    assert out["warnings"] == ["packages/only.yaml was not searched: TimeoutError."]
+
+
+async def test_absent_bracketed_literal_is_reported_not_implied():
+    """The named file does not exist, only a sibling the class matches.
+
+    Without a word about it the caller reads ``files_searched: 1`` as "your
+    file was searched and has no such key" - the same affirmative "I looked"
+    this PR removes, wearing a different coat.
+    """
+    list_files, _ = _bracket_dir("svca.yaml")
+
+    fn, _ = await _make_tool(
+        {"list_files": list_files, "read_file": _read_ok("- name: sibling\n")}
+    )
+
+    out = await fn(yaml_path="rest", file="packages/svc[a].yaml")
+
+    assert out["files_searched"] == 1
+    assert out["count"] == 1
+    assert out["warnings"] == [
+        "No file is literally named packages/svc[a].yaml; searched the 1 "
+        "file(s) matching it as a pattern."
+    ]
+
+
+async def test_bracket_class_searches_its_siblings():
+    """The motivating case for keeping the pattern pass at all.
+
+    ``svc[12].yaml`` is written as a class on purpose and no such file exists;
+    both members must be searched, and the caller is told the literal was not
+    among them.
+    """
+    list_files, _ = _bracket_dir("svc1.yaml", "svc2.yaml")
+
+    fn, _ = await _make_tool(
+        {"list_files": list_files, "read_file": _read_ok("- name: member\n")}
+    )
+
+    out = await fn(yaml_path="rest", file="packages/svc[12].yaml")
+
+    assert out["files_searched"] == 2
+    assert [m["file"] for m in out["matches"]] == [
+        "packages/svc1.yaml",
+        "packages/svc2.yaml",
+    ]
+    assert out["warnings"] == [
+        "No file is literally named packages/svc[12].yaml; searched the 2 "
+        "file(s) matching it as a pattern."
+    ]
+
+
+async def test_literal_lookup_failure_raises():
+    """Both lookups walk the same directory, so a listing failure on the second
+    is a broken request, not one unreadable file - it raises rather than
+    silently returning only what the pattern pass found."""
+
+    def list_files(payload):
+        if payload["pattern"] == "svc[[]a].yaml":
+            return {"success": False, "error": "Path not allowed.", "files": []}
+        return {
+            "success": True,
+            "files": [{"path": "packages/svca.yaml", "is_dir": False}],
+        }
+
+    fn, _ = await _make_tool({"list_files": list_files, "read_file": _read_ok("x\n")})
+
+    with pytest.raises(ToolError):
+        await fn(yaml_path="rest", file="packages/svc[a].yaml")
+
+
+async def test_unclosed_bracket_resolves_to_one_target():
+    """An unclosed bracket is literal to ``fnmatch``, so it matches its own
+    name and both lookups return it. The merge is what keeps that a single
+    target rather than reading the same file twice."""
+    list_files, patterns = _bracket_dir("svc[a.yaml")
+
+    fn, _ = await _make_tool(
+        {"list_files": list_files, "read_file": _read_ok("- name: probe\n")}
+    )
+
+    out = await fn(yaml_path="rest", file="packages/svc[a.yaml")
+
+    assert out["files_searched"] == 1
+    assert [m["file"] for m in out["matches"]] == ["packages/svc[a.yaml"]
+    assert patterns == ["svc[a.yaml", "svc[[]a.yaml"]
+    assert "warnings" not in out


### PR DESCRIPTION
## What does this PR do?

`ha_config_get_yaml` never reads a config file whose real name carries a bracket class, and says nothing about it.

The tool classifies its `file` argument as a literal path or a glob by scanning for `*`, `?` or `[`, then hands the name part to the component's `list_files`, which filters with `fnmatch`. Of those three metacharacters, only a closed, non-empty bracket class cannot match its own name: `fnmatch` reads `svc[a].yaml` as the character class `a`, so `fnmatch("svc[a].yaml", "svc[a].yaml")` is `False` (`*` and `?` do match themselves, and an unclosed or empty bracket is literal). A file actually called `packages/svc[a].yaml` therefore never appears in its own expansion, and the call returns `success: true` with `count: 0, files_searched: 0` - which an agent reads as "that key is not defined here" for a file that was never opened. Bracketed names are legal on the filesystem HA runs on, and the component already treats package *folder* names carrying metacharacters as literals (#1854), so the same reading was missing for file names.

A bracketed name is genuinely ambiguous - `svc[12].yaml` may well be intended as a class matching `svc1.yaml` and `svc2.yaml` - so this resolves it both ways and merges the results. Both lookups always run for a bracketed name: stopping once the pattern matched something would let an unrelated sibling mask the exact name the caller asked for, and report `files_searched: 1` while doing so. Names without a bracket keep their single lookup.

Two corrections in the same code path, both surfaced while testing the above:

- Only the file name decides whether to expand at all. `pack[a]ges/svc.yaml` names exactly one file (the component resolves directories literally), so it is now read directly and a typo in it answers "file not found" instead of a silent empty result.
- Strictness becomes a property of each target instead of the requested string. Previously any metacharacter anywhere in the argument made the whole request lenient, so a real file whose name carries one had its parse failure reported as a warning next to `count: 0` rather than a raised `CONFIG_INVALID`. Now the target that *is* the requested path - compared normalized, since the component reports the path it walked - raises, while expanded targets keep degrading so one unreadable file cannot sink a search. Every read returns its exception as a value so that decision is made in one place, which also keeps a glob lenient when it happens to expand to exactly one file.

## Type of change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [ ] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

Eight new unit tests in `tests/src/unit/test_yaml_read_tool.py`, each verified by injection to fail when its own half of the change is reverted: the bracketed literal read, the sibling that must not mask it, the strict contract for a lone bracketed literal, the same contract holding when a sibling tags along, the normalized path comparison, the bracketed directory with a plain name, the single lookup for bracket-free globs, and the one-file glob that must still warn rather than abort. The `list_files` mock filters with the real `fnmatch` and accepts the normalized directory, so it answers the way the component does rather than the way the fix expects.

Run locally: `test_yaml_read_tool.py`, `test_yaml_config_tool.py` and `test_custom_component_filesystem.py` pass together (296 tests), plus `ruff check`, `ruff format --check` on both changed files and `mypy` on the changed source file (CI's mypy scope is `src/ custom_components/ homeassistant-addon/ scripts/`). The full suite is left to CI, and the change is not exercised against a live agent. There is no e2e counterpart yet: the behaviour is entirely about what the component's `fnmatch` does, so an e2e that seeds a bracketed file would be the stronger proof.

## Checklist
- [x] I have updated documentation if needed
