### PR TITLE
test: resolve HAOS addon container names across the app_ prefix rename

### DIFF
--- a/tests/src/haos_runtime.py
+++ b/tests/src/haos_runtime.py
@@ -132,7 +132,7 @@ SSHPASS_BIN = os.environ.get("HAOS_TEST_SSHPASS_BIN", "sshpass")
 
 
 def ssh_exec(
-    cmd: list[str], *, timeout: float = 30.0
+    cmd: list[str], *, timeout: float = 30.0, retry_deadline: float | None = None
 ) -> subprocess.CompletedProcess[str]:
     """Run ``cmd`` over SSH against the booted HAOS's Advanced SSH addon.
 
@@ -188,7 +188,9 @@ def ssh_exec(
     # Retry the entire ``subprocess.run`` on that specific stderr token
     # (and the connection-refused variant) so cold-start races don't
     # require every caller to embed retry logic.
-    deadline = time.monotonic() + max(timeout, 60.0)
+    deadline = time.monotonic() + (
+        retry_deadline if retry_deadline is not None else max(timeout, 60.0)
+    )
     attempt = 0
     while True:
         attempt += 1
@@ -208,6 +210,12 @@ def ssh_exec(
                 or "connection reset by peer" in stderr
                 or "connection refused" in stderr
                 or "no route to host" in stderr
+                # Addon restarts (settings /restart self-restart, the real
+                # Supervisor restart in TestSettingsUiRestartReal) tear the
+                # container down briefly, so a name miss during that window is
+                # as transient as the SSH races above. The caller-supplied
+                # retry_deadline sizes the window.
+                or "no such container" in stderr
             )
             if transient and time.monotonic() < deadline:
                 LOG.debug(
@@ -222,10 +230,62 @@ def ssh_exec(
             # and would otherwise be lost in CI output. Re-raise as
             # RuntimeError with full stderr+stdout so failures are
             # actionable.
+            diag = ""
+            if "no such container" in stderr:
+                diag = _container_miss_diagnostics(ssh_cmd, env)
             raise RuntimeError(
                 f"ssh_exec failed (exit {exc.returncode}, attempt={attempt}): "
-                f"cmd={cmd!r} stderr={exc.stderr!r} stdout={exc.stdout!r}"
+                f"cmd={cmd!r} stderr={exc.stderr!r} stdout={exc.stdout!r}{diag}"
             ) from exc
+
+
+def _container_miss_diagnostics(ssh_cmd: list[str], env: dict[str, str]) -> str:
+    """Best-effort VM state capture for a persistent container-name miss.
+
+    A container absent through the whole retry window while the addon's
+    HTTP endpoint still serves means the container exists under a name
+    the test did not predict — so the failure message must carry the
+    actual names. Reuses the caller's assembled ssh wrapper with the
+    remote command swapped out; failures here must never mask the
+    original error.
+    """
+    captured: list[str] = []
+    for label, remote in (
+        ("docker_ps", "docker ps -a --format '{{.Names}} {{.Status}}'"),
+        ("ha_addons", "ha addons --raw-json | head -c 2000"),
+    ):
+        try:
+            probe = subprocess.run(
+                [*ssh_cmd[:-1], remote],
+                capture_output=True,
+                text=True,
+                timeout=20.0,
+                env=env,
+            )
+            captured.append(f"{label}={probe.stdout.strip()!r}")
+        except Exception as probe_err:  # pragma: no cover - diagnostics best-effort
+            captured.append(f"{label}_error={probe_err!r}")
+    return " | " + " | ".join(captured)
+
+
+def _resolve_addon_container(addon_slug: str) -> str:
+    """Return the addon's actual container name on the booted HAOS.
+
+    Supervisor's addon container prefix changed from ``addon_`` to ``app_``
+    (the add-ons to apps rename), and HAOS self-updates Supervisor at boot,
+    so which prefix a CI VM uses depends on the Supervisor build it booted
+    with — run 30553159100's capture shows ``app_local_ha_mcp_dev`` running
+    while ``addon_local_ha_mcp_dev`` resolves to nothing. Read the name from
+    docker instead of assuming a prefix; on a listing miss (e.g. the addon is
+    mid-restart) fall back to the legacy name so the caller's retry window
+    still applies.
+    """
+    listing = ssh_exec(["docker", "ps", "-a", "--format", "{{.Names}}"], timeout=20.0)
+    candidates = {f"addon_{addon_slug}", f"app_{addon_slug}"}
+    for name in listing.stdout.split():
+        if name in candidates:
+            return name
+    return f"addon_{addon_slug}"
 
 
 def docker_exec_in_addon(
@@ -234,18 +294,23 @@ def docker_exec_in_addon(
     """Run ``cmd`` inside an addon container via SSH + docker exec.
 
     ``addon_slug`` is the Supervisor slug (e.g. ``local_ha_mcp_dev``);
