### PR TITLE
refactor(internal): drop two orphaned locale keys and pin the direction that let them in

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -722,9 +722,10 @@ That list of codes is itself pinned by
 code here, in the same PR, or the suite goes red.
 
 Settings UI catalogs are auto-discovered (no registration). Their `messages` may
-omit keys — English is the per-key fallback — but `tool_groups` and `tools` may
-not: each locale must carry exactly the renderable group headings and every tool
-name, no key more and none fewer. **Adding a tool therefore means translating it
+omit keys — English is the per-key fallback — but may not carry one `en.json`
+lacks: nothing renders it. `tool_groups` and `tools` may do neither: each locale
+must carry exactly the renderable group headings and every tool name, no key
+more and none fewer. **Adding a tool therefore means translating it
 in every locale, in the PR that adds it**: the check derives the tool set from
 the sources (`scripts/extract_tools.py`), not from the committed
 `site/src/data/tools.json` that `sync-tool-docs.yml` regenerates only after

--- a/src/ha_mcp/settings_ui/locales/es.json
+++ b/src/ha_mcp/settings_ui/locales/es.json
@@ -373,8 +373,6 @@
     "advanced.verify_ssl.help": "Desactiva la verificación TLS solo en redes de confianza. Hay que reiniciar.",
     "advanced.fuzzy_threshold.label": "Umbral de la búsqueda difusa",
     "advanced.fuzzy_threshold.help": "Los valores más bajos permiten una coincidencia de entidades más laxa. Rango 0–100.",
-    "advanced.entity_search_limit.label": "Límite de resultados de la búsqueda de entidades",
-    "advanced.entity_search_limit.help": "Número máximo de entidades que devuelve ha_search_entities. Rango 1–1000.",
     "advanced.automation_config_time_budget.label": "Presupuesto de tiempo para la configuración de automatizaciones (s)",
     "advanced.automation_config_time_budget.help": "Tiempo máximo que la búsqueda profunda dedica a obtener configuraciones de automatizaciones. Rango 1–600. Hay que reiniciar.",
     "advanced.script_config_time_budget.label": "Presupuesto de tiempo para la configuración de scripts (s)",

--- a/src/ha_mcp/settings_ui/locales/it.json
+++ b/src/ha_mcp/settings_ui/locales/it.json
@@ -373,8 +373,6 @@
     "advanced.verify_ssl.help": "Disattiva la verifica TLS solo su reti fidate. È necessario il riavvio.",
     "advanced.fuzzy_threshold.label": "Soglia della ricerca approssimata",
     "advanced.fuzzy_threshold.help": "Valori più bassi rendono più permissiva la corrispondenza delle entità. Intervallo 0–100.",
-    "advanced.entity_search_limit.label": "Limite dei risultati nella ricerca delle entità",
-    "advanced.entity_search_limit.help": "Numero massimo di entità restituite da ha_search_entities. Intervallo 1–1000.",
     "advanced.automation_config_time_budget.label": "Tempo massimo per le configurazioni delle automazioni (s)",
     "advanced.automation_config_time_budget.help": "Tempo massimo che la ricerca approfondita dedica al recupero delle configurazioni delle automazioni. Intervallo 1–600. È necessario il riavvio.",
     "advanced.script_config_time_budget.label": "Tempo massimo per le configurazioni degli script (s)",

--- a/tests/src/unit/test_locale_parity.py
+++ b/tests/src/unit/test_locale_parity.py
@@ -1077,6 +1077,36 @@ def test_settings_catalog_keys_name_real_groups_and_tools(locale: str) -> None:
     )
 
 
