### PR TITLE
fix: return service_response once at top level in ha_call_service

### DIFF
--- a/src/ha_mcp/tools/tools_service.py
+++ b/src/ha_mcp/tools/tools_service.py
@@ -420,17 +420,18 @@ class ServiceTools:
         changed states to project into ``result``. Returning it in both places
         shipped it twice, byte-identical, doubling its token cost (issue #2085).
 
-        A dict that is not the expected envelope surfaces whole as the response
-        data with no changed states, and a legitimately null ``service_response``
-        is still reported as present (``True``) so the caller emits the key.
+        A dict with no ``service_response`` key is not the expected envelope, so
+        it surfaces whole as the response data with no changed states — echoing it
+        AND projecting its ``changed_states`` would ship those records twice, the
+        very duplication this split removes. A legitimately null
+        ``service_response`` is still reported as present (``True``) so the caller
+        emits the key.
         """
         if not (return_response and isinstance(result, dict)):
             return result, None, False
-        return (
-            result.get("changed_states") or [],
-            result.get("service_response", result),
-            True,
-        )
+        if "service_response" not in result:
+            return [], result, True
+        return result.get("changed_states") or [], result["service_response"], True
 
     @staticmethod
     def _project_service_result(
@@ -921,8 +922,13 @@ class ServiceTools:
         }
         if projection_warnings:
             response.setdefault("warnings", []).extend(projection_warnings)
-        if return_response and component_result.get("service_response") is not None:
-            response["service_response"] = component_result["service_response"]
+        if return_response:
+            # Emit the key whenever it was requested, even for a null response —
+            # the legacy path does the same (``_split_return_response_envelope``),
+            # and gating on ``is not None`` made the two paths answer the same
+            # call with different shapes. The component only sets the key for a
+            # non-null response, so a null one arrives as an absent key here.
+            response["service_response"] = component_result.get("service_response")
         if should_wait:
             if component_result.get("partial"):
                 # Dispatched, but the confirming state_changed did not arrive within
@@ -1115,8 +1121,9 @@ class ServiceTools:
           to the targeted entity's record (drops parent-group propagation) and
           stripped of ``context`` / ``last_*`` metadata and heavy attribute
           lists (``effect_list``, ``hue_scenes``). Escape hatches: ``verbose=True``
-          for the raw HA response, or ``result_fields`` / ``result_attribute_keys``
-          for explicit per-record projection (mirrors ``ha_get_state``).
+          for the raw changed-state records, or ``result_fields`` /
+          ``result_attribute_keys`` for explicit per-record projection (mirrors
+          ``ha_get_state``).
         - **return_response** (default False): the service's response data is
           returned once, as the top-level ``service_response`` key — never nested
           inside ``result``, which carries the changed entity states.

--- a/src/ha_mcp/tools/tools_service.py
+++ b/src/ha_mcp/tools/tools_service.py
@@ -446,6 +446,9 @@ class ServiceTools:
         Issue #1446. Precedence:
 
         - ``verbose=True``: bypass every transformation; return ``result`` as-is.
+          (A ``return_response`` envelope is split off BEFORE this helper runs —
+          see ``_split_return_response_envelope`` — so ``result`` here is always
+          the changed states, whatever the mode.)
         - Explicit ``fields`` or ``attribute_keys``: apply per-record projection
           via ``project_entity_record`` to every record. No compaction; this is
           the power-user path.
@@ -1029,9 +1032,12 @@ class ServiceTools:
             bool,
             Field(
                 description=(
-                    "Return HA's raw service response unchanged (default: False). "
-                    "Use as an escape hatch when you need the full propagation "
-                    "chain or raw attribute payload (debug / inspection). "
+                    "Return HA's raw changed-state records unchanged (default: "
+                    "False). Use as an escape hatch when you need the full "
+                    "propagation chain or raw attribute payload (debug / "
+                    "inspection). With return_response=True the response data "
+                    "still surfaces once as the top-level service_response key, "
+                    "never nested in result. "
                     "WARNING: brings back token-bloat for nested-group targets — "
                     "prefer result_fields / result_attribute_keys for targeted control."
                 ),

--- a/src/ha_mcp/tools/tools_service.py
+++ b/src/ha_mcp/tools/tools_service.py
@@ -459,43 +459,39 @@ class ServiceTools:
         changed states to project into ``result``. Returning it in both places
         shipped it twice, byte-identical, doubling its token cost (issue #2085).
 
-        A dict with no ``service_response`` key is not the expected envelope, so
-        it surfaces whole as the response data with no changed states — echoing it
-        AND projecting its ``changed_states`` would ship those records twice, the
-        very duplication this split removes. A legitimately null
-        ``service_response`` is still reported as present (``True``) so the caller
-        emits the key.
+        A legitimately null ``service_response`` is still reported as present
+        (``True``) so the caller emits the key.
 
         With ``return_response`` false there is no envelope to split: HA returns a
         plain changed-states list, so it passes through untouched and no
         ``service_response`` key is emitted (``present`` False). That is the
         overwhelming majority of calls.
 
-        Anything that is not that envelope — a non-dict reply, a missing key, or a
-        ``changed_states`` that is not a list — means a non-conforming responder
-        (HA core always sends both keys, with a list). The empty ``result`` that
-        follows would otherwise read as an affirmative "no entity states changed",
-        so every such shape returns a *warning* AND still surfaces the reply under
-        ``service_response``: a caller that asked for response data must never get
-        back neither the data nor an explanation.
+        Anything else — a non-dict reply, a missing key, or a ``changed_states``
+        that is not a list — means a non-conforming responder (HA core always
+        sends both keys, with a list). Every such shape takes ONE path: the whole
+        reply becomes the response data, ``result`` stays empty, and a warning
+        says so. Uniformity is the point — peeling a recognised key out of an
+        unrecognised envelope would silently discard whatever else it carried,
+        and an empty ``result`` would otherwise read as an affirmative "no entity
+        states changed". A caller that asked for response data must never get back
+        neither the data nor an explanation.
         """
         if not return_response:
             return result, None, False, []
-        if not isinstance(result, dict):
-            # Not an envelope at all. Surface the raw reply as the response data
-            # rather than dropping the key the caller explicitly asked for.
-            return [], result, True, [_NON_ENVELOPE_WARNING]
-        if "service_response" not in result:
-            # Echoing the dict whole AND projecting its ``changed_states`` would
-            # ship those records twice — the duplication this split removes.
-            return [], result, True, [_NON_ENVELOPE_WARNING]
-        states = result.get("changed_states")
-        if not isinstance(states, list):
-            # A non-list ``changed_states`` would sail through projection
-            # untouched (``compact_service_result`` returns non-lists as-is),
-            # silently ignoring result_fields and emitting the raw value.
-            return [], result["service_response"], True, [_NON_ENVELOPE_WARNING]
-        return states, result["service_response"], True, []
+        if (
+            isinstance(result, dict)
+            and "service_response" in result
+            and isinstance(result.get("changed_states"), list)
+        ):
+            return result["changed_states"], result["service_response"], True, []
+        # Any other shape is non-conforming. Hand the WHOLE reply back as the
+        # response data rather than guessing which part is which: splitting one
+        # recognised key out of an unrecognised envelope discards the rest (a
+        # non-list ``changed_states`` would vanish entirely) and would make the
+        # warning's "the whole reply is reported under 'service_response'" a lie.
+        # Projecting nothing into ``result`` keeps the records from shipping twice.
+        return [], result, True, [_NON_ENVELOPE_WARNING]
 
     @staticmethod
     def _project_service_result(

--- a/src/ha_mcp/tools/tools_service.py
+++ b/src/ha_mcp/tools/tools_service.py
@@ -151,6 +151,32 @@ _NON_STATE_CHANGING_DOMAINS = {
     "system_log",
 }
 
+#: Emitted when a ``return_response=true`` reply is not HA's
+#: ``{"changed_states": [...], "service_response": ...}`` envelope. Without it an
+#: empty ``result`` reads as an affirmative "no entity states changed" rather than
+#: "the records could not be separated out". Module-level so the tests that
+#: pin the behaviour assert against this exact string instead of a prose fragment
+#: that goes tautologically green when the wording is edited.
+_NON_ENVELOPE_WARNING = (
+    "Home Assistant's return_response reply did not match the expected "
+    "{changed_states, service_response} envelope, so no changed-state records "
+    "could be separated from the response data. An empty 'result' here does NOT "
+    "mean nothing changed — the whole reply is reported under 'service_response'."
+)
+
+#: Emitted when the component served a ``return_response`` call but returned no
+#: ``service_response`` key. The component only sets that key for a non-null
+#: response, so an absent key is ambiguous server-side: the service may genuinely
+#: have returned nothing, or the component may have discarded the response on its
+#: dispatched-but-unconfirmed path. Only raised alongside ``partial`` — the case
+#: where the discard is actually possible — so a plain null response stays quiet.
+_COMPONENT_RESPONSE_UNCONFIRMED_WARNING = (
+    "The service was dispatched but its confirmation did not arrive, and no "
+    "response data came back with it. A null 'service_response' here does NOT "
+    "prove the service returned nothing — the response may have been produced "
+    "and lost with the confirmation. Re-read state to confirm the outcome."
+)
+
 # ``_SERVICE_TO_STATE`` (the service -> expected primary-state map) is the single
 # source of truth in ``util_helpers`` — imported above and shared with the bulk
 # consumer (``device_control``) so both write paths hand the component the same
@@ -343,9 +369,18 @@ class ServiceTools:
         service: str,
         entity_id: str | None,
         data: str | dict[str, Any] | None,
+        *,
+        return_response: bool = False,
     ) -> dict[str, Any]:
-        """Build a partial-success response for service call timeouts."""
-        return {
+        """Build a partial-success response for service call timeouts.
+
+        When ``return_response`` was requested the key is emitted here too, so a
+        caller never has to branch on whether the key exists: every successful
+        reply carries it. It is necessarily null — the reply never arrived — and
+        that null proves nothing about what the service returned, so it comes
+        with the same ambiguity warning the component's unconfirmed path uses.
+        """
+        response: dict[str, Any] = {
             "success": True,
             "partial": True,
             "domain": domain,
@@ -366,6 +401,10 @@ class ServiceTools:
                 "The service was dispatched and may still be executing."
             ],
         }
+        if return_response:
+            response["service_response"] = None
+            response["warnings"].append(_COMPONENT_RESPONSE_UNCONFIRMED_WARNING)
+        return response
 
     async def _capture_initial_state(self, entity_id: str | None) -> str | None:
         """Capture the current state of an entity before a service call."""
@@ -427,31 +466,36 @@ class ServiceTools:
         ``service_response`` is still reported as present (``True``) so the caller
         emits the key.
 
-        Either key missing means a non-conforming responder (HA core always sends
-        both), and the empty ``result`` that follows would otherwise read as an
-        affirmative "no entity states changed". The returned *warnings* say so
-        explicitly; the caller surfaces them rather than letting the emptiness lie.
+        With ``return_response`` false there is no envelope to split: HA returns a
+        plain changed-states list, so it passes through untouched and no
+        ``service_response`` key is emitted (``present`` False). That is the
+        overwhelming majority of calls.
+
+        Anything that is not that envelope — a non-dict reply, a missing key, or a
+        ``changed_states`` that is not a list — means a non-conforming responder
+        (HA core always sends both keys, with a list). The empty ``result`` that
+        follows would otherwise read as an affirmative "no entity states changed",
+        so every such shape returns a *warning* AND still surfaces the reply under
+        ``service_response``: a caller that asked for response data must never get
+        back neither the data nor an explanation.
         """
-        if not (return_response and isinstance(result, dict)):
+        if not return_response:
             return result, None, False, []
-        warnings = (
-            []
-            if "changed_states" in result and "service_response" in result
-            else [
-                "Home Assistant's return_response reply did not match the expected "
-                "{changed_states, service_response} envelope, so no changed-state "
-                "records could be identified. An empty 'result' here does NOT mean "
-                "nothing changed — the reply is reported under 'service_response'."
-            ]
-        )
+        if not isinstance(result, dict):
+            # Not an envelope at all. Surface the raw reply as the response data
+            # rather than dropping the key the caller explicitly asked for.
+            return [], result, True, [_NON_ENVELOPE_WARNING]
         if "service_response" not in result:
-            return [], result, True, warnings
-        return (
-            result.get("changed_states") or [],
-            result["service_response"],
-            True,
-            warnings,
-        )
+            # Echoing the dict whole AND projecting its ``changed_states`` would
+            # ship those records twice — the duplication this split removes.
+            return [], result, True, [_NON_ENVELOPE_WARNING]
+        states = result.get("changed_states")
+        if not isinstance(states, list):
+            # A non-list ``changed_states`` would sail through projection
+            # untouched (``compact_service_result`` returns non-lists as-is),
+            # silently ignoring result_fields and emitting the raw value.
+            return [], result["service_response"], True, [_NON_ENVELOPE_WARNING]
+        return states, result["service_response"], True, []
 
     @staticmethod
     def _project_service_result(
@@ -467,9 +511,10 @@ class ServiceTools:
         Issue #1446. Precedence:
 
         - ``verbose=True``: bypass every transformation; return ``result`` as-is.
-          (A ``return_response`` envelope is split off BEFORE this helper runs —
-          see ``_split_return_response_envelope`` — so ``result`` here is always
-          the changed states, whatever the mode.)
+          (``result`` here is always changed-state records, never an envelope:
+          the legacy path splits the envelope off before calling this — see
+          ``_split_return_response_envelope`` — and the component path passes
+          transition ``new_state``s, which are never enveloped to begin with.)
         - Explicit ``fields`` or ``attribute_keys``: apply per-record projection
           via ``project_entity_record`` to every record. No compaction; this is
           the power-user path.
@@ -520,6 +565,7 @@ class ServiceTools:
         service: str,
         entity_id: str | None,
         data: str | dict[str, Any] | None,
+        return_response: bool = False,
     ) -> dict[str, Any]:
         """Handle a HomeAssistantConnectionError raised while calling a service.
 
@@ -531,7 +577,9 @@ class ServiceTools:
         # mean the service was dispatched but HA didn't respond in time.
         # The operation is likely still running (e.g., update.install, long automations).
         if isinstance(error.__cause__, httpx.TimeoutException):
-            return self._build_timeout_response(domain, service, entity_id, data)
+            return self._build_timeout_response(
+                domain, service, entity_id, data, return_response=return_response
+            )
         # Non-timeout connection errors are real failures
         exception_to_structured_error(
             error,
@@ -949,6 +997,16 @@ class ServiceTools:
             # call with different shapes. The component only sets the key for a
             # non-null response, so a null one arrives as an absent key here.
             response["service_response"] = component_result.get("service_response")
+            # ...which makes an absent key ambiguous: genuinely-null response, or
+            # one the component produced and dropped with the confirmation on its
+            # dispatched-unconfirmed path. Only the latter is possible when
+            # ``partial``, so warn there rather than on every null.
+            if "service_response" not in component_result and component_result.get(
+                "partial"
+            ):
+                response.setdefault("warnings", []).append(
+                    _COMPONENT_RESPONSE_UNCONFIRMED_WARNING
+                )
         if should_wait:
             if component_result.get("partial"):
                 # Dispatched, but the confirming state_changed did not arrive within
@@ -1020,7 +1078,9 @@ class ServiceTools:
             return_response=return_response,
         )
         if isinstance(component_result, _AmbiguousDispatch):
-            return self._build_timeout_response(domain, service, entity_id, data)
+            return self._build_timeout_response(
+                domain, service, entity_id, data, return_response=return_response
+            )
         if component_result is None:
             return None
         return self._build_component_call_response(
@@ -1289,6 +1349,10 @@ class ServiceTools:
                 service=service,
                 entity_id=entity_id,
                 data=data,
+                # The parameter, not ``return_response_bool`` — that local is
+                # bound inside the try and would be unbound if the error fired
+                # before it.
+                return_response=return_response,
             )
         except ToolError:
             raise

--- a/src/ha_mcp/tools/tools_service.py
+++ b/src/ha_mcp/tools/tools_service.py
@@ -407,6 +407,32 @@ class ServiceTools:
             )
 
     @staticmethod