-    the helper resolves it to the Docker container name (
-    ``addon_<slug>``). Returns stdout of the command. Raises
-    ``RuntimeError`` with stderr+stdout context on non-zero exit
-    (via the wrapping in ``ssh_exec``).
+    the container name is resolved from docker via
+    :func:`_resolve_addon_container` (the prefix differs across Supervisor
+    builds). Returns stdout of the command. Raises ``RuntimeError`` with
+    stderr+stdout context on non-zero exit (via the wrapping in
+    ``ssh_exec``).
 
     Used by item 8's filesystem-poisoning E2E to make
     ``/data/saved_tools.json`` unwriteable inside the dev addon
     container mid-test, force the save-warning rollback, then chmod
     back in the test's finally block.
     """
-    container = f"addon_{addon_slug}"
-    result = ssh_exec(["docker", "exec", container, *cmd], timeout=timeout)
+    container = _resolve_addon_container(addon_slug)
+    result = ssh_exec(
+        ["docker", "exec", container, *cmd],
+        timeout=timeout,
+        retry_deadline=180.0,
+    )
     return result.stdout
 
 

--- a/tests/src/haos_runtime.py
+++ b/tests/src/haos_runtime.py
@@ -132,7 +132,7 @@ SSHPASS_BIN = os.environ.get("HAOS_TEST_SSHPASS_BIN", "sshpass")
 
 
 def ssh_exec(
-    cmd: list[str], *, timeout: float = 30.0, retry_deadline: float | None = None
+    cmd: list[str], *, timeout: float = 30.0
 ) -> subprocess.CompletedProcess[str]:
     """Run ``cmd`` over SSH against the booted HAOS's Advanced SSH addon.
 
