### PR TITLE
docs: pin mcp<2.0.0 in the mcp-proxy configs we generate

### DIFF
--- a/homeassistant-addon/DOCS.md
+++ b/homeassistant-addon/DOCS.md
@@ -73,7 +73,7 @@ Then add to your Claude Desktop configuration file:
   "mcpServers": {
     "home-assistant": {
       "command": "uvx",
-      "args": ["mcp-proxy", "--transport", "streamablehttp", "http://192.168.1.100:9583/private_zctpwlX7ZkIAr7oqdfLPxw"]
+      "args": ["--with", "mcp<2.0.0", "mcp-proxy", "--transport", "streamablehttp", "http://192.168.1.100:9583/private_zctpwlX7ZkIAr7oqdfLPxw"]
     }
   }
 }
@@ -84,6 +84,8 @@ Replace the URL in `args` with the one from your add-on logs. No token goes here
 **Restart Claude Desktop** after saving the configuration.
 
 **How it works:** `uvx` runs mcp-proxy, which converts the add-on's HTTP endpoint to the stdio Claude Desktop expects.
+
+**Why `--with "mcp<2.0.0"`:** it pins the MCP SDK below version 2, which mcp-proxy does not yet support. Without the pin, mcp-proxy fails to start with `ImportError: cannot import name 'request_ctx'` and Claude Desktop shows "Server disconnected" ([#2073](https://github.com/homeassistant-ai/ha-mcp/issues/2073)).
 
 </details>
 

--- a/site/src/pages/faq.astro
+++ b/site/src/pages/faq.astro
@@ -216,6 +216,32 @@ uvx --from=ha-mcp@latest ha-mcp-oauth</code></pre>
           </ol>
         </div>
 
+        <div class="faq-item" id="mcp-proxy-request-ctx">
+          <h3 class="text-lg font-medium text-white mb-2">mcp-proxy fails with <code class="bg-slate-800 px-1 rounded">ImportError: cannot import name 'request_ctx'</code></h3>
+          <p class="text-slate-300 mb-3">A previously working <code class="bg-slate-800 px-1 rounded">uvx mcp-proxy</code> config stops connecting and the client shows "Server disconnected". Running the command by hand shows:</p>
+          <pre class="code-block mb-3"><code>from mcp.server.lowlevel.server import request_ctx
+ImportError: cannot import name 'request_ctx' from 'mcp.server.lowlevel.server'</code></pre>
+          <p class="text-slate-300 mb-3"><strong class="text-white">Cause:</strong> the <code class="bg-slate-800 px-1 rounded">mcp</code> SDK released version 2.0.0, which removed <code class="bg-slate-800 px-1 rounded">request_ctx</code>. mcp-proxy depends on <code class="bg-slate-800 px-1 rounded">mcp</code> without an upper version bound, so <code class="bg-slate-800 px-1 rounded">uvx</code> installs the incompatible 2.x release. Clearing the uv cache does not help — a fresh install picks the same version.</p>
+          <p class="text-slate-300 mb-3">This only affects clients that reach an HTTP ha-mcp deployment through the mcp-proxy bridge (Claude Desktop and JetBrains). The local stdio setup — <code class="bg-slate-800 px-1 rounded">uvx ha-mcp@latest</code> — is unaffected, and so are the add-on, Docker, and the custom component themselves: ha-mcp already pins the SDK below 2.0.</p>
+          <p class="text-slate-300 mb-2"><strong class="text-white">Fix:</strong> pin the SDK in the mcp-proxy config's <code class="bg-slate-800 px-1 rounded">args</code>. <code class="bg-slate-800 px-1 rounded">--with</code> is a global <code class="bg-slate-800 px-1 rounded">uv</code> option, so it must come <em>before</em> the package name:</p>
+          <pre class="code-block"><code>{`{
+  "mcpServers": {
+    "home-assistant": {
+      "command": "uvx",
+      "args": [
+        "--with",
+        "mcp<2.0.0",
+        "mcp-proxy",
+        "--transport",
+        "streamablehttp",
+        "http://192.168.1.100:9583/private_your_secret_path"
+      ]
+    }
+  }
+}`}</code></pre>
+          <p class="text-slate-400 text-sm mt-3">Restart the client after saving. The <a href={withBase('/setup')} class="text-blue-400 hover:underline">Setup Wizard</a> now generates this pin automatically — existing configs written before it need the two <code class="bg-slate-800 px-1 rounded">args</code> entries added by hand. See <a href="https://github.com/homeassistant-ai/ha-mcp/issues/2073" class="text-blue-400 hover:underline" target="_blank" rel="noopener noreferrer">#2073</a>.</p>
+        </div>
+
         <div class="faq-item" id="uv-tls-interception">
           <h3 class="text-lg font-medium text-white mb-2">uvx fails with <code class="bg-slate-800 px-1 rounded">invalid peer certificate: UnknownIssuer</code></h3>
           <p class="text-slate-300 mb-3">If <code class="bg-slate-800 px-1 rounded">uvx</code> can't download ha-mcp (or <code class="bg-slate-800 px-1 rounded">mcp-proxy</code>, if you connect to the app through it) and the log shows a certificate error fetching from PyPI, the failure is in <code class="bg-slate-800 px-1 rounded">uv</code>'s package download — it never reaches Home Assistant:</p>

--- a/site/src/pages/guide-addon.astro
+++ b/site/src/pages/guide-addon.astro
@@ -102,6 +102,8 @@ winget install --id=astral-sh.uv -e</code></pre>
     "home-assistant": {
       "command": "uvx",
       "args": [
+        "--with",
+        "mcp<2.0.0",
         "mcp-proxy",
         "--transport",
         "streamablehttp",
@@ -110,6 +112,7 @@ winget install --id=astral-sh.uv -e</code></pre>
     }
   }
 }`}</code></pre>
+          <p class="text-slate-400 text-sm mt-3">The <code class="bg-slate-800 px-1 rounded">--with "mcp&lt;2.0.0"</code> entry pins the MCP SDK below version 2, which mcp-proxy does not yet support. Without it, mcp-proxy fails to start with <code class="bg-slate-800 px-1 rounded">ImportError: cannot import name 'request_ctx'</code> and the client shows "Server disconnected". See <a href="https://github.com/homeassistant-ai/ha-mcp/issues/2073" class="text-blue-400 hover:underline" target="_blank" rel="noopener noreferrer">#2073</a>.</p>
           <div class="bg-amber-900/20 border border-amber-700/50 rounded-xl p-4 mt-4">
             <p class="text-amber-200/90 text-sm"><strong class="text-amber-300">No token goes here.</strong> The app already handles authentication behind the secret path in the URL. Do <strong>not</strong> add <code class="bg-slate-800 px-1 rounded">HOMEASSISTANT_URL</code>, <code class="bg-slate-800 px-1 rounded">HOMEASSISTANT_TOKEN</code>, or an <code class="bg-slate-800 px-1 rounded">env</code> block &mdash; that is the local/stdio config, and pasting it alongside the app is a known cause of connection hangs.</p>
           </div>

--- a/site/src/pages/setup.astro
+++ b/site/src/pages/setup.astro
@@ -1787,7 +1787,8 @@ ingress:
       const mcpProxyInstr = `<div class="instruction-block border-yellow-700/50 bg-yellow-900/10">
         <h3 class="instruction-title text-yellow-300">mcp-proxy Required</h3>
         <p class="text-slate-300 mb-2">${state.client.name} only supports stdio. Use mcp-proxy to connect to HTTP servers:</p>
-        <pre class="code-block"><code># mcp-proxy is run automatically via uvx in the config below</code></pre>${brewNote}
+        <pre class="code-block"><code># mcp-proxy is run automatically via uvx in the config below</code></pre>
+        <p class="text-xs text-slate-400 mt-2">The config below pins <code>mcp&lt;2.0.0</code>. mcp-proxy is not yet compatible with version 2 of the MCP SDK, and without the pin it fails to start with <code>ImportError: cannot import name 'request_ctx'</code>.</p>${brewNote}
       </div>`;
       instructions.push(mcpProxyInstr);
     }
@@ -1939,11 +1940,18 @@ ingress:
             }
           }, null, 2);
         } else {
+          // `--with "mcp<2.0.0"` pins the MCP SDK below 2.0. mcp-proxy 0.12.0
+          // declares an unbounded `mcp>=1.27.1` but imports `request_ctx` from
+          // `mcp.server.lowlevel.server`, which mcp 2.0.0 removed — so an
+          // unconstrained `uvx mcp-proxy` resolves 2.x and dies on an
+          // ImportError before it ever connects (#2073). `--with` is a global
+          // uvx option, so it must precede the package name. Drop the pin once
+          // mcp-proxy ships an mcp 2.x-compatible release.
           config = JSON.stringify({
             mcpServers: {
               "home-assistant": {
                 command: "uvx",
-                args: ["mcp-proxy", "--transport", "streamablehttp", mcpUrl]
+                args: ["--with", "mcp<2.0.0", "mcp-proxy", "--transport", "streamablehttp", mcpUrl]
               }
             }
           }, null, 2);

--- a/tests/src/unit/test_astro_setup_js_behavior.py
+++ b/tests/src/unit/test_astro_setup_js_behavior.py
@@ -531,6 +531,69 @@ class TestPerClientInstructionTemplate:
         )
 
 
+class TestMcpProxySdkPin:
+    """The generated mcp-proxy config must pin the MCP SDK below 2.0.
+
+    mcp-proxy imports ``request_ctx`` from ``mcp.server.lowlevel.server``
+    but declares an unbounded ``mcp>=`` dependency, so an unconstrained
+    ``uvx mcp-proxy`` resolves mcp 2.x and dies on an ImportError before
+    it ever connects (#2073). ``--with`` is a *global* uvx option, so
+    dropping it after the package name silently stops constraining
+    anything — hence the ordering assertion.
+
+    Every stdio-only client that goes through the bridge is covered:
+    Zed is excluded because it takes the URL directly.
+    """
+
+    @pytest.mark.parametrize("client_id", ["claude-desktop", "jetbrains"])
+    def test_generated_config_pins_mcp_below_2(
+        self,
+        client_id: str,
+        setup_script: str,
+        prelude: str,
+        wizard_vars: dict[str, Any],
+    ) -> None:
+        assert client_id in wizard_vars["stdioOnlyClients"], (
+            f"test premise: {client_id!r} must be a stdio-only client"
+        )
+        result = run_script(
+            setup_script,
+            prelude=prelude,
+            initial_html=_build_wizard_dom(wizard_vars),
+            invoke=(
+                _click("server-method", "ha-addon")
+                + _click("client", client_id)
+                + _click("scope", "local")
+                + _click("platform", "macos")
+                + "document.body.dataset.configCode = "
+                "document.querySelector('#config-output code').textContent || '';\n"
+            ),
+        )
+        _assert_clean_init(result)
+        match = re.search(r'data-config-code="([^"]*)"', result.dom)
+        assert match is not None, "config-output was not captured"
+        # The capture round-trips through an HTML attribute, so `"` in the
+        # emitted JSON comes back as `&quot;`. Parse the args out of the
+        # unescaped text rather than substring-matching quoted fragments.
+        config = json.loads(match.group(1).replace("&quot;", '"'))
+        args = config["mcpServers"]["home-assistant"]["args"]
+
+        assert "mcp-proxy" in args, f"{client_id}: not an mcp-proxy config: {args}"
+        assert "--with" in args, (
+            f"{client_id}: mcp-proxy config does not pin the MCP SDK — an "
+            f"unconstrained uvx resolves mcp 2.x and fails on ImportError "
+            f"(#2073); args={args}"
+        )
+        assert args[args.index("--with") + 1] == "mcp<2.0.0", (
+            f"{client_id}: --with must be followed by the mcp<2.0.0 "
+            f"constraint; args={args}"
+        )
+        assert args.index("--with") < args.index("mcp-proxy"), (
+            f"{client_id}: --with is a global uv option and must precede the "
+            f"package name, otherwise it constrains nothing; args={args}"
+        )
+
+
 # ---------------------------------------------------------------------------
 # Remote-path tile filtering (updateSections -> remotePathsForMethod)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

Fixes #2073.

`mcp` 2.0.0 was released on 2026-07-28 and removed `request_ctx` from
`mcp.server.lowlevel.server`. `mcp-proxy` 0.12.0 imports that symbol directly and
declares an unbounded `mcp>=1.27.1`, so an unconstrained `uvx mcp-proxy` now
resolves 2.x and dies on `ImportError: cannot import name 'request_ctx'` before it
ever connects. Every mcp-proxy config this repo generates was unconstrained.

Adds `--with "mcp<2.0.0"` to the three places we emit that config:

- `site/src/pages/setup.astro` — the Setup Wizard's generated client config
- `site/src/pages/guide-addon.astro` — the add-on guide's Claude Desktop config
- `homeassistant-addon/DOCS.md` — the add-on's own docs

`--with` is a global `uv` option, so it precedes the package name (same placement
rule as `--native-tls` in #1506).

Also adds an FAQ entry (`#mcp-proxy-request-ctx`), because users whose configs
were written before this change won't re-run the wizard and need to add the two
`args` entries by hand.

**Scope of the breakage:** only clients that reach an HTTP deployment through the
bridge — Claude Desktop and JetBrains. It applies to every HTTP method (custom
component, add-on, Docker, `ha-mcp-web`, the app) and to both local and remote
scope, since `needsMcpProxy` keys off the client alone. Zed is stdio-only but
takes the URL directly, so it is unaffected.

**ha-mcp itself is not affected.** `fastmcp==3.4.4` depends on
`fastmcp-slim[client,server]`, which declares `mcp<2.0,>=1.24.0`. Verified: a
clean `fastmcp==3.4.4` environment resolves `mcp 1.29.0`. The Webhook Proxy
add-on is also unaffected — it has no `mcp` SDK dependency at all (no pip install
in its `Dockerfile`, no `requirements` in its `manifest.json`).

**Verification:** reproduced the `ImportError` with `uvx mcp-proxy --help`, and
confirmed `uvx --with "mcp<2.0.0" mcp-proxy --help` runs clean.

The pin should be dropped once mcp-proxy ships an mcp 2.x-compatible release; a
comment at the wizard emit site says so.

## Type of change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [x] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [ ] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

New `TestMcpProxySdkPin` asserts the constraint is present, has the right value,
and precedes the package name. It fails against the unpinned config and passes
with the fix, for both `claude-desktop` and `jetbrains`.

## Checklist
- [x] I have updated documentation if needed