+    def _split_return_response_envelope(
+        result: Any, *, return_response: bool
+    ) -> tuple[Any, Any, bool]:
+        """Split HA's ``return_response`` reply into (changed states, response, present).
+
+        HA answers ``return_response=true`` with an envelope
+        ``{"changed_states": [...], "service_response": ...}``. The response data
+        belongs at the top level of ha_call_service's reply exactly ONCE — the
+        placement the component path (``_build_component_call_response``) already
+        uses — so it is peeled off here, BEFORE projection, leaving only the
+        changed states to project into ``result``. Returning it in both places
+        shipped it twice, byte-identical, doubling its token cost (issue #2085).
+
+        A dict that is not the expected envelope surfaces whole as the response
+        data with no changed states, and a legitimately null ``service_response``
+        is still reported as present (``True``) so the caller emits the key.
+        """
+        if not (return_response and isinstance(result, dict)):
+            return result, None, False
+        return (
+            result.get("changed_states") or [],
+            result.get("service_response", result),
+            True,
+        )
+
+    @staticmethod
     def _project_service_result(
         result: Any,
         *,
@@ -1085,6 +1111,9 @@ class ServiceTools:
           lists (``effect_list``, ``hue_scenes``). Escape hatches: ``verbose=True``
           for the raw HA response, or ``result_fields`` / ``result_attribute_keys``
           for explicit per-record projection (mirrors ``ha_get_state``).
+        - **return_response** (default False): the service's response data is
+          returned once, as the top-level ``service_response`` key — never nested
+          inside ``result``, which carries the changed entity states.
 
         **For detailed service documentation, use ha_get_skill_guide.**
 
@@ -1177,6 +1206,15 @@ class ServiceTools:
                 domain, service, service_data, return_response=return_response_bool
             )
 
