### PR TITLE
chore(internal): enable targeted ruff pylint rules, fix 104 violations

### DIFF
--- a/custom_components/ha_mcp_tools/config_flow.py
+++ b/custom_components/ha_mcp_tools/config_flow.py
@@ -228,7 +228,7 @@ def _sentence_prefix(sentence: str, language: str, english: str) -> str:
     if not sentence:
         return sentence
     if (
-        language.split("-")[0].lower() in _NO_ASCII_SENTENCE_SPACE
+        language.split("-", maxsplit=1)[0].lower() in _NO_ASCII_SENTENCE_SPACE
         and sentence != english
     ):
         return sentence

--- a/custom_components/ha_mcp_tools/websocket_api.py
+++ b/custom_components/ha_mcp_tools/websocket_api.py
@@ -1977,8 +1977,7 @@ def _name_tier(query_lower: str, texts: Any, *, exact: bool) -> int | None:
             if query_norm and query_norm in _sep_normalized(text_lower):
                 return 100
             ratio = _calc_ratio(query_lower, text_lower)
-            if ratio > best_ratio:
-                best_ratio = ratio
+            best_ratio = max(best_ratio, ratio)
     if not exact and best_ratio >= FUZZY_THRESHOLD:
         return best_ratio
     return None
@@ -3206,7 +3205,7 @@ def _exposure_enrichment(
     rather than crashing the join).
     """
     join = _registry_enrichment(view, entity_id)
-    domain = entity_id.split(".")[0] if "." in entity_id else ""
+    domain = entity_id.split(".", maxsplit=1)[0] if "." in entity_id else ""
     info: dict[str, Any] = {
         "domain": domain,
         "area": join["area"],
@@ -5196,7 +5195,7 @@ def _assist_default_exposed(hass: HomeAssistant, entity_id: str) -> bool:
         or getattr(entry, "hidden_by", None) is not None
     ):
         return False
-    domain = entity_id.split(".")[0] if "." in entity_id else entity_id
+    domain = entity_id.split(".", maxsplit=1)[0] if "." in entity_id else entity_id
     if domain in DEFAULT_EXPOSED_DOMAINS:
         return True
     from homeassistant.exceptions import HomeAssistantError

--- a/homeassistant-addon-webhook-proxy-dev/CHANGELOG.md
+++ b/homeassistant-addon-webhook-proxy-dev/CHANGELOG.md
@@ -9,6 +9,11 @@ history from before the fork.
 -->
 
 
+## v2.1.1.dev3 (2026-07-31)
+
+Internal: lint cleanup (ruff pylint rules) — no behavior change.
+
+
 ## v2.1.1.dev2 (2026-07-30)
 
 Documentation: warn Tailscale Funnel users that Claude.ai connectors require the

--- a/homeassistant-addon-webhook-proxy-dev/config.yaml
+++ b/homeassistant-addon-webhook-proxy-dev/config.yaml
@@ -1,6 +1,6 @@
 name: "Nabu Casa - Webhook Proxy for HA MCP (Dev)"
 description: "DEV CHANNEL (unstable) — remote access proxy via Nabu Casa or any reverse proxy. Cannot run alongside the stable Webhook Proxy add-on."
-version: "2.1.1.dev2"
+version: "2.1.1.dev3"
 slug: "ha_mcp_webhook_proxy_dev"
 url: "https://github.com/homeassistant-ai/ha-mcp"
 stage: experimental

--- a/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/__init__.py
+++ b/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/__init__.py
@@ -280,7 +280,9 @@ def _validate_and_mask_target(target_url: str, webhook_id: str) -> str:
     """
     # Mask sensitive values in logs to avoid leaking secrets
     if "/private_" in target_url:
-        masked_target = target_url.split("/private_")[0] + "/private_********"
+        masked_target = (
+            target_url.split("/private_", maxsplit=1)[0] + "/private_********"
+        )
     else:
         masked_target = target_url
     masked_wh = webhook_id[:6] + "..." if len(webhook_id) > 6 else "***"

--- a/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/manifest.json
+++ b/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/manifest.json
@@ -7,5 +7,5 @@
   "dependencies": ["webhook"],
   "documentation": "https://github.com/homeassistant-ai/ha-mcp",
   "iot_class": "local_push",
-  "version": "2.1.1.dev2"
+  "version": "2.1.1.dev3"
 }

--- a/homeassistant-addon-webhook-proxy-dev/start.py
+++ b/homeassistant-addon-webhook-proxy-dev/start.py
@@ -1509,41 +1509,40 @@ def _install_integration_and_handle_restart() -> None:
                 {"notification_id": "mcp_proxy_dev_restart"},
             )
             log_info("Setup completed after HA restart")
+    elif not _ensure_config_entry():
+        log_error(
+            "Could not create config entry. Webhook is NOT active. "
+            "Restart Home Assistant; if the problem persists, "
+            "remove and re-add the integration manually from "
+            "Settings → Devices & Services."
+        )
+        _ha_core_api(
+            "POST",
+            "/services/persistent_notification/create",
+            {
+                "title": ("MCP Webhook Proxy: webhook URL is not active"),
+                "message": (
+                    "The addon could not create the integration's "
+                    "config entry, so the webhook URL is currently "
+                    "**not active**. Restart Home Assistant; if "
+                    "the problem persists, remove and re-add the "
+                    "MCP Webhook Proxy integration from "
+                    "Settings → Devices & Services."
+                ),
+                "notification_id": "mcp_proxy_dev_setup_failed",
+            },
+        )
     else:
-        if not _ensure_config_entry():
-            log_error(
-                "Could not create config entry. Webhook is NOT active. "
-                "Restart Home Assistant; if the problem persists, "
-                "remove and re-add the integration manually from "
-                "Settings → Devices & Services."
-            )
-            _ha_core_api(
-                "POST",
-                "/services/persistent_notification/create",
-                {
-                    "title": ("MCP Webhook Proxy: webhook URL is not active"),
-                    "message": (
-                        "The addon could not create the integration's "
-                        "config entry, so the webhook URL is currently "
-                        "**not active**. Restart Home Assistant; if "
-                        "the problem persists, remove and re-add the "
-                        "MCP Webhook Proxy integration from "
-                        "Settings → Devices & Services."
-                    ),
-                    "notification_id": "mcp_proxy_dev_setup_failed",
-                },
-            )
-        else:
-            # Reload the config entry so the integration reads the fresh
-            # config file we just wrote (it may have loaded with stale data
-            # during HA boot, before this addon started).
-            _reload_config_entry()
-            # Dismiss any leftover restart notification from first install
-            _ha_core_api(
-                "POST",
-                "/services/persistent_notification/dismiss",
-                {"notification_id": "mcp_proxy_dev_restart"},
-            )
+        # Reload the config entry so the integration reads the fresh
+        # config file we just wrote (it may have loaded with stale data
+        # during HA boot, before this addon started).
+        _reload_config_entry()
+        # Dismiss any leftover restart notification from first install
+        _ha_core_api(
+            "POST",
+            "/services/persistent_notification/dismiss",
+            {"notification_id": "mcp_proxy_dev_restart"},
+        )
 
 
 def _enforce_oauth_or_disable(enable_oauth: bool) -> None:

