### PR TITLE
test: pin the mixed-entities status gate and search fallbacks

### DIFF
--- a/tests/src/e2e/error_handling/test_network_errors.py
+++ b/tests/src/e2e/error_handling/test_network_errors.py
@@ -148,31 +148,43 @@ class TestErrorHandling:
         # 3. MISSING REQUIRED PARAMETERS: Try to call service without required params
         logger.info("📋 Testing missing required parameters...")
 
-        # Try to call light.turn_on without entity_id (if lights exist)
+        # Try to call light.turn_on without entity_id (if lights exist).
+        # A failed search is not "no lights": parse_mcp_result renders both
+        # _safe_tool_call fallbacks as empty content, so the markers must be
+        # read before the parse. Only the wrapper timeout is tolerated.
         search_result = await self._safe_tool_call(
             mcp_client,
             "ha_search",
             {"query": "light", "domain_filter": "light", "limit": 1},
         )
 
-        search_data = parse_mcp_result(search_result)
-        if search_data.get("success") and search_data.get("entities"):
-            # Call service without entity_id to test parameter validation
-            missing_params_result = await self._safe_tool_call(
-                mcp_client,
-                "ha_call_service",
-                {
-                    "domain": "light",
-                    "service": "turn_on",
-                    # Missing entity_id
-                },
+        if isinstance(search_result, dict) and search_result.get("timed_out"):
+            logger.warning(
+                "  entity search timed out; skipping the missing-params probe"
             )
+        else:
+            assert not (
+                isinstance(search_result, dict)
+                and search_result.get("success") is False
+            ), f"ha_search with valid params must not error: {search_result}"
+            search_data = parse_mcp_result(search_result)
+            if search_data.get("success") and search_data.get("entities"):
+                # Call service without entity_id to test parameter validation
+                missing_params_result = await self._safe_tool_call(
+                    mcp_client,
+                    "ha_call_service",
+                    {
+                        "domain": "light",
+                        "service": "turn_on",
+                        # Missing entity_id
+                    },
+                )
 
-            missing_params_data = parse_mcp_result(missing_params_result)
-            # This might succeed (affects all lights) or fail depending on HA config
-            logger.info(
-                f"  Service call without entity_id: {'succeeded' if missing_params_data.get('success') else 'failed'}"
-            )
+                missing_params_data = parse_mcp_result(missing_params_result)
+                # This might succeed (affects all lights) or fail depending on HA config
+                logger.info(
+                    f"  Service call without entity_id: {'succeeded' if missing_params_data.get('success') else 'failed'}"
+                )
 
         logger.info("✅ Service call error handling test completed")
 
@@ -304,6 +316,56 @@ class TestErrorHandling:
 
         logger.info("✅ Template error conditions test completed")
 
+    async def _assert_dispatched_status_contract(
+        self, mcp_client, operation_ids: list[str]
+    ) -> None:
+        """Assert live status for the ids a bulk batch just dispatched.
+
+        Fabricated entities never appear in this list (they are rejected
+        before dispatch — the not_found VALUE contract for unknown ids is
+        pinned by test_operation_status.py's test_list_operation_ids_invalid),
+        so every id present must resolve to a live per-item entry whose status
+        is one a dispatched operation can actually reach — never not_found,
+        which would mean the batch lost track of an operation it just created.
+        """
+        # Keep the poll window below _safe_tool_call's 10s wrapper timeout so
+        # a still-pending operation returns a pending entry instead of
+        # tripping the wrapper.
+        status_result = await self._safe_tool_call(
+            mcp_client,
+            "ha_get_operation_status",
+            {"operation_id": operation_ids, "timeout_seconds": 5},
+        )
+
+        # Same discrimination as the bulk call: tolerate only the wrapper
+        # timeout; a failed status call on ids the batch just created is a
+        # regression, not a skip.
+        if isinstance(status_result, dict) and status_result.get("timed_out"):
+            logger.warning("  status call timed out; tolerated on flaky lanes")
+            return
+
+        assert not (
+            isinstance(status_result, dict) and status_result.get("success") is False
+        ), f"bulk status must not fail on ids the batch just created: {status_result}"
+        status_data = parse_mcp_result(status_result)
+        detailed = status_data.get("detailed_results", [])
+        by_status = {
+            entry.get("operation_id"): entry.get("status") for entry in detailed
+        }
+        assert set(by_status) == set(operation_ids), (
+            f"bulk status must cover exactly the dispatched ids: {status_data}"
+        )
+        stray = {
+            op_id: status
+            for op_id, status in by_status.items()
+            if status not in ("completed", "pending", "timeout", "failed")
+        }
+        assert not stray, (
+            f"dispatched operations reported an impossible status "
+            f"(batch lost track of them): {stray}"
+        )
+        logger.info(f"    dispatched statuses: {by_status}")
+
     async def test_bulk_operation_error_scenarios(self, mcp_client):
         """
         Test: Bulk operation error scenarios
@@ -331,17 +393,31 @@ class TestErrorHandling:
         # 2. INVALID ENTITIES: Mix of valid and invalid entity IDs
         logger.info("❌ Testing mixed valid/invalid entities...")
 
-        # Get one valid entity
+        # Get one valid entity. Both _safe_tool_call fallbacks parse as
+        # empty content, which reads exactly like "no lights on this
+        # instance" — and an empty valid_entities silently degrades every
+        # contract below (nothing dispatches, so no operation ids and no
+        # status section). Discriminate before the parse: the wrapper
+        # timeout is tolerated, a tool error is a regression.
         search_result = await self._safe_tool_call(
             mcp_client,
             "ha_search",
             {"query": "light", "domain_filter": "light", "limit": 1},
         )
 
-        search_data = parse_mcp_result(search_result)
         valid_entities = []
-        if search_data.get("success") and search_data.get("entities"):
-            valid_entities = [search_data["entities"][0]["entity_id"]]
+        if isinstance(search_result, dict) and search_result.get("timed_out"):
+            logger.warning(
+                "  entity search timed out; proceeding with fabricated entities only"
+            )
+        else:
+            assert not (
+                isinstance(search_result, dict)
+                and search_result.get("success") is False
+            ), f"ha_search with valid params must not error: {search_result}"
+            search_data = parse_mcp_result(search_result)
+            if search_data.get("success") and search_data.get("entities"):
+                valid_entities = [search_data["entities"][0]["entity_id"]]
 
         mixed_entities = valid_entities + ["nonexistent.entity", "invalid.test"]
 
@@ -402,6 +478,16 @@ class TestErrorHandling:
                     f"both fabricated entities must fail as per-item entries "
                     f"(not abort the batch): {mixed_bulk_data}"
                 )
+                if valid_entities:
+                    assert operation_ids, (
+                        f"a batch that dispatched a valid entity takes the "
+                        f"legacy tier and must return polling handles; an "
+                        f"empty list means this batch became "
+                        f"component-servable (that tier builds its response "
+                        f"with no operation ids by construction) and the "
+                        f"status contract below must be consciously updated "
+                        f"rather than silently skipped: {mixed_bulk_data}"
+                    )
                 logger.info(
                     f"  ✅ Mixed entities handled: "
                     f"{mixed_bulk_data.get('successful_commands')} succeeded, "
@@ -410,62 +496,14 @@ class TestErrorHandling:
                 )
 
                 # Legacy tier only: dispatched operations get polling
-                # handles. Fabricated entities never appear here (they are
-                # rejected before dispatch — the not_found VALUE contract
-                # for unknown ids is pinned by test_operation_status.py's
-                # test_list_operation_ids_invalid), so every id present
-                # must resolve to a live per-item entry whose status is one
-                # a dispatched operation can actually reach — never
-                # not_found, which would mean the batch lost track of an
-                # operation it just created.
+                # handles — the assert above pins that routing claim, so
+                # this gate covers only the tolerated search-timeout leg,
+                # where no valid entity dispatched and the list is
+                # legitimately empty.
                 if operation_ids:
-                    # Keep the poll window below _safe_tool_call's 10s
-                    # wrapper timeout so a still-pending operation returns
-                    # a pending entry instead of tripping the wrapper.
-                    status_result = await self._safe_tool_call(
-                        mcp_client,
-                        "ha_get_operation_status",
-                        {"operation_id": operation_ids, "timeout_seconds": 5},
+                    await self._assert_dispatched_status_contract(
+                        mcp_client, operation_ids
                     )
-
-                    # Same discrimination as the bulk call: tolerate only
-                    # the wrapper timeout; a failed status call on ids the
-                    # batch just created is a regression, not a skip.
-                    if isinstance(status_result, dict) and status_result.get(
-                        "timed_out"
-                    ):
-                        logger.warning(
-                            "  status call timed out; tolerated on flaky lanes"
-                        )
-                    else:
-                        assert not (
-                            isinstance(status_result, dict)
-                            and status_result.get("success") is False
-                        ), (
-                            f"bulk status must not fail on ids the batch "
-                            f"just created: {status_result}"
-                        )
-                        status_data = parse_mcp_result(status_result)
-                        detailed = status_data.get("detailed_results", [])
-                        by_status = {
-                            entry.get("operation_id"): entry.get("status")
-                            for entry in detailed
-                        }
-                        assert set(by_status) == set(operation_ids), (
-                            f"bulk status must cover exactly the dispatched "
-                            f"ids: {status_data}"
-                        )
-                        stray = {
-                            op_id: status
-                            for op_id, status in by_status.items()
-                            if status
-                            not in ("completed", "pending", "timeout", "failed")
-                        }
-                        assert not stray, (
-                            f"dispatched operations reported an impossible "
-                            f"status (batch lost track of them): {stray}"
-                        )
-                        logger.info(f"    dispatched statuses: {by_status}")
 
         # 3. INVALID ACTION: Bulk operation with invalid action
         logger.info("🎬 Testing invalid action...")
@@ -633,12 +671,22 @@ class TestErrorHandling:
 
         logger.info("🚀 Testing concurrent operation handling...")
 
-        # Get some test entities
+        # Get some test entities. The early return below no-ops the whole
+        # test, so a failed search must not reach it disguised as an empty
+        # result set: both _safe_tool_call fallbacks parse as empty content.
+        # Tolerate the wrapper timeout, fail hard on a tool error.
         search_result = await self._safe_tool_call(
             mcp_client,
             "ha_search",
             {"query": "light", "domain_filter": "light", "limit": 3},
         )
+
+        if isinstance(search_result, dict) and search_result.get("timed_out"):
+            logger.warning("  entity search timed out; tolerated on flaky lanes")
+            return
+        assert not (
+            isinstance(search_result, dict) and search_result.get("success") is False
+        ), f"ha_search with valid params must not error: {search_result}"
 
         search_data = parse_mcp_result(search_result)
         if not search_data.get("success") or not search_data.get("entities"):

--- a/tests/src/e2e/error_handling/test_network_errors.py
+++ b/tests/src/e2e/error_handling/test_network_errors.py
@@ -14,20 +14,17 @@ from typing import Any
 import pytest
 
 from ..utilities.assertions import (
+    _parse_error_result,
     parse_mcp_result,
 )
 
 logger = logging.getLogger(__name__)
 
-
-def _error_text_from_result(result: Any) -> str:
-    """Best-effort error text from a tool result flagged with isError."""
-    content = getattr(result, "content", None)
-    if content:
-        text = getattr(content[0], "text", None)
-        if text:
-            return str(text)
-    return str(result)
+# The demo lights are registry-seeded everywhere, but only the HAOS lanes
+# gate boot on light.bed_light reaching the state machine — see
+# _search_lights_or_tolerate_timeout for the full reasoning.
+_SEEDED_LIGHT_POLL_SECONDS = 15.0
+_SEEDED_LIGHT_POLL_INTERVAL = 1.0
 
 
 def _get_error_str(data: dict, max_len: int = 50) -> str:
@@ -53,22 +50,27 @@ class TestErrorHandling:
             )
             # A tool failure reaches callers two ways depending on the
             # transport: as a raised ToolError (the except below) or as a
-            # returned result carrying isError. Fold the returned form into
-            # the same marked dict so marker-based discrimination is
-            # transport-independent.
-            if getattr(result, "isError", False):
+            # returned result carrying the error flag — ``is_error`` on
+            # fastmcp's CallToolResult, ``isError`` on the raw MCP one.
+            # Fold either spelling into the same marked dict, keeping the
+            # structured error payload the shared parser recovers so
+            # _get_error_str still finds a message, and marker-based
+            # discrimination stays transport-independent.
+            if getattr(result, "is_error", False) or getattr(result, "isError", False):
                 return {
+                    **_parse_error_result(result),
                     "success": False,
                     "tool_error": True,
-                    "error": _error_text_from_result(result),
                 }
             return result
         except TimeoutError:
             logger.warning(f"Tool call {tool_name} timed out after {timeout}s")
             # "timed_out" lets callers tolerate the wrapper-timeout leg on
-            # flaky lanes while still failing hard on a tool error — the
-            # two legs are indistinguishable after parse_mcp_result, so
-            # the marker must be set here, before the parse.
+            # flaky lanes while still failing hard on a tool error. This
+            # dict reaches parse_mcp_result unchanged (its passthrough
+            # guard returns an already-parsed dict as-is), so the marker
+            # survives; callers read it before acting on the payload and
+            # settle each leg at its own decision point.
             return {
                 "success": False,
                 "timed_out": True,
@@ -78,26 +80,15 @@ class TestErrorHandling:
             logger.warning(f"Tool call {tool_name} failed: {e}")
             return {"success": False, "tool_error": True, "error": str(e)}
 
-    async def _search_lights_or_tolerate_timeout(
+    async def _search_lights_once(
         self, mcp_client, limit: int
-    ) -> list[dict[str, Any]] | None:
-        """Search for lights, tolerating only the wrapper-timeout leg.
+    ) -> dict[str, Any] | None:
+        """Run one light search, discriminating the markers before the parse.
 
-        Both _safe_tool_call fallbacks parse as empty content, so a failed
-        search reads exactly like "this instance has no lights" and silently
-        degrades every contract downstream of it. The markers therefore have
-        to be read before the parse: the wrapper timeout is tolerated (None
-        comes back, so the caller can warn and drop just that leg), a tool
-        error is a regression.
-
-        An empty result set is a regression too, not an empty instance: the
-        e2e environments seed the demo platform's six lights (bed_light,
-        ceiling_lights, kitchen_lights, office_rgbw_lights,
-        living_room_rgbww_lights, entrance_color_white_lights) and conftest's
-        boot wait polls light.bed_light into the state machine before any
-        test runs, so a successful light search always has entities.
-
-        Returns the raw entity dicts, or None on the tolerated timeout.
+        Returns the parsed search payload (whose ``entities`` may legitimately
+        be empty), or None on the tolerated wrapper timeout. A tool error is a
+        regression and fails here rather than reaching a caller disguised as an
+        empty result set.
         """
         search_result = await self._safe_tool_call(
             mcp_client,
@@ -116,11 +107,68 @@ class TestErrorHandling:
         assert search_data.get("success"), (
             f"ha_search with valid params must succeed: {search_data}"
         )
+        return search_data
+
+    async def _search_lights_or_tolerate_timeout(
+        self, mcp_client, limit: int, require_entities: bool = True
+    ) -> list[dict[str, Any]] | None:
+        """Search for lights, tolerating only the wrapper-timeout leg.
+
+        The markers _safe_tool_call sets do survive parse_mcp_result — its
+        passthrough guard returns an already-parsed dict unchanged — but they
+        only discriminate anything if someone reads them, and an unread
+        tool-error dict carries no entities, so it reads exactly like "this
+        instance has no lights" and silently degrades every contract
+        downstream of it. Each leg is therefore settled here: the wrapper
+        timeout is tolerated (None comes back, so the caller can warn and drop
+        just that leg), a tool error is a regression.
+
+        Lights are registry-seeded on EVERY backend — the demo config entry is
+        baked into tests/initial_test_state/.storage/core.config_entries and
+        copied in at container prep — so a successful search on a settled
+        instance always has entities. The boot poll that waits for
+        light.bed_light to land in the state machine
+        (conftest._wait_for_haos_light_ready) runs only on the HAOS lanes,
+        though, and the demo platform publishes its states after the
+        integration's async_setup returns, so container / embedded lanes can
+        briefly race a search that fires first (documented at
+        conftest.py:1863-1874, PR #1379). With ``require_entities`` the
+        bounded poll below absorbs that lag, and only a still-empty result
+        after the window is a search regression rather than an empty instance.
+
+        ``require_entities=False`` is the single-shot form for the
+        service-call probe, which only needs to know whether this instance has
+        a light to aim at right now: it returns a possibly-empty list and
+        leaves the skip decision to the caller.
+
+        Returns the raw entity dicts, or None on the tolerated timeout.
+        """
+        search_data = await self._search_lights_once(mcp_client, limit)
+        if search_data is None:
+            return None
+
         entities = search_data.get("entities") or []
+        if entities or not require_entities:
+            return entities
+
+        # Empty on the first shot means the state machine may still be
+        # catching up with the registry seeding, so re-poll the search on a
+        # bounded window before calling it a regression.
+        deadline = time.monotonic() + _SEEDED_LIGHT_POLL_SECONDS
+        while time.monotonic() < deadline:
+            await asyncio.sleep(_SEEDED_LIGHT_POLL_INTERVAL)
+            search_data = await self._search_lights_once(mcp_client, limit)
+            if search_data is None:
+                return None
+            entities = search_data.get("entities") or []
+            if entities:
+                return entities
+
         assert entities, (
-            f"the seeded demo lights must be searchable, so an empty result "
-            f"is a search regression rather than an empty instance: "
-            f"{search_data}"
+            f"the registry-seeded demo lights must become searchable within "
+            f"{_SEEDED_LIGHT_POLL_SECONDS:.0f}s, so a still-empty result after "
+            f"the poll window is a search regression rather than an empty "
+            f"instance: {search_data}"
         )
         return entities
 
@@ -218,10 +266,21 @@ class TestErrorHandling:
 
         # Try to call light.turn_on without entity_id. The probe only means
         # something on an instance that has lights, and the helper is what
-        # keeps "no lights" from standing in for a failed search.
-        if await self._search_lights_or_tolerate_timeout(mcp_client, 1) is None:
+        # keeps "no lights" from standing in for a failed search. This site
+        # takes the single-shot form: it is a presence check, not a contract
+        # on the seeding, so an empty result skips the probe instead of
+        # spending the poll window on it.
+        probe_lights = await self._search_lights_or_tolerate_timeout(
+            mcp_client, 1, require_entities=False
+        )
+        if probe_lights is None:
             logger.warning(
                 "  entity search timed out; skipping the missing-params probe"
+            )
+        elif not probe_lights:
+            logger.warning(
+                "  no lights are currently searchable; skipping the "
+                "missing-params probe"
             )
         else:
             # Call service without entity_id to test parameter validation
@@ -409,9 +468,11 @@ class TestErrorHandling:
         ), f"bulk status must not fail on ids the batch just created: {status_result}"
         status_data = parse_mcp_result(status_result)
         detailed = status_data.get("detailed_results", [])