+            # Peel the return_response envelope apart BEFORE projection so the
+            # response data is emitted once, top-level, and only the changed
+            # states reach ``result`` (issue #2085).
+            result, service_response, has_response_envelope = (
+                self._split_return_response_envelope(
+                    result, return_response=return_response_bool
+                )
+            )
+
             projected_result, projection_warnings = self._project_service_result(
                 result,
                 entity_id=entity_id,
@@ -1197,9 +1235,8 @@ class ServiceTools:
             if projection_warnings:
                 response.setdefault("warnings", []).extend(projection_warnings)
 
-            # If return_response was requested, include the service_response key prominently
-            if return_response_bool and isinstance(result, dict):
-                response["service_response"] = result.get("service_response", result)
+            if has_response_envelope:
+                response["service_response"] = service_response
 
             # Wait for entity state to change
             if should_wait and entity_id is not None:

--- a/src/ha_mcp/tools/tools_service.py
+++ b/src/ha_mcp/tools/tools_service.py
@@ -409,8 +409,8 @@ class ServiceTools:
     @staticmethod
     def _split_return_response_envelope(
         result: Any, *, return_response: bool
-    ) -> tuple[Any, Any, bool]:
-        """Split HA's ``return_response`` reply into (changed states, response, present).
+    ) -> tuple[Any, Any, bool, list[str]]:
+        """Split HA's reply into (changed states, response, present, warnings).
 
         HA answers ``return_response=true`` with an envelope
         ``{"changed_states": [...], "service_response": ...}``. The response data
@@ -426,12 +426,32 @@ class ServiceTools:
         very duplication this split removes. A legitimately null
         ``service_response`` is still reported as present (``True``) so the caller
         emits the key.
+
+        Either key missing means a non-conforming responder (HA core always sends
+        both), and the empty ``result`` that follows would otherwise read as an
+        affirmative "no entity states changed". The returned *warnings* say so
+        explicitly; the caller surfaces them rather than letting the emptiness lie.
         """
         if not (return_response and isinstance(result, dict)):
-            return result, None, False
+            return result, None, False, []
+        warnings = (
+            []
+            if "changed_states" in result and "service_response" in result
+            else [
+                "Home Assistant's return_response reply did not match the expected "
+                "{changed_states, service_response} envelope, so no changed-state "
+                "records could be identified. An empty 'result' here does NOT mean "
+                "nothing changed — the reply is reported under 'service_response'."
+            ]
+        )
         if "service_response" not in result:
-            return [], result, True
-        return result.get("changed_states") or [], result["service_response"], True
+            return [], result, True, warnings
+        return (
+            result.get("changed_states") or [],
+            result["service_response"],
+            True,
+            warnings,
+        )
 
     @staticmethod
     def _project_service_result(
@@ -1222,7 +1242,7 @@ class ServiceTools:
             # Peel the return_response envelope apart BEFORE projection so the
             # response data is emitted once, top-level, and only the changed
             # states reach ``result`` (issue #2085).
-            result, service_response, has_response_envelope = (
+            result, service_response, has_response_envelope, envelope_warnings = (
                 self._split_return_response_envelope(
                     result, return_response=return_response_bool
                 )
@@ -1245,8 +1265,9 @@ class ServiceTools:
                 "result": projected_result,
                 "message": f"Successfully executed {domain}.{service}",
             }
-            if projection_warnings:
-                response.setdefault("warnings", []).extend(projection_warnings)
+            call_warnings = [*projection_warnings, *envelope_warnings]
+            if call_warnings:
+                response.setdefault("warnings", []).extend(call_warnings)
 
             if has_response_envelope:
                 response["service_response"] = service_response

--- a/src/ha_mcp/tools/util_helpers.py
+++ b/src/ha_mcp/tools/util_helpers.py
@@ -346,8 +346,9 @@ def compact_service_result(
     3. Drop known-heavy attribute keys (``effect_list``, ``hue_scenes``) from
        every record's ``attributes`` dict.
 
-    Returns ``result`` unchanged when not a list (e.g. dict from
-    ``return_response=True`` services), or when the list is empty.
+    Returns ``result`` unchanged when it is not a list (defensive — every
+    ha_call_service path now projects a changed-state list), or when the list
+    is empty.
     """
     if not isinstance(result, list) or not result:
         return result

--- a/src/ha_mcp/tools/util_helpers.py
+++ b/src/ha_mcp/tools/util_helpers.py
@@ -497,6 +497,14 @@ def unwrap_service_response(result: dict[str, Any]) -> dict[str, Any]:
     HA's call_service with return_response wraps results in
     {"changed_states": [...], "service_response": {...}}.
     Returns service_response if present and is a dict, otherwise the original result.
+
+    Deliberately NOT the same rule as ``ServiceTools._split_return_response_envelope``,
+    which powers ha_call_service: that one returns the response whatever its type and
+    reports the whole reply only when the key is absent. The two disagree solely for a
+    NON-DICT ``service_response`` (this helper hands back the envelope, the split hands
+    back the value). Consumers here read component services that always answer with a
+    dict, so the divergence is unreachable — but do not "align" one to the other
+    without checking those ~20 call sites.
     """
     sr = result.get("service_response")
     return sr if isinstance(sr, dict) else result

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -3,7 +3,7 @@
 ## Custom Component (ha_mcp_tools)
 
 - Component is installed into the Docker container by `_install_custom_component` in `src/e2e/conftest.py`
-- HA's `call_service(return_response=True)` wraps results in `{"changed_states": [], "service_response": {...}}` — tools unwrap this with `result.get("service_response", result)` before returning
+- HA's `call_service(return_response=True)` wraps results in `{"changed_states": [], "service_response": {...}}`. Most tools unwrap it with `unwrap_service_response()` (`src/ha_mcp/tools/util_helpers.py`); `ha_call_service` instead *splits* it, projecting `changed_states` into `result` and surfacing `service_response` once at the top level (issue #2085)
 - `hass.async_add_executor_job` only passes positional args — use `lambda:` wrappers for calls needing kwargs (e.g., `mkdir(parents=True, exist_ok=True)`)
 - HA Docker image uses `annotatedyaml` (PyYAML wrapper), NOT `ruamel.yaml` — custom components needing ruamel must declare it in `manifest.json` requirements
 - Feature flags (`ENABLE_YAML_CONFIG_EDITING`, `HAMCP_ENABLE_FILESYSTEM_TOOLS`) are set in `ha_container_with_fresh_config` fixture

--- a/tests/src/e2e/workflows/services/test_call_service_return_response.py
+++ b/tests/src/e2e/workflows/services/test_call_service_return_response.py
@@ -18,21 +18,23 @@ from datetime import UTC, datetime, timedelta
 
 import pytest
 
-from ...utilities.assertions import MCPAssertions, parse_mcp_result
+from ...utilities.assertions import MCPAssertions
 
 logger = logging.getLogger(__name__)
 
 
-async def _find_calendar_entity(mcp_client) -> str | None:
-    """Find a calendar entity in the test container (a writable local_calendar)."""
-    result = await mcp_client.call_tool(
-        "ha_search",
-        {"query": "calendar", "domain_filter": "calendar", "limit": 10},
-    )
-    entities = parse_mcp_result(result).get("entities", [])
-    if not entities:
-        return None
-    return entities[0].get("entity_id")
+async def _find_calendar_entity(mcp_client) -> str:
+    """Find the seeded local_calendar entity — its absence is a failure, not a skip."""
+    async with MCPAssertions(mcp_client) as mcp:
+        data = await mcp.call_tool_success(
+            "ha_search",
+            {"query": "calendar", "domain_filter": "calendar", "limit": 10},
+        )
+    entities = data.get("entities", [])
+    assert entities, f"seeded local_calendar not found via ha_search: {data!r}"
+    entity_id = entities[0].get("entity_id")
+    assert entity_id, f"calendar search record lacks an entity_id: {entities[0]!r}"
+    return entity_id
 
 
 @pytest.mark.asyncio
@@ -42,8 +44,6 @@ class TestReturnResponsePlacement:
 
     async def test_get_events_response_is_not_duplicated(self, mcp_client):
         calendar_entity = await _find_calendar_entity(mcp_client)
-        if not calendar_entity:
-            pytest.skip("No calendar entities available for testing")
 
         start = datetime.now(UTC)
         end = start + timedelta(days=7)

--- a/tests/src/e2e/workflows/services/test_call_service_return_response.py
+++ b/tests/src/e2e/workflows/services/test_call_service_return_response.py
@@ -1,0 +1,99 @@
+"""E2E coverage for ha_call_service's return_response placement (issue #2085).
+
+``calendar.get_events`` is a ``SupportsResponse.ONLY`` service, so calling it with
+``return_response=True`` against the test container exercises a real Home Assistant
+``return_response`` envelope (``{"changed_states": [...], "service_response": {...}}``).
+
+ha_call_service used to ship that response twice — once nested in ``result`` (the
+whole envelope passed through projection) and once as a top-level
+``service_response`` sibling — doubling its token cost. These assertions are
+path-agnostic: they hold whether the component ``call_service`` capability or the
+legacy REST POST serves the call, since both must surface the response exactly once
+at the top level.
+"""
+
+import json
+import logging
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from ...utilities.assertions import MCPAssertions, parse_mcp_result
+
+logger = logging.getLogger(__name__)
+
+
+async def _find_calendar_entity(mcp_client) -> str | None:
+    """Find a calendar entity in the test container (a writable local_calendar)."""
+    result = await mcp_client.call_tool(
+        "ha_search",
+        {"query": "calendar", "domain_filter": "calendar", "limit": 10},
+    )
+    entities = parse_mcp_result(result).get("entities", [])
+    if not entities:
+        return None
+    return entities[0].get("entity_id")
+
+
+@pytest.mark.asyncio
+@pytest.mark.services
+class TestReturnResponsePlacement:
+    """The service response is returned once, at the top level."""
+
+    async def test_get_events_response_is_not_duplicated(self, mcp_client):
+        calendar_entity = await _find_calendar_entity(mcp_client)
+        if not calendar_entity:
+            pytest.skip("No calendar entities available for testing")
+
+        start = datetime.now(UTC)
+        end = start + timedelta(days=7)
+
+        logger.info(
+            f"Calling calendar.get_events on {calendar_entity} with return_response"
+        )
+
+        async with MCPAssertions(mcp_client) as mcp:
+            data = await mcp.call_tool_success(
+                "ha_call_service",
+                {
+                    "domain": "calendar",
+                    "service": "get_events",
+                    "entity_id": calendar_entity,
+                    "data": {
+                        "start_date_time": start.strftime("%Y-%m-%d %H:%M:%S"),
+                        "end_date_time": end.strftime("%Y-%m-%d %H:%M:%S"),
+                    },
+                    "return_response": True,
+                },
+            )
+
+        assert "service_response" in data, (
+            f"return_response=True must surface a top-level service_response: {data!r}"
+        )
+        service_response = data["service_response"]
+
+        result = data.get("result")
+        assert not (isinstance(result, dict) and "service_response" in result), (
+            f"result must not carry a nested service_response copy: {result!r}"
+        )
+
+        # The response must carry the payload exactly once — the token cost the
+        # issue is about. Count the key first (cheap and always meaningful), then
+        # the serialized payload itself when it is distinctive enough for a
+        # substring match to mean something (a bare ``{}`` would match any empty
+        # dict elsewhere in the response).
+        serialized = json.dumps(data, sort_keys=True)
+        assert serialized.count('"service_response"') == 1, (
+            f"service_response key appears more than once: {data!r}"
+        )
+        payload = json.dumps(service_response, sort_keys=True)
+        if len(payload) > 8:
+            assert serialized.count(payload) == 1, (
+                f"service_response payload appears {serialized.count(payload)} "
+                f"times, expected exactly 1: {data!r}"
+            )
+
+        logger.info(
+            f"calendar.get_events returned its response once: "
+            f"{list(service_response) if isinstance(service_response, dict) else service_response!r}"
+        )

--- a/tests/src/e2e/workflows/services/test_call_service_return_response.py
+++ b/tests/src/e2e/workflows/services/test_call_service_return_response.py
@@ -40,7 +40,7 @@ async def _find_calendar_entity(mcp_client) -> str:
             {"query": "calendar", "domain_filter": "calendar", "limit": 10},
         )
     entities = data.get("entities", [])
-    assert entities, f"seeded local_calendar not found via ha_search: {data!r}"
+    assert entities, f"no calendar entity found via ha_search: {data!r}"
     entity_id = entities[0].get("entity_id")
     assert entity_id, f"calendar search record lacks an entity_id: {entities[0]!r}"
     return entity_id
@@ -81,26 +81,31 @@ class TestReturnResponsePlacement:
         )
         service_response = data["service_response"]
 
-        result = data.get("result")
-        assert not (isinstance(result, dict) and "service_response" in result), (
-            f"result must not carry a nested service_response copy: {result!r}"
+        # Assert the key EXISTS before asserting what it doesn't contain — a
+        # regression that dropped ``result`` entirely would satisfy the negative
+        # check vacuously.
+        assert isinstance(data.get("result"), list), (
+            f"result must be the projected changed-state list: {data!r}"
         )
+        result = data["result"]
+        assert not any(
+            isinstance(record, dict) and "service_response" in record
+            for record in result
+        ), f"result must not carry a nested service_response copy: {result!r}"
 
         # The response must carry the payload exactly once — the token cost the
-        # issue is about. Count the key first (cheap and always meaningful), then
-        # the serialized payload itself when it is distinctive enough for a
-        # substring match to mean something (a bare ``{}`` would match any empty
-        # dict elsewhere in the response).
+        # issue is about. Assert it structurally rather than by substring count:
+        # a small payload (``{}``, ``[]``) matches incidentally anywhere else in
+        # the response, so a length-gated substring check silently skipped the
+        # strongest assertion exactly when the payload was cheapest to duplicate.
         serialized = json.dumps(data, sort_keys=True)
         assert serialized.count('"service_response"') == 1, (
             f"service_response key appears more than once: {data!r}"
         )
-        payload = json.dumps(service_response, sort_keys=True)
-        if len(payload) > 8:
-            assert serialized.count(payload) == 1, (
-                f"service_response payload appears {serialized.count(payload)} "
-                f"times, expected exactly 1: {data!r}"
-            )
+        records = result if isinstance(result, list) else [result]
+        assert all(record != service_response for record in records), (
+            f"result carries a copy of the service response: {result!r}"
+        )
 
         logger.info(
             f"calendar.get_events returned its response once: "

--- a/tests/src/e2e/workflows/services/test_call_service_return_response.py
+++ b/tests/src/e2e/workflows/services/test_call_service_return_response.py
@@ -6,10 +6,15 @@
 
 ha_call_service used to ship that response twice — once nested in ``result`` (the
 whole envelope passed through projection) and once as a top-level
-``service_response`` sibling — doubling its token cost. These assertions are
-path-agnostic: they hold whether the component ``call_service`` capability or the
-legacy REST POST serves the call, since both must surface the response exactly once
-at the top level.
+``service_response`` sibling — doubling its token cost.
+
+This exercises the legacy REST path, which is the only one that can serve the call:
+the component route requires ``should_wait``, i.e. a service in
+``_STATE_CHANGING_SERVICES``, and ``get_events`` is not one. The assertions
+themselves are written against the shared contract (the response surfaces exactly
+once, at the top level) rather than either path's internals, so they stay valid if
+routing ever changes; the component path's own coverage is in
+``tests/src/unit/test_ha_call_service_component_routing.py``.
 """
 
 import json
@@ -24,7 +29,11 @@ logger = logging.getLogger(__name__)
 
 
 async def _find_calendar_entity(mcp_client) -> str:
-    """Find the seeded local_calendar entity — its absence is a failure, not a skip."""
+    """Find a calendar entity — its absence is a failure, not a skip.
+
+    Any calendar will do (the test only needs a service that returns a response),
+    so this takes the first match rather than preferring the seeded local_calendar.
+    """
     async with MCPAssertions(mcp_client) as mcp:
         data = await mcp.call_tool_success(
             "ha_search",

--- a/tests/src/unit/test_call_service_return_response.py
+++ b/tests/src/unit/test_call_service_return_response.py
@@ -15,9 +15,11 @@ import json
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import httpx
 import pytest
 
-from ha_mcp.tools.tools_service import ServiceTools
+from ha_mcp.client.rest_client import HomeAssistantConnectionError
+from ha_mcp.tools.tools_service import _NON_ENVELOPE_WARNING, ServiceTools
 
 _SHELL_RESPONSE = {"stdout": "abc", "stderr": "", "returncode": 0}
 
@@ -54,9 +56,12 @@ def _occurrences(response: dict[str, Any], needle: str) -> int:
 def _no_component():
     """Belt-and-braces pin to the legacy REST path (component advertises nothing).
 
-    These tests already take that path without the patch: none passes an
-    ``entity_id``, so ``should_wait`` is False and ``_maybe_component_call_service``
-    early-returns before consulting the component at all. The patch keeps the
+    These tests already take that path without the patch: none calls a service in
+    ``_STATE_CHANGING_SERVICES`` (they all use ``shell_command.test``), so
+    ``should_wait`` is False and ``_maybe_component_call_service`` early-returns
+    before consulting the component at all. The service name is what is
+    load-bearing here, NOT the absence of an ``entity_id`` —
+    ``test_entity_id_filters_the_changed_states`` passes one. The patch keeps the
     routing decision from silently changing if that early-out ever moves —
     ``component_supports(None, ...)`` is False, so ``_call_service_via_component``
     returns None and ``ha_call_service`` falls through to the REST POST.
@@ -136,7 +141,7 @@ class TestReturnResponsePlacement:
         )
         # An empty result here is an artifact of the unrecognized shape, not a
         # claim that nothing changed — say so rather than letting it read that way.
-        assert any("does NOT mean" in w for w in response["warnings"]), (
+        assert _NON_ENVELOPE_WARNING in response["warnings"], (
             f"an unrecognized envelope must warn about the empty result: {response!r}"
         )
 
@@ -150,8 +155,52 @@ class TestReturnResponsePlacement:
 
         assert response["service_response"] == _SHELL_RESPONSE
         assert response["result"] == []
-        assert any("does NOT mean" in w for w in response["warnings"]), (
+        assert _NON_ENVELOPE_WARNING in response["warnings"], (
             f"a missing changed_states must warn about the empty result: {response!r}"
+        )
+
+    async def test_non_dict_reply_still_surfaces_the_requested_key(self):
+        """A non-envelope reply must not drop BOTH the key and the explanation.
+
+        Returning neither is the masking this PR exists to remove: the caller
+        asked for response data and would learn nothing about where it went.
+        """
+        tools = _make_tools([_CHANGED_STATE])
+
+        response = await tools.ha_call_service(
+            domain="shell_command", service="test", return_response=True
+        )
+
+        assert response["service_response"] == [_CHANGED_STATE]
+        assert response["result"] == []
+        assert _NON_ENVELOPE_WARNING in response["warnings"], (
+            f"a non-dict reply must warn rather than silently drop: {response!r}"
+        )
+
+    async def test_non_list_changed_states_warns_and_does_not_reach_projection(self):
+        """A non-list ``changed_states`` would sail through projection untouched.
+
+        ``compact_service_result`` returns non-lists unchanged, so the raw value
+        would be emitted as ``result`` with ``result_fields`` silently ignored.
+        """
+        tools = _make_tools(
+            {
+                "changed_states": {"unexpected": "shape"},
+                "service_response": _SHELL_RESPONSE,
+            }
+        )
+
+        response = await tools.ha_call_service(
+            domain="shell_command",
+            service="test",
+            return_response=True,
+            result_fields=["entity_id"],
+        )
+
+        assert response["service_response"] == _SHELL_RESPONSE
+        assert response["result"] == []
+        assert _NON_ENVELOPE_WARNING in response["warnings"], (
+            f"a non-list changed_states must warn: {response!r}"
         )
 
     async def test_conforming_envelope_emits_no_envelope_warning(self):
@@ -164,7 +213,7 @@ class TestReturnResponsePlacement:
             domain="shell_command", service="test", return_response=True
         )
 
-        assert not any("does NOT mean" in w for w in response.get("warnings", [])), (
+        assert "warnings" not in response, (
             f"a conforming envelope must not warn: {response!r}"
         )
 
@@ -223,6 +272,55 @@ class TestReturnResponsePlacement:
             f"the propagation chain must be filtered to the target: {result!r}"
         )
         assert response["service_response"] == _SHELL_RESPONSE
+
+    async def test_projection_and_envelope_warnings_both_surface(self):
+        """Warnings from projection and from the envelope split are concatenated.
+
+        ``result_attribute_keys`` without ``attributes`` in ``result_fields`` emits
+        a projection warning; the missing ``service_response`` emits the envelope
+        warning. Both must reach the caller — one source must not shadow the other.
+        """
+        tools = _make_tools({"changed_states": [_CHANGED_STATE]})
+
+        response = await tools.ha_call_service(
+            domain="shell_command",
+            service="test",
+            return_response=True,
+            result_fields=["state"],
+            result_attribute_keys=["brightness"],
+        )
+
+        warnings = response["warnings"]
+        assert _NON_ENVELOPE_WARNING in warnings, (
+            f"the envelope warning must survive alongside projection ones: {warnings!r}"
+        )
+        assert any("result_attribute_keys was ignored" in w for w in warnings), (
+            f"the projection warning must survive alongside the envelope one: {warnings!r}"
+        )
+
+    async def test_timeout_still_emits_the_requested_key(self):
+        """A timed-out call must not be the one shape missing service_response.
+
+        The reply never arrived, so the value is necessarily null — and that null
+        proves nothing, hence the ambiguity warning rather than a bare null.
+        """
+        timed_out = HomeAssistantConnectionError("timed out")
+        # ``_handle_connection_error`` classifies on ``__cause__`` — an httpx
+        # timeout is a dispatched-but-unanswered call, not a failure.
+        timed_out.__cause__ = httpx.ReadTimeout("slow")
+        tools = _make_tools(None)
+        tools._client.call_service = AsyncMock(side_effect=timed_out)
+
+        response = await tools.ha_call_service(
+            domain="shell_command", service="test", return_response=True
+        )
+
+        assert response["partial"] is True
+        assert "service_response" in response
+        assert response["service_response"] is None
+        assert any("does NOT prove" in w for w in response["warnings"]), (
+            f"a timed-out return_response call must flag the ambiguity: {response!r}"
+        )
 
     async def test_return_response_false_has_no_service_response_key(self):
         """Without return_response the REST reply is a plain changed-states list."""

--- a/tests/src/unit/test_call_service_return_response.py
+++ b/tests/src/unit/test_call_service_return_response.py
@@ -39,7 +39,15 @@ def _make_tools(call_service_return: Any) -> ServiceTools:
 
 
 def _occurrences(response: dict[str, Any], needle: str) -> int:
-    return json.dumps(response).count(needle)
+    """Count *needle* in the response payload, ignoring ``warnings`` prose.
+
+    These counts exist to catch a payload shipped twice (issue #2085). Warning
+    text is human-facing prose that legitimately names the envelope keys, so
+    counting it would confuse "the records duplicated" with "we explained why
+    the result is empty".
+    """
+    payload = {k: v for k, v in response.items() if k != "warnings"}
+    return json.dumps(payload).count(needle)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/src/unit/test_call_service_return_response.py
+++ b/tests/src/unit/test_call_service_return_response.py
@@ -1,0 +1,137 @@
+"""Regression tests for ha_call_service's return_response placement (issue #2085).
+
+Home Assistant's REST reply to ``return_response=true`` is an envelope:
+``{"changed_states": [...], "service_response": {...}}``. The legacy REST path in
+``ha_call_service`` used to hand that whole envelope to ``_project_service_result``
+(which returns dicts unchanged) *and* copy ``service_response`` to the top level,
+so the service's response shipped twice, byte-identical, doubling its token cost.
+
+The envelope is now split before projection: ``result`` carries only the changed
+states and ``service_response`` appears exactly once at the top level — the same
+placement ``_build_component_call_response`` already used for the component path.
+"""
+
+import json
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from ha_mcp.tools.tools_service import ServiceTools
+
+_SHELL_RESPONSE = {"stdout": "abc", "stderr": "", "returncode": 0}
+
+_CHANGED_STATE = {
+    "entity_id": "light.x",
+    "state": "on",
+    "attributes": {},
+    "context": {"id": "ctx-1"},
+    "last_changed": "t",
+    "last_updated": "t",
+    "last_reported": "t",
+}
+
+
+def _make_tools(call_service_return: Any) -> ServiceTools:
+    client = MagicMock()
+    client.call_service = AsyncMock(return_value=call_service_return)
+    tools = ServiceTools.__new__(ServiceTools)
+    tools._client = client
+    tools._device_tools = MagicMock()
+    return tools
+
+
+def _occurrences(response: dict[str, Any], needle: str) -> int:
+    return json.dumps(response).count(needle)
+
+
+@pytest.fixture(autouse=True)
+def _no_component():
+    """Pin every test to the legacy REST path (component advertises nothing).
+
+    ``component_supports(None, ...)`` is False, so ``_call_service_via_component``
+    returns None and ``ha_call_service`` falls through to the REST POST.
+    """
+    with patch(
+        "ha_mcp.tools.tools_service.get_component_caps",
+        new=AsyncMock(return_value=None),
+    ):
+        yield
+
+
+class TestReturnResponsePlacement:
+    async def test_service_response_appears_once_at_top_level(self):
+        """The envelope splits: response data top-level, changed states in result."""
+        tools = _make_tools(
+            {"changed_states": [_CHANGED_STATE], "service_response": _SHELL_RESPONSE}
+        )
+
+        response = await tools.ha_call_service(
+            domain="shell_command", service="test", return_response=True
+        )
+
+        assert response["service_response"] == _SHELL_RESPONSE
+        result = response["result"]
+        assert isinstance(result, list), (
+            f"result must be the projected changed_states list, got: {result!r}"
+        )
+        assert len(result) == 1
+        assert result[0]["entity_id"] == "light.x"
+        assert "service_response" not in result[0]
+        assert _occurrences(response, "stdout") == 1, (
+            f"service_response must be serialized exactly once: {response!r}"
+        )
+
+    async def test_verbose_still_returns_one_copy(self):
+        """verbose=True bypasses projection but must not resurrect the duplicate."""
+        tools = _make_tools(
+            {"changed_states": [_CHANGED_STATE], "service_response": _SHELL_RESPONSE}
+        )
+
+        response = await tools.ha_call_service(
+            domain="shell_command", service="test", return_response=True, verbose=True
+        )
+
+        assert response["service_response"] == _SHELL_RESPONSE
+        # verbose returns the changed states raw (metadata kept), never the envelope.
+        assert response["result"] == [_CHANGED_STATE]
+        assert _occurrences(response, "stdout") == 1, (
+            f"service_response must be serialized exactly once: {response!r}"
+        )
+
+    async def test_envelope_without_service_response_key_surfaces_whole_dict(self):
+        """No ``service_response`` key: the whole dict goes top-level, once."""
+        tools = _make_tools({"changed_states": []})
+
+        response = await tools.ha_call_service(
+            domain="shell_command", service="test", return_response=True
+        )
+
+        assert response["service_response"] == {"changed_states": []}
+        assert response["result"] == []
+        assert _occurrences(response, "changed_states") == 1, (
+            f"the fallback dict must be serialized exactly once: {response!r}"
+        )
+
+    async def test_null_service_response_is_still_set(self):
+        """A legitimately null response data is reported, not dropped."""
+        tools = _make_tools({"changed_states": [], "service_response": None})
+
+        response = await tools.ha_call_service(
+            domain="shell_command", service="test", return_response=True
+        )
+
+        assert "service_response" in response
+        assert response["service_response"] is None
+        assert response["result"] == []
+
+    async def test_return_response_false_has_no_service_response_key(self):
+        """Without return_response the REST reply is a plain changed-states list."""
+        tools = _make_tools([_CHANGED_STATE])
+
+        response = await tools.ha_call_service(domain="shell_command", service="test")
+
+        assert "service_response" not in response
+        result = response["result"]
+        assert isinstance(result, list)
+        assert result[0]["entity_id"] == "light.x"

--- a/tests/src/unit/test_call_service_return_response.py
+++ b/tests/src/unit/test_call_service_return_response.py
@@ -47,8 +47,12 @@ def _occurrences(response: dict[str, Any], needle: str) -> int:
 
 @pytest.fixture(autouse=True)
 def _no_component():
-    """Pin every test to the legacy REST path (component advertises nothing).
+    """Belt-and-braces pin to the legacy REST path (component advertises nothing).
 
+    These tests already take that path without the patch: none passes an
+    ``entity_id``, so ``should_wait`` is False and ``_maybe_component_call_service``
+    early-returns before consulting the component at all. The patch keeps the
+    routing decision from silently changing if that early-out ever moves —
     ``component_supports(None, ...)`` is False, so ``_call_service_via_component``
     returns None and ``ha_call_service`` falls through to the REST POST.
     """
@@ -78,6 +82,10 @@ class TestReturnResponsePlacement:
         assert len(result) == 1
         assert result[0]["entity_id"] == "light.x"
         assert "service_response" not in result[0]
+        # The changed states now go through default compaction like every other
+        # path — pre-fix they bypassed it entirely as part of the raw envelope.
+        assert "context" not in result[0]
+        assert "last_changed" not in result[0]
         assert _occurrences(response, "stdout") == 1, (
             f"service_response must be serialized exactly once: {response!r}"
         )
@@ -100,15 +108,24 @@ class TestReturnResponsePlacement:
         )
 
     async def test_envelope_without_service_response_key_surfaces_whole_dict(self):
-        """No ``service_response`` key: the whole dict goes top-level, once."""
-        tools = _make_tools({"changed_states": []})
+        """No ``service_response`` key: the whole dict goes top-level, once.
+
+        Carries a NON-empty ``changed_states`` on purpose: echoing the dict whole
+        *and* projecting its states into ``result`` would ship those records twice
+        — #2085 all over again, inside the branch meant to be the safe fallback.
+        An empty list cannot tell the two behaviors apart.
+        """
+        tools = _make_tools({"changed_states": [_CHANGED_STATE]})
 
         response = await tools.ha_call_service(
             domain="shell_command", service="test", return_response=True
         )
 
-        assert response["service_response"] == {"changed_states": []}
+        assert response["service_response"] == {"changed_states": [_CHANGED_STATE]}
         assert response["result"] == []
+        assert _occurrences(response, "light.x") == 1, (
+            f"the fallback dict must not double-ship its changed states: {response!r}"
+        )
         assert _occurrences(response, "changed_states") == 1, (
             f"the fallback dict must be serialized exactly once: {response!r}"
         )
@@ -124,6 +141,50 @@ class TestReturnResponsePlacement:
         assert "service_response" in response
         assert response["service_response"] is None
         assert response["result"] == []
+
+    async def test_result_fields_projects_the_changed_states(self):
+        """result_fields now reaches the changed states on a return_response call.
+
+        Pre-fix ``result`` was the envelope dict, so ``_project_service_result``
+        bailed on its ``not isinstance(result, list)`` guard and the parameter was
+        silently ignored.
+        """
+        tools = _make_tools(
+            {"changed_states": [_CHANGED_STATE], "service_response": _SHELL_RESPONSE}
+        )
+
+        response = await tools.ha_call_service(
+            domain="shell_command",
+            service="test",
+            return_response=True,
+            result_fields=["entity_id"],
+        )
+
+        assert response["result"] == [{"entity_id": "light.x"}]
+        assert response["service_response"] == _SHELL_RESPONSE
+
+    async def test_entity_id_filters_the_changed_states(self):
+        """Compaction's target filter now applies to return_response changed states."""
+        other_state = {**_CHANGED_STATE, "entity_id": "light.parent_group"}
+        tools = _make_tools(
+            {
+                "changed_states": [_CHANGED_STATE, other_state],
+                "service_response": _SHELL_RESPONSE,
+            }
+        )
+
+        response = await tools.ha_call_service(
+            domain="shell_command",
+            service="test",
+            entity_id="light.x",
+            return_response=True,
+        )
+
+        result = response["result"]
+        assert [record["entity_id"] for record in result] == ["light.x"], (
+            f"the propagation chain must be filtered to the target: {result!r}"
+        )
+        assert response["service_response"] == _SHELL_RESPONSE
 
     async def test_return_response_false_has_no_service_response_key(self):
         """Without return_response the REST reply is a plain changed-states list."""

--- a/tests/src/unit/test_call_service_return_response.py
+++ b/tests/src/unit/test_call_service_return_response.py
@@ -170,6 +170,16 @@ class TestReturnResponsePlacement:
 
         Returning neither is the masking this PR exists to remove: the caller
         asked for response data and would learn nothing about where it went.
+
+        Direct contract test — this shape does NOT arrive through the real
+        client. ``HomeAssistantClient.call_service`` normalises first: with
+        ``return_response=True`` a non-dict reply is wrapped as
+        ``{"service_response": <reply>}`` (``rest_client.py``), which reaches the
+        helper as a dict missing ``changed_states`` and lands in the same
+        fallback — the reachable shape, pinned by
+        ``test_missing_changed_states_warns``. Kept because the helper is a
+        static function with its own contract, not because the wiring can
+        deliver this.
         """
         tools = _make_tools([_CHANGED_STATE])
 

--- a/tests/src/unit/test_call_service_return_response.py
+++ b/tests/src/unit/test_call_service_return_response.py
@@ -146,14 +146,20 @@ class TestReturnResponsePlacement:
         )
 
     async def test_missing_changed_states_warns(self):
-        """A reply with no ``changed_states`` warns instead of implying no changes."""
-        tools = _make_tools({"service_response": _SHELL_RESPONSE})
+        """A reply with no ``changed_states`` warns instead of implying no changes.
+
+        The whole reply is handed back, not just the recognised key — every
+        non-conforming shape takes the same path, so the warning's "the whole
+        reply is reported under 'service_response'" is true without exception.
+        """
+        reply = {"service_response": _SHELL_RESPONSE}
+        tools = _make_tools(reply)
 
         response = await tools.ha_call_service(
             domain="shell_command", service="test", return_response=True
         )
 
-        assert response["service_response"] == _SHELL_RESPONSE
+        assert response["service_response"] == reply
         assert response["result"] == []
         assert _NON_ENVELOPE_WARNING in response["warnings"], (
             f"a missing changed_states must warn about the empty result: {response!r}"
@@ -177,18 +183,21 @@ class TestReturnResponsePlacement:
             f"a non-dict reply must warn rather than silently drop: {response!r}"
         )
 
-    async def test_non_list_changed_states_warns_and_does_not_reach_projection(self):
+    async def test_non_list_changed_states_warns_and_keeps_the_whole_reply(self):
         """A non-list ``changed_states`` would sail through projection untouched.
 
         ``compact_service_result`` returns non-lists unchanged, so the raw value
         would be emitted as ``result`` with ``result_fields`` silently ignored.
+        The whole reply — malformed ``changed_states`` included — must survive
+        under ``service_response``: peeling only the recognised key out would
+        discard it AND make the warning's "the whole reply is reported under
+        'service_response'" false.
         """
-        tools = _make_tools(
-            {
-                "changed_states": {"unexpected": "shape"},
-                "service_response": _SHELL_RESPONSE,
-            }
-        )
+        reply = {
+            "changed_states": {"unexpected": "shape"},
+            "service_response": _SHELL_RESPONSE,
+        }
+        tools = _make_tools(reply)
 
         response = await tools.ha_call_service(
             domain="shell_command",
@@ -197,7 +206,9 @@ class TestReturnResponsePlacement:
             result_fields=["entity_id"],
         )
 
-        assert response["service_response"] == _SHELL_RESPONSE
+        assert response["service_response"] == reply, (
+            f"the malformed changed_states must not be discarded: {response!r}"
+        )
         assert response["result"] == []
         assert _NON_ENVELOPE_WARNING in response["warnings"], (
             f"a non-list changed_states must warn: {response!r}"

--- a/tests/src/unit/test_call_service_return_response.py
+++ b/tests/src/unit/test_call_service_return_response.py
@@ -35,10 +35,7 @@ _CHANGED_STATE = {
 def _make_tools(call_service_return: Any) -> ServiceTools:
     client = MagicMock()
     client.call_service = AsyncMock(return_value=call_service_return)
-    tools = ServiceTools.__new__(ServiceTools)
-    tools._client = client
-    tools._device_tools = MagicMock()
-    return tools
+    return ServiceTools(client, MagicMock())
 
 
 def _occurrences(response: dict[str, Any], needle: str) -> int:
@@ -128,6 +125,39 @@ class TestReturnResponsePlacement:
         )
         assert _occurrences(response, "changed_states") == 1, (
             f"the fallback dict must be serialized exactly once: {response!r}"
+        )
+        # An empty result here is an artifact of the unrecognized shape, not a
+        # claim that nothing changed — say so rather than letting it read that way.
+        assert any("does NOT mean" in w for w in response["warnings"]), (
+            f"an unrecognized envelope must warn about the empty result: {response!r}"
+        )
+
+    async def test_missing_changed_states_warns(self):
+        """A reply with no ``changed_states`` warns instead of implying no changes."""
+        tools = _make_tools({"service_response": _SHELL_RESPONSE})
+
+        response = await tools.ha_call_service(
+            domain="shell_command", service="test", return_response=True
+        )
+
+        assert response["service_response"] == _SHELL_RESPONSE
+        assert response["result"] == []
+        assert any("does NOT mean" in w for w in response["warnings"]), (
+            f"a missing changed_states must warn about the empty result: {response!r}"
+        )
+
+    async def test_conforming_envelope_emits_no_envelope_warning(self):
+        """The normal HA shape must not add warning noise."""
+        tools = _make_tools(
+            {"changed_states": [_CHANGED_STATE], "service_response": _SHELL_RESPONSE}
+        )
+
+        response = await tools.ha_call_service(
+            domain="shell_command", service="test", return_response=True
+        )
+
+        assert not any("does NOT mean" in w for w in response.get("warnings", [])), (
+            f"a conforming envelope must not warn: {response!r}"
         )
 
     async def test_null_service_response_is_still_set(self):

--- a/tests/src/unit/test_compact_service_result.py
+++ b/tests/src/unit/test_compact_service_result.py
@@ -210,7 +210,11 @@ class TestProjectServiceResult:
         assert "nonexistent_attr" in warnings[0]
 
     def test_non_list_result_passthrough(self):
-        """A dict result passes through every mode (defensive — see above)."""
+        """A dict result passes through every mode.
+
+        Defensive only: ha_call_service splits the return_response envelope before
+        projection, so both its paths hand this helper a changed-state list.
+        """
         result = {"service_response": {"forecast": []}}
         projected, warnings = ServiceTools._project_service_result(
             result,

--- a/tests/src/unit/test_compact_service_result.py
+++ b/tests/src/unit/test_compact_service_result.py
@@ -120,7 +120,7 @@ class TestCompactServiceResult:
         assert compact_service_result([], "light.kitchen") == []
 
     def test_non_list_passthrough(self):
-        """``return_response=True`` services return dicts — leave them alone."""
+        """Non-list input is left alone (defensive — no caller passes a dict now)."""
         as_dict = {"service_response": {"foo": "bar"}}
         assert compact_service_result(as_dict, "light.kitchen") is as_dict
         assert compact_service_result(None, "light.kitchen") is None
@@ -210,7 +210,7 @@ class TestProjectServiceResult:
         assert "nonexistent_attr" in warnings[0]
 
     def test_non_list_result_passthrough(self):
-        """Dict result (return_response services) passes through every mode."""
+        """A dict result passes through every mode (defensive — see above)."""
         result = {"service_response": {"forecast": []}}
         projected, warnings = ServiceTools._project_service_result(
             result,

--- a/tests/src/unit/test_ha_call_service_component_routing.py
+++ b/tests/src/unit/test_ha_call_service_component_routing.py
@@ -381,6 +381,61 @@ async def test_return_response_null_still_emits_the_key() -> None:
 
 
 @pytest.mark.asyncio
+async def test_partial_without_response_warns_that_null_is_not_proof() -> None:
+    """A dispatched-unconfirmed call can lose a response the service produced.
+
+    The component only sets ``service_response`` for a non-null response, so an
+    absent key on the partial path is ambiguous: the service may have returned
+    nothing, or the component may have discarded the response along with the
+    confirmation. Emitting a bare ``service_response: null`` would assert the
+    first, so the ambiguity is warned about instead.
+    """
+    ws = make_ws(
+        "ha_mcp_tools/call_service",
+        info_result=_CAPS_CALL,
+        cmd_result=_partial_result("light.a"),
+    )
+    client = RoutingClient()
+    call_service = _build_call_service(client)
+
+    with patch_ws(ws, tools_service):
+        resp = await call_service(
+            domain="light",
+            service="turn_on",
+            entity_id="light.a",
+            return_response=True,
+        )
+
+    assert resp["service_response"] is None
+    assert any("does NOT prove" in w for w in resp["warnings"]), (
+        f"a partial call with no response must flag the ambiguity: {resp!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_confirmed_null_response_does_not_warn() -> None:
+    """A confirmed call's null response is unambiguous — no warning noise."""
+    ws = make_ws(
+        "ha_mcp_tools/call_service",
+        info_result=_CAPS_CALL,
+        cmd_result=_confirmed_result("light.a"),
+    )
+    client = RoutingClient()
+    call_service = _build_call_service(client)
+
+    with patch_ws(ws, tools_service):
+        resp = await call_service(
+            domain="light",
+            service="turn_on",
+            entity_id="light.a",
+            return_response=True,
+        )
+
+    assert resp["service_response"] is None
+    assert not any("does NOT prove" in w for w in resp.get("warnings", []))
+
+
+@pytest.mark.asyncio
 async def test_no_return_response_omits_the_key() -> None:
     """Without return_response the component path emits no service_response key."""
     ws = make_ws(

--- a/tests/src/unit/test_ha_call_service_component_routing.py
+++ b/tests/src/unit/test_ha_call_service_component_routing.py
@@ -352,6 +352,54 @@ async def test_return_response_passed_through() -> None:
 
 
 @pytest.mark.asyncio
+async def test_return_response_null_still_emits_the_key() -> None:
+    """A null service_response emits the key, matching the legacy REST path.
+
+    The component only sets ``service_response`` for a non-null response, so a
+    null one arrives as an absent key. Gating the mapping on ``is not None`` made
+    the two paths answer the same call with different shapes — key omitted here,
+    ``service_response: null`` on legacy (``_split_return_response_envelope``).
+    """
+    ws = make_ws(
+        "ha_mcp_tools/call_service",
+        info_result=_CAPS_CALL,
+        cmd_result=_confirmed_result("light.a"),
+    )
+    client = RoutingClient()
+    call_service = _build_call_service(client)
+
+    with patch_ws(ws, tools_service):
+        resp = await call_service(
+            domain="light",
+            service="turn_on",
+            entity_id="light.a",
+            return_response=True,
+        )
+
+    assert "service_response" in resp
+    assert resp["service_response"] is None
+
+
+@pytest.mark.asyncio
+async def test_no_return_response_omits_the_key() -> None:
+    """Without return_response the component path emits no service_response key."""
+    ws = make_ws(
+        "ha_mcp_tools/call_service",
+        info_result=_CAPS_CALL,
+        cmd_result=_confirmed_result("light.a"),
+    )
+    client = RoutingClient()
+    call_service = _build_call_service(client)
+
+    with patch_ws(ws, tools_service):
+        resp = await call_service(
+            domain="light", service="turn_on", entity_id="light.a"
+        )
+
+    assert "service_response" not in resp
+
+
+@pytest.mark.asyncio
 async def test_no_capability_uses_legacy_post() -> None:
     """Component without call_service → legacy REST POST, no call_service frame."""
     ws = make_ws("ha_mcp_tools/call_service", info_result=_CAPS_NONE)


### PR DESCRIPTION
## What does this PR do?

Fixes #2085. `ha_call_service` with `return_response=true` returned the service's response twice — once nested at `result.service_response` (HA's raw envelope passed through projection untouched) and once as a top-level `service_response` sibling — byte-identical, doubling the token cost of every response-returning call (e.g. `shell_command.*`).

The legacy REST path now splits HA's `{"changed_states": [...], "service_response": ...}` envelope before projection: `service_response` surfaces exactly once at the top level and only the changed states feed `result`. As a side effect, default compaction and `result_fields` projection now apply to the changed-state records on `return_response` calls, matching every other path.

**Every path that was asked for a response now emits the key**, so a caller never branches on whether it exists. That closed three holes where the response silently vanished: a non-dict reply, a non-list `changed_states`, and a timed-out call. Any reply that is not HA's envelope hands the whole reply back under `service_response` and warns — an empty `result` would otherwise read as an affirmative "no entity states changed".

A null `service_response` is not always proof the service returned nothing: on the component's dispatched-but-unconfirmed path the response may have been produced and discarded with the confirmation, and on a timeout the reply never arrived. Both now say so rather than asserting an authoritative null; a plain confirmed null stays quiet.

**Component path:** `service_response` is now emitted whenever requested (previously gated on non-null), so both paths answer the same call with the same shape.

Not touched: the REST client envelope (internal callers consume it via `unwrap_service_response`) and the `ws_command` escape hatch.

## Type of change
- [x] 🐛 Bug fix

## Testing
- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`) — regression tests in `tests/src/unit/test_call_service_return_response.py` verified to fail on master and pass with the fix; component-path parity in `tests/src/unit/test_ha_call_service_component_routing.py`; e2e in `tests/src/e2e/workflows/services/test_call_service_return_response.py` (legacy REST path — the component route cannot serve a response-returning service)
- [x] Code follows style guidelines (`uv run ruff check`)

## Checklist
- [x] I have updated documentation if needed (tool docstring documents the `service_response` placement; `tests/AGENTS.md` corrected — it still described the deleted `result.get("service_response", result)` unwrap)