--- a/homeassistant-addon-webhook-proxy/mcp_proxy/__init__.py
+++ b/homeassistant-addon-webhook-proxy/mcp_proxy/__init__.py
@@ -280,7 +280,9 @@ def _validate_and_mask_target(target_url: str, webhook_id: str) -> str:
     """
     # Mask sensitive values in logs to avoid leaking secrets
     if "/private_" in target_url:
-        masked_target = target_url.split("/private_")[0] + "/private_********"
+        masked_target = (
+            target_url.split("/private_", maxsplit=1)[0] + "/private_********"
+        )
     else:
         masked_target = target_url
     masked_wh = webhook_id[:6] + "..." if len(webhook_id) > 6 else "***"

--- a/homeassistant-addon-webhook-proxy/mcp_proxy/__init__.py
+++ b/homeassistant-addon-webhook-proxy/mcp_proxy/__init__.py
@@ -280,9 +280,7 @@ def _validate_and_mask_target(target_url: str, webhook_id: str) -> str:
     """
     # Mask sensitive values in logs to avoid leaking secrets
     if "/private_" in target_url:
-        masked_target = (
-            target_url.split("/private_", maxsplit=1)[0] + "/private_********"
-        )
+        masked_target = target_url.split("/private_")[0] + "/private_********"
     else:
         masked_target = target_url
     masked_wh = webhook_id[:6] + "..." if len(webhook_id) > 6 else "***"

--- a/homeassistant-addon-webhook-proxy/start.py
+++ b/homeassistant-addon-webhook-proxy/start.py
@@ -1507,41 +1507,40 @@ def _install_integration_and_handle_restart() -> None:
                 {"notification_id": "mcp_proxy_restart"},
             )
             log_info("Setup completed after HA restart")
+    elif not _ensure_config_entry():
+        log_error(
+            "Could not create config entry. Webhook is NOT active. "
+            "Restart Home Assistant; if the problem persists, "
+            "remove and re-add the integration manually from "
+            "Settings → Devices & Services."
+        )
+        _ha_core_api(
+            "POST",
+            "/services/persistent_notification/create",
+            {
+                "title": ("MCP Webhook Proxy: webhook URL is not active"),
+                "message": (
+                    "The addon could not create the integration's "
+                    "config entry, so the webhook URL is currently "
+                    "**not active**. Restart Home Assistant; if "
+                    "the problem persists, remove and re-add the "
+                    "MCP Webhook Proxy integration from "
+                    "Settings → Devices & Services."
+                ),
+                "notification_id": "mcp_proxy_setup_failed",
+            },
+        )
     else:
-        if not _ensure_config_entry():
-            log_error(
-                "Could not create config entry. Webhook is NOT active. "
-                "Restart Home Assistant; if the problem persists, "
-                "remove and re-add the integration manually from "
-                "Settings → Devices & Services."
-            )
-            _ha_core_api(
-                "POST",
-                "/services/persistent_notification/create",
-                {
-                    "title": ("MCP Webhook Proxy: webhook URL is not active"),
-                    "message": (
-                        "The addon could not create the integration's "
-                        "config entry, so the webhook URL is currently "
-                        "**not active**. Restart Home Assistant; if "
-                        "the problem persists, remove and re-add the "
-                        "MCP Webhook Proxy integration from "
-                        "Settings → Devices & Services."
-                    ),
-                    "notification_id": "mcp_proxy_setup_failed",
-                },
-            )
-        else:
-            # Reload the config entry so the integration reads the fresh
-            # config file we just wrote (it may have loaded with stale data
-            # during HA boot, before this addon started).
-            _reload_config_entry()
-            # Dismiss any leftover restart notification from first install
-            _ha_core_api(
-                "POST",
-                "/services/persistent_notification/dismiss",
-                {"notification_id": "mcp_proxy_restart"},
-            )
+        # Reload the config entry so the integration reads the fresh
+        # config file we just wrote (it may have loaded with stale data
+        # during HA boot, before this addon started).
+        _reload_config_entry()
+        # Dismiss any leftover restart notification from first install
+        _ha_core_api(
+            "POST",
+            "/services/persistent_notification/dismiss",
+            {"notification_id": "mcp_proxy_restart"},
+        )
 
 
 def _enforce_oauth_or_disable(enable_oauth: bool) -> None:

--- a/homeassistant-addon-webhook-proxy/start.py
+++ b/homeassistant-addon-webhook-proxy/start.py
@@ -1507,40 +1507,41 @@ def _install_integration_and_handle_restart() -> None:
                 {"notification_id": "mcp_proxy_restart"},
             )
             log_info("Setup completed after HA restart")
-    elif not _ensure_config_entry():
-        log_error(
-            "Could not create config entry. Webhook is NOT active. "
-            "Restart Home Assistant; if the problem persists, "
-            "remove and re-add the integration manually from "
-            "Settings → Devices & Services."
-        )
-        _ha_core_api(
-            "POST",
-            "/services/persistent_notification/create",
-            {
-                "title": ("MCP Webhook Proxy: webhook URL is not active"),
-                "message": (
-                    "The addon could not create the integration's "
-                    "config entry, so the webhook URL is currently "
-                    "**not active**. Restart Home Assistant; if "
-                    "the problem persists, remove and re-add the "
-                    "MCP Webhook Proxy integration from "
-                    "Settings → Devices & Services."
-                ),
-                "notification_id": "mcp_proxy_setup_failed",
-            },
-        )
     else:
-        # Reload the config entry so the integration reads the fresh
-        # config file we just wrote (it may have loaded with stale data
-        # during HA boot, before this addon started).
-        _reload_config_entry()
-        # Dismiss any leftover restart notification from first install
-        _ha_core_api(
-            "POST",
-            "/services/persistent_notification/dismiss",
-            {"notification_id": "mcp_proxy_restart"},
-        )
+        if not _ensure_config_entry():
+            log_error(
+                "Could not create config entry. Webhook is NOT active. "
+                "Restart Home Assistant; if the problem persists, "
+                "remove and re-add the integration manually from "
+                "Settings → Devices & Services."
+            )
+            _ha_core_api(
+                "POST",
+                "/services/persistent_notification/create",
+                {
+                    "title": ("MCP Webhook Proxy: webhook URL is not active"),
+                    "message": (
+                        "The addon could not create the integration's "
+                        "config entry, so the webhook URL is currently "
+                        "**not active**. Restart Home Assistant; if "
+                        "the problem persists, remove and re-add the "
+                        "MCP Webhook Proxy integration from "
+                        "Settings → Devices & Services."
+                    ),
+                    "notification_id": "mcp_proxy_setup_failed",
+                },
+            )
+        else:
+            # Reload the config entry so the integration reads the fresh
+            # config file we just wrote (it may have loaded with stale data
+            # during HA boot, before this addon started).
+            _reload_config_entry()
+            # Dismiss any leftover restart notification from first install
+            _ha_core_api(
+                "POST",
+                "/services/persistent_notification/dismiss",
+                {"notification_id": "mcp_proxy_restart"},
+            )
 
 
 def _enforce_oauth_or_disable(enable_oauth: bool) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -182,6 +182,12 @@ ignore = [
 [tool.ruff.lint.per-file-ignores]
 "__init__.py" = ["F401"]
 "tests/**/*" = ["E501", "B011"]
+# Temporary: the equivalent PLC0207/PLR5501 fixes landed in
+# homeassistant-addon-webhook-proxy-dev/ only, per the dev-first/promote-only
+# flow (allow-stable-edit is for stable-only hotfixes, not routine sweeps —
+# see homeassistant-addon-webhook-proxy/AGENTS.md "Dev-first, promote-only").
+# Remove this ignore once the next promote carries the fix into stable.
+"homeassistant-addon-webhook-proxy/**" = ["PLC0207", "PLR5501"]
 # C901 is enforced repo-wide with no per-file exemptions (the grandfathered
 # list was fully cleared by issue #925). Do NOT add "path" = ["C901"] entries
 # here — extract helpers to bring the function below the threshold instead:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -140,6 +140,26 @@ select = [
     "A",     # builtin shadowing
     "LOG",   # logging best practices
     "SIM",   # simplify
+    "PLE",   # pylint errors (real bugs: bad logging args, await outside async)
+    # Targeted pylint conventions/refactors/warnings. The PL family is NOT
+    # selected wholesale: PLC0415 (import-outside-top-level) fights the
+    # deliberate lazy-init architecture, and PLR2004 (magic values),
+    # PLR0913/PLR0917 (wide FastMCP tool signatures) and PLR0911 (too many
+    # returns -- a separate signal from C901's cyclomatic complexity, and
+    # noisy on this codebase's early-return validation style) are noise
+    # here. Add codes individually so a new upstream PLR rule does not land
+    # enabled by default.
+    "PLC0206", # dict-index-missing-items
+    "PLC0207", # missing-maxsplit-arg
+    "PLR0402", # manual-from-import
+    "PLR1711", # useless-return
+    "PLR1714", # repeated-equality-comparison
+    "PLR1730", # if-stmt-min-max
+    "PLR5501", # collapsible-else-if
+    "PLW0108", # unnecessary-lambda
+    "PLW0602", # global-variable-not-assigned
+    "PLW1510", # subprocess-run-without-check
+    "PLW2901", # redefined-loop-name
 ]
 ignore = [
     "E501",    # line too long — formatter handles this

--- a/scripts/build_mirror_release_notes.py
+++ b/scripts/build_mirror_release_notes.py
@@ -110,6 +110,7 @@ def _run_git(args: list[str], repo_dir: Path) -> str:
         cwd=repo_dir,
         capture_output=True,
         text=True,
+        check=False,
     )
     if result.returncode != 0:
         raise RuntimeError(f"git {' '.join(args)} failed: {result.stderr.strip()}")

--- a/src/ha_mcp/__main__.py
+++ b/src/ha_mcp/__main__.py
@@ -574,8 +574,6 @@ def _get_timestamped_uvicorn_log_config() -> dict:
 
 async def _cleanup_resources() -> None:
     """Clean up all server resources gracefully."""
-    global _server
-
     logger.info("Cleaning up server resources...")
 
     # Close WebSocket listener service if running
@@ -730,7 +728,7 @@ def _signal_handler(signum: int, frame: Any) -> None:
     This handler initiates graceful shutdown on first signal.
     On second signal, forces immediate exit.
     """
-    global _shutdown_in_progress, _shutdown_event
+    global _shutdown_in_progress
 
     sig_name = signal.Signals(signum).name
 

--- a/src/ha_mcp/backup_manager.py
+++ b/src/ha_mcp/backup_manager.py
@@ -1128,15 +1128,15 @@ def _diff_dict_node(
     max_ops: int,
 ) -> None:
     """Diff two dicts into JSON-Patch ops (add/remove/recurse per key)."""
-    for key in stored:
+    for key, stored_value in stored.items():
         seg = _pointer_segment(str(key))
         sub_path = f"{path}/{seg}"
         if key not in current:
-            out.append({"op": "add", "path": sub_path, "value": stored[key]})
+            out.append({"op": "add", "path": sub_path, "value": stored_value})
             if len(out) >= max_ops:
                 return
         else:
-            _diff_node(stored[key], current[key], sub_path, out, max_ops)
+            _diff_node(stored_value, current[key], sub_path, out, max_ops)
             if len(out) >= max_ops:
                 return
     for key in current:

--- a/src/ha_mcp/policy/evaluator.py
+++ b/src/ha_mcp/policy/evaluator.py
@@ -128,7 +128,7 @@ def match_predicate(predicate: Predicate, args: dict[str, Any]) -> bool:
 
 
 def match_rule(rule: Rule, tool_name: str, args: dict[str, Any]) -> bool:
-    if rule.tool_name != "*" and rule.tool_name != tool_name:
+    if rule.tool_name not in ("*", tool_name):
         return False
     return all(match_predicate(p, args) for p in rule.when)
 

--- a/src/ha_mcp/settings_ui/_persistence.py
+++ b/src/ha_mcp/settings_ui/_persistence.py
@@ -116,14 +116,14 @@ def _seed_tool_config_from_env(settings: Settings) -> dict[str, str]:
     tools: dict[str, str] = {}
     disabled_raw = getattr(settings, "disabled_tools", "")
     if disabled_raw:
-        for name in disabled_raw.split(","):
-            name = name.strip()
+        for raw_name in disabled_raw.split(","):
+            name = raw_name.strip()
             if name:
                 tools[name] = "disabled"
     pinned_raw = getattr(settings, "pinned_tools", "")
     if pinned_raw:
-        for name in pinned_raw.split(","):
-            name = name.strip()
+        for raw_name in pinned_raw.split(","):
+            name = raw_name.strip()
             if name and name not in tools:
                 tools[name] = "pinned"
     return tools
@@ -176,12 +176,12 @@ def env_pinned_tools(settings: Settings | None = None) -> dict[str, str]:
     if settings is None:
         settings = get_global_settings()
     pinned: dict[str, str] = {}
-    for name in (settings.disabled_tools or "").split(","):
-        name = name.strip()
+    for raw_name in (settings.disabled_tools or "").split(","):
+        name = raw_name.strip()
         if name:
             pinned[name] = "disabled"
-    for name in (settings.pinned_tools or "").split(","):
-        name = name.strip()
+    for raw_name in (settings.pinned_tools or "").split(","):
+        name = raw_name.strip()
         if name:
             pinned[name] = "pinned"
     return pinned

--- a/src/ha_mcp/tools/device_control.py
+++ b/src/ha_mcp/tools/device_control.py
@@ -126,7 +126,7 @@ class DeviceControlTools:
                     )
                 )
 
-            domain = entity_id.split(".")[0]
+            domain = entity_id.split(".", maxsplit=1)[0]
             handler = get_domain_handler(domain)
 
             # Validate entity exists if requested
@@ -749,7 +749,7 @@ class DeviceControlTools:
         try:
             if "." not in entity_id:
                 return None
-            domain = entity_id.split(".")[0]
+            domain = entity_id.split(".", maxsplit=1)[0]
             handler = get_domain_handler(domain)
             valid_actions = handler.get("valid_actions", ["on", "off", "toggle"])
             if action not in valid_actions:

--- a/src/ha_mcp/tools/smart_search/_entities.py
+++ b/src/ha_mcp/tools/smart_search/_entities.py
@@ -680,7 +680,7 @@ class EntitySearchMixin(_SearchBase):
             "_hidden_by": "hidden" if entity_id in hidden_entity_ids else None,
         }
         if include_domain:
-            record["domain"] = entity_id.split(".")[0]
+            record["domain"] = entity_id.split(".", maxsplit=1)[0]
         return record
 
     @classmethod

--- a/src/ha_mcp/tools/tools_addons.py
+++ b/src/ha_mcp/tools/tools_addons.py
@@ -80,15 +80,13 @@ def _slice_ws_messages(
     offset/limit were applied.
     """
     total_collected = len(messages)