-        # Count first: the id-set comparison below collapses duplicate and
-        # keyless entries, so a batch that dropped or doubled an entry would
-        # still satisfy it.
+        # Count first. The id-set comparison below collapses duplicates, so
+        # only a key-set-preserving duplication (the same id reported twice,
+        # or an extra keyless entry alongside a full set) slips past it —
+        # gather builds exactly one entry per id today, so treat this as a
+        # forward regression guard on that invariant rather than a live bug.
         assert len(detailed) == len(operation_ids), (
             f"bulk status must return one entry per dispatched id, got "
             f"{len(detailed)} for {len(operation_ids)} ids: {status_data}"
@@ -444,6 +505,79 @@ class TestErrorHandling:
         )
         logger.info(f"    dispatched statuses: {by_status}")
 
+    async def _assert_empty_batch_rejected(self, mcp_client) -> None:
+        """Assert an empty operations list is rejected rather than accepted.
+
+        bulk_device_control raises before touching any entity when the list is
+        empty (VALIDATION_MISSING_PARAMETER, "No operations provided"), so the
+        wrapper hands back an explicit ``success: False``. An accepted empty
+        batch would mean the guard is gone and a caller's typo'd payload now
+        reports a clean no-op run.
+        """
+        empty_bulk_result = await self._safe_tool_call(
+            mcp_client, "ha_bulk_control", {"operations": []}
+        )
+
+        if isinstance(empty_bulk_result, dict) and empty_bulk_result.get("timed_out"):
+            logger.warning("  empty-batch call timed out; tolerated on flaky lanes")
+            return
+
+        empty_bulk_data = parse_mcp_result(empty_bulk_result)
+        assert empty_bulk_data.get("success") is False, (
+            f"an empty operations list must be rejected, not accepted as a "
+            f"no-op batch: {empty_bulk_data}"
+        )
+        logger.info(
+            f"  ✅ Empty entity list correctly failed: {_get_error_str(empty_bulk_data)}"
+        )
+
+    async def _assert_invalid_action_rejected(
+        self, mcp_client, valid_entities: list[str]
+    ) -> None:
+        """Assert an invalid action fails every item and dispatches nothing.
+
+        The action check runs before anything is dispatched:
+        control_device_smart raises SERVICE_INVALID_ACTION as soon as the
+        action is outside the domain handler's valid_actions, ahead of
+        _build_service_call and of store_pending_operation, and the component
+        tier bails the whole batch back to legacy at resolution time for the
+        same reason. So every item lands in the response as a per-item failure
+        and no service call is ever dispatched — which is exactly what a
+        vocabulary drift would quietly undo.
+        """
+        invalid_action_result = await self._safe_tool_call(
+            mcp_client,
+            "ha_bulk_control",
+            {
+                "operations": [
+                    {"entity_id": entity_id, "action": "invalid_action"}
+                    for entity_id in valid_entities
+                ]
+            },
+        )
+
+        if isinstance(invalid_action_result, dict) and invalid_action_result.get(
+            "timed_out"
+        ):
+            logger.warning("  invalid-action call timed out; tolerated on flaky lanes")
+            return
+
+        invalid_action_data = parse_mcp_result(invalid_action_result)
+        assert invalid_action_data.get("failed_commands") == len(valid_entities), (
+            f"every operation carrying an invalid action must fail as a "
+            f"per-item entry ({len(valid_entities)} expected): "
+            f"{invalid_action_data}"
+        )
+        assert invalid_action_data.get("successful_commands") == 0, (
+            f"an invalid action is rejected before dispatch, so nothing may "
+            f"report success: {invalid_action_data}"
+        )
+        logger.info(
+            f"  ✅ Invalid action correctly failed per item: "
+            f"{invalid_action_data.get('failed_commands')} failed, "
+            f"{invalid_action_data.get('successful_commands')} succeeded"
+        )
+
     async def test_bulk_operation_error_scenarios(self, mcp_client):
         """
         Test: Bulk operation error scenarios
@@ -456,17 +590,7 @@ class TestErrorHandling:
 
         # 1. EMPTY ENTITY LIST: Bulk operation with no entities
         logger.info("🔳 Testing empty entity list...")
-        empty_bulk_result = await self._safe_tool_call(
-            mcp_client, "ha_bulk_control", {"operations": []}
-        )
-
-        empty_bulk_data = parse_mcp_result(empty_bulk_result)
-        if not empty_bulk_data.get("success"):
-            logger.info(
-                f"  ✅ Empty entity list correctly failed: {_get_error_str(empty_bulk_data)}"
-            )
-        else:
-            logger.warning("  ⚠️ Empty entity list unexpectedly succeeded")
+        await self._assert_empty_batch_rejected(mcp_client)
 
         # 2. INVALID ENTITIES: Mix of valid and invalid entity IDs
         logger.info("❌ Testing mixed valid/invalid entities...")
@@ -507,8 +631,9 @@ class TestErrorHandling:
         # an aborted batch arrives as a ToolError (folded into a
         # plain dict by _safe_tool_call), never as a response with
         # per-item entries. Only the wrapper-timeout leg is tolerated
-        # (flaky lanes) — the "timed_out" marker is set before
-        # parse_mcp_result collapses both legs into the same shape.
+        # (flaky lanes), and the markers make the two legs tellable
+        # apart — parse_mcp_result hands a wrapper dict back unchanged,
+        # so read them here rather than after the parse.
         if isinstance(mixed_bulk_result, dict) and mixed_bulk_result.get("timed_out"):
             logger.warning("  bulk call timed out; tolerated on flaky lanes")
         else:
@@ -561,27 +686,12 @@ class TestErrorHandling:
             if operation_ids:
                 await self._assert_dispatched_status_contract(mcp_client, operation_ids)
 
-        # 3. INVALID ACTION: Bulk operation with invalid action
+        # 3. INVALID ACTION: Bulk operation with invalid action.
+        # Gated on valid_entities because the tolerated search-timeout leg
+        # leaves nothing to aim the invalid action at.
         logger.info("🎬 Testing invalid action...")
         if valid_entities:
-            invalid_action_result = await self._safe_tool_call(
-                mcp_client,
-                "ha_bulk_control",
-                {
-                    "operations": [
-                        {"entity_id": entity_id, "action": "invalid_action"}
-                        for entity_id in valid_entities
-                    ]
-                },
-            )
-
-            invalid_action_data = parse_mcp_result(invalid_action_result)
-            if not invalid_action_data.get("success"):
-                logger.info(
-                    f"  ✅ Invalid action correctly failed: {_get_error_str(invalid_action_data)}"
-                )
-            else:
-                logger.warning("  ⚠️ Invalid action unexpectedly succeeded")
+            await self._assert_invalid_action_rejected(mcp_client, valid_entities)
 
         logger.info("✅ Bulk operation error scenarios test completed")
 
@@ -755,14 +865,15 @@ async def _safe_tool_call_standalone(
         result = await asyncio.wait_for(
             mcp_client.call_tool(tool_name, params), timeout=timeout
         )
-        # Marker parity with the method twin: a returned isError result and
-        # a raised ToolError are the same failure over different transports,
-        # and callers discriminate on the markers, not the shape.
-        if getattr(result, "isError", False):
+        # Marker parity with the method twin: a returned error-flagged result
+        # and a raised ToolError are the same failure over different
+        # transports, and callers discriminate on the markers, not the shape.
+        # fastmcp spells the flag ``is_error``, the raw MCP type ``isError``.
+        if getattr(result, "is_error", False) or getattr(result, "isError", False):
             return {
+                **_parse_error_result(result),
                 "success": False,
                 "tool_error": True,
-                "error": _error_text_from_result(result),
             }
         return result
     except TimeoutError:
@@ -781,10 +892,12 @@ def _hard_failures(results: list[Any]) -> list[Any]:
     """Pick the concurrent results that failed for an untolerated reason.
 
     A raised exception always counts. Among returned dicts only an explicit