@@ -188,9 +188,7 @@ def ssh_exec(
     # Retry the entire ``subprocess.run`` on that specific stderr token
     # (and the connection-refused variant) so cold-start races don't
     # require every caller to embed retry logic.
-    deadline = time.monotonic() + (
-        retry_deadline if retry_deadline is not None else max(timeout, 60.0)
-    )
+    deadline = time.monotonic() + max(timeout, 60.0)
     attempt = 0
     while True:
         attempt += 1
@@ -210,12 +208,6 @@ def ssh_exec(
                 or "connection reset by peer" in stderr
                 or "connection refused" in stderr
                 or "no route to host" in stderr
-                # Addon restarts (settings /restart self-restart, the real
-                # Supervisor restart in TestSettingsUiRestartReal) tear the
-                # container down briefly, so a name miss during that window is
-                # as transient as the SSH races above. The caller-supplied
-                # retry_deadline sizes the window.
-                or "no such container" in stderr
             )
             if transient and time.monotonic() < deadline:
                 LOG.debug(
@@ -240,14 +232,13 @@ def ssh_exec(
 
 
 def _container_miss_diagnostics(ssh_cmd: list[str], env: dict[str, str]) -> str:
-    """Best-effort VM state capture for a persistent container-name miss.
+    """Best-effort VM state capture for a container-name miss.
 
-    A container absent through the whole retry window while the addon's
-    HTTP endpoint still serves means the container exists under a name
-    the test did not predict — so the failure message must carry the
-    actual names. Reuses the caller's assembled ssh wrapper with the
-    remote command swapped out; failures here must never mask the
-    original error.
+    A container docker reports as absent while the addon's HTTP endpoint
+    still serves means the container exists under a name the test did not
+    predict — so the failure message must carry the actual names. Reuses
+    the caller's assembled ssh wrapper with the remote command swapped
+    out; failures here must never mask the original error.
     """
     captured: list[str] = []
     for label, remote in (
@@ -268,7 +259,7 @@ def _container_miss_diagnostics(ssh_cmd: list[str], env: dict[str, str]) -> str:
     return " | " + " | ".join(captured)
 
 
-def _resolve_addon_container(addon_slug: str) -> str:
+def _resolve_addon_container(addon_slug: str) -> str | None:
     """Return the addon's actual container name on the booted HAOS.
 
     Supervisor's addon container prefix changed from ``addon_`` to ``app_``
@@ -276,16 +267,31 @@ def _resolve_addon_container(addon_slug: str) -> str:
     so which prefix a CI VM uses depends on the Supervisor build it booted
     with — run 30553159100's capture shows ``app_local_ha_mcp_dev`` running
     while ``addon_local_ha_mcp_dev`` resolves to nothing. Read the name from
-    docker instead of assuming a prefix; on a listing miss (e.g. the addon is
-    mid-restart) fall back to the legacy name so the caller's retry window
-    still applies.
+    docker instead of assuming a prefix.
+
+    A clean listing that carries neither name (e.g. the addon is mid-restart)
+    resolves to the legacy name. If the ``docker ps`` call itself fails this
+    returns ``None`` rather than propagating, so an unreadable listing degrades
+    to the caller trying both supported names instead of blocking an exec that
+    would have worked.
     """
-    listing = ssh_exec(["docker", "ps", "-a", "--format", "{{.Names}}"], timeout=20.0)
+    try:
+        listing = ssh_exec(
+            ["docker", "ps", "-a", "--format", "{{.Names}}"], timeout=20.0
+        )
+    except (RuntimeError, subprocess.TimeoutExpired) as err:
+        LOG.debug("container listing failed (%s); trying both prefixes", err)
+        return None
     candidates = {f"addon_{addon_slug}", f"app_{addon_slug}"}
     for name in listing.stdout.split():
         if name in candidates:
             return name
     return f"addon_{addon_slug}"
+
+
+def _is_container_miss(err: Exception) -> bool:
+    """Whether ``err`` is docker reporting the target container as absent."""
+    return "no such container" in str(err).lower()
 
 
 def docker_exec_in_addon(
@@ -298,20 +304,37 @@ def docker_exec_in_addon(
     :func:`_resolve_addon_container` (the prefix differs across Supervisor
     builds). Returns stdout of the command. Raises ``RuntimeError`` with
     stderr+stdout context on non-zero exit (via the wrapping in
-    ``ssh_exec``).
+    ``ssh_exec``), carrying the ``docker ps`` and Supervisor addon list for a
+    container-name miss.
+
+    A name miss fails fast — there is no retry window. It only costs one
+    second attempt: the resolved name can go stale (a listing taken while the
+    addon is mid-restart resolves to the legacy fallback, then the real
+    container returns under the other prefix), so a miss re-resolves once and
+    re-runs only when the name actually changed. When the listing was
+    unreadable to begin with, the second attempt is the other prefix.
 
     Used by item 8's filesystem-poisoning E2E to make
     ``/data/saved_tools.json`` unwriteable inside the dev addon
     container mid-test, force the save-warning rollback, then chmod
     back in the test's finally block.
     """
-    container = _resolve_addon_container(addon_slug)
-    result = ssh_exec(
-        ["docker", "exec", container, *cmd],
-        timeout=timeout,
-        retry_deadline=180.0,
-    )
-    return result.stdout
+    resolved = _resolve_addon_container(addon_slug)
+    first = resolved if resolved is not None else f"addon_{addon_slug}"
+    try:
+        return ssh_exec(["docker", "exec", first, *cmd], timeout=timeout).stdout
+    except RuntimeError as err:
+        if not _is_container_miss(err):
+            raise
+        second = (
+            _resolve_addon_container(addon_slug)
+            if resolved is not None
+            else f"app_{addon_slug}"
+        )
+        if second is None or second == first:
+            raise
+        LOG.debug("container %r missing; retrying once as %r", first, second)
+        return ssh_exec(["docker", "exec", second, *cmd], timeout=timeout).stdout
 
 
 def is_haos_inaddon_mode() -> bool:

--- a/tests/src/haos_runtime.py
+++ b/tests/src/haos_runtime.py
@@ -131,6 +131,13 @@ SSH_ADDON_PASSWORD = os.environ.get("HAOS_TEST_SSH_PASSWORD", "haosdebug")
 SSHPASS_BIN = os.environ.get("HAOS_TEST_SSHPASS_BIN", "sshpass")
 
 
+# docker's two ways of saying the target container cannot be exec'd into: the
+# name matches nothing, or it matches a container that is not running. Both mean
+# the resolved name is stale, so both take the same re-resolve and both are
+# worth capturing VM state for.
+_CONTAINER_MISS_TOKENS = ("no such container", "is not running")
+
+
 def ssh_exec(
     cmd: list[str], *, timeout: float = 30.0
 ) -> subprocess.CompletedProcess[str]:
@@ -223,7 +230,7 @@ def ssh_exec(
             # RuntimeError with full stderr+stdout so failures are
             # actionable.
             diag = ""
-            if "no such container" in stderr:
+            if any(token in stderr for token in _CONTAINER_MISS_TOKENS):
                 diag = _container_miss_diagnostics(ssh_cmd, env)
             raise RuntimeError(
                 f"ssh_exec failed (exit {exc.returncode}, attempt={attempt}): "
@@ -232,13 +239,15 @@ def ssh_exec(
 
 
 def _container_miss_diagnostics(ssh_cmd: list[str], env: dict[str, str]) -> str:
-    """Best-effort VM state capture for a container-name miss.
+    """Best-effort VM state capture for a container miss.
 
-    A container docker reports as absent while the addon's HTTP endpoint
-    still serves means the container exists under a name the test did not
-    predict — so the failure message must carry the actual names. Reuses
-    the caller's assembled ssh wrapper with the remote command swapped
-    out; failures here must never mask the original error.
+    A container docker reports as absent or stopped while the addon's HTTP
+    endpoint still serves means the container exists under a name the test
+    did not predict — so the failure message must carry the actual names.
+    This capture deliberately uses ``docker ps -a`` with statuses: unlike
+    resolution, seeing the exited containers is the point. Reuses the
+    caller's assembled ssh wrapper with the remote command swapped out;
+    failures here must never mask the original error.
     """
     captured: list[str] = []
     for label, remote in (
@@ -269,6 +278,12 @@ def _resolve_addon_container(addon_slug: str) -> str | None:
     while ``addon_local_ha_mcp_dev`` resolves to nothing. Read the name from
     docker instead of assuming a prefix.
 
+    Only RUNNING containers are listed: ``docker exec`` requires one, so an
+    Exited leftover under either prefix is never the right answer. Candidates
+    are tested in a fixed order — ``app_`` before the legacy ``addon_`` — so a
+    VM that somehow carries both resolves to the current name deterministically
+    rather than by listing order.
+
     A clean listing that carries neither name (e.g. the addon is mid-restart)
     resolves to the legacy name. If the ``docker ps`` call itself fails this
     returns ``None`` rather than propagating, so an unreadable listing degrades
@@ -276,22 +291,25 @@ def _resolve_addon_container(addon_slug: str) -> str | None:
     would have worked.
     """
     try:
-        listing = ssh_exec(
-            ["docker", "ps", "-a", "--format", "{{.Names}}"], timeout=20.0
-        )
+        listing = ssh_exec(["docker", "ps", "--format", "{{.Names}}"], timeout=20.0)
     except (RuntimeError, subprocess.TimeoutExpired) as err:
         LOG.debug("container listing failed (%s); trying both prefixes", err)
         return None
-    candidates = {f"addon_{addon_slug}", f"app_{addon_slug}"}
-    for name in listing.stdout.split():
-        if name in candidates:
-            return name
+    running = set(listing.stdout.split())
+    for candidate in (f"app_{addon_slug}", f"addon_{addon_slug}"):
+        if candidate in running:
+            return candidate
     return f"addon_{addon_slug}"
 
 
 def _is_container_miss(err: Exception) -> bool:
-    """Whether ``err`` is docker reporting the target container as absent."""
-    return "no such container" in str(err).lower()
+    """Whether ``err`` is docker refusing the exec for want of a live container.
+
+    Both shapes count: the name matching nothing, and a container that stopped
+    between the listing and the exec.
+    """
+    text = str(err).lower()
+    return any(token in text for token in _CONTAINER_MISS_TOKENS)
 
 
 def docker_exec_in_addon(
@@ -305,14 +323,15 @@ def docker_exec_in_addon(
     builds). Returns stdout of the command. Raises ``RuntimeError`` with
     stderr+stdout context on non-zero exit (via the wrapping in
     ``ssh_exec``), carrying the ``docker ps`` and Supervisor addon list for a
-    container-name miss.
+    container miss.
 
-    A name miss fails fast — there is no retry window. It only costs one
-    second attempt: the resolved name can go stale (a listing taken while the
-    addon is mid-restart resolves to the legacy fallback, then the real
-    container returns under the other prefix), so a miss re-resolves once and
-    re-runs only when the name actually changed. When the listing was
-    unreadable to begin with, the second attempt is the other prefix.
+    A miss fails fast — there is no retry window. It only costs one second
+    attempt: the resolved name can go stale (a listing taken while the addon is
+    mid-restart resolves to the legacy fallback, then the real container
+    returns under the other prefix; or the container stops between listing and
+    exec), so a miss re-resolves once and re-runs only when the name actually
+    changed. When the listing was unreadable to begin with, the second attempt
+    is the other prefix.
 
     Used by item 8's filesystem-poisoning E2E to make
     ``/data/saved_tools.json`` unwriteable inside the dev addon
@@ -2160,7 +2179,7 @@ def trigger_dev_addon_update(
         _await_supervisor_ws_result(ws, msg_id, op_endpoint, op_deadline)
 
     def _supervisor_post_with_job_retry(
-        endpoint: str, op_timeout: int, *, data: dict | None = None
+        endpoint: str, op_timeout: float, *, data: dict | None = None
     ) -> None:
         """POST a Supervisor endpoint, retrying the transient per-addon
         ``Another job is running for job group ...`` collision.

--- a/tests/src/unit/test_haos_addon_container_resolve.py
+++ b/tests/src/unit/test_haos_addon_container_resolve.py
@@ -1,0 +1,193 @@
+"""Unit tests for the HAOS addon container resolution in ``haos_runtime``.
+
+Supervisor renamed addon containers from ``addon_<slug>`` to ``app_<slug>``
+and HAOS CI VMs self-update Supervisor at boot, so which prefix a VM uses
+depends on the build it booted with. ``docker_exec_in_addon`` therefore
+resolves the name from docker rather than assuming a prefix, and recovers
+from a resolution that went stale between the listing and the exec.
+
+These paths used to be observable only through the HAOS in-addon lane (a
+~40 min VM boot), so a regression in them cost a full CI round-trip to see.
+Covered here directly: prefix resolution, running-only listing, the fixed
+candidate preference, exact-name matching, the single re-resolve on a stale
+name, and the degradation when the listing itself is unreadable.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from tests.src.haos_runtime import _resolve_addon_container, docker_exec_in_addon
+
+SLUG = "local_ha_mcp_dev"
+APP = f"app_{SLUG}"
+ADDON = f"addon_{SLUG}"
+
+_LIST = ("list", None)
+
+
+def _miss(container: str) -> RuntimeError:
+    """The RuntimeError ``ssh_exec`` raises when the name matches nothing."""
+    return RuntimeError(
+        f"ssh_exec failed (exit 1, attempt=1): cmd=['docker', 'exec'] "
+        f'stderr="Error response from daemon: No such container: {container}"'
+    )
+
+
+def _not_running(container: str) -> RuntimeError:
+    """The RuntimeError ``ssh_exec`` raises for a stopped container."""
+    return RuntimeError(
+        f"ssh_exec failed (exit 1, attempt=1): cmd=['docker', 'exec'] "
+        f'stderr="Error response from daemon: Container {container} is not running"'
+    )
+
+
+class _FakeSSH:
+    """Scripted ``ssh_exec`` stand-in recording listing and exec calls.
+
+    ``listings`` and ``execs`` are consumed in order; a queued
+    ``BaseException`` is raised instead of returned. Running past the end of
+    either queue is a test-authoring bug, so it raises ``AssertionError``
+    rather than silently succeeding.
+    """
+
+    def __init__(
+        self, listings: list[Any] | None = None, execs: list[Any] | None = None
+    ) -> None:
+        self._listings = list(listings or [])
+        self._execs = list(execs or [])
+        self.calls: list[tuple[str, str | None]] = []
+        self.listing_cmds: list[list[str]] = []
+
+    def __call__(
+        self, cmd: list[str], *, timeout: float = 30.0
+    ) -> subprocess.CompletedProcess[str]:
+        if cmd[:2] == ["docker", "ps"]:
+            self.listing_cmds.append(list(cmd))
+            self.calls.append(_LIST)
+            return self._serve(self._listings, cmd)
+        assert cmd[:2] == ["docker", "exec"], f"unexpected command: {cmd!r}"
+        self.calls.append(("exec", cmd[2]))
+        return self._serve(self._execs, cmd)
+
+    @staticmethod
+    def _serve(queue: list[Any], cmd: list[str]) -> subprocess.CompletedProcess[str]:
+        if not queue:
+            raise AssertionError(f"unscripted call: {cmd!r}")
+        item = queue.pop(0)
+        if isinstance(item, BaseException):
+            raise item
+        return subprocess.CompletedProcess(cmd, 0, stdout=item, stderr="")
+
+    @property
+    def exec_targets(self) -> list[str | None]:
+        return [name for kind, name in self.calls if kind == "exec"]
+
+
+def _run(fake: _FakeSSH) -> str:
+    with patch("tests.src.haos_runtime.ssh_exec", fake):
+        return docker_exec_in_addon(SLUG, ["chmod", "444", "/data/saved_tools.json"])
+
+
+def test_resolves_app_prefix() -> None:
+    """A VM on the renamed prefix execs against ``app_<slug>``."""
+    fake = _FakeSSH([f"{APP}\nhomeassistant\n"], ["ok"])
+    assert _run(fake) == "ok"
+    assert fake.calls == [_LIST, ("exec", APP)]
+
+
+def test_resolves_legacy_addon_prefix() -> None:
+    """A VM still on the old prefix execs against ``addon_<slug>``."""
+    fake = _FakeSSH([f"{ADDON}\nhomeassistant\n"], ["ok"])
+    assert _run(fake) == "ok"
+    assert fake.calls == [_LIST, ("exec", ADDON)]
+
+
+def test_resolution_lists_running_containers_only() -> None:
+    """Resolution must not pass ``-a`` -- exec needs a RUNNING container.
+
+    The regression this guards: with ``-a`` the listing also carries Exited
+    leftovers, and the ``app_``-first preference would then select a dead
+    ``app_`` container over the ``addon_`` one that is actually serving.
+    """
+    fake = _FakeSSH([f"{ADDON}\nhomeassistant\n"], ["ok"])
+    assert _run(fake) == "ok"
+    assert fake.listing_cmds == [["docker", "ps", "--format", "{{.Names}}"]]
+    assert "-a" not in fake.listing_cmds[0]
+    assert fake.exec_targets == [ADDON]
+
+
+def test_prefers_app_over_legacy_when_both_running() -> None:
+    """Preference is the fixed candidate order, not the listing's order."""
+    fake = _FakeSSH([f"{ADDON}\n{APP}\n"])
+    with patch("tests.src.haos_runtime.ssh_exec", fake):
+        assert _resolve_addon_container(SLUG) == APP
+
+
+def test_similar_name_does_not_match_slug() -> None:
+    """Matching is exact: ``app_<slug>2`` is a different addon, not ours."""
+    fake = _FakeSSH([f"{APP}2\nhomeassistant\n"], ["ok"])
+    assert _run(fake) == "ok"
+    # Falls back to the legacy name rather than hijacking the 2-suffixed one.
+    assert fake.exec_targets == [ADDON]
+    assert f"{APP}2" not in fake.exec_targets
+
+
+def test_stale_resolution_reresolves_and_retries_once() -> None:
+    """A listing taken mid-restart pins the legacy name; the miss recovers.
+
+    This is the case that made the fallback dangerous: on an ``app_`` VM the
+    legacy fallback names a container that will never exist, so without the
+    re-resolve the exec fails even though the real container came back.
+    """
+    fake = _FakeSSH(["homeassistant\n", f"{APP}\n"], [_miss(ADDON), "ok"])
+    assert _run(fake) == "ok"
+    assert fake.calls == [_LIST, ("exec", ADDON), _LIST, ("exec", APP)]
+
+
+def test_not_running_error_takes_the_reresolve_path() -> None:
+    """A container that stopped between listing and exec re-resolves too."""
+    fake = _FakeSSH([f"{ADDON}\n", f"{APP}\n"], [_not_running(ADDON), "ok"])
+    assert _run(fake) == "ok"
+    assert fake.calls == [_LIST, ("exec", ADDON), _LIST, ("exec", APP)]
+
+
+def test_unchanged_reresolve_reraises_without_second_exec() -> None:
+    """An unchanged name is not worth re-running -- fail fast, one exec only."""
+    fake = _FakeSSH(["homeassistant\n", "homeassistant\n"], [_miss(ADDON)])
+    with pytest.raises(RuntimeError, match="No such container"):
+        _run(fake)
+    assert fake.calls == [_LIST, ("exec", ADDON), _LIST]
+    assert fake.exec_targets == [ADDON]
+
+
+def test_unreadable_listing_degrades_to_both_names() -> None:
+    """A broken listing must not block an exec that would have worked."""
+    fake = _FakeSSH(
+        [RuntimeError("ssh_exec failed: connection closed")], [_miss(ADDON), "ok"]
+    )
+    assert _run(fake) == "ok"
+    # One listing attempt only -- the second name comes from the prefix pair.
+    assert fake.calls == [_LIST, ("exec", ADDON), ("exec", APP)]
+
+
+def test_listing_timeout_degrades_to_both_names() -> None:
+    """``ssh_exec`` does not wrap TimeoutExpired; it must still degrade."""
+    fake = _FakeSSH([subprocess.TimeoutExpired("ssh", 20.0)], [_miss(ADDON), "ok"])
+    assert _run(fake) == "ok"
+    assert fake.calls == [_LIST, ("exec", ADDON), ("exec", APP)]
+
+
+def test_non_miss_failure_propagates_without_reresolve() -> None:
+    """An unrelated exec failure is a real failure -- no retry, no re-resolve."""
+    fake = _FakeSSH(
+        [f"{APP}\n"],
+        [RuntimeError('ssh_exec failed (exit 1): stderr="chmod: permission denied"')],
+    )
+    with pytest.raises(RuntimeError, match="permission denied"):
+        _run(fake)
+    assert fake.calls == [_LIST, ("exec", APP)]


### PR DESCRIPTION
## What does this PR do?

Fixes the HAOS inaddon E2E lane, which fails on any CI VM whose Supervisor self-updated at boot: Supervisor renamed addon containers from `addon_<slug>` to `app_<slug>`, and the docker-exec test harness hardcoded the old prefix, so the filesystem-poisoning E2E failed with "No such container" while the addon itself was up and serving. Because the rename rides Supervisor's rollout, lanes flapped green/red across unrelated PRs depending on each VM's boot-time update race.

`docker_exec_in_addon` now resolves the actual container name from the running-container listing, preferring `app_<slug>` over the legacy name deterministically (an Exited container is never a valid exec target). A name miss fails fast — there is no retry window: an exec that fails because the resolution went stale ("no such container" or "is not running") re-resolves once and retries a single time only when the name actually changed, an unreadable listing degrades to attempting both prefixes directly, and the failure message attaches `docker ps` plus the Supervisor addon list so any future naming drift reports itself instead of requiring instrumentation rounds.

Extracted from #2087 (where the diagnosis ran: instrumented capture on run 30553159100 shows `app_local_ha_mcp_dev` up while `addon_local_ha_mcp_dev` resolves to nothing) so every PR's inaddon lane is unblocked without waiting on that PR's review. #2087 will resolve the resulting conflict after this merges.

## Type of change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [x] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

The resolver and its retry/degradation paths carry direct unit coverage — `tests/src/unit/test_haos_addon_container_resolve.py`, 11 tests following the existing patch-`ssh_exec` pattern — so regressions no longer depend on the HAOS inaddon lane to surface. The full inaddon lane ran green on both prior commits of this branch after failing 6/6 runs with the hardcoded prefix. `ruff check`, `ruff format --check`, and the local CodeQL approximation are clean.

## Checklist
- [x] I have updated documentation if needed