-    if offset < 0:
-        offset = 0
+    offset = max(offset, 0)
     if offset > total_collected:
         sliced: list[Any] = []
     elif limit is None:
         sliced = messages[offset:]
     else:
-        if limit < 0:
-            limit = 0
+        limit = max(limit, 0)
         sliced = messages[offset : offset + limit]
 
     pagination: dict[str, Any] = {
@@ -158,9 +156,8 @@ def _summarize_ws_messages(
                 flush(i)
                 run_start = None
             result.append(msg)
-        else:
-            if run_start is None:
-                run_start = i
+        elif run_start is None:
+            run_start = i
 
     if run_start is not None:
         flush(len(messages))

--- a/src/ha_mcp/tools/tools_camera.py
+++ b/src/ha_mcp/tools/tools_camera.py
@@ -120,7 +120,7 @@ class CameraTools:
                 "Expected format: camera.entity_name"
             )
 
-        domain = entity_id.split(".")[0]
+        domain = entity_id.split(".", maxsplit=1)[0]
         if domain != "camera":
             raise ValueError(
                 f"Entity {entity_id} is not a camera entity. "

--- a/src/ha_mcp/tools/tools_config_dashboards.py
+++ b/src/ha_mcp/tools/tools_config_dashboards.py
@@ -745,9 +745,8 @@ def _card_matches(
             pattern = entity_id.replace(".", r"\.").replace("*", ".*")
             if not any(re.match(pattern, e) for e in all_entities if e):
                 return False
-        else:
-            if entity_id not in all_entities:
-                return False
+        elif entity_id not in all_entities:
+            return False
 
     # Heading filter (for heading cards or section titles)
     if heading is not None:

--- a/src/ha_mcp/tools/tools_entities.py
+++ b/src/ha_mcp/tools/tools_entities.py
@@ -594,8 +594,8 @@ class EntityTools:
                     context={"new_entity_id": new_entity_id},
                 )
             )
-        current_domain = entity_id.split(".")[0]
-        new_domain = new_entity_id.split(".")[0]
+        current_domain = entity_id.split(".", maxsplit=1)[0]
+        new_domain = new_entity_id.split(".", maxsplit=1)[0]
         if current_domain != new_domain:
             raise_tool_error(
                 create_error_response(

--- a/src/ha_mcp/tools/tools_registry.py
+++ b/src/ha_mcp/tools/tools_registry.py
@@ -50,7 +50,11 @@ def _process_device_domain(
         return value, is_z2m, zwave_node_id
     # Z2M: identifier is ["mqtt", "zigbee2mqtt_0xIEEE"] or "zigbee2mqtt_bridge_0xIEEE"
     if domain == "mqtt" and "zigbee2mqtt" in value.lower():
-        extracted = "0x" + value.split("_0x")[-1] if "_0x" in value else ieee_address
+        extracted = (
+            "0x" + value.rsplit("_0x", maxsplit=1)[-1]
+            if "_0x" in value
+            else ieee_address
+        )
         return extracted, True, zwave_node_id
     # Z-Wave JS: identifier is ["zwave_js", "{home_id}-{node_id}"]
     if domain == "zwave_js" and "-" in value:

--- a/src/ha_mcp/tools/tools_resources.py
+++ b/src/ha_mcp/tools/tools_resources.py
@@ -333,7 +333,7 @@ def _decode_legacy_worker_url(url: str) -> str | None:
         return None
     try:
         # Extract base64 part: https://worker.dev/{base64}?type=module
-        encoded = url[len(prefix) :].split("?")[0]
+        encoded = url[len(prefix) :].split("?", maxsplit=1)[0]
         # validate=True mirrors _decode_data_uri: urlsafe_b64decode otherwise
         # silently DISCARDS non-alphabet characters, so a junk path could
         # decode to plausible text and be masked as inline content.

--- a/src/ha_mcp/tools/tools_traces.py
+++ b/src/ha_mcp/tools/tools_traces.py
@@ -734,7 +734,7 @@ def _categorize_step_path(path: str, domain: str) -> str | None:
         return "condition"
     if path == "action" or path.startswith(("action/", "sequence/")):
         return "action"
-    if domain == "script" and path.split("/")[0].isdigit():
+    if domain == "script" and path.split("/", maxsplit=1)[0].isdigit():
         return "action"
     return None
 

--- a/src/ha_mcp/utils/domain_handlers.py
+++ b/src/ha_mcp/utils/domain_handlers.py
@@ -205,7 +205,7 @@ def get_domain_handler(entity_id: str) -> dict[str, Any]:
         # Fallback for invalid entity ID format
         return get_default_handler()
 
-    domain = entity_id.split(".")[0]
+    domain = entity_id.split(".", maxsplit=1)[0]
     return DOMAIN_HANDLERS.get(domain, get_default_handler())
 
 

--- a/src/ha_mcp/visibility/resolver.py
+++ b/src/ha_mcp/visibility/resolver.py
@@ -185,7 +185,7 @@ def _is_assist_exposed(
         entry.get("entity_category") is not None or entry.get("hidden_by") is not None
     ):
         return False
-    domain = eid.split(".")[0]
+    domain = eid.split(".", maxsplit=1)[0]
     if domain in DEFAULT_EXPOSED_DOMAINS:
         return True
     if domain == "binary_sensor":

--- a/tests/addon/test_addon_startup.py
+++ b/tests/addon/test_addon_startup.py
@@ -295,6 +295,7 @@ def _build_addon_image():
         ],
         capture_output=True,
         text=True,
+        check=False,
     )
     if result.returncode != 0:
         pytest.fail(f"Failed to build {IMAGE_TAG}:\n{result.stderr}")

--- a/tests/haos_image_build/build_image.py
+++ b/tests/haos_image_build/build_image.py
@@ -1878,6 +1878,7 @@ def bake_test_state(qcow2: Path) -> None:
             capture_output=True,
             text=True,
             timeout=120,
+            check=False,
         )
         LOG.info("guestfish filesystems on qcow2:\n%s", probe.stdout)
         if probe.returncode != 0:

--- a/tests/src/e2e/run_tests.py
+++ b/tests/src/e2e/run_tests.py
@@ -42,7 +42,7 @@ def main():
     print(f"🧪 Running E2E tests: {' '.join(args)}")
 
     # Run pytest
-    result = subprocess.run(args)
+    result = subprocess.run(args, check=False)
     sys.exit(result.returncode)
 
 

--- a/tests/src/haos_runtime.py
+++ b/tests/src/haos_runtime.py
@@ -261,6 +261,7 @@ def _container_miss_diagnostics(ssh_cmd: list[str], env: dict[str, str]) -> str:
                 text=True,
                 timeout=20.0,
                 env=env,
+                check=False,
             )
             captured.append(f"{label}={probe.stdout.strip()!r}")
         except Exception as probe_err:  # pragma: no cover - diagnostics best-effort

--- a/tests/src/unit/test_backup_manager.py
+++ b/tests/src/unit/test_backup_manager.py
@@ -488,9 +488,7 @@ class TestWithAutoBackupDecorator:
         class _Settings:
             enable_auto_backup = True
 