-    ``success: False`` does: the bulk response carries no top-level
-    ``success`` key at all, so a plain truthiness test would flag healthy
-    batches. The wrapper timeout stays the one tolerated failure class on
-    flaky lanes, matching the sequential call sites above.
+    ``success: False`` does — a missing key is not a failure, because several
+    healthy tool payloads simply do not carry one. The bulk response is the
+    family that matters here: it reports per-item counts and no top-level
+    ``success`` at all, so a plain truthiness test would flag every healthy
+    batch. The wrapper timeout stays the one tolerated failure class on flaky
+    lanes, matching the sequential call sites above.
     """
     return [
         r
@@ -870,8 +983,12 @@ async def _run_concurrent_bulk_operations(mcp_client, entities):
 
     bulk_tasks = [
         # "on"/"off" is the control-action vocabulary (valid_actions
-        # tables); "turn_on"/"turn_off" fails per-item at dispatch, which
-        # kept this helper exercising nothing while reporting success.
+        # tables); "turn_on"/"turn_off" is rejected per item at action
+        # validation, before anything dispatches — control_device_smart
+        # raises SERVICE_INVALID_ACTION ahead of _build_service_call, and
+        # the component tier bails the batch to legacy at resolution time
+        # for the same reason. That kept this helper exercising nothing
+        # while reporting success.
         bulk_operation(entity_groups[0], "on"),
         bulk_operation(entity_groups[1] if len(entity_groups) > 1 else [], "off"),
     ]
@@ -893,13 +1010,17 @@ async def _run_concurrent_bulk_operations(mcp_client, entities):
     # A wholesale failure is not the only quiet leg: an invalid action (or a
     # vocabulary drift) fails PER ITEM inside an otherwise healthy-looking
     # response, so pin the per-item counts on every batch that dispatched.
+    # Compare against 0 rather than testing truthiness: a dispatched batch
+    # always reports the key, so a MISSING one means the response is not the
+    # shape this assert believes it is checking, and must flag rather than
+    # slip through as "no failures".
     item_failures = {
         i: r.get("failed_commands")
         for i, r in enumerate(bulk_results)
         if isinstance(r, dict)
         and not r.get("timed_out")
         and r.get("error") != "No entities"
-        and r.get("failed_commands")
+        and r.get("failed_commands") != 0
     }
     assert not item_failures, (
         f"concurrent bulk operations on seeded lights must not fail "

--- a/tests/src/e2e/error_handling/test_network_errors.py
+++ b/tests/src/e2e/error_handling/test_network_errors.py
@@ -20,6 +20,16 @@ from ..utilities.assertions import (
 logger = logging.getLogger(__name__)
 
 
+def _error_text_from_result(result: Any) -> str:
+    """Best-effort error text from a tool result flagged with isError."""
+    content = getattr(result, "content", None)
+    if content:
+        text = getattr(content[0], "text", None)
+        if text:
+            return str(text)
+    return str(result)
+
+
 def _get_error_str(data: dict, max_len: int = 50) -> str:
     """Extract error string from response data, handling both string and dict errors."""
     error = data.get("error", "")
@@ -38,9 +48,21 @@ class TestErrorHandling:
     ):
         """Safe wrapper for tool calls with timeout protection."""
         try:
-            return await asyncio.wait_for(
+            result = await asyncio.wait_for(
                 mcp_client.call_tool(tool_name, params), timeout=timeout
             )
+            # A tool failure reaches callers two ways depending on the
+            # transport: as a raised ToolError (the except below) or as a
+            # returned result carrying isError. Fold the returned form into
+            # the same marked dict so marker-based discrimination is
+            # transport-independent.
+            if getattr(result, "isError", False):
+                return {
+                    "success": False,
+                    "tool_error": True,
+                    "error": _error_text_from_result(result),
+                }
+            return result
         except TimeoutError:
             logger.warning(f"Tool call {tool_name} timed out after {timeout}s")
             # "timed_out" lets callers tolerate the wrapper-timeout leg on
@@ -55,6 +77,52 @@ class TestErrorHandling:
         except Exception as e:
             logger.warning(f"Tool call {tool_name} failed: {e}")
             return {"success": False, "tool_error": True, "error": str(e)}
+
+    async def _search_lights_or_tolerate_timeout(
+        self, mcp_client, limit: int
+    ) -> list[dict[str, Any]] | None:
+        """Search for lights, tolerating only the wrapper-timeout leg.
+
+        Both _safe_tool_call fallbacks parse as empty content, so a failed
+        search reads exactly like "this instance has no lights" and silently
+        degrades every contract downstream of it. The markers therefore have
+        to be read before the parse: the wrapper timeout is tolerated (None
+        comes back, so the caller can warn and drop just that leg), a tool
+        error is a regression.
+
+        An empty result set is a regression too, not an empty instance: the
+        e2e environments seed the demo platform's six lights (bed_light,
+        ceiling_lights, kitchen_lights, office_rgbw_lights,
+        living_room_rgbww_lights, entrance_color_white_lights) and conftest's
+        boot wait polls light.bed_light into the state machine before any
+        test runs, so a successful light search always has entities.
+
+        Returns the raw entity dicts, or None on the tolerated timeout.
+        """
+        search_result = await self._safe_tool_call(
+            mcp_client,
+            "ha_search",
+            {"query": "light", "domain_filter": "light", "limit": limit},
+        )
+
+        if isinstance(search_result, dict) and search_result.get("timed_out"):
+            return None
+
+        assert not (
+            isinstance(search_result, dict) and search_result.get("success") is False
+        ), f"ha_search with valid params must not error: {search_result}"
+
+        search_data = parse_mcp_result(search_result)
+        assert search_data.get("success"), (
+            f"ha_search with valid params must succeed: {search_data}"
+        )
+        entities = search_data.get("entities") or []
+        assert entities, (
+            f"the seeded demo lights must be searchable, so an empty result "
+            f"is a search regression rather than an empty instance: "
+            f"{search_data}"
+        )
+        return entities
 
     async def test_invalid_entity_id_handling(self, mcp_client):
         """
