### PR TITLE
docs: self-host the README star history chart

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,13 +4,14 @@ on:
   push:
     branches: [master]
     paths:
+      - '.github/workflows/deploy.yml'
+      - 'scripts/generate_star_history.py'
       - 'site/**'
+  schedule:
+    - cron: '17 3 * * 0'
   workflow_dispatch:
 
-permissions:
-  contents: read
-  pages: write
-  id-token: write
+permissions: {}
 
 concurrency:
   group: "pages"
@@ -18,6 +19,8 @@ concurrency:
 
 jobs:
   build:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -26,15 +29,20 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
 
+      - name: Generate star history charts
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: >-
+          python3 ../scripts/generate_star_history.py
+          --repository "${{ github.repository }}"
+          --output-dir public/star-history
+
       - name: Setup Node
         uses: actions/setup-node@v7
         with:
           node-version: "22"
           cache: npm
           cache-dependency-path: site/package-lock.json
-
-      - name: Setup Pages
-        uses: actions/configure-pages@v6
 
       - name: Install dependencies
         run: npm ci
@@ -48,6 +56,9 @@ jobs:
           path: ./site/dist
 
   deploy:
+    permissions:
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/README.md
+++ b/README.md
@@ -480,10 +480,8 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 
 ## Star History
 
-<a href="https://www.star-history.com/?repos=homeassistant-ai%2Fha-mcp&type=date&legend=top-left">
- <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=homeassistant-ai/ha-mcp&type=date&theme=dark&legend=top-left&sealed_token=Q-MH9ocwRsHw_ar_hpfqQEnHbimdgmBpCS-8O_-4kCHhPgcUTlHh2QCnrPdgMt7pFh8zKHdRBvEGddVGTIhwxt29vMsHu2oc-bBuqP5f8CVgx8ZyupZc5sbxxQ2LFh8HBDKKCzMPHMYr9ciMSBPCBFwHR8c0p_Gol1wb2FyDeKuZ_73XyWAXhvEZypvy" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=homeassistant-ai/ha-mcp&type=date&legend=top-left&sealed_token=Q-MH9ocwRsHw_ar_hpfqQEnHbimdgmBpCS-8O_-4kCHhPgcUTlHh2QCnrPdgMt7pFh8zKHdRBvEGddVGTIhwxt29vMsHu2oc-bBuqP5f8CVgx8ZyupZc5sbxxQ2LFh8HBDKKCzMPHMYr9ciMSBPCBFwHR8c0p_Gol1wb2FyDeKuZ_73XyWAXhvEZypvy" />
-   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=homeassistant-ai/ha-mcp&type=date&legend=top-left&sealed_token=Q-MH9ocwRsHw_ar_hpfqQEnHbimdgmBpCS-8O_-4kCHhPgcUTlHh2QCnrPdgMt7pFh8zKHdRBvEGddVGTIhwxt29vMsHu2oc-bBuqP5f8CVgx8ZyupZc5sbxxQ2LFh8HBDKKCzMPHMYr9ciMSBPCBFwHR8c0p_Gol1wb2FyDeKuZ_73XyWAXhvEZypvy" />
- </picture>
-</a>
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="https://homeassistant-ai.github.io/ha-mcp/star-history/dark.svg" />
+  <source media="(prefers-color-scheme: light)" srcset="https://homeassistant-ai.github.io/ha-mcp/star-history/light.svg" />
+  <img alt="Star history chart for homeassistant-ai/ha-mcp" src="https://homeassistant-ai.github.io/ha-mcp/star-history/light.svg" />
+</picture>