-        monkeypatch.setattr(
-            "ha_mcp.tools.auto_backup.get_global_settings", lambda: _Settings()
-        )
+        monkeypatch.setattr("ha_mcp.tools.auto_backup.get_global_settings", _Settings)
         monkeypatch.setattr(
             "ha_mcp.tools.auto_backup.get_backup_manager", lambda _c, _s: _FakeMgr()
         )
@@ -518,9 +516,7 @@ class TestWithAutoBackupDecorator:
         class _Settings:
             enable_auto_backup = True
 
-        monkeypatch.setattr(
-            "ha_mcp.tools.auto_backup.get_global_settings", lambda: _Settings()
-        )
+        monkeypatch.setattr("ha_mcp.tools.auto_backup.get_global_settings", _Settings)
         monkeypatch.setattr(
             "ha_mcp.tools.auto_backup.get_backup_manager", lambda _c, _s: _FakeMgr()
         )

--- a/tests/src/unit/test_config.py
+++ b/tests/src/unit/test_config.py
@@ -176,6 +176,7 @@ class TestConfigErrorHandling:
             capture_output=True,
             text=True,
             timeout=30,
+            check=False,
         )
 
         # Should exit with error code
@@ -206,6 +207,7 @@ class TestConfigErrorHandling:
             capture_output=True,
             text=True,
             timeout=30,
+            check=False,
         )
 
         assert result.returncode != 0
@@ -224,6 +226,7 @@ class TestConfigErrorHandling:
             capture_output=True,
             text=True,
             timeout=30,
+            check=False,
         )
 
         assert result.returncode != 0
@@ -242,6 +245,7 @@ class TestConfigErrorHandling:
             capture_output=True,
             text=True,
             timeout=30,
+            check=False,
         )
 
         # Should NOT contain the old noisy warning
@@ -260,6 +264,7 @@ class TestConfigErrorHandling:
             capture_output=True,
             text=True,
             timeout=60,
+            check=False,
         )
 
         assert result.returncode == 0

--- a/tests/src/unit/test_dashboard_screenshot.py
+++ b/tests/src/unit/test_dashboard_screenshot.py
@@ -25,7 +25,7 @@ import pytest
 from fastmcp.exceptions import ToolError
 from pydantic import ValidationError
 
-import ha_mcp.config as config
+from ha_mcp import config
 from ha_mcp.dashboard_screenshot.provision import EngineTarget
 
 _PNG = b"\x89PNG\r\n\x1a\nunit"

--- a/tests/src/unit/test_deep_search_tier3_parallel.py
+++ b/tests/src/unit/test_deep_search_tier3_parallel.py
@@ -114,7 +114,7 @@ class TestAttemptCParallelFetch:
         fetched_uids = []
 
         async def _individual_fetch(method: str, url: str) -> dict:
-            uid = url.split("/")[-1]
+            uid = url.rsplit("/", maxsplit=1)[-1]
             fetched_uids.append(uid)
             # "Morning Routine" references sensor.kitchen_temp in condition
             if uid == "uid_morning":
@@ -180,7 +180,7 @@ class TestAttemptCParallelFetch:
 
         async def _slow_fetch(method: str, url: str) -> dict:
             nonlocal call_count
-            uid = url.split("/")[-1]
+            uid = url.rsplit("/", maxsplit=1)[-1]
             if url.rstrip("/") == "/config/automation/config":
                 raise Exception("Bulk unavailable")
             call_count += 1

--- a/tests/src/unit/test_embedded_server.py
+++ b/tests/src/unit/test_embedded_server.py
@@ -2383,7 +2383,7 @@ class TestLifecycle:
         monkeypatch.setattr(es, "_purge_ha_mcp_modules", lambda: calls.append("purge"))
         # Replace the thread body so no real ha_mcp import happens.
         started = []
-        monkeypatch.setattr(mgr, "_thread_main", lambda token: started.append(token))
+        monkeypatch.setattr(mgr, "_thread_main", started.append)
 
         await mgr.async_start()
         if mgr._thread is not None:

--- a/tests/src/unit/test_embedded_setup.py
+++ b/tests/src/unit/test_embedded_setup.py
@@ -1467,7 +1467,6 @@ class TestFinishUpdateCycle:
         async def _refresh():
             if refresh_side_effect is not None:
                 raise refresh_side_effect
-            return None
 
         coordinator.async_refresh = AsyncMock(side_effect=_refresh)
         return coordinator