@@ -148,43 +216,30 @@ class TestErrorHandling:
         # 3. MISSING REQUIRED PARAMETERS: Try to call service without required params
         logger.info("📋 Testing missing required parameters...")
 
-        # Try to call light.turn_on without entity_id (if lights exist).
-        # A failed search is not "no lights": parse_mcp_result renders both
-        # _safe_tool_call fallbacks as empty content, so the markers must be
-        # read before the parse. Only the wrapper timeout is tolerated.
-        search_result = await self._safe_tool_call(
-            mcp_client,
-            "ha_search",
-            {"query": "light", "domain_filter": "light", "limit": 1},
-        )
-
-        if isinstance(search_result, dict) and search_result.get("timed_out"):
+        # Try to call light.turn_on without entity_id. The probe only means
+        # something on an instance that has lights, and the helper is what
+        # keeps "no lights" from standing in for a failed search.
+        if await self._search_lights_or_tolerate_timeout(mcp_client, 1) is None:
             logger.warning(
                 "  entity search timed out; skipping the missing-params probe"
             )
         else:
-            assert not (
-                isinstance(search_result, dict)
-                and search_result.get("success") is False
-            ), f"ha_search with valid params must not error: {search_result}"
-            search_data = parse_mcp_result(search_result)
-            if search_data.get("success") and search_data.get("entities"):
-                # Call service without entity_id to test parameter validation
-                missing_params_result = await self._safe_tool_call(
-                    mcp_client,
-                    "ha_call_service",
-                    {
-                        "domain": "light",
-                        "service": "turn_on",
-                        # Missing entity_id
-                    },
-                )
+            # Call service without entity_id to test parameter validation
+            missing_params_result = await self._safe_tool_call(
+                mcp_client,
+                "ha_call_service",
+                {
+                    "domain": "light",
+                    "service": "turn_on",
+                    # Missing entity_id
+                },
+            )
 
-                missing_params_data = parse_mcp_result(missing_params_result)
-                # This might succeed (affects all lights) or fail depending on HA config
-                logger.info(
-                    f"  Service call without entity_id: {'succeeded' if missing_params_data.get('success') else 'failed'}"
-                )
+            missing_params_data = parse_mcp_result(missing_params_result)
+            # This might succeed (affects all lights) or fail depending on HA config
+            logger.info(
+                f"  Service call without entity_id: {'succeeded' if missing_params_data.get('success') else 'failed'}"
+            )
 
         logger.info("✅ Service call error handling test completed")
 
