### PR TITLE
feat: embed inline dashboard resources as data: URIs instead of the Cloudflare worker

### DIFF
--- a/src/ha_mcp/tools/tools_resources.py
+++ b/src/ha_mcp/tools/tools_resources.py
@@ -38,20 +38,39 @@ from .util_helpers import build_pagination_metadata
 
 logger = logging.getLogger(__name__)
 
-# Retired Cloudflare Worker URL. Only used to recognize and locally decode
-# inline resources created before the data: URI switch (#2060) — never fetched.
+# Legacy Cloudflare Worker URL. Only used to recognize and locally decode
+# inline resources created before the data: URI switch (#2060) — this server
+# never fetches it. The worker deployment stays up so pre-existing dashboards
+# keep loading until their resources are converted.
 LEGACY_WORKER_BASE_URL = "https://ha-mcp-resources.rapid-math-bbad.workers.dev"
 
 # data: URI media types per resource_type ('js' is rejected for inline mode).
-_DATA_URI_MIME = {"module": "text/javascript", "css": "text/css"}
+# CSS carries an explicit charset because stylesheets, unlike module scripts,
+# have no spec-mandated UTF-8 fallback.
+_DATA_URI_MIME = {"module": "text/javascript", "css": "text/css;charset=utf-8"}
 
-_DATA_URI_PREFIX = "data:"
+# URL prefixes recognized as ha-mcp inline resources. Scoped to the media
+# types this tool writes (with and without the charset param) so foreign
+# data: resources a user registered by other means are passed through
+# untouched instead of being claimed and masked as "[inline]".
+_ALLOWED_DATA_URI_PREFIXES = tuple(
+    f"data:{mime}{charset};base64,"
+    for mime in ("text/javascript", "text/css")
+    for charset in ("", ";charset=utf-8")
+)
+# Scheme and media type are case-insensitive (RFC 3986/2397); prefixes are
+# lowercase, so matching lowercases the URL head. Longest prefix is 42 chars.
+_DATA_URI_HEAD = max(len(p) for p in _ALLOWED_DATA_URI_PREFIXES)
 
-# Maximum inline content size. Browsers load data: modules far larger than
-# this (verified to 2MB), so the bound is prudence about the resource
-# registry (.storage/lovelace_resources) and WS message sizes, not a URL
-# limit like the old worker's 24KB cap.
-MAX_CONTENT_SIZE = 1_000_000
+# Characters of decoded content shown in list previews.
+_PREVIEW_LENGTH = 150
+
+# Maximum inline content size — unchanged from the worker era. Browsers load
+# data: URIs far larger (verified to 2MB), but the registered URL is shipped
+# to every browser on every dashboard load and snapshotted whole by
+# auto-backup on every edit, so the bound is response/footprint prudence,
+# no longer a URL-length limit.
+MAX_CONTENT_SIZE = 24000
 
 # Top-level HA-config YAML keys that LLMs sometimes emit when they pick this
 # tool (`ha_config_set_dashboard_resource`) to "create a scene/automation/...".
@@ -133,20 +152,45 @@ def _data_uri_for(content: str, resource_type: str) -> str:
     Standard base64 (not URL-safe): browsers decode data: URIs with the
     standard alphabet. Deterministic — same content, same URI.
     """
-    mime = _DATA_URI_MIME[resource_type]
+    mime = _DATA_URI_MIME.get(resource_type)
+    if mime is None:
+        raise_tool_error(
+            create_error_response(
+                code=ErrorCode.VALIDATION_INVALID_PARAMETER,
+                message=f"Inline content does not support resource_type={resource_type!r}",
+                suggestions=["Use resource_type='module' or 'css' for inline content"],
+            )
+        )
     encoded = base64.b64encode(content.encode("utf-8")).decode("ascii")
     return f"data:{mime};base64,{encoded}"
 
 
+def _match_data_uri_prefix(url: str) -> str | None:
+    """Return the matched ha-mcp inline data: prefix of ``url``, else None.
+
+    Prefix matching is case-insensitive (scheme and media type are
+    case-insensitive per RFC 3986/2397); the payload's case is preserved.
+    """
+    head = url[:_DATA_URI_HEAD].lower()
+    for prefix in _ALLOWED_DATA_URI_PREFIXES:
+        if head.startswith(prefix):
+            return prefix
+    return None
+
+
 def _decode_data_uri(url: str) -> str | None:
-    """Decode a base64 ``data:`` URI back to content. None if not one of ours."""
-    if not url.startswith(_DATA_URI_PREFIX):
-        return None
-    header, sep, payload = url.partition(",")
-    if not sep or not header.endswith(";base64"):
+    """Decode one of our base64 ``data:`` URIs back to content.
+
+    None for foreign data: URLs (other media types, percent-encoded form) —
+    those are passed through untouched, not claimed as inline resources —
+    and for corrupt payloads (``validate=True``: a payload the browser's
+    forgiving-base64 would reject must not be reported as valid content).
+    """
+    prefix = _match_data_uri_prefix(url)
+    if prefix is None:
         return None
     try:
-        return base64.b64decode(payload).decode("utf-8")
+        return base64.b64decode(url[len(prefix) :], validate=True).decode("utf-8")
     except Exception:
         return None
 
@@ -155,13 +199,15 @@ def _decode_legacy_worker_url(url: str) -> str | None:
     """Decode a legacy worker inline URL back to content (pure local base64).
 
     The worker embedded URL-safe base64 in its path; decoding needs no
-    network. Returns None if the URL is not a legacy worker URL.
+    network. Anchored to the worker origin — lookalike hosts that merely
+    contain the worker host string are not decoded. Returns None if the URL
+    is not a legacy worker URL.
     """
-    if LEGACY_WORKER_BASE_URL not in url:
+    if not url.startswith(f"{LEGACY_WORKER_BASE_URL}/"):
         return None
     try:
         # Extract base64 part: https://worker.dev/{base64}?type=module
-        encoded = url.replace(f"{LEGACY_WORKER_BASE_URL}/", "").split("?")[0]
+        encoded = url.removeprefix(f"{LEGACY_WORKER_BASE_URL}/").split("?")[0]
         return base64.urlsafe_b64decode(encoded).decode("utf-8")
     except Exception:
         return None
@@ -169,7 +215,9 @@ def _decode_legacy_worker_url(url: str) -> str | None:
 
 def _is_inline_url(url: str) -> bool:
     """Check if a URL is an inline resource URL (current data: or legacy worker)."""
-    return url.startswith(_DATA_URI_PREFIX) or LEGACY_WORKER_BASE_URL in url
+    return _match_data_uri_prefix(url) is not None or url.startswith(
+        f"{LEGACY_WORKER_BASE_URL}/"
+    )
 
 
 class ResourceTools:
@@ -258,21 +306,24 @@ class ResourceTools:
             else:
                 resources = []
 
-            # Process resources - decode inline URLs for preview
-            processed = _process_resource_list(resources, include_content)
-
-            # Categorize resources by type
-            categorized: dict[str, list[Any]] = {"module": [], "js": [], "css": []}
+            # Summaries cover ALL resources via cheap URL-shape checks; the
+            # decode/preview work runs only on the returned page, so
+            # include_content=True responses stay bounded by limit/offset
+            # instead of materializing every inline resource's content.
+            by_type_counts = {"module": 0, "js": 0, "css": 0}
             inline_count = 0
-            for res in processed:
+            for resource in resources:
+                res = resource if isinstance(resource, dict) else {}
                 res_type = res.get("type", "unknown")
-                if res_type in categorized:
-                    categorized[res_type].append(res)
-                if res.get("_inline"):
+                if res_type in by_type_counts:
+                    by_type_counts[res_type] += 1
+                url = res.get("url", "")
+                if isinstance(url, str) and _is_inline_url(url):
                     inline_count += 1
 
-            total_count = len(processed)
-            paginated = processed[offset : offset + limit]
+            total_count = len(resources)
+            page = resources[offset : offset + limit]
+            paginated = _process_resource_list(page, include_content)
 
             return {
                 "success": True,
@@ -280,11 +331,7 @@ class ResourceTools:
                 "resources": paginated,
                 **build_pagination_metadata(total_count, offset, limit, len(paginated)),
                 "inline_count": inline_count,
-                "by_type": {
-                    "module": len(categorized["module"]),
-                    "js": len(categorized["js"]),
-                    "css": len(categorized["css"]),
-                },
+                "by_type": by_type_counts,
             }
         except ToolError:
             raise
@@ -319,7 +366,7 @@ class ResourceTools:
         content: Annotated[
             str | None,
             Field(
-                description="JavaScript or CSS code to host inline. "
+                description="JavaScript or CSS code to host inline (max ~24KB). "
                 "The code is embedded directly in the resource URL as a data: URI - "
                 "no file storage or external hosting involved. "
                 "Mutually exclusive with url. Supports 'module' and 'css' types only."
@@ -361,9 +408,11 @@ class ResourceTools:
         INLINE MODE (content=):
         - Custom card code written inline
         - CSS styling for dashboards
+        - Small self-contained files only (max ~24KB)
         - URLs are deterministic (same content = same URL)
-        - Content must be self-contained (a data: URI has no base URL, so
-          relative imports inside the module cannot resolve)
+        - Content must be self-contained: a data: URI has no base URL, so
+          relative imports inside a module and relative url() references
+          inside CSS cannot resolve (use fully-qualified URLs instead)
         - Supports 'module' and 'css' types only (not 'js')
 
         URL MODE (url=):
@@ -442,6 +491,23 @@ class ResourceTools:
 
         if content is not None:
             return await self._set_inline_resource(content, resource_type, resource_id)
+
+        # Hand-built data: URLs would bypass every inline-mode guard (empty /
+        # size / type checks and the #1072 YAML-misroute rejection) now that
+        # the inline format is documented in this docstring. Route callers to
+        # content=, where those guards run.
+        if url is not None and url[:5].lower() == "data:":
+            raise_tool_error(
+                create_error_response(
+                    code=ErrorCode.VALIDATION_INVALID_PARAMETER,
+                    message="data: URLs cannot be registered via url= — "
+                    "pass the code itself via content= instead",
+                    suggestions=[
+                        "Use content=<your JS/CSS source> (the tool builds the data: URI)",
+                        "url= is for /local/, /hacsfiles/, and https:// resources",
+                    ],
+                )
+            )
         return await self._set_url_resource(url, resource_type, resource_id)
 
     def _raise_ha_config_yaml_misroute(
@@ -536,6 +602,9 @@ class ResourceTools:
                 )
             )
 
+        if resource_id is not None:
+            await self._reject_truncated_preview_resave(content, resource_id)
+
         resource_url = _data_uri_for(content, resource_type)
 
         try:
@@ -587,6 +656,58 @@ class ResourceTools:
             # explicit raise makes the function's exit unambiguous (no implicit
             # ``return None`` fall-through) and is never reached at runtime.
             raise
+
+    async def _reject_truncated_preview_resave(
+        self, content: str, resource_id: str
+    ) -> None:
+        """Refuse to overwrite an inline resource with its own truncated preview.
+
+        The list tool's default output carries ``_preview`` — the first
+        ``_PREVIEW_LENGTH`` characters plus ``"..."``. An agent that re-saves
+        a resource using that string as ``content`` would silently replace
+        the user's card with a syntactically broken fragment. Only content
+        shaped exactly like a preview triggers the (one WS round-trip) check
+        against the stored resource, so normal updates pay nothing.
+        """
+        if not (len(content) == _PREVIEW_LENGTH + 3 and content.endswith("...")):
+            return
+        try:
+            result = await self._client.send_websocket_message(
+                {"type": "lovelace/resources"}
+            )
+        except Exception:
+            # Best-effort guard: a listing hiccup must not block the update;
+            # a real connectivity problem fails the upsert itself right after.
+            return
+        resources = result.get("result") if isinstance(result, dict) else result
+        if not isinstance(resources, list):
+            return
+        for res in resources:
+            if str(res.get("id")) != str(resource_id):
+                continue
+            url = res.get("url", "")
+            stored = None
+            if isinstance(url, str):
+                stored = _decode_data_uri(url) or _decode_legacy_worker_url(url)
+            if (
+                stored
+                and len(stored) > _PREVIEW_LENGTH
+                and content == stored[:_PREVIEW_LENGTH] + "..."
+            ):
+                raise_tool_error(
+                    create_error_response(
+                        code=ErrorCode.VALIDATION_INVALID_PARAMETER,
+                        message="Content is the truncated 150-char preview from "
+                        "ha_config_list_dashboard_resources, not the full "
+                        "resource code — saving it would destroy the resource",
+                        context={"resource_id": resource_id},
+                        suggestions=[
+                            "Fetch the full code with ha_config_list_dashboard_resources(include_content=True)",
+                            "Then re-save with the complete content",
+                        ],
+                    )
+                )
+            return
 
     async def _set_url_resource(
         self,
@@ -829,25 +950,31 @@ def _process_resource_list(
 
         if isinstance(url, str) and _is_inline_url(url):
             content = _decode_data_uri(url)
-            if content is None:
+            if not content:
                 content = _decode_legacy_worker_url(url)
-                if content is not None:
+                if content:
                     res["_legacy_worker"] = True
                     res["_migration"] = (
-                        "Hosted on the retired Cloudflare worker. Re-save with "
+                        "Hosted on the legacy Cloudflare worker. First fetch "
+                        "the FULL code with ha_config_list_dashboard_resources("
+                        "include_content=True), then re-save it with "
                         "ha_config_set_dashboard_resource(content=..., "
-                        "resource_id=...) to convert it to a self-contained "
-                        "data: URI."
+                        "resource_id=...) to convert this resource to a "
+                        "self-contained data: URI. Never use _preview as "
+                        "content — it is truncated."
                     )
-            if content is not None:
+            # Empty or undecodable payloads fall through with their real URL
+            # visible — masking them as "[inline]" would hide exactly what a
+            # user debugging a broken resource needs to see.
+            if content:
                 res["_inline"] = True
-                res["_size"] = len(content)
+                res["_size"] = len(content.encode("utf-8"))
 
                 if include_content:
                     res["_content"] = content
                 else:
-                    preview = content[:150]
-                    if len(content) > 150:
+                    preview = content[:_PREVIEW_LENGTH]
+                    if len(content) > _PREVIEW_LENGTH:
                         preview += "..."
                     res["_preview"] = preview
 

--- a/src/ha_mcp/tools/tools_resources.py
+++ b/src/ha_mcp/tools/tools_resources.py
@@ -196,6 +196,48 @@ def _decode_data_uri(url: str) -> str | None:
         return None
 
 
+def _normalize_url_for_scheme_check(url: str) -> str:
+    """Normalize ``url`` the way a browser's URL parser does, for scheme checks.
+
+    WHATWG URL parsing strips leading/trailing C0-control-or-space and
+    removes every ASCII tab/newline before reading the scheme, so
+    ``" data:..."`` and ``"da\\tta:..."`` both parse as ``data:``. Checking
+    the raw string would miss those and let them through.
+    """
+    return (
+        url.strip(
+            "\x00\x01\x02\x03\x04\x05\x06\x07\x08\t\n\x0b\x0c\r\x0e\x0f"
+            "\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1a\x1b\x1c\x1d"
+            "\x1e\x1f "
+        )
+        .replace("\t", "")
+        .replace("\n", "")
+        .replace("\r", "")
+    )
+
+
+def _is_data_url(url: str) -> bool:
+    """True when ``url`` parses as the ``data:`` scheme in a browser."""
+    return _normalize_url_for_scheme_check(url)[:5].lower() == "data:"
+
+
+def _decode_inline_content(url: str) -> tuple[str | None, bool]:
+    """Decode an inline resource URL. Returns ``(content, is_legacy_worker)``.
+
+    ``content`` is None when the URL is not one of ours, or is one of ours
+    but holds an empty/corrupt payload — the single source of truth for
+    "is this an inline resource we can show", so the list summary counts
+    and the per-resource markers can never disagree.
+    """
+    content = _decode_data_uri(url)
+    if content:
+        return content, False
+    legacy = _decode_legacy_worker_url(url)
+    if legacy:
+        return legacy, True
+    return None, False
+
+
 def _decode_legacy_worker_url(url: str) -> str | None:
     """Decode a legacy worker inline URL back to content (pure local base64).
 
@@ -212,13 +254,6 @@ def _decode_legacy_worker_url(url: str) -> str | None:
         return base64.urlsafe_b64decode(encoded).decode("utf-8")
     except Exception:
         return None
-
-
-def _is_inline_url(url: str) -> bool:
-    """Check if a URL is an inline resource URL (current data: or legacy worker)."""
-    return _match_data_uri_prefix(url) is not None or url.startswith(
-        f"{LEGACY_WORKER_BASE_URL}/"
-    )
 
 
 class ResourceTools:
@@ -319,7 +354,10 @@ class ResourceTools:
                 if res_type in by_type_counts:
                     by_type_counts[res_type] += 1
                 url = res.get("url", "")
-                if isinstance(url, str) and _is_inline_url(url):
+                # Decode (discarding the content) rather than shape-matching
+                # the URL: the count must agree with the per-resource
+                # markers, which only appear when the payload decodes.
+                if isinstance(url, str) and _decode_inline_content(url)[0]:
                     inline_count += 1
 
             total_count = len(resources)
@@ -497,7 +535,7 @@ class ResourceTools:
         # size / type checks and the #1072 YAML-misroute rejection) now that
         # the inline format is documented in this docstring. Route callers to
         # content=, where those guards run.
