### PR TITLE
fix: offload secrets.yaml masking to the executor

### DIFF
--- a/custom_components/ha_mcp_tools/__init__.py
+++ b/custom_components/ha_mcp_tools/__init__.py
@@ -2766,9 +2766,11 @@ async def _shape_read_file_response(
     # Apply special handling for specific files
     normalized = os.path.normpath(rel_path)  # noqa: ASYNC240
 
-    # Mask secrets.yaml
+    # Mask secrets.yaml. Offloaded because the first make_yaml() call on a
+    # thread constructs a ruamel YAML instance, whose plugin discovery globs
+    # the site-packages tree — blocking work that must stay off the loop.
     if normalized == "secrets.yaml":
-        content = _mask_secrets_content(content)
+        content = await hass.async_add_executor_job(_mask_secrets_content, content)
 
     # Apply tail for log files
     if normalized == "home-assistant.log":

--- a/tests/src/unit/test_custom_component_filesystem.py
+++ b/tests/src/unit/test_custom_component_filesystem.py
@@ -984,8 +984,9 @@ class TestReadFileSecretsMaskingOrder:
         return inspect.getsource(_shape_read_file_response)
 
     def test_full_content_is_captured_after_masking(self):
+        """Handed to the executor as bare args, so the anchor carries no "("."""
         src = self._handler_source()
-        mask = src.index("_mask_secrets_content(content)")
+        mask = src.index("_mask_secrets_content, content")
         capture = src.index("full_content = content")
         assert mask < capture, (
             "full_content must be captured AFTER _mask_secrets_content, or "
@@ -999,6 +1000,47 @@ class TestReadFileSecretsMaskingOrder:
         """
         src = self._handler_source()
         assert "_extract_yaml_views, full_content, yaml_path" in src
+
+
+class TestReadFileSecretsMaskingOffload:
+    """Masking secrets.yaml must not run on the event loop.
+
+    ``_mask_secrets_content`` calls ``make_yaml()``, and the first such call on
+    a given thread constructs a ruamel ``YAML`` instance whose plugin discovery
+    globs the site-packages tree. Home Assistant flags that as a blocking call
+    when it happens on the loop, so the masking belongs in the executor like
+    every other ``make_yaml()`` caller in this module.
+    """
+
+    async def test_masking_is_offloaded_to_the_executor(self):
+        from custom_components.ha_mcp_tools import (
+            _mask_secrets_content,
+            _shape_read_file_response,
+        )
+
+        offloaded: list = []
+
+        async def fake_executor(func, *args):
+            offloaded.append(func)
+            return func(*args)
+
+        hass = MagicMock()
+        hass.async_add_executor_job = AsyncMock(side_effect=fake_executor)
+
+        response = await _shape_read_file_response(
+            hass,
+            "secrets.yaml",
+            {"content": "api_key: hunter2\n", "mtime": 0, "size": 17},
+            tail_lines=None,
+            yaml_path=None,
+            include_parsed=False,
+        )
+
+        assert _mask_secrets_content in offloaded, (
+            "secrets.yaml masking must go through hass.async_add_executor_job, "
+            "or ruamel's plugin discovery blocks the event loop"
+        )
+        assert response["content"] == 'api_key: "[MASKED]"'
 
 
 class TestEditYamlConfigBackCompat:


### PR DESCRIPTION
## What does this PR do?

Fixes #2067 — reading `secrets.yaml` ran the masking step on the event loop, and Home
Assistant reported three blocking calls (`glob`, `iglob`, `scandir`) against this integration.

`_mask_secrets_content` calls `make_yaml()`. The first such call on a given thread constructs
a ruamel `YAML` instance, and ruamel discovers its plug-ins per instance by globbing the
site-packages tree. `_shape_read_file_response` invoked it inline, so the globbing happened on
the loop.

The per-thread cache introduced in #1371 (refactored in #1396) hides this after the first
call, which is why it surfaces once per thread rather than on every read. The import-time warm-up in
`_register_ha_tags` does not cover it either: it builds a throwaway instance to register the HA
tags on the class-level registries and never stores it, so the loop thread still constructs its
own. This was the only one of the seven `make_yaml()` call sites still reached on the loop —
the other six already go through the executor.

The fix hands the masking to the executor, matching every other `make_yaml()` caller the
event loop reaches. The file read itself was already offloaded.

Two test changes come with it. The existing source guard
(`TestReadFileSecretsMaskingOrder::test_full_content_is_captured_after_masking`) anchored on the
literal `_mask_secrets_content(content)`, which the executor hand-off removes; it now anchors on
the bare-args form, matching the sibling guard one test below it that already documents this
shape. The new `TestReadFileSecretsMaskingOffload` pins the offload itself.

I verified both guards bite by reverting the hand-off: the source guard fails with
`ValueError: substring not found` and the new test fails its assertion. Restoring produced a
byte-identical file.

## Type of change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [ ] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

Being precise about the two I left unchecked rather than ticking them loosely:

- `tests/src/unit/test_custom_component_filesystem.py` passes in full (230 passed), and `ruff
  check`, `ruff format --check` and `mypy` are clean on both changed files. I have not run the
  whole suite locally — CI covers that.
- The change is not exercised through an agent against a live instance. The reproduction is the
  Home Assistant warning itself, which is what #2067 documents.

## Checklist
- [x] I have updated documentation if needed