@@ -321,12 +376,17 @@ class TestErrorHandling:
     ) -> None:
         """Assert live status for the ids a bulk batch just dispatched.
 
-        Fabricated entities never appear in this list (they are rejected
-        before dispatch — the not_found VALUE contract for unknown ids is
-        pinned by test_operation_status.py's test_list_operation_ids_invalid),
-        so every id present must resolve to a live per-item entry whose status
-        is one a dispatched operation can actually reach — never not_found,
-        which would mean the batch lost track of an operation it just created.
+        Fabricated entities never appear in this list because the batch keeps
+        the validate_first=True default: control_device_smart validates the
+        entity before store_pending_operation registers an id, so a rejected
+        entity never gets one. Every id present therefore has to resolve to a
+        live per-item entry whose status is one a dispatched operation can
+        actually reach — never not_found, which would mean the batch lost
+        track of an operation it just created.
+
+        The not_found VALUE contract for ids that were never dispatched is
+        pinned separately by test_operation_status.py's
+        test_list_operation_ids_invalid.
         """
         # Keep the poll window below _safe_tool_call's 10s wrapper timeout so
         # a still-pending operation returns a pending entry instead of
@@ -349,12 +409,30 @@ class TestErrorHandling:
         ), f"bulk status must not fail on ids the batch just created: {status_result}"
         status_data = parse_mcp_result(status_result)
         detailed = status_data.get("detailed_results", [])
+        # Count first: the id-set comparison below collapses duplicate and
+        # keyless entries, so a batch that dropped or doubled an entry would
+        # still satisfy it.
+        assert len(detailed) == len(operation_ids), (
+            f"bulk status must return one entry per dispatched id, got "
+            f"{len(detailed)} for {len(operation_ids)} ids: {status_data}"
+        )
         by_status = {
             entry.get("operation_id"): entry.get("status") for entry in detailed
         }
         assert set(by_status) == set(operation_ids), (
             f"bulk status must cover exactly the dispatched ids: {status_data}"
         )
