### PR TITLE
fix: normalize the remaining loading ellipses via the translation pipeline

### DIFF
--- a/src/ha_mcp/settings_ui/locales/de.json
+++ b/src/ha_mcp/settings_ui/locales/de.json
@@ -156,7 +156,7 @@
     "status.loaded": "Geladen",
     "status.loading_ellipsis": "Lädt…",
     "status.loading_parentheses": "(wird geladen…)",
-    "status.unsaved": "Nicht gespeicherte Änderungen...",
+    "status.unsaved": "Ungespeicherte Änderungen…",
     "status.saving": "Speichert…",
     "status.saving_server_setting": "Speichert Server-Einstellung...",
     "status.saved": "Gespeichert.",

--- a/src/ha_mcp/settings_ui/locales/en.json
+++ b/src/ha_mcp/settings_ui/locales/en.json
@@ -156,7 +156,7 @@
     "status.loaded": "Loaded",
     "status.loading_ellipsis": "Loading…",
     "status.loading_parentheses": "(loading…)",
-    "status.unsaved": "Unsaved changes...",
+    "status.unsaved": "Unsaved changes…",
     "status.saving": "Saving…",
     "status.saving_server_setting": "Saving server setting...",
     "status.saved": "Saved.",

--- a/src/ha_mcp/settings_ui/locales/es.json
+++ b/src/ha_mcp/settings_ui/locales/es.json
@@ -156,7 +156,7 @@
     "status.loaded": "Cargado",
     "status.loading_ellipsis": "Cargando…",
     "status.loading_parentheses": "(cargando…)",
-    "status.unsaved": "Cambios sin guardar...",
+    "status.unsaved": "Cambios sin guardar…",
     "status.saving": "Guardando…",
     "status.saving_server_setting": "Guardando el ajuste del servidor...",
     "status.saved": "Guardado.",

--- a/src/ha_mcp/settings_ui/locales/fr.json
+++ b/src/ha_mcp/settings_ui/locales/fr.json
@@ -156,7 +156,7 @@
     "status.loaded": "Chargé",
     "status.loading_ellipsis": "Chargement…",
     "status.loading_parentheses": "(chargement…)",
-    "status.unsaved": "Modifications non enregistrées...",
+    "status.unsaved": "Modifications non enregistrées…",
     "status.saving": "Enregistrement…",
     "status.saving_server_setting": "Enregistrement du paramètre serveur...",
     "status.saved": "Enregistré.",

--- a/src/ha_mcp/settings_ui/locales/it.json
+++ b/src/ha_mcp/settings_ui/locales/it.json
@@ -156,7 +156,7 @@
     "status.loaded": "Caricato",
     "status.loading_ellipsis": "Caricamento…",
     "status.loading_parentheses": "(caricamento…)",
-    "status.unsaved": "Modifiche non salvate...",
+    "status.unsaved": "Modifiche non salvate…",
     "status.saving": "Salvataggio…",
     "status.saving_server_setting": "Salvataggio dell'impostazione del server...",
     "status.saved": "Salvato.",

--- a/src/ha_mcp/settings_ui/locales/ru.json
+++ b/src/ha_mcp/settings_ui/locales/ru.json
@@ -156,7 +156,7 @@
     "status.loaded": "Загружено",
     "status.loading_ellipsis": "Загрузка…",
     "status.loading_parentheses": "(загрузка…)",
-    "status.unsaved": "Есть несохранённые изменения...",
+    "status.unsaved": "Несохранённые изменения…",
     "status.saving": "Сохранение…",
     "status.saving_server_setting": "Сохранение настройки сервера...",
     "status.saved": "Сохранено.",

--- a/tests/src/unit/locale_source_baseline.json
+++ b/tests/src/unit/locale_source_baseline.json
@@ -641,7 +641,7 @@
     "messages.status.stopped_connection": "110e9148b9c248fc",
     "messages.status.stopped_offline": "49a5ce61497c157f",
     "messages.status.stopping": "6f68db105f37fff1",
-    "messages.status.unsaved": "c29ef0329c2c62a9",
+    "messages.status.unsaved": "118f65c49c181ad4",
     "messages.status.waiting_addon": "e48ae677e783e56e",
     "messages.tabs.accessibility": "d3368cbffe23c98d",
     "messages.tabs.aria": "e26d51d36781ba17",


### PR DESCRIPTION
## What does this PR do?

Stacked on #2095 (GitHub stacked-PRs public preview) as its live demonstration: the only hand-written change here is one English string (`status.unsaved`: `"Unsaved changes..."` → `"Unsaved changes…"`); the commit after it is `locale-sync.yml`'s automatic machine-translation of that key into every language, pushed by the workflow with no human involvement. Review this PR to see exactly what the pipeline does to a PR that touches an English source.

## Type of change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

## Checklist
- [ ] I have updated documentation if needed