### PR TITLE
fix: reject cross-panel links that point at a tab which does not exist

### DIFF
--- a/src/ha_mcp/settings_ui/_i18n.py
+++ b/src/ha_mcp/settings_ui/_i18n.py
@@ -113,6 +113,7 @@ def load_catalogs(directory: Path = LOCALES_DIR) -> dict[str, dict[str, Any]]:
         )
     _validate_placeholder_parity(catalogs)
     _validate_inline_markup(catalogs)
+    _validate_panel_links(catalogs)
     return catalogs
 
 
@@ -164,6 +165,52 @@ _TAG_LIKE_RE = re.compile(r"</?[a-zA-Z][^>]*>")
 _ALLOWED_TAGS_RE = re.compile(
     r'</?code>|</?strong>|</a>|<a href="#" data-panel-link="[a-z][a-z-]*">'
 )
+# The tab a cross-panel link switches to. The allowlist above only accepts the
+# tag *shape*, so "outils" or "backup" passes it and then silently does
+# nothing: settings.js hands the value to activateTab, which no-ops on an
+# unknown panel. Read the real ids out of the page rather than restating them.
+_PANEL_LINK_RE = re.compile(r'data-panel-link="([a-z][a-z-]*)"')
+_PANEL_ID_RE = re.compile(r'data-panel="([a-z][a-z-]*)"')
+_SETTINGS_HTML = Path(__file__).parent / "settings.html"
+
+
+def _known_panels() -> set[str]:
+    """Panel ids declared by the settings page itself."""
+    try:
+        markup = _SETTINGS_HTML.read_text(encoding="utf-8")
+    except OSError as exc:  # pragma: no cover - packaging guard
+        raise ImportError(f"Unable to read {_SETTINGS_HTML}") from exc
+    return set(_PANEL_ID_RE.findall(markup))
+
+
+def _validate_panel_links(catalogs: dict[str, dict[str, Any]]) -> None:
+    """Reject cross-panel links that point at a tab which does not exist.
+
+    A mistyped target is invisible to every other check: the tag shape is
+    allowlisted, the string carries no placeholders, and the visible link text
+    still reads correctly. The link just stops working, in that one language.
+    """
+    panels = _known_panels()
+    english_messages = catalogs[DEFAULT_LOCALE]["messages"]
+    for locale, catalog in catalogs.items():
+        for key, value in catalog["messages"].items():
+            targets = _PANEL_LINK_RE.findall(value)
+            unknown = sorted(set(targets) - panels)
+            if unknown:
+                raise ValueError(
+                    f"Locale {locale} message {key!r} links to panel(s) "
+                    f"{unknown}, which settings.html does not declare; "
+                    f"known panels: {sorted(panels)}"
+                )
+            source = english_messages.get(key)
+            if source is None or locale == DEFAULT_LOCALE:
+                continue
+            source_targets = _PANEL_LINK_RE.findall(source)
+            if targets != source_targets:
+                raise ValueError(
+                    f"Locale {locale} message {key!r} links to {targets}, "
+                    f"but English links to {source_targets}"
+                )
 
 
 def _validate_inline_markup(catalogs: dict[str, dict[str, Any]]) -> None:

--- a/src/ha_mcp/settings_ui/_i18n.py
+++ b/src/ha_mcp/settings_ui/_i18n.py
@@ -217,6 +217,11 @@ def _validate_panel_links(
     A mistyped target is invisible to every other check: the tag shape is
     allowlisted, the string carries no placeholders, and the visible link text
     still reads correctly. The link just stops working, in that one language.
+
+    Scoped to ``messages`` for the same reason ``_validate_inline_markup`` is:
+    only those render through ``tHtml``, which restores the anchor. Tool names
+    and group labels go through ``escapeHtml``, so a link written there shows
+    as visible garbled markup rather than a dead link — wrong, but not silent.
     """
     panels = _known_panels(settings_html)
     english_messages = catalogs[DEFAULT_LOCALE]["messages"]

--- a/src/ha_mcp/settings_ui/_i18n.py
+++ b/src/ha_mcp/settings_ui/_i18n.py
@@ -16,6 +16,8 @@ from typing import Any
 DEFAULT_LOCALE = "en"
 LOCALE_COOKIE = "ha_mcp_locale"
 LOCALES_DIR = Path(__file__).parent / "locales"
+# The page whose tab buttons define the valid cross-panel link targets.
+_SETTINGS_HTML = Path(__file__).parent / "settings.html"
 
 _PLACEHOLDER_RE = re.compile(r"\{([a-zA-Z_][a-zA-Z0-9_]*)\}")
 
@@ -61,8 +63,14 @@ def _validate_tools(value: Any, *, context: str) -> dict[str, dict[str, str]]:
     return result
 
 
-def load_catalogs(directory: Path = LOCALES_DIR) -> dict[str, dict[str, Any]]:
-    """Load and validate every JSON translation catalog in ``directory``."""
+def load_catalogs(
+    directory: Path = LOCALES_DIR, settings_html: Path = _SETTINGS_HTML
+) -> dict[str, dict[str, Any]]:
+    """Load and validate every JSON translation catalog in ``directory``.
+
+    ``settings_html`` is the page whose tab buttons define the valid
+    cross-panel link targets; overridable so tests need not depend on the
+    shipped page's panel ids."""
     catalogs: dict[str, dict[str, Any]] = {}
     try:
         paths = sorted(directory.glob("*.json"))
@@ -114,7 +122,7 @@ def load_catalogs(directory: Path = LOCALES_DIR) -> dict[str, dict[str, Any]]:
         )
     _validate_placeholder_parity(catalogs)
     _validate_inline_markup(catalogs)
-    _validate_panel_links(catalogs)
+    _validate_panel_links(catalogs, settings_html)
     return catalogs
 
 