+        # A failed entry carries the structured payload of the single-op
+        # error it was folded back from, and the only code that maps to
+        # "failed" on purpose is SERVICE_CALL_FAILED — anything else lands
+        # there through the unknown-code fallback and would hide what
+        # actually went wrong.
+        for entry in detailed:
+            if entry.get("status") == "failed":
+                assert entry.get("error", {}).get("code") == "SERVICE_CALL_FAILED", (
+                    f"a failed operation must report SERVICE_CALL_FAILED, not "
+                    f"an unmapped code folded into the same status: {entry}"
+                )
         stray = {
             op_id: status
             for op_id, status in by_status.items()
@@ -393,117 +471,95 @@ class TestErrorHandling:
         # 2. INVALID ENTITIES: Mix of valid and invalid entity IDs
         logger.info("❌ Testing mixed valid/invalid entities...")
 
-        # Get one valid entity. Both _safe_tool_call fallbacks parse as
-        # empty content, which reads exactly like "no lights on this
-        # instance" — and an empty valid_entities silently degrades every
+        # Get one valid entity. An empty valid_entities degrades every
         # contract below (nothing dispatches, so no operation ids and no
-        # status section). Discriminate before the parse: the wrapper
-        # timeout is tolerated, a tool error is a regression.
-        search_result = await self._safe_tool_call(
-            mcp_client,
-            "ha_search",
-            {"query": "light", "domain_filter": "light", "limit": 1},
-        )
-
-        valid_entities = []
-        if isinstance(search_result, dict) and search_result.get("timed_out"):
+        # status section), which is why the helper only lets the tolerated
+        # search timeout produce one.
+        found = await self._search_lights_or_tolerate_timeout(mcp_client, 1)
+        if found is None:
             logger.warning(
                 "  entity search timed out; proceeding with fabricated entities only"
             )
+            valid_entities: list[str] = []
         else:
-            assert not (
-                isinstance(search_result, dict)
-                and search_result.get("success") is False
-            ), f"ha_search with valid params must not error: {search_result}"
-            search_data = parse_mcp_result(search_result)
-            if search_data.get("success") and search_data.get("entities"):
-                valid_entities = [search_data["entities"][0]["entity_id"]]
+            valid_entities = [found[0]["entity_id"]]
 
+        # Always non-empty: the two fabricated ids are unconditional.
         mixed_entities = valid_entities + ["nonexistent.entity", "invalid.test"]
 
-        if mixed_entities:
-            mixed_bulk_result = await self._safe_tool_call(
-                mcp_client,
-                "ha_bulk_control",
-                {
-                    "operations": [
-                        # "on" is the control-action vocabulary
-                        # (valid_actions tables); "turn_on" is rejected
-                        # upfront for every entity, which kept this whole
-                        # block dead.
-                        {"entity_id": entity_id, "action": "on"}
-                        for entity_id in mixed_entities
-                    ]
-                },
+        mixed_bulk_result = await self._safe_tool_call(
+            mcp_client,
+            "ha_bulk_control",
+            {
+                "operations": [
+                    # "on" is the control-action vocabulary
+                    # (valid_actions tables); "turn_on" is rejected
+                    # upfront for every entity, which kept this whole
+                    # block dead.
+                    {"entity_id": entity_id, "action": "on"}
+                    for entity_id in mixed_entities
+                ]
+            },
+        )
+
+        # A wholesale batch failure is the exact outcome this block
+        # exists to rule out, so it must FAIL the test, not skip it:
+        # an aborted batch arrives as a ToolError (folded into a
+        # plain dict by _safe_tool_call), never as a response with
+        # per-item entries. Only the wrapper-timeout leg is tolerated
+        # (flaky lanes) — the "timed_out" marker is set before
+        # parse_mcp_result collapses both legs into the same shape.
+        if isinstance(mixed_bulk_result, dict) and mixed_bulk_result.get("timed_out"):
+            logger.warning("  bulk call timed out; tolerated on flaky lanes")
+        else:
+            assert not (
+                isinstance(mixed_bulk_result, dict)
+                and mixed_bulk_result.get("success") is False
+            ), (
+                f"bulk_device_control must not abort wholesale on a "
+                f"batch containing invalid entities: {mixed_bulk_result}"
+            )
+            mixed_bulk_data = parse_mcp_result(mixed_bulk_result)
+            # The BATCH SHAPE is what routes this call to the LEGACY
+            # dispatch path, independent of whether a valid entity is in
+            # it: _build_service_call keeps each entity's own domain, so
+            # the fabricated IDs resolve to unknown services
+            # (nonexistent.turn_on), the component runs all guards before
+            # any dispatch and the whole frame raises, and
+            # _bulk_via_component treats that as a fallback signal — so
+            # legacy serves the batch and any dispatched entity gets a
+            # polling handle.
+            #
+            # Value-check the per-item contract on the response: the
+            # valid entities succeed and both fabricated entities fail
+            # as structured per-item entries (a missing entity becomes
+            # ENTITY_NOT_FOUND inside the batch) instead of aborting it.
+            operation_ids = mixed_bulk_data.get("operation_ids", [])
+            assert mixed_bulk_data.get("successful_commands") == len(valid_entities), (
+                f"the valid entities must succeed: {mixed_bulk_data}"
+            )
+            assert mixed_bulk_data.get("failed_commands") == 2, (
+                f"both fabricated entities must fail as per-item entries "
+                f"(not abort the batch): {mixed_bulk_data}"
+            )
+            if valid_entities:
+                assert len(operation_ids) == len(valid_entities), (
+                    f"the status contract below must be consciously updated, "
+                    f"not silently skipped: {mixed_bulk_data}"
+                )
+            logger.info(
+                f"  ✅ Mixed entities handled: "
+                f"{mixed_bulk_data.get('successful_commands')} succeeded, "
+                f"{mixed_bulk_data.get('failed_commands')} failed, "
+                f"{len(operation_ids)} operation ids"
             )
 
-            # A wholesale batch failure is the exact outcome this block
-            # exists to rule out, so it must FAIL the test, not skip it:
-            # an aborted batch arrives as a ToolError (folded into a
-            # plain dict by _safe_tool_call), never as a response with
-            # per-item entries. Only the wrapper-timeout leg is tolerated
-            # (flaky lanes) — the "timed_out" marker is set before
-            # parse_mcp_result collapses both legs into the same shape.
-            if isinstance(mixed_bulk_result, dict) and mixed_bulk_result.get(
-                "timed_out"
-            ):
-                logger.warning("  bulk call timed out; tolerated on flaky lanes")
-            else:
-                assert not (
-                    isinstance(mixed_bulk_result, dict)
-                    and mixed_bulk_result.get("success") is False
-                ), (
-                    f"bulk_device_control must not abort wholesale on a "
-                    f"batch containing invalid entities: {mixed_bulk_result}"
-                )
-                mixed_bulk_data = parse_mcp_result(mixed_bulk_result)
-                # This batch always exercises the LEGACY dispatch path:
-                # _build_service_call keeps each entity's own domain, so the
-                # fabricated IDs resolve to unknown services
-                # (nonexistent.turn_on), the component runs all guards
-                # before any dispatch and the whole frame raises, and
-                # _bulk_via_component treats that as a fallback signal —
-                # so operation_ids carries the real light and the status
-                # block below executes.
-                #
-                # Value-check the per-item contract on the response: the
-                # valid entities succeed and both fabricated entities fail
-                # as structured per-item entries (a missing entity becomes
-                # ENTITY_NOT_FOUND inside the batch) instead of aborting it.
-                operation_ids = mixed_bulk_data.get("operation_ids", [])
-                assert mixed_bulk_data.get("successful_commands") == len(
-                    valid_entities
-                ), f"the valid entities must succeed: {mixed_bulk_data}"
-                assert mixed_bulk_data.get("failed_commands") == 2, (
-                    f"both fabricated entities must fail as per-item entries "
-                    f"(not abort the batch): {mixed_bulk_data}"
-                )
-                if valid_entities:
-                    assert operation_ids, (
-                        f"a batch that dispatched a valid entity takes the "
-                        f"legacy tier and must return polling handles; an "
-                        f"empty list means this batch became "
-                        f"component-servable (that tier builds its response "
-                        f"with no operation ids by construction) and the "
-                        f"status contract below must be consciously updated "
-                        f"rather than silently skipped: {mixed_bulk_data}"
-                    )
-                logger.info(
-                    f"  ✅ Mixed entities handled: "
-                    f"{mixed_bulk_data.get('successful_commands')} succeeded, "
-                    f"{mixed_bulk_data.get('failed_commands')} failed, "
-                    f"{len(operation_ids)} operation ids"
-                )
-
-                # Legacy tier only: dispatched operations get polling
-                # handles — the assert above pins that routing claim, so
-                # this gate covers only the tolerated search-timeout leg,
-                # where no valid entity dispatched and the list is
-                # legitimately empty.
-                if operation_ids:
-                    await self._assert_dispatched_status_contract(
-                        mcp_client, operation_ids
-                    )
+            # Legacy tier only: dispatched operations get polling
+            # handles — the assert above pins that count, so this gate
+            # covers only the tolerated search-timeout leg, where no
+            # valid entity dispatched and the list is legitimately empty.
+            if operation_ids:
+                await self._assert_dispatched_status_contract(mcp_client, operation_ids)
 
         # 3. INVALID ACTION: Bulk operation with invalid action
         logger.info("🎬 Testing invalid action...")
@@ -671,29 +727,14 @@ class TestErrorHandling:
 
         logger.info("🚀 Testing concurrent operation handling...")
 
-        # Get some test entities. The early return below no-ops the whole
-        # test, so a failed search must not reach it disguised as an empty
-        # result set: both _safe_tool_call fallbacks parse as empty content.
-        # Tolerate the wrapper timeout, fail hard on a tool error.
-        search_result = await self._safe_tool_call(
-            mcp_client,
-            "ha_search",
-            {"query": "light", "domain_filter": "light", "limit": 3},
-        )
-
-        if isinstance(search_result, dict) and search_result.get("timed_out"):
+        # Get some test entities. An early return here no-ops the whole
+        # test, so only the tolerated search timeout is allowed to take it.
+        found = await self._search_lights_or_tolerate_timeout(mcp_client, 3)
+        if found is None:
             logger.warning("  entity search timed out; tolerated on flaky lanes")
             return
-        assert not (
-            isinstance(search_result, dict) and search_result.get("success") is False
-        ), f"ha_search with valid params must not error: {search_result}"
 
-        search_data = parse_mcp_result(search_result)
-        if not search_data.get("success") or not search_data.get("entities"):
-            logger.warning("⚠️ No entities found for concurrent operation test")
-            return
-
-        entities = search_data["entities"][:3]
+        entities = found[:3]
 
         await _run_concurrent_individual_operations(mcp_client, entities)
 
@@ -711,15 +752,48 @@ async def _safe_tool_call_standalone(
     if params is None:
         params = {}
     try:
-        return await asyncio.wait_for(
+        result = await asyncio.wait_for(
             mcp_client.call_tool(tool_name, params), timeout=timeout
         )
+        # Marker parity with the method twin: a returned isError result and
+        # a raised ToolError are the same failure over different transports,
+        # and callers discriminate on the markers, not the shape.
+        if getattr(result, "isError", False):
+            return {
+                "success": False,
+                "tool_error": True,
+                "error": _error_text_from_result(result),
+            }
+        return result
     except TimeoutError:
         logger.warning(f"Tool call {tool_name} timed out after {timeout}s")
-        return {"success": False, "error": f"Operation timed out after {timeout}s"}
+        return {
+            "success": False,
+            "timed_out": True,
+            "error": f"Operation timed out after {timeout}s",
+        }
     except Exception as e:
         logger.warning(f"Tool call {tool_name} failed: {e}")
-        return {"success": False, "error": str(e)}
+        return {"success": False, "tool_error": True, "error": str(e)}
+
+
+def _hard_failures(results: list[Any]) -> list[Any]:
+    """Pick the concurrent results that failed for an untolerated reason.
+
+    A raised exception always counts. Among returned dicts only an explicit
+    ``success: False`` does: the bulk response carries no top-level
+    ``success`` key at all, so a plain truthiness test would flag healthy
+    batches. The wrapper timeout stays the one tolerated failure class on
+    flaky lanes, matching the sequential call sites above.
+    """
+    return [
+        r
+        for r in results
+        if isinstance(r, Exception)
+        or (
+            isinstance(r, dict) and r.get("success") is False and not r.get("timed_out")
+        )
+    ]
 
 
 async def _run_concurrent_individual_operations(mcp_client, entities):
@@ -748,6 +822,12 @@ async def _run_concurrent_individual_operations(mcp_client, entities):
     # Execute concurrent operations
     concurrent_tasks = [call_service_for_entity(entity) for entity in entities]
     concurrent_results = await asyncio.gather(*concurrent_tasks, return_exceptions=True)
+
+    hard_failures = _hard_failures(concurrent_results)
+    assert not hard_failures, (
+        f"concurrent service calls must not fail outside the tolerated "
+        f"wrapper timeout: {hard_failures}"
+    )
 
     successful_ops = sum(
         1
@@ -795,10 +875,24 @@ async def _run_concurrent_bulk_operations(mcp_client, entities):
 
     bulk_results = await asyncio.gather(*bulk_tasks, return_exceptions=True)
 
+    hard_failures = [
+        r
+        for r in _hard_failures(bulk_results)
+        # An empty entity group is a fixture shortfall, not a tool failure:
+        # bulk_operation returns this sentinel without calling anything.
+        if not (isinstance(r, dict) and r.get("error") == "No entities")
+    ]
+    assert not hard_failures, (
+        f"concurrent bulk operations must not fail outside the tolerated "
+        f"wrapper timeout: {hard_failures}"
+    )
+
+    # A dispatched batch reports per-item counts and carries no top-level
+    # success key, so "succeeded" here means "came back without an explicit
+    # failure" — counting result.get("success") would report 0 of 2 on a
+    # perfectly healthy run.
     successful_bulk = sum(
-        1
-        for result in bulk_results
-        if isinstance(result, dict) and result.get("success")
+        1 for r in bulk_results if isinstance(r, dict) and r.get("success") is not False
     )
     logger.info(
         f"  ✅ {successful_bulk}/{len(bulk_tasks)} concurrent bulk operations succeeded"
@@ -838,6 +932,12 @@ async def _run_concurrent_helper_creation(mcp_client, cleanup_tracker):
     ]
 
     helper_results = await asyncio.gather(*helper_tasks, return_exceptions=True)
+
+    hard_failures = _hard_failures(helper_results)
+    assert not hard_failures, (
+        f"concurrent helper creations must not fail outside the tolerated "
+        f"wrapper timeout: {hard_failures}"
+    )
 
     successful_helpers = sum(
         1

--- a/tests/src/e2e/error_handling/test_network_errors.py
+++ b/tests/src/e2e/error_handling/test_network_errors.py
@@ -869,8 +869,11 @@ async def _run_concurrent_bulk_operations(mcp_client, entities):
             return {"success": False, "error": str(e)}
 
     bulk_tasks = [
-        bulk_operation(entity_groups[0], "turn_on"),
-        bulk_operation(entity_groups[1] if len(entity_groups) > 1 else [], "turn_off"),
+        # "on"/"off" is the control-action vocabulary (valid_actions
+        # tables); "turn_on"/"turn_off" fails per-item at dispatch, which
+        # kept this helper exercising nothing while reporting success.
+        bulk_operation(entity_groups[0], "on"),
+        bulk_operation(entity_groups[1] if len(entity_groups) > 1 else [], "off"),
     ]
 
     bulk_results = await asyncio.gather(*bulk_tasks, return_exceptions=True)
@@ -885,6 +888,22 @@ async def _run_concurrent_bulk_operations(mcp_client, entities):
     assert not hard_failures, (
         f"concurrent bulk operations must not fail outside the tolerated "
         f"wrapper timeout: {hard_failures}"
+    )
+
+    # A wholesale failure is not the only quiet leg: an invalid action (or a
+    # vocabulary drift) fails PER ITEM inside an otherwise healthy-looking
+    # response, so pin the per-item counts on every batch that dispatched.
+    item_failures = {
+        i: r.get("failed_commands")
+        for i, r in enumerate(bulk_results)
+        if isinstance(r, dict)
+        and not r.get("timed_out")
+        and r.get("error") != "No entities"
+        and r.get("failed_commands")
+    }
+    assert not item_failures, (
+        f"concurrent bulk operations on seeded lights must not fail "
+        f"per-item: {item_failures} in {bulk_results}"
     )
 
     # A dispatched batch reports per-item counts and carries no top-level

--- a/tests/src/e2e/utilities/assertions.py
+++ b/tests/src/e2e/utilities/assertions.py
@@ -31,7 +31,7 @@ def extract_error_message(data: dict[str, Any]) -> str:
 
 
 def _parse_error_result(result) -> dict[str, Any]:
-    """Parse an isError=true result, whose content is a serialized ToolError."""
+    """Parse an error-flagged result, whose content is a serialized ToolError."""
     if hasattr(result, "content") and result.content:
         if hasattr(result.content[0], "text"):
             error_text = result.content[0].text
@@ -46,19 +46,24 @@ def _parse_error_result(result) -> dict[str, Any]:
 def parse_mcp_result(result) -> dict[str, Any]:
     """Parse MCP tool result from FastMCP client response.
 
-    Handles both success responses and error responses (isError=true).
-    When isError is true, the error content is parsed as JSON if possible.
+    Handles both success responses and error-flagged responses. When the
+    error flag is set, the error content is parsed as JSON if possible.
     """
-    # A plain dict is the fallback shape the tests' own _safe_tool_call
-    # wrappers return when a call times out or errors. It is already parsed,
-    # and running it through the content extraction below would replace both
-    # its discrimination markers and its real error text with the generic
-    # "No content in result" placeholder.
+    # General contract of this shared helper: an already-parsed dict comes
+    # back unchanged. Several hundred e2e call sites feed results through
+    # here, and not all of them come from the client — the tests' own
+    # _safe_tool_call wrappers return a plain marked dict when a call times
+    # out or errors. Running such a dict through the content extraction
+    # below would replace both its discrimination markers and its real
+    # error text with the generic "No content in result" placeholder.
     if isinstance(result, dict):
         return result
 
-    # Check if this is an error response (isError=true from ToolError)
-    if hasattr(result, "isError") and result.isError:
+    # Check if this is an error response (from ToolError). fastmcp's
+    # CallToolResult spells the flag ``is_error``; the raw MCP CallToolResult
+    # spells it ``isError``. Accept either so the gate holds whichever type
+    # reaches this helper.
+    if getattr(result, "is_error", False) or getattr(result, "isError", False):
         return _parse_error_result(result)
 
     # Tools that return a FastMCP ``ToolResult`` with a non-text content block

--- a/tests/src/e2e/utilities/assertions.py
+++ b/tests/src/e2e/utilities/assertions.py
@@ -30,23 +30,36 @@ def extract_error_message(data: dict[str, Any]) -> str:
     return str(error_obj)
 
 
+def _parse_error_result(result) -> dict[str, Any]:
+    """Parse an isError=true result, whose content is a serialized ToolError."""
+    if hasattr(result, "content") and result.content:
+        if hasattr(result.content[0], "text"):
+            error_text = result.content[0].text
+            try:
+                # ToolError content is JSON-serialized structured error
+                return json.loads(error_text)
+            except json.JSONDecodeError:
+                return {"success": False, "error": error_text}
+    return {"success": False, "error": "Unknown error (isError=true)"}
+
+
 def parse_mcp_result(result) -> dict[str, Any]:
     """Parse MCP tool result from FastMCP client response.
 
     Handles both success responses and error responses (isError=true).
     When isError is true, the error content is parsed as JSON if possible.
     """
+    # A plain dict is the fallback shape the tests' own _safe_tool_call
+    # wrappers return when a call times out or errors. It is already parsed,
+    # and running it through the content extraction below would replace both
+    # its discrimination markers and its real error text with the generic
+    # "No content in result" placeholder.
+    if isinstance(result, dict):
+        return result
+
     # Check if this is an error response (isError=true from ToolError)
     if hasattr(result, "isError") and result.isError:
-        if hasattr(result, "content") and result.content:
-            if hasattr(result.content[0], "text"):
-                error_text = result.content[0].text
-                try:
-                    # ToolError content is JSON-serialized structured error
-                    return json.loads(error_text)
-                except json.JSONDecodeError:
-                    return {"success": False, "error": error_text}
-        return {"success": False, "error": "Unknown error (isError=true)"}
+        return _parse_error_result(result)
 
     # Tools that return a FastMCP ``ToolResult`` with a non-text content block
     # (e.g. ``include_screenshot`` / ``return_screenshot`` attach an image)

--- a/tests/src/e2e/workflows/dashboards/test_lifecycle.py
+++ b/tests/src/e2e/workflows/dashboards/test_lifecycle.py
@@ -32,6 +32,10 @@ logger = logging.getLogger(__name__)
 
 def parse_mcp_result(result) -> dict[str, Any]:
     """Parse MCP result from tool response."""
+    # Same passthrough contract as the shared utilities.assertions helper:
+    # an already-parsed dict comes back unchanged.
+    if isinstance(result, dict):
+        return result
     try:
         if hasattr(result, "content") and result.content:
             response_text = str(result.content[0].text)

--- a/tests/src/e2e/workflows/scripts/test_lifecycle.py
+++ b/tests/src/e2e/workflows/scripts/test_lifecycle.py
@@ -38,6 +38,10 @@ logger = logging.getLogger(__name__)
 
 def enhanced_parse_mcp_result(result) -> dict[str, Any]:
     """Enhanced MCP result parser with better error handling."""
+    # Same passthrough contract as the shared utilities.assertions helper:
+    # an already-parsed dict comes back unchanged.
+    if isinstance(result, dict):
+        return result
     try:
         if hasattr(result, "content") and result.content:
             response_text = str(result.content[0].text)

--- a/tests/src/e2e/workflows/todo/test_lifecycle.py
+++ b/tests/src/e2e/workflows/todo/test_lifecycle.py
@@ -35,6 +35,10 @@ logger = logging.getLogger(__name__)
 
 def enhanced_parse_mcp_result(result) -> dict[str, Any]:
     """Enhanced MCP result parser with better error handling."""
+    # Same passthrough contract as the shared utilities.assertions helper:
+    # an already-parsed dict comes back unchanged.
+    if isinstance(result, dict):
+        return result
     try:
         if hasattr(result, "content") and result.content:
             response_text = str(result.content[0].text)

--- a/tests/src/unit/test_e2e_assertions.py
+++ b/tests/src/unit/test_e2e_assertions.py
@@ -1,0 +1,205 @@
+"""Unit tests for the e2e result-parsing and failure-classification contracts.
+
+These pin three pieces of test infrastructure whose breakage is invisible from
+the e2e suite itself, because every failure mode they guard degrades into a
+*passing* run rather than a red one:
+
+- ``parse_mcp_result``'s dict passthrough
+  (``tests/src/e2e/utilities/assertions.py``). Hundreds of e2e call sites feed
+  it results, and some of those never came from the client at all -- the
+  ``_safe_tool_call`` wrappers return a marked dict. Losing the passthrough
+  would replace the discrimination markers with a generic placeholder.
+- The error-flag gate in the same helper. fastmcp's ``CallToolResult`` spells
+  the flag ``is_error``; the raw MCP one spells it ``isError``. A gate that
+  checks only one spelling is silently dead against the other transport, and
+  a JSON error envelope decodes identically down the success branch, so
+  nothing observable changes until the payload is not JSON.
+- ``_hard_failures``
+  (``tests/src/e2e/error_handling/test_network_errors.py``), which decides
+  which concurrent results are regressions. Too strict and healthy bulk
+  batches fail the suite; too loose and real tool errors ride through.
+
+No Docker and no HA instance: every input here is a plain object.
+"""
+
+from __future__ import annotations
+
+import json
+
+from tests.src.e2e.error_handling.test_network_errors import _hard_failures
+from tests.src.e2e.utilities.assertions import parse_mcp_result
+
+
+class _TextBlock:
+    """Minimal stand-in for an MCP text content block."""
+
+    def __init__(self, text: str) -> None:
+        self.text = text
+
+
+class _FastmcpResult:
+    """Stand-in for fastmcp's ``CallToolResult`` (flag spelled ``is_error``).
+
+    Deliberately a plain class rather than a ``MagicMock``: attribute
+    auto-creation would make *every* flag spelling read truthy and hide
+    exactly the bug these tests exist to catch.
+    """
+
+    def __init__(self, text: str, is_error: bool = False) -> None:
+        self.content = [_TextBlock(text)]
+        self.structured_content = None
+        self.is_error = is_error
+
+
+class _RawMcpResult:
+    """Stand-in for the raw MCP ``CallToolResult`` (flag spelled ``isError``)."""
+
+    def __init__(self, text: str, error_flag: bool = False) -> None:
+        self.content = [_TextBlock(text)]
+        self.structured_content = None
+        self.isError = error_flag
+
+
+class TestParsedDictPassthrough:
+    """An already-parsed dict comes back unchanged, markers intact."""
+
+    def test_timed_out_wrapper_dict_is_returned_identically(self):
+        wrapper_dict = {
+            "success": False,
+            "timed_out": True,
+            "error": "Operation timed out after 10.0s",
+        }
+        parsed = parse_mcp_result(wrapper_dict)
+        assert parsed is wrapper_dict
+        assert parsed == wrapper_dict
+
+    def test_tool_error_marker_and_structured_error_survive(self):
+        """The marker AND the structured error body both have to survive.
+
+        Callers discriminate on ``tool_error`` and then render the message
+        out of the structured ``error`` dict, so flattening either one turns
+        a hard failure into an unreadable one.
+        """
+        wrapper_dict = {
+            "success": False,
+            "tool_error": True,
+            "error": {
+                "code": "SERVICE_INVALID_ACTION",
+                "message": "Invalid action 'invalid_action' for domain 'light'",
+            },
+        }
+        parsed = parse_mcp_result(wrapper_dict)
+        assert parsed == wrapper_dict
+        assert parsed["tool_error"] is True
+        assert parsed["error"]["code"] == "SERVICE_INVALID_ACTION"
+
+
+class TestContentTextParsing:
+    """A result carrying JSON in ``content[0].text`` parses to that body."""
+
+    def test_json_text_block_parses_to_body(self):
+        body = {
+            "success": True,
+            "entities": [{"entity_id": "light.bed_light", "state": "on"}],
+        }
+        assert parse_mcp_result(_FastmcpResult(json.dumps(body))) == body
+
+    def test_non_json_text_block_falls_back_to_raw_response(self):
+        assert parse_mcp_result(_FastmcpResult("not json at all")) == {
+            "raw_response": "not json at all"
+        }
+
+
+_ERROR_ENVELOPE = {
+    "success": False,
+    "error": {
+        "code": "VALIDATION_MISSING_PARAMETER",
+        "message": "No operations provided",
+    },
+}
+
+
+class TestErrorFlagRouting:
+    """Both flag spellings route to the structured-error envelope."""
+
+    def test_is_error_routes_to_parsed_envelope(self):
+        result = _FastmcpResult(json.dumps(_ERROR_ENVELOPE), is_error=True)
+        assert parse_mcp_result(result) == _ERROR_ENVELOPE
+
+    def test_legacy_iserror_spelling_also_routes(self):
+        result = _RawMcpResult(json.dumps(_ERROR_ENVELOPE), error_flag=True)
+        assert parse_mcp_result(result) == _ERROR_ENVELOPE
+
+    def test_is_error_with_non_json_body_takes_the_error_branch(self):
+        """The spelling bug is only *observable* on a non-JSON body.
+
+        Both branches ``json.loads`` a JSON envelope into the same dict, so a
+        dead gate looks identical there. A non-JSON body separates them: the
+        error branch yields ``{"success": False, "error": ...}``, the success
+        branch yields ``{"raw_response": ...}``.
+        """
+        assert parse_mcp_result(_FastmcpResult("boom", is_error=True)) == {
+            "success": False,
+            "error": "boom",
+        }
+
+    def test_legacy_iserror_with_non_json_body_takes_the_error_branch(self):
+        assert parse_mcp_result(_RawMcpResult("boom", error_flag=True)) == {
+            "success": False,
+            "error": "boom",
+        }
+
+    def test_unflagged_result_stays_on_the_success_branch(self):
+        """A false flag must not route -- the gate reads the value, not the
+        mere presence of the attribute."""
+        assert parse_mcp_result(_FastmcpResult("boom")) == {"raw_response": "boom"}
+        assert parse_mcp_result(_RawMcpResult("boom")) == {"raw_response": "boom"}
+
+
+class TestHardFailureClassifier:
+    """``_hard_failures`` flags regressions and only regressions."""
+
+    def test_exception_instance_is_flagged(self):
+        exc = RuntimeError("asyncio.gather captured this")
+        assert _hard_failures([exc]) == [exc]
+
+    def test_tool_error_dict_is_flagged(self):
+        failure = {
+            "success": False,
+            "tool_error": True,
+            "error": "Invalid action 'invalid_action' for domain 'light'",
+        }
+        assert _hard_failures([failure]) == [failure]
+
+    def test_timed_out_dict_is_tolerated(self):
+        tolerated = {
+            "success": False,
+            "timed_out": True,
+            "error": "Operation timed out after 10.0s",
+        }
+        assert _hard_failures([tolerated]) == []
+
+    def test_healthy_bulk_response_without_success_key_is_not_flagged(self):
+        """A dispatched batch reports per-item counts and no top-level
+        ``success``; truthiness-testing it would fail every healthy run."""
+        healthy_bulk = {
+            "total_operations": 1,
+            "successful_commands": 1,
+            "failed_commands": 0,
+            "skipped_operations": 0,
+            "execution_mode": "parallel",
+            "operation_ids": ["op-1"],
+            "results": [{"command_sent": True}],
+        }
+        assert _hard_failures([healthy_bulk]) == []
+
+    def test_explicit_success_true_is_not_flagged(self):
+        assert _hard_failures([{"success": True, "data": {}}]) == []
+
+    def test_mixed_batch_returns_only_the_untolerated_failures(self):
+        exc = RuntimeError("transport dropped")
+        tool_error = {"success": False, "tool_error": True, "error": "boom"}
+        tolerated = {"success": False, "timed_out": True, "error": "slow"}
+        healthy_bulk = {"successful_commands": 2, "failed_commands": 0}
+        results = [exc, tolerated, tool_error, healthy_bulk, {"success": True}]
+        assert _hard_failures(results) == [exc, tool_error]

--- a/tests/src/unit/test_e2e_wait_helpers.py
+++ b/tests/src/unit/test_e2e_wait_helpers.py
@@ -39,12 +39,15 @@ from tests.src.e2e.utilities.wait_helpers import (
 
 def _mcp_result(text: str) -> MagicMock:
     """Build an MCP ``call_tool`` result that ``parse_mcp_result`` will
-    decode as ``json.loads(text)``. ``isError`` must be ``False``
-    explicitly — a bare ``MagicMock()`` would return a truthy MagicMock
-    from attribute access and route the parser down the error path."""
+    decode as ``json.loads(text)``. BOTH error-flag spellings must be
+    ``False`` explicitly — the parser accepts fastmcp's ``is_error`` and the
+    raw MCP ``isError``, and a bare ``MagicMock()`` returns a truthy
+    MagicMock from either attribute access, routing the parser down the
+    error path."""
     text_part = MagicMock()
     text_part.text = text
     result = MagicMock()
+    result.is_error = False
     result.isError = False
     result.content = [text_part]
     return result


### PR DESCRIPTION
## What does this PR do?

Hardens the e2e error-handling suite against the silent-skip paths described in #2103, plus the adjacent ones found while closing them.

- The operation-status section of `test_bulk_operation_error_scenarios` sat behind `if operation_ids:` with nothing asserting the list is non-empty. The routing is now pinned: whenever a valid entity dispatched, the test asserts `len(operation_ids) == len(valid_entities)`, so a routing change to the component tier (which returns no polling handles by construction) fails loudly instead of quietly skipping the only e2e assertions on live operation status. The status helper additionally pins entry count and requires failed entries to carry `SERVICE_CALL_FAILED` rather than an unmapped code folded into the same status.
- The `ha_search` call sites that gate later work parsed their results without checking `_safe_tool_call`'s `timed_out`/`tool_error` markers, so a failed search read as "no entities found" and degraded the dependent blocks to no-ops. A shared helper now discriminates the markers before parsing (wrapper timeout tolerated with a warning, tool error fails hard) and hard-asserts the registry-seeded demo lights are found — with a bounded poll absorbing the documented post-boot state-machine lag on the container/embedded lanes, where the `light.bed_light` boot gate does not run.
- `parse_mcp_result` collapsed the wrappers' fallback dicts into a generic placeholder, erasing both the markers and the real error text; it now passes already-parsed dicts through unchanged (the three local shadow parsers mirror the guard). The wrappers also normalize error-flagged *returned* results — checking `is_error`, fastmcp's actual spelling, alongside the raw-MCP `isError`; the previous spelling-only check was dead code — and preserve the structured error payload.
- The concurrent sub-helpers asserted nothing (0/3 passed identically to 3/3) and `_run_concurrent_bulk_operations` sent `turn_on`/`turn_off`, which the `valid_actions` vocabulary rejects per item before dispatch — it exercised nothing while logging success. They now use the real vocabulary and fail on any non-timeout error, with per-item counts pinned. The empty-batch and invalid-action sections assert their outcomes instead of logging them.
- New unit file `tests/src/unit/test_e2e_assertions.py` pins the dict passthrough, both error-flag spellings (observable only on non-JSON bodies), and the hard-failure classifier — the contracts whose breakage degrades e2e runs into passes rather than failures.

Closes #2103

## Type of change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [x] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

## Checklist
- [x] I have updated documentation if needed
