### PR TITLE
fix: resubmit config keys redeclared by later flow steps

### DIFF
--- a/src/ha_mcp/tools/config_entry_flow.py
+++ b/src/ha_mcp/tools/config_entry_flow.py
@@ -208,13 +208,22 @@ class _ReuseState:
     def record(
         self, path_prefix: str, name: str, value: Any, *, scoped_only: bool
     ) -> None:
-        """Snapshot a value the caller supplied at this declaration site."""
+        """Snapshot a value the caller supplied at this declaration site.
+
+        A flat value that lands on a path already recorded from an explicit
+        section dict also replaces that scoped entry: the flat key is the one
+        actually submitted for the path (flat overrides explicit), so the
+        record must carry the effective value or a later redeclaration of the
+        path would resurrect the overridden one.
+        """
         dotted = _section_path(path_prefix, name)
         self.filled.add(dotted)
         if scoped_only:
             self.scoped[dotted] = copy.deepcopy(value)
         else:
             self.flat[name] = copy.deepcopy(value)
+            if dotted in self.scoped:
+                self.scoped[dotted] = copy.deepcopy(value)
 
     def recorded_value(self, path_prefix: str, name: str) -> Any:
         """Return the value recorded for this declaration site, else _MISSING_DEFAULT."""

--- a/src/ha_mcp/tools/config_entry_flow.py
+++ b/src/ha_mcp/tools/config_entry_flow.py
@@ -244,6 +244,7 @@ def _consume_section_schema(
     ignored_config_keys: set[str] | None,
     consumed_config_keys: set[str] | None,
     path_prefix: str,
+    consumed_values: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Consume config values for a nested flow section."""
     nested_schema = field.get("schema")
@@ -263,6 +264,7 @@ def _consume_section_schema(
                 ignored_config_keys,
                 consumed_config_keys,
                 section_path,
+                consumed_values,
             )
         )
         _record_ignored_section_keys(
@@ -278,6 +280,7 @@ def _consume_section_schema(
             ignored_config_keys,
             consumed_config_keys,
             section_path,
+            consumed_values,
         )
     )
     return nested_data
@@ -315,19 +318,80 @@ def _auto_confirm_form_payload(current_step: dict[str, Any]) -> dict[str, Any] |
     return {name: True}
 
 
+def _reused_consumed_value(
+    field: dict[str, Any],
+    name: str,
+    consumed_values: dict[str, Any] | None,
+) -> Any:
+    """Return an earlier step's value to resubmit for ``field``, else _MISSING_DEFAULT.
+
+    A supplied config key applies to every form step that declares it, not
+    only the first one to consume it — but it never overrides a default or
+    suggested value the step's own serialized schema carries. Reuse therefore
+    fires only where the redeclared field is required AND has no default of
+    its own, which is exactly where omitting the key is a guaranteed
+    voluptuous failure.
+
+    A redeclared field that *does* carry a default belongs to an edit-style
+    form HA pre-filled with the current value; resubmitting an earlier step's
+    unrelated value over that default would silently change data the caller
+    never named. Menu selection keys never reach here.
+
+    Motivating regression (issue #2057): an options flow — LocalTuya's — that
+    declares the same field on an early step and again on a later one.
+    """
+    if consumed_values is None or name not in consumed_values:
+        return _MISSING_DEFAULT
+    if not field.get("required"):
+        return _MISSING_DEFAULT
+    if _field_default_value(field) is not _MISSING_DEFAULT:
+        return _MISSING_DEFAULT
+    return copy.deepcopy(consumed_values[name])
+
+
+def _consume_leaf_field(
+    field: dict[str, Any],
+    name: str,
+    form_data: dict[str, Any],
+    remaining_config: dict[str, Any],
+    consumed_config_keys: set[str] | None,
+    consumed_values: dict[str, Any] | None,
+    path_prefix: str,
+) -> None:
+    """Add ``name``'s caller-supplied — or earlier-consumed — value to ``form_data``.
+
+    Values are recorded in ``consumed_values`` under the leaf name so a later
+    step redeclaring the same field can resubmit them.
+    """
+    if name in remaining_config:
+        value = remaining_config.pop(name)
+        form_data[name] = value
+        _mark_consumed(consumed_config_keys, path_prefix, name)
+        if consumed_values is not None:
+            consumed_values[name] = value
+        return
+
+    reused = _reused_consumed_value(field, name, consumed_values)
+    if reused is not _MISSING_DEFAULT:
+        form_data[name] = reused
+        _mark_consumed(consumed_config_keys, path_prefix, name)
+
+
 def _consume_form_schema(
     data_schema: list[Any],
     remaining_config: dict[str, Any],
     ignored_config_keys: set[str] | None = None,
     consumed_config_keys: set[str] | None = None,
     path_prefix: str = "",
+    consumed_values: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Consume matching config values and shape nested flow sections.
 
     Mutates ``remaining_config`` by removing every consumed key. Flat child
     values override the same value inside an explicitly supplied section dict.
     Unknown keys inside explicit section dicts are added to
-    ``ignored_config_keys`` with their dotted section path.
+    ``ignored_config_keys`` with their dotted section path. Fields already
+    consumed by an earlier step are resubmitted per :func:`_reused_consumed_value`.
     """
     form_data: dict[str, Any] = {}
 
@@ -355,6 +419,7 @@ def _consume_form_schema(
                 ignored_config_keys,
                 consumed_config_keys,
                 path_prefix,
+                consumed_values,
             )
             if nested_data:
                 if section_name is not None:
@@ -363,13 +428,16 @@ def _consume_form_schema(
                     form_data.update(nested_data)
             continue
 
-        if (
-            isinstance(name, str)
-            and name not in _MENU_SELECTION_KEYS
-            and name in remaining_config
-        ):
-            form_data[name] = remaining_config.pop(name)
-            _mark_consumed(consumed_config_keys, path_prefix, name)
+        if isinstance(name, str) and name not in _MENU_SELECTION_KEYS:
+            _consume_leaf_field(
+                field,
+                name,
+                form_data,
+                remaining_config,
+                consumed_config_keys,
+                consumed_values,
+                path_prefix,
+            )
 
     return form_data
 
@@ -399,6 +467,7 @@ def _handle_form_step(
     remaining_config: dict[str, Any],
     ignored_config_keys: set[str] | None = None,
     consumed_config_keys: set[str] | None = None,
+    consumed_values: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Validate a form step and return form data to submit.
 
@@ -407,6 +476,11 @@ def _handle_form_step(
     keys remain available for subsequent steps. Menu selection keys are never
     submitted. Fields declared inside a section are grouped under the section
     key; callers may provide them flat or inside an explicit section dict.
+
+    Consumed values are recorded in ``consumed_values`` by leaf field name.
+    A field this step declares that an earlier step already consumed is
+    resubmitted from that record, but only when the field is required here and
+    has no default of its own — see :func:`_reused_consumed_value`.
 
     When ``data_schema`` is absent (HA didn't tell us field names), falls
     back to legacy behaviour: submit all non-menu keys and clear them. This
@@ -439,11 +513,19 @@ def _handle_form_step(
         for key in list(remaining_config.keys()):
             if key in _MENU_SELECTION_KEYS:
                 continue
-            form_data[key] = remaining_config.pop(key)
+            value = remaining_config.pop(key)
+            form_data[key] = value
             _mark_consumed(consumed_config_keys, "", key)
+            if consumed_values is not None:
+                consumed_values[key] = value
     else:
         form_data = _consume_form_schema(
-            data_schema, remaining_config, ignored_config_keys, consumed_config_keys
+            data_schema,
+            remaining_config,
+            ignored_config_keys,
+            consumed_config_keys,
+            "",
+            consumed_values,
         )
 
     return form_data
@@ -819,7 +901,10 @@ async def _handle_flow_steps(
         initial_step: The first step returned by the flow start call
         config: Full caller-provided config dict. Menu selection keys are
             consumed by menu steps; remaining keys are submitted on the
-            first form step.
+            first form step whose schema declares them. A later step that
+            redeclares an already-consumed field gets that value resubmitted
+            when the step marks it required with no default of its own
+            (see :func:`_reused_consumed_value`).
         submit_fn: Async function to submit a step. Defaults to
             client.submit_config_flow_step (create). Pass
             client.submit_options_flow_step for options (update) flows.
@@ -842,6 +927,7 @@ async def _handle_flow_steps(
     current_step = initial_step
     last_menu_choice: str | None = None
     ignored_config_keys: set[str] = set()
+    consumed_values: dict[str, Any] = {}
     supplied_keys = sorted(k for k in config if k not in _MENU_SELECTION_KEYS)
     saw_form_step = False
     any_form_key_consumed = False
@@ -896,6 +982,7 @@ async def _handle_flow_steps(
                     remaining_config,
                     ignored_config_keys,
                     consumed_form_keys,
+                    consumed_values,
                 )
             if consumed_form_keys:
                 any_form_key_consumed = True
@@ -957,12 +1044,14 @@ async def _handle_config_subentry_flow_steps(
     """Walk a config subentry flow and accept HA's reconfigure-success abort.
 
     Successful results include ``warnings`` when caller-supplied config keys
-    were not declared by any flow step.
+    were not declared by any flow step. Fields redeclared by a later step are
+    resubmitted on the same terms as :func:`_handle_flow_steps`.
     """
     remaining_config = dict(config)
     current_step = initial_step
     last_menu_choice: str | None = None
     ignored_config_keys: set[str] = set()
+    consumed_values: dict[str, Any] = {}
     max_steps = 10
 
     for step_num in range(max_steps):
@@ -1025,6 +1114,7 @@ async def _handle_config_subentry_flow_steps(
                 current_step,
                 remaining_config,
                 ignored_config_keys,
+                consumed_values=consumed_values,
             )
             logger.debug(
                 "Config subentry flow step %s: form submit (step_id=%s, keys=%s)",

--- a/src/ha_mcp/tools/config_entry_flow.py
+++ b/src/ha_mcp/tools/config_entry_flow.py
@@ -453,11 +453,11 @@ def _step_owned_submission_value(field: dict[str, Any]) -> Any:
     "what does the step itself say to submit", which is a different question:
 
     - ``voluptuous_serialize`` emits ``"default"`` only for an actual
-      voluptuous default, so a default is HA's to fill in and never needs to be
-      submitted. HA's edit-style pre-fill
-      (``add_suggested_values_to_schema``) instead lands the current value in
-      ``description.suggested_value`` with no ``"default"`` key at all, and
-      omitting the key would fail validation.
+      voluptuous default. HA's edit-style pre-fill
+      (``add_suggested_values_to_schema``) copies the marker and overwrites
+      only its description, so a marker that already carried a default
+      serializes with both keys; the suggestion is the stored current value
+      and outranks the static default.
     - A constant field serializes as ``{"type": "constant", "value": X}`` and
       ``X`` is the only value it accepts.
 
@@ -490,16 +490,19 @@ def _redeclared_field_submission(
     and the caller's value for this step outranks anything injected. Otherwise,
     in order:
 
-    1. The field carries a ``"default"`` key: omit it and let voluptuous fill
-       the default in. Key presence is the test, so ``default: None`` is a
-       default too.
-    2. The field is not required: omit it. Nothing is ever injected into an
+    1. The field is not required: omit it. Nothing is ever injected into an
        optional field, or into a section that is neither required nor named by
        the caller (``allow_reuse``) — materializing either would invent data.
-    3. The step's own schema supplies a value — a suggestion or a constant's
+    2. The step's own schema supplies a value — a suggestion or a constant's
        only legal value, per :func:`_step_owned_submission_value`: submit that.
        It is schema data rather than a caller key, so it is neither marked
-       consumed nor warned about.
+       consumed nor warned about. A suggestion outranks a coexisting
+       ``"default"``: both keys can serialize together, and the suggestion is
+       the stored current value while the default is the static schema one —
+       omitting would let voluptuous substitute the static value over it.
+    3. The field carries a ``"default"`` key (and no value of its own): omit it
+       and let voluptuous fill the default in. Key presence is the test, so
+       ``default: None`` is a default too.
     4. Otherwise the field is required, has no default and has no value of its
        own, which makes omitting it a guaranteed "required key not provided":
        resubmit the value the caller supplied for an earlier step, warn, and
@@ -515,13 +518,13 @@ def _redeclared_field_submission(
     dotted = _section_path(path_prefix, name)
     if dotted in reuse_state.filled:
         return _NO_SUBMISSION
-    if "default" in field:
-        return _NO_SUBMISSION
     if not field.get("required"):
         return _NO_SUBMISSION
     step_owned = _step_owned_submission_value(field)
     if step_owned is not _MISSING_DEFAULT:
         return step_owned, False
+    if "default" in field:
+        return _NO_SUBMISSION
     recorded = reuse_state.recorded_value(path_prefix, name)
     if recorded is _MISSING_DEFAULT:
         return _NO_SUBMISSION

--- a/src/ha_mcp/tools/config_entry_flow.py
+++ b/src/ha_mcp/tools/config_entry_flow.py
@@ -8,12 +8,20 @@ Config Entry Flow API.
 The create/update entry point is the unified ha_config_set_helper tool in
 tools_config_helpers.py, which routes to create_flow_helper / update_flow_helper
 for the 15 helper types listed in FLOW_HELPER_TYPES.
+
+The same flow walkers drive every other config-entry surface, not just
+helpers: ``ha_set_integration`` creates entries for arbitrary domains through
+``create_config_entry`` and edits them through ``update_config_entry_options``,
+and ``ha_config_set_helper(helper_type="config_subentry")`` drives subentry
+flows through ``set_config_subentry``.
 """
 
 import asyncio
 import copy
 import logging
 from collections.abc import Iterator
+from dataclasses import dataclass
+from dataclasses import field as dc_field
 from enum import StrEnum
 from typing import Any, Literal, NoReturn
 
@@ -80,6 +88,8 @@ _RECONFIGURE_SUCCESS_REASONS = frozenset(
     }
 )
 _MISSING_DEFAULT = object()
+# "Submit nothing for this field" — see _redeclared_field_submission.
+_NO_SUBMISSION: tuple[Any, bool] = (_MISSING_DEFAULT, False)
 
 
 class _FlowType(StrEnum):
@@ -157,6 +167,80 @@ def _section_path(path_prefix: str, name: Any) -> str:
     if not isinstance(name, str):
         return path_prefix
     return f"{path_prefix}.{name}" if path_prefix else name
+
+
+@dataclass
+class _ReuseState:
+    """Caller-supplied form values a flow's steps have already consumed.
+
+    A config key applies to every form step that declares it, not only the
+    first step to pop it out of ``remaining_config`` — see
+    :func:`_redeclared_field_submission` for when a recorded value is
+    resubmitted. The record is split by how the caller wrote the value:
+
+    - ``scoped`` maps a dotted declaration path to a value that came out of an
+      explicitly supplied section dict. The caller named that section, so the
+      value belongs to that path and nowhere else.
+    - ``flat`` maps a leaf name to a value that came out of the flat caller
+      dict. The caller named no section, so the value is position-agnostic and
+      fills that leaf wherever a later step declares it.
+
+    ``filled`` holds the dotted paths the current step already filled from the
+    caller's own keys, so nothing is injected over a value the caller wrote for
+    this very step; it is cleared per step. ``fired`` bounds resubmission to
+    one write per (step, path) for the whole flow, ``notes`` collects the
+    warning each of those writes emits, and ``step_id`` names the step being
+    consumed.
+    """
+
+    scoped: dict[str, Any] = dc_field(default_factory=dict)
+    flat: dict[str, Any] = dc_field(default_factory=dict)
+    filled: set[str] = dc_field(default_factory=set)
+    fired: set[str] = dc_field(default_factory=set)
+    notes: list[str] = dc_field(default_factory=list)
+    step_id: str | None = None
+
+    def begin_step(self, step_id: Any) -> None:
+        """Start recording for a new form step."""
+        self.step_id = step_id if isinstance(step_id, str) else None
+        self.filled.clear()
+
+    def record(
+        self, path_prefix: str, name: str, value: Any, *, scoped_only: bool
+    ) -> None:
+        """Snapshot a value the caller supplied at this declaration site."""
+        dotted = _section_path(path_prefix, name)
+        self.filled.add(dotted)
+        if scoped_only:
+            self.scoped[dotted] = copy.deepcopy(value)
+        else:
+            self.flat[name] = copy.deepcopy(value)
+
+    def recorded_value(self, path_prefix: str, name: str) -> Any:
+        """Return the value recorded for this declaration site, else _MISSING_DEFAULT."""
+        dotted = _section_path(path_prefix, name)
+        if dotted in self.scoped:
+            return copy.deepcopy(self.scoped[dotted])
+        if name in self.flat:
+            return copy.deepcopy(self.flat[name])
+        return _MISSING_DEFAULT
+
+    def claim_write(self, dotted: str) -> bool:
+        """Spend the single resubmission allowed for this (step, path), if unspent.
+
+        A flow that re-presents the same step gets one reused write and then
+        HA's own loud "required key not provided" naming the field, rather than
+        an unbounded run of silent rewrites.
+        """
+        key = f"{self.step_id}:{dotted}"
+        if key in self.fired:
+            return False
+        self.fired.add(key)
+        self.notes.append(
+            f"Resubmitted '{dotted}' at step '{self.step_id}': supplied once "
+            "but declared at more than one site in this flow"
+        )
+        return True
 
 
 def _record_ignored_section_keys(
@@ -237,6 +321,22 @@ def _ignored_keys_warnings(
     return warnings
 
 
+def _success_warnings(
+    ignored_config_keys: set[str],
+    remaining_config: dict[str, Any],
+    reuse_state: _ReuseState,
+) -> list[str]:
+    """Build a success response's ``warnings`` list (empty when there is nothing to say).
+
+    Merges the keys no step declared with the resubmissions the walk performed,
+    keeping ``warnings`` a flat ``list[str]`` per the response contract in
+    ``tests/src/unit/test_helper_response_shape.py``.
+    """
+    return _ignored_keys_warnings(ignored_config_keys, remaining_config) + list(
+        reuse_state.notes
+    )
+
+
 def _consume_section_schema(
     field: dict[str, Any],
     explicit_section: dict[str, Any] | None,
@@ -244,9 +344,17 @@ def _consume_section_schema(
     ignored_config_keys: set[str] | None,
     consumed_config_keys: set[str] | None,
     path_prefix: str,
-    consumed_values: dict[str, Any] | None = None,
+    reuse_state: _ReuseState | None = None,
+    *,
+    allow_reuse: bool = True,
+    explicit_source: bool = False,
 ) -> dict[str, Any]:
-    """Consume config values for a nested flow section."""
+    """Consume config values for a nested flow section.
+
+    Values inside an explicitly supplied section dict are consumed first, then
+    flat caller keys, which is what lets a flat child override the same key
+    written inside the section dict.
+    """
     nested_schema = field.get("schema")
     if not isinstance(nested_schema, list):
         return {}
@@ -264,7 +372,9 @@ def _consume_section_schema(
                 ignored_config_keys,
                 consumed_config_keys,
                 section_path,
-                consumed_values,
+                reuse_state,
+                allow_reuse=allow_reuse,
+                explicit_source=True,
             )
         )
         _record_ignored_section_keys(
@@ -280,7 +390,9 @@ def _consume_section_schema(
             ignored_config_keys,
             consumed_config_keys,
             section_path,
-            consumed_values,
+            reuse_state,
+            allow_reuse=allow_reuse,
+            explicit_source=explicit_source,
         )
     )
     return nested_data
@@ -291,7 +403,13 @@ def _mark_consumed(
     path_prefix: str,
     name: str,
 ) -> None:
-    """Record that a caller-supplied form key, not an injected default, was used."""
+    """Record that a caller-supplied value was used, fresh or resubmitted.
+
+    Values the step's own schema supplies — section defaults, suggestions,
+    constants — are never marked: they are HA's data, and marking them would
+    let a config of nothing but misspelled keys look partially applied to
+    :func:`_finish_flow_entry`.
+    """
     if consumed_config_keys is not None:
         consumed_config_keys.add(_section_path(path_prefix, name))
 
@@ -318,35 +436,89 @@ def _auto_confirm_form_payload(current_step: dict[str, Any]) -> dict[str, Any] |
     return {name: True}
 
 
-def _reused_consumed_value(
+def _step_owned_submission_value(field: dict[str, Any]) -> Any:
+    """Return the value a step's own schema supplies for ``field``, else _MISSING_DEFAULT.
+
+    Deliberately distinct from :func:`_field_default_value`, which answers
+    "what would the UI show in this box" and is what seeds a form. This answers
+    "what does the step itself say to submit", which is a different question:
+
+    - ``voluptuous_serialize`` emits ``"default"`` only for an actual
+      voluptuous default, so a default is HA's to fill in and never needs to be
+      submitted. HA's edit-style pre-fill
+      (``add_suggested_values_to_schema``) instead lands the current value in
+      ``description.suggested_value`` with no ``"default"`` key at all, and
+      omitting the key would fail validation.
+    - A constant field serializes as ``{"type": "constant", "value": X}`` and
+      ``X`` is the only value it accepts.
+
+    The bare top-level ``suggested_value`` shape is not something
+    ``voluptuous_serialize`` produces; it is read defensively alongside the
+    nested one.
+    """
+    description = field.get("description")
+    if isinstance(description, dict) and description.get("suggested_value") is not None:
+        return copy.deepcopy(description["suggested_value"])
+    if field.get("suggested_value") is not None:
+        return copy.deepcopy(field["suggested_value"])
+    if field.get("type") == "constant" and field.get("value") is not None:
+        return copy.deepcopy(field["value"])
+    return _MISSING_DEFAULT
+
+
+def _redeclared_field_submission(
     field: dict[str, Any],
     name: str,
-    consumed_values: dict[str, Any] | None,
-) -> Any:
-    """Return an earlier step's value to resubmit for ``field``, else _MISSING_DEFAULT.
+    path_prefix: str,
+    reuse_state: _ReuseState | None,
+    allow_reuse: bool,
+) -> tuple[Any, bool]:
+    """Decide what to submit for a declared field the caller named no key for here.
 
-    A supplied config key applies to every form step that declares it, not
-    only the first one to consume it — but it never overrides a default or
-    suggested value the step's own serialized schema carries. Reuse therefore
-    fires only where the redeclared field is required AND has no default of
-    its own, which is exactly where omitting the key is a guaranteed
-    voluptuous failure.
+    Returns ``(value, from_caller)``, or ``_NO_SUBMISSION`` to omit the key
+    entirely. A site the caller's own key already filled earlier in this same
+    step is left alone — a section dict and a flat key can name the same leaf,
+    and the caller's value for this step outranks anything injected. Otherwise,
+    in order:
 
-    A redeclared field that *does* carry a default belongs to an edit-style
-    form HA pre-filled with the current value; resubmitting an earlier step's
-    unrelated value over that default would silently change data the caller
-    never named. Menu selection keys never reach here.
+    1. The field carries a ``"default"`` key: omit it and let voluptuous fill
+       the default in. Key presence is the test, so ``default: None`` is a
+       default too.
+    2. The field is not required: omit it. Nothing is ever injected into an
+       optional field, or into a section that is neither required nor named by
+       the caller (``allow_reuse``) — materializing either would invent data.
+    3. The step's own schema supplies a value — a suggestion or a constant's
+       only legal value, per :func:`_step_owned_submission_value`: submit that.
+       It is schema data rather than a caller key, so it is neither marked
+       consumed nor warned about.
+    4. Otherwise the field is required, has no default and has no value of its
+       own, which makes omitting it a guaranteed "required key not provided":
+       resubmit the value the caller supplied for an earlier step, warn, and
+       spend the one write allowed per (step, path).
 
-    Motivating regression (issue #2057): an options flow — LocalTuya's — that
-    declares the same field on an early step and again on a later one.
+    Mutates ``reuse_state`` on the fourth branch. Menu selection keys never
+    reach here. Motivating regression (issue #2057): an options flow —
+    LocalTuya's — that declares the same field on an early step and again on a
+    later one.
     """
-    if consumed_values is None or name not in consumed_values:
-        return _MISSING_DEFAULT
+    if reuse_state is None or not allow_reuse:
+        return _NO_SUBMISSION
+    dotted = _section_path(path_prefix, name)
+    if dotted in reuse_state.filled:
+        return _NO_SUBMISSION
+    if "default" in field:
+        return _NO_SUBMISSION
     if not field.get("required"):
-        return _MISSING_DEFAULT
-    if _field_default_value(field) is not _MISSING_DEFAULT:
-        return _MISSING_DEFAULT
-    return copy.deepcopy(consumed_values[name])
+        return _NO_SUBMISSION
+    step_owned = _step_owned_submission_value(field)
+    if step_owned is not _MISSING_DEFAULT:
+        return step_owned, False
+    recorded = reuse_state.recorded_value(path_prefix, name)
+    if recorded is _MISSING_DEFAULT:
+        return _NO_SUBMISSION
+    if not reuse_state.claim_write(dotted):
+        return _NO_SUBMISSION
+    return recorded, True
 
 
 def _consume_leaf_field(
@@ -355,26 +527,87 @@ def _consume_leaf_field(
     form_data: dict[str, Any],
     remaining_config: dict[str, Any],
     consumed_config_keys: set[str] | None,
-    consumed_values: dict[str, Any] | None,
+    reuse_state: _ReuseState | None,
     path_prefix: str,
+    *,
+    allow_reuse: bool = True,
+    explicit_source: bool = False,
 ) -> None:
-    """Add ``name``'s caller-supplied — or earlier-consumed — value to ``form_data``.
+    """Fill ``name`` in ``form_data`` from the caller's config or from the step itself.
 
-    Values are recorded in ``consumed_values`` under the leaf name so a later
-    step redeclaring the same field can resubmit them.
+    A key the caller supplied here is popped, submitted, and recorded in
+    ``reuse_state`` — scoped to this dotted path when it came out of an
+    explicitly supplied section dict, keyed by leaf name when it came out of
+    the flat caller dict. With no key to pop,
+    :func:`_redeclared_field_submission` chooses between omitting the field,
+    submitting the step's own value, and resubmitting the recorded one.
     """
     if name in remaining_config:
         value = remaining_config.pop(name)
         form_data[name] = value
         _mark_consumed(consumed_config_keys, path_prefix, name)
-        if consumed_values is not None:
-            consumed_values[name] = value
+        if reuse_state is not None:
+            reuse_state.record(path_prefix, name, value, scoped_only=explicit_source)
         return
 
-    reused = _reused_consumed_value(field, name, consumed_values)
-    if reused is not _MISSING_DEFAULT:
-        form_data[name] = reused
+    value, from_caller = _redeclared_field_submission(
+        field, name, path_prefix, reuse_state, allow_reuse
+    )
+    if value is _MISSING_DEFAULT:
+        return
+    form_data[name] = value
+    if from_caller:
         _mark_consumed(consumed_config_keys, path_prefix, name)
+
+
+def _consume_declared_section(
+    field: dict[str, Any],
+    form_data: dict[str, Any],
+    remaining_config: dict[str, Any],
+    ignored_config_keys: set[str] | None,
+    consumed_config_keys: set[str] | None,
+    path_prefix: str,
+    reuse_state: _ReuseState | None,
+    *,
+    allow_reuse: bool,
+    explicit_source: bool,
+) -> None:
+    """Merge one section field's data into ``form_data``.
+
+    A caller who supplies the section as a non-dict value gets it submitted
+    verbatim — HA, not this walker, decides what that means. Reuse is allowed
+    inside the section only when HA marks it required or the caller named it,
+    so an untouched optional section is never brought into existence.
+    """
+    name = field.get("name")
+    section_name = name if isinstance(name, str) else None
+    explicit_section: dict[str, Any] | None = None
+    if section_name is not None and section_name in remaining_config:
+        explicit_value = remaining_config.pop(section_name)
+        if not isinstance(explicit_value, dict):
+            form_data[section_name] = explicit_value
+            _mark_consumed(consumed_config_keys, path_prefix, section_name)
+            return
+        explicit_section = explicit_value
+
+    nested_data = _consume_section_schema(
+        field,
+        explicit_section,
+        remaining_config,
+        ignored_config_keys,
+        consumed_config_keys,
+        path_prefix,
+        reuse_state,
+        allow_reuse=allow_reuse
+        and (bool(field.get("required")) or explicit_section is not None),
+        explicit_source=explicit_source,
+    )
+    if not nested_data:
+        return
+    if section_name is not None:
+        form_data[section_name] = nested_data
+    else:
+        form_data.update(nested_data)
 
 
 def _consume_form_schema(
@@ -383,15 +616,19 @@ def _consume_form_schema(
     ignored_config_keys: set[str] | None = None,
     consumed_config_keys: set[str] | None = None,
     path_prefix: str = "",
-    consumed_values: dict[str, Any] | None = None,
+    reuse_state: _ReuseState | None = None,
+    *,
+    allow_reuse: bool = True,
+    explicit_source: bool = False,
 ) -> dict[str, Any]:
     """Consume matching config values and shape nested flow sections.
 
     Mutates ``remaining_config`` by removing every consumed key. Flat child
     values override the same value inside an explicitly supplied section dict.
     Unknown keys inside explicit section dicts are added to
-    ``ignored_config_keys`` with their dotted section path. Fields already
-    consumed by an earlier step are resubmitted per :func:`_reused_consumed_value`.
+    ``ignored_config_keys`` with their dotted section path. A declared field the
+    caller named no key for is filled per
+    :func:`_redeclared_field_submission`.
     """
     form_data: dict[str, Any] = {}
 
@@ -400,32 +637,18 @@ def _consume_form_schema(
             continue
 
         name = field.get("name")
-        nested_schema = field.get("schema")
-        if isinstance(nested_schema, list):
-            section_name = name if isinstance(name, str) else None
-            explicit_section = None
-            if section_name is not None and section_name in remaining_config:
-                explicit_value = remaining_config.pop(section_name)
-                if not isinstance(explicit_value, dict):
-                    form_data[section_name] = explicit_value
-                    _mark_consumed(consumed_config_keys, path_prefix, section_name)
-                    continue
-                explicit_section = explicit_value
-
-            nested_data = _consume_section_schema(
+        if isinstance(field.get("schema"), list):
+            _consume_declared_section(
                 field,
-                explicit_section,
+                form_data,
                 remaining_config,
                 ignored_config_keys,
                 consumed_config_keys,
                 path_prefix,
-                consumed_values,
+                reuse_state,
+                allow_reuse=allow_reuse,
+                explicit_source=explicit_source,
             )
-            if nested_data:
-                if section_name is not None:
-                    form_data[section_name] = nested_data
-                else:
-                    form_data.update(nested_data)
             continue
 
         if isinstance(name, str) and name not in _MENU_SELECTION_KEYS:
@@ -435,8 +658,10 @@ def _consume_form_schema(
                 form_data,
                 remaining_config,
                 consumed_config_keys,
-                consumed_values,
+                reuse_state,
                 path_prefix,
+                allow_reuse=allow_reuse,
+                explicit_source=explicit_source,
             )
 
     return form_data
@@ -461,13 +686,38 @@ def _extract_schema_field_names(data_schema: Any) -> set[str] | None:
     return names
 
 
+def _consume_all_remaining_keys(
+    remaining_config: dict[str, Any],
+    consumed_config_keys: set[str] | None,
+    reuse_state: _ReuseState | None,
+) -> dict[str, Any]:
+    """Submit every non-menu key, for a step whose schema HA did not send.
+
+    Without field names there is nothing to filter on, so the whole config is
+    dumped into this one submit and cleared out of ``remaining_config``. Each
+    consumed key is still recorded by leaf name, so a later step that *does*
+    arrive with a schema declaring one of them can be filled from the record
+    rather than submitted without it.
+    """
+    form_data: dict[str, Any] = {}
+    for key in list(remaining_config.keys()):
+        if key in _MENU_SELECTION_KEYS:
+            continue
+        value = remaining_config.pop(key)
+        form_data[key] = value
+        _mark_consumed(consumed_config_keys, "", key)
+        if reuse_state is not None:
+            reuse_state.record("", key, value, scoped_only=False)
+    return form_data
+
+
 def _handle_form_step(
     flow_id: str,
     current_step: dict[str, Any],
     remaining_config: dict[str, Any],
     ignored_config_keys: set[str] | None = None,
     consumed_config_keys: set[str] | None = None,
-    consumed_values: dict[str, Any] | None = None,
+    reuse_state: _ReuseState | None = None,
 ) -> dict[str, Any]:
     """Validate a form step and return form data to submit.
 
@@ -477,10 +727,14 @@ def _handle_form_step(
     submitted. Fields declared inside a section are grouped under the section
     key; callers may provide them flat or inside an explicit section dict.
 
-    Consumed values are recorded in ``consumed_values`` by leaf field name.
-    A field this step declares that an earlier step already consumed is
-    resubmitted from that record, but only when the field is required here and
-    has no default of its own — see :func:`_reused_consumed_value`.
+    Caller-supplied values are recorded in ``reuse_state``. A field this step
+    declares but the caller named no key for here is filled per
+    :func:`_redeclared_field_submission`: omitted when the schema carries a
+    ``"default"`` or the field is optional, submitted from the step's own
+    suggestion or constant, and otherwise — required, no default, no value of
+    its own — resubmitted once from an earlier step's caller value with a
+    warning. Nothing is injected into an optional field, or into a section
+    neither marked required nor named by the caller.
 
     When ``data_schema`` is absent (HA didn't tell us field names), falls
     back to legacy behaviour: submit all non-menu keys and clear them. This
@@ -503,32 +757,23 @@ def _handle_form_step(
             )
         )
 
-    data_schema = current_step.get("data_schema")
+    if reuse_state is not None:
+        reuse_state.begin_step(current_step.get("step_id"))
 
-    form_data: dict[str, Any] = {}
+    data_schema = current_step.get("data_schema")
     if not isinstance(data_schema, list):
-        # Legacy fallback: no schema info — dump every non-menu key and
-        # consume them all so a follow-up step (rare without schema) won't
-        # re-submit the same data.
-        for key in list(remaining_config.keys()):
-            if key in _MENU_SELECTION_KEYS:
-                continue
-            value = remaining_config.pop(key)
-            form_data[key] = value
-            _mark_consumed(consumed_config_keys, "", key)
-            if consumed_values is not None:
-                consumed_values[key] = value
-    else:
-        form_data = _consume_form_schema(
-            data_schema,
-            remaining_config,
-            ignored_config_keys,
-            consumed_config_keys,
-            "",
-            consumed_values,
+        return _consume_all_remaining_keys(
+            remaining_config, consumed_config_keys, reuse_state
         )
 
-    return form_data
+    return _consume_form_schema(
+        data_schema,
+        remaining_config,
+        ignored_config_keys,
+        consumed_config_keys,
+        "",
+        reuse_state,
+    )
 
 
 def _parse_flow_api_error(
@@ -820,6 +1065,7 @@ def _finish_flow_entry(
     any_form_key_consumed: bool,
     ignored_config_keys: set[str],
     remaining_config: dict[str, Any],
+    reuse_state: _ReuseState,
 ) -> dict[str, Any]:
     """Build the CREATE_ENTRY success response, or raise on total key miss.
 
@@ -852,7 +1098,7 @@ def _finish_flow_entry(
             )
         )
     response: dict[str, Any] = {"success": True, "entry": current_step}
-    warnings = _ignored_keys_warnings(ignored_config_keys, remaining_config)
+    warnings = _success_warnings(ignored_config_keys, remaining_config, reuse_state)
     if warnings:
         response["warnings"] = warnings
     return response
@@ -900,11 +1146,13 @@ async def _handle_flow_steps(
         flow_id: Flow ID from start_config_flow or start_options_flow
         initial_step: The first step returned by the flow start call
         config: Full caller-provided config dict. Menu selection keys are
-            consumed by menu steps; remaining keys are submitted on the
-            first form step whose schema declares them. A later step that
-            redeclares an already-consumed field gets that value resubmitted
-            when the step marks it required with no default of its own
-            (see :func:`_reused_consumed_value`).
+            consumed by menu steps; remaining keys are submitted on the first
+            form step whose schema declares them or, when HA omits the schema,
+            on the first form step outright. A later step that redeclares an
+            already-consumed field gets that value resubmitted once, with a
+            warning, where the step marks it required and supplies neither a
+            default nor a value of its own (see
+            :func:`_redeclared_field_submission`).
         submit_fn: Async function to submit a step. Defaults to
             client.submit_config_flow_step (create). Pass
             client.submit_options_flow_step for options (update) flows.
@@ -915,8 +1163,9 @@ async def _handle_flow_steps(
     Returns:
         ``{"success": True, "entry": result}`` on success, plus ``warnings``
         when SOME caller-supplied config keys were not declared by any flow
-        step. When the flow presented at least one form step and NONE of the
-        supplied keys were consumed, raises ``VALIDATION_INVALID_PARAMETER``
+        step, or when a key had to be resubmitted to a later step that
+        redeclared it. When the flow presented at least one form step and NONE
+        of the supplied keys were consumed, raises ``VALIDATION_INVALID_PARAMETER``
         instead of reporting a misleading success — the flow completed on
         empty forms (defaults), applying nothing the caller asked for (see
         :func:`_finish_flow_entry`). Raises ToolError on any failure.
@@ -927,7 +1176,7 @@ async def _handle_flow_steps(
     current_step = initial_step
     last_menu_choice: str | None = None
     ignored_config_keys: set[str] = set()
-    consumed_values: dict[str, Any] = {}
+    reuse_state = _ReuseState()
     supplied_keys = sorted(k for k in config if k not in _MENU_SELECTION_KEYS)
     saw_form_step = False
     any_form_key_consumed = False
@@ -945,6 +1194,7 @@ async def _handle_flow_steps(
                 any_form_key_consumed=any_form_key_consumed,
                 ignored_config_keys=ignored_config_keys,
                 remaining_config=remaining_config,
+                reuse_state=reuse_state,
             )
 
         if result_type == _FlowType.ABORT:
@@ -971,7 +1221,9 @@ async def _handle_flow_steps(
             # _handle_form_step pops only the keys declared in the current
             # step's data_schema, leaving any other keys in remaining_config
             # for subsequent steps (HA can present multi-step forms, e.g.
-            # statistics: user step then pick-characteristic step).
+            # statistics: user step then pick-characteristic step), and records
+            # what it consumed for any later step that redeclares the same
+            # field.
             saw_form_step = True
             consumed_form_keys: set[str] = set()
             form_data = _auto_confirm_form_payload(current_step)
@@ -982,7 +1234,7 @@ async def _handle_flow_steps(
                     remaining_config,
                     ignored_config_keys,
                     consumed_form_keys,
-                    consumed_values,
+                    reuse_state,
                 )
             if consumed_form_keys:
                 any_form_key_consumed = True
@@ -1044,14 +1296,15 @@ async def _handle_config_subentry_flow_steps(
     """Walk a config subentry flow and accept HA's reconfigure-success abort.
 
     Successful results include ``warnings`` when caller-supplied config keys
-    were not declared by any flow step. Fields redeclared by a later step are
-    resubmitted on the same terms as :func:`_handle_flow_steps`.
+    were not declared by any flow step, or when a key was resubmitted to a
+    later step that redeclared it. Fields redeclared by a later step are filled
+    on the same terms as :func:`_handle_flow_steps`.
     """
     remaining_config = dict(config)
     current_step = initial_step
     last_menu_choice: str | None = None
     ignored_config_keys: set[str] = set()
-    consumed_values: dict[str, Any] = {}
+    reuse_state = _ReuseState()
     max_steps = 10
 
     for step_num in range(max_steps):
@@ -1063,7 +1316,9 @@ async def _handle_config_subentry_flow_steps(
                 "operation": "created",
                 "flow_result": current_step,
             }
-            warnings = _ignored_keys_warnings(ignored_config_keys, remaining_config)
+            warnings = _success_warnings(
+                ignored_config_keys, remaining_config, reuse_state
+            )
             if warnings:
                 response["warnings"] = warnings
             return response
@@ -1076,7 +1331,9 @@ async def _handle_config_subentry_flow_steps(
                     "operation": "reconfigured",
                     "flow_result": current_step,
                 }
-                warnings = _ignored_keys_warnings(ignored_config_keys, remaining_config)
+                warnings = _success_warnings(
+                    ignored_config_keys, remaining_config, reuse_state
+                )
                 if warnings:
                     response["warnings"] = warnings
                 return response
@@ -1114,7 +1371,7 @@ async def _handle_config_subentry_flow_steps(
                 current_step,
                 remaining_config,
                 ignored_config_keys,
-                consumed_values=consumed_values,
+                reuse_state=reuse_state,
             )
             logger.debug(
                 "Config subentry flow step %s: form submit (step_id=%s, keys=%s)",

--- a/tests/src/haos_runtime.py
+++ b/tests/src/haos_runtime.py
@@ -132,7 +132,7 @@ SSHPASS_BIN = os.environ.get("HAOS_TEST_SSHPASS_BIN", "sshpass")
 
 
 def ssh_exec(
-    cmd: list[str], *, timeout: float = 30.0
+    cmd: list[str], *, timeout: float = 30.0, retry_deadline: float | None = None
 ) -> subprocess.CompletedProcess[str]:
     """Run ``cmd`` over SSH against the booted HAOS's Advanced SSH addon.
 
@@ -188,7 +188,9 @@ def ssh_exec(
     # Retry the entire ``subprocess.run`` on that specific stderr token
     # (and the connection-refused variant) so cold-start races don't
     # require every caller to embed retry logic.
-    deadline = time.monotonic() + max(timeout, 60.0)
+    deadline = time.monotonic() + (
+        retry_deadline if retry_deadline is not None else max(timeout, 60.0)
+    )
     attempt = 0
     while True:
         attempt += 1
@@ -208,12 +210,15 @@ def ssh_exec(
                 or "connection reset by peer" in stderr
                 or "connection refused" in stderr
                 or "no route to host" in stderr
-                # The dev addon self-restarts mid-suite (settings /restart in
-                # test_addon_debug_log_level.py), tearing its container down
-                # for 5-25s; a docker exec from the other xdist worker racing
-                # that window sees the name unresolved. The container comes
-                # back on its own, so the miss is as transient as the SSH
-                # races above.
+                # Sibling tests restart the dev addon mid-suite (the settings
+                # /restart self-restart, and the real Supervisor restart in
+                # test_supervisor_inaddon.py::TestSettingsUiRestartReal),
+                # tearing its container down; a docker exec from the other
+                # xdist worker racing that window sees the name unresolved.
+                # The container comes back on its own, so the miss is as
+                # transient as the SSH races above — but the window can exceed
+                # 60s on a loaded runner (run 30548328308 outlasted 30
+                # attempts), hence the caller-supplied retry_deadline.
                 or "no such container" in stderr
             )
             if transient and time.monotonic() < deadline:
@@ -252,7 +257,11 @@ def docker_exec_in_addon(
     back in the test's finally block.
     """
     container = f"addon_{addon_slug}"
-    result = ssh_exec(["docker", "exec", container, *cmd], timeout=timeout)
+    result = ssh_exec(
+        ["docker", "exec", container, *cmd],
+        timeout=timeout,
+        retry_deadline=180.0,
+    )
     return result.stdout
 
 

--- a/tests/src/haos_runtime.py
+++ b/tests/src/haos_runtime.py
@@ -234,10 +234,42 @@ def ssh_exec(
             # and would otherwise be lost in CI output. Re-raise as
             # RuntimeError with full stderr+stdout so failures are
             # actionable.
+            diag = ""
+            if "no such container" in stderr:
+                diag = _container_miss_diagnostics(ssh_cmd, env)
             raise RuntimeError(
                 f"ssh_exec failed (exit {exc.returncode}, attempt={attempt}): "
-                f"cmd={cmd!r} stderr={exc.stderr!r} stdout={exc.stdout!r}"
+                f"cmd={cmd!r} stderr={exc.stderr!r} stdout={exc.stdout!r}{diag}"
             ) from exc
+
+
+def _container_miss_diagnostics(ssh_cmd: list[str], env: dict[str, str]) -> str:
+    """Best-effort VM state capture for a persistent container-name miss.
+
+    A container absent through the whole retry window while the addon's
+    HTTP endpoint still serves means the container exists under a name
+    the test did not predict — so the failure message must carry the
+    actual names. Reuses the caller's assembled ssh wrapper with the
+    remote command swapped out; failures here must never mask the
+    original error.
+    """
+    captured: list[str] = []
+    for label, remote in (
+        ("docker_ps", "docker ps -a --format '{{.Names}} {{.Status}}'"),
+        ("ha_addons", "ha addons --raw-json | head -c 2000"),
+    ):
+        try:
+            probe = subprocess.run(
+                [*ssh_cmd[:-1], remote],
+                capture_output=True,
+                text=True,
+                timeout=20.0,
+                env=env,
+            )
+            captured.append(f"{label}={probe.stdout.strip()!r}")
+        except Exception as probe_err:  # pragma: no cover - diagnostics best-effort
+            captured.append(f"{label}_error={probe_err!r}")
+    return " | " + " | ".join(captured)
 
 
 def docker_exec_in_addon(

--- a/tests/src/haos_runtime.py
+++ b/tests/src/haos_runtime.py
@@ -210,15 +210,11 @@ def ssh_exec(
                 or "connection reset by peer" in stderr
                 or "connection refused" in stderr
                 or "no route to host" in stderr
-                # Sibling tests restart the dev addon mid-suite (the settings
-                # /restart self-restart, and the real Supervisor restart in
-                # test_supervisor_inaddon.py::TestSettingsUiRestartReal),
-                # tearing its container down; a docker exec from the other
-                # xdist worker racing that window sees the name unresolved.
-                # The container comes back on its own, so the miss is as
-                # transient as the SSH races above — but the window can exceed
-                # 60s on a loaded runner (run 30548328308 outlasted 30
-                # attempts), hence the caller-supplied retry_deadline.
+                # Addon restarts (settings /restart self-restart, the real
+                # Supervisor restart in TestSettingsUiRestartReal) tear the
+                # container down briefly, so a name miss during that window is
+                # as transient as the SSH races above. The caller-supplied
+                # retry_deadline sizes the window.
                 or "no such container" in stderr
             )
             if transient and time.monotonic() < deadline:
@@ -272,23 +268,44 @@ def _container_miss_diagnostics(ssh_cmd: list[str], env: dict[str, str]) -> str:
     return " | " + " | ".join(captured)
 
 
+def _resolve_addon_container(addon_slug: str) -> str:
+    """Return the addon's actual container name on the booted HAOS.
+
+    Supervisor's addon container prefix changed from ``addon_`` to ``app_``
+    (the add-ons to apps rename), and HAOS self-updates Supervisor at boot,
+    so which prefix a CI VM uses depends on the Supervisor build it booted
+    with — run 30553159100's capture shows ``app_local_ha_mcp_dev`` running
+    while ``addon_local_ha_mcp_dev`` resolves to nothing. Read the name from
+    docker instead of assuming a prefix; on a listing miss (e.g. the addon is
+    mid-restart) fall back to the legacy name so the caller's retry window
+    still applies.
+    """
+    listing = ssh_exec(["docker", "ps", "-a", "--format", "{{.Names}}"], timeout=20.0)
+    candidates = {f"addon_{addon_slug}", f"app_{addon_slug}"}
+    for name in listing.stdout.split():
+        if name in candidates:
+            return name
+    return f"addon_{addon_slug}"
+
+
 def docker_exec_in_addon(
     addon_slug: str, cmd: list[str], *, timeout: float = 30.0
 ) -> str:
     """Run ``cmd`` inside an addon container via SSH + docker exec.
 
     ``addon_slug`` is the Supervisor slug (e.g. ``local_ha_mcp_dev``);
-    the helper resolves it to the Docker container name (
-    ``addon_<slug>``). Returns stdout of the command. Raises
-    ``RuntimeError`` with stderr+stdout context on non-zero exit
-    (via the wrapping in ``ssh_exec``).
+    the container name is resolved from docker via
+    :func:`_resolve_addon_container` (the prefix differs across Supervisor
+    builds). Returns stdout of the command. Raises ``RuntimeError`` with
+    stderr+stdout context on non-zero exit (via the wrapping in
+    ``ssh_exec``).
 
     Used by item 8's filesystem-poisoning E2E to make
     ``/data/saved_tools.json`` unwriteable inside the dev addon
     container mid-test, force the save-warning rollback, then chmod
     back in the test's finally block.
     """
-    container = f"addon_{addon_slug}"
+    container = _resolve_addon_container(addon_slug)
     result = ssh_exec(
         ["docker", "exec", container, *cmd],
         timeout=timeout,

--- a/tests/src/haos_runtime.py
+++ b/tests/src/haos_runtime.py
@@ -208,6 +208,13 @@ def ssh_exec(
                 or "connection reset by peer" in stderr
                 or "connection refused" in stderr
                 or "no route to host" in stderr
+                # The dev addon self-restarts mid-suite (settings /restart in
+                # test_addon_debug_log_level.py), tearing its container down
+                # for 5-25s; a docker exec from the other xdist worker racing
+                # that window sees the name unresolved. The container comes
+                # back on its own, so the miss is as transient as the SSH
+                # races above.
+                or "no such container" in stderr
             )
             if transient and time.monotonic() < deadline:
                 LOG.debug(

--- a/tests/src/unit/test_flow_multistep.py
+++ b/tests/src/unit/test_flow_multistep.py
@@ -9,8 +9,16 @@ Regression guard: prior code wiped ``remaining_config`` after the first form
 step, which made step 2+ submit ``{}`` and HA respond with HTTP 400. This
 broke ``statistics`` (multi-step user → pick-characteristic) and
 ``utility_meter`` UPDATE.
+
+``TestRedeclaredFieldReuse`` covers the other half of that split (issue
+#2057): a key the caller supplies once, consumed by an early step and then
+declared again by a later step, is resubmitted from a scoped record — but only
+where the later step marks it required and supplies neither a default nor a
+value of its own, only once per step, and never into an optional field or a
+section the caller never named.
 """
 
+import copy
 from typing import Any
 from unittest.mock import AsyncMock
 
@@ -22,6 +30,7 @@ from ha_mcp.tools.config_entry_flow import (
     _handle_config_subentry_flow_steps,
     _handle_flow_steps,
     _handle_form_step,
+    _ReuseState,
     _submit_step,
 )
 
@@ -756,8 +765,16 @@ class TestSubentryFlowIgnoredKeys:
         ]
 
 
+def _reuse_warning(dotted: str, step_id: str) -> str:
+    """The warning a resubmitted key adds to the walk's success response."""
+    return (
+        f"Resubmitted '{dotted}' at step '{step_id}': supplied once "
+        "but declared at more than one site in this flow"
+    )
+
+
 def _later_step(redeclared_field: dict[str, Any]) -> dict[str, Any]:
-    """Build a second step that redeclares ``friendly_name`` alongside its own key."""
+    """Build a second step declaring its own ``id`` key plus ``redeclared_field``."""
     return {
         "type": "form",
         "flow_id": "flow-2057",
@@ -770,7 +787,7 @@ def _later_step(redeclared_field: dict[str, Any]) -> dict[str, Any]:
 
 
 def _first_step() -> dict[str, Any]:
-    """Build a first step that consumes ``friendly_name`` before any later step."""
+    """Build a first step that consumes ``friendly_name`` and ``host``."""
     return {
         "type": "form",
         "flow_id": "flow-2057",
@@ -785,13 +802,15 @@ def _first_step() -> dict[str, Any]:
 class TestRedeclaredFieldReuse:
     """A later step redeclaring a field an earlier step consumed (issue #2057).
 
-    A supplied config key applies to every step that declares it, but never
-    overrides a default or suggested value the step's own schema carries.
-    Before the fix the first step popped the key out of ``remaining_config``,
-    so a later step declaring the same name was submitted without it and HA
-    answered "required key not provided". Reuse now fires exactly where
-    omitting the key is a guaranteed voluptuous failure: the redeclared field
-    is required AND carries no default of its own.
+    The first step pops the key out of ``remaining_config``, so a later step
+    declaring the same name would be submitted without it and HA would answer
+    "required key not provided". Resubmission from the record closes that gap,
+    and is deliberately the last resort: a ``"default"`` key means voluptuous
+    fills the value in, a suggested value or a constant means the step supplies
+    its own, an optional field means nothing may be injected, and a section the
+    caller never named must not be brought into existence. Where it does fire
+    the response says so, and it fires at most once per step so a flow that
+    re-presents a form cannot be rewritten indefinitely.
     """
 
     async def test_later_step_resubmits_required_field_with_no_default(self) -> None:
@@ -819,8 +838,16 @@ class TestRedeclaredFieldReuse:
             submit_fn=submit_fn,
         )
 
-        # No warnings: a resubmitted key was consumed, not ignored.
-        assert result == {"success": True, "entry": final_entry}
+        # The resubmission is reported: the caller wrote one value and two
+        # steps were given it.
+        assert result == {
+            "success": True,
+            "entry": final_entry,
+            "warnings": [
+                "Resubmitted 'friendly_name' at step 'details': supplied once "
+                "but declared at more than one site in this flow"
+            ],
+        }
         assert submit_fn.await_args_list[0].args[1] == {
             "friendly_name": "Device1",
             "host": "10.0.0.5",
@@ -830,21 +857,16 @@ class TestRedeclaredFieldReuse:
             "friendly_name": "Device1",
         }
 
-    @pytest.mark.parametrize(
-        "default_source",
-        [
-            {"description": {"suggested_value": "Existing entity name"}},
-            {"suggested_value": "Existing entity name"},
-            {"default": ""},
-        ],
-    )
+    @pytest.mark.parametrize("default_source", [{"default": ""}, {"default": None}])
     async def test_redeclared_field_with_a_default_is_not_resubmitted(
         self, default_source: dict[str, Any]
     ) -> None:
-        """Edit-style forms serialize the current value as the default.
+        """A ``"default"`` key means voluptuous fills the value in itself.
 
-        The step's own default wins: resubmitting the earlier step's value over
-        it would change data the caller never named for this step.
+        Key presence is the whole test, so ``default: None`` counts: HA
+        serializes a default only from an actual voluptuous default, and
+        submitting an earlier step's value over one would change data the caller
+        never named for this step.
         """
         final_entry: dict[str, Any] = {
             "type": "create_entry",
@@ -859,7 +881,7 @@ class TestRedeclaredFieldReuse:
             ]
         )
 
-        await _handle_flow_steps(
+        result = await _handle_flow_steps(
             client=None,
             flow_id="flow-2057",
             initial_step=_first_step(),
@@ -868,6 +890,122 @@ class TestRedeclaredFieldReuse:
         )
 
         assert submit_fn.await_args_list[1].args[1] == {"id": 20}
+        assert "warnings" not in result
+
+    @pytest.mark.parametrize(
+        "suggestion_source",
+        [
+            {"description": {"suggested_value": "Existing entity name"}},
+            {"suggested_value": "Existing entity name"},
+        ],
+    )
+    async def test_redeclared_field_submits_the_steps_own_suggested_value(
+        self, suggestion_source: dict[str, Any]
+    ) -> None:
+        """HA's edit-style pre-fill is the step's own data, and it is submitted.
+
+        ``add_suggested_values_to_schema`` puts the current value in
+        ``description.suggested_value`` and emits no ``"default"``, so omitting
+        the key would fail validation while resubmitting the caller's value
+        would overwrite the value being edited. The bare top-level
+        ``suggested_value`` shape is read defensively — ``voluptuous_serialize``
+        never emits it — and behaves identically.
+        """
+        final_entry: dict[str, Any] = {
+            "type": "create_entry",
+            "result": {"entry_id": "entry-2"},
+        }
+        submit_fn = AsyncMock(
+            side_effect=[
+                _later_step(
+                    {"name": "friendly_name", "required": True, **suggestion_source}
+                ),
+                final_entry,
+            ]
+        )
+
+        result = await _handle_flow_steps(
+            client=None,
+            flow_id="flow-2057",
+            initial_step=_first_step(),
+            config={"friendly_name": "Device1", "host": "10.0.0.5", "id": 20},
+            submit_fn=submit_fn,
+        )
+
+        assert submit_fn.await_args_list[1].args[1] == {
+            "id": 20,
+            "friendly_name": "Existing entity name",
+        }
+        # Schema data, not a caller key: nothing to report.
+        assert "warnings" not in result
+
+    async def test_redeclared_constant_field_submits_its_only_legal_value(self) -> None:
+        final_entry: dict[str, Any] = {
+            "type": "create_entry",
+            "result": {"entry_id": "entry-2b"},
+        }
+        submit_fn = AsyncMock(
+            side_effect=[
+                _later_step(
+                    {
+                        "name": "friendly_name",
+                        "required": True,
+                        "type": "constant",
+                        "value": "LOCKED",
+                    }
+                ),
+                final_entry,
+            ]
+        )
+
+        result = await _handle_flow_steps(
+            client=None,
+            flow_id="flow-2057",
+            initial_step=_first_step(),
+            config={"friendly_name": "Device1", "host": "10.0.0.5", "id": 20},
+            submit_fn=submit_fn,
+        )
+
+        assert submit_fn.await_args_list[1].args[1] == {
+            "id": 20,
+            "friendly_name": "LOCKED",
+        }
+        assert "warnings" not in result
+
+    @pytest.mark.parametrize(
+        "null_suggestion",
+        [{"description": {"suggested_value": None}}, {"suggested_value": None}],
+    )
+    async def test_present_but_null_suggestion_falls_back_to_the_caller_value(
+        self, null_suggestion: dict[str, Any]
+    ) -> None:
+        """A null suggestion is no value at all, so the caller's is the last resort."""
+        final_entry: dict[str, Any] = {
+            "type": "create_entry",
+            "result": {"entry_id": "entry-2c"},
+        }
+        submit_fn = AsyncMock(
+            side_effect=[
+                _later_step(
+                    {"name": "friendly_name", "required": True, **null_suggestion}
+                ),
+                final_entry,
+            ]
+        )
+
+        result = await _handle_flow_steps(
+            client=None,
+            flow_id="flow-2057",
+            initial_step=_first_step(),
+            config={"friendly_name": "Device1", "host": "10.0.0.5", "id": 20},
+            submit_fn=submit_fn,
+        )
+
+        assert submit_fn.await_args_list[1].args[1] == {
+            "id": 20,
+            "friendly_name": "Device1",
+        }
+        assert result["warnings"] == [_reuse_warning("friendly_name", "details")]
 
     @pytest.mark.parametrize("required_source", [{}, {"required": False}])
     async def test_redeclared_optional_field_is_not_resubmitted(
@@ -915,7 +1053,7 @@ class TestRedeclaredFieldReuse:
         }
         submit_fn = AsyncMock(side_effect=[later_step, final_entry])
 
-        await _handle_flow_steps(
+        result = await _handle_flow_steps(
             client=None,
             flow_id="flow-2057",
             initial_step=_first_step(),
@@ -927,6 +1065,10 @@ class TestRedeclaredFieldReuse:
             "id": 20,
             "advanced": {"friendly_name": "Device1"},
         }
+        # The warning names the dotted path the value landed on.
+        assert result["warnings"] == [
+            _reuse_warning("advanced.friendly_name", "details")
+        ]
 
     async def test_resubmitted_value_is_a_copy(self) -> None:
         """Two submissions must not share a mutable value object."""
@@ -983,7 +1125,9 @@ class TestRedeclaredFieldReuse:
         )
 
         assert result["operation"] == "created"
-        assert "warnings" not in result
+        # Parity with _handle_flow_steps: the subentry walker reports the
+        # resubmission on its own success path.
+        assert result["warnings"] == [_reuse_warning("friendly_name", "details")]
         submitted = client.submit_config_subentry_flow_step.await_args_list
         assert submitted[0].args[1] == {
             "friendly_name": "Device1",
@@ -991,11 +1135,15 @@ class TestRedeclaredFieldReuse:
         }
         assert submitted[1].args[1] == {"id": 20, "friendly_name": "Device1"}
 
-    async def test_repeated_step_resubmits_on_every_iteration(self) -> None:
-        """A flow that presents the same step again keeps getting the value.
+    async def test_repeated_step_is_resubmitted_once_then_left_alone(self) -> None:
+        """One reused write per step, however often the flow re-presents it.
 
-        Reuse legitimately fires on each later iteration; the walk still
-        terminates on ``max_steps`` and each payload is an independent object.
+        Iteration 1 submits the caller's own key. Iteration 2 resubmits it from
+        the record, because a step asking again for a required field with no
+        default cannot be answered with nothing. From iteration 3 the key is
+        omitted, so a flow stuck on one form gets HA's loud "required key not
+        provided" naming the field instead of a silent rewrite loop. Each
+        payload is an independent object.
         """
         repeated: dict[str, Any] = {
             "type": "form",
@@ -1020,14 +1168,23 @@ class TestRedeclaredFieldReuse:
         )
 
         assert result["success"] is True
-        assert "warnings" not in result
+        assert result["warnings"] == [_reuse_warning("entity_ids", "user")]
         payloads = [call.args[1] for call in submit_fn.await_args_list]
-        assert payloads == [{"entity_ids": ["sensor.a"]}] * 4
-        values = [payload["entity_ids"] for payload in payloads]
-        assert len({id(value) for value in values}) == len(values)
+        assert payloads == [
+            {"entity_ids": ["sensor.a"]},
+            {"entity_ids": ["sensor.a"]},
+            {},
+            {},
+        ]
+        first, reused = payloads[0]["entity_ids"], payloads[1]["entity_ids"]
+        assert reused is not first
 
     async def test_walk_still_bounded_when_a_repeated_step_never_finishes(self) -> None:
-        """A flow that keeps re-presenting the same form hits the step ceiling."""
+        """A flow that keeps re-presenting the same form hits the step ceiling.
+
+        The ceiling is what ends the walk; the fire-once bound is what keeps the
+        run in between from writing the same value ten times.
+        """
         import json
 
         from fastmcp.exceptions import ToolError
@@ -1052,6 +1209,352 @@ class TestRedeclaredFieldReuse:
         body = json.loads(str(exc_info.value))
         assert body["error"]["code"] == "TIMEOUT_OPERATION"
         assert submit_fn.await_count == 10
+        payloads = [call.args[1] for call in submit_fn.await_args_list]
+        assert payloads[:2] == [{"entity_ids": ["sensor.a"]}] * 2
+        assert payloads[2:] == [{}] * 8
+
+
+class TestReuseScoping:
+    """Where a recorded value may resurface, and where it must not."""
+
+    @staticmethod
+    def _named_section_step(step_id: str, section: str) -> dict[str, Any]:
+        return {
+            "type": "form",
+            "flow_id": "flow-scope",
+            "step_id": step_id,
+            "data_schema": [
+                {"name": "id", "required": True},
+                {
+                    "type": "expandable",
+                    "name": section,
+                    "required": True,
+                    "schema": [{"name": "name", "required": True}],
+                },
+            ],
+        }
+
+    async def test_value_from_an_explicit_section_is_not_reused_for_a_sibling(
+        self,
+    ) -> None:
+        """``{"left": {"name": ...}}`` names one section, so it fills only that one."""
+        final_entry: dict[str, Any] = {
+            "type": "create_entry",
+            "result": {"entry_id": "entry-scope-1"},
+        }
+        first_step: dict[str, Any] = {
+            "type": "form",
+            "flow_id": "flow-scope",
+            "step_id": "left_step",
+            "data_schema": [
+                {
+                    "type": "expandable",
+                    "name": "left",
+                    "required": True,
+                    "schema": [{"name": "name", "required": True}],
+                }
+            ],
+        }
+        submit_fn = AsyncMock(
+            side_effect=[self._named_section_step("right_step", "right"), final_entry]
+        )
+
+        result = await _handle_flow_steps(
+            client=None,
+            flow_id="flow-scope",
+            initial_step=first_step,
+            config={"left": {"name": "LEFT"}, "id": 20},
+            submit_fn=submit_fn,
+        )
+
+        assert submit_fn.await_args_list[0].args[1] == {"left": {"name": "LEFT"}}
+        # right.name is required with no default, but nothing the caller wrote
+        # belongs there — HA's own error is the right answer, not "LEFT".
+        assert submit_fn.await_args_list[1].args[1] == {"id": 20}
+        assert "warnings" not in result
+
+    async def test_flat_value_is_reused_inside_a_later_section(self) -> None:
+        """A flat key names no section, so it fills the leaf wherever it is declared."""
+        final_entry: dict[str, Any] = {
+            "type": "create_entry",
+            "result": {"entry_id": "entry-scope-2"},
+        }
+        first_step: dict[str, Any] = {
+            "type": "form",
+            "flow_id": "flow-scope",
+            "step_id": "name_step",
+            "data_schema": [{"name": "name", "required": True}],
+        }
+        submit_fn = AsyncMock(
+            side_effect=[self._named_section_step("right_step", "right"), final_entry]
+        )
+
+        result = await _handle_flow_steps(
+            client=None,
+            flow_id="flow-scope",
+            initial_step=first_step,
+            config={"name": "FLAT", "id": 20},
+            submit_fn=submit_fn,
+        )
+
+        assert submit_fn.await_args_list[1].args[1] == {
+            "id": 20,
+            "right": {"name": "FLAT"},
+        }
+        assert result["warnings"] == [_reuse_warning("right.name", "right_step")]
+
+    async def test_untouched_optional_section_is_not_materialized(self) -> None:
+        """Reuse never invents a section the caller did not name."""
+        final_entry: dict[str, Any] = {
+            "type": "create_entry",
+            "result": {"entry_id": "entry-scope-3"},
+        }
+        later_step: dict[str, Any] = {
+            "type": "form",
+            "flow_id": "flow-2057",
+            "step_id": "details",
+            "data_schema": [
+                {"name": "id", "required": True},
+                {
+                    "type": "expandable",
+                    "name": "advanced",
+                    "required": False,
+                    "schema": [{"name": "friendly_name", "required": True}],
+                },
+            ],
+        }
+        submit_fn = AsyncMock(side_effect=[later_step, final_entry])
+
+        result = await _handle_flow_steps(
+            client=None,
+            flow_id="flow-2057",
+            initial_step=_first_step(),
+            config={"friendly_name": "Device1", "host": "10.0.0.5", "id": 20},
+            submit_fn=submit_fn,
+        )
+
+        assert submit_fn.await_args_list[1].args[1] == {"id": 20}
+        assert "warnings" not in result
+
+    async def test_explicitly_supplied_optional_section_allows_reuse(self) -> None:
+        """Naming the section is consent to fill the rest of what it requires."""
+        final_entry: dict[str, Any] = {
+            "type": "create_entry",
+            "result": {"entry_id": "entry-scope-4"},
+        }
+        later_step: dict[str, Any] = {
+            "type": "form",
+            "flow_id": "flow-2057",
+            "step_id": "details",
+            "data_schema": [
+                {"name": "id", "required": True},
+                {
+                    "type": "expandable",
+                    "name": "advanced",
+                    "required": False,
+                    "schema": [
+                        {"name": "friendly_name", "required": True},
+                        {"name": "extra"},
+                    ],
+                },
+            ],
+        }
+        submit_fn = AsyncMock(side_effect=[later_step, final_entry])
+
+        result = await _handle_flow_steps(
+            client=None,
+            flow_id="flow-2057",
+            initial_step=_first_step(),
+            config={
+                "friendly_name": "Device1",
+                "host": "10.0.0.5",
+                "id": 20,
+                "advanced": {"extra": 7},
+            },
+            submit_fn=submit_fn,
+        )
+
+        assert submit_fn.await_args_list[1].args[1] == {
+            "id": 20,
+            "advanced": {"extra": 7, "friendly_name": "Device1"},
+        }
+        assert result["warnings"] == [
+            _reuse_warning("advanced.friendly_name", "details")
+        ]
+
+    def test_one_step_declaring_a_leaf_twice_fills_both(self) -> None:
+        """Flat and sectioned declarations of one name in a single step."""
+        state = _ReuseState()
+        step: dict[str, Any] = {
+            "type": "form",
+            "step_id": "user",
+            "data_schema": [
+                {"name": "name", "required": True},
+                {
+                    "type": "expandable",
+                    "name": "advanced",
+                    "required": True,
+                    "schema": [{"name": "name", "required": True}],
+                },
+            ],
+        }
+        remaining = {"name": "X"}
+
+        form_data = _handle_form_step("flow-1", step, remaining, reuse_state=state)
+
+        assert form_data == {"name": "X", "advanced": {"name": "X"}}
+        assert remaining == {}
+        assert state.notes == [_reuse_warning("advanced.name", "user")]
+
+    async def test_legacy_schemaless_step_records_what_it_dumped(self) -> None:
+        """A step HA sent no schema for still feeds later schema'd steps."""
+        final_entry: dict[str, Any] = {
+            "type": "create_entry",
+            "result": {"entry_id": "entry-scope-5"},
+        }
+        first_step: dict[str, Any] = {
+            "type": "form",
+            "flow_id": "flow-2057",
+            "step_id": "user",
+            "data_schema": None,
+        }
+        submit_fn = AsyncMock(
+            side_effect=[
+                _later_step({"name": "friendly_name", "required": True}),
+                final_entry,
+            ]
+        )
+
+        result = await _handle_flow_steps(
+            client=None,
+            flow_id="flow-2057",
+            initial_step=first_step,
+            config={"friendly_name": "Device1", "host": "10.0.0.5", "id": 20},
+            submit_fn=submit_fn,
+        )
+
+        assert submit_fn.await_args_list[0].args[1] == {
+            "friendly_name": "Device1",
+            "host": "10.0.0.5",
+            "id": 20,
+        }
+        # Both of step 2's required no-default fields came out of the dump.
+        assert submit_fn.await_args_list[1].args[1] == {
+            "id": 20,
+            "friendly_name": "Device1",
+        }
+        assert result["warnings"] == [
+            _reuse_warning("id", "details"),
+            _reuse_warning("friendly_name", "details"),
+        ]
+
+    async def test_injected_section_defaults_are_not_recorded_for_reuse(self) -> None:
+        """Mirror of the consumed-keys rule: HA's own defaults are not caller values."""
+        final_entry: dict[str, Any] = {
+            "type": "create_entry",
+            "result": {"entry_id": "entry-scope-6"},
+        }
+        first_step: dict[str, Any] = {
+            "type": "form",
+            "flow_id": "flow-2057",
+            "step_id": "user",
+            "data_schema": [
+                {"name": "host", "required": True},
+                {
+                    "type": "expandable",
+                    "name": "advanced",
+                    "required": True,
+                    "schema": [{"name": "framerate", "default": 2}],
+                },
+            ],
+        }
+        later_step: dict[str, Any] = {
+            "type": "form",
+            "flow_id": "flow-2057",
+            "step_id": "details",
+            "data_schema": [{"name": "framerate", "required": True}],
+        }
+        submit_fn = AsyncMock(side_effect=[later_step, final_entry])
+
+        result = await _handle_flow_steps(
+            client=None,
+            flow_id="flow-2057",
+            initial_step=first_step,
+            config={"host": "1.2.3.4"},
+            submit_fn=submit_fn,
+        )
+
+        assert submit_fn.await_args_list[0].args[1] == {
+            "host": "1.2.3.4",
+            "advanced": {"framerate": 2},
+        }
+        assert submit_fn.await_args_list[1].args[1] == {}
+        assert "warnings" not in result
+
+    async def test_menu_selection_key_is_never_reused_by_a_form_step(self) -> None:
+        final_entry: dict[str, Any] = {
+            "type": "create_entry",
+            "result": {"entry_id": "entry-scope-7"},
+        }
+        later_step: dict[str, Any] = {
+            "type": "form",
+            "flow_id": "flow-menu",
+            "step_id": "options",
+            "data_schema": [
+                {"name": "name", "required": True},
+                {"name": "group_type", "required": True},
+            ],
+        }
+        submit_fn = AsyncMock(side_effect=[later_step, final_entry])
+
+        result = await _handle_flow_steps(
+            client=None,
+            flow_id="flow-menu",
+            initial_step={
+                "type": "menu",
+                "flow_id": "flow-menu",
+                "step_id": "user",
+                "menu_options": ["light", "switch"],
+            },
+            config={"group_type": "light", "name": "x"},
+            submit_fn=submit_fn,
+        )
+
+        assert submit_fn.await_args_list[0].args[1] == {"next_step_id": "light"}
+        assert submit_fn.await_args_list[1].args[1] == {"name": "x"}
+        assert "warnings" not in result
+
+    async def test_recorded_value_is_snapshotted_at_record_time(self) -> None:
+        """Mutating the caller's list after step 1 cannot reach step 2's payload."""
+        config: dict[str, Any] = {"entity_ids": ["sensor.a"]}
+        step: dict[str, Any] = {
+            "type": "form",
+            "flow_id": "flow-2057",
+            "step_id": "user",
+            "data_schema": [{"name": "entity_ids", "required": True}],
+        }
+        later_step = dict(step, step_id="details")
+        final_entry: dict[str, Any] = {
+            "type": "create_entry",
+            "result": {"entry_id": "entry-scope-8"},
+        }
+        payloads: list[dict[str, Any]] = []
+
+        def submit(flow_id: str, payload: dict[str, Any]) -> dict[str, Any]:
+            payloads.append(copy.deepcopy(payload))
+            config["entity_ids"].append("sensor.MUTATED")
+            return later_step if len(payloads) == 1 else final_entry
+
+        await _handle_flow_steps(
+            client=None,
+            flow_id="flow-2057",
+            initial_step=step,
+            config=config,
+            submit_fn=AsyncMock(side_effect=submit),
+        )
+
+        assert config["entity_ids"] == ["sensor.a", "sensor.MUTATED", "sensor.MUTATED"]
+        assert payloads == [{"entity_ids": ["sensor.a"]}, {"entity_ids": ["sensor.a"]}]
 
 
 class TestSubmitStep:
@@ -1176,6 +1679,48 @@ class TestAllKeysIgnoredIsAnError:
         assert body["error"]["code"] == "VALIDATION_INVALID_PARAMETER"
         assert "without consuming any" in body["error"]["message"]
         assert submit_fn.await_args.args[1] == {"advanced": {"framerate": 2}}
+
+    async def test_step_owned_submission_does_not_count_as_consumed_keys(self) -> None:
+        """A step's own suggestion fills a form but applies nothing the caller asked for."""
+        import json
+
+        from fastmcp.exceptions import ToolError
+
+        final_entry = {"type": "create_entry", "result": {"entry_id": "e1"}}
+        later_step = {
+            "type": "form",
+            "flow_id": "flow-typo",
+            "step_id": "details",
+            "data_schema": [
+                {
+                    "name": "friendly_name",
+                    "required": True,
+                    "description": {"suggested_value": "HA name"},
+                }
+            ],
+        }
+        submit_fn = AsyncMock(side_effect=[later_step, final_entry])
+        initial_step = {
+            "type": "form",
+            "flow_id": "flow-typo",
+            "step_id": "user",
+            "data_schema": [{"name": "entities"}],
+        }
+
+        with pytest.raises(ToolError) as exc_info:
+            await _handle_flow_steps(
+                client=None,
+                flow_id="flow-typo",
+                initial_step=initial_step,
+                config={"typo_key": 5},
+                submit_fn=submit_fn,
+            )
+
+        body = json.loads(str(exc_info.value))
+        assert body["error"]["code"] == "VALIDATION_INVALID_PARAMETER"
+        assert "without consuming any" in body["error"]["message"]
+        payloads = [call.args[1] for call in submit_fn.await_args_list]
+        assert payloads == [{}, {"friendly_name": "HA name"}]
 
     async def test_preview_confirm_form_is_auto_advanced(self) -> None:
         confirm_step = {

--- a/tests/src/unit/test_flow_multistep.py
+++ b/tests/src/unit/test_flow_multistep.py
@@ -1253,6 +1253,58 @@ class TestRedeclaredFieldReuse:
         assert payloads[:2] == [{"entity_ids": ["sensor.a"]}] * 2
         assert payloads[2:] == [{}] * 8
 
+    async def test_every_later_step_redeclaring_one_field_gets_its_own_write(
+        self,
+    ) -> None:
+        """The bound is one write per step, not one per field for the whole flow.
+
+        Three steps declare ``friendly_name`` and only the first gets the
+        caller's key. Both steps after it must be answered: a bound spent at
+        one of them would leave the next submitting nothing for a required
+        field with no default, which is the "required key not provided" that
+        resubmission exists to prevent. Each write names the step it happened
+        at.
+        """
+        second_step: dict[str, Any] = {
+            "type": "form",
+            "flow_id": "flow-2057",
+            "step_id": "second",
+            "data_schema": [
+                {"name": "id", "required": True},
+                {"name": "friendly_name", "required": True},
+            ],
+        }
+        third_step: dict[str, Any] = {
+            "type": "form",
+            "flow_id": "flow-2057",
+            "step_id": "third",
+            "data_schema": [{"name": "friendly_name", "required": True}],
+        }
+        final_entry: dict[str, Any] = {
+            "type": "create_entry",
+            "result": {"entry_id": "entry-8"},
+        }
+        submit_fn = AsyncMock(side_effect=[second_step, third_step, final_entry])
+
+        result = await _handle_flow_steps(
+            client=None,
+            flow_id="flow-2057",
+            initial_step=dict(_first_step(), step_id="first"),
+            config={"friendly_name": "Device1", "host": "10.0.0.5", "id": 20},
+            submit_fn=submit_fn,
+        )
+
+        payloads = [call.args[1] for call in submit_fn.await_args_list]
+        assert payloads == [
+            {"friendly_name": "Device1", "host": "10.0.0.5"},
+            {"id": 20, "friendly_name": "Device1"},
+            {"friendly_name": "Device1"},
+        ]
+        assert result["warnings"] == [
+            _reuse_warning("friendly_name", "second"),
+            _reuse_warning("friendly_name", "third"),
+        ]
+
 
 class TestReuseScoping:
     """Where a recorded value may resurface, and where it must not."""
@@ -1389,6 +1441,72 @@ class TestReuseScoping:
             "advanced": {"name": "FLAT"},
         }
         assert result["warnings"] == [_reuse_warning("advanced.name", "later_step")]
+
+    async def test_scoped_record_outranks_a_flat_one_for_the_same_leaf(self) -> None:
+        """Both records hold ``label``; a sectioned redeclaration takes the scoped one.
+
+        Step order is load-bearing. The step declaring ``label`` flat has to
+        run first: with the section step first, its explicit
+        ``{"left": {"label": ...}}`` would still be sitting beside an
+        unconsumed flat ``label``, and a flat child overrides the section value
+        it duplicates — the scoped record would be rewritten to the flat value
+        (see ``test_flat_override_wins_over_stale_scoped_record_on_reuse``) and
+        both lookups would then answer the same thing.
+        """
+        flat_step: dict[str, Any] = {
+            "type": "form",
+            "flow_id": "flow-scope",
+            "step_id": "flat_step",
+            "data_schema": [{"name": "label", "required": True}],
+        }
+        section_step: dict[str, Any] = {
+            "type": "form",
+            "flow_id": "flow-scope",
+            "step_id": "section_step",
+            "data_schema": [
+                {
+                    "type": "expandable",
+                    "name": "left",
+                    "required": True,
+                    "schema": [{"name": "label", "required": True}],
+                }
+            ],
+        }
+        redeclaring_step: dict[str, Any] = {
+            "type": "form",
+            "flow_id": "flow-scope",
+            "step_id": "redeclaring_step",
+            "data_schema": [
+                {"name": "id", "required": True},
+                {
+                    "type": "expandable",
+                    "name": "left",
+                    "required": True,
+                    "schema": [{"name": "label", "required": True}],
+                },
+            ],
+        }
+        final_entry: dict[str, Any] = {
+            "type": "create_entry",
+            "result": {"entry_id": "entry-scope-9"},
+        }
+        submit_fn = AsyncMock(side_effect=[section_step, redeclaring_step, final_entry])
+
+        result = await _handle_flow_steps(
+            client=None,
+            flow_id="flow-scope",
+            initial_step=flat_step,
+            config={"label": "FLAT", "left": {"label": "SCOPED"}, "id": 20},
+            submit_fn=submit_fn,
+        )
+
+        payloads = [call.args[1] for call in submit_fn.await_args_list]
+        assert payloads == [
+            {"label": "FLAT"},
+            {"left": {"label": "SCOPED"}},
+            {"id": 20, "left": {"label": "SCOPED"}},
+        ]
+        assert result["warnings"] == [_reuse_warning("left.label", "redeclaring_step")]
 
     async def test_untouched_optional_section_is_not_materialized(self) -> None:
         """Reuse never invents a section the caller did not name."""

--- a/tests/src/unit/test_flow_multistep.py
+++ b/tests/src/unit/test_flow_multistep.py
@@ -905,11 +905,11 @@ class TestRedeclaredFieldReuse:
         """HA's edit-style pre-fill is the step's own data, and it is submitted.
 
         ``add_suggested_values_to_schema`` puts the current value in
-        ``description.suggested_value`` and emits no ``"default"``, so omitting
-        the key would fail validation while resubmitting the caller's value
-        would overwrite the value being edited. The bare top-level
-        ``suggested_value`` shape is read defensively — ``voluptuous_serialize``
-        never emits it — and behaves identically.
+        ``description.suggested_value``; with no voluptuous default on the
+        marker, omitting the key would fail validation, while resubmitting the
+        caller's value would overwrite the value being edited. The bare
+        top-level ``suggested_value`` shape is read defensively —
+        ``voluptuous_serialize`` never emits it — and behaves identically.
         """
         final_entry: dict[str, Any] = {
             "type": "create_entry",
@@ -937,6 +937,46 @@ class TestRedeclaredFieldReuse:
             "friendly_name": "Existing entity name",
         }
         # Schema data, not a caller key: nothing to report.
+        assert "warnings" not in result
+
+    async def test_suggestion_outranks_a_coexisting_static_default(self) -> None:
+        """A marker keeps its voluptuous default when HA injects a suggestion.
+
+        Both keys then serialize together: the default is the static schema
+        value and the suggestion is the stored current one. The suggestion is
+        submitted — omission would let voluptuous substitute the static value
+        over the stored one.
+        """
+        final_entry: dict[str, Any] = {
+            "type": "create_entry",
+            "result": {"entry_id": "entry-2b"},
+        }
+        submit_fn = AsyncMock(
+            side_effect=[
+                _later_step(
+                    {
+                        "name": "friendly_name",
+                        "required": True,
+                        "default": 30,
+                        "description": {"suggested_value": 300},
+                    }
+                ),
+                final_entry,
+            ]
+        )
+
+        result = await _handle_flow_steps(
+            client=None,
+            flow_id="flow-2057",
+            initial_step=_first_step(),
+            config={"friendly_name": "Device1", "host": "10.0.0.5", "id": 20},
+            submit_fn=submit_fn,
+        )
+
+        assert submit_fn.await_args_list[1].args[1] == {
+            "id": 20,
+            "friendly_name": 300,
+        }
         assert "warnings" not in result
 
     async def test_redeclared_constant_field_submits_its_only_legal_value(self) -> None:

--- a/tests/src/unit/test_flow_multistep.py
+++ b/tests/src/unit/test_flow_multistep.py
@@ -1303,6 +1303,53 @@ class TestReuseScoping:
         }
         assert result["warnings"] == [_reuse_warning("right.name", "right_step")]
 
+    async def test_flat_override_wins_over_stale_scoped_record_on_reuse(self) -> None:
+        """The record carries the value actually submitted for a path.
+
+        A flat key overrides an explicit section value at the step declaring
+        both (see ``test_flat_section_field_overrides_explicit_section_value``),
+        so a later redeclaration of that path must resubmit the override, not
+        the overridden section value.
+        """
+        final_entry: dict[str, Any] = {
+            "type": "create_entry",
+            "result": {"entry_id": "entry-scope-3"},
+        }
+        first_step: dict[str, Any] = {
+            "type": "form",
+            "flow_id": "flow-scope",
+            "step_id": "advanced_step",
+            "data_schema": [
+                {
+                    "type": "expandable",
+                    "name": "advanced",
+                    "required": True,
+                    "schema": [{"name": "name", "required": True}],
+                }
+            ],
+        }
+        submit_fn = AsyncMock(
+            side_effect=[
+                self._named_section_step("later_step", "advanced"),
+                final_entry,
+            ]
+        )
+
+        result = await _handle_flow_steps(
+            client=None,
+            flow_id="flow-scope",
+            initial_step=first_step,
+            config={"advanced": {"name": "SCOPED"}, "name": "FLAT", "id": 20},
+            submit_fn=submit_fn,
+        )
+
+        assert submit_fn.await_args_list[0].args[1] == {"advanced": {"name": "FLAT"}}
+        assert submit_fn.await_args_list[1].args[1] == {
+            "id": 20,
+            "advanced": {"name": "FLAT"},
+        }
+        assert result["warnings"] == [_reuse_warning("advanced.name", "later_step")]
+
     async def test_untouched_optional_section_is_not_materialized(self) -> None:
         """Reuse never invents a section the caller did not name."""
         final_entry: dict[str, Any] = {

--- a/tests/src/unit/test_flow_multistep.py
+++ b/tests/src/unit/test_flow_multistep.py
@@ -756,6 +756,304 @@ class TestSubentryFlowIgnoredKeys:
         ]
 
 
+def _later_step(redeclared_field: dict[str, Any]) -> dict[str, Any]:
+    """Build a second step that redeclares ``friendly_name`` alongside its own key."""
+    return {
+        "type": "form",
+        "flow_id": "flow-2057",
+        "step_id": "details",
+        "data_schema": [
+            {"name": "id", "required": True},
+            redeclared_field,
+        ],
+    }
+
+
+def _first_step() -> dict[str, Any]:
+    """Build a first step that consumes ``friendly_name`` before any later step."""
+    return {
+        "type": "form",
+        "flow_id": "flow-2057",
+        "step_id": "user",
+        "data_schema": [
+            {"name": "friendly_name", "required": True, "default": ""},
+            {"name": "host", "required": True, "default": "1.2.3.4"},
+        ],
+    }
+
+
+class TestRedeclaredFieldReuse:
+    """A later step redeclaring a field an earlier step consumed (issue #2057).
+
+    A supplied config key applies to every step that declares it, but never
+    overrides a default or suggested value the step's own schema carries.
+    Before the fix the first step popped the key out of ``remaining_config``,
+    so a later step declaring the same name was submitted without it and HA
+    answered "required key not provided". Reuse now fires exactly where
+    omitting the key is a guaranteed voluptuous failure: the redeclared field
+    is required AND carries no default of its own.
+    """
+
+    async def test_later_step_resubmits_required_field_with_no_default(self) -> None:
+        final_entry: dict[str, Any] = {
+            "type": "create_entry",
+            "flow_id": "flow-2057",
+            "result": {
+                "entry_id": "entry-1",
+                "title": "Device1",
+                "domain": "demo",
+            },
+        }
+        submit_fn = AsyncMock(
+            side_effect=[
+                _later_step({"name": "friendly_name", "required": True}),
+                final_entry,
+            ]
+        )
+
+        result = await _handle_flow_steps(
+            client=None,
+            flow_id="flow-2057",
+            initial_step=_first_step(),
+            config={"friendly_name": "Device1", "host": "10.0.0.5", "id": 20},
+            submit_fn=submit_fn,
+        )
+
+        # No warnings: a resubmitted key was consumed, not ignored.
+        assert result == {"success": True, "entry": final_entry}
+        assert submit_fn.await_args_list[0].args[1] == {
+            "friendly_name": "Device1",
+            "host": "10.0.0.5",
+        }
+        assert submit_fn.await_args_list[1].args[1] == {
+            "id": 20,
+            "friendly_name": "Device1",
+        }
+
+    @pytest.mark.parametrize(
+        "default_source",
+        [
+            {"description": {"suggested_value": "Existing entity name"}},
+            {"suggested_value": "Existing entity name"},
+            {"default": ""},
+        ],
+    )
+    async def test_redeclared_field_with_a_default_is_not_resubmitted(
+        self, default_source: dict[str, Any]
+    ) -> None:
+        """Edit-style forms serialize the current value as the default.
+
+        The step's own default wins: resubmitting the earlier step's value over
+        it would change data the caller never named for this step.
+        """
+        final_entry: dict[str, Any] = {
+            "type": "create_entry",
+            "result": {"entry_id": "entry-2"},
+        }
+        submit_fn = AsyncMock(
+            side_effect=[
+                _later_step(
+                    {"name": "friendly_name", "required": True, **default_source}
+                ),
+                final_entry,
+            ]
+        )
+
+        await _handle_flow_steps(
+            client=None,
+            flow_id="flow-2057",
+            initial_step=_first_step(),
+            config={"friendly_name": "Device1", "host": "10.0.0.5", "id": 20},
+            submit_fn=submit_fn,
+        )
+
+        assert submit_fn.await_args_list[1].args[1] == {"id": 20}
+
+    @pytest.mark.parametrize("required_source", [{}, {"required": False}])
+    async def test_redeclared_optional_field_is_not_resubmitted(
+        self, required_source: dict[str, Any]
+    ) -> None:
+        final_entry: dict[str, Any] = {
+            "type": "create_entry",
+            "result": {"entry_id": "entry-3"},
+        }
+        submit_fn = AsyncMock(
+            side_effect=[
+                _later_step({"name": "friendly_name", **required_source}),
+                final_entry,
+            ]
+        )
+
+        await _handle_flow_steps(
+            client=None,
+            flow_id="flow-2057",
+            initial_step=_first_step(),
+            config={"friendly_name": "Device1", "host": "10.0.0.5", "id": 20},
+            submit_fn=submit_fn,
+        )
+
+        assert submit_fn.await_args_list[1].args[1] == {"id": 20}
+
+    async def test_resubmits_into_a_later_section_nested_field(self) -> None:
+        final_entry: dict[str, Any] = {
+            "type": "create_entry",
+            "result": {"entry_id": "entry-4"},
+        }
+        later_step: dict[str, Any] = {
+            "type": "form",
+            "flow_id": "flow-2057",
+            "step_id": "details",
+            "data_schema": [
+                {"name": "id", "required": True},
+                {
+                    "type": "expandable",
+                    "name": "advanced",
+                    "required": True,
+                    "schema": [{"name": "friendly_name", "required": True}],
+                },
+            ],
+        }
+        submit_fn = AsyncMock(side_effect=[later_step, final_entry])
+
+        await _handle_flow_steps(
+            client=None,
+            flow_id="flow-2057",
+            initial_step=_first_step(),
+            config={"friendly_name": "Device1", "host": "10.0.0.5", "id": 20},
+            submit_fn=submit_fn,
+        )
+
+        assert submit_fn.await_args_list[1].args[1] == {
+            "id": 20,
+            "advanced": {"friendly_name": "Device1"},
+        }
+
+    async def test_resubmitted_value_is_a_copy(self) -> None:
+        """Two submissions must not share a mutable value object."""
+        final_entry: dict[str, Any] = {
+            "type": "create_entry",
+            "result": {"entry_id": "entry-5"},
+        }
+        later_step: dict[str, Any] = {
+            "type": "form",
+            "flow_id": "flow-2057",
+            "step_id": "details",
+            "data_schema": [{"name": "entity_ids", "required": True}],
+        }
+        submit_fn = AsyncMock(side_effect=[later_step, final_entry])
+        initial_step: dict[str, Any] = {
+            "type": "form",
+            "flow_id": "flow-2057",
+            "step_id": "user",
+            "data_schema": [{"name": "entity_ids", "required": True, "default": []}],
+        }
+
+        await _handle_flow_steps(
+            client=None,
+            flow_id="flow-2057",
+            initial_step=initial_step,
+            config={"entity_ids": ["sensor.a"]},
+            submit_fn=submit_fn,
+        )
+
+        first = submit_fn.await_args_list[0].args[1]["entity_ids"]
+        second = submit_fn.await_args_list[1].args[1]["entity_ids"]
+        assert second == ["sensor.a"]
+        assert second is not first
+
+    async def test_subentry_walker_resubmits_redeclared_required_field(self) -> None:
+        final_entry: dict[str, Any] = {
+            "type": "create_entry",
+            "result": {"entry_id": "entry-6"},
+        }
+        client = AsyncMock()
+        client.submit_config_subentry_flow_step = AsyncMock(
+            side_effect=[
+                _later_step({"name": "friendly_name", "required": True}),
+                final_entry,
+            ]
+        )
+
+        result = await _handle_config_subentry_flow_steps(
+            client,
+            "flow-2057-sub",
+            _first_step(),
+            {"friendly_name": "Device1", "host": "10.0.0.5", "id": 20},
+            is_reconfigure=False,
+        )
+
+        assert result["operation"] == "created"
+        assert "warnings" not in result
+        submitted = client.submit_config_subentry_flow_step.await_args_list
+        assert submitted[0].args[1] == {
+            "friendly_name": "Device1",
+            "host": "10.0.0.5",
+        }
+        assert submitted[1].args[1] == {"id": 20, "friendly_name": "Device1"}
+
+    async def test_repeated_step_resubmits_on_every_iteration(self) -> None:
+        """A flow that presents the same step again keeps getting the value.
+
+        Reuse legitimately fires on each later iteration; the walk still
+        terminates on ``max_steps`` and each payload is an independent object.
+        """
+        repeated: dict[str, Any] = {
+            "type": "form",
+            "flow_id": "flow-2057",
+            "step_id": "user",
+            "data_schema": [{"name": "entity_ids", "required": True}],
+        }
+        final_entry: dict[str, Any] = {
+            "type": "create_entry",
+            "result": {"entry_id": "entry-7"},
+        }
+        submit_fn = AsyncMock(
+            side_effect=[repeated, repeated, repeated, final_entry],
+        )
+
+        result = await _handle_flow_steps(
+            client=None,
+            flow_id="flow-2057",
+            initial_step=repeated,
+            config={"entity_ids": ["sensor.a"]},
+            submit_fn=submit_fn,
+        )
+
+        assert result["success"] is True
+        assert "warnings" not in result
+        payloads = [call.args[1] for call in submit_fn.await_args_list]
+        assert payloads == [{"entity_ids": ["sensor.a"]}] * 4
+        values = [payload["entity_ids"] for payload in payloads]
+        assert len({id(value) for value in values}) == len(values)
+
+    async def test_walk_still_bounded_when_a_repeated_step_never_finishes(self) -> None:
+        """A flow that keeps re-presenting the same form hits the step ceiling."""
+        import json
+
+        from fastmcp.exceptions import ToolError
+
+        repeated: dict[str, Any] = {
+            "type": "form",
+            "flow_id": "flow-2057",
+            "step_id": "user",
+            "data_schema": [{"name": "entity_ids", "required": True}],
+        }
+        submit_fn = AsyncMock(return_value=repeated)
+
+        with pytest.raises(ToolError) as exc_info:
+            await _handle_flow_steps(
+                client=None,
+                flow_id="flow-2057",
+                initial_step=repeated,
+                config={"entity_ids": ["sensor.a"]},
+                submit_fn=submit_fn,
+            )
+
+        body = json.loads(str(exc_info.value))
+        assert body["error"]["code"] == "TIMEOUT_OPERATION"
+        assert submit_fn.await_count == 10
+
+
 class TestSubmitStep:
     """Unit tests for _submit_step error propagation."""
 


### PR DESCRIPTION
## What does this PR do?

Fixes #2057.

The shared config-flow walker popped each supplied config key out of the pending config at the first form step whose `data_schema` declared it. A later step that redeclared the same field name was then submitted without it, and Home Assistant rejected the step with "required key not provided" — with the key absent from `submitted_keys`, because an earlier step had silently consumed it. Reported against LocalTuya's options flow, where `configure_device` (device name) and `configure_entity` (entity name) both declare `friendly_name`; verified against a live LocalTuya options flow that `configure_device` declares `friendly_name` as required (the `configure_entity` redeclaration is per the issue report and LocalTuya source).

The walker now records consumed values by leaf field name, and a supplied config key applies to every form step that declares it rather than only the first. Reuse never overrides a default or suggested value carried by the step's own serialized schema: it fires only when the redeclared field is required with no default of its own — exactly where omitting the key is a guaranteed validation failure. Redeclared fields that do carry defaults (edit-style forms pre-filled with current values) keep their own defaults, so the fix never silently overwrites values the caller did not name for that step.

The change is integration-agnostic and applies uniformly to both walkers, covering add-integration flows, options flows, the 15 flow-based helpers, and config subentries. Flows whose steps use distinct field names behave identically to before.

A second commit hardens the mechanism per review (Codex + internal): omission is keyed on an actual voluptuous `default` (key presence) — a required redeclared field carrying only a suggested value or a serialized constant gets that step-owned value submitted instead, since `voluptuous_serialize` never turns suggestions into defaults and omitting such a field is a guaranteed "required key not provided". Caller-value resubmission is the last resort: it is surfaced through the top-level `warnings` contract and bounded to one write per step/field, so a re-presented step fails loud instead of writing repeatedly. Recording is path-scoped — values supplied inside an explicit section dict are reused only at that dotted path, flat keys stay position-agnostic, and optional sections the caller never named are not materialized. The step-owned submission arm also covers required suggestion-only fields that no step consumed, where omission could never succeed.

## Type of change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

TDD: the new `TestRedeclaredFieldReuse` regression tests were confirmed failing against the unmodified walker before the fix. Locally ran the targeted unit files (`test_flow_multistep.py`, `test_flow_name_injection.py`, `test_flow_error_parsing.py`, `test_helper_response_shape.py`): 110 passed after the review round (58 in the walker test file alone); full suite left to CI, where all unit, E2E, and HAOS legs are green on both commits. `ruff check`, `ruff format --check`, and `mypy src/` are clean.

## Checklist
- [x] I have updated documentation if needed