--- a/scripts/generate_star_history.py
+++ b/scripts/generate_star_history.py
@@ -1,0 +1,438 @@
+#!/usr/bin/env python3
+"""Generate privacy-preserving star-history SVGs for the project website."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+import sys
+from collections import Counter
+from collections.abc import Callable, Iterable, Sequence
+from datetime import UTC, date, datetime, timedelta
+from html import escape
+from itertools import pairwise
+from pathlib import Path
+from typing import Any, NamedTuple
+from urllib.error import HTTPError, URLError
+from urllib.parse import quote
+from urllib.request import Request, urlopen
+
+API_VERSION = "2022-11-28"
+DEFAULT_REPOSITORY = "homeassistant-ai/ha-mcp"
+DEFAULT_OUTPUT_DIR = Path("site/public/star-history")
+DEFAULT_START_ON = date(2026, 1, 1)
+WIDTH = 960
+HEIGHT = 520
+PLOT_LEFT = 82
+PLOT_RIGHT = 900
+PLOT_TOP = 154
+PLOT_BOTTOM = 432
+
+
+class DailyPoint(NamedTuple):
+    day: date
+    stars: int
+
+
+class StarHistory(NamedTuple):
+    repository: str
+    generated_on: date
+    points: tuple[DailyPoint, ...]
+
+    @property
+    def total(self) -> int:
+        return self.points[-1].stars
+
+    @property
+    def started_on(self) -> date:
+        return self.points[0].day
+
+
+class Theme(NamedTuple):
+    surface: str
+    plot_surface: str
+    text: str
+    secondary_text: str
+    muted_text: str
+    grid: str
+    border: str
+    accent: str
+    accent_end: str
+
+
+LINE_WIDTH = 3.2
+AREA_OPACITY = 0.16
+THEMES = {
+    "light": Theme(
+        "#EFF9FE",
+        "#FFFFFF",
+        "#001721",
+        "#004156",
+        "#4A6B75",
+        "#DFF3FC",
+        "#B9E6FC",
+        "#009AC7",
+        "#2FC1CF",
+    ),
+    "dark": Theme(
+        "#001721",
+        "#002E3E",
+        "#EFF9FE",
+        "#B9E6FC",
+        "#7BD4FB",
+        "#004156",
+        "#006787",
+        "#009AC7",
+        "#2FC1CF",
+    ),
+}
+
+
+def _api_url(repository: str, page: int) -> str:
+    owner, separator, name = repository.partition("/")
+    if not separator or not owner or not name or "/" in name:
+        raise ValueError("repository must use the OWNER/REPO format")
+    return (
+        "https://api.github.com/repos/"
+        f"{quote(owner, safe='')}/{quote(name, safe='')}/stargazers"
+        f"?per_page=100&page={page}"
+    )
+
+
+def fetch_starred_at(
+    repository: str,
+    token: str,
+    *,
+    opener: Callable[..., Any] = urlopen,
+) -> list[datetime]:
+    """Fetch timestamped stars while retaining no account identity fields."""
+    if not token:
+        raise ValueError("GITHUB_TOKEN or GH_TOKEN is required")
+
+    starred_at: list[datetime] = []
+    page = 1
+    while True:
+        request = Request(
+            _api_url(repository, page),
+            headers={
+                "Accept": "application/vnd.github.star+json",
+                "Authorization": f"Bearer {token}",
+                "User-Agent": "ha-mcp-star-history",
+                "X-GitHub-Api-Version": API_VERSION,
+            },
+        )
+        try:
+            with opener(request, timeout=30) as response:
+                payload = json.load(response)
+        except HTTPError as err:
+            detail = err.read().decode("utf-8", errors="replace")
+            raise RuntimeError(
+                f"GitHub stargazers request failed with HTTP {err.code}: {detail}"
+            ) from err
+        except URLError as err:
+            raise RuntimeError(f"GitHub stargazers request failed: {err.reason}") from err
+
+        if not isinstance(payload, list):
+            raise RuntimeError("GitHub stargazers response was not a list")
+        for item in payload:
+            if not isinstance(item, dict) or not isinstance(
+                item.get("starred_at"), str
+            ):
+                raise RuntimeError("GitHub response omitted a starred_at timestamp")
+            starred_at.append(_parse_timestamp(item["starred_at"]))
+
+        if len(payload) < 100:
+            return starred_at
+        page += 1
+
+
+def _parse_timestamp(value: str) -> datetime:
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as err:
+        raise RuntimeError(f"Invalid GitHub starred_at timestamp: {value!r}") from err
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=UTC)
+    return parsed.astimezone(UTC)
+
+
+def aggregate_daily(
+    repository: str,
+    timestamps: Iterable[datetime],
+    *,
+    generated_on: date | None = None,
+) -> StarHistory:
+    """Aggregate timestamps into cumulative daily totals."""
+    counts = Counter(timestamp.astimezone(UTC).date() for timestamp in timestamps)
+    if not counts:
+        raise ValueError("at least one stargazer timestamp is required")
+
+    last_star_day = max(counts)
+    end = generated_on or datetime.now(tz=UTC).date()
+    if end < last_star_day:
+        raise ValueError("generated_on cannot precede the latest star")
+
+    current = min(counts)
+    cumulative = 0
+    points: list[DailyPoint] = []
+    while current <= end:
+        cumulative += counts[current]
+        points.append(DailyPoint(current, cumulative))
+        current += timedelta(days=1)
+    return StarHistory(repository, end, tuple(points))
+
+
+def _nice_ticks(total: int) -> tuple[int, list[int]]:
+    rough_step = max(total / 4, 1)
+    magnitude = 10 ** math.floor(math.log10(rough_step))
+    normalized = rough_step / magnitude
+    step_factor = min((1, 2, 2.5, 5, 10), key=lambda value: abs(value - normalized))
+    step = max(1, int(step_factor * magnitude))
+    maximum = math.ceil(total / step) * step
+    ticks = list(range(0, maximum + step, step))
+    return maximum, ticks
+
+
+def _format_count(value: int) -> str:
+    return f"{value:,}"
+
+
+def _compact_count(value: int) -> str:
+    if value < 1_000:
+        return str(value)
+    if value < 10_000:
+        return f"{value / 1_000:.1f}K".replace(".0K", "K")
+    return f"{round(value / 1_000):.0f}K"
+
+
+def _coordinates(
+    history: StarHistory, maximum: int
+) -> tuple[list[tuple[float, float]], Callable[[date], float]]:
+    span_days = max((history.generated_on - history.started_on).days, 1)
+
+    def x_for(day: date) -> float:
+        ratio = (day - history.started_on).days / span_days
+        return PLOT_LEFT + ratio * (PLOT_RIGHT - PLOT_LEFT)
+
+    coordinates = [
+        (
+            x_for(point.day),
+            PLOT_BOTTOM
+            - (point.stars / maximum) * (PLOT_BOTTOM - PLOT_TOP),
+        )
+        for point in history.points
+    ]
+    return coordinates, x_for
+
+
+def _monotone_tangents(
+    coordinates: Sequence[tuple[float, float]],
+) -> list[float]:
+    slopes = [
+        (next_y - y) / (next_x - x)
+        for (x, y), (next_x, next_y) in pairwise(coordinates)
+    ]
+    tangents = [slopes[0]]
+    for previous, following in pairwise(slopes):
+        tangents.append(0.0 if previous * following <= 0 else (previous + following) / 2)
+    tangents.append(slopes[-1])
+
+    for index, slope in enumerate(slopes):
+        if slope == 0:
+            tangents[index] = 0.0
+            tangents[index + 1] = 0.0
+            continue
+        alpha = tangents[index] / slope
+        beta = tangents[index + 1] / slope
+        magnitude = alpha * alpha + beta * beta
+        if magnitude > 9:
+            scale = 3 / math.sqrt(magnitude)
+            tangents[index] = scale * alpha * slope
+            tangents[index + 1] = scale * beta * slope
+    return tangents
+
+
+def _line_path(coordinates: Sequence[tuple[float, float]]) -> str:
+    first_x, first_y = coordinates[0]
+    commands = [f"M {first_x:.2f} {first_y:.2f}"]
+    if len(coordinates) == 1:
+        return commands[0]
+
+    tangents = _monotone_tangents(coordinates)
+    for index, ((x, y), (next_x, next_y)) in enumerate(pairwise(coordinates)):
+        width = next_x - x
+        control_1_x = x + width / 3
+        control_1_y = y + tangents[index] * width / 3
+        control_2_x = next_x - width / 3
+        control_2_y = next_y - tangents[index + 1] * width / 3
+        commands.append(
+            f"C {control_1_x:.2f} {control_1_y:.2f} "
+            f"{control_2_x:.2f} {control_2_y:.2f} "
+            f"{next_x:.2f} {next_y:.2f}"
+        )
+    return " ".join(commands)
+
+
+def _window_history(history: StarHistory, start_on: date) -> StarHistory:
+    points = tuple(point for point in history.points if point.day >= start_on)
+    if not points:
+        raise ValueError("chart start date must not follow generated_on")
+    return StarHistory(history.repository, history.generated_on, points)
+
+
+def _date_ticks(history: StarHistory, count: int = 5) -> list[date]:
+    span = (history.generated_on - history.started_on).days
+    return [
+        history.started_on + timedelta(days=round(span * index / (count - 1)))
+        for index in range(count)
+    ]
+
+
+def _header_svg(theme: Theme, history: StarHistory) -> str:
+    return f"""
+  <text x="82" y="58" fill="{theme.muted_text}" font-size="12" font-weight="650" letter-spacing="1.1">COMMUNITY GROWTH</text>
+  <text x="82" y="91" fill="{theme.text}" font-size="28" font-weight="700">Star history</text>
+  <text x="900" y="65" fill="{theme.text}" font-size="36" font-weight="720" text-anchor="end">{_format_count(history.total)}</text>
+  <text x="900" y="91" fill="{theme.secondary_text}" font-size="13" text-anchor="end">{escape(history.repository)}</text>"""
+
+
+def render_svg(
+    history: StarHistory,
+    mode: str,
+    *,
+    start_on: date = DEFAULT_START_ON,
+) -> str:
+    """Render one standalone, accessible star-history SVG."""
+    history = _window_history(history, start_on)
+    try:
+        theme = THEMES[mode]
+    except KeyError as err:
+        raise ValueError("mode must be 'light' or 'dark'") from err
+
+    maximum, y_ticks = _nice_ticks(history.total)
+    coordinates, x_for = _coordinates(history, maximum)
+    path = _line_path(coordinates)
+    area = (
+        f"{path} L {coordinates[-1][0]:.2f} {PLOT_BOTTOM} "
+        f"L {coordinates[0][0]:.2f} {PLOT_BOTTOM} Z"
+    )
+    gradient_id = f"area-{mode}"
+    line_gradient_id = f"line-{mode}"
+
+    horizontal_grid = []
+    for tick in y_ticks:
+        y = PLOT_BOTTOM - (tick / maximum) * (PLOT_BOTTOM - PLOT_TOP)
+        horizontal_grid.append(
+            f'<line x1="{PLOT_LEFT}" y1="{y:.2f}" x2="{PLOT_RIGHT}" '
+            f'y2="{y:.2f}" stroke="{theme.grid}"/>'
+        )
+        horizontal_grid.append(
+            f'<text x="{PLOT_LEFT - 14}" y="{y + 4:.2f}" fill="{theme.muted_text}" '
+            f'font-size="11" text-anchor="end">{_compact_count(tick)}</text>'
+        )
+
+    date_grid = []
+    for tick_day in _date_ticks(history):
+        x = x_for(tick_day)
+        date_grid.append(
+            f'<text x="{x:.2f}" y="{PLOT_BOTTOM + 28}" fill="{theme.muted_text}" '
+            f'font-size="11" text-anchor="middle">{tick_day:%b %Y}</text>'
+        )
+
+    area_element = (
+        f'<path d="{area}" fill="url(#{gradient_id})" opacity="{AREA_OPACITY}"/>'
+    )
+    end_x, end_y = coordinates[-1]
+    endpoint_elements = f"""
+  <circle cx="{end_x:.2f}" cy="{end_y:.2f}" r="5" fill="{theme.accent_end}" stroke="{theme.plot_surface}" stroke-width="3"/>
+  <text x="{end_x - 10:.2f}" y="{max(PLOT_TOP + 14, end_y - 12):.2f}" fill="{theme.text}" font-size="12" font-weight="700" text-anchor="end">{_format_count(history.total)}</text>"""
+    description = escape(
+        f"{history.repository} grew from {history.points[0].stars:,} stars on "
+        f"{history.started_on:%B %-d, %Y} to {history.total:,} stars on "
+        f"{history.generated_on:%B %-d, %Y}."
+    )
+
+    return f"""<svg xmlns="http://www.w3.org/2000/svg" width="{WIDTH}" height="{HEIGHT}" viewBox="0 0 {WIDTH} {HEIGHT}" role="img" aria-labelledby="chart-title chart-description">
+  <title id="chart-title">Star history for {escape(history.repository)}</title>
+  <desc id="chart-description">{description}</desc>
+  <defs>
+    <linearGradient id="{gradient_id}" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="{theme.accent}" stop-opacity="1"/>
+      <stop offset="1" stop-color="{theme.accent_end}" stop-opacity="0.08"/>
+    </linearGradient>
+    <linearGradient id="{line_gradient_id}" x1="{PLOT_LEFT}" y1="0" x2="{PLOT_RIGHT}" y2="0" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="{theme.accent}"/>
+      <stop offset="1" stop-color="{theme.accent_end}"/>
+    </linearGradient>
+  </defs>
+  <rect width="{WIDTH}" height="{HEIGHT}" rx="18" fill="{theme.surface}"/>
+  {_header_svg(theme, history)}
+  <rect x="{PLOT_LEFT}" y="{PLOT_TOP}" width="{PLOT_RIGHT - PLOT_LEFT}" height="{PLOT_BOTTOM - PLOT_TOP}" rx="8" fill="{theme.plot_surface}" stroke="{theme.border}"/>
+  <g stroke-width="1" shape-rendering="crispEdges">
+    {''.join(horizontal_grid)}
+    {''.join(date_grid)}
+  </g>
+  {area_element}
+  <path d="{path}" fill="none" stroke="url(#{line_gradient_id})" stroke-width="{LINE_WIDTH}" stroke-linecap="round" stroke-linejoin="round"/>
+  {endpoint_elements}
+  <text x="{PLOT_LEFT}" y="493" fill="{theme.muted_text}" font-size="10">Updated {history.generated_on:%Y-%m-%d} · generated from GitHub's stargazers API</text>
+</svg>
+"""
+
+
+def write_charts(history: StarHistory, output_dir: Path) -> list[Path]:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    written = []
+    for mode in ("light", "dark"):
+        destination = output_dir / f"{mode}.svg"
+        destination.write_text(render_svg(history, mode), encoding="utf-8")
+        written.append(destination)
+    return written
+
+
+def _load_timestamps(path: Path) -> list[datetime]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, list) or not all(isinstance(item, str) for item in payload):
+        raise ValueError("input JSON must be an array of timestamp strings")
+    return [_parse_timestamp(item) for item in payload]
+
+
+def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--repository",
+        default=os.environ.get("GITHUB_REPOSITORY", DEFAULT_REPOSITORY),
+    )
+    parser.add_argument("--output-dir", type=Path, default=DEFAULT_OUTPUT_DIR)
+    parser.add_argument("--input-json", type=Path)
+    parser.add_argument("--generated-on", type=date.fromisoformat)
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parse_args(argv)
+    try:
+        if args.input_json:
+            timestamps = _load_timestamps(args.input_json)
+        else:
+            token = os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN", "")
+            timestamps = fetch_starred_at(args.repository, token)
+        history = aggregate_daily(
+            args.repository, timestamps, generated_on=args.generated_on
+        )
+        written = write_charts(history, args.output_dir)
+    except (OSError, RuntimeError, ValueError) as err:
+        print(f"error: {err}", file=sys.stderr)
+        return 1
+
+    print(
+        f"Generated {len(written)} SVGs for {history.total:,} stars "
+        f"through {history.generated_on.isoformat()}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/generate_star_history.py
+++ b/scripts/generate_star_history.py
@@ -132,7 +132,9 @@ def fetch_starred_at(
                 f"GitHub stargazers request failed with HTTP {err.code}: {detail}"
             ) from err
         except URLError as err:
-            raise RuntimeError(f"GitHub stargazers request failed: {err.reason}") from err
+            raise RuntimeError(
+                f"GitHub stargazers request failed: {err.reason}"
+            ) from err
 
         if not isinstance(payload, list):
             raise RuntimeError("GitHub stargazers response was not a list")
@@ -219,8 +221,7 @@ def _coordinates(
     coordinates = [
         (
             x_for(point.day),
-            PLOT_BOTTOM
-            - (point.stars / maximum) * (PLOT_BOTTOM - PLOT_TOP),
+            PLOT_BOTTOM - (point.stars / maximum) * (PLOT_BOTTOM - PLOT_TOP),
         )
         for point in history.points
     ]
@@ -236,7 +237,9 @@ def _monotone_tangents(
     ]
     tangents = [slopes[0]]
     for previous, following in pairwise(slopes):
-        tangents.append(0.0 if previous * following <= 0 else (previous + following) / 2)
+        tangents.append(
+            0.0 if previous * following <= 0 else (previous + following) / 2
+        )
     tangents.append(slopes[-1])
 
     for index, slope in enumerate(slopes):
@@ -371,8 +374,8 @@ def render_svg(
   {_header_svg(theme, history)}
   <rect x="{PLOT_LEFT}" y="{PLOT_TOP}" width="{PLOT_RIGHT - PLOT_LEFT}" height="{PLOT_BOTTOM - PLOT_TOP}" rx="8" fill="{theme.plot_surface}" stroke="{theme.border}"/>
   <g stroke-width="1" shape-rendering="crispEdges">
-    {''.join(horizontal_grid)}
-    {''.join(date_grid)}
+    {"".join(horizontal_grid)}
+    {"".join(date_grid)}
   </g>
   {area_element}
   <path d="{path}" fill="none" stroke="url(#{line_gradient_id})" stroke-width="{LINE_WIDTH}" stroke-linecap="round" stroke-linejoin="round"/>
@@ -394,7 +397,9 @@ def write_charts(history: StarHistory, output_dir: Path) -> list[Path]:
 
 def _load_timestamps(path: Path) -> list[datetime]:
     payload = json.loads(path.read_text(encoding="utf-8"))
-    if not isinstance(payload, list) or not all(isinstance(item, str) for item in payload):
+    if not isinstance(payload, list) or not all(
+        isinstance(item, str) for item in payload
+    ):
         raise ValueError("input JSON must be an array of timestamp strings")
     return [_parse_timestamp(item) for item in payload]
 

--- a/tests/src/unit/test_generate_star_history.py
+++ b/tests/src/unit/test_generate_star_history.py
@@ -1,0 +1,159 @@
+"""Unit tests for the self-hosted star-history chart generator."""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+import xml.etree.ElementTree as ET
+from datetime import UTC, date, datetime
+from itertools import pairwise
+from pathlib import Path
+
+import pytest
+
+_SCRIPT = Path(__file__).resolve().parents[3] / "scripts" / "generate_star_history.py"
+_spec = importlib.util.spec_from_file_location("generate_star_history", _SCRIPT)
+assert _spec and _spec.loader
+generator = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(generator)
+
+
+class _Response(io.BytesIO):
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        self.close()
+
+
+def _history():
+    return generator.aggregate_daily(
+        "homeassistant-ai/ha-mcp",
+        [
+            datetime(2026, 1, 1, 12, tzinfo=UTC),
+            datetime(2026, 1, 1, 18, tzinfo=UTC),
+            datetime(2026, 1, 3, 9, tzinfo=UTC),
+            datetime(2026, 1, 5, 20, tzinfo=UTC),
+        ],
+        generated_on=date(2026, 1, 6),
+    )
+
+
+def test_fetch_starred_at_paginates_and_discards_identity() -> None:
+    first_page = [
+        {
+            "starred_at": f"2026-01-{1 + index // 24:02d}T{index % 24:02d}:00:00Z",
+            "user": {"login": f"private-user-{index}"},
+        }
+        for index in range(100)
+    ]
+    second_page = [
+        {
+            "starred_at": "2026-01-06T00:00:00Z",
+            "user": {"login": "private-user-final"},
+        }
+    ]
+    responses = [first_page, second_page]
+    requested_pages = []
+
+    def opener(request, *, timeout):
+        assert timeout == 30
+        assert request.headers["Authorization"] == "Bearer test-token"
+        assert request.headers["Accept"] == "application/vnd.github.star+json"
+        requested_pages.append(request.full_url)
+        return _Response(json.dumps(responses.pop(0)).encode())
+
+    timestamps = generator.fetch_starred_at(
+        "homeassistant-ai/ha-mcp", "test-token", opener=opener
+    )
+
+    assert len(timestamps) == 101
+    assert requested_pages[0].endswith("per_page=100&page=1")
+    assert requested_pages[1].endswith("per_page=100&page=2")
+    assert all(isinstance(timestamp, datetime) for timestamp in timestamps)
+    assert not any("private-user" in str(timestamp) for timestamp in timestamps)
+
+
+def test_aggregate_daily_fills_gaps_and_accumulates() -> None:
+    history = _history()
+
+    assert history.started_on == date(2026, 1, 1)
+    assert history.generated_on == date(2026, 1, 6)
+    assert history.total == 4
+    assert [(point.day, point.stars) for point in history.points] == [
+        (date(2026, 1, 1), 2),
+        (date(2026, 1, 2), 2),
+        (date(2026, 1, 3), 3),
+        (date(2026, 1, 4), 3),
+        (date(2026, 1, 5), 4),
+        (date(2026, 1, 6), 4),
+    ]
+
+
+def test_aggregate_daily_rejects_empty_history() -> None:
+    with pytest.raises(ValueError, match="at least one"):
+        generator.aggregate_daily("owner/repo", [])
+
+
+def test_render_starts_on_january_2026_and_smooths_monotonically() -> None:
+    history = generator.aggregate_daily(
+        "homeassistant-ai/ha-mcp",
+        [
+            datetime(2025, 12, 30, 12, tzinfo=UTC),
+            datetime(2025, 12, 31, 12, tzinfo=UTC),
+            datetime(2026, 1, 2, 12, tzinfo=UTC),
+            datetime(2026, 1, 4, 12, tzinfo=UTC),
+        ],
+        generated_on=date(2026, 1, 5),
+    )
+
+    svg = generator.render_svg(history, "light")
+
+    assert "Jan 2026" in svg
+    assert "Dec 2025" not in svg
+    assert "grew from 2 stars on January 1, 2026" in svg
+    assert " C " in svg
+
+
+def test_monotone_tangents_do_not_overshoot_flat_growth() -> None:
+    coordinates = [(0.0, 10.0), (1.0, 10.0), (2.0, 8.0), (3.0, 5.0)]
+    tangents = generator._monotone_tangents(coordinates)
+
+    assert tangents[0] == 0
+    assert tangents[1] == 0
+    for index, ((x, y), (next_x, next_y)) in enumerate(pairwise(coordinates)):
+        width = next_x - x
+        control_y = y + tangents[index] * width / 3
+        next_control_y = next_y - tangents[index + 1] * width / 3
+        low, high = sorted((y, next_y))
+        assert low <= control_y <= high
+        assert low <= next_control_y <= high
+
+
+def test_repository_must_use_owner_repo_format() -> None:
+    with pytest.raises(ValueError, match="OWNER/REPO"):
+        generator.fetch_starred_at("invalid", "token", opener=lambda *_a, **_k: None)
+
+
+@pytest.mark.parametrize("mode", ["light", "dark"])
+def test_chart_is_valid_accessible_svg(mode: str) -> None:
+    svg = generator.render_svg(_history(), mode)
+    root = ET.fromstring(svg)
+    namespace = {"svg": "http://www.w3.org/2000/svg"}
+
+    assert root.tag == "{http://www.w3.org/2000/svg}svg"
+    assert root.attrib["role"] == "img"
+    assert root.attrib["aria-labelledby"] == "chart-title chart-description"
+    assert root.find("svg:title", namespace) is not None
+    assert root.find("svg:desc", namespace) is not None
+    assert "private-user" not in svg
+    assert "homeassistant-ai/ha-mcp" in svg
+    assert "4" in svg
+
+
+def test_write_charts_uses_stable_production_names(tmp_path: Path) -> None:
+    written = generator.write_charts(_history(), tmp_path)
+
+    assert written == [tmp_path / "light.svg", tmp_path / "dark.svg"]
+    assert all(path.is_file() for path in written)


### PR DESCRIPTION
## Summary

- generate accessible light and dark star-history SVGs during the existing Pages build
- refresh the chart on site deployments and weekly without a PAT or repository content writes
- replace the third-party README image and sealed token with GitHub Pages assets
- aggregate only star timestamps, discard account identity data, and show history from January 2026 with monotone curve smoothing

## Security

- uses the repository-scoped, short-lived `GITHUB_TOKEN` only in the chart generation step
- grants the build job `contents: read`; only the deploy job receives `pages: write` and `id-token: write`
- publishes aggregate star counts only

## Testing

- `uv run pytest tests/src/unit/test_generate_star_history.py -q`
- `uv run ruff check scripts/generate_star_history.py tests/src/unit/test_generate_star_history.py`
- `uv run ruff check src tests`
- `uv run mypy src`
- `actionlint .github/workflows/deploy.yml`
- `npm run check`
- `npm run lint`
- `npm run build`
- `npm run audit:a11y`
- full PR CI suite: unit, E2E, HAOS, CodeQL, and site validation passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)