+@pytest.mark.parametrize("locale", _non_english_settings_locales())
+def test_settings_messages_carry_no_key_english_dropped(locale: str) -> None:
+    """The one direction nothing else here looks in.
+
+    ``messages`` may omit keys — English is the per-key fallback, and AGENTS.md
+    states the allowance — so this asserts the other direction only. A key with
+    no English counterpart is not a fallback, it is text that reaches nobody:
+    ``build_payload`` ships it and ``t()`` never asks for it.
+
+    #2043 removed ``advanced.entity_search_limit.label`` and ``.help`` from
+    ``en`` and from the five catalogs it knew about, and two got past it by
+    different routes — ``es`` was not one of the five, and ``it`` was written
+    against the older English source and rebased past the removal. Neither
+    failed anything: the ceilings count English keys a locale is missing, and
+    the baseline hashes English sources only, so a key English does not have is
+    outside both. The sibling sections have had this covered all along, by
+    ``test_settings_catalog_keys_name_real_groups_and_tools``; the component
+    and add-on surfaces by their own key checks.
+    """
+    english = set(_settings_catalog("en")["messages"])
+    orphaned = sorted(set(_settings_catalog(locale)["messages"]) - english)
+
+    assert not orphaned, (
+        f"src/ha_mcp/settings_ui/locales/{locale}.json translates message "
+        f"key(s) en.json does not have: {orphaned}. Nothing renders them — "
+        "delete them, or restore the English key if it went missing by "
+        "mistake."
+    )
+
+
 # A catalog wholesale-copied from English passes key parity, placeholder
 # parity and the markup allowlist — every existing check. All four surfaces
 # get a ceiling: leaving one of them out accepts a wholesale-English catalog
@@ -1084,7 +1114,7 @@ def test_settings_catalog_keys_name_real_groups_and_tools(locale: str) -> None:
 #
 # The ceilings differ because what legitimately repeats differs. The settings
 # UI messages sit far under theirs: the highest among the shipped locales is 9
-# of 421 (2.1%), all words that genuinely read the same in that language. The
+# of 419 (2.1%), all words that genuinely read the same in that language. The
 # component catalogs are short and carry the product names as keys of their
 # own, so ``de``'s 7 of 93 (7.5%) — six product names plus ``Update`` — is
 # correct and the ceiling has to clear it. Both add-on flavors translate


### PR DESCRIPTION
## What does this PR do?

`es.json` and `it.json` each carried `advanced.entity_search_limit.label` and
`.help`, which `en.json` has not had since #2043. This deletes all four and adds
the check that would have caught them.

They got in by two different routes. #2043 removed the pair from `en`, `de`,
`fr`, `ru`, `zh-Hans` and the baseline; `es` was already merged and was not one
of the catalogs that PR knew about, so it kept them. `it` was written against
the older English source and rebased past the removal while its PR was open.
Neither failed anything.

Nothing failed because every key check here runs the other way. The ceilings
count English keys a locale is *missing*, and the baseline hashes English
sources only, so a key with no English counterpart is outside both. Nothing
renders such a key either: `build_payload` ships it and `t()` never asks for
it, since every lookup goes through a key `en.json` declares.

The new test asserts the orphan direction on the settings UI `messages`
section, and AGENTS.md gains the matching half-sentence. Scope is deliberately
that narrow:

- **The missing direction is not asserted.** `messages` may omit keys — English
  is the per-key fallback, and AGENTS.md states the allowance — so asserting it
  would forbid something the contract permits. A wholesale omission is already
  covered as a share by the 5% ceiling.
- **The other three surfaces are not touched.** `tool_groups` and `tools` are
  pinned in both directions against the parsed tool set by
  `test_settings_catalog_keys_name_real_groups_and_tools`, the component
  catalogs have their own key check, and
  `tests/addon/test_addon_structure.py::test_translations_cover_every_schema_key`
  already rejects a `configuration.<key>` the schema no longer declares. Adding
  them here would have been a second check of the same thing.

Also corrects the ceiling comment's denominator, which #2043 left saying 421
when it took `en.json` down to 419. `_assert_not_a_copy` divides by
`len(english)`, so the code had been computing over 419 the whole time.

## Type of change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [x] 📚 Documentation
- [x] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [ ] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

`tests/src/unit/test_locale_parity.py` (77) and
`tests/src/unit/test_settings_ui_i18n.py` (31) both pass; I ran those two
modules rather than the full suite and left the box above unticked for that
reason. `ruff check` and `ruff format --check` are clean at the version
`uv.lock` pins (0.16.0). `mypy` reports the two import-resolution errors this
file already has on master, on lines my diff does not reach.

Three injections against the test as it ships here, each reverted:

| Injection | Expected | Result |
|---|---|---|
| Put both dead keys back | red | 2 failed (`es`, `it`) |
| Give `it` one key `en` lacks | only `it` red | 1 failed (`it`) |
| Have `fr` omit a key `en` has | **green** — the allowance | 30 passed |

The last one is the one that decides the scope: it fails if the test
over-reaches into the omission the contract permits.

## Checklist
- [x] I have updated documentation if needed
