### PR TITLE
fix: propagate cancellation in deep-search fan-outs and usage logging

### DIFF
--- a/src/ha_mcp/tools/helpers.py
+++ b/src/ha_mcp/tools/helpers.py
@@ -526,9 +526,12 @@ def log_tool_usage(func: Any) -> Any:
             elif hasattr(result, "__len__"):
                 response_size = len(str(result).encode("utf-8"))
             return result
-        except Exception as e:
+        except BaseException as e:
+            # BaseException, not Exception: a cancelled tool call must not be
+            # recorded as a success. str() is empty on a bare CancelledError,
+            # so the class name stands in.
             success = False
-            error_message = str(e)
+            error_message = str(e) or type(e).__name__
             raise
         finally:
             execution_time_ms = (time.time() - start_time) * 1000

--- a/src/ha_mcp/tools/smart_search/_deep.py
+++ b/src/ha_mcp/tools/smart_search/_deep.py
@@ -913,6 +913,9 @@ class DeepSearchMixin(SceneSearchMixin):
             return_exceptions=True,
         )
         for result in type_results:
+            if isinstance(result, BaseException) and not isinstance(result, Exception):
+                # Never swallow cancellation/shutdown into a failed-type count.
+                raise result
             if isinstance(result, tuple):
                 type_matches, type_failed = result
                 results.extend(type_matches)
@@ -1166,6 +1169,11 @@ class DeepSearchMixin(SceneSearchMixin):
             results: list[dict[str, Any]] = []
             failed_count = 1 if list_failed else 0
             for dash_result in dash_results:
+                if isinstance(dash_result, BaseException) and not isinstance(
+                    dash_result, Exception
+                ):
+                    # Never swallow cancellation/shutdown into a failure count.
+                    raise dash_result
                 if isinstance(dash_result, tuple):
                     dash_matches, dash_failed = dash_result
                     results.extend(dash_matches)
@@ -1491,6 +1499,9 @@ class DeepSearchMixin(SceneSearchMixin):
         out: list[dict[str, Any]] = []
         probe_failures = 0
         for item in scored:
+            if isinstance(item, BaseException) and not isinstance(item, Exception):
+                # Never swallow cancellation/shutdown into a probe-failure log.
+                raise item
             if isinstance(item, tuple):
                 result, probe_failed = item
                 if result is not None:

--- a/tests/src/unit/test_deep_search_cancellation.py
+++ b/tests/src/unit/test_deep_search_cancellation.py
@@ -1,0 +1,89 @@
+"""Cancellation must propagate out of deep-search's per-item fan-outs.
+
+The three gathers in ``_deep.py`` run with ``return_exceptions=True``, so a
+``CancelledError`` raised inside a child comes back as a *value*. The result
+loops used to branch ``isinstance(result, tuple)`` / ``elif isinstance(result,
+Exception)`` with nothing below — a ``BaseException`` matched neither arm and
+was silently discarded, so a cancelled search reported itself as one that ran
+and found nothing. Each loop now re-raises non-``Exception`` results, the same
+line the per-item fan-outs in ``tools_entities`` and ``tools_search`` draw.
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from ha_mcp.tools.smart_search import SmartSearchTools
+
+
+def _make_tools() -> SmartSearchTools:
+    client = MagicMock()
+    with patch("ha_mcp.tools.smart_search.get_global_settings") as mock_settings:
+        mock_settings.return_value.fuzzy_threshold = 60
+        return SmartSearchTools(client=client)
+
+
+async def test_helper_type_cancellation_propagates():
+    """A cancelled input_* list fetch must not become a silent no-result.
+
+    Six helper types are gathered; the second one's task is cancelled. Before
+    the guard, the ``CancelledError`` matched neither loop arm and the search
+    returned normally with the cancelled type simply missing.
+    """
+    tools = _make_tools()
+    tools._search_helper_type = AsyncMock(
+        side_effect=[
+            ([], False),
+            asyncio.CancelledError(),
+            ([], False),
+            ([], False),
+            ([], False),
+            ([], False),
+        ]
+    )
+
+    with pytest.raises(asyncio.CancelledError):
+        await tools._deep_search_helpers("query", False, asyncio.Semaphore(5), False)
+
+
+async def test_dashboard_cancellation_propagates():
+    """A cancelled per-dashboard fetch must not be dropped from the count.
+
+    The enclosing ``except Exception`` re-raise does not catch it either —
+    ``CancelledError`` is a ``BaseException`` — so it reaches the caller.
+    """
+    tools = _make_tools()
+    tools._search_one_dashboard = AsyncMock(
+        side_effect=[([], False), asyncio.CancelledError()]
+    )
+
+    with (
+        patch(
+            "ha_mcp.tools.smart_search._deep.fetch_dashboards_list",
+            AsyncMock(return_value=[{"url_path": "dash-a", "title": "A"}]),
+        ),
+        pytest.raises(asyncio.CancelledError),
+    ):
+        await tools._deep_search_dashboards("query", False, asyncio.Semaphore(5))
+
+
+async def test_flow_helper_cancellation_propagates():
+    """A cancelled options-flow probe must not be logged away as a code bug.
+
+    The old loop's ``elif isinstance(item, Exception)`` arm was written for
+    scoring bugs; a ``CancelledError`` matched nothing and vanished.
+    """
+    tools = _make_tools()
+    tools.client._request = AsyncMock(
+        return_value=[{"entry_id": "1"}, {"entry_id": "2"}]
+    )
+    tools._is_flow_helper_entry = lambda _entry: True
+    tools._score_flow_entry = AsyncMock(
+        side_effect=[(None, False), asyncio.CancelledError()]
+    )
+
+    with pytest.raises(asyncio.CancelledError):
+        await tools._search_flow_helpers(
+            "query", False, asyncio.Semaphore(5), include_config=False
+        )

--- a/tests/src/unit/test_usage_logger.py
+++ b/tests/src/unit/test_usage_logger.py
@@ -1,5 +1,6 @@
 """Unit tests for the usage logger with ring buffer."""
 
+import asyncio
 import tempfile
 import threading
 import time
@@ -249,6 +250,40 @@ class TestUsageLoggerGlobalFunctions:
         )
         assert our_entry is not None
         assert our_entry["success"] is True
+
+
+class TestLogToolUsageDecorator:
+    """Tests for the @log_tool_usage decorator in ha_mcp.tools.helpers."""
+
+    @pytest.fixture(autouse=True)
+    def reset_global_logger(self):
+        shutdown_usage_logger()
+        yield
+        shutdown_usage_logger()
+
+    async def test_cancelled_call_is_not_logged_as_success(self):
+        """A cancelled tool call never completed, so recording it as a success
+        would make the usage log claim a result that was never produced.
+
+        ``CancelledError`` skips ``except Exception``, so the decorator's
+        handler must catch ``BaseException`` for the ``finally`` log to carry
+        ``success: False``; ``str()`` is empty on a bare ``CancelledError``, so
+        the class name stands in as the error message.
+        """
+        from ha_mcp.tools.helpers import log_tool_usage
+
+        @log_tool_usage
+        async def ha_cancelled_tool():
+            raise asyncio.CancelledError()
+
+        with pytest.raises(asyncio.CancelledError):
+            await ha_cancelled_tool()
+
+        entry = next(
+            e for e in get_recent_logs(5) if e["tool_name"] == "ha_cancelled_tool"
+        )
+        assert entry["success"] is False
+        assert entry["error_message"] == "CancelledError"
 
 
 class TestParameterRedaction:


### PR DESCRIPTION
## What does this PR do?

Two cancellation swallows, both surfaced during #2036's review, which made this tool's `CancelledError` propagation deliberate:

- `smart_search/_deep.py`'s three per-item gather loops branch `isinstance(result, tuple)` / `elif isinstance(result, Exception)` with nothing below, so a `CancelledError` handed back as a value by `return_exceptions=True` matched neither arm and was silently discarded — a cancelled search reported itself as one that ran and found nothing. Each loop now re-raises non-`Exception` results, the line `tools_entities` and `tools_search` already draw.
- `log_tool_usage` caught `Exception` only, so a cancelled tool call skipped the handler and the `finally` recorded it as `success: true` in the usage log. The handler now catches `BaseException`; the class name stands in for the empty `str()` of a bare `CancelledError`.

## Type of change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [ ] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

Four regression tests, each verified red against the unfixed source: one per fan-out loop (helper types, dashboards, flow helpers) and one for the decorator. Run locally: the two touched unit files (28 tests) plus `ruff format --check`/`check` on all four files and `mypy` on the two source files; the full suite is left to CI.

## Checklist
- [x] I have updated documentation if needed
