### PR TITLE
fix: retry Supervisor add-on calls on job-group collisions

### DIFF
--- a/src/ha_mcp/tools/tools_addons.py
+++ b/src/ha_mcp/tools/tools_addons.py
@@ -210,6 +210,15 @@ def _merge_options(base: dict, override: dict) -> dict:
     return merged
 
 
+# Substring of Supervisor's per-job-group rejection ("Another job is running
+# for job group addon_<slug>"), matched case-insensitively, plus the bounded
+# wall-clock window and backoff used to ride it out. See _supervisor_api_call.
+_JOB_COLLISION_MARKER = "another job is running"
+_JOB_COLLISION_RETRY_WINDOW = 60.0
+_JOB_COLLISION_RETRY_INITIAL_DELAY = 1.0
+_JOB_COLLISION_RETRY_MAX_DELAY = 5.0
+
+
 async def _supervisor_api_call(
     client: HomeAssistantClient,
     endpoint: str,
@@ -252,16 +261,43 @@ async def _supervisor_api_call(
         # ``{"success": False, "error": ...}``; re-raise it as the same
         # ``HomeAssistantCommandError`` the dedicated send_command used to raise
         # so the classifier below maps schema/not-found/etc. identically.
-        result = await client.send_websocket_message(
-            {"type": "supervisor/api", "_wait_timeout": wait_timeout, **kwargs}
-        )
-
-        if not result.get("success"):
-            raise HomeAssistantCommandError(
-                str(result.get("error", f"Supervisor API call failed: {endpoint}"))
+        #
+        # Supervisor serialises jobs per add-on job group, so a state-changing
+        # call is rejected outright with "Another job is running for job group
+        # addon_<slug>" whenever a still-settling job (a watchdog restart, a
+        # prior start/stop, a store reload) still holds that group. The holder
+        # clears within seconds and the caller can do nothing useful with the
+        # failure, so retry inside one bounded wall-clock window rather than
+        # surfacing it. The window is total, not per-attempt, so a persistently
+        # blocked group cannot stretch this into N * timeout. Matched as a
+        # case-insensitive substring on Supervisor's own error text; every
+        # other failure raises on the first attempt, so this never masks a
+        # real error.
+        deadline = time.monotonic() + _JOB_COLLISION_RETRY_WINDOW
+        delay = _JOB_COLLISION_RETRY_INITIAL_DELAY
+        while True:
+            result = await client.send_websocket_message(
+                {"type": "supervisor/api", "_wait_timeout": wait_timeout, **kwargs}
             )
 
-        return {"success": True, "result": result.get("result", {})}
+            if result.get("success"):
+                return {"success": True, "result": result.get("result", {})}
+
+            error_text = str(
+                result.get("error", f"Supervisor API call failed: {endpoint}")
+            )
+            remaining = deadline - time.monotonic()
+            if _JOB_COLLISION_MARKER not in error_text.lower() or remaining <= 0:
+                raise HomeAssistantCommandError(error_text)
+
+            logger.info(
+                "Supervisor job-group collision on %s; retrying in %.1fs (%s)",
+                endpoint,
+                delay,
+                error_text,
+            )
+            await asyncio.sleep(min(delay, remaining))
+            delay = min(delay * 2, _JOB_COLLISION_RETRY_MAX_DELAY)
 
     except ToolError:
         raise

--- a/src/ha_mcp/tools/tools_addons.py
+++ b/src/ha_mcp/tools/tools_addons.py
@@ -210,10 +210,14 @@ def _merge_options(base: dict, override: dict) -> dict:
     return merged
 
 
-# Substring of Supervisor's per-job-group rejection ("Another job is running
-# for job group addon_<slug>"), matched case-insensitively, plus the bounded
-# wall-clock window and backoff used to ride it out. See _supervisor_api_call.
-_JOB_COLLISION_MARKER = "another job is running"
+# Supervisor's per-job-group rejection, matched case-insensitively, plus the
+# bounded window and backoff used to ride it out. See _supervisor_api_call.
+# The "for job group" tail is load-bearing: JobGroup.acquire raises
+# "Another job is running for job group <name>" for the transient per-add-on
+# collision, while the job-level JobConcurrency.REJECT path raises a bare
+# "Another job is running" for long operations (OS update, data-disk wipe)
+# that must NOT be retried on this schedule.
+_JOB_COLLISION_MARKER = "another job is running for job group"
 _JOB_COLLISION_RETRY_WINDOW = 60.0
 _JOB_COLLISION_RETRY_INITIAL_DELAY = 1.0
 _JOB_COLLISION_RETRY_MAX_DELAY = 5.0
@@ -237,8 +241,13 @@ async def _supervisor_api_call(
         data: Optional request body data
         timeout: Optional timeout override
 
+    A transient Supervisor job-group collision is retried with backoff, so a
+    contended add-on endpoint can block for up to
+    ``_JOB_COLLISION_RETRY_WINDOW`` before returning or raising.
+
     Returns:
-        The "result" field from a successful response, or an error dict.
+        ``{"success": True, "result": ...}``. Every failure raises — this
+        never returns an error dict.
     """
     try:
         kwargs: dict[str, Any] = {"endpoint": endpoint, "method": method}
@@ -262,20 +271,21 @@ async def _supervisor_api_call(
         # ``HomeAssistantCommandError`` the dedicated send_command used to raise
         # so the classifier below maps schema/not-found/etc. identically.
         #
-        # Supervisor serialises jobs per add-on job group, so a state-changing
-        # call is rejected outright with "Another job is running for job group
-        # addon_<slug>" whenever a still-settling job (a watchdog restart, a
-        # prior start/stop, a store reload) still holds that group. The holder
-        # clears within seconds and the caller can do nothing useful with the
-        # failure, so retry inside one bounded wall-clock window rather than
-        # surfacing it. The window is total, not per-attempt, so a persistently
-        # blocked group cannot stretch this into N * timeout. Matched as a
-        # case-insensitive substring on Supervisor's own error text; every
-        # other failure raises on the first attempt, so this never masks a
-        # real error.
+        # Supervisor serialises jobs per add-on job group and rejects a
+        # state-changing call outright while a still-settling job (a watchdog
+        # restart, a prior start/stop, a store reload) holds that group. The
+        # rejection happens before the job body runs, so nothing was applied
+        # and retrying cannot double-execute. The holder clears within seconds
+        # and the caller can do nothing useful with the failure, so ride it out
+        # inside one bounded window. The window is total rather than
+        # per-attempt, so a wedged group gives up once the window elapses
+        # instead of after some fixed retry count. Any other failure raises
+        # immediately, without retrying.
         deadline = time.monotonic() + _JOB_COLLISION_RETRY_WINDOW
         delay = _JOB_COLLISION_RETRY_INITIAL_DELAY
+        attempts = 0
         while True:
+            attempts += 1
             result = await client.send_websocket_message(
                 {"type": "supervisor/api", "_wait_timeout": wait_timeout, **kwargs}
             )
@@ -286,9 +296,43 @@ async def _supervisor_api_call(
             error_text = str(
                 result.get("error", f"Supervisor API call failed: {endpoint}")
             )
-            remaining = deadline - time.monotonic()
-            if _JOB_COLLISION_MARKER not in error_text.lower() or remaining <= 0:
+            if _JOB_COLLISION_MARKER not in error_text.lower():
                 raise HomeAssistantCommandError(error_text)
+
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                # A group still held after the whole window is wedged, not
+                # settling. Raise a ToolError here (the guard below re-raises
+                # it untouched) so the caller gets guidance about the stuck
+                # job instead of the generic connectivity suggestion the
+                # exception handler attaches to every other failure.
+                waited = _JOB_COLLISION_RETRY_WINDOW - remaining
+                logger.warning(
+                    "Supervisor job group still busy on %s after %.0fs "
+                    "(%d attempts); giving up: %s",
+                    endpoint,
+                    waited,
+                    attempts,
+                    error_text,
+                )
+                raise_tool_error(
+                    create_error_response(
+                        ErrorCode.SERVICE_CALL_FAILED,
+                        error_text,
+                        context={
+                            "endpoint": endpoint,
+                            "attempts": attempts,
+                            "waited_seconds": round(waited, 1),
+                        },
+                        suggestions=[
+                            "Another job has held this add-on's job group for "
+                            f"over {_JOB_COLLISION_RETRY_WINDOW:.0f}s — check "
+                            "Supervisor logs for a stuck or long-running job",
+                            "Retry once the in-flight add-on operation "
+                            "(install, update, restart or backup) finishes",
+                        ],
+                    )
+                )
 
             logger.info(
                 "Supervisor job-group collision on %s; retrying in %.1fs (%s)",

--- a/tests/src/unit/test_tools_addons.py
+++ b/tests/src/unit/test_tools_addons.py
@@ -3775,7 +3775,7 @@ class TestSupervisorJobGroupCollisionRetry:
     addon_<slug>" whenever a still-settling job holds that group. The holder
     clears within seconds, so the call is retried inside one bounded window
     instead of surfacing a failure the caller can do nothing with. Every other
-    failure must still raise on the first attempt.
+    failure must raise immediately, without retrying.
     """
 
     @staticmethod
@@ -3799,16 +3799,39 @@ class TestSupervisorJobGroupCollisionRetry:
             ]
         )
 
-        with patch("ha_mcp.tools.tools_addons.asyncio.sleep", new=AsyncMock()):
+        sleep = AsyncMock()
+        with patch("ha_mcp.tools.tools_addons.asyncio.sleep", new=sleep):
             result = await _supervisor_api_call(
                 client, "/addons/a0d7b954_appdaemon/stop", method="POST"
             )
 
         assert result == {"success": True, "result": {"state": "stopped"}}
         assert client.send_websocket_message.await_count == 3
+        # Backoff doubles from the initial delay; a flat or runaway schedule
+        # would still pass an outcome-only assertion.
+        assert [c.args[0] for c in sleep.await_args_list] == [1.0, 2.0]
 
     @pytest.mark.asyncio
-    async def test_other_failures_raise_on_first_attempt(self):
+    async def test_backoff_is_capped(self):
+        """Delay doubles but never exceeds the max — an uncapped schedule would
+        overshoot the window on a long-held group."""
+        from ha_mcp.tools.tools_addons import _supervisor_api_call
+
+        client = _make_mock_client()
+        client.send_websocket_message = AsyncMock(
+            side_effect=[self._collision()] * 5 + [{"success": True, "result": {}}]
+        )
+
+        sleep = AsyncMock()
+        with patch("ha_mcp.tools.tools_addons.asyncio.sleep", new=sleep):
+            await _supervisor_api_call(
+                client, "/addons/a0d7b954_appdaemon/stop", method="POST"
+            )
+
+        assert [c.args[0] for c in sleep.await_args_list] == [1.0, 2.0, 4.0, 5.0, 5.0]
+
+    @pytest.mark.asyncio
+    async def test_other_failures_raise_without_retrying(self):
         """A non-collision failure must not be retried — it would mask the error."""
         from ha_mcp.tools.tools_addons import _supervisor_api_call
 
@@ -3828,15 +3851,86 @@ class TestSupervisorJobGroupCollisionRetry:
         assert client.send_websocket_message.await_count == 1
 
     @pytest.mark.asyncio
+    async def test_real_error_after_a_collision_raises_immediately(self):
+        """ "Raises immediately" is per-failure, not just on the literal first
+        attempt: a genuine error arriving mid-retry must not be ridden out."""
+        from ha_mcp.tools.tools_addons import _supervisor_api_call
+
+        client = _make_mock_client()
+        client.send_websocket_message = AsyncMock(
+            side_effect=[
+                self._collision(),
+                {"success": False, "error": "Addon is not installed"},
+                {"success": True, "result": {}},
+            ]
+        )
+
+        with (
+            patch("ha_mcp.tools.tools_addons.asyncio.sleep", new=AsyncMock()),
+            pytest.raises(ToolError) as exc_info,
+        ):
+            await _supervisor_api_call(
+                client, "/addons/a0d7b954_appdaemon/stop", method="POST"
+            )
+
+        assert client.send_websocket_message.await_count == 2
+        assert "not installed" in str(exc_info.value).lower()
+
+    @pytest.mark.asyncio
+    async def test_bare_job_level_rejection_is_not_retried(self):
+        """Supervisor's job-level REJECT ("Another job is running", no group
+        suffix) guards long OS/data-disk operations and must not ride this
+        seconds-scale schedule."""
+        from ha_mcp.tools.tools_addons import _supervisor_api_call
+
+        client = _make_mock_client()
+        client.send_websocket_message = AsyncMock(
+            return_value={"success": False, "error": "Another job is running"}
+        )
+
+        with (
+            patch("ha_mcp.tools.tools_addons.asyncio.sleep", new=AsyncMock()),
+            pytest.raises(ToolError),
+        ):
+            await _supervisor_api_call(client, "/os/update", method="POST")
+
+        assert client.send_websocket_message.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_retry_forwards_timeout_on_every_attempt(self):
+        """The Supervisor-side timeout and the extended local wait must ride
+        every retried attempt, not just the first."""
+        from ha_mcp.tools.tools_addons import _supervisor_api_call
+
+        client = _make_mock_client()
+        client.send_websocket_message = AsyncMock(
+            side_effect=[self._collision(), {"success": True, "result": {}}]
+        )
+
+        with patch("ha_mcp.tools.tools_addons.asyncio.sleep", new=AsyncMock()):
+            await _supervisor_api_call(
+                client,
+                "/addons/a0d7b954_appdaemon/restart",
+                method="POST",
+                timeout=120,
+            )
+
+        for call in client.send_websocket_message.await_args_list:
+            assert call.args[0]["timeout"] == 120
+            assert call.args[0]["_wait_timeout"] == 135.0
+
+    @pytest.mark.asyncio
     async def test_retry_window_is_bounded(self):
-        """A group that never clears gives up rather than retrying forever."""
+        """A group that never clears gives up rather than retrying forever, and
+        surfaces the stuck-job guidance instead of the generic connectivity
+        suggestion the exception handler attaches to every other failure."""
         from ha_mcp.tools.tools_addons import _supervisor_api_call
 
         client = _make_mock_client()
         client.send_websocket_message = AsyncMock(return_value=self._collision())
 
-        # Advance the clock past the window on each poll so the bound is hit
-        # deterministically, without sleeping in the test.
+        # monotonic() is called once for the deadline, then once per failed
+        # attempt; 20s ticks exhaust the 60s window on the third attempt.
         ticks = iter([0.0] + [float(i) * 20.0 for i in range(1, 40)])
         with (
             patch("ha_mcp.tools.tools_addons.asyncio.sleep", new=AsyncMock()),
@@ -3844,13 +3938,19 @@ class TestSupervisorJobGroupCollisionRetry:
                 "ha_mcp.tools.tools_addons.time.monotonic",
                 side_effect=lambda: next(ticks),
             ),
-            pytest.raises(ToolError),
+            pytest.raises(ToolError) as exc_info,
         ):
             await _supervisor_api_call(
                 client, "/addons/a0d7b954_appdaemon/stop", method="POST"
             )
 
-        assert client.send_websocket_message.await_count < 10
+        assert client.send_websocket_message.await_count == 3
+        payload = json.loads(str(exc_info.value))["error"]
+        # Supervisor's own text survives the give-up path...
+        assert "another job is running for job group" in payload["message"].lower()
+        # ...and the guidance names the stuck job, not the connection.
+        assert any("Supervisor logs" in s for s in payload["suggestions"])
+        assert not any("connection" in s.lower() for s in payload["suggestions"])
 
 
 class TestManageAddonActionMode:

--- a/tests/src/unit/test_tools_addons.py
+++ b/tests/src/unit/test_tools_addons.py
@@ -3768,6 +3768,91 @@ class TestSupervisorApiCallTimeout:
         assert "timeout" not in message
 
 
+class TestSupervisorJobGroupCollisionRetry:
+    """Supervisor serialises jobs per add-on job group.
+
+    A state-changing call lands on "Another job is running for job group
+    addon_<slug>" whenever a still-settling job holds that group. The holder
+    clears within seconds, so the call is retried inside one bounded window
+    instead of surfacing a failure the caller can do nothing with. Every other
+    failure must still raise on the first attempt.
+    """
+
+    @staticmethod
+    def _collision(slug: str = "a0d7b954_appdaemon") -> dict:
+        return {
+            "success": False,
+            "error": f"Another job is running for job group addon_{slug}",
+        }
+
+    @pytest.mark.asyncio
+    async def test_job_group_collision_is_retried_until_it_clears(self):
+        """The transient collision is retried and the eventual success returned."""
+        from ha_mcp.tools.tools_addons import _supervisor_api_call
+
+        client = _make_mock_client()
+        client.send_websocket_message = AsyncMock(
+            side_effect=[
+                self._collision(),
+                self._collision(),
+                {"success": True, "result": {"state": "stopped"}},
+            ]
+        )
+
+        with patch("ha_mcp.tools.tools_addons.asyncio.sleep", new=AsyncMock()):
+            result = await _supervisor_api_call(
+                client, "/addons/a0d7b954_appdaemon/stop", method="POST"
+            )
+
+        assert result == {"success": True, "result": {"state": "stopped"}}
+        assert client.send_websocket_message.await_count == 3
+
+    @pytest.mark.asyncio
+    async def test_other_failures_raise_on_first_attempt(self):
+        """A non-collision failure must not be retried — it would mask the error."""
+        from ha_mcp.tools.tools_addons import _supervisor_api_call
+
+        client = _make_mock_client()
+        client.send_websocket_message = AsyncMock(
+            return_value={"success": False, "error": "Addon is not installed"}
+        )
+
+        with (
+            patch("ha_mcp.tools.tools_addons.asyncio.sleep", new=AsyncMock()),
+            pytest.raises(ToolError),
+        ):
+            await _supervisor_api_call(
+                client, "/addons/a0d7b954_appdaemon/stop", method="POST"
+            )
+
+        assert client.send_websocket_message.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_retry_window_is_bounded(self):
+        """A group that never clears gives up rather than retrying forever."""
+        from ha_mcp.tools.tools_addons import _supervisor_api_call
+
+        client = _make_mock_client()
+        client.send_websocket_message = AsyncMock(return_value=self._collision())
+
+        # Advance the clock past the window on each poll so the bound is hit
+        # deterministically, without sleeping in the test.
+        ticks = iter([0.0] + [float(i) * 20.0 for i in range(1, 40)])
+        with (
+            patch("ha_mcp.tools.tools_addons.asyncio.sleep", new=AsyncMock()),
+            patch(
+                "ha_mcp.tools.tools_addons.time.monotonic",
+                side_effect=lambda: next(ticks),
+            ),
+            pytest.raises(ToolError),
+        ):
+            await _supervisor_api_call(
+                client, "/addons/a0d7b954_appdaemon/stop", method="POST"
+            )
+
+        assert client.send_websocket_message.await_count < 10
+
+
 class TestManageAddonActionMode:
     """Lifecycle (action) mode: install/start/stop/etc. via Supervisor."""
 


### PR DESCRIPTION
## What does this PR do?

Supervisor serialises jobs per add-on job group, so a state-changing call is rejected outright with `Another job is running for job group addon_<slug>` whenever a still-settling job (a watchdog restart, a prior start/stop, a store reload) still holds that group.

`ha_manage_addon` surfaced that as `SERVICE_CALL_FAILED` with the suggestion "Check Home Assistant connection and Supervisor availability" — neither accurate nor actionable, since nothing is wrong with the connection and the holding job clears within seconds. An agent has no way to act on it.

`_supervisor_api_call` now retries the call inside one bounded wall-clock window with backoff:

- The window is **total**, not per-attempt, so a wedged group gives up once the window elapses rather than after some fixed retry count.
- Retrying is safe for non-idempotent calls: `JobGroup.acquire` rejects **before** the job body runs, so nothing was applied and a retry cannot double-execute a start/stop/install.
- The marker is anchored on `another job is running for job group`. Supervisor's job-level `JobConcurrency.REJECT` path raises a bare `Another job is running` for long OS/data-disk operations, which must not ride a seconds-scale retry.
- **Every other failure raises immediately, without retrying** — including a genuine error that arrives mid-retry.
- If the group is still held when the window elapses, the call raises with stuck-job guidance ("check Supervisor logs for a stuck or long-running job") and Supervisor's original error text, instead of the generic connectivity suggestion. It also logs at WARNING with the attempt count and elapsed time.

This also removes a real source of e2e flakiness: the add-on lifecycle tests drive stop/start/restart against a live Supervisor, so a sibling add-on job in flight could fail an otherwise-good run with this error.

## Type of change
- [x] 🐛 Bug fix

## Testing
- [x] Code follows style guidelines (`uv run ruff check`)

`TestSupervisorJobGroupCollisionRetry` pins the behaviour: retry-until-clear with the exact backoff schedule, the backoff cap, a non-collision failure raising without retrying, a real error arriving mid-retry, the bare job-level rejection not being retried, `timeout` forwarding across retried attempts, and the bounded give-up preserving Supervisor's text while dropping the connectivity hint. All patch `asyncio.sleep` (and, for the bound, `time.monotonic`) so they add no wall-clock time.

## Checklist
- [x] I have updated documentation if needed