-        if url is not None and url[:5].lower() == "data:":
+        if url is not None and _is_data_url(url):
             raise_tool_error(
                 create_error_response(
                     code=ErrorCode.VALIDATION_INVALID_PARAMETER,
@@ -689,7 +727,7 @@ class ResourceTools:
             url = res.get("url", "")
             stored = None
             if isinstance(url, str):
-                stored = _decode_data_uri(url) or _decode_legacy_worker_url(url)
+                stored = _decode_inline_content(url)[0]
             if (
                 stored
                 and len(stored) > _PREVIEW_LENGTH
@@ -949,24 +987,24 @@ def _process_resource_list(
         res = dict(resource)
         url = res.get("url", "")
 
-        if isinstance(url, str) and _is_inline_url(url):
-            content = _decode_data_uri(url)
-            if not content:
-                content = _decode_legacy_worker_url(url)
-                if content:
-                    res["_legacy_worker"] = True
-                    res["_migration"] = (
-                        "Hosted on the legacy Cloudflare worker. First fetch "
-                        "the FULL code with ha_config_list_dashboard_resources("
-                        "include_content=True), then re-save it with "
-                        "ha_config_set_dashboard_resource(content=..., "
-                        "resource_id=...) to convert this resource to a "
-                        "self-contained data: URI. Never use _preview as "
-                        "content — it is truncated."
-                    )
-            # Empty or undecodable payloads fall through with their real URL
-            # visible — masking them as "[inline]" would hide exactly what a
-            # user debugging a broken resource needs to see.
+        if isinstance(url, str):
+            # Empty or undecodable payloads decode to None and fall through
+            # with their real URL visible — masking them as "[inline]" would
+            # hide exactly what a user debugging a broken resource needs to
+            # see. The same call drives ``inline_count``, so the summary and
+            # these markers cannot disagree.
+            content, is_legacy = _decode_inline_content(url)
+            if content and is_legacy:
+                res["_legacy_worker"] = True
+                res["_migration"] = (
+                    "Hosted on the legacy Cloudflare worker. First fetch "
+                    "the FULL code with ha_config_list_dashboard_resources("
+                    "include_content=True), then re-save it with "
+                    "ha_config_set_dashboard_resource(content=..., "
+                    "resource_id=...) to convert this resource to a "
+                    "self-contained data: URI. Never use _preview as "
+                    "content — it is truncated."
+                )
             if content:
                 res["_inline"] = True
                 res["_size"] = len(content.encode("utf-8"))

--- a/src/ha_mcp/tools/tools_resources.py
+++ b/src/ha_mcp/tools/tools_resources.py
@@ -2,10 +2,19 @@
 Dashboard resource hosting tools for Home Assistant MCP server.
 
 Provides tools for managing dashboard resources (custom cards, CSS, JS):
-- Inline resources: Code embedded in URL via Cloudflare Worker
+- Inline resources: Code embedded directly in the resource URL as a
+  ``data:`` URI — stored in HA's own resource registry, served by nothing
 - External resources: URLs to /local/, /hacsfiles/, or external CDNs
 
-See: https://github.com/homeassistant-ai/ha-mcp/issues/266
+Inline resources were previously served by a Cloudflare Worker that decoded
+base64 content embedded in its URL, based on issue #71's claim that browsers
+reject ``data:`` URIs for ES6 modules. That claim was wrong — HA's WS API
+applies no URL-scheme validation, HA ships no CSP, and every layer loads
+``data:`` modules and stylesheets fine (verified live; see #2060). Inline
+content now goes straight into a ``data:`` URI: same storage location
+(the resource registry), no third-party hop on dashboard loads.
+``LEGACY_WORKER_BASE_URL`` survives only to recognize and locally decode
+resources created before the switch — the worker is never contacted.
 """
 
 import base64
@@ -29,15 +38,20 @@ from .util_helpers import build_pagination_metadata
 
 logger = logging.getLogger(__name__)
 
-# Cloudflare Worker URL for resource hosting
-WORKER_BASE_URL = "https://ha-mcp-resources.rapid-math-bbad.workers.dev"
+# Retired Cloudflare Worker URL. Only used to recognize and locally decode
+# inline resources created before the data: URI switch (#2060) — never fetched.
+LEGACY_WORKER_BASE_URL = "https://ha-mcp-resources.rapid-math-bbad.workers.dev"
 
-# Maximum base64-encoded URL path length (tested limit: 32KB)
-MAX_ENCODED_LENGTH = 32000
+# data: URI media types per resource_type ('js' is rejected for inline mode).
+_DATA_URI_MIME = {"module": "text/javascript", "css": "text/css"}
 
-# Maximum content size (~24KB before base64 encoding)
-# Base64 encoding increases size by ~33%, so 24KB * 1.33 ≈ 32KB
-MAX_CONTENT_SIZE = 24000
+_DATA_URI_PREFIX = "data:"
+
+# Maximum inline content size. Browsers load data: modules far larger than
+# this (verified to 2MB), so the bound is prudence about the resource
+# registry (.storage/lovelace_resources) and WS message sizes, not a URL
+# limit like the old worker's 24KB cap.
+MAX_CONTENT_SIZE = 1_000_000
 
 # Top-level HA-config YAML keys that LLMs sometimes emit when they pick this
 # tool (`ha_config_set_dashboard_resource`) to "create a scene/automation/...".
@@ -113,28 +127,49 @@ def _detect_ha_config_yaml(content: str) -> str | None:
     return None
 
 
-def _encode_content(content: str) -> tuple[str, int, int]:
-    """Encode content to URL-safe base64. Returns (encoded, content_size, encoded_size)."""
-    content_bytes = content.encode("utf-8")
-    encoded = base64.urlsafe_b64encode(content_bytes).decode("ascii")
-    return encoded, len(content_bytes), len(encoded)
+def _data_uri_for(content: str, resource_type: str) -> str:
+    """Encode content as a base64 ``data:`` URI for the given resource type.
+
+    Standard base64 (not URL-safe): browsers decode data: URIs with the
+    standard alphabet. Deterministic — same content, same URI.
+    """
+    mime = _DATA_URI_MIME[resource_type]
+    encoded = base64.b64encode(content.encode("utf-8")).decode("ascii")
+    return f"data:{mime};base64,{encoded}"
 
 
-def _decode_inline_url(url: str) -> str | None:
-    """Decode an inline resource URL back to content. Returns None if not an inline URL."""
-    if WORKER_BASE_URL not in url:
+def _decode_data_uri(url: str) -> str | None:
+    """Decode a base64 ``data:`` URI back to content. None if not one of ours."""
+    if not url.startswith(_DATA_URI_PREFIX):
+        return None
+    header, sep, payload = url.partition(",")
+    if not sep or not header.endswith(";base64"):
+        return None
+    try:
+        return base64.b64decode(payload).decode("utf-8")
+    except Exception:
+        return None
+
+
+def _decode_legacy_worker_url(url: str) -> str | None:
+    """Decode a legacy worker inline URL back to content (pure local base64).
+
+    The worker embedded URL-safe base64 in its path; decoding needs no
+    network. Returns None if the URL is not a legacy worker URL.
+    """
+    if LEGACY_WORKER_BASE_URL not in url:
         return None
     try:
         # Extract base64 part: https://worker.dev/{base64}?type=module
-        encoded = url.replace(f"{WORKER_BASE_URL}/", "").split("?")[0]
+        encoded = url.replace(f"{LEGACY_WORKER_BASE_URL}/", "").split("?")[0]
         return base64.urlsafe_b64decode(encoded).decode("utf-8")
     except Exception:
         return None
 
 
 def _is_inline_url(url: str) -> bool:
-    """Check if a URL is an inline resource URL."""
-    return WORKER_BASE_URL in url
+    """Check if a URL is an inline resource URL (current data: or legacy worker)."""
+    return url.startswith(_DATA_URI_PREFIX) or LEGACY_WORKER_BASE_URL in url
 
 
 class ResourceTools:
@@ -284,8 +319,9 @@ class ResourceTools:
         content: Annotated[
             str | None,
             Field(
-                description="JavaScript or CSS code to host inline (max ~24KB). "
-                "The code is embedded in the URL via Cloudflare Worker - no file storage needed. "
+                description="JavaScript or CSS code to host inline. "
+                "The code is embedded directly in the resource URL as a data: URI - "
+                "no file storage or external hosting involved. "
                 "Mutually exclusive with url. Supports 'module' and 'css' types only."
             ),
         ] = None,
@@ -318,14 +354,16 @@ class ResourceTools:
         Create or update a dashboard resource (inline code or external URL).
 
         Provide exactly one of:
-        - content: Inline JavaScript or CSS code (embedded in URL, no file storage needed)
+        - content: Inline JavaScript or CSS code (embedded in the resource URL
+          as a data: URI — no file storage or external hosting involved)
         - url: External resource URL (/local/, /hacsfiles/, or https://...)
 
         INLINE MODE (content=):
         - Custom card code written inline
         - CSS styling for dashboards
-        - Small utility modules (<24KB)
         - URLs are deterministic (same content = same URL)
+        - Content must be self-contained (a data: URI has no base URL, so
+          relative imports inside the module cannot resolve)
         - Supports 'module' and 'css' types only (not 'js')
 
         URL MODE (url=):
@@ -498,18 +536,7 @@ class ResourceTools:
                 )
             )
 
-        encoded, _, encoded_size = _encode_content(content)
-
-        if encoded_size > MAX_ENCODED_LENGTH:
-            raise_tool_error(
-                create_error_response(
-                    code=ErrorCode.VALIDATION_INVALID_PARAMETER,
-                    message=f"Encoded content too large: {encoded_size:,} chars (max {MAX_ENCODED_LENGTH:,})",
-                    context={"size": content_size},
-                )
-            )
-
-        resource_url = f"{WORKER_BASE_URL}/{encoded}?type={resource_type}"
+        resource_url = _data_uri_for(content, resource_type)
 
         try:
             result, action = await self._upsert_resource(
@@ -789,15 +816,30 @@ def register_resources_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
 def _process_resource_list(
     resources: list[Any], include_content: bool
 ) -> list[dict[str, Any]]:
-    """Process raw resources, decoding inline URLs for preview."""
+    """Process raw resources, decoding inline URLs for preview.
+
+    Current inline resources are ``data:`` URIs; resources created before
+    the worker retirement (#2060) still point at the worker and get a
+    migration hint. Both decode locally — no network involved.
+    """
     processed = []
     for resource in resources:
         res = dict(resource)
         url = res.get("url", "")
 
-        if _is_inline_url(url):
-            content = _decode_inline_url(url)
-            if content:
+        if isinstance(url, str) and _is_inline_url(url):
+            content = _decode_data_uri(url)
+            if content is None:
+                content = _decode_legacy_worker_url(url)
+                if content is not None:
+                    res["_legacy_worker"] = True
+                    res["_migration"] = (
+                        "Hosted on the retired Cloudflare worker. Re-save with "
+                        "ha_config_set_dashboard_resource(content=..., "
+                        "resource_id=...) to convert it to a self-contained "
+                        "data: URI."
+                    )
+            if content is not None:
                 res["_inline"] = True
                 res["_size"] = len(content)
 

--- a/src/ha_mcp/tools/tools_resources.py
+++ b/src/ha_mcp/tools/tools_resources.py
@@ -753,6 +753,7 @@ class ResourceTools:
                 )
 
             new_resource_id = _extract_resource_id(result, resource_id)
+            _require_created_resource_id(new_resource_id, action)
 
             logger.info(
                 f"Inline dashboard resource {action}: id={new_resource_id}, "
@@ -828,8 +829,7 @@ class ResourceTools:
                     context={"resource_id": resource_id},
                     suggestions=[
                         "Fetch the full code with ha_config_list_dashboard_resources(include_content=True)",
-                        "Re-save with the complete content (this check only "
-                        "triggers on preview-shaped content)",
+                        "Re-save with the complete content (this check only triggers on preview-shaped content)",
                     ],
                 )
             )
@@ -908,6 +908,7 @@ class ResourceTools:
                 )
 
             new_resource_id = _extract_resource_id(result, resource_id)
+            _require_created_resource_id(new_resource_id, action)
 
             logger.info(
                 f"Dashboard resource {action}: id={new_resource_id}, "
@@ -1199,8 +1200,33 @@ def _check_ws_error(result: Any) -> str | None:
 
 
 def _extract_resource_id(result: Any, fallback_id: str | None) -> str | None:
-    """Extract resource ID from a WebSocket result."""
+    """Extract resource ID from a WebSocket result.
+
+    On the create path ``fallback_id`` is None, so a response without an id
+    would yield ``resource_id: None`` alongside ``success: True`` — leaving
+    the caller no handle to update or delete what it just created. Callers
+    guard that with ``_require_created_resource_id``.
+    """
     resource_info = result.get("result") if isinstance(result, dict) else result
     if isinstance(resource_info, dict):
         return resource_info.get("id", fallback_id)
     return fallback_id
+
+
+def _require_created_resource_id(resource_id: str | None, action: str) -> None:
+    """Fail a create that came back without an id rather than reporting success."""
+    if action == "created" and not resource_id:
+        raise_tool_error(
+            create_error_response(
+                code=ErrorCode.SERVICE_CALL_FAILED,
+                message=(
+                    "Home Assistant reported the resource was created but "
+                    "returned no resource_id, so it cannot be updated or "
+                    "deleted by this tool"
+                ),
+                context={"action": action},
+                suggestions=[
+                    "Run ha_config_list_dashboard_resources() to locate the resource and confirm whether it was created",
+                ],
+            )
+        )

--- a/src/ha_mcp/tools/tools_resources.py
+++ b/src/ha_mcp/tools/tools_resources.py
@@ -65,12 +65,13 @@ _DATA_URI_HEAD = max(len(p) for p in _ALLOWED_DATA_URI_PREFIXES)
 # Characters of decoded content shown in list previews.
 _PREVIEW_LENGTH = 150
 
-# Maximum inline content size — unchanged from the worker era. Browsers load
-# data: URIs far larger (verified to 2MB), but the registered URL is shipped
-# to every browser on every dashboard load and snapshotted whole by
-# auto-backup on every edit, so the bound is response/footprint prudence,
-# no longer a URL-length limit.
-MAX_CONTENT_SIZE = 24000
+# Maximum inline content size. The old 24KB bound was the worker's URL-path
+# limit; data: URIs have no such limit (browsers verified to 2MB), so the cap
+# is sized to fit established single-file card bundles without truncation
+# while bounding what every dashboard load ships (the registered URL rides
+# the Lovelace bootstrap to every browser) and what auto-backup snapshots
+# per edit.
+MAX_CONTENT_SIZE = 128_000
 
 # Top-level HA-config YAML keys that LLMs sometimes emit when they pick this
 # tool (`ha_config_set_dashboard_resource`) to "create a scene/automation/...".
@@ -366,7 +367,7 @@ class ResourceTools:
         content: Annotated[
             str | None,
             Field(
-                description="JavaScript or CSS code to host inline (max ~24KB). "
+                description="JavaScript or CSS code to host inline (max ~128KB). "
                 "The code is embedded directly in the resource URL as a data: URI - "
                 "no file storage or external hosting involved. "
                 "Mutually exclusive with url. Supports 'module' and 'css' types only."
@@ -408,7 +409,7 @@ class ResourceTools:
         INLINE MODE (content=):
         - Custom card code written inline
         - CSS styling for dashboards
-        - Small self-contained files only (max ~24KB)
+        - Self-contained files up to ~128KB
         - URLs are deterministic (same content = same URL)
         - Content must be self-contained: a data: URI has no base URL, so
           relative imports inside a module and relative url() references

--- a/src/ha_mcp/tools/tools_resources.py
+++ b/src/ha_mcp/tools/tools_resources.py
@@ -13,13 +13,13 @@ applies no URL-scheme validation, HA ships no CSP, and every layer loads
 ``data:`` modules and stylesheets fine (verified live; see #2060). Inline
 content now goes straight into a ``data:`` URI: same storage location
 (the resource registry), no third-party hop on dashboard loads.
-``LEGACY_WORKER_BASE_URL`` survives only to recognize and locally decode
-resources created before the switch — the worker is never contacted.
 """
 
 import base64
 import logging
+import re
 from typing import Annotated, Any, Literal, NoReturn
+from urllib.parse import urlsplit
 
 from fastmcp.exceptions import ToolError
 from fastmcp.tools import tool
@@ -44,33 +44,67 @@ logger = logging.getLogger(__name__)
 # keep loading until their resources are converted.
 LEGACY_WORKER_BASE_URL = "https://ha-mcp-resources.rapid-math-bbad.workers.dev"
 
-# data: URI media types per resource_type ('js' is rejected for inline mode).
+# data: URI media types per inline resource_type ('js' is url-mode only).
 # CSS carries an explicit charset because stylesheets, unlike module scripts,
 # have no spec-mandated UTF-8 fallback.
-_DATA_URI_MIME = {"module": "text/javascript", "css": "text/css;charset=utf-8"}
+_RESOURCE_TYPE = Literal["module", "js", "css"]
+_INLINE_RESOURCE_TYPE = Literal["module", "css"]
+_DATA_URI_MIME: dict[_INLINE_RESOURCE_TYPE, str] = {
+    "module": "text/javascript",
+    "css": "text/css;charset=utf-8",
+}
 
-# URL prefixes recognized as ha-mcp inline resources. Scoped to the media
-# types this tool writes (with and without the charset param) so foreign
-# data: resources a user registered by other means are passed through
-# untouched instead of being claimed and masked as "[inline]".
+# URL prefixes recognized as ha-mcp inline resources — DERIVED from the media
+# types above rather than restated, so the read side cannot drift from the
+# write side (a desync would make the server fail to recognize its own
+# output, leaking raw base64 URLs into list responses). Each media type is
+# accepted with and without the charset parameter so resources written
+# before and after a charset change both still decode. Foreign data: URLs
+# match nothing here and pass through untouched instead of being claimed.
 _ALLOWED_DATA_URI_PREFIXES = tuple(
-    f"data:{mime}{charset};base64,"
-    for mime in ("text/javascript", "text/css")
+    f"data:{base}{charset};base64,"
+    # dict.fromkeys dedupes while keeping a deterministic order.
+    for base in dict.fromkeys(mime.split(";", 1)[0] for mime in _DATA_URI_MIME.values())
     for charset in ("", ";charset=utf-8")
 )
 # Scheme and media type are case-insensitive (RFC 3986/2397); prefixes are
 # lowercase, so matching lowercases the URL head. Longest prefix is 42 chars.
 _DATA_URI_HEAD = max(len(p) for p in _ALLOWED_DATA_URI_PREFIXES)
 
+_B64_URLSAFE_RE = re.compile(r"[A-Za-z0-9_-]*={0,2}")
+
+# Longest data: URL echoed verbatim for a resource we cannot decode.
+# Beyond this the value is truncated: a corrupt or foreign payload can be
+# ~171KB of base64, and echoing it whole would flood the response.
+_MAX_ECHOED_URL = 300
+
 # Characters of decoded content shown in list previews.
 _PREVIEW_LENGTH = 150
 
-# Maximum inline content size. The old 24KB bound was the worker's URL-path
-# limit; data: URIs have no such limit (browsers verified to 2MB), so the cap
-# is sized to fit established single-file card bundles without truncation
-# while bounding what every dashboard load ships (the registered URL rides
-# the Lovelace bootstrap to every browser) and what auto-backup snapshots
-# per edit.
+# Total decoded content emitted per include_content=True response. A page
+# of max-size resources would otherwise return limit x MAX_CONTENT_SIZE
+# (up to ~64MB). Rows past the budget are FLAGGED, never shortened —
+# handing back a silently-truncated payload is how a resource gets
+# destroyed on write-back.
+_MAX_CONTENT_BUDGET = 512_000
+
+# Emitted once per response (not per resource) when any listed resource
+# still lives on the legacy worker.
+_LEGACY_MIGRATION_HINT = (
+    "Resources flagged '_legacy_worker' are still hosted on the legacy "
+    "Cloudflare worker. To convert one: fetch its FULL code with "
+    "ha_config_list_dashboard_resources(include_content=True), then re-save "
+    "it with ha_config_set_dashboard_resource(content=..., resource_id=...). "
+    "Never pass '_preview' as content — it is truncated and would destroy "
+    "the resource."
+)
+
+# Maximum inline content size, in UTF-8 bytes. The old 24KB bound was the
+# content budget derived from the worker's ~32KB encoded URL-path limit;
+# data: URIs impose no comparable limit, so the cap is now sized to fit
+# established single-file card bundles without truncation while bounding
+# what every dashboard load ships (the registered URL rides the Lovelace
+# bootstrap to every browser) and what auto-backup snapshots per edit.
 MAX_CONTENT_SIZE = 128_000
 
 # Top-level HA-config YAML keys that LLMs sometimes emit when they pick this
@@ -147,7 +181,7 @@ def _detect_ha_config_yaml(content: str) -> str | None:
     return None
 
 
-def _data_uri_for(content: str, resource_type: str) -> str:
+def _data_uri_for(content: str, resource_type: _INLINE_RESOURCE_TYPE) -> str:
     """Encode content as a base64 ``data:`` URI for the given resource type.
 
     Standard base64 (not URL-safe): browsers decode data: URIs with the
@@ -196,38 +230,85 @@ def _decode_data_uri(url: str) -> str | None:
         return None
 
 
-def _normalize_url_for_scheme_check(url: str) -> str:
-    """Normalize ``url`` the way a browser's URL parser does, for scheme checks.
-
-    WHATWG URL parsing strips leading/trailing C0-control-or-space and
-    removes every ASCII tab/newline before reading the scheme, so
-    ``" data:..."`` and ``"da\\tta:..."`` both parse as ``data:``. Checking
-    the raw string would miss those and let them through.
-    """
-    return (
-        url.strip(
-            "\x00\x01\x02\x03\x04\x05\x06\x07\x08\t\n\x0b\x0c\r\x0e\x0f"
-            "\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1a\x1b\x1c\x1d"
-            "\x1e\x1f "
-        )
-        .replace("\t", "")
-        .replace("\n", "")
-        .replace("\r", "")
-    )
-
-
 def _is_data_url(url: str) -> bool:
-    """True when ``url`` parses as the ``data:`` scheme in a browser."""
-    return _normalize_url_for_scheme_check(url)[:5].lower() == "data:"
+    """True when ``url`` parses as the ``data:`` scheme in a browser.
+
+    ``urlsplit`` applies WHATWG's leading C0-control-or-space strip and
+    ASCII tab/newline/CR removal before reading the scheme (the
+    CVE-2023-24329 hardening; this package requires Python >=3.13), and
+    lowercases it. A raw ``url[:5]`` check would miss ``" data:..."`` and
+    ``"da\\tta:..."``, which browsers still load.
+    """
+    return urlsplit(url).scheme == "data"
 
 
-def _decode_inline_content(url: str) -> tuple[str | None, bool]:
-    """Decode an inline resource URL. Returns ``(content, is_legacy_worker)``.
+def _pad_b64(encoded: str) -> str:
+    """Reject non-alphabet characters, then restore any stripped ``=`` padding.
 
-    ``content`` is None when the URL is not one of ours, or is one of ours
-    but holds an empty/corrupt payload — the single source of truth for
-    "is this an inline resource we can show", so the list summary counts
-    and the per-resource markers can never disagree.
+    ``urlsafe_b64decode`` has no ``validate=`` parameter, so strictness has
+    to be enforced here; the padding fix-up keeps genuine worker URLs (which
+    always carried padding) working either way.
+    """
+    if not _B64_URLSAFE_RE.fullmatch(encoded):
+        raise ValueError("non-base64 characters in payload")
+    return encoded + "=" * (-len(encoded) % 4)
+
+
+def _has_inline_url_shape(url: str) -> bool:
+    """True when ``url`` LOOKS like one of ours, regardless of decodability.
+
+    Only used to flag a recognized-but-corrupt payload; the decode result
+    itself (never this) decides what counts as an inline resource.
+    """
+    if _match_data_uri_prefix(url) is not None:
+        return True
+    prefix = f"{LEGACY_WORKER_BASE_URL}/"
+    return url[: len(prefix)].lower() == prefix.lower()
+
+
+def _looks_like_preview(content: str) -> bool:
+    """Cheap pre-filter: could ``content`` be a list-tool ``_preview``?
+
+    Previews are ``_PREVIEW_LENGTH`` characters plus a trailing ``"..."``.
+    Two shapes qualify: that signature itself (tolerating surrounding
+    whitespace), and exactly ``_PREVIEW_LENGTH`` characters, which is what
+    an agent produces by stripping the ellipsis.
+
+    Deliberately narrow. Everything matching pays a WS round-trip and, if
+    that round-trip fails, is refused — so matching ordinary short content
+    (a legitimate 20-character CSS tweak) would make routine updates
+    fragile for no safety gain, since such content cannot be a preview of
+    anything.
+    """
+    stripped = content.strip()
+    if stripped.endswith("...") and len(stripped) <= _PREVIEW_LENGTH + 3:
+        return True
+    return len(stripped) == _PREVIEW_LENGTH
+
+
+def _is_preview_of(content: str, stored: str) -> bool:
+    """True when ``content`` is the truncated preview of ``stored``.
+
+    Tolerates the ellipsis being stripped and surrounding whitespace, so a
+    lightly-mangled preview writeback is still caught.
+    """
+    if len(stored) <= _PREVIEW_LENGTH:
+        # Short resources have no truncated preview to confuse with.
+        return False
+    candidate = content.strip().removesuffix("...")
+    return bool(candidate) and stored.startswith(candidate)
+
+
+def _decode_inline_content(url: str) -> tuple[str, bool] | None:
+    """Decode an inline resource URL to ``(content, is_legacy_worker)``.
+
+    ``None`` when the URL is not one of ours, or is one of ours but holds
+    an empty/corrupt payload. This is the single source of truth for "is
+    this an inline resource we can show", so the list summary counts and
+    the per-resource markers can never disagree. Returning one ``None``
+    rather than a ``(None, bool)`` pair keeps the meaningless
+    "not-ours-but-legacy" combination unrepresentable and forces callers
+    through one check instead of indexing the tuple.
     """
     content = _decode_data_uri(url)
     if content:
@@ -235,7 +316,7 @@ def _decode_inline_content(url: str) -> tuple[str | None, bool]:
     legacy = _decode_legacy_worker_url(url)
     if legacy:
         return legacy, True
-    return None, False
+    return None
 
 
 def _decode_legacy_worker_url(url: str) -> str | None:
@@ -246,12 +327,17 @@ def _decode_legacy_worker_url(url: str) -> str | None:
     contain the worker host string are not decoded. Returns None if the URL
     is not a legacy worker URL.
     """
-    if not url.startswith(f"{LEGACY_WORKER_BASE_URL}/"):
+    prefix = f"{LEGACY_WORKER_BASE_URL}/"
+    # Scheme and host are case-insensitive; the base64 payload is not.
+    if url[: len(prefix)].lower() != prefix.lower():
         return None
     try:
         # Extract base64 part: https://worker.dev/{base64}?type=module
-        encoded = url.removeprefix(f"{LEGACY_WORKER_BASE_URL}/").split("?")[0]
-        return base64.urlsafe_b64decode(encoded).decode("utf-8")
+        encoded = url[len(prefix) :].split("?")[0]
+        # validate=True mirrors _decode_data_uri: urlsafe_b64decode otherwise
+        # silently DISCARDS non-alphabet characters, so a junk path could
+        # decode to plausible text and be masked as inline content.
+        return base64.urlsafe_b64decode(_pad_b64(encoded)).decode("utf-8")
     except Exception:
         return None
 
@@ -342,29 +428,17 @@ class ResourceTools:
             else:
                 resources = []
 
-            # Summaries cover ALL resources via cheap URL-shape checks; the
-            # decode/preview work runs only on the returned page, so
-            # include_content=True responses stay bounded by limit/offset
-            # instead of materializing every inline resource's content.
-            by_type_counts = {"module": 0, "js": 0, "css": 0}
-            inline_count = 0
-            for resource in resources:
-                res = resource if isinstance(resource, dict) else {}
-                res_type = res.get("type", "unknown")
-                if res_type in by_type_counts:
-                    by_type_counts[res_type] += 1
-                url = res.get("url", "")
-                # Decode (discarding the content) rather than shape-matching
-                # the URL: the count must agree with the per-resource
-                # markers, which only appear when the payload decodes.
-                if isinstance(url, str) and _decode_inline_content(url)[0]:
-                    inline_count += 1
+            by_type_counts, decoded_by_index = _summarize_resources(resources)
+            inline_count = len(decoded_by_index)
 
             total_count = len(resources)
             page = resources[offset : offset + limit]
-            paginated = _process_resource_list(page, include_content)
+            page_decoded = [decoded_by_index.get(offset + i) for i in range(len(page))]
+            paginated, truncated_count = _process_resource_list(
+                page, page_decoded, include_content
+            )
 
-            return {
+            response: dict[str, Any] = {
                 "success": True,
                 "action": "list",
                 "resources": paginated,
@@ -372,6 +446,18 @@ class ResourceTools:
                 "inline_count": inline_count,
                 "by_type": by_type_counts,
             }
+            if truncated_count:
+                response["content_truncated"] = truncated_count
+                response["content_truncation_note"] = (
+                    f"{truncated_count} resource(s) exceeded the "
+                    f"{_MAX_CONTENT_BUDGET:,}-byte per-response content budget and "
+                    "carry '_content_truncated': True. Re-request them with a "
+                    "smaller limit (e.g. limit=1 plus offset) to get their full "
+                    "content — never save a truncated value back."
+                )
+            if any(r.get("_legacy_worker") for r in paginated):
+                response["migration_hint"] = _LEGACY_MIGRATION_HINT
+            return response
         except ToolError:
             raise
         except Exception as e:
@@ -452,6 +538,11 @@ class ResourceTools:
         - Content must be self-contained: a data: URI has no base URL, so
           relative imports inside a module and relative url() references
           inside CSS cannot resolve (use fully-qualified URLs instead)
+        - If Home Assistant is behind a reverse proxy that injects a
+          Content-Security-Policy without 'data:' in script-src/style-src,
+          the browser blocks these resources: this call still succeeds and
+          the card simply never renders. Register the code as a file and
+          use url='/local/...' on such a deployment. (HA itself ships no CSP.)
         - Supports 'module' and 'css' types only (not 'js')
 
         URL MODE (url=):
@@ -592,7 +683,7 @@ class ResourceTools:
     async def _set_inline_resource(
         self,
         content: str,
-        resource_type: str,
+        resource_type: _RESOURCE_TYPE,
         resource_id: str | None,
     ) -> dict[str, Any]:
         """Create or update an inline dashboard resource."""
@@ -704,39 +795,72 @@ class ResourceTools:
         The list tool's default output carries ``_preview`` — the first
         ``_PREVIEW_LENGTH`` characters plus ``"..."``. An agent that re-saves
         a resource using that string as ``content`` would silently replace
-        the user's card with a syntactically broken fragment. Only content
-        shaped exactly like a preview triggers the (one WS round-trip) check
-        against the stored resource, so normal updates pay nothing.
+        the user's card with a syntactically broken fragment.
+
+        Only preview-shaped content triggers the (one WS round-trip) check,
+        so normal updates pay nothing. When the check itself cannot run, it
+        FAILS CLOSED: the write is refused rather than allowed unverified.
+        A preview-shaped payload is already the suspicious case, and the
+        costs are lopsided — a wrong refusal costs one retry with the real
+        content, a wrong allow destroys the user's card and still reports
+        ``success: True``.
         """
-        if not (len(content) == _PREVIEW_LENGTH + 3 and content.endswith("...")):
+        if not _looks_like_preview(content):
             return
+
+        def _unverifiable(detail: str) -> NoReturn:
+            logger.warning(
+                "Preview-writeback guard could not verify resource %s (%s); "
+                "refusing the update rather than risking content loss",
+                resource_id,
+                detail,
+            )
+            raise_tool_error(
+                create_error_response(
+                    code=ErrorCode.SERVICE_CALL_FAILED,
+                    message=(
+                        "Content looks like the truncated preview from "
+                        "ha_config_list_dashboard_resources, and the stored "
+                        f"resource could not be read back to confirm ({detail}). "
+                        "Refusing the write: saving a preview would destroy the "
+                        "resource."
+                    ),
+                    context={"resource_id": resource_id},
+                    suggestions=[
+                        "Fetch the full code with ha_config_list_dashboard_resources(include_content=True)",
+                        "Re-save with the complete content (this check only "
+                        "triggers on preview-shaped content)",
+                    ],
+                )
+            )
+
         try:
             result = await self._client.send_websocket_message(
                 {"type": "lovelace/resources"}
             )
-        except Exception:
-            # Best-effort guard: a listing hiccup must not block the update;
-            # a real connectivity problem fails the upsert itself right after.
-            return
+        except Exception as e:
+            _unverifiable(f"listing the resources failed: {e}")
+        error_msg = _check_ws_error(result)
+        if error_msg:
+            _unverifiable(f"Home Assistant rejected the listing: {error_msg}")
         resources = result.get("result") if isinstance(result, dict) else result
         if not isinstance(resources, list):
-            return
+            _unverifiable("Home Assistant returned an unreadable resource list")
         for res in resources:
-            if str(res.get("id")) != str(resource_id):
+            # Element type is guarded too: a malformed entry must not raise a
+            # bare AttributeError out of the tool.
+            if not isinstance(res, dict) or str(res.get("id")) != str(resource_id):
                 continue
             url = res.get("url", "")
             stored = None
             if isinstance(url, str):
-                stored = _decode_inline_content(url)[0]
-            if (
-                stored
-                and len(stored) > _PREVIEW_LENGTH
-                and content == stored[:_PREVIEW_LENGTH] + "..."
-            ):
+                decoded = _decode_inline_content(url)
+                stored = decoded[0] if decoded else None
+            if stored and _is_preview_of(content, stored):
                 raise_tool_error(
                     create_error_response(
                         code=ErrorCode.VALIDATION_INVALID_PARAMETER,
-                        message="Content is the truncated 150-char preview from "
+                        message="Content is the truncated preview from "
                         "ha_config_list_dashboard_resources, not the full "
                         "resource code — saving it would destroy the resource",
                         context={"resource_id": resource_id},
@@ -751,7 +875,7 @@ class ResourceTools:
     async def _set_url_resource(
         self,
         url: str | None,
-        resource_type: str,
+        resource_type: _RESOURCE_TYPE,
         resource_id: str | None,
     ) -> dict[str, Any]:
         """Create or update an external URL dashboard resource."""
@@ -824,7 +948,7 @@ class ResourceTools:
         self,
         resource_id: str | None,
         url: str | None,
-        resource_type: str,
+        resource_type: _RESOURCE_TYPE,
     ) -> tuple[dict[str, Any], str]:
         """Create or update a lovelace resource. Returns (result, action)."""
         # ``None`` stays the documented "create-new" sentinel; explicit
@@ -973,54 +1097,94 @@ def register_resources_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
     register_tool_methods(mcp, ResourceTools(client))
 
 
-def _process_resource_list(
-    resources: list[Any], include_content: bool
-) -> list[dict[str, Any]]:
-    """Process raw resources, decoding inline URLs for preview.
+def _summarize_resources(
+    resources: list[Any],
+) -> tuple[dict[str, int], dict[int, tuple[str, bool]]]:
+    """Count resources by type and decode every inline one, exactly once.
 
-    Current inline resources are ``data:`` URIs; resources created before
-    the worker retirement (#2060) still point at the worker and get a
-    migration hint. Both decode locally — no network involved.
+    Returns ``(by_type_counts, {index: (content, is_legacy)})``. The decode
+    map is the single source of truth for both ``inline_count`` and the
+    per-resource ``_inline`` markers, so the two can never disagree, and no
+    resource is decoded a second time when the page is rendered.
     """
-    processed = []
-    for resource in resources:
-        res = dict(resource)
+    by_type_counts = {"module": 0, "js": 0, "css": 0}
+    decoded_by_index: dict[int, tuple[str, bool]] = {}
+    for index, resource in enumerate(resources):
+        res = resource if isinstance(resource, dict) else {}
+        res_type = res.get("type", "unknown")
+        if res_type in by_type_counts:
+            by_type_counts[res_type] += 1
         url = res.get("url", "")
-
         if isinstance(url, str):
-            # Empty or undecodable payloads decode to None and fall through
-            # with their real URL visible — masking them as "[inline]" would
-            # hide exactly what a user debugging a broken resource needs to
-            # see. The same call drives ``inline_count``, so the summary and
-            # these markers cannot disagree.
-            content, is_legacy = _decode_inline_content(url)
-            if content and is_legacy:
+            decoded = _decode_inline_content(url)
+            if decoded:
+                decoded_by_index[index] = decoded
+    return by_type_counts, decoded_by_index
+
+
+def _process_resource_list(
+    resources: list[Any],
+    decoded_page: list[tuple[str, bool] | None],
+    include_content: bool,
+) -> tuple[list[dict[str, Any]], int]:
+    """Render one page of resources. Returns ``(rows, truncated_count)``.
+
+    ``decoded_page`` carries the already-decoded ``(content, is_legacy)`` for
+    each row (``None`` when the resource is not a decodable inline one), so
+    this never re-decodes and can never classify a resource differently than
+    the caller's summary did.
+
+    With ``include_content``, content is emitted until the per-response byte
+    budget is spent; rows past it are marked ``_content_truncated`` rather
+    than silently shortened, because a truncated value written back would
+    destroy the resource.
+    """
+    processed: list[dict[str, Any]] = []
+    truncated_count = 0
+    content_budget = _MAX_CONTENT_BUDGET
+
+    for resource, decoded in zip(resources, decoded_page, strict=False):
+        res = dict(resource) if isinstance(resource, dict) else {"url": resource}
+        url = res.get("url", "")
+        content, is_legacy = decoded if decoded else (None, False)
+
+        if content:
+            res["_inline"] = True
+            res["_size"] = len(content.encode("utf-8"))
+            if is_legacy:
+                # The full remediation text lives once at response level;
+                # repeating it per resource wasted ~330 chars each.
                 res["_legacy_worker"] = True
-                res["_migration"] = (
-                    "Hosted on the legacy Cloudflare worker. First fetch "
-                    "the FULL code with ha_config_list_dashboard_resources("
-                    "include_content=True), then re-save it with "
-                    "ha_config_set_dashboard_resource(content=..., "
-                    "resource_id=...) to convert this resource to a "
-                    "self-contained data: URI. Never use _preview as "
-                    "content — it is truncated."
-                )
-            if content:
-                res["_inline"] = True
-                res["_size"] = len(content.encode("utf-8"))
 
-                if include_content:
+            if include_content:
+                cost = len(content.encode("utf-8"))
+                if cost <= content_budget:
                     res["_content"] = content
+                    content_budget -= cost
                 else:
-                    preview = content[:_PREVIEW_LENGTH]
-                    if len(content) > _PREVIEW_LENGTH:
-                        preview += "..."
-                    res["_preview"] = preview
+                    res["_content_truncated"] = True
+                    truncated_count += 1
+            else:
+                preview = content[:_PREVIEW_LENGTH]
+                if len(content) > _PREVIEW_LENGTH:
+                    preview += "..."
+                res["_preview"] = preview
 
-                res["url"] = "[inline]"
+            res["url"] = "[inline]"
+        elif isinstance(url, str) and _has_inline_url_shape(url):
+            # Recognized as one of ours but the payload does not decode
+            # (empty, corrupt, or not UTF-8). Say so explicitly: without a
+            # marker this reads as "an external resource, not my problem",
+            # which is the wrong conclusion for someone debugging a card
+            # that stopped rendering. The real URL stays visible (truncated
+            # if huge) because that is what diagnosis needs.
+            res["_decode_error"] = True
+            if len(url) > _MAX_ECHOED_URL:
+                res["_url_length"] = len(url)
+                res["url"] = url[:_MAX_ECHOED_URL] + "…[truncated]"
 
         processed.append(res)
-    return processed
+    return processed, truncated_count
 
 
 def _check_ws_error(result: Any) -> str | None:

--- a/src/ha_mcp/tools/tools_resources.py
+++ b/src/ha_mcp/tools/tools_resources.py
@@ -428,8 +428,9 @@ class ResourceTools:
             else:
                 resources = []
 
-            by_type_counts, decoded_by_index = _summarize_resources(resources)
-            inline_count = len(decoded_by_index)
+            by_type_counts, inline_count, decoded_by_index = _summarize_resources(
+                resources, offset, offset + limit
+            )
 
             total_count = len(resources)
             page = resources[offset : offset + limit]
@@ -1100,15 +1101,27 @@ def register_resources_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
 
 def _summarize_resources(
     resources: list[Any],
-) -> tuple[dict[str, int], dict[int, tuple[str, bool]]]:
-    """Count resources by type and decode every inline one, exactly once.
+    keep_start: int,
+    keep_stop: int,
+) -> tuple[dict[str, int], int, dict[int, tuple[str, bool]]]:
+    """Count resources by type, and decode every inline one exactly once.
 
-    Returns ``(by_type_counts, {index: (content, is_legacy)})``. The decode
-    map is the single source of truth for both ``inline_count`` and the
-    per-resource ``_inline`` markers, so the two can never disagree, and no
-    resource is decoded a second time when the page is rendered.
+    Returns ``(by_type_counts, inline_count, {index: (content, is_legacy)})``.
+
+    Decoding is deliberately WHOLE-SET: ``inline_count`` reports the full
+    registry and must agree with the per-resource ``_inline`` markers, and
+    only a real decode can tell a genuine inline resource from a corrupt
+    payload that merely looks like one.
+
+    RETENTION, by contrast, is page-scoped: only indices in
+    ``[keep_start, keep_stop)`` are kept in the returned map. Holding every
+    decoded payload would mean a ``limit=1`` call sat on the whole
+    registry's content — up to ``MAX_CONTENT_SIZE`` per resource — for a
+    one-row response. Because the page's entries are retained, nothing is
+    decoded twice.
     """
     by_type_counts = {"module": 0, "js": 0, "css": 0}
+    inline_count = 0
     decoded_by_index: dict[int, tuple[str, bool]] = {}
     for index, resource in enumerate(resources):
         res = resource if isinstance(resource, dict) else {}
@@ -1119,8 +1132,10 @@ def _summarize_resources(
         if isinstance(url, str):
             decoded = _decode_inline_content(url)
             if decoded:
-                decoded_by_index[index] = decoded
-    return by_type_counts, decoded_by_index
+                inline_count += 1
+                if keep_start <= index < keep_stop:
+                    decoded_by_index[index] = decoded
+    return by_type_counts, inline_count, decoded_by_index
 
 
 def _process_resource_list(
@@ -1144,21 +1159,22 @@ def _process_resource_list(
     truncated_count = 0
     content_budget = _MAX_CONTENT_BUDGET
 
-    for resource, decoded in zip(resources, decoded_page, strict=False):
+    for resource, decoded in zip(resources, decoded_page, strict=True):
         res = dict(resource) if isinstance(resource, dict) else {"url": resource}
         url = res.get("url", "")
         content, is_legacy = decoded if decoded else (None, False)
 
         if content:
+            content_bytes = len(content.encode("utf-8"))
             res["_inline"] = True
-            res["_size"] = len(content.encode("utf-8"))
+            res["_size"] = content_bytes
             if is_legacy:
                 # The full remediation text lives once at response level;
                 # repeating it per resource wasted ~330 chars each.
                 res["_legacy_worker"] = True
 
             if include_content:
-                cost = len(content.encode("utf-8"))
+                cost = content_bytes
                 if cost <= content_budget:
                     res["_content"] = content
                     content_budget -= cost

--- a/src/ha_mcp/tools/util_helpers.py
+++ b/src/ha_mcp/tools/util_helpers.py
@@ -517,6 +517,13 @@ BLOCKED_WS_WRITE_COMMANDS: frozenset[str] = frozenset(
         "lovelace/dashboards/create",
         "lovelace/dashboards/delete",
         "lovelace/dashboards/update",
+        # Resource writes carry the same wrapping-tool validation as the
+        # dashboard commands above -- auto-backup, the #1072 HA-config-YAML
+        # misroute rejection, the inline size cap, and the data:-URL routing
+        # guard all live in ha_config_set_dashboard_resource (#2060).
+        "lovelace/resources/create",
+        "lovelace/resources/delete",
+        "lovelace/resources/update",
         "config/area_registry/delete",
         "config/area_registry/disable",
         "config/area_registry/update",

--- a/tests/src/e2e/basic/test_backend_dispatch_smoke.py
+++ b/tests/src/e2e/basic/test_backend_dispatch_smoke.py
@@ -86,7 +86,7 @@ _SKIP_CEILING_PER_LANE = {
     # marker-gated additions rather than runtime skips.
     "container": 72,  # was 71; +1 Puppet-management test (haos_only + inaddon_only)
     "haos": 46,  # was 45; +1 py3.14 invalidate_caches recovery e2e (container_only)
-    "haos_inaddon": 74,  # was 73; +1 visibility enforce-mode e2e (external_only, #2015)
+    "haos_inaddon": 75,  # was 74; +1 inline dashboard_resource auto-backup e2e (external_only, #2060)
     # Embedded backend (#1527, E2E_BACKEND=embedded). Skips exactly the container
     # lane's marker-skips PLUS two embedded-specific additions:
     #   - haos_only + inaddon_only tests skip on embedded just like on container
@@ -96,11 +96,11 @@ _SKIP_CEILING_PER_LANE = {
     #     workflows/embedded smoke test (not_on_embedded).
     # Static def-level derivation (Docker-less, so parametrize item-inflation isn't
     # visible locally): haos_only 52 + inaddon_only-outside-haos 11 + external_only
-    # 35 (auto_backup 18, supervisor_mock 15, self_update_notice 1, file_operations
-    # 1) + not_on_embedded 2 = 100. Initially set to 115 as a buffer for
+    # 36 (auto_backup 19, supervisor_mock 15, self_update_notice 1, file_operations
+    # 1) + not_on_embedded 2 = 101. Initially set to 115 as a buffer for
     # parametrize item-inflation; round 6 (run 28709196071) observed the exact
     # item count and the entry below is pinned to it.
-    "embedded": 129,  # was 128; +1 py3.14 invalidate_caches recovery e2e (not_on_embedded)
+    "embedded": 130,  # was 129; +1 inline dashboard_resource auto-backup e2e (external_only, #2060)
     # HAOS embedded backend (#1527, HAOS_TEST_MODE=embedded). A HAOS lane, so it
     # skips the SAME set as the external HAOS lane (container_only + inaddon_only)
     # PLUS two haos_embedded-specific additions:
@@ -112,13 +112,13 @@ _SKIP_CEILING_PER_LANE = {
     #     the session backend already enables the entry + drives the server.
     # Static def-level derivation (Docker/HAOS-less locally, so parametrize
     # item-inflation isn't visible): container_only 16 + inaddon_only 20 +
-    # external_only 39 + smoke 3 = 78 (no overlaps: no external_only test is also
+    # external_only 40 + smoke 3 = 79 (no overlaps: no external_only test is also
     # container_only/inaddon_only, and the 2 not_on_embedded tests are already
     # container_only). Applying the ~1.16x parametrize inflation the other HAOS
     # lanes show (haos def 30 → ~35 observed; haos_inaddon def 50 → ~58) gives
     # ~84; initially set to 90 with a small buffer, and round 8 observed
     # exactly 90 — the entry below is pinned to the observed count.
-    "haos_embedded": 103,  # was 102; +1 py3.14 invalidate_caches recovery e2e (container_only)
+    "haos_embedded": 104,  # was 103; +1 inline dashboard_resource auto-backup e2e (external_only, #2060)
 }
 
 

--- a/tests/src/e2e/workflows/auto_backup/test_capture_and_restore.py
+++ b/tests/src/e2e/workflows/auto_backup/test_capture_and_restore.py
@@ -1613,6 +1613,82 @@ class TestDashboardResourceCaptureRestore:
             {"resource_id": resource_id},
         )
 
+    async def test_inline_dashboard_resource_full_loop(
+        self, mcp_client, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Same loop for an INLINE resource, whose URL is the content itself.
+
+        The url= lane above snapshots a ~30-character URL. An inline
+        resource's URL is a data: URI carrying the whole card, so this is
+        the case where capture and restore actually move the payload — and
+        the one the inline size cap is reasoned about (auto-backup stores
+        the URL whole on every edit).
+        """
+        _enable_auto_backup(monkeypatch)
+        suffix = uuid.uuid4().hex[:8]
+        original = f"export const E2E_BK = '{suffix}';" + ("// pad" * 200)
+
+        create = await safe_call_tool(
+            mcp_client,
+            "ha_config_set_dashboard_resource",
+            {"content": original, "resource_type": "module"},
+        )
+        if create.get("success") is False:
+            pytest.skip(f"inline dashboard_resource create unsupported: {create}")
+        resource_id = create.get("data", {}).get("resource_id") or create.get(
+            "resource_id"
+        )
+        assert resource_id, f"resource_id missing: {create}"
+        await asyncio.sleep(_HA_PROPAGATION_SETTLE_SECONDS)
+
+        edit = await safe_call_tool(
+            mcp_client,
+            "ha_config_set_dashboard_resource",
+            {
+                "resource_id": resource_id,
+                "content": f"export const E2E_BK_EDITED = '{suffix}';",
+                "resource_type": "module",
+            },
+        )
+        assert edit.get("success") is not False
+
+        backup_name = await _wait_for_backup(
+            mcp_client, domain="dashboard_resource", entity_id=str(resource_id)
+        )
+
+        restore = await safe_call_tool(
+            mcp_client,
+            "ha_manage_backup",
+            {"scope": "edits", "action": "restore", "backup_name": backup_name},
+        )
+        assert restore.get("success") is True
+
+        # The restored resource must carry the ORIGINAL content back,
+        # byte-identical — a snapshot that dropped or mangled the data: URI
+        # would still "restore" successfully without this assertion.
+        listed = await safe_call_tool(
+            mcp_client,
+            "ha_config_list_dashboard_resources",
+            {"include_content": True},
+        )
+        restored = next(
+            (r for r in listed.get("resources", []) if r.get("id") == resource_id),
+            None,
+        )
+        assert restored is not None, "restored resource missing from listing"
+        assert restored.get("_content") == original
+
+        await safe_call_tool(
+            mcp_client,
+            "ha_manage_backup",
+            {"scope": "edits", "action": "delete", "backup_name": backup_name},
+        )
+        await safe_call_tool(
+            mcp_client,
+            "ha_config_delete_dashboard_resource",
+            {"resource_id": resource_id},
+        )
+
 
 # ---------------------------------------------------------------- calendar/todo lanes
 #

--- a/tests/src/e2e/workflows/dashboards/test_resources.py
+++ b/tests/src/e2e/workflows/dashboards/test_resources.py
@@ -411,16 +411,47 @@ class TestDashboardResourceList:
         logger.info("Starting list resources include_content test")
         mcp = MCPAssertions(mcp_client)
 
-        # Just verify the tool accepts the parameter and doesn't error
-        list_data = await mcp.call_tool_success(
-            "ha_config_list_dashboard_resources", {"include_content": False}
+        # Create a known inline resource so the flag has something to act on;
+        # asserting only success would pass with include_content ignored.
+        content = "export const INCLUDE_CONTENT_PROBE = 1;" + ("// pad" * 40)
+        created = await mcp.call_tool_success(
+            "ha_config_set_dashboard_resource",
+            {"content": content, "resource_type": "module"},
         )
-        assert list_data["success"] is True
+        resource_id = created.get("resource_id")
+        try:
 
-        list_data_with_content = await mcp.call_tool_success(
-            "ha_config_list_dashboard_resources", {"include_content": True}
-        )
-        assert list_data_with_content["success"] is True
+            def _find(payload):
+                return next(
+                    (
+                        r
+                        for r in payload.get("resources", [])
+                        if r.get("id") == resource_id
+                    ),
+                    None,
+                )
+
+            without = await mcp.call_tool_success(
+                "ha_config_list_dashboard_resources", {"include_content": False}
+            )
+            row = _find(without)
+            assert row is not None
+            assert "_content" not in row, "content leaked without the flag"
+            assert row["_preview"].endswith("...")
+
+            with_content = await mcp.call_tool_success(
+                "ha_config_list_dashboard_resources", {"include_content": True}
+            )
+            row = _find(with_content)
+            assert row is not None
+            assert row["_content"] == content
+            assert "_preview" not in row
+        finally:
+            if resource_id:
+                await mcp_client.call_tool(
+                    "ha_config_delete_dashboard_resource",
+                    {"resource_id": resource_id},
+                )
 
         logger.info("List resources include_content test completed successfully")
 
@@ -518,6 +549,25 @@ async def _raw_resource_url(
     return None
 
 
+async def _assert_stored_as_data_uri(
+    ha_client: HomeAssistantClient,
+    resource_id: str | None,
+    mime_prefix: str,
+    expected_content: str,
+) -> None:
+    """Assert HA stored the resource as a data: URI decoding byte-identically.
+
+    Goes through the raw WS API deliberately: the MCP list tool masks inline
+    URLs as "[inline]", so only this side channel can prove what HA actually
+    holds.
+    """
+    raw_url = await _raw_resource_url(ha_client, resource_id)
+    assert raw_url is not None
+    assert raw_url.startswith(mime_prefix)
+    decoded = base64.b64decode(raw_url.partition(",")[2]).decode("utf-8")
+    assert decoded == expected_content
+
+
 class TestInlineDashboardResource:
     """Test inline dashboard resource creation (code to data: URI)."""
 
@@ -543,11 +593,9 @@ class TestInlineDashboardResource:
 
             # Ground truth: HA's registry holds a self-contained data: URI
             # that decodes byte-identical to the submitted content.
-            raw_url = await _raw_resource_url(ha_client, resource_id)
-            assert raw_url is not None
-            assert raw_url.startswith("data:text/javascript;base64,")
-            decoded = base64.b64decode(raw_url.partition(",")[2]).decode("utf-8")
-            assert decoded == content
+            await _assert_stored_as_data_uri(
+                ha_client, resource_id, "data:text/javascript;base64,", content
+            )
 
             # Verify it appears in list with inline marker
             list_data = await mcp.call_tool_success(
@@ -594,11 +642,9 @@ class TestInlineDashboardResource:
             assert create_data["success"] is True
             assert create_data["resource_type"] == "css"
 
-            raw_url = await _raw_resource_url(ha_client, resource_id)
-            assert raw_url is not None
-            assert raw_url.startswith("data:text/css;charset=utf-8;base64,")
-            decoded = base64.b64decode(raw_url.partition(",")[2]).decode("utf-8")
-            assert decoded == content
+            await _assert_stored_as_data_uri(
+                ha_client, resource_id, "data:text/css;charset=utf-8;base64,", content
+            )
         finally:
             if resource_id:
                 await mcp_client.call_tool(
@@ -730,11 +776,9 @@ class TestInlineDashboardResource:
             )
             assert update_data["action"] == "updated"
 
-            raw_url = await _raw_resource_url(ha_client, resource_id)
-            assert raw_url is not None
-            assert raw_url.startswith("data:text/javascript;base64,")
-            decoded = base64.b64decode(raw_url.partition(",")[2]).decode("utf-8")
-            assert decoded == new_content
+            await _assert_stored_as_data_uri(
+                ha_client, resource_id, "data:text/javascript;base64,", new_content
+            )
 
             # The list tool no longer flags it as legacy-hosted.
             post_list = await mcp.call_tool_success(

--- a/tests/src/e2e/workflows/dashboards/test_resources.py
+++ b/tests/src/e2e/workflows/dashboards/test_resources.py
@@ -592,7 +592,7 @@ class TestInlineDashboardResource:
 
             raw_url = await _raw_resource_url(ha_client, resource_id)
             assert raw_url is not None
-            assert raw_url.startswith("data:text/css;base64,")
+            assert raw_url.startswith("data:text/css;charset=utf-8;base64,")
             decoded = base64.b64decode(raw_url.partition(",")[2]).decode("utf-8")
             assert decoded == content
         finally:
@@ -616,8 +616,12 @@ class TestInlineDashboardResource:
         logger.info("Starting legacy worker migration test")
         mcp = MCPAssertions(mcp_client)
 
-        legacy_content = "export const LEGACY = 1;"
+        # The ÿ forces bytes whose base64 uses the URL-safe alphabet's
+        # '-'/'_' characters, so the legacy decoder's distinct alphabet is
+        # actually exercised (standard-b64 decode of it would differ).
+        legacy_content = "export const LEGACY = 'ÿÿ';"
         encoded = base64.urlsafe_b64encode(legacy_content.encode()).decode()
+        assert "-" in encoded or "_" in encoded
         legacy_url = (
             "https://ha-mcp-resources.rapid-math-bbad.workers.dev/"
             f"{encoded}?type=module"
@@ -646,6 +650,7 @@ class TestInlineDashboardResource:
             assert legacy_res.get("_inline") is True
             assert legacy_res.get("_legacy_worker") is True
             assert legacy_res.get("_content") == legacy_content
+            assert "include_content=True" in legacy_res.get("_migration", "")
 
             # Re-save with content= → migrated to a data: URI.
             new_content = "export const MIGRATED = 2;"
@@ -664,6 +669,23 @@ class TestInlineDashboardResource:
             assert raw_url.startswith("data:text/javascript;base64,")
             decoded = base64.b64decode(raw_url.partition(",")[2]).decode("utf-8")
             assert decoded == new_content
+
+            # The list tool no longer flags it as legacy-hosted.
+            post_list = await mcp.call_tool_success(
+                "ha_config_list_dashboard_resources", {"include_content": True}
+            )
+            migrated = next(
+                (
+                    r
+                    for r in post_list.get("resources", [])
+                    if r.get("id") == resource_id
+                ),
+                None,
+            )
+            assert migrated is not None
+            assert migrated.get("_inline") is True
+            assert "_legacy_worker" not in migrated
+            assert migrated.get("_content") == new_content
         finally:
             if resource_id:
                 await mcp_client.call_tool(

--- a/tests/src/e2e/workflows/dashboards/test_resources.py
+++ b/tests/src/e2e/workflows/dashboards/test_resources.py
@@ -13,6 +13,7 @@ Each test uses real Home Assistant API calls via the MCP server to ensure
 production-level functionality and compatibility.
 """
 
+import base64
 import logging
 
 # Import test utilities
@@ -498,11 +499,26 @@ class TestDashboardResourceUrlPatterns:
         logger.info("Hacsfiles URL pattern test completed successfully")
 
 
-class TestInlineDashboardResource:
-    """Test inline dashboard resource creation (code to URL)."""
+async def _raw_resource_url(ha_client, resource_id) -> str | None:
+    """Fetch a resource's URL straight from HA's registry over the raw WS API.
 
-    async def test_create_inline_module(self, mcp_client):
-        """Test creating an inline module resource."""
+    Ground truth for what the tool actually registered — the MCP list tool
+    masks inline URLs as "[inline]", so proving the stored URL is a
+    self-contained data: URI needs this side channel.
+    """
+    result = await ha_client.send_websocket_message({"type": "lovelace/resources"})
+    resources = result.get("result") if isinstance(result, dict) else result
+    for res in resources or []:
+        if str(res.get("id")) == str(resource_id):
+            return res.get("url")
+    return None
+
+
+class TestInlineDashboardResource:
+    """Test inline dashboard resource creation (code to data: URI)."""
+
+    async def test_create_inline_module(self, mcp_client, ha_client):
+        """Inline module: registered as a data: URI holding the exact content."""
         logger.info("Starting inline module creation test")
         mcp = MCPAssertions(mcp_client)
 
@@ -521,9 +537,17 @@ class TestInlineDashboardResource:
             assert create_data["size"] == len(content.encode("utf-8"))
             assert resource_id is not None
 
+            # Ground truth: HA's registry holds a self-contained data: URI
+            # that decodes byte-identical to the submitted content.
+            raw_url = await _raw_resource_url(ha_client, resource_id)
+            assert raw_url is not None
+            assert raw_url.startswith("data:text/javascript;base64,")
+            decoded = base64.b64decode(raw_url.partition(",")[2]).decode("utf-8")
+            assert decoded == content
+
             # Verify it appears in list with inline marker
             list_data = await mcp.call_tool_success(
-                "ha_config_list_dashboard_resources", {}
+                "ha_config_list_dashboard_resources", {"include_content": True}
             )
 
             # Find our inline resource
@@ -538,7 +562,8 @@ class TestInlineDashboardResource:
             assert our_resource is not None
             assert our_resource.get("_inline") is True
             assert our_resource.get("url") == "[inline]"
-            assert "_preview" in our_resource or "_size" in our_resource
+            assert our_resource.get("_content") == content
+            assert "_legacy_worker" not in our_resource
 
         finally:
             if resource_id:
@@ -549,8 +574,8 @@ class TestInlineDashboardResource:
 
         logger.info("Inline module creation test completed successfully")
 
-    async def test_create_inline_css(self, mcp_client):
-        """Test creating an inline CSS resource."""
+    async def test_create_inline_css(self, mcp_client, ha_client):
+        """Inline CSS: registered as a data:text/css URI holding the content."""
         logger.info("Starting inline CSS creation test")
         mcp = MCPAssertions(mcp_client)
 
@@ -564,6 +589,12 @@ class TestInlineDashboardResource:
         try:
             assert create_data["success"] is True
             assert create_data["resource_type"] == "css"
+
+            raw_url = await _raw_resource_url(ha_client, resource_id)
+            assert raw_url is not None
+            assert raw_url.startswith("data:text/css;base64,")
+            decoded = base64.b64decode(raw_url.partition(",")[2]).decode("utf-8")
+            assert decoded == content
         finally:
             if resource_id:
                 await mcp_client.call_tool(
@@ -572,6 +603,75 @@ class TestInlineDashboardResource:
                 )
 
         logger.info("Inline CSS creation test completed successfully")
+
+    async def test_legacy_worker_resource_migrates_on_update(
+        self, mcp_client, ha_client
+    ):
+        """A pre-switch worker-hosted resource converts to a data: URI on update.
+
+        Installations that created inline resources before the worker
+        retirement (#2060) still have workers.dev URLs registered; re-saving
+        with content= must replace them with self-contained data: URIs.
+        """
+        logger.info("Starting legacy worker migration test")
+        mcp = MCPAssertions(mcp_client)
+
+        legacy_content = "export const LEGACY = 1;"
+        encoded = base64.urlsafe_b64encode(legacy_content.encode()).decode()
+        legacy_url = (
+            "https://ha-mcp-resources.rapid-math-bbad.workers.dev/"
+            f"{encoded}?type=module"
+        )
+
+        # Seed the pre-switch state via url= mode (a plain URL registration).
+        create_data = await mcp.call_tool_success(
+            "ha_config_set_dashboard_resource",
+            {"url": legacy_url, "resource_type": "module"},
+        )
+        resource_id = create_data.get("resource_id")
+        try:
+            # The list tool must recognize it, decode it locally, and flag it.
+            list_data = await mcp.call_tool_success(
+                "ha_config_list_dashboard_resources", {"include_content": True}
+            )
+            legacy_res = next(
+                (
+                    r
+                    for r in list_data.get("resources", [])
+                    if r.get("id") == resource_id
+                ),
+                None,
+            )
+            assert legacy_res is not None
+            assert legacy_res.get("_inline") is True
+            assert legacy_res.get("_legacy_worker") is True
+            assert legacy_res.get("_content") == legacy_content
+
+            # Re-save with content= → migrated to a data: URI.
+            new_content = "export const MIGRATED = 2;"
+            update_data = await mcp.call_tool_success(
+                "ha_config_set_dashboard_resource",
+                {
+                    "content": new_content,
+                    "resource_type": "module",
+                    "resource_id": resource_id,
+                },
+            )
+            assert update_data["action"] == "updated"
+
+            raw_url = await _raw_resource_url(ha_client, resource_id)
+            assert raw_url is not None
+            assert raw_url.startswith("data:text/javascript;base64,")
+            decoded = base64.b64decode(raw_url.partition(",")[2]).decode("utf-8")
+            assert decoded == new_content
+        finally:
+            if resource_id:
+                await mcp_client.call_tool(
+                    "ha_config_delete_dashboard_resource",
+                    {"resource_id": resource_id},
+                )
+
+        logger.info("Legacy worker migration test completed successfully")
 
     async def test_inline_empty_content_error(self, mcp_client):
         """Test that empty content returns error."""

--- a/tests/src/e2e/workflows/dashboards/test_resources.py
+++ b/tests/src/e2e/workflows/dashboards/test_resources.py
@@ -693,17 +693,32 @@ class TestInlineDashboardResource:
             assert decoded == content
 
             # And the tool can hand it back intact (the migration path
-            # depends on full-fidelity read-back).
+            # depends on full-fidelity read-back). Locate the resource
+            # deterministically first: a fixed limit=1/offset=0 window only
+            # ever inspects the first registry row, so the assertion below
+            # would silently be skipped whenever this resource is not it.
+            index_probe = await mcp.call_tool_success(
+                "ha_config_list_dashboard_resources", {"limit": 500}
+            )
+            ids = [r.get("id") for r in index_probe.get("resources", [])]
+            assert resource_id in ids, f"resource {resource_id} missing from listing"
+            offset = ids.index(resource_id)
+
+            # Fetch exactly that row, so the whole content budget is
+            # available to it regardless of what else is registered.
             listed = await mcp.call_tool_success(
                 "ha_config_list_dashboard_resources",
-                {"include_content": True, "limit": 1, "offset": 0},
+                {"include_content": True, "limit": 1, "offset": offset},
             )
             match = next(
                 (r for r in listed.get("resources", []) if r.get("id") == resource_id),
                 None,
             )
-            if match is not None and "_content" in match:
-                assert match["_content"] == content
+            assert match is not None, "resource not returned at its own offset"
+            assert not match.get("_content_truncated"), (
+                "a lone max-size resource must fit the per-response budget"
+            )
+            assert match["_content"] == content
         finally:
             if resource_id:
                 await mcp_client.call_tool(

--- a/tests/src/e2e/workflows/dashboards/test_resources.py
+++ b/tests/src/e2e/workflows/dashboards/test_resources.py
@@ -608,6 +608,65 @@ class TestInlineDashboardResource:
 
         logger.info("Inline CSS creation test completed successfully")
 
+    async def test_large_inline_resource_round_trips(self, mcp_client, ha_client):
+        """A near-cap payload survives HA storage and comes back byte-identical.
+
+        The cap raise to 128KB is what this PR exists to enable, and the
+        failure modes it could hit (HA WS message limits, the .storage
+        write, the MCP response path) only appear against real HA — an
+        in-process encode/decode round trip cannot catch them.
+        """
+        logger.info("Starting large inline resource test")
+        mcp = MCPAssertions(mcp_client)
+
+        # Realistic single-file bundle shape, sized just under the cap.
+        newline = chr(10)
+        filler = ("// padding to emulate a bundled card" + newline) * 3000
+        content = (
+            "class BigE2ECard extends HTMLElement {"
+            "  setConfig(c) { this.config = c; }"
+            "}"
+            "customElements.define('big-e2e-card', BigE2ECard);" + newline + filler
+        )
+        content = content[:120_000]
+        assert len(content.encode("utf-8")) > 100_000, "payload should be large"
+
+        create_data = await mcp.call_tool_success(
+            "ha_config_set_dashboard_resource",
+            {"content": content, "resource_type": "module"},
+        )
+        resource_id = create_data.get("resource_id")
+        try:
+            assert create_data["success"] is True
+            assert create_data["size"] == len(content.encode("utf-8"))
+
+            # HA really stored the whole thing.
+            raw_url = await _raw_resource_url(ha_client, resource_id)
+            assert raw_url is not None
+            decoded = base64.b64decode(raw_url.partition(",")[2]).decode("utf-8")
+            assert decoded == content
+
+            # And the tool can hand it back intact (the migration path
+            # depends on full-fidelity read-back).
+            listed = await mcp.call_tool_success(
+                "ha_config_list_dashboard_resources",
+                {"include_content": True, "limit": 1, "offset": 0},
+            )
+            match = next(
+                (r for r in listed.get("resources", []) if r.get("id") == resource_id),
+                None,
+            )
+            if match is not None and "_content" in match:
+                assert match["_content"] == content
+        finally:
+            if resource_id:
+                await mcp_client.call_tool(
+                    "ha_config_delete_dashboard_resource",
+                    {"resource_id": resource_id},
+                )
+
+        logger.info("Large inline resource test completed successfully")
+
     async def test_legacy_worker_resource_migrates_on_update(
         self, mcp_client, ha_client
     ):
@@ -654,7 +713,10 @@ class TestInlineDashboardResource:
             assert legacy_res.get("_inline") is True
             assert legacy_res.get("_legacy_worker") is True
             assert legacy_res.get("_content") == legacy_content
-            assert "include_content=True" in legacy_res.get("_migration", "")
+            # The remediation text is emitted once per response, not per
+            # resource, and must route agents through include_content=True
+            # (the default response carries only the truncated _preview).
+            assert "include_content=True" in list_data.get("migration_hint", "")
 
             # Re-save with content= → migrated to a data: URI.
             new_content = "export const MIGRATED = 2;"

--- a/tests/src/e2e/workflows/dashboards/test_resources.py
+++ b/tests/src/e2e/workflows/dashboards/test_resources.py
@@ -16,6 +16,8 @@ production-level functionality and compatibility.
 import base64
 import logging
 
+from ha_mcp.client import HomeAssistantClient
+
 # Import test utilities
 from ...utilities.assertions import (
     MCPAssertions,
@@ -499,7 +501,9 @@ class TestDashboardResourceUrlPatterns:
         logger.info("Hacsfiles URL pattern test completed successfully")
 
 
-async def _raw_resource_url(ha_client, resource_id) -> str | None:
+async def _raw_resource_url(
+    ha_client: HomeAssistantClient, resource_id: str | None
+) -> str | None:
     """Fetch a resource's URL straight from HA's registry over the raw WS API.
 
     Ground truth for what the tool actually registered — the MCP list tool

--- a/tests/src/unit/test_call_service_ws_command.py
+++ b/tests/src/unit/test_call_service_ws_command.py
@@ -239,6 +239,12 @@ class TestWsCommandBlockedWriteCommands:
             "config/entity_registry/remove",
             "config/core/update",
             "LOVELACE/CONFIG/SAVE",
+            # Resource writes carry the same wrapping-tool guards (#2060):
+            # auto-backup, the #1072 YAML-misroute rejection, the inline
+            # size cap and the data:-URL routing guard.
+            "lovelace/resources/create",
+            "lovelace/resources/update",
+            "lovelace/resources/delete",
         ],
         ids=[
             "lovelace_config_save",
@@ -246,6 +252,9 @@ class TestWsCommandBlockedWriteCommands:
             "config_entity_registry_remove",
             "config_core_update",
             "case_variant",
+            "lovelace_resources_create",
+            "lovelace_resources_update",
+            "lovelace_resources_delete",
         ],
     )
     async def test_blocked_write_command_rejected(self, command):

--- a/tests/src/unit/test_identifier_validation_family.py
+++ b/tests/src/unit/test_identifier_validation_family.py
@@ -461,9 +461,12 @@ class TestResourcesIdentifierValidation:
 
     async def test_set_with_none_resource_id_routes_to_create(self, tools):
         # Control: None remains the documented "create-new" sentinel.
+        # HA returns the created resource keyed by ``id`` (which is what
+        # _extract_resource_id reads); the previous ``resource_id`` key was
+        # read by nothing, so the create silently yielded resource_id=None.
         tools._client.send_websocket_message.return_value = {
             "success": True,
-            "result": {"resource_id": "x"},
+            "result": {"id": "x"},
         }
         result = await tools.ha_config_set_dashboard_resource(
             url="/local/test.js", resource_type="module"

--- a/tests/src/unit/test_tools_resources.py
+++ b/tests/src/unit/test_tools_resources.py
@@ -13,9 +13,10 @@ from ha_mcp.tools.tools_resources import (
     ResourceTools,
     _data_uri_for,
     _decode_data_uri,
+    _decode_inline_content,
     _decode_legacy_worker_url,
     _detect_ha_config_yaml,
-    _is_inline_url,
+    _is_data_url,
     register_resources_tools,
 )
 
@@ -92,36 +93,60 @@ class TestHelperFunctions:
         payload = url[len("data:text/javascript;base64,") :]
         assert _decode_data_uri(upper_head + payload) == content
 
-    def test_is_inline_url_data_uri(self):
-        """Our data: URIs are inline resources (case-insensitive scheme)."""
-        assert _is_inline_url("data:text/javascript;base64,YWJj") is True
-        assert _is_inline_url("DATA:TEXT/JAVASCRIPT;BASE64,YWJj") is True
-        assert _is_inline_url("data:text/css;charset=utf-8;base64,YWJj") is True
+    def test_decode_inline_content_data_uri(self):
+        """Our data: URIs decode as non-legacy inline content."""
+        content = "export const x = 1;"
+        assert _decode_inline_content(_data_uri_for(content, "module")) == (
+            content,
+            False,
+        )
+        assert _decode_inline_content(_data_uri_for(".x {}", "css")) == (".x {}", False)
 
-    def test_is_inline_url_foreign_data_uri_false(self):
-        """Foreign data: URLs are NOT inline resources."""
-        assert _is_inline_url("data:image/png;base64,aGVsbG8=") is False
-        assert _is_inline_url("data:text/javascript,console.log(1)") is False
+    def test_decode_inline_content_legacy_worker(self):
+        """Legacy worker URLs decode and are flagged as legacy."""
+        content = "export const legacy = 1;"
+        assert _decode_inline_content(_legacy_url(content)) == (content, True)
 
-    def test_is_inline_url_legacy_worker(self):
-        """Legacy worker URLs still count as inline resources."""
-        assert _is_inline_url(f"{LEGACY_WORKER_BASE_URL}/abc123?type=module") is True
+    def test_decode_inline_content_non_inline(self):
+        """Foreign and undecodable URLs yield no content.
 
-    def test_is_inline_url_false(self):
-        """Test non-inline URL detection."""
-        assert _is_inline_url("/local/card.js") is False
-        assert _is_inline_url("https://cdn.example.com/card.js") is False
+        This is the single source of truth for the list tool's inline_count
+        AND its per-resource markers, so anything returning None here must
+        also be left unmarked and uncounted.
+        """
+        for url in (
+            "/local/card.js",
+            "https://cdn.example.com/card.js",
+            "data:image/png;base64,aGVsbG8=",
+            "data:text/javascript,console.log(1)",
+            "data:text/css;charset=utf-8;base64,",
+            "data:text/javascript;base64,!!not-base64!!",
+        ):
+            assert _decode_inline_content(url) == (None, False), url
 
-    def test_is_inline_url_lookalike_host_false(self):
+    def test_decode_inline_content_lookalike_host(self):
         """Detection is anchored — lookalike hosts embedding the worker host
-        string are neither classified inline nor decoded."""
+        string are neither decoded nor flagged."""
         lookalike = LEGACY_WORKER_BASE_URL.replace(
             "https://", "https://evil.example.com/"
         )
-        assert _is_inline_url(f"{lookalike}/YWJj?type=module") is False
-        assert _decode_legacy_worker_url(f"{lookalike}/YWJj?type=module") is None
+        assert _decode_inline_content(f"{lookalike}/YWJj?type=module") == (None, False)
         suffixed = f"{LEGACY_WORKER_BASE_URL}.evil.example.com/YWJj"
-        assert _is_inline_url(suffixed) is False
+        assert _decode_inline_content(suffixed) == (None, False)
+
+    def test_is_data_url_normalizes_like_a_browser(self):
+        """Leading C0/space and embedded tab/newline are stripped before the
+        scheme check, matching WHATWG URL parsing — otherwise a padded
+        data: URL slips past the url= guard and still loads in a browser."""
+        assert _is_data_url("data:text/javascript;base64,YWJj") is True
+        assert _is_data_url("DATA:text/javascript;base64,YWJj") is True
+        assert _is_data_url(" data:text/javascript,x") is True
+        assert _is_data_url("\tdata:text/javascript,x") is True
+        assert _is_data_url("\n data:text/javascript,x") is True
+        assert _is_data_url("\x00data:text/javascript,x") is True
+        assert _is_data_url("da\tta:text/javascript,x") is True
+        assert _is_data_url("/local/card.js") is False
+        assert _is_data_url("https://cdn.example.com/data:x") is False
 
     def test_decode_legacy_worker_url(self):
         """Test decoding legacy worker URL (pure local base64)."""

--- a/tests/src/unit/test_tools_resources.py
+++ b/tests/src/unit/test_tools_resources.py
@@ -37,9 +37,19 @@ class TestHelperFunctions:
         assert url.startswith("data:text/javascript;base64,")
         assert _decode_data_uri(url) == content
 
+    def test_data_uri_css_roundtrip_with_charset(self):
+        """CSS gets an explicit UTF-8 charset and round-trips non-ASCII."""
+        content = '.card::before { content: "ünïcode ✓"; }'
+        url = _data_uri_for(content, "css")
+
+        assert url.startswith("data:text/css;charset=utf-8;base64,")
+        assert _decode_data_uri(url) == content
+
     def test_data_uri_mime_by_type(self):
-        """module → text/javascript, css → text/css."""
-        assert _data_uri_for(".x {}", "css").startswith("data:text/css;base64,")
+        """module → text/javascript, css → text/css with charset."""
+        assert _data_uri_for(".x {}", "css").startswith(
+            "data:text/css;charset=utf-8;base64,"
+        )
         assert _data_uri_for("1;", "module").startswith("data:text/javascript;base64,")
 
     def test_data_uri_deterministic(self):
@@ -48,18 +58,50 @@ class TestHelperFunctions:
             "const a = 1;", "module"
         )
 
+    def test_data_uri_roundtrip_at_max_size(self):
+        """A payload at exactly MAX_CONTENT_SIZE survives the round-trip."""
+        content = "x" * MAX_CONTENT_SIZE
+        assert _decode_data_uri(_data_uri_for(content, "module")) == content
+
     def test_decode_data_uri_rejects_non_data(self):
         """Non-data: URLs decode to None."""
         assert _decode_data_uri("/local/card.js") is None
         assert _decode_data_uri("https://cdn.example.com/card.js") is None
 
-    def test_decode_data_uri_rejects_non_base64_form(self):
-        """Percent-encoded (non-base64) data: URIs decode to None, not garbage."""
+    def test_decode_data_uri_rejects_percent_encoded_form(self):
+        """Percent-encoded (non-base64) data: URIs are not claimed as ours."""
         assert _decode_data_uri("data:text/javascript,console.log(1)") is None
 
+    def test_decode_data_uri_rejects_foreign_media_type(self):
+        """data: URLs with media types we never write are not claimed."""
+        assert _decode_data_uri("data:image/png;base64,aGVsbG8=") is None
+        assert _decode_data_uri("data:text/html;base64,aGVsbG8=") is None
+
+    def test_decode_data_uri_rejects_corrupt_payload(self):
+        """Non-alphabet bytes in the payload decode to None, not silently
+        truncated content — the browser's forgiving-base64 rejects them, so
+        reporting 'valid' content would point diagnosis away from the cause."""
+        good = _data_uri_for("console.log(1)", "module")
+        assert _decode_data_uri(good + "!!junktail") is None
+
+    def test_decode_data_uri_scheme_case_insensitive(self):
+        """Scheme/media type match case-insensitively; payload case preserved."""
+        content = "const CasePreserved = 1;"
+        url = _data_uri_for(content, "module")
+        upper_head = url[: len("data:text/javascript;base64,")].upper()
+        payload = url[len("data:text/javascript;base64,") :]
+        assert _decode_data_uri(upper_head + payload) == content
+
     def test_is_inline_url_data_uri(self):
-        """data: URIs are inline resources."""
+        """Our data: URIs are inline resources (case-insensitive scheme)."""
         assert _is_inline_url("data:text/javascript;base64,YWJj") is True
+        assert _is_inline_url("DATA:TEXT/JAVASCRIPT;BASE64,YWJj") is True
+        assert _is_inline_url("data:text/css;charset=utf-8;base64,YWJj") is True
+
+    def test_is_inline_url_foreign_data_uri_false(self):
+        """Foreign data: URLs are NOT inline resources."""
+        assert _is_inline_url("data:image/png;base64,aGVsbG8=") is False
+        assert _is_inline_url("data:text/javascript,console.log(1)") is False
 
     def test_is_inline_url_legacy_worker(self):
         """Legacy worker URLs still count as inline resources."""
@@ -69,6 +111,17 @@ class TestHelperFunctions:
         """Test non-inline URL detection."""
         assert _is_inline_url("/local/card.js") is False
         assert _is_inline_url("https://cdn.example.com/card.js") is False
+
+    def test_is_inline_url_lookalike_host_false(self):
+        """Detection is anchored — lookalike hosts embedding the worker host
+        string are neither classified inline nor decoded."""
+        lookalike = LEGACY_WORKER_BASE_URL.replace(
+            "https://", "https://evil.example.com/"
+        )
+        assert _is_inline_url(f"{lookalike}/YWJj?type=module") is False
+        assert _decode_legacy_worker_url(f"{lookalike}/YWJj?type=module") is None
+        suffixed = f"{LEGACY_WORKER_BASE_URL}.evil.example.com/YWJj"
+        assert _is_inline_url(suffixed) is False
 
     def test_decode_legacy_worker_url(self):
         """Test decoding legacy worker URL (pure local base64)."""
@@ -255,7 +308,11 @@ class TestHaConfigListDashboardResources:
         assert resource["_inline"] is True
         assert resource["_preview"] == content
         assert resource["_legacy_worker"] is True
-        assert "retired" in resource["_migration"]
+        # The hint MUST route agents through include_content=True — the
+        # default response only carries the truncated _preview, and
+        # re-saving that would destroy the resource.
+        assert "include_content=True" in resource["_migration"]
+        assert "_preview" in resource["_migration"]
         assert resource["url"] == "[inline]"
 
     @pytest.mark.asyncio
@@ -290,6 +347,78 @@ class TestHaConfigListDashboardResources:
         assert "_content" in resource
         assert resource["_content"] == content
         assert "_preview" not in resource  # Preview not included when content is
+
+    @pytest.mark.asyncio
+    async def test_list_size_is_bytes(self, list_tool, mock_client):
+        """_size reports UTF-8 bytes, matching the set response's size field."""
+        content = "const s = 'ünïcode';"
+        mock_client.send_websocket_message.return_value = {
+            "result": [
+                {"id": "1", "type": "module", "url": _data_uri_for(content, "module")}
+            ]
+        }
+
+        result = await list_tool()
+
+        assert result["resources"][0]["_size"] == len(content.encode("utf-8"))
+
+    @pytest.mark.asyncio
+    async def test_list_foreign_data_uri_passes_through(self, list_tool, mock_client):
+        """Foreign data: resources keep their real URL and are not claimed."""
+        url = "data:image/png;base64,aGVsbG8="
+        mock_client.send_websocket_message.return_value = {
+            "result": [{"id": "1", "type": "module", "url": url}]
+        }
+
+        result = await list_tool()
+
+        resource = result["resources"][0]
+        assert resource["url"] == url
+        assert "_inline" not in resource
+        assert result["inline_count"] == 0
+
+    @pytest.mark.asyncio
+    async def test_list_undecodable_inline_passes_through(self, list_tool, mock_client):
+        """Empty or corrupt payloads keep their real URL visible.
+
+        Masking them as "[inline]" would hide exactly what a user debugging
+        a broken resource needs to see.
+        """
+        empty = "data:text/css;charset=utf-8;base64,"
+        corrupt = "data:text/javascript;base64,!!not-base64!!"
+        mock_client.send_websocket_message.return_value = {
+            "result": [
+                {"id": "1", "type": "css", "url": empty},
+                {"id": "2", "type": "module", "url": corrupt},
+            ]
+        }
+
+        result = await list_tool()
+
+        assert result["resources"][0]["url"] == empty
+        assert "_inline" not in result["resources"][0]
+        assert result["resources"][1]["url"] == corrupt
+        assert "_inline" not in result["resources"][1]
+
+    @pytest.mark.asyncio
+    async def test_list_decodes_only_the_returned_page(self, list_tool, mock_client):
+        """Content is materialized for the requested page only, while
+        inline_count still summarizes the full set — include_content=True
+        responses stay bounded by limit/offset."""
+        contents = [f"export const page_test_{i} = {i};" for i in range(3)]
+        mock_client.send_websocket_message.return_value = {
+            "result": [
+                {"id": str(i), "type": "module", "url": _data_uri_for(c, "module")}
+                for i, c in enumerate(contents)
+            ]
+        }
+
+        result = await list_tool(include_content=True, limit=1, offset=1)
+
+        assert result["total_count"] == 3
+        assert result["inline_count"] == 3
+        assert len(result["resources"]) == 1
+        assert result["resources"][0]["_content"] == contents[1]
 
 
 class TestHaConfigSetDashboardResource:
@@ -367,7 +496,7 @@ class TestHaConfigSetDashboardResource:
         assert result["resource_type"] == "css"
 
         call_args = mock_client.send_websocket_message.call_args[0][0]
-        assert call_args["url"].startswith("data:text/css;base64,")
+        assert call_args["url"].startswith("data:text/css;charset=utf-8;base64,")
         assert _decode_data_uri(call_args["url"]) == ".card { color: red; }"
 
     @pytest.mark.asyncio
@@ -397,11 +526,81 @@ class TestHaConfigSetDashboardResource:
 
         # Updates always write the current data: URI form — updating a
         # legacy worker-hosted resource with new content migrates it off
-        # the retired worker as a side effect.
+        # the legacy worker as a side effect.
         call_args = mock_client.send_websocket_message.call_args[0][0]
         assert call_args["type"] == "lovelace/resources/update"
         assert call_args["resource_id"] == "existing"
         assert call_args["url"].startswith("data:text/javascript;base64,")
+
+    @pytest.mark.asyncio
+    async def test_update_rejects_truncated_preview_resave(self, set_tool, mock_client):
+        """Re-saving the list tool's truncated _preview as content is refused.
+
+        The default list response carries only the 150-char preview + "...";
+        an agent that writes that back would destroy the user's card.
+        """
+        full = "x" * 200
+        preview = full[:150] + "..."
+        mock_client.send_websocket_message.return_value = {
+            "result": [
+                {"id": "res1", "type": "module", "url": _data_uri_for(full, "module")}
+            ]
+        }
+
+        with pytest.raises(ToolError) as exc_info:
+            await set_tool(content=preview, resource_type="module", resource_id="res1")
+
+        error_data = json.loads(str(exc_info.value))
+        assert "truncated" in error_data["error"]["message"]
+        suggestions = error_data["error"]["suggestions"]
+        assert any("include_content=True" in s for s in suggestions)
+        # Only the guard's listing call ran — no update was sent.
+        assert mock_client.send_websocket_message.call_count == 1
+        sent = mock_client.send_websocket_message.call_args[0][0]
+        assert sent["type"] == "lovelace/resources"
+
+    @pytest.mark.asyncio
+    async def test_update_rejects_truncated_preview_of_legacy_resource(
+        self, set_tool, mock_client
+    ):
+        """The preview guard also protects legacy worker-hosted resources."""
+        full = "y" * 300
+        preview = full[:150] + "..."
+        mock_client.send_websocket_message.return_value = {
+            "result": [{"id": "res1", "type": "module", "url": _legacy_url(full)}]
+        }
+
+        with pytest.raises(ToolError):
+            await set_tool(content=preview, resource_type="module", resource_id="res1")
+
+        assert mock_client.send_websocket_message.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_update_allows_legit_content_shaped_like_preview(
+        self, set_tool, mock_client
+    ):
+        """153-char content ending in '...' that is NOT the stored preview saves."""
+        legit = "a" * 150 + "..."
+        stored = "completely different stored content " * 10
+        mock_client.send_websocket_message.side_effect = [
+            {
+                "result": [
+                    {
+                        "id": "res1",
+                        "type": "module",
+                        "url": _data_uri_for(stored, "module"),
+                    }
+                ]
+            },
+            {"result": {"id": "res1"}},
+        ]
+
+        result = await set_tool(
+            content=legit, resource_type="module", resource_id="res1"
+        )
+
+        assert result["success"] is True
+        assert result["action"] == "updated"
 
     @pytest.mark.asyncio
     async def test_inline_empty_content_error(self, set_tool, mock_client):
@@ -633,6 +832,32 @@ class TestHaConfigSetDashboardResource:
         assert result["success"] is True
         assert result["resource_type"] == "js"
 
+    @pytest.mark.asyncio
+    async def test_url_mode_rejects_data_urls(self, set_tool, mock_client):
+        """Hand-built data: URLs can't bypass the inline-mode guards via url=.
+
+        url= runs none of the inline validations (empty/size/type checks and
+        the #1072 YAML-misroute rejection), so a documented data: format
+        registered through it would be a guard bypass.
+        """
+        with pytest.raises(ToolError) as exc_info:
+            await set_tool(url="data:text/javascript;base64,eA==")
+
+        error_data = json.loads(str(exc_info.value))
+        assert "content=" in error_data["error"]["message"]
+        mock_client.send_websocket_message.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_url_mode_rejects_data_urls_any_case_and_type(
+        self, set_tool, mock_client
+    ):
+        """The data: rejection is scheme-case-insensitive and mime-agnostic."""
+        with pytest.raises(ToolError):
+            await set_tool(url="DATA:text/javascript;base64,eA==")
+        with pytest.raises(ToolError):
+            await set_tool(url="data:image/png;base64,eA==", resource_type="js")
+        mock_client.send_websocket_message.assert_not_called()
+
 
 class TestHaConfigDeleteDashboardResource:
     """Test ha_config_delete_dashboard_resource tool."""
@@ -705,10 +930,8 @@ class TestToolRegistration:
 class TestConstants:
     """Test module constants."""
 
-    def test_legacy_worker_url_is_https(self):
-        """Legacy recognition constant still matches the worker's https URL."""
-        assert LEGACY_WORKER_BASE_URL.startswith("https://")
-
-    def test_size_limit_not_below_old_worker_cap(self):
-        """The data: URI limit must not regress below the old 24KB worker cap."""
-        assert MAX_CONTENT_SIZE >= 24000
+    def test_max_content_size_pinned(self):
+        """Pin the cap at the worker-era 24KB: the registered URL ships to
+        every browser on every dashboard load and auto-backup snapshots it
+        whole per edit, so raising this needs a deliberate decision."""
+        assert MAX_CONTENT_SIZE == 24000

--- a/tests/src/unit/test_tools_resources.py
+++ b/tests/src/unit/test_tools_resources.py
@@ -55,6 +55,20 @@ class TestHelperFunctions:
         )
         assert _data_uri_for("1;", "module").startswith("data:text/javascript;base64,")
 
+    def test_data_uri_for_rejects_non_inline_type(self):
+        """The runtime guard is exercised directly, not only via the caller.
+
+        _set_inline_resource rejects 'js' earlier, so this branch is
+        statically unreachable through the tool; the test keeps it honest
+        as defence for any future dynamic caller.
+        """
+        with pytest.raises(ToolError) as exc_info:
+            _data_uri_for("x", "js")  # type: ignore[arg-type]
+
+        error_data = json.loads(str(exc_info.value))
+        assert error_data["error"]["code"] == "VALIDATION_INVALID_PARAMETER"
+        assert "js" in error_data["error"]["message"]
+
     def test_data_uri_deterministic(self):
         """Same content always maps to the same URL."""
         assert _data_uri_for("const a = 1;", "module") == _data_uri_for(
@@ -621,6 +635,33 @@ class TestHaConfigSetDashboardResource:
         assert call_args["res_type"] == "module"
         assert call_args["url"].startswith("data:text/javascript;base64,")
         assert _decode_data_uri(call_args["url"]) == content
+
+    @pytest.mark.asyncio
+    async def test_create_without_resource_id_fails(self, set_tool, mock_client):
+        """A create that returns no id is an error, not a success.
+
+        Reporting success would leave the caller with no handle to update
+        or delete the resource it just created.
+        """
+        mock_client.send_websocket_message.return_value = {"result": None}
+
+        with pytest.raises(ToolError) as exc_info:
+            await set_tool(content="const x = 1;", resource_type="module")
+
+        error_data = json.loads(str(exc_info.value))
+        assert "no resource_id" in error_data["error"]["message"]
+
+    @pytest.mark.asyncio
+    async def test_update_tolerates_missing_id_in_response(self, set_tool, mock_client):
+        """The guard is create-only — an update echoes back its known id."""
+        mock_client.send_websocket_message.return_value = {"result": None}
+
+        result = await set_tool(
+            content="const x = 1;", resource_type="module", resource_id="known"
+        )
+
+        assert result["success"] is True
+        assert result["resource_id"] == "known"
 
     @pytest.mark.asyncio
     async def test_create_inline_css(self, set_tool, mock_client):

--- a/tests/src/unit/test_tools_resources.py
+++ b/tests/src/unit/test_tools_resources.py
@@ -8,52 +8,76 @@ import pytest
 from fastmcp.exceptions import ToolError
 
 from ha_mcp.tools.tools_resources import (
+    LEGACY_WORKER_BASE_URL,
     MAX_CONTENT_SIZE,
-    MAX_ENCODED_LENGTH,
-    WORKER_BASE_URL,
     ResourceTools,
-    _decode_inline_url,
+    _data_uri_for,
+    _decode_data_uri,
+    _decode_legacy_worker_url,
     _detect_ha_config_yaml,
-    _encode_content,
     _is_inline_url,
     register_resources_tools,
 )
 
 
+def _legacy_url(content: str, resource_type: str = "module") -> str:
+    """Build a legacy worker inline URL the way the retired writer did."""
+    encoded = base64.urlsafe_b64encode(content.encode()).decode()
+    return f"{LEGACY_WORKER_BASE_URL}/{encoded}?type={resource_type}"
+
+
 class TestHelperFunctions:
     """Test helper functions."""
 
-    def test_encode_content(self):
-        """Test content encoding."""
-        content = "test content"
-        encoded, content_size, encoded_size = _encode_content(content)
+    def test_data_uri_roundtrip(self):
+        """Content encodes to a data: URI that decodes back byte-identical."""
+        content = "export const x = 'ünïcode';"
+        url = _data_uri_for(content, "module")
 
-        assert content_size == len(content.encode("utf-8"))
-        assert encoded_size == len(encoded)
-        assert base64.urlsafe_b64decode(encoded).decode("utf-8") == content
+        assert url.startswith("data:text/javascript;base64,")
+        assert _decode_data_uri(url) == content
 
-    def test_is_inline_url_true(self):
-        """Test inline URL detection."""
-        url = f"{WORKER_BASE_URL}/abc123?type=module"
-        assert _is_inline_url(url) is True
+    def test_data_uri_mime_by_type(self):
+        """module → text/javascript, css → text/css."""
+        assert _data_uri_for(".x {}", "css").startswith("data:text/css;base64,")
+        assert _data_uri_for("1;", "module").startswith("data:text/javascript;base64,")
+
+    def test_data_uri_deterministic(self):
+        """Same content always maps to the same URL."""
+        assert _data_uri_for("const a = 1;", "module") == _data_uri_for(
+            "const a = 1;", "module"
+        )
+
+    def test_decode_data_uri_rejects_non_data(self):
+        """Non-data: URLs decode to None."""
+        assert _decode_data_uri("/local/card.js") is None
+        assert _decode_data_uri("https://cdn.example.com/card.js") is None
+
+    def test_decode_data_uri_rejects_non_base64_form(self):
+        """Percent-encoded (non-base64) data: URIs decode to None, not garbage."""
+        assert _decode_data_uri("data:text/javascript,console.log(1)") is None
+
+    def test_is_inline_url_data_uri(self):
+        """data: URIs are inline resources."""
+        assert _is_inline_url("data:text/javascript;base64,YWJj") is True
+
+    def test_is_inline_url_legacy_worker(self):
+        """Legacy worker URLs still count as inline resources."""
+        assert _is_inline_url(f"{LEGACY_WORKER_BASE_URL}/abc123?type=module") is True
 
     def test_is_inline_url_false(self):
         """Test non-inline URL detection."""
         assert _is_inline_url("/local/card.js") is False
         assert _is_inline_url("https://cdn.example.com/card.js") is False
 
-    def test_decode_inline_url(self):
-        """Test decoding inline URL."""
+    def test_decode_legacy_worker_url(self):
+        """Test decoding legacy worker URL (pure local base64)."""
         content = "export const x = 1;"
-        encoded = base64.urlsafe_b64encode(content.encode()).decode()
-        url = f"{WORKER_BASE_URL}/{encoded}?type=module"
+        assert _decode_legacy_worker_url(_legacy_url(content)) == content
 
-        decoded = _decode_inline_url(url)
-        assert decoded == content
-
-    def test_decode_inline_url_non_inline(self):
-        """Test decoding non-inline URL returns None."""
-        assert _decode_inline_url("/local/card.js") is None
+    def test_decode_legacy_worker_url_non_worker(self):
+        """Test decoding non-worker URL returns None."""
+        assert _decode_legacy_worker_url("/local/card.js") is None
 
 
 class TestDetectHaConfigYaml:
@@ -197,10 +221,9 @@ class TestHaConfigListDashboardResources:
 
     @pytest.mark.asyncio
     async def test_list_inline_resources_decoded(self, list_tool, mock_client):
-        """Test that inline resources are decoded with preview."""
+        """Test that data: URI inline resources are decoded with preview."""
         content = "export const myFunction = () => 'hello world';"
-        encoded = base64.urlsafe_b64encode(content.encode()).decode()
-        inline_url = f"{WORKER_BASE_URL}/{encoded}?type=module"
+        inline_url = _data_uri_for(content, "module")
 
         mock_client.send_websocket_message.return_value = {
             "result": [{"id": "1", "type": "module", "url": inline_url}]
@@ -215,13 +238,31 @@ class TestHaConfigListDashboardResources:
         assert resource["_size"] == len(content)
         assert resource["_preview"] == content
         assert resource["url"] == "[inline]"  # URL replaced
+        assert "_legacy_worker" not in resource
+
+    @pytest.mark.asyncio
+    async def test_list_legacy_worker_resources_flagged(self, list_tool, mock_client):
+        """Legacy worker resources decode locally and carry a migration hint."""
+        content = "export const legacy = true;"
+        mock_client.send_websocket_message.return_value = {
+            "result": [{"id": "1", "type": "module", "url": _legacy_url(content)}]
+        }
+
+        result = await list_tool()
+
+        assert result["inline_count"] == 1
+        resource = result["resources"][0]
+        assert resource["_inline"] is True
+        assert resource["_preview"] == content
+        assert resource["_legacy_worker"] is True
+        assert "retired" in resource["_migration"]
+        assert resource["url"] == "[inline]"
 
     @pytest.mark.asyncio
     async def test_list_inline_preview_truncated(self, list_tool, mock_client):
         """Test that long inline content preview is truncated."""
         content = "x" * 200
-        encoded = base64.urlsafe_b64encode(content.encode()).decode()
-        inline_url = f"{WORKER_BASE_URL}/{encoded}?type=module"
+        inline_url = _data_uri_for(content, "module")
 
         mock_client.send_websocket_message.return_value = {
             "result": [{"id": "1", "type": "module", "url": inline_url}]
@@ -237,8 +278,7 @@ class TestHaConfigListDashboardResources:
     async def test_list_include_content_flag(self, list_tool, mock_client):
         """Test that include_content=True returns full content."""
         content = "x" * 200
-        encoded = base64.urlsafe_b64encode(content.encode()).decode()
-        inline_url = f"{WORKER_BASE_URL}/{encoded}?type=module"
+        inline_url = _data_uri_for(content, "module")
 
         mock_client.send_websocket_message.return_value = {
             "result": [{"id": "1", "type": "module", "url": inline_url}]
@@ -308,11 +348,13 @@ class TestHaConfigSetDashboardResource:
         assert result["resource_type"] == "module"
         assert result["size"] == len(content.encode("utf-8"))
 
-        # Verify WebSocket call uses Cloudflare Worker URL
+        # Registered URL is a self-contained data: URI holding exactly the
+        # submitted content — nothing external involved.
         call_args = mock_client.send_websocket_message.call_args[0][0]
         assert call_args["type"] == "lovelace/resources/create"
         assert call_args["res_type"] == "module"
-        assert WORKER_BASE_URL in call_args["url"]
+        assert call_args["url"].startswith("data:text/javascript;base64,")
+        assert _decode_data_uri(call_args["url"]) == content
 
     @pytest.mark.asyncio
     async def test_create_inline_css(self, set_tool, mock_client):
@@ -323,6 +365,10 @@ class TestHaConfigSetDashboardResource:
 
         assert result["success"] is True
         assert result["resource_type"] == "css"
+
+        call_args = mock_client.send_websocket_message.call_args[0][0]
+        assert call_args["url"].startswith("data:text/css;base64,")
+        assert _decode_data_uri(call_args["url"]) == ".card { color: red; }"
 
     @pytest.mark.asyncio
     async def test_default_type_is_module(self, set_tool, mock_client):
@@ -349,9 +395,13 @@ class TestHaConfigSetDashboardResource:
         assert result["action"] == "updated"
         assert result["resource_id"] == "existing"
 
+        # Updates always write the current data: URI form — updating a
+        # legacy worker-hosted resource with new content migrates it off
+        # the retired worker as a side effect.
         call_args = mock_client.send_websocket_message.call_args[0][0]
         assert call_args["type"] == "lovelace/resources/update"
         assert call_args["resource_id"] == "existing"
+        assert call_args["url"].startswith("data:text/javascript;base64,")
 
     @pytest.mark.asyncio
     async def test_inline_empty_content_error(self, set_tool, mock_client):
@@ -655,17 +705,10 @@ class TestToolRegistration:
 class TestConstants:
     """Test module constants."""
 
-    def test_worker_url_is_https(self):
-        """Test worker URL uses HTTPS."""
-        assert WORKER_BASE_URL.startswith("https://")
+    def test_legacy_worker_url_is_https(self):
+        """Legacy recognition constant still matches the worker's https URL."""
+        assert LEGACY_WORKER_BASE_URL.startswith("https://")
 
-    def test_size_limits_reasonable(self):
-        """Test size limits allow useful content."""
-        assert MAX_CONTENT_SIZE >= 20000  # At least 20KB
-        assert MAX_ENCODED_LENGTH >= 30000  # At least 30KB
-
-    def test_base64_overhead_accounted(self):
-        """Test content limit accounts for base64 expansion."""
-        # Base64 increases size by 4/3
-        expected_encoded = (MAX_CONTENT_SIZE * 4 + 2) // 3
-        assert expected_encoded <= MAX_ENCODED_LENGTH
+    def test_size_limit_not_below_old_worker_cap(self):
+        """The data: URI limit must not regress below the old 24KB worker cap."""
+        assert MAX_CONTENT_SIZE >= 24000

--- a/tests/src/unit/test_tools_resources.py
+++ b/tests/src/unit/test_tools_resources.py
@@ -7,7 +7,9 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 from fastmcp.exceptions import ToolError
 
+from ha_mcp.tools import tools_resources
 from ha_mcp.tools.tools_resources import (
+    _ALLOWED_DATA_URI_PREFIXES,
     LEGACY_WORKER_BASE_URL,
     MAX_CONTENT_SIZE,
     ResourceTools,
@@ -122,7 +124,7 @@ class TestHelperFunctions:
             "data:text/css;charset=utf-8;base64,",
             "data:text/javascript;base64,!!not-base64!!",
         ):
-            assert _decode_inline_content(url) == (None, False), url
+            assert _decode_inline_content(url) is None, url
 
     def test_decode_inline_content_lookalike_host(self):
         """Detection is anchored — lookalike hosts embedding the worker host
@@ -130,9 +132,9 @@ class TestHelperFunctions:
         lookalike = LEGACY_WORKER_BASE_URL.replace(
             "https://", "https://evil.example.com/"
         )
-        assert _decode_inline_content(f"{lookalike}/YWJj?type=module") == (None, False)
+        assert _decode_inline_content(f"{lookalike}/YWJj?type=module") is None
         suffixed = f"{LEGACY_WORKER_BASE_URL}.evil.example.com/YWJj"
-        assert _decode_inline_content(suffixed) == (None, False)
+        assert _decode_inline_content(suffixed) is None
 
     def test_is_data_url_normalizes_like_a_browser(self):
         """Leading C0/space and embedded tab/newline are stripped before the
@@ -147,6 +149,55 @@ class TestHelperFunctions:
         assert _is_data_url("da\tta:text/javascript,x") is True
         assert _is_data_url("/local/card.js") is False
         assert _is_data_url("https://cdn.example.com/data:x") is False
+
+    @pytest.mark.parametrize("prefix", _ALLOWED_DATA_URI_PREFIXES)
+    def test_decode_data_uri_accepts_every_generated_prefix(self, prefix):
+        """All four accepted prefixes decode, including the two read-compat
+        forms the writer never emits (js-with-charset, css-without).
+
+        Dropping them as 'dead' would silently stop recognizing resources
+        written by a differently-versioned ha-mcp: they would lose _inline,
+        fall out of inline_count, and — critically — escape the truncated
+        preview guard, so an agent could overwrite them with a preview.
+        """
+        import base64 as _b64
+
+        content = "export const x = 1;"
+        url = prefix + _b64.b64encode(content.encode()).decode()
+        assert _decode_data_uri(url) == content
+
+    def test_decode_data_uri_rejects_invalid_utf8(self):
+        """Valid base64 that is not valid UTF-8 decodes to None.
+
+        Distinct code path from the corrupt-alphabet case (UnicodeDecodeError
+        rather than binascii.Error).
+        """
+        import base64 as _b64
+
+        payload = _b64.b64encode(bytes([255, 254, 0]) + b"abc").decode()
+        assert _decode_data_uri("data:text/javascript;base64," + payload) is None
+
+    def test_decode_legacy_worker_url_rejects_corrupt_payload(self):
+        """The legacy decoder is as strict as the data: one.
+
+        urlsafe_b64decode silently DISCARDS non-alphabet characters, so
+        without an explicit check a junk path could decode to plausible text
+        and be masked as inline content.
+        """
+        assert (
+            _decode_legacy_worker_url(f"{LEGACY_WORKER_BASE_URL}/$$$$aGVsbG8=") is None
+        )
+        assert (
+            _decode_legacy_worker_url(f"{LEGACY_WORKER_BASE_URL}/some-random-path")
+            is None
+        )
+
+    def test_decode_legacy_worker_url_case_insensitive_origin(self):
+        """Scheme/host case does not lose a legacy resource its migration path."""
+        content = "export const legacy = 1;"
+        url = _legacy_url(content)
+        shouty = url.replace("https://", "HTTPS://", 1)
+        assert _decode_legacy_worker_url(shouty) == content
 
     def test_decode_legacy_worker_url(self):
         """Test decoding legacy worker URL (pure local base64)."""
@@ -333,12 +384,14 @@ class TestHaConfigListDashboardResources:
         assert resource["_inline"] is True
         assert resource["_preview"] == content
         assert resource["_legacy_worker"] is True
-        # The hint MUST route agents through include_content=True — the
-        # default response only carries the truncated _preview, and
-        # re-saving that would destroy the resource.
-        assert "include_content=True" in resource["_migration"]
-        assert "_preview" in resource["_migration"]
         assert resource["url"] == "[inline]"
+        # The hint is emitted ONCE per response, not repeated per resource,
+        # and MUST route agents through include_content=True — the default
+        # response only carries the truncated _preview, and re-saving that
+        # would destroy the resource.
+        assert "_migration" not in resource
+        assert "include_content=True" in result["migration_hint"]
+        assert "_preview" in result["migration_hint"]
 
     @pytest.mark.asyncio
     async def test_list_inline_preview_truncated(self, list_tool, mock_client):
@@ -424,9 +477,19 @@ class TestHaConfigListDashboardResources:
         assert "_inline" not in result["resources"][0]
         assert result["resources"][1]["url"] == corrupt
         assert "_inline" not in result["resources"][1]
+        # The summary must agree with the markers — this is the ONLY input
+        # shape where a decode-based count and a URL-shape count differ, so
+        # it is what pins the "cannot disagree" invariant.
+        assert result["inline_count"] == 0
+        # Recognized as ours but undecodable: say so, or a user debugging a
+        # dead card reads it as someone else's resource.
+        assert result["resources"][0]["_decode_error"] is True
+        assert result["resources"][1]["_decode_error"] is True
 
     @pytest.mark.asyncio
-    async def test_list_decodes_only_the_returned_page(self, list_tool, mock_client):
+    async def test_list_decodes_only_the_returned_page(
+        self, list_tool, mock_client, monkeypatch
+    ):
         """Content is materialized for the requested page only, while
         inline_count still summarizes the full set — include_content=True
         responses stay bounded by limit/offset."""
@@ -438,12 +501,61 @@ class TestHaConfigListDashboardResources:
             ]
         }
 
+        seen_page_sizes = []
+        real_process = tools_resources._process_resource_list
+
+        def _spy(page, decoded_page, include):
+            seen_page_sizes.append(len(page))
+            return real_process(page, decoded_page, include)
+
+        monkeypatch.setattr(tools_resources, "_process_resource_list", _spy)
+
         result = await list_tool(include_content=True, limit=1, offset=1)
 
         assert result["total_count"] == 3
         assert result["inline_count"] == 3
         assert len(result["resources"]) == 1
         assert result["resources"][0]["_content"] == contents[1]
+        # The probe is what actually pins the behavior: reverting to
+        # "process everything, then slice" would still satisfy the
+        # assertions above, but would hand the renderer all 3 records.
+        assert seen_page_sizes == [1]
+
+    @pytest.mark.asyncio
+    async def test_list_content_budget_flags_rather_than_shortens(
+        self, list_tool, mock_client
+    ):
+        """Past the per-response content budget, rows are FLAGGED not cut.
+
+        Handing back a silently-shortened payload is exactly how a resource
+        gets destroyed when an agent writes it back, so the budget must
+        never produce a partial _content value.
+        """
+        big = "q" * 200_000
+        mock_client.send_websocket_message.return_value = {
+            "result": [
+                {
+                    "id": str(i),
+                    "type": "module",
+                    "url": _data_uri_for(big + str(i), "module"),
+                }
+                for i in range(4)
+            ]
+        }
+
+        result = await list_tool(include_content=True)
+
+        emitted = [r for r in result["resources"] if "_content" in r]
+        flagged = [r for r in result["resources"] if r.get("_content_truncated")]
+        assert emitted and flagged, "expected some emitted and some flagged"
+        assert len(emitted) + len(flagged) == 4
+        # Nothing partial: every emitted value is the whole resource.
+        for row in emitted:
+            assert row["_content"].startswith(big)
+        for row in flagged:
+            assert "_content" not in row
+        assert result["content_truncated"] == len(flagged)
+        assert "limit=1" in result["content_truncation_note"]
 
 
 class TestHaConfigSetDashboardResource:
@@ -601,6 +713,116 @@ class TestHaConfigSetDashboardResource:
         assert mock_client.send_websocket_message.call_count == 1
 
     @pytest.mark.asyncio
+    async def test_short_legit_update_skips_the_preview_check(
+        self, set_tool, mock_client
+    ):
+        """Ordinary short content must not trigger the guard at all.
+
+        The guard fails closed, so matching routine short updates would
+        make them fail whenever a listing hiccups — for content that
+        cannot be a preview of anything.
+        """
+        mock_client.send_websocket_message.return_value = {"result": {"id": "existing"}}
+
+        result = await set_tool(
+            content="/* tweak */", resource_type="css", resource_id="existing"
+        )
+
+        assert result["success"] is True
+        # One call only: the update. No verification listing was needed.
+        assert mock_client.send_websocket_message.call_count == 1
+        assert (
+            mock_client.send_websocket_message.call_args[0][0]["type"]
+            == "lovelace/resources/update"
+        )
+
+    @pytest.mark.asyncio
+    async def test_preview_guard_fails_closed_when_listing_raises(
+        self, set_tool, mock_client
+    ):
+        """An unverifiable preview-shaped write is REFUSED, not allowed.
+
+        A timeout on the (now large) listing does not imply the connection
+        is dead, so the small upsert frame right after would succeed and
+        destroy the card while reporting success.
+        """
+        mock_client.send_websocket_message.side_effect = TimeoutError("no answer")
+
+        with pytest.raises(ToolError) as exc_info:
+            await set_tool(
+                content="x" * 150 + "...", resource_type="module", resource_id="res1"
+            )
+
+        error_data = json.loads(str(exc_info.value))
+        assert "could not be read back" in error_data["error"]["message"]
+        # Exactly one call — the listing. No update was attempted.
+        assert mock_client.send_websocket_message.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_preview_guard_fails_closed_on_ws_error_envelope(
+        self, set_tool, mock_client
+    ):
+        """An HA-side rejection of the listing also fails closed."""
+        mock_client.send_websocket_message.return_value = {
+            "success": False,
+            "error": {"message": "unauthorized"},
+        }
+
+        with pytest.raises(ToolError) as exc_info:
+            await set_tool(
+                content="x" * 150 + "...", resource_type="module", resource_id="res1"
+            )
+
+        assert "unauthorized" in str(exc_info.value)
+        assert mock_client.send_websocket_message.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_preview_guard_survives_malformed_listing_entries(
+        self, set_tool, mock_client
+    ):
+        """A non-dict entry must not escape as a bare AttributeError."""
+        full = "y" * 400
+        mock_client.send_websocket_message.side_effect = [
+            {
+                "result": [
+                    "not-a-dict",
+                    None,
+                    {
+                        "id": "res1",
+                        "type": "module",
+                        "url": _data_uri_for(full, "module"),
+                    },
+                ]
+            },
+            {"result": {"id": "res1"}},
+        ]
+
+        with pytest.raises(ToolError) as exc_info:
+            await set_tool(
+                content=full[:150] + "...", resource_type="module", resource_id="res1"
+            )
+
+        error_data = json.loads(str(exc_info.value))
+        assert error_data["error"]["code"] == "VALIDATION_INVALID_PARAMETER"
+
+    @pytest.mark.asyncio
+    async def test_preview_guard_catches_ellipsis_stripped_preview(
+        self, set_tool, mock_client
+    ):
+        """The guard tolerates an agent trimming the ellipsis or whitespace."""
+        full = "z" * 500
+        mock_client.send_websocket_message.return_value = {
+            "result": [
+                {"id": "res1", "type": "module", "url": _data_uri_for(full, "module")}
+            ]
+        }
+
+        with pytest.raises(ToolError):
+            await set_tool(
+                content=full[:150], resource_type="module", resource_id="res1"
+            )
+
+    @pytest.mark.asyncio
     async def test_update_allows_legit_content_shaped_like_preview(
         self, set_tool, mock_client
     ):
@@ -658,6 +880,50 @@ class TestHaConfigSetDashboardResource:
         assert error_data["success"] is False
         assert "too large" in error_data["error"]["message"].lower()
         assert "suggestions" in error_data["error"]
+
+    @pytest.mark.asyncio
+    async def test_inline_size_is_utf8_bytes_not_characters(
+        self, set_tool, mock_client
+    ):
+        """size (and the cap) are measured in UTF-8 bytes, not characters.
+
+        Every other size test uses ASCII, where the two are identical — so
+        a refactor to len(content) would pass them all while letting a
+        multibyte payload up to 4x over the cap through.
+        """
+        mock_client.send_websocket_message.return_value = {"result": {"id": "1"}}
+        content = chr(233) * 100  # 100 chars, 200 UTF-8 bytes
+
+        result = await set_tool(content=content, resource_type="module")
+
+        assert result["size"] == len(content.encode("utf-8")) == 200
+        assert result["size"] != len(content)
+
+    @pytest.mark.asyncio
+    async def test_inline_cap_counts_bytes_not_characters(self, set_tool, mock_client):
+        """Content under the cap in characters but over it in bytes is rejected."""
+        content = chr(233) * (MAX_CONTENT_SIZE // 2 + 1)  # 2 bytes each -> over
+
+        with pytest.raises(ToolError) as exc_info:
+            await set_tool(content=content, resource_type="module")
+
+        assert len(content) < MAX_CONTENT_SIZE  # would pass a character check
+        error_data = json.loads(str(exc_info.value))
+        assert "too large" in error_data["error"]["message"].lower()
+        mock_client.send_websocket_message.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_inline_cap_boundary(self, set_tool, mock_client):
+        """Exactly MAX_CONTENT_SIZE is accepted; one byte over is rejected."""
+        mock_client.send_websocket_message.return_value = {"result": {"id": "1"}}
+
+        at_cap = "x" * MAX_CONTENT_SIZE
+        result = await set_tool(content=at_cap, resource_type="module")
+        assert result["success"] is True
+        assert result["size"] == MAX_CONTENT_SIZE
+
+        with pytest.raises(ToolError):
+            await set_tool(content="x" * (MAX_CONTENT_SIZE + 1), resource_type="module")
 
     @pytest.mark.asyncio
     async def test_inline_js_type_not_supported(self, set_tool, mock_client):

--- a/tests/src/unit/test_tools_resources.py
+++ b/tests/src/unit/test_tools_resources.py
@@ -931,7 +931,8 @@ class TestConstants:
     """Test module constants."""
 
     def test_max_content_size_pinned(self):
-        """Pin the cap at the worker-era 24KB: the registered URL ships to
-        every browser on every dashboard load and auto-backup snapshots it
-        whole per edit, so raising this needs a deliberate decision."""
-        assert MAX_CONTENT_SIZE == 24000
+        """Pin the cap at 128KB — sized to fit established single-file card
+        bundles. The registered URL ships to every browser on each dashboard
+        load and auto-backup snapshots it whole per edit, so changing this
+        needs a deliberate decision."""
+        assert MAX_CONTENT_SIZE == 128_000

--- a/tests/src/unit/test_tools_resources.py
+++ b/tests/src/unit/test_tools_resources.py
@@ -501,12 +501,18 @@ class TestHaConfigListDashboardResources:
         assert result["resources"][1]["_decode_error"] is True
 
     @pytest.mark.asyncio
-    async def test_list_decodes_only_the_returned_page(
+    async def test_list_retains_content_for_the_returned_page_only(
         self, list_tool, mock_client, monkeypatch
     ):
-        """Content is materialized for the requested page only, while
-        inline_count still summarizes the full set — include_content=True
-        responses stay bounded by limit/offset."""
+        """Decoded content is RETAINED only for the requested page.
+
+        Decoding itself is whole-set on purpose (inline_count reports the
+        full registry and must agree with the per-resource markers), but
+        holding every payload would mean a limit=1 call sat on the entire
+        registry's content. This pins retention scope directly, via the
+        decode map the renderer is handed — asserting on the response
+        alone cannot distinguish the two designs.
+        """
         contents = [f"export const page_test_{i} = {i};" for i in range(3)]
         mock_client.send_websocket_message.return_value = {
             "result": [
@@ -516,10 +522,12 @@ class TestHaConfigListDashboardResources:
         }
 
         seen_page_sizes = []
+        retained_counts = []
         real_process = tools_resources._process_resource_list
 
         def _spy(page, decoded_page, include):
             seen_page_sizes.append(len(page))
+            retained_counts.append(sum(1 for d in decoded_page if d is not None))
             return real_process(page, decoded_page, include)
 
         monkeypatch.setattr(tools_resources, "_process_resource_list", _spy)
@@ -530,10 +538,33 @@ class TestHaConfigListDashboardResources:
         assert result["inline_count"] == 3
         assert len(result["resources"]) == 1
         assert result["resources"][0]["_content"] == contents[1]
-        # The probe is what actually pins the behavior: reverting to
-        # "process everything, then slice" would still satisfy the
-        # assertions above, but would hand the renderer all 3 records.
         assert seen_page_sizes == [1]
+        # The load-bearing assertion: exactly ONE decoded payload was
+        # retained, not all three. Retaining the whole registry would still
+        # satisfy every assertion above.
+        assert retained_counts == [1]
+
+    @pytest.mark.asyncio
+    async def test_summarize_retains_only_the_page_window(self):
+        """Unit-level proof of the same property, independent of the tool."""
+        rows = [
+            {
+                "id": str(i),
+                "type": "module",
+                "url": _data_uri_for(f"const x={i};", "module"),
+            }
+            for i in range(5)
+        ]
+
+        by_type, inline_count, decoded = tools_resources._summarize_resources(
+            rows, 1, 3
+        )
+
+        # Counting spans the whole registry...
+        assert by_type["module"] == 5
+        assert inline_count == 5
+        # ...while retention is confined to [1, 3).
+        assert sorted(decoded) == [1, 2]
 
     @pytest.mark.asyncio
     async def test_list_content_budget_flags_rather_than_shortens(


### PR DESCRIPTION
## What does this PR do?

Removes the Cloudflare worker dependency from inline dashboard resources. Closes #2060. `ha_config_set_dashboard_resource(content=...)` now embeds the code directly in the registered resource URL as a self-contained `data:text/javascript;base64,...` (or `data:text/css;charset=utf-8;base64,...`) URI, so dashboard JS/CSS never leaves the Home Assistant instance.

The worker existed because of #71's claim that browsers reject `data:` URIs for ES6 modules due to CORS. That claim was untested and is wrong at every layer: HA's `lovelace/resources/create` applies no URL-scheme validation (`cv.string`), HA has never shipped a CSP, and `data:` module loading is spec-mandated (WHATWG Fetch gives `data:` responses "basic" tainting, which is what module CORS-mode fetches require). Verified live on HA 2026.7 — a `data:` module custom card registers, loads, and renders — and cross-engine via WPT `/import-maps/data-url-specifiers.sub.html`: 20/20 on stable Chrome 151, Firefox 153, Safari 26.5.2, Edge 150. Working prior art: gosungrow registers `data:text/javascript;base64` Lovelace modules the same way.

- Works identically on every install method (pip, Docker, add-on) — no external service, no custom component, no filesystem access.
- URLs remain deterministic (same content → same URI), stored in HA's own `.storage/lovelace_resources` — exactly where the worker version stored them, minus the workers.dev prefix that routed every dashboard load through Cloudflare.
- `MAX_CONTENT_SIZE` raised 24KB → 128KB: the old bound was the worker's URL-path limit, which no longer exists. 128KB fits established single-file card bundles without truncation while still bounding what every dashboard load ships (the registered URL rides the Lovelace bootstrap to every browser) and what auto-backup snapshots per edit.
- Legacy worker URLs are still recognized and decoded locally (anchored to the worker origin, `validate=True`; the worker is never contacted): list shows a preview plus `_legacy_worker` and a migration hint that routes agents through `include_content=True`. Re-saving with `content=` + `resource_id` converts the resource to a `data:` URI. The worker deployment stays up, so pre-existing dashboards keep loading until converted.
- Guards added with the switch:
  - `url=` rejects `data:` URLs (any case, any media type) — now that the inline format is documented, a hand-built `data:` URL would bypass the inline validations including the #1072 YAML-misroute rejection.
  - Re-saving a resource with its own truncated 150-char list preview (`_preview` + `...`) is refused — that path would silently destroy the user's card. Normal updates pay nothing (the check only triggers on preview-shaped content).
  - Only ha-mcp's own media types are claimed as inline; foreign `data:` resources, percent-encoded forms, empty and corrupt payloads all pass through with their real URL visible.
- List summaries (`inline_count`, `by_type`) cover the full set, and decoding is whole-set on purpose: only a real decode distinguishes a genuine inline resource from a corrupt payload that merely looks like one, so the count and the per-resource `_inline` markers come from the same pass. Decoded content is **retained and rendered for the returned page only**, so neither the response nor the retained payloads scale with registry size. `include_content=True` responses are additionally bounded by a per-response byte budget.
- Inline content must be self-contained — relative module imports and relative CSS `url()` references cannot resolve against a `data:` base (documented; the worker had the same limitation). JS errors attribute to the `data:` URI itself, so stack traces are ugly but functional.
- Deployment note: a reverse proxy that injects a CSP like `script-src 'self' https:` would have allowed the worker URL but blocks `data:` scripts — the tool reports success and the card silently doesn't load. HA itself ships no CSP.
- e2e proves the stored registry URL is byte-identical `data:` content via the raw WS API on every backend (no component dependency, no skips), and covers the legacy→`data:` migration path including the URL-safe/standard base64 alphabet distinction.

## Type of change
- [x] ✨ New feature

## Testing
- [x] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

## Checklist
- [x] I have updated documentation if needed