--- a/tests/src/unit/test_hacs_nudge.py
+++ b/tests/src/unit/test_hacs_nudge.py
@@ -48,9 +48,7 @@ def _fake_hacs(*, repos=None, category: str = "integration"):
     """
     repos = repos or {}
     hacs = MagicMock(name="hacs")
-    hacs.repositories.get_by_full_name = MagicMock(
-        side_effect=lambda full_name: repos.get(full_name)
-    )
+    hacs.repositories.get_by_full_name = MagicMock(side_effect=repos.get)
     coordinator = MagicMock(name="coordinator")
     hacs.coordinators = {category: coordinator}
     return hacs, coordinator

--- a/tests/src/unit/test_llm_api.py
+++ b/tests/src/unit/test_llm_api.py
@@ -25,7 +25,7 @@ from ._embedded_stubs import fake_llm_apis, install
 
 install()
 
-import custom_components.ha_mcp_tools.llm_api as llm_api  # noqa: E402
+from custom_components.ha_mcp_tools import llm_api  # noqa: E402
 from custom_components.ha_mcp_tools.const import (  # noqa: E402
     DATA_LLM_API_UNSUB,
     DOMAIN,

--- a/tests/src/unit/test_llm_exposure.py
+++ b/tests/src/unit/test_llm_exposure.py
@@ -60,7 +60,7 @@ class TestOverridesLoading:
     def test_loads_only_bool_values(self, monkeypatch):
         # load_llm_api_overrides imports load_tool_config lazily from
         # settings_ui — patch it there.
-        import ha_mcp.settings_ui as settings_ui
+        from ha_mcp import settings_ui
 
         monkeypatch.setattr(
             settings_ui,
@@ -79,7 +79,7 @@ class TestOverridesLoading:
         }
 
     def test_missing_or_malformed_key_is_empty(self, monkeypatch):
-        import ha_mcp.settings_ui as settings_ui
+        from ha_mcp import settings_ui
 
         monkeypatch.setattr(settings_ui, "load_tool_config", dict)
         assert load_llm_api_overrides() == {}
@@ -91,7 +91,7 @@ class TestOverridesLoading:
 
 class TestPinnedNames:
     def test_mirrors_server_tool_search_semantics(self, monkeypatch):
-        import ha_mcp.settings_ui as settings_ui
+        from ha_mcp import settings_ui
         from ha_mcp.transforms import DEFAULT_PINNED_TOOLS
 
         default_pinned = next(iter(DEFAULT_PINNED_TOOLS))

--- a/tests/src/unit/test_oauth.py
+++ b/tests/src/unit/test_oauth.py
@@ -1750,9 +1750,7 @@ class TestRunOAuthServerSettingsUI:
         async def fake_run_async(**kwargs):
             pass
 
-        mock_mcp.run_async = MagicMock(
-            side_effect=lambda **kwargs: fake_run_async(**kwargs)
-        )
+        mock_mcp.run_async = MagicMock(side_effect=fake_run_async)
         mock_server = MagicMock()
         mock_server.mcp = mock_mcp
 

--- a/tests/src/unit/test_oauth_legacy_component.py
+++ b/tests/src/unit/test_oauth_legacy_component.py
@@ -54,7 +54,7 @@ if "yarl" not in sys.modules:
     sys.modules["yarl"] = _yarl
 
 import custom_components.ha_mcp_tools.embedded_entry as eentry  # noqa: E402
-import custom_components.ha_mcp_tools.oauth_legacy as oauth_legacy  # noqa: E402
+from custom_components.ha_mcp_tools import oauth_legacy  # noqa: E402
 from custom_components.ha_mcp_tools.const import (  # noqa: E402
     DATA_OAUTH_CLIENT_ID,
     DATA_OAUTH_CLIENT_SECRET,

--- a/tests/src/unit/test_oidc_entrypoint.py
+++ b/tests/src/unit/test_oidc_entrypoint.py
@@ -285,9 +285,7 @@ class TestRunOidcServer:
         async def fake_run_async(**kwargs):
             pass
 
-        mock_mcp.run_async = MagicMock(
-            side_effect=lambda **kwargs: fake_run_async(**kwargs)
-        )
+        mock_mcp.run_async = MagicMock(side_effect=fake_run_async)
         mock_server.mcp = mock_mcp
 
         async def noop_shutdown(coro):
@@ -339,9 +337,7 @@ class TestRunOidcServer:
         async def fake_run_async(**kwargs):
             pass
 
-        mock_mcp.run_async = MagicMock(
-            side_effect=lambda **kwargs: fake_run_async(**kwargs)
-        )
+        mock_mcp.run_async = MagicMock(side_effect=fake_run_async)
         mock_server.mcp = mock_mcp
 
         async def noop_shutdown(coro):
@@ -389,9 +385,7 @@ class TestRunOidcServer:
         async def fake_run_async(**kwargs):
             pass
 
-        mock_mcp.run_async = MagicMock(
-            side_effect=lambda **kwargs: fake_run_async(**kwargs)
-        )
+        mock_mcp.run_async = MagicMock(side_effect=fake_run_async)
         mock_server.mcp = mock_mcp
 
         async def noop_shutdown(coro):
@@ -440,7 +434,7 @@ class TestRunOidcServer:
         async def fake_coro(**kwargs):
             pass
 
-        mock_mcp.run_async = MagicMock(side_effect=lambda **kwargs: fake_coro(**kwargs))
+        mock_mcp.run_async = MagicMock(side_effect=fake_coro)
         mock_server.mcp = mock_mcp
 
         async def capture_run_with_shutdown(coro):
@@ -536,9 +530,7 @@ class TestRunOidcServer:
         async def fake_run_async(**kwargs):
             pass
 
-        mock_mcp.run_async = MagicMock(
-            side_effect=lambda **kwargs: fake_run_async(**kwargs)
-        )
+        mock_mcp.run_async = MagicMock(side_effect=fake_run_async)
         mock_server.mcp = mock_mcp
 
         async def noop_shutdown(coro):
@@ -586,9 +578,7 @@ class TestRunOidcServer:
         async def fake_run_async(**kwargs):
             pass
 
-        mock_mcp.run_async = MagicMock(
-            side_effect=lambda **kwargs: fake_run_async(**kwargs)
-        )
+        mock_mcp.run_async = MagicMock(side_effect=fake_run_async)
         mock_server.mcp = mock_mcp
 
         async def noop_shutdown(coro):
@@ -643,9 +633,7 @@ class TestRunOidcServer:
         async def fake_run_async(**kwargs):
             pass
 
-        mock_mcp.run_async = MagicMock(
-            side_effect=lambda **kwargs: fake_run_async(**kwargs)
-        )
+        mock_mcp.run_async = MagicMock(side_effect=fake_run_async)
         mock_server.mcp = mock_mcp
 
         async def noop_shutdown(coro):
@@ -696,9 +684,7 @@ class TestRunOidcServer:
         async def fake_run_async(**kwargs):
             pass
 
-        mock_mcp.run_async = MagicMock(
-            side_effect=lambda **kwargs: fake_run_async(**kwargs)
-        )
+        mock_mcp.run_async = MagicMock(side_effect=fake_run_async)
         mock_server.mcp = mock_mcp
 
         async def noop_shutdown(coro):
@@ -744,9 +730,7 @@ class TestRunOidcServer:
         async def fake_run_async(**kwargs):
             pass
 
-        mock_mcp.run_async = MagicMock(
-            side_effect=lambda **kwargs: fake_run_async(**kwargs)
-        )
+        mock_mcp.run_async = MagicMock(side_effect=fake_run_async)
         mock_server.mcp = mock_mcp
 
         async def noop_shutdown(coro):
@@ -799,9 +783,7 @@ class TestRunOidcServer:
         async def fake_run_async(**kwargs):
             pass
 
-        mock_mcp.run_async = MagicMock(
-            side_effect=lambda **kwargs: fake_run_async(**kwargs)
-        )
+        mock_mcp.run_async = MagicMock(side_effect=fake_run_async)
         mock_server.mcp = mock_mcp
 
         async def noop_shutdown(coro):
@@ -847,9 +829,7 @@ class TestRunOidcServer:
         async def fake_run_async(**kwargs):
             pass
 
-        mock_mcp.run_async = MagicMock(
-            side_effect=lambda **kwargs: fake_run_async(**kwargs)
-        )
+        mock_mcp.run_async = MagicMock(side_effect=fake_run_async)
         mock_server.mcp = mock_mcp
 
         async def noop_shutdown(coro):
@@ -895,9 +875,7 @@ class TestRunOidcServer:
         async def fake_run_async(**kwargs):
             pass
 
-        mock_mcp.run_async = MagicMock(
-            side_effect=lambda **kwargs: fake_run_async(**kwargs)
-        )
+        mock_mcp.run_async = MagicMock(side_effect=fake_run_async)
         mock_server.mcp = mock_mcp
 
         async def noop_shutdown(coro):
@@ -948,9 +926,7 @@ class TestRunOidcServer:
         async def fake_run_async(**kwargs):
             pass
 
-        mock_mcp.run_async = MagicMock(
-            side_effect=lambda **kwargs: fake_run_async(**kwargs)
-        )
+        mock_mcp.run_async = MagicMock(side_effect=fake_run_async)
         mock_server.mcp = mock_mcp
 
         async def noop_shutdown(coro):
@@ -1007,9 +983,7 @@ class TestRunOidcServer:
         async def fake_run_async(**kwargs):
             pass
 
-        mock_mcp.run_async = MagicMock(
-            side_effect=lambda **kwargs: fake_run_async(**kwargs)
-        )
+        mock_mcp.run_async = MagicMock(side_effect=fake_run_async)
         mock_server.mcp = mock_mcp
 
         async def noop_shutdown(coro):
@@ -1063,9 +1037,7 @@ class TestRunOidcServer:
         async def fake_run_async(**kwargs):
             pass
 
-        mock_mcp.run_async = MagicMock(
-            side_effect=lambda **kwargs: fake_run_async(**kwargs)
-        )
+        mock_mcp.run_async = MagicMock(side_effect=fake_run_async)
         mock_server.mcp = mock_mcp
 
         async def noop_shutdown(coro):
@@ -1119,9 +1091,7 @@ class TestRunOidcServer:
         async def fake_run_async(**kwargs):
             pass
 
-        mock_mcp.run_async = MagicMock(
-            side_effect=lambda **kwargs: fake_run_async(**kwargs)
-        )
+        mock_mcp.run_async = MagicMock(side_effect=fake_run_async)
         mock_server.mcp = mock_mcp
 
         async def noop_shutdown(coro):
@@ -1171,9 +1141,7 @@ class TestRunOidcServer:
         async def fake_run_async(**kwargs):
             pass
 
-        mock_mcp.run_async = MagicMock(
-            side_effect=lambda **kwargs: fake_run_async(**kwargs)
-        )
+        mock_mcp.run_async = MagicMock(side_effect=fake_run_async)
         mock_server.mcp = mock_mcp
 
         async def noop_shutdown(coro):
@@ -1267,9 +1235,7 @@ class TestRunOidcServerSettingsUI:
         async def fake_run_async(**kwargs):
             pass
 
-        mock_mcp.run_async = MagicMock(
-            side_effect=lambda **kwargs: fake_run_async(**kwargs)
-        )
+        mock_mcp.run_async = MagicMock(side_effect=fake_run_async)
         mock_server = MagicMock()
         mock_server.mcp = mock_mcp
 

--- a/tests/src/unit/test_performance_parallelization.py
+++ b/tests/src/unit/test_performance_parallelization.py
@@ -70,7 +70,7 @@ class MockClient:
             ]
 
         if path.startswith("/config/automation/config/"):
-            uid = path.split("/")[-1]
+            uid = path.rsplit("/", maxsplit=1)[-1]
             return {
                 "id": uid,
                 "alias": f"Test Automation {uid}",

--- a/tests/src/unit/test_saved_tools_persistence.py
+++ b/tests/src/unit/test_saved_tools_persistence.py
@@ -16,7 +16,7 @@ essentially file-I/O behaviour.
 import json
 from pathlib import Path
 
-import ha_mcp.tools.tools_code as tools_code
+from ha_mcp.tools import tools_code
 
 
 class TestLoadSavedTools:

--- a/tests/src/unit/test_tools_config_scenes.py
+++ b/tests/src/unit/test_tools_config_scenes.py
@@ -297,7 +297,6 @@ class TestScenePythonTransform:
 
         async def _capture_category(*args, **kwargs):
             calls.append((args, kwargs))
-            return None
 
         from ha_mcp.tools import tools_config_scenes as scene_mod
 

--- a/tests/src/unit/test_tools_registry.py
+++ b/tests/src/unit/test_tools_registry.py
@@ -191,7 +191,7 @@ class TestDevModeSettingsFallback:
         # (built before the field existed) can still be the cached singleton;
         # the read must degrade to "dev mode off", never AttributeError
         # (the exact crash in issues #1783/#1785).
-        import ha_mcp.config as config
+        from ha_mcp import config
         from ha_mcp.tools.tools_dev import is_dev_mode_enabled
 
         monkeypatch.setattr(config, "get_global_settings", SimpleNamespace)

--- a/tests/src/unit/test_triage_prompt_budget.py
+++ b/tests/src/unit/test_triage_prompt_budget.py
@@ -64,6 +64,7 @@ def test_budget_harness_passes() -> None:
         capture_output=True,
         text=True,
         cwd=_REPO_ROOT,
+        check=False,
     )
     assert result.returncode == 0, (
         f"verify_triage_prompt_budget.mjs failed:\n{result.stdout}\n{result.stderr}"

--- a/tests/src/unit/test_ui_panel.py
+++ b/tests/src/unit/test_ui_panel.py
@@ -18,7 +18,7 @@ from ._embedded_stubs import FakeSession, FakeUpstream, install
 
 install()
 
-import custom_components.ha_mcp_tools.ui_panel as ui_panel  # noqa: E402
+from custom_components.ha_mcp_tools import ui_panel  # noqa: E402
 from custom_components.ha_mcp_tools.const import DATA_WEBHOOK, DOMAIN  # noqa: E402
 
 _TARGET = "http://127.0.0.1:9584/private_abc"

--- a/tests/test_docker/test_docker_build.py
+++ b/tests/test_docker/test_docker_build.py
@@ -14,6 +14,7 @@ class TestDockerBuild:
             ["docker", "build", "-t", "ha-mcp-test", "."],
             capture_output=True,
             text=True,
+            check=False,
         )
         assert result.returncode == 0, f"Build failed: {result.stderr}"
 
@@ -23,6 +24,7 @@ class TestDockerBuild:
             ["docker", "run", "--rm", "ha-mcp-test", "which", "uv"],
             capture_output=True,
             text=True,
+            check=False,
         )
         assert result.returncode != 0, "uv should not be in the runtime image"
 
@@ -32,6 +34,7 @@ class TestDockerBuild:
             ["docker", "run", "--rm", "ha-mcp-test", "which", "ha-mcp"],
             capture_output=True,
             text=True,
+            check=False,
         )
         assert result.returncode == 0
 
@@ -41,6 +44,7 @@ class TestDockerBuild:
             ["docker", "run", "--rm", "ha-mcp-test", "whoami"],
             capture_output=True,
             text=True,
+            check=False,
         )
         assert result.stdout.strip() == "mcpuser"
 
@@ -50,6 +54,7 @@ class TestDockerBuild:
             ["docker", "run", "--rm", "ha-mcp-test", "python", "--version"],
             capture_output=True,
             text=True,
+            check=False,
         )
         assert "Python 3.1" in result.stdout
 
@@ -66,6 +71,7 @@ class TestDockerBuild:
             ["docker", "run", "--rm", "ha-mcp-test", "sh", "-c", "echo $HOME"],
             capture_output=True,
             text=True,
+            check=False,
         )
         assert result.stdout.strip() == "/home/mcpuser"
 
@@ -90,6 +96,7 @@ class TestDockerBuild:
             ],
             capture_output=True,
             text=True,
+            check=False,
         )
         assert result.stdout.strip() == "755"
 
@@ -114,6 +121,7 @@ class TestDockerBuild:
             ["docker", "run", "--rm", "ha-mcp-test", "id", "-u", "mcpuser"],
             capture_output=True,
             text=True,
+            check=False,
         )
         assert result.stdout.strip() == "999", f"unexpected UID: {result.stdout!r}"
 
@@ -121,6 +129,7 @@ class TestDockerBuild:
             ["docker", "run", "--rm", "ha-mcp-test", "id", "-g", "mcpuser"],
             capture_output=True,
             text=True,
+            check=False,
         )
         assert result.stdout.strip() == "999", f"unexpected GID: {result.stdout!r}"
 
@@ -139,6 +148,7 @@ class TestDockerBuild:
             ["docker", "run", "--rm", "ha-mcp-test", "stat", "-c", "%U", DATA_DIR],
             capture_output=True,
             text=True,
+            check=False,
         )
         assert result.returncode == 0, f"{DATA_DIR} missing from image: {result.stderr}"
         assert result.stdout.strip() == "mcpuser"
@@ -157,7 +167,10 @@ class TestDockerBuild:
         # Start clean: a volume left over from an earlier run would keep its
         # old ownership and mask a regression in the image's mount point.
         subprocess.run(
-            ["docker", "volume", "rm", "-f", volume], capture_output=True, text=True
+            ["docker", "volume", "rm", "-f", volume],
+            capture_output=True,
+            text=True,
+            check=False,
         )
         try:
             write = subprocess.run(
@@ -174,6 +187,7 @@ class TestDockerBuild:
                 ],
                 capture_output=True,
                 text=True,
+                check=False,
             )
             assert write.returncode == 0, (
                 f"mcpuser cannot write to a named volume at {DATA_DIR}: {write.stderr}"
@@ -193,6 +207,7 @@ class TestDockerBuild:
                 ],
                 capture_output=True,
                 text=True,
+                check=False,
             )
             assert read.returncode == 0, (
                 f"{marker} did not survive container re-creation: {read.stderr}"
@@ -203,4 +218,5 @@ class TestDockerBuild:
                 ["docker", "volume", "rm", "-f", volume],
                 capture_output=True,
                 text=True,
+                check=False,
             )

--- a/tests/test_env_manager.py
+++ b/tests/test_env_manager.py
@@ -220,7 +220,9 @@ class HomeAssistantTestEnvironment:
         cmd = [sys.executable, "-m", "pytest", "tests/src/e2e/", "-v", "--tb=short"]
 
         try:
-            result = subprocess.run(cmd, env=env, cwd=Path(__file__).parent.parent)
+            result = subprocess.run(
+                cmd, env=env, cwd=Path(__file__).parent.parent, check=False
+            )
             if result.returncode == 0:
                 logger.info("✅ All tests passed!")
             else:

--- a/tests/uat/run_uat.py
+++ b/tests/uat/run_uat.py
@@ -157,6 +157,7 @@ def preflight_check_docker(timeout: float = 5.0) -> str | None:
             capture_output=True,
             text=True,
             timeout=timeout,
+            check=False,
         )
     except FileNotFoundError:
         return "'docker' CLI not found on PATH (install Docker or pass --ha-url)"

--- a/tests/uat/stories/run_story.py
+++ b/tests/uat/stories/run_story.py
@@ -439,6 +439,7 @@ def _run_test_prompt(
         capture_output=True,
         text=True,
         timeout=600,
+        check=False,
     )
 
     for line in result.stderr.splitlines():
@@ -672,6 +673,7 @@ def get_git_info() -> tuple[str, str]:
             capture_output=True,
             text=True,
             cwd=str(REPO_ROOT),
+            check=False,
         )
         sha = result.stdout.strip()
     except Exception:
@@ -683,6 +685,7 @@ def get_git_info() -> tuple[str, str]:
             capture_output=True,
             text=True,
             cwd=str(REPO_ROOT),
+            check=False,
         )
         describe = result.stdout.strip()
     except Exception:

--- a/tests/uat/stories/scripts/ha_query.py
+++ b/tests/uat/stories/scripts/ha_query.py
@@ -90,6 +90,7 @@ def run_gemini_query(
             cwd=str(workdir),
             timeout=timeout,
             env=env,
+            check=False,
         )
 
         output = result.stdout
@@ -162,6 +163,7 @@ def run_claude_query(
             text=True,
             timeout=timeout,
             env=env,
+            check=False,
         )
 
         output = result.stdout

--- a/tests/uat/stories/scripts/measure_tools.py
+++ b/tests/uat/stories/scripts/measure_tools.py
@@ -138,6 +138,7 @@ asyncio.run(run())
             capture_output=True,
             text=True,
             timeout=120,
+            check=False,
         )
         if result.returncode != 0:
             print(f"Branch measurement failed: {result.stderr}", file=sys.stderr)

--- a/tests/uat/stories/test_stories.py
+++ b/tests/uat/stories/test_stories.py
@@ -114,6 +114,7 @@ def _run_bat_scenario(scenario: dict, agent: str, ha_url: str, ha_token: str) ->
         capture_output=True,
         text=True,
         timeout=300,
+        check=False,
     )
 
     if result.returncode != 0:

--- a/tests/uat/test_openai_agent.py
+++ b/tests/uat/test_openai_agent.py
@@ -27,6 +27,7 @@ class TestArgParsing:
             [sys.executable, str(AGENT_SCRIPT)],
             capture_output=True,
             text=True,
+            check=False,
         )
         assert result.returncode != 0
 
@@ -36,6 +37,7 @@ class TestArgParsing:
             [sys.executable, str(AGENT_SCRIPT), "--help"],
             capture_output=True,
             text=True,
+            check=False,
         )
         assert result.returncode == 0
         assert "--prompt" in result.stdout


### PR DESCRIPTION
## What does this PR do?

Enables a targeted set of ruff pylint rules and fixes every resulting violation (104 total, 56 files) — a pure lint-compliance sweep, no behavior changes.

`pyproject.toml`: added the `PLE` prefix (pylint errors — real bugs, zero violations today) plus 11 individually-listed codes (`PLC0206`, `PLC0207`, `PLR0402`, `PLR1711`, `PLR1714`, `PLR1730`, `PLR5501`, `PLW0108`, `PLW0602`, `PLW1510`, `PLW2901`). The rest of the `PL` family (`PLC0415`, `PLR2004`, `PLR0913`/`PLR0917`, `PLR0911`) is deliberately excluded — see the inline comment for why each fights this codebase's patterns (lazy-init imports, wide FastMCP tool signatures, etc).

Fixes applied:
- **36 sites**: explicit `check=False` on `subprocess.run()` calls (was already the implicit default; every site already inspects `returncode`/`stdout`/`stderr` downstream, several asserting on non-zero-exit paths, so `check=True` would have broken those tests)
- **23 sites**: removed unnecessary lambda wrappers (`MagicMock(side_effect=lambda **kw: f(**kw))` → `MagicMock(side_effect=f)`, verified none of the wrapped names are rebound between definition and invocation)
- **2 sites**: narrowed `global` statements in `src/ha_mcp/__main__.py` to only the name actually assigned in that function
- **4 sites**: collapsed `if/else: if/else` nests to `if/elif/else` (verified identical branch reachability)
- **23 sites**: added `maxsplit=1` to `split`/`rsplit` calls (verified equivalent on all actual input shapes)
- Misc: dict-index-missing-items, repeated-equality-comparison, manual-from-import, useless-return

Also bumps `homeassistant-addon-webhook-proxy-dev` version 2.1.1.dev2 → 2.1.1.dev3 (config.yaml + manifest.json + CHANGELOG entry), required by `webhook-proxy-dev-version-guard` since this PR touches files under that tree. The two equivalent fixes (PLC0207, PLR5501) land in the **dev** flavor only, per the dev-first/promote-only flow (`allow-stable-edit` is documented for stable-only hotfixes, not routine sweeps — h/t Codex review). The stable flavor keeps a temporary per-file-ignore for those two rules, removed at the next promote.

## Type of change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [x] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent — not applicable, no LLM-facing tool behavior changed
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

Verified locally: `ruff check` clean across all seven CI-linted dirs, `ruff format --check` clean, `mypy src/` clean (139 files), unit suite 8878 passed / 0 failed (one pre-existing local-only environment timeout in `test_config.py::TestConfigErrorHandling`, confirmed unrelated to this branch — reproduces identically on unmodified `master`). Docker-dependent tests (`tests/test_docker/`, e2e) were not run locally (Docker daemon not running in the dev environment) but are covered by CI.

## Checklist
- [ ] I have updated documentation if needed
