### PR TITLE
fix: authenticate star history generation

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,8 +30,9 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Generate star history charts
+        # The built-in token cannot access GitHub's restricted stargazer history.
         env:
-          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ secrets.STAR_HISTORY_TOKEN }}
         run: >-
           python3 ../scripts/generate_star_history.py
           --repository "${{ github.repository }}"


### PR DESCRIPTION
## Summary

- use the dedicated `STAR_HISTORY_TOKEN` secret for the restricted stargazer-history endpoint
- keep the credential scoped to the chart-generation step
- document why the built-in Actions token cannot be used

## Testing

- direct timestamped stargazer API request returned HTTP 200
- full chart generator produced both light and dark SVGs
- `actionlint .github/workflows/deploy.yml`
- PR CI will validate the workflow-only change before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)