@@ -175,26 +183,42 @@ _ALLOWED_TAGS_RE = re.compile(
 # is documentation, not navigation.
 _PANEL_LINK_RE = re.compile(r'<a href="#" data-panel-link="([a-z][a-z-]*)">')
 _PANEL_ID_RE = re.compile(r'data-panel="([a-z][a-z-]*)"')
-_SETTINGS_HTML = Path(__file__).parent / "settings.html"
+# Only a real tab button declares a panel. Scanning the whole page for the
+# attribute would let a future code sample or doc comment mentioning
+# `data-panel="example"` register a tab that does not exist — the same gap
+# between "textually present" and "functionally real" this module closes on
+# the link side.
+_TAB_BUTTON_RE = re.compile(r"<button\b[^>]*>")
 
 
-def _known_panels() -> set[str]:
-    """Panel ids declared by the settings page itself."""
+def _known_panels(settings_html: Path = _SETTINGS_HTML) -> set[str]:
+    """Panel ids declared by the settings page's own tab buttons."""
     try:
-        markup = _SETTINGS_HTML.read_text(encoding="utf-8")
+        markup = settings_html.read_text(encoding="utf-8")
     except OSError as exc:  # pragma: no cover - packaging guard
-        raise ImportError(f"Unable to read {_SETTINGS_HTML}") from exc
-    return set(_PANEL_ID_RE.findall(markup))
+        raise ImportError(
+            f"settings.html missing at {settings_html}. It must ship in "
+            "package-data (wheel), MANIFEST.in (sdist), and the PyInstaller "
+            "datas (binary) -- this is a packaging bug, not a usage error."
+        ) from exc
+    return {
+        panel
+        for tag in _TAB_BUTTON_RE.findall(markup)
+        if 'role="tab"' in tag
+        for panel in _PANEL_ID_RE.findall(tag)
+    }
 
 
-def _validate_panel_links(catalogs: dict[str, dict[str, Any]]) -> None:
+def _validate_panel_links(
+    catalogs: dict[str, dict[str, Any]], settings_html: Path = _SETTINGS_HTML
+) -> None:
     """Reject cross-panel links that point at a tab which does not exist.
 
     A mistyped target is invisible to every other check: the tag shape is
     allowlisted, the string carries no placeholders, and the visible link text
     still reads correctly. The link just stops working, in that one language.
     """
-    panels = _known_panels()
+    panels = _known_panels(settings_html)
     english_messages = catalogs[DEFAULT_LOCALE]["messages"]
     for locale, catalog in catalogs.items():
         for key, value in catalog["messages"].items():

--- a/src/ha_mcp/settings_ui/_i18n.py
+++ b/src/ha_mcp/settings_ui/_i18n.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import json
 import re
+from collections import Counter
 from pathlib import Path
 from typing import Any
 
@@ -206,10 +207,14 @@ def _validate_panel_links(catalogs: dict[str, dict[str, Any]]) -> None:
             if source is None or locale == DEFAULT_LOCALE:
                 continue
             source_targets = _PANEL_LINK_RE.findall(source)
-            if targets != source_targets:
+            # Order-independent: a translation may reorder two links to suit
+            # its grammar and still point at the same tabs. Counter keeps the
+            # multiplicity check, so dropping one of a repeated pair fails.
+            if Counter(targets) != Counter(source_targets):
                 raise ValueError(
-                    f"Locale {locale} message {key!r} links to {targets}, "
-                    f"but English links to {source_targets}"
+                    f"Locale {locale} message {key!r} links to "
+                    f"{sorted(targets)}, but English links to "
+                    f"{sorted(source_targets)}"
                 )
 
 

--- a/src/ha_mcp/settings_ui/_i18n.py
+++ b/src/ha_mcp/settings_ui/_i18n.py
@@ -170,7 +170,10 @@ _ALLOWED_TAGS_RE = re.compile(
 # tag *shape*, so "outils" or "backup" passes it and then silently does
 # nothing: settings.js hands the value to activateTab, which no-ops on an
 # unknown panel. Read the real ids out of the page rather than restating them.
-_PANEL_LINK_RE = re.compile(r'data-panel-link="([a-z][a-z-]*)"')
+# Matches the whole anchor, not a bare attribute: a message may legitimately
+# show `<code>data-panel-link="example"</code>` as literal help text, and that
+# is documentation, not navigation.
+_PANEL_LINK_RE = re.compile(r'<a href="#" data-panel-link="([a-z][a-z-]*)">')
 _PANEL_ID_RE = re.compile(r'data-panel="([a-z][a-z-]*)"')
 _SETTINGS_HTML = Path(__file__).parent / "settings.html"
 

--- a/tests/src/unit/test_settings_ui_i18n.py
+++ b/tests/src/unit/test_settings_ui_i18n.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import re
 from pathlib import Path
 
 import pytest
@@ -268,3 +269,60 @@ def test_allowlisted_inline_markup_loads(tmp_path: Path) -> None:
     )
     catalogs = load_catalogs(tmp_path)
     assert "note" in catalogs["en"]["messages"]
+
+
+def test_panel_link_to_unknown_tab_is_rejected(tmp_path: Path) -> None:
+    """A mistyped target passes the markup allowlist and then does nothing.
+
+    ``settings.js`` hands the value straight to ``activateTab``, which no-ops
+    on an id no panel declares — so the link silently stops working in that
+    one language while the visible text still reads correctly.
+    """
+    _write_catalog(
+        tmp_path,
+        "en",
+        native_name="English",
+        messages={"note": '<a href="#" data-panel-link="tools">Tools</a>'},
+    )
+    _write_catalog(
+        tmp_path,
+        "fr",
+        native_name="Français",
+        messages={"note": '<a href="#" data-panel-link="outils">Outils</a>'},
+    )
+
+    with pytest.raises(ValueError, match=re.escape("settings.html does not declare")):
+        load_catalogs(tmp_path)
+
+
+def test_panel_link_must_target_the_same_tab_as_english(tmp_path: Path) -> None:
+    """Both ids are real, so only a cross-locale comparison catches this."""
+    _write_catalog(
+        tmp_path,
+        "en",
+        native_name="English",
+        messages={"note": '<a href="#" data-panel-link="tools">Tools</a>'},
+    )
+    _write_catalog(
+        tmp_path,
+        "de",
+        native_name="Deutsch",
+        messages={"note": '<a href="#" data-panel-link="backups">Backups</a>'},
+    )
+
+    with pytest.raises(ValueError, match="but English links to"):
+        load_catalogs(tmp_path)
+
+
+def test_shipped_catalogs_only_link_to_declared_panels() -> None:
+    """The real catalogs, not a fixture: this is what ships."""
+    from ha_mcp.settings_ui._i18n import CATALOGS, _known_panels
+
+    panels = _known_panels()
+    assert panels, "settings.html declares no data-panel ids"
+    for locale, catalog in CATALOGS.items():
+        for key, value in catalog["messages"].items():
+            for target in re.findall(r'data-panel-link="([a-z][a-z-]*)"', value):
+                assert target in panels, (
+                    f"{locale} message {key!r} links to unknown panel {target!r}"
+                )

--- a/tests/src/unit/test_settings_ui_i18n.py
+++ b/tests/src/unit/test_settings_ui_i18n.py
@@ -271,61 +271,67 @@ def test_allowlisted_inline_markup_loads(tmp_path: Path) -> None:
     assert "note" in catalogs["en"]["messages"]
 
 
+def _write_settings_html(directory: Path, *panels: str) -> Path:
+    """A stand-in settings page declaring exactly ``panels`` as tabs.
+
+    The panel-link tests own their tab ids this way rather than borrowing the
+    shipped page's, so renaming a real tab cannot make them fail for a reason
+    that has nothing to do with what they assert.
+    """
+    path = directory / "settings.html"
+    path.write_text(
+        "\n".join(
+            f'<button class="tab" data-panel="{panel}" role="tab">{panel}</button>'
+            for panel in panels
+        ),
+        encoding="utf-8",
+    )
+    return path
+
+
 def test_panel_link_to_unknown_tab_is_rejected(tmp_path: Path) -> None:
     """A mistyped target passes the markup allowlist and then does nothing.
 
     ``settings.js`` hands the value straight to ``activateTab``, which no-ops
     on an id no panel declares — so the link silently stops working in that
-    one language while the visible text still reads correctly.
+    one language while the visible link text still reads correctly.
     """
+    settings_html = _write_settings_html(tmp_path, "alpha", "beta")
     _write_catalog(
         tmp_path,
         "en",
         native_name="English",
-        messages={"note": '<a href="#" data-panel-link="tools">Tools</a>'},
+        messages={"note": '<a href="#" data-panel-link="alpha">Alpha</a>'},
     )
     _write_catalog(
         tmp_path,
         "fr",
         native_name="Français",
-        messages={"note": '<a href="#" data-panel-link="outils">Outils</a>'},
+        messages={"note": '<a href="#" data-panel-link="alfa">Alfa</a>'},
     )
 
     with pytest.raises(ValueError, match=re.escape("settings.html does not declare")):
-        load_catalogs(tmp_path)
+        load_catalogs(tmp_path, settings_html)
 
 
 def test_panel_link_must_target_the_same_tab_as_english(tmp_path: Path) -> None:
     """Both ids are real, so only a cross-locale comparison catches this."""
+    settings_html = _write_settings_html(tmp_path, "alpha", "beta")
     _write_catalog(
         tmp_path,
         "en",
         native_name="English",
-        messages={"note": '<a href="#" data-panel-link="tools">Tools</a>'},
+        messages={"note": '<a href="#" data-panel-link="alpha">Alpha</a>'},
     )
     _write_catalog(
         tmp_path,
         "de",
         native_name="Deutsch",
-        messages={"note": '<a href="#" data-panel-link="backups">Backups</a>'},
+        messages={"note": '<a href="#" data-panel-link="beta">Beta</a>'},
     )
 
     with pytest.raises(ValueError, match="but English links to"):
-        load_catalogs(tmp_path)
-
-
-def test_shipped_catalogs_only_link_to_declared_panels() -> None:
-    """The real catalogs, not a fixture: this is what ships."""
-    from ha_mcp.settings_ui._i18n import CATALOGS, _known_panels
-
-    panels = _known_panels()
-    assert panels, "settings.html declares no data-panel ids"
-    for locale, catalog in CATALOGS.items():
-        for key, value in catalog["messages"].items():
-            for target in re.findall(r'data-panel-link="([a-z][a-z-]*)"', value):
-                assert target in panels, (
-                    f"{locale} message {key!r} links to unknown panel {target!r}"
-                )
+        load_catalogs(tmp_path, settings_html)
 
 
 def test_panel_links_may_be_reordered_by_a_translation(tmp_path: Path) -> None:
@@ -334,44 +340,58 @@ def test_panel_links_may_be_reordered_by_a_translation(tmp_path: Path) -> None:
     ``load_catalogs`` runs at import, so rejecting a legitimately reordered
     pair would stop the server from starting.
     """
-    english = (
-        'See <a href="#" data-panel-link="tools">Tools</a> then '
-        '<a href="#" data-panel-link="backups">Backups</a>'
+    settings_html = _write_settings_html(tmp_path, "alpha", "beta")
+    _write_catalog(
+        tmp_path,
+        "en",
+        native_name="English",
+        messages={
+            "note": (
+                '<a href="#" data-panel-link="alpha">Alpha</a> then '
+                '<a href="#" data-panel-link="beta">Beta</a>'
+            )
+        },
     )
-    _write_catalog(tmp_path, "en", native_name="English", messages={"note": english})
     _write_catalog(
         tmp_path,
         "fr",
         native_name="Français",
         messages={
             "note": (
-                '<a href="#" data-panel-link="backups">Sauvegardes</a> puis '
-                '<a href="#" data-panel-link="tools">Outils</a>'
+                '<a href="#" data-panel-link="beta">Bêta</a> puis '
+                '<a href="#" data-panel-link="alpha">Alpha</a>'
             )
         },
     )
 
-    catalogs = load_catalogs(tmp_path)
+    catalogs = load_catalogs(tmp_path, settings_html)
 
     assert "note" in catalogs["fr"]["messages"]
 
 
 def test_dropping_one_of_two_panel_links_is_rejected(tmp_path: Path) -> None:
     """Order-independence must not become "any subset will do"."""
-    english = (
-        'See <a href="#" data-panel-link="tools">Tools</a> then '
-        '<a href="#" data-panel-link="backups">Backups</a>'
+    settings_html = _write_settings_html(tmp_path, "alpha", "beta")
+    _write_catalog(
+        tmp_path,
+        "en",
+        native_name="English",
+        messages={
+            "note": (
+                '<a href="#" data-panel-link="alpha">Alpha</a> then '
+                '<a href="#" data-panel-link="beta">Beta</a>'
+            )
+        },
     )
-    _write_catalog(tmp_path, "en", native_name="English", messages={"note": english})
     _write_catalog(
         tmp_path,
         "fr",
         native_name="Français",
-        messages={"note": '<a href="#" data-panel-link="tools">Outils</a>'},
+        messages={"note": '<a href="#" data-panel-link="alpha">Alpha</a>'},
     )
 
     with pytest.raises(ValueError, match="but English links to"):
-        load_catalogs(tmp_path)
+        load_catalogs(tmp_path, settings_html)
 
 
 def test_panel_link_attribute_shown_as_literal_text_is_not_a_link(
@@ -383,6 +403,7 @@ def test_panel_link_attribute_shown_as_literal_text_is_not_a_link(
     ``data-panel-link="example"`` inside ``<code>`` neither has to name a real
     panel nor has to match English's targets.
     """
+    settings_html = _write_settings_html(tmp_path, "alpha")
     _write_catalog(
         tmp_path,
         "en",
@@ -396,6 +417,47 @@ def test_panel_link_attribute_shown_as_literal_text_is_not_a_link(
         messages={"note": 'Schreibe <code>data-panel-link="beispiel"</code>.'},
     )
 
-    catalogs = load_catalogs(tmp_path)
+    catalogs = load_catalogs(tmp_path, settings_html)
 
     assert "note" in catalogs["de"]["messages"]
+
+
+def test_only_tab_buttons_declare_panels(tmp_path: Path) -> None:
+    """A page that merely mentions the attribute declares no tab.
+
+    Scanning the whole page would let a code sample or doc comment register a
+    panel that has no button, so a link to it would pass this check and then
+    dead-end in the UI — the same "textually present, functionally absent" gap
+    the link side closes.
+    """
+    settings_html = tmp_path / "settings.html"
+    settings_html.write_text(
+        '<!-- to add a tab, set data-panel="ghost" on the button -->\n'
+        '<button class="tab" data-panel="alpha" role="tab">Alpha</button>',
+        encoding="utf-8",
+    )
+    _write_catalog(
+        tmp_path,
+        "en",
+        native_name="English",
+        messages={"note": '<a href="#" data-panel-link="ghost">Ghost</a>'},
+    )
+
+    with pytest.raises(ValueError, match=re.escape("settings.html does not declare")):
+        load_catalogs(tmp_path, settings_html)
+
+
+def test_shipped_catalogs_only_link_to_declared_panels() -> None:
+    """The real catalogs against the real page: this is what ships."""
+    from ha_mcp.settings_ui._i18n import CATALOGS, _known_panels
+
+    panels = _known_panels()
+    assert panels, "settings.html declares no tab buttons"
+    for locale, catalog in CATALOGS.items():
+        for key, value in catalog["messages"].items():
+            for target in re.findall(
+                r'<a href="#" data-panel-link="([a-z][a-z-]*)">', value
+            ):
+                assert target in panels, (
+                    f"{locale} message {key!r} links to unknown panel {target!r}"
+                )

--- a/tests/src/unit/test_settings_ui_i18n.py
+++ b/tests/src/unit/test_settings_ui_i18n.py
@@ -372,3 +372,30 @@ def test_dropping_one_of_two_panel_links_is_rejected(tmp_path: Path) -> None:
 
     with pytest.raises(ValueError, match="but English links to"):
         load_catalogs(tmp_path)
+
+
+def test_panel_link_attribute_shown_as_literal_text_is_not_a_link(
+    tmp_path: Path,
+) -> None:
+    """Help text may document the attribute; that is not navigation.
+
+    The extraction matches the whole allowlisted anchor, so a message showing
+    ``data-panel-link="example"`` inside ``<code>`` neither has to name a real
+    panel nor has to match English's targets.
+    """
+    _write_catalog(
+        tmp_path,
+        "en",
+        native_name="English",
+        messages={"note": 'Write <code>data-panel-link="example"</code> to link.'},
+    )
+    _write_catalog(
+        tmp_path,
+        "de",
+        native_name="Deutsch",
+        messages={"note": 'Schreibe <code>data-panel-link="beispiel"</code>.'},
+    )
+
+    catalogs = load_catalogs(tmp_path)
+
+    assert "note" in catalogs["de"]["messages"]

--- a/tests/src/unit/test_settings_ui_i18n.py
+++ b/tests/src/unit/test_settings_ui_i18n.py
@@ -326,3 +326,49 @@ def test_shipped_catalogs_only_link_to_declared_panels() -> None:
                 assert target in panels, (
                     f"{locale} message {key!r} links to unknown panel {target!r}"
                 )
+
+
+def test_panel_links_may_be_reordered_by_a_translation(tmp_path: Path) -> None:
+    """Grammar reorders links; the targets are what must match, not the order.
+
+    ``load_catalogs`` runs at import, so rejecting a legitimately reordered
+    pair would stop the server from starting.
+    """
+    english = (
+        'See <a href="#" data-panel-link="tools">Tools</a> then '
+        '<a href="#" data-panel-link="backups">Backups</a>'
+    )
+    _write_catalog(tmp_path, "en", native_name="English", messages={"note": english})
+    _write_catalog(
+        tmp_path,
+        "fr",
+        native_name="Français",
+        messages={
+            "note": (
+                '<a href="#" data-panel-link="backups">Sauvegardes</a> puis '
+                '<a href="#" data-panel-link="tools">Outils</a>'
+            )
+        },
+    )
+
+    catalogs = load_catalogs(tmp_path)
+
+    assert "note" in catalogs["fr"]["messages"]
+
+
+def test_dropping_one_of_two_panel_links_is_rejected(tmp_path: Path) -> None:
+    """Order-independence must not become "any subset will do"."""
+    english = (
+        'See <a href="#" data-panel-link="tools">Tools</a> then '
+        '<a href="#" data-panel-link="backups">Backups</a>'
+    )
+    _write_catalog(tmp_path, "en", native_name="English", messages={"note": english})
+    _write_catalog(
+        tmp_path,
+        "fr",
+        native_name="Français",
+        messages={"note": '<a href="#" data-panel-link="tools">Outils</a>'},
+    )
+
+    with pytest.raises(ValueError, match="but English links to"):
+        load_catalogs(tmp_path)

--- a/tests/src/unit/test_settings_ui_i18n.py
+++ b/tests/src/unit/test_settings_ui_i18n.py
@@ -447,17 +447,35 @@ def test_only_tab_buttons_declare_panels(tmp_path: Path) -> None:
         load_catalogs(tmp_path, settings_html)
 
 
-def test_shipped_catalogs_only_link_to_declared_panels() -> None:
-    """The real catalogs against the real page: this is what ships."""
-    from ha_mcp.settings_ui._i18n import CATALOGS, _known_panels
+def test_english_message_with_unknown_panel_target_is_rejected(tmp_path: Path) -> None:
+    """The source catalog is checked too, not just the translations.
 
-    panels = _known_panels()
-    assert panels, "settings.html declares no tab buttons"
-    for locale, catalog in CATALOGS.items():
-        for key, value in catalog["messages"].items():
-            for target in re.findall(
-                r'<a href="#" data-panel-link="([a-z][a-z-]*)">', value
-            ):
-                assert target in panels, (
-                    f"{locale} message {key!r} links to unknown panel {target!r}"
-                )
+    The cross-locale comparison skips English by definition, so only the
+    known-panel check covers it. Nothing else would notice a dead link written
+    into ``en.json`` itself.
+    """
+    settings_html = _write_settings_html(tmp_path, "alpha")
+    _write_catalog(
+        tmp_path,
+        "en",
+        native_name="English",
+        messages={"note": '<a href="#" data-panel-link="bogus">Bogus</a>'},
+    )
+
+    with pytest.raises(ValueError, match=re.escape("settings.html does not declare")):
+        load_catalogs(tmp_path, settings_html)
+
+
+def test_panel_link_in_a_locale_only_key_is_still_checked(tmp_path: Path) -> None:
+    """A key English does not have skips the comparison, not the panel check."""
+    settings_html = _write_settings_html(tmp_path, "alpha")
+    _write_catalog(tmp_path, "en", native_name="English", messages={"other": "hi"})
+    _write_catalog(
+        tmp_path,
+        "fr",
+        native_name="Français",
+        messages={"extra": '<a href="#" data-panel-link="bogus">Bogus</a>'},
+    )
+
+    with pytest.raises(ValueError, match=re.escape("settings.html does not declare")):
+        load_catalogs(tmp_path, settings_html)


### PR DESCRIPTION
## What does this PR do?

Translated strings can carry `<a href="#" data-panel-link="tools">`, and the markup allowlist only checks the tag *shape*. A target like `outils` or `backup` passes it and then silently does nothing — `settings.js` hands the value to `activateTab`, which no-ops on an id no panel declares.

Nothing else catches it: the string carries no `{placeholders}`, and the visible link text still reads correctly. The link just stops working, in that one language. Surfaced while reviewing #2038; fr's value is correct, and so are de's, ru's and zh-Hans' — the gap is systemic, not theirs.

`load_catalogs` now rejects:

- a target the settings page does not declare — the ids are read from the page's own `<button role="tab">` elements rather than restated, so renaming a panel can't leave the catalogs pointing at a dead tab
- a target set differing from English's for the same key — both ids are real in that case, so only a cross-locale comparison sees it

This sits with the existing `_validate_placeholder_parity` / `_validate_inline_markup` checks and fails the same way, at load.

Three rounds of review shaped the details, each closing a case where valid content would have failed catalog load — which, since `load_catalogs` runs at import, means a server that will not start:

- link targets are compared as a multiset, so a translation may reorder two cross-links to suit its grammar
- extraction matches the whole allowlisted anchor, so a help string documenting `<code>data-panel-link="example"</code>` is text, not navigation
- panels come only from real tab buttons, so a doc comment mentioning the attribute cannot register a tab that has no button — the same "textually present, functionally absent" gap this PR closes on the link side

`load_catalogs` takes the settings page as a parameter, mirroring its existing `directory` parameter, so the tests declare their own tabs instead of borrowing the shipped page's ids.

## Type of change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

Eight tests cover the validator: an unknown target, a real-but-different target, a reordered pair (allowed), a dropped link (rejected), literal `<code>` attribute text (allowed), a doc comment declaring no tab, a dead link in English's own catalog, and a link under a key English does not have.

## Checklist
- [x] I have updated documentation if needed — the rule is enforced in code, so AGENTS.md § Translations needs no new prose
