### PR TITLE
fix: read only the project .env, and close the CI lint-scope gaps from the #2102 review

### DIFF
--- a/.claude/skills/bat-story-eval/SKILL.md
+++ b/.claude/skills/bat-story-eval/SKILL.md
@@ -133,8 +133,9 @@ uv run python tests/uat/stories/scripts/ha_query.py \
 ```
 Record each answer as **confirmed** / **denied** / **unclear**. A non-zero exit
 from `ha_query.py` means the query itself failed (the output carries an
-`[exit N]` marker) — that is not one of the three outcomes; re-run it, and if it
-keeps failing record the story as unverified rather than scoring it.
+`[exit N]` marker; `[exit 124]` is a timeout) — that is not one of the three
+outcomes; re-run it, and if it keeps failing record the story as `unverified`
+(Step 5) rather than scoring it. See `references/evaluation-protocol.md`.
 
 Run remaining pre-built stories on the same container:
 ```bash
@@ -259,9 +260,11 @@ For each story+agent:
 
 Append eval results as NEW lines (never modify existing):
 ```python
-record["eval_score"] = "pass"  # or "partial" or "fail"
+record["eval_score"] = "pass"  # or "partial", "fail", or "unverified"
 record["eval_notes"] = "Entity created, triggers verified"
 record["eval_trend"] = "stable"  # or "new", "improved", "decreased"
+# "unverified" is for a story whose verification query itself failed — it is
+# not a result, so it carries no trend and is not compared to the baseline.
 ```
 
 ## Step 6: Report
@@ -356,6 +359,8 @@ Flag >5% total size increase (directly impacts token cost per turn).
 | `tests/uat/stories/scripts/ha_query.py` | Query live HA via agent+MCP for verification |
 | `tests/uat/stories/catalog/s*.yaml` | Pre-built story definitions |
 | `local/uat-results.jsonl` | Historical results (gitignored) |
+| `references/evaluation-protocol.md` | Scoring rules, verification questions, cross-agent checks |
+| `references/regression-protocol.md` | Regression classification and flaky handling |
 
 ## Important Notes
 

--- a/.claude/skills/bat-story-eval/SKILL.md
+++ b/.claude/skills/bat-story-eval/SKILL.md
@@ -131,7 +131,10 @@ uv run python tests/uat/stories/scripts/ha_query.py \
   --agent <agent> \
   "Does an automation with alias 'Sunset Porch Light' exist?"
 ```
-Record each answer as **confirmed** / **denied** / **unclear**.
+Record each answer as **confirmed** / **denied** / **unclear**. A non-zero exit
+from `ha_query.py` means the query itself failed (the output carries an
+`[exit N]` marker) — that is not one of the three outcomes; re-run it, and if it
+keeps failing record the story as unverified rather than scoring it.
 
 Run remaining pre-built stories on the same container:
 ```bash

--- a/.claude/skills/bat-story-eval/references/evaluation-protocol.md
+++ b/.claude/skills/bat-story-eval/references/evaluation-protocol.md
@@ -29,7 +29,13 @@ uv run python tests/uat/stories/scripts/ha_query.py \
   "Does an automation with alias 'Sunset Porch Light' exist? Show its triggers and actions."
 ```
 
-Evaluate the response:
+Check the exit code first. `ha_query.py` exits non-zero when the agent CLI
+itself failed, and prints `[exit N]` (plus stderr, when there is any) after
+whatever text the CLI managed to produce. A failed query is **not a
+measurement**: do not score it as any of the three outcomes below — re-run it,
+and if it keeps failing, record the story as unverified and say why.
+
+Only when the query exited 0, evaluate the response:
 - **Confirmed**: The answer clearly confirms the expected outcome
 - **Denied**: The answer clearly shows the expected outcome did NOT happen
 - **Unclear**: The answer is ambiguous or incomplete

--- a/.claude/skills/bat-story-eval/references/evaluation-protocol.md
+++ b/.claude/skills/bat-story-eval/references/evaluation-protocol.md
@@ -31,9 +31,12 @@ uv run python tests/uat/stories/scripts/ha_query.py \
 
 Check the exit code first. `ha_query.py` exits non-zero when the agent CLI
 itself failed, and prints `[exit N]` (plus stderr, when there is any) after
-whatever text the CLI managed to produce. A failed query is **not a
-measurement**: do not score it as any of the three outcomes below — re-run it,
-and if it keeps failing, record the story as unverified and say why.
+whatever text the CLI managed to produce — `[exit 124]` for a query that hung
+past its timeout. The one non-zero exit without a marker is `Error: <agent>
+CLI not found`, which means the agent is not installed: fix the environment
+rather than re-running. A failed query is **not a measurement**: do not score
+it as any of the three outcomes below — re-run it, and if it keeps failing,
+record the story as `unverified` (see Step 5 of SKILL.md) and say why.
 
 Only when the query exited 0, evaluate the response:
 - **Confirmed**: The answer clearly confirms the expected outcome

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -270,7 +270,7 @@ jobs:
       run: uv sync --dev
 
     - name: Run ruff check
-      run: uv run ruff check src/ tests/ custom_components/ homeassistant-addon/ homeassistant-addon-webhook-proxy/ homeassistant-addon-webhook-proxy-dev/ scripts/
+      run: uv run ruff check src/ tests/ custom_components/ homeassistant-addon/ homeassistant-addon-webhook-proxy/ homeassistant-addon-webhook-proxy-dev/ packaging/ scripts/
 
     - name: Run ruff format check on changed Python files
       run: |

--- a/packaging/mcpb/generate_manifest.py
+++ b/packaging/mcpb/generate_manifest.py
@@ -12,7 +12,7 @@ from pathlib import Path
 def _get_docstring_description(node: ast.AsyncFunctionDef) -> str:
     """Get the first line of a function's docstring for use as a description."""
     docstring = ast.get_docstring(node) or ""
-    return docstring.split("\n")[0].strip() if docstring else ""
+    return docstring.split("\n", maxsplit=1)[0].strip() if docstring else ""
 
 
 def _extract_title_and_decorator_description(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -186,8 +186,11 @@ ignore = [
 # homeassistant-addon-webhook-proxy-dev/ only, per the dev-first/promote-only
 # flow (allow-stable-edit is for stable-only hotfixes, not routine sweeps —
 # see homeassistant-addon-webhook-proxy/AGENTS.md "Dev-first, promote-only").
-# Remove this ignore once the next promote carries the fix into stable.
+# The dev entry covers a reset-dev-from-stable run, which overwrites the dev
+# tree with the still-unfixed stable code. Remove both entries once the next
+# promote carries the fixes into stable.
 "homeassistant-addon-webhook-proxy/**" = ["PLC0207", "PLR5501"]
+"homeassistant-addon-webhook-proxy-dev/**" = ["PLC0207", "PLR5501"]
 # C901 is enforced repo-wide with no per-file exemptions (the grandfathered
 # list was fully cleared by issue #925). Do NOT add "path" = ["C901"] entries
 # here — extract helpers to bring the function below the threshold instead:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -186,11 +186,16 @@ ignore = [
 # homeassistant-addon-webhook-proxy-dev/ only, per the dev-first/promote-only
 # flow (allow-stable-edit is for stable-only hotfixes, not routine sweeps —
 # see homeassistant-addon-webhook-proxy/AGENTS.md "Dev-first, promote-only").
-# The dev entry covers a reset-dev-from-stable run, which overwrites the dev
-# tree with the still-unfixed stable code. Remove both entries once the next
+# The -dev entries name where a reset-dev-from-stable run puts those same two
+# stable files (start.py stays put, mcp_proxy/ is renamed to mcp_proxy_dev/),
+# so the auto-opened reset PR lints clean. Scoped per file and per rule so
+# both rules stay live everywhere else in both trees — the -dev tree is where
+# all new webhook-proxy code is authored. Remove all four once the next
 # promote carries the fixes into stable.
-"homeassistant-addon-webhook-proxy/**" = ["PLC0207", "PLR5501"]
-"homeassistant-addon-webhook-proxy-dev/**" = ["PLC0207", "PLR5501"]
+"homeassistant-addon-webhook-proxy/start.py" = ["PLR5501"]
+"homeassistant-addon-webhook-proxy/mcp_proxy/__init__.py" = ["PLC0207"]
+"homeassistant-addon-webhook-proxy-dev/start.py" = ["PLR5501"]
+"homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/__init__.py" = ["PLC0207"]
 # C901 is enforced repo-wide with no per-file exemptions (the grandfathered
 # list was fully cleared by issue #925). Do NOT add "path" = ["C901"] entries
 # here — extract helpers to bring the function below the threshold instead:

--- a/src/ha_mcp/config.py
+++ b/src/ha_mcp/config.py
@@ -33,15 +33,13 @@ OAUTH_MODE_TOKEN = "oauth-mode-token"
 # Support for different environment files via HAMCP_ENV_FILE
 env_file = os.getenv("HAMCP_ENV_FILE", ".env")
 env_path = project_root / env_file
+if not env_path.exists():
+    # Fallback to default .env
+    env_path = project_root / ".env"
 
-# Load the specified environment file (silently, since env vars may come from other sources)
+# Load the environment file (silently, since env vars may come from other sources)
 if env_path.exists():
     load_dotenv(env_path)
-else:
-    # Fallback to default .env
-    default_env_path = project_root / ".env"
-    if default_env_path.exists():
-        load_dotenv(default_env_path)
 
 
 class Settings(BaseSettings):
@@ -565,7 +563,15 @@ class Settings(BaseSettings):
         return port
 
     model_config = SettingsConfigDict(
-        env_file=".env", env_file_encoding="utf-8", case_sensitive=False, extra="allow"
+        # Absolute, and the same file load_dotenv already resolved above. A
+        # relative ".env" here would be a second, independent read that
+        # pydantic-settings resolves against the process's working directory —
+        # so HAMCP_ENV_FILE would not govern it, and a stray .env in whatever
+        # directory the server was launched from would silently supply values.
+        env_file=str(env_path),
+        env_file_encoding="utf-8",
+        case_sensitive=False,
+        extra="allow",
     )
 
 

--- a/tests/src/unit/test_config.py
+++ b/tests/src/unit/test_config.py
@@ -248,6 +248,14 @@ class TestConfigErrorHandling:
             check=False,
         )
 
+        # Liveness anchor: the run has to reach the credential check and fail
+        # there. Without this, a startup crash (import error, packaging break)
+        # never prints the warning either and passes the assertion below.
+        assert result.returncode != 0
+        assert "Configuration Error" in result.stderr
+        assert "HOMEASSISTANT_URL" in result.stderr
+        assert "HOMEASSISTANT_TOKEN" in result.stderr
+
         # Should NOT contain the old noisy warning
         combined_output = result.stdout + result.stderr
         assert "[ENV] WARNING: No environment file found" not in combined_output

--- a/tests/src/unit/test_config.py
+++ b/tests/src/unit/test_config.py
@@ -161,14 +161,30 @@ def test_read_only_mode_env_var_coercion_rejected(env_value):
 class TestConfigErrorHandling:
     """Test configuration error handling and user-friendly messages."""
 
-    def test_missing_env_vars_shows_friendly_message(self):
+    @pytest.fixture
+    def child_env(self, tmp_path):
+        """Child-process env that ignores the developer's project ``.env``.
+
+        ``ha_mcp.config`` loads ``<project_root>/.env`` by absolute path, so
+        dropping the credential vars from the child environment is not enough:
+        on a machine with the documented local ``.env`` the subprocess would
+        start up fine and never print the message under test. Only an
+        ``HAMCP_ENV_FILE`` that *exists* wins over that fallback — a path that
+        does not exist falls straight back to ``.env``.
+        """
+        empty_env_file = tmp_path / "empty.env"
+        empty_env_file.write_text("")
+        env = os.environ.copy()
+        env["HAMCP_ENV_FILE"] = str(empty_env_file)
+        return env
+
+    def test_missing_env_vars_shows_friendly_message(self, child_env):
         """When HOMEASSISTANT_URL and TOKEN are missing, show friendly error."""
         # Run ha-mcp without any env vars set
-        env = os.environ.copy()
+        env = child_env
         # Remove any HA env vars that might be set
         env.pop("HOMEASSISTANT_URL", None)
         env.pop("HOMEASSISTANT_TOKEN", None)
-        env.pop("HAMCP_ENV_FILE", None)
 
         result = subprocess.run(
             [sys.executable, "-m", "ha_mcp"],
@@ -185,8 +201,11 @@ class TestConfigErrorHandling:
         # Should show friendly message, not raw stacktrace
         stderr = result.stderr
         assert "Configuration Error" in stderr
-        assert "HOMEASSISTANT_URL" in stderr
-        assert "HOMEASSISTANT_TOKEN" in stderr
+        # The two-space-dash prefix is the dynamic "what is actually missing"
+        # list. The static body of the banner names both variables regardless
+        # of which one is missing, so a bare name match proves nothing.
+        assert "  - HOMEASSISTANT_URL" in stderr
+        assert "  - HOMEASSISTANT_TOKEN" in stderr
         assert "Long-Lived Access Tokens" in stderr
         assert "github.com/homeassistant-ai/ha-mcp" in stderr
 
@@ -194,11 +213,10 @@ class TestConfigErrorHandling:
         assert "pydantic_core._pydantic_core.ValidationError" not in stderr
         assert "Field required [type=missing" not in stderr
 
-    def test_missing_only_url_shows_that_var(self):
+    def test_missing_only_url_shows_that_var(self, child_env):
         """When only HOMEASSISTANT_URL is missing, show that in message."""
-        env = os.environ.copy()
+        env = child_env
         env.pop("HOMEASSISTANT_URL", None)
-        env.pop("HAMCP_ENV_FILE", None)
         env["HOMEASSISTANT_TOKEN"] = "test_token_value"
 
         result = subprocess.run(
@@ -211,13 +229,15 @@ class TestConfigErrorHandling:
         )
 
         assert result.returncode != 0
-        assert "HOMEASSISTANT_URL" in result.stderr
+        # Match the dynamic missing-list entry, and require the variable that
+        # IS set to be absent from it — the static banner body names both.
+        assert "  - HOMEASSISTANT_URL" in result.stderr
+        assert "  - HOMEASSISTANT_TOKEN" not in result.stderr
 
-    def test_missing_only_token_shows_that_var(self):
+    def test_missing_only_token_shows_that_var(self, child_env):
         """When only HOMEASSISTANT_TOKEN is missing, show that in message."""
-        env = os.environ.copy()
+        env = child_env
         env.pop("HOMEASSISTANT_TOKEN", None)
-        env.pop("HAMCP_ENV_FILE", None)
         env["HOMEASSISTANT_URL"] = "http://test.local:8123"
 
         result = subprocess.run(
@@ -230,14 +250,16 @@ class TestConfigErrorHandling:
         )
 
         assert result.returncode != 0
-        assert "HOMEASSISTANT_TOKEN" in result.stderr
+        # Match the dynamic missing-list entry, and require the variable that
+        # IS set to be absent from it — the static banner body names both.
+        assert "  - HOMEASSISTANT_TOKEN" in result.stderr
+        assert "  - HOMEASSISTANT_URL" not in result.stderr
 
-    def test_no_env_file_warning_removed(self):
+    def test_no_env_file_warning_removed(self, child_env):
         """No warning should be shown when .env file is missing."""
-        env = os.environ.copy()
+        env = child_env
         env.pop("HOMEASSISTANT_URL", None)
         env.pop("HOMEASSISTANT_TOKEN", None)
-        env.pop("HAMCP_ENV_FILE", None)
 
         result = subprocess.run(
             [sys.executable, "-m", "ha_mcp"],
@@ -250,21 +272,22 @@ class TestConfigErrorHandling:
 
         # Liveness anchor: the run has to reach the credential check and fail
         # there. Without this, a startup crash (import error, packaging break)
-        # never prints the warning either and passes the assertion below.
+        # never prints the warning either and passes the assertion below. The
+        # two-space-dash entries are the dynamic missing-vars list, which no
+        # other startup banner emits.
         assert result.returncode != 0
         assert "Configuration Error" in result.stderr
-        assert "HOMEASSISTANT_URL" in result.stderr
-        assert "HOMEASSISTANT_TOKEN" in result.stderr
+        assert "  - HOMEASSISTANT_URL" in result.stderr
+        assert "  - HOMEASSISTANT_TOKEN" in result.stderr
 
         # Should NOT contain the old noisy warning
         combined_output = result.stdout + result.stderr
         assert "[ENV] WARNING: No environment file found" not in combined_output
 
-    def test_smoke_test_still_works(self):
+    def test_smoke_test_still_works(self, child_env):
         """Smoke test should work with dummy credentials."""
-        env = os.environ.copy()
         # Smoke test sets its own dummy credentials
-        env.pop("HAMCP_ENV_FILE", None)
+        env = child_env
 
         result = subprocess.run(
             [sys.executable, "-m", "ha_mcp", "--smoke-test"],

--- a/tests/src/unit/test_config.py
+++ b/tests/src/unit/test_config.py
@@ -163,14 +163,22 @@ class TestConfigErrorHandling:
 
     @pytest.fixture
     def child_env(self, tmp_path):
-        """Child-process env that ignores the developer's project ``.env``.
+        """Child-process env for half of the isolation from a developer ``.env``.
 
-        ``ha_mcp.config`` loads ``<project_root>/.env`` by absolute path, so
-        dropping the credential vars from the child environment is not enough:
-        on a machine with the documented local ``.env`` the subprocess would
-        start up fine and never print the message under test. Only an
-        ``HAMCP_ENV_FILE`` that *exists* wins over that fallback — a path that
-        does not exist falls straight back to ``.env``.
+        Dropping the credential vars from the child environment is not enough
+        on a machine with the documented local ``.env``: the subprocess would
+        start up fine and never print the message under test. There are two
+        independent readers of that file and each needs its own mitigation.
+
+        This fixture handles the first: ``ha_mcp.config`` runs ``load_dotenv``
+        on ``<project_root>/.env`` by absolute path at import. Only an
+        ``HAMCP_ENV_FILE`` that *exists* wins over it — a path that does not
+        exist falls straight back to ``.env``, so an empty file is the lever.
+
+        The second is ``Settings.model_config``'s ``env_file=".env"``, which
+        pydantic-settings resolves against the child's **cwd** and which
+        ``HAMCP_ENV_FILE`` cannot reach. Every test here therefore also passes
+        ``cwd=tmp_path``. Both are required; neither alone isolates the child.
         """
         empty_env_file = tmp_path / "empty.env"
         empty_env_file.write_text("")
@@ -178,7 +186,7 @@ class TestConfigErrorHandling:
         env["HAMCP_ENV_FILE"] = str(empty_env_file)
         return env
 
-    def test_missing_env_vars_shows_friendly_message(self, child_env):
+    def test_missing_env_vars_shows_friendly_message(self, child_env, tmp_path):
         """When HOMEASSISTANT_URL and TOKEN are missing, show friendly error."""
         # Run ha-mcp without any env vars set
         env = child_env
@@ -189,6 +197,7 @@ class TestConfigErrorHandling:
         result = subprocess.run(
             [sys.executable, "-m", "ha_mcp"],
             env=env,
+            cwd=tmp_path,
             capture_output=True,
             text=True,
             timeout=30,
@@ -213,7 +222,7 @@ class TestConfigErrorHandling:
         assert "pydantic_core._pydantic_core.ValidationError" not in stderr
         assert "Field required [type=missing" not in stderr
 
-    def test_missing_only_url_shows_that_var(self, child_env):
+    def test_missing_only_url_shows_that_var(self, child_env, tmp_path):
         """When only HOMEASSISTANT_URL is missing, show that in message."""
         env = child_env
         env.pop("HOMEASSISTANT_URL", None)
@@ -222,6 +231,7 @@ class TestConfigErrorHandling:
         result = subprocess.run(
             [sys.executable, "-m", "ha_mcp"],
             env=env,
+            cwd=tmp_path,
             capture_output=True,
             text=True,
             timeout=30,
@@ -234,7 +244,7 @@ class TestConfigErrorHandling:
         assert "  - HOMEASSISTANT_URL" in result.stderr
         assert "  - HOMEASSISTANT_TOKEN" not in result.stderr
 
-    def test_missing_only_token_shows_that_var(self, child_env):
+    def test_missing_only_token_shows_that_var(self, child_env, tmp_path):
         """When only HOMEASSISTANT_TOKEN is missing, show that in message."""
         env = child_env
         env.pop("HOMEASSISTANT_TOKEN", None)
@@ -243,6 +253,7 @@ class TestConfigErrorHandling:
         result = subprocess.run(
             [sys.executable, "-m", "ha_mcp"],
             env=env,
+            cwd=tmp_path,
             capture_output=True,
             text=True,
             timeout=30,
@@ -255,7 +266,7 @@ class TestConfigErrorHandling:
         assert "  - HOMEASSISTANT_TOKEN" in result.stderr
         assert "  - HOMEASSISTANT_URL" not in result.stderr
 
-    def test_no_env_file_warning_removed(self, child_env):
+    def test_no_env_file_warning_removed(self, child_env, tmp_path):
         """No warning should be shown when .env file is missing."""
         env = child_env
         env.pop("HOMEASSISTANT_URL", None)
@@ -264,6 +275,7 @@ class TestConfigErrorHandling:
         result = subprocess.run(
             [sys.executable, "-m", "ha_mcp"],
             env=env,
+            cwd=tmp_path,
             capture_output=True,
             text=True,
             timeout=30,
@@ -284,7 +296,7 @@ class TestConfigErrorHandling:
         combined_output = result.stdout + result.stderr
         assert "[ENV] WARNING: No environment file found" not in combined_output
 
-    def test_smoke_test_still_works(self, child_env):
+    def test_smoke_test_still_works(self, child_env, tmp_path):
         """Smoke test should work with dummy credentials."""
         # Smoke test sets its own dummy credentials
         env = child_env
@@ -292,6 +304,7 @@ class TestConfigErrorHandling:
         result = subprocess.run(
             [sys.executable, "-m", "ha_mcp", "--smoke-test"],
             env=env,
+            cwd=tmp_path,
             capture_output=True,
             text=True,
             timeout=60,

--- a/tests/src/unit/test_config.py
+++ b/tests/src/unit/test_config.py
@@ -115,6 +115,25 @@ def test_enable_strict_mandatory_bps_env_var_coercion_rejected(env_value):
         )
 
 
+def test_settings_ignores_an_env_file_in_the_working_directory(tmp_path, monkeypatch):
+    """The project ``.env`` is the only one read — never the cwd's.
+
+    ``model_config``'s ``env_file`` is a second dotenv read, independent of the
+    ``load_dotenv`` at import. Left relative it resolves against the process's
+    working directory, so launching the server from a directory holding an
+    unrelated ``.env`` silently supplied values for any matching field name
+    (``timeout``, ``debug``, ``log_level`` … are common in other projects'
+    files), and ``HAMCP_ENV_FILE`` could not override it.
+    """
+    (tmp_path / ".env").write_text("HOMEASSISTANT_URL=http://from-cwd:8123\n")
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("HOMEASSISTANT_URL", raising=False)
+
+    from ha_mcp.config import Settings
+
+    assert Settings().homeassistant_url != "http://from-cwd:8123"
+
+
 def test_read_only_mode_disabled_by_default():
     """read_only_mode defaults to False (opt-in safety toggle, #1569)."""
     from ha_mcp.config import Settings

--- a/tests/src/unit/test_ha_query_exit_contract.py
+++ b/tests/src/unit/test_ha_query_exit_contract.py
@@ -1,0 +1,133 @@
+"""Unit tests for the ha_query.py failure contract.
+
+``ha_query.py`` is the black-box verification leg of ``/bat-story-eval``: it
+asks a live HA instance a question through an agent CLI and the answer is
+scored. A CLI that fails after printing something partial used to be
+indistinguishable from a real answer, so the script now returns the CLI's exit
+code alongside the text and exits non-zero itself. These tests pin that.
+
+The script lives under ``tests/uat/``, which no CI lane runs; loading it by
+path from the unit suite is what puts the contract under CI.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+SCRIPT = (
+    Path(__file__).resolve().parents[2] / "uat" / "stories" / "scripts" / "ha_query.py"
+)
+spec = importlib.util.spec_from_file_location("ha_query", str(SCRIPT))
+assert spec is not None and spec.loader is not None
+ha_query = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(ha_query)
+
+
+def _completed(returncode: int, stdout: str = "", stderr: str = ""):
+    return subprocess.CompletedProcess(
+        args=["agent"], returncode=returncode, stdout=stdout, stderr=stderr
+    )
+
+
+QUERY_FUNCS = [
+    pytest.param(lambda: ha_query.run_gemini_query, id="gemini"),
+    pytest.param(lambda: ha_query.run_claude_query, id="claude"),
+]
+
+
+@pytest.mark.parametrize("get_func", QUERY_FUNCS)
+def test_successful_query_returns_text_and_zero(get_func):
+    """A clean run returns the CLI's stdout and exit code 0, unannotated."""
+    with patch.object(
+        ha_query.subprocess, "run", return_value=_completed(0, stdout="the answer")
+    ):
+        text, returncode = get_func()("q", "http://ha.local:8123", "token")
+
+    assert returncode == 0
+    assert text == "the answer"
+    assert "[exit" not in text
+
+
+@pytest.mark.parametrize("get_func", QUERY_FUNCS)
+def test_failed_query_reports_exit_code_even_without_stderr(get_func):
+    """A non-zero exit is surfaced even when the CLI wrote nothing to stderr.
+
+    This is the regression: the old code only annotated the output when stderr
+    was non-empty, so a silent failure was consumed as a real answer.
+    """
+    with patch.object(
+        ha_query.subprocess, "run", return_value=_completed(2, stdout="partial")
+    ):
+        text, returncode = get_func()("q", "http://ha.local:8123", "token")
+
+    assert returncode == 2
+    assert "[exit 2]" in text
+    # The partial answer is kept — the marker is what makes it non-scorable.
+    assert "partial" in text
+
+
+@pytest.mark.parametrize("get_func", QUERY_FUNCS)
+def test_failed_query_appends_stderr_when_present(get_func):
+    with patch.object(
+        ha_query.subprocess,
+        "run",
+        return_value=_completed(1, stdout="", stderr="boom"),
+    ):
+        text, returncode = get_func()("q", "http://ha.local:8123", "token")
+
+    assert returncode == 1
+    assert "[exit 1]" in text
+    assert "boom" in text
+
+
+def test_gemini_json_envelope_is_unwrapped():
+    """The gemini CLI's JSON envelope still yields the bare response text."""
+    with patch.object(
+        ha_query.subprocess,
+        "run",
+        return_value=_completed(0, stdout='{"response": "unwrapped"}'),
+    ):
+        text, returncode = ha_query.run_gemini_query("q", "http://ha", "token")
+
+    assert (text, returncode) == ("unwrapped", 0)
+
+
+def test_main_exits_non_zero_when_the_query_failed(monkeypatch, capsys):
+    """A failed query must not exit 0 — that is what let it be scored."""
+    monkeypatch.setattr(
+        ha_query.sys,
+        "argv",
+        ["ha_query.py", "--ha-url", "http://ha", "--ha-token", "t", "question"],
+    )
+    monkeypatch.setattr(ha_query.shutil, "which", lambda _: "/usr/bin/gemini")
+    monkeypatch.setattr(
+        ha_query, "run_gemini_query", lambda *a, **kw: ("partial\n[exit 2]", 2)
+    )
+
+    with pytest.raises(SystemExit) as excinfo:
+        ha_query.main()
+
+    assert excinfo.value.code == 1
+    captured = capsys.readouterr()
+    # The answer still reaches stdout — consumers read it regardless.
+    assert "partial" in captured.out
+    assert "exited with code 2" in captured.err
+
+
+def test_main_exits_zero_on_success(monkeypatch, capsys):
+    monkeypatch.setattr(
+        ha_query.sys,
+        "argv",
+        ["ha_query.py", "--ha-url", "http://ha", "--ha-token", "t", "question"],
+    )
+    monkeypatch.setattr(ha_query.shutil, "which", lambda _: "/usr/bin/gemini")
+    monkeypatch.setattr(ha_query, "run_gemini_query", lambda *a, **kw: ("answer", 0))
+
+    ha_query.main()
+
+    assert "answer" in capsys.readouterr().out

--- a/tests/src/unit/test_ha_query_exit_contract.py
+++ b/tests/src/unit/test_ha_query_exit_contract.py
@@ -62,13 +62,18 @@ def test_failed_query_reports_exit_code_even_without_stderr(get_func):
     """
     with patch.object(
         ha_query.subprocess, "run", return_value=_completed(2, stdout="partial")
-    ):
+    ) as mock_run:
         text, returncode = get_func()("q", "http://ha.local:8123", "token")
 
     assert returncode == 2
     assert "[exit 2]" in text
     # The partial answer is kept — the marker is what makes it non-scorable.
     assert "partial" in text
+    # check=False is load-bearing: with check=True the non-zero exit raises
+    # CalledProcessError, which these functions do not catch, so neither the
+    # annotation above nor the tuple return is ever reached. A return_value
+    # mock cannot express that, so assert the kwarg directly.
+    assert mock_run.call_args.kwargs["check"] is False
 
 
 @pytest.mark.parametrize("get_func", QUERY_FUNCS)

--- a/tests/src/unit/test_ha_query_exit_contract.py
+++ b/tests/src/unit/test_ha_query_exit_contract.py
@@ -85,6 +85,24 @@ def test_failed_query_appends_stderr_when_present(get_func):
     assert "boom" in text
 
 
+@pytest.mark.parametrize("get_func", QUERY_FUNCS)
+def test_timed_out_query_is_annotated_and_keeps_its_partial_output(get_func):
+    """A hung CLI is a failed query, not a missing one.
+
+    Without this the exception escapes ``main()`` as a traceback: the answer
+    is never printed, so the partial output the CLI did manage is lost along
+    with the ``[exit N]`` marker the skill docs tell evaluators to look for.
+    """
+    timeout = subprocess.TimeoutExpired(cmd=["agent"], timeout=120, output=b"partial")
+    with patch.object(ha_query.subprocess, "run", side_effect=timeout):
+        text, returncode = get_func()("q", "http://ha.local:8123", "token")
+
+    assert returncode == ha_query.TIMEOUT_EXIT
+    assert f"[exit {ha_query.TIMEOUT_EXIT}]" in text
+    assert "timed out after" in text
+    assert "partial" in text
+
+
 def test_gemini_json_envelope_is_unwrapped():
     """The gemini CLI's JSON envelope still yields the bare response text."""
     with patch.object(
@@ -97,17 +115,31 @@ def test_gemini_json_envelope_is_unwrapped():
     assert (text, returncode) == ("unwrapped", 0)
 
 
-def test_main_exits_non_zero_when_the_query_failed(monkeypatch, capsys):
+# Both dispatch arms of main() unpack the new tuple, so both must be driven.
+AGENTS = [("gemini", "run_gemini_query"), ("claude", "run_claude_query")]
+
+
+def _fake_argv(agent: str) -> list[str]:
+    return [
+        "ha_query.py",
+        "--ha-url",
+        "http://ha",
+        "--ha-token",
+        "t",
+        "--agent",
+        agent,
+        "question",
+    ]
+
+
+@pytest.mark.parametrize(("agent", "func_name"), AGENTS)
+def test_main_exits_non_zero_when_the_query_failed(
+    agent, func_name, monkeypatch, capsys
+):
     """A failed query must not exit 0 — that is what let it be scored."""
-    monkeypatch.setattr(
-        ha_query.sys,
-        "argv",
-        ["ha_query.py", "--ha-url", "http://ha", "--ha-token", "t", "question"],
-    )
-    monkeypatch.setattr(ha_query.shutil, "which", lambda _: "/usr/bin/gemini")
-    monkeypatch.setattr(
-        ha_query, "run_gemini_query", lambda *a, **kw: ("partial\n[exit 2]", 2)
-    )
+    monkeypatch.setattr(ha_query.sys, "argv", _fake_argv(agent))
+    monkeypatch.setattr(ha_query.shutil, "which", lambda _: f"/usr/bin/{agent}")
+    monkeypatch.setattr(ha_query, func_name, lambda *a, **kw: ("partial\n[exit 2]", 2))
 
     with pytest.raises(SystemExit) as excinfo:
         ha_query.main()
@@ -119,14 +151,11 @@ def test_main_exits_non_zero_when_the_query_failed(monkeypatch, capsys):
     assert "exited with code 2" in captured.err
 
 
-def test_main_exits_zero_on_success(monkeypatch, capsys):
-    monkeypatch.setattr(
-        ha_query.sys,
-        "argv",
-        ["ha_query.py", "--ha-url", "http://ha", "--ha-token", "t", "question"],
-    )
-    monkeypatch.setattr(ha_query.shutil, "which", lambda _: "/usr/bin/gemini")
-    monkeypatch.setattr(ha_query, "run_gemini_query", lambda *a, **kw: ("answer", 0))
+@pytest.mark.parametrize(("agent", "func_name"), AGENTS)
+def test_main_exits_zero_on_success(agent, func_name, monkeypatch, capsys):
+    monkeypatch.setattr(ha_query.sys, "argv", _fake_argv(agent))
+    monkeypatch.setattr(ha_query.shutil, "which", lambda _: f"/usr/bin/{agent}")
+    monkeypatch.setattr(ha_query, func_name, lambda *a, **kw: ("answer", 0))
 
     ha_query.main()
 

--- a/tests/src/unit/test_ruff_scope_covers_the_tree.py
+++ b/tests/src/unit/test_ruff_scope_covers_the_tree.py
@@ -11,14 +11,31 @@ Precedent for asserting on workflow contents: ``test_triage_prompt_budget.py``.
 from __future__ import annotations
 
 import shlex
-import subprocess
 from pathlib import Path
-
-import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 PR_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "pr.yml"
 _RUFF_CHECK = "uv run ruff check "
+
+# Build/tooling directories that hold no source of ours. Anything starting with
+# a dot is skipped separately. ``worktree`` is the repo's own gitignored
+# worktree root (AGENTS.md) — it contains whole checkouts, so walking into it
+# would report the same directories over again.
+_NOT_SOURCE = frozenset(
+    {
+        "__pycache__",
+        "build",
+        "dist",
+        "eggs",
+        "htmlcov",
+        "local",
+        "node_modules",
+        "sdist",
+        "venv",
+        "wheels",
+        "worktree",
+    }
+)
 
 
 def _ruff_check_dirs() -> set[str]:
@@ -42,36 +59,54 @@ def _ruff_check_dirs() -> set[str]:
     }
 
 
-def _tracked_python_top_levels() -> set[str]:
-    """Top-level directories containing tracked ``*.py`` files."""
-    try:
-        result = subprocess.run(
-            ["git", "ls-files", "*.py"],
-            cwd=REPO_ROOT,
-            capture_output=True,
-            text=True,
-            check=True,
-        )
-    except FileNotFoundError:
-        pytest.skip("git is not installed")
+def _holds_python(directory: Path) -> bool:
+    """True if the tree under ``directory`` contains a ``.py`` file.
 
-    tops = set()
-    for line in result.stdout.splitlines():
-        parts = line.split("/")
-        # A root-level .py file has no directory argument that could cover it.
-        assert len(parts) > 1, f"root-level Python file is unlintable in CI: {line}"
-        tops.add(parts[0])
-    assert tops, "git ls-files matched no Python at all — check the invocation"
+    Walked directly rather than via ``git ls-files`` so the test does not
+    depend on git being installed, or on the checkout passing git's
+    ownership check — CI containers run as a different UID than the checkout
+    owner, which is why ``pr.yml`` re-adds ``safe.directory`` for its own git
+    calls.
+    """
+    for path in directory.rglob("*.py"):
+        if any(
+            part in _NOT_SOURCE or part.startswith(".")
+            for part in path.relative_to(directory).parts
+        ):
+            continue
+        return True
+    return False
+
+
+def _top_levels_holding_python() -> set[str]:
+    tops = {
+        entry.name
+        for entry in REPO_ROOT.iterdir()
+        if entry.is_dir()
+        and not entry.name.startswith(".")
+        and entry.name not in _NOT_SOURCE
+        and _holds_python(entry)
+    }
+    assert tops, "Found no Python anywhere in the tree — check the walk"
     return tops
 
 
 def test_ruff_check_covers_every_directory_holding_python():
-    uncovered = _tracked_python_top_levels() - _ruff_check_dirs()
+    uncovered = _top_levels_holding_python() - _ruff_check_dirs()
     assert not uncovered, (
-        "These directories contain tracked Python but are not passed to ruff in "
-        f"the 'Run ruff check' step of pr.yml: {sorted(uncovered)}. Add them "
+        "These directories contain Python but are not passed to ruff in the "
+        f"'Run ruff check' step of pr.yml: {sorted(uncovered)}. Add them "
         "there — lefthook already lints them via **/*.py, so the gap shows up "
         "only in CI."
+    )
+
+
+def test_no_root_level_python_escapes_the_directory_list():
+    """A ``.py`` file at the repo root has no directory argument covering it."""
+    root_python = [p.name for p in REPO_ROOT.glob("*.py")]
+    assert not root_python, (
+        f"Root-level Python files are not linted by CI: {sorted(root_python)}. "
+        "Move them into a directory that pr.yml passes to ruff."
     )
 
 

--- a/tests/src/unit/test_ruff_scope_covers_the_tree.py
+++ b/tests/src/unit/test_ruff_scope_covers_the_tree.py
@@ -1,0 +1,81 @@
+"""The CI ruff invocation must cover every directory that holds Python.
+
+``pr.yml`` passes ruff an explicit directory list while lefthook lints
+``**/*.py``, so a new top-level directory gets linted on commit but not in CI —
+which is exactly how ``packaging/`` went uncovered. This pins the list to the
+tree, so the next one fails here instead of going quietly unlinted.
+
+Precedent for asserting on workflow contents: ``test_triage_prompt_budget.py``.
+"""
+
+from __future__ import annotations
+
+import shlex
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+PR_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "pr.yml"
+_RUFF_CHECK = "uv run ruff check "
+
+
+def _ruff_check_dirs() -> set[str]:
+    """Path arguments of the workflow's ``uv run ruff check`` step.
+
+    Parsed as text rather than YAML so this test needs no third-party import;
+    the command is a single unbroken line in ``pr.yml``.
+    """
+    matches = [
+        line.split(_RUFF_CHECK, 1)[1]
+        for line in PR_WORKFLOW.read_text().splitlines()
+        if _RUFF_CHECK in line
+    ]
+    assert matches, f"No '{_RUFF_CHECK.strip()}' command found in {PR_WORKFLOW.name}"
+    assert len(matches) == 1, (
+        f"Expected exactly one ruff check command in {PR_WORKFLOW.name}, "
+        f"found {len(matches)} — update this test to cover them all."
+    )
+    return {
+        arg.rstrip("/") for arg in shlex.split(matches[0]) if not arg.startswith("-")
+    }
+
+
+def _tracked_python_top_levels() -> set[str]:
+    """Top-level directories containing tracked ``*.py`` files."""
+    try:
+        result = subprocess.run(
+            ["git", "ls-files", "*.py"],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except FileNotFoundError:
+        pytest.skip("git is not installed")
+
+    tops = set()
+    for line in result.stdout.splitlines():
+        parts = line.split("/")
+        # A root-level .py file has no directory argument that could cover it.
+        assert len(parts) > 1, f"root-level Python file is unlintable in CI: {line}"
+        tops.add(parts[0])
+    assert tops, "git ls-files matched no Python at all — check the invocation"
+    return tops
+
+
+def test_ruff_check_covers_every_directory_holding_python():
+    uncovered = _tracked_python_top_levels() - _ruff_check_dirs()
+    assert not uncovered, (
+        "These directories contain tracked Python but are not passed to ruff in "
+        f"the 'Run ruff check' step of pr.yml: {sorted(uncovered)}. Add them "
+        "there — lefthook already lints them via **/*.py, so the gap shows up "
+        "only in CI."
+    )
+
+
+def test_ruff_check_lists_no_directory_that_is_gone():
+    """A stale entry would make the step fail on a missing path."""
+    missing = [d for d in _ruff_check_dirs() if not (REPO_ROOT / d).exists()]
+    assert not missing, f"pr.yml passes ruff paths that no longer exist: {missing}"

--- a/tests/test_docker/test_docker_build.py
+++ b/tests/test_docker/test_docker_build.py
@@ -27,8 +27,10 @@ class TestDockerBuild:
             check=False,
         )
         # Exactly 1 — that is ``which`` reporting "not found". Any other
-        # non-zero code means docker never ran the command (125/126/127), which
-        # would otherwise pass as if the image were clean.
+        # non-zero code means the check never happened: 125/126 for docker
+        # failing to start the container, 127 usually for ``which`` itself
+        # being absent from the image. Those would otherwise pass as if the
+        # image were clean.
         assert result.returncode == 1, (
             f"expected `which uv` to exit 1 (not found), got {result.returncode}: "
             f"{result.stderr.strip() or result.stdout.strip()}"

--- a/tests/test_docker/test_docker_build.py
+++ b/tests/test_docker/test_docker_build.py
@@ -26,7 +26,13 @@ class TestDockerBuild:
             text=True,
             check=False,
         )
-        assert result.returncode != 0, "uv should not be in the runtime image"
+        # Exactly 1 — that is ``which`` reporting "not found". Any other
+        # non-zero code means docker never ran the command (125/126/127), which
+        # would otherwise pass as if the image were clean.
+        assert result.returncode == 1, (
+            f"expected `which uv` to exit 1 (not found), got {result.returncode}: "
+            f"{result.stderr.strip() or result.stdout.strip()}"
+        )
 
     def test_ha_mcp_command_exists(self):
         """Verify ha-mcp command is installed."""

--- a/tests/uat/stories/run_story.py
+++ b/tests/uat/stories/run_story.py
@@ -673,11 +673,12 @@ def get_git_info() -> tuple[str, str]:
             capture_output=True,
             text=True,
             cwd=str(REPO_ROOT),
-            check=False,
+            check=True,
         )
         sha = result.stdout.strip()
     except Exception:
-        # Best-effort git lookup; keep the "unknown" default if git is unavailable.
+        # Best-effort git lookup; keep the "unknown" default if git is
+        # unavailable or fails.
         pass
     try:
         result = subprocess.run(
@@ -685,11 +686,12 @@ def get_git_info() -> tuple[str, str]:
             capture_output=True,
             text=True,
             cwd=str(REPO_ROOT),
-            check=False,
+            check=True,
         )
         describe = result.stdout.strip()
     except Exception:
-        # Best-effort git lookup; keep the "unknown" default if git is unavailable.
+        # Best-effort git lookup; keep the "unknown" default if git is
+        # unavailable or fails.
         pass
     return sha, describe
 

--- a/tests/uat/stories/run_story.py
+++ b/tests/uat/stories/run_story.py
@@ -676,10 +676,11 @@ def get_git_info() -> tuple[str, str]:
             check=True,
         )
         sha = result.stdout.strip()
-    except Exception:
+    except Exception as e:
         # Best-effort git lookup; keep the "unknown" default if git is
-        # unavailable or fails.
-        pass
+        # unavailable or fails. Say so — otherwise every result row records
+        # "unknown" with no trace of why the commit identity was lost.
+        logger.warning("git rev-parse failed, recording sha=unknown: %s", e)
     try:
         result = subprocess.run(
             ["git", "describe", "--tags", "--always"],
@@ -689,10 +690,11 @@ def get_git_info() -> tuple[str, str]:
             check=True,
         )
         describe = result.stdout.strip()
-    except Exception:
+    except Exception as e:
         # Best-effort git lookup; keep the "unknown" default if git is
-        # unavailable or fails.
-        pass
+        # unavailable or fails. Say so — otherwise every result row records
+        # "unknown" with no trace of why the commit identity was lost.
+        logger.warning("git describe failed, recording describe=unknown: %s", e)
     return sha, describe
 
 

--- a/tests/uat/stories/run_story.py
+++ b/tests/uat/stories/run_story.py
@@ -679,8 +679,14 @@ def get_git_info() -> tuple[str, str]:
     except Exception as e:
         # Best-effort git lookup; keep the "unknown" default if git is
         # unavailable or fails. Say so — otherwise every result row records
-        # "unknown" with no trace of why the commit identity was lost.
-        logger.warning("git rev-parse failed, recording sha=unknown: %s", e)
+        # "unknown" with no trace of why the commit identity was lost. The
+        # reason is in git's stderr, not in str(CalledProcessError), which
+        # renders only the exit status.
+        logger.warning(
+            "git rev-parse failed, recording sha=unknown: %s %s",
+            e,
+            getattr(e, "stderr", "") or "",
+        )
     try:
         result = subprocess.run(
             ["git", "describe", "--tags", "--always"],
@@ -693,8 +699,14 @@ def get_git_info() -> tuple[str, str]:
     except Exception as e:
         # Best-effort git lookup; keep the "unknown" default if git is
         # unavailable or fails. Say so — otherwise every result row records
-        # "unknown" with no trace of why the commit identity was lost.
-        logger.warning("git describe failed, recording describe=unknown: %s", e)
+        # "unknown" with no trace of why the commit identity was lost. The
+        # reason is in git's stderr, not in str(CalledProcessError), which
+        # renders only the exit status.
+        logger.warning(
+            "git describe failed, recording describe=unknown: %s %s",
+            e,
+            getattr(e, "stderr", "") or "",
+        )
     return sha, describe
 
 

--- a/tests/uat/stories/scripts/ha_query.py
+++ b/tests/uat/stories/scripts/ha_query.py
@@ -52,8 +52,12 @@ def run_gemini_query(
     ha_token: str,
     branch: str | None = None,
     timeout: int = 120,
-) -> str:
-    """Run a query via Gemini CLI with MCP tools."""
+) -> tuple[str, int]:
+    """Run a query via Gemini CLI with MCP tools.
+
+    Returns the answer text and the CLI's exit code, so callers can tell an
+    empty answer apart from a failed query.
+    """
     workdir = Path(tempfile.mkdtemp(prefix="ha_query_gemini_"))
     try:
         cmd = mcp_server_command(branch)
@@ -103,10 +107,14 @@ def run_gemini_query(
             # Output wasn't JSON; keep the raw stdout text as-is.
             pass
 
-        if result.returncode != 0 and result.stderr:
-            output += f"\n[stderr]: {result.stderr}"
+        # Any non-zero exit is a failed query, stderr or not — a silent
+        # failure would otherwise be consumed as a real (empty) answer.
+        if result.returncode != 0:
+            output += f"\n[exit {result.returncode}]"
+            if result.stderr:
+                output += f"\n[stderr]: {result.stderr}"
 
-        return output
+        return output, result.returncode
     finally:
         shutil.rmtree(workdir, ignore_errors=True)
 
@@ -117,8 +125,12 @@ def run_claude_query(
     ha_token: str,
     branch: str | None = None,
     timeout: int = 120,
-) -> str:
-    """Run a query via Claude CLI with MCP tools."""
+) -> tuple[str, int]:
+    """Run a query via Claude CLI with MCP tools.
+
+    Returns the answer text and the CLI's exit code, so callers can tell an
+    empty answer apart from a failed query.
+    """
     cmd = mcp_server_command(branch)
     config = {
         "mcpServers": {
@@ -167,10 +179,14 @@ def run_claude_query(
         )
 
         output = result.stdout
-        if result.returncode != 0 and result.stderr:
-            output += f"\n[stderr]: {result.stderr}"
+        # Any non-zero exit is a failed query, stderr or not — a silent
+        # failure would otherwise be consumed as a real (empty) answer.
+        if result.returncode != 0:
+            output += f"\n[exit {result.returncode}]"
+            if result.stderr:
+                output += f"\n[stderr]: {result.stderr}"
 
-        return output
+        return output, result.returncode
     finally:
         config_file.unlink(missing_ok=True)
 
@@ -203,15 +219,23 @@ def main() -> None:
         sys.exit(1)
 
     if args.agent == "gemini":
-        response = run_gemini_query(
+        response, returncode = run_gemini_query(
             args.query, args.ha_url, args.ha_token, args.branch, args.timeout
         )
     else:
-        response = run_claude_query(
+        response, returncode = run_claude_query(
             args.query, args.ha_url, args.ha_token, args.branch, args.timeout
         )
 
+    # Print the answer first either way — consumers read stdout — then exit
+    # non-zero so a failed query can't be scored as a verification result.
     print(response)
+    if returncode != 0:
+        print(
+            f"Error: {args.agent} CLI exited with code {returncode}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/tests/uat/stories/scripts/ha_query.py
+++ b/tests/uat/stories/scripts/ha_query.py
@@ -17,6 +17,11 @@ Usage:
       --ha-url http://localhost:PORT --ha-token TOKEN \
       --agent gemini --branch v6.6.1 \
       "List all automations and their states."
+
+Exit status is part of the contract: 0 means the agent CLI answered, and any
+non-zero exit means the query failed and its output must not be scored as a
+verification result. The answer text is still printed to stdout either way,
+annotated with an ``[exit N]`` marker, because consumers read stdout.
 """
 
 from __future__ import annotations
@@ -32,6 +37,36 @@ from pathlib import Path
 
 SCRIPT_DIR = Path(__file__).resolve().parent
 REPO_ROOT = SCRIPT_DIR.parent.parent.parent.parent
+
+# GNU timeout(1)'s convention, so a hang is distinguishable from a CLI error.
+TIMEOUT_EXIT = 124
+
+
+def _annotate_failure(output: str, returncode: int, stderr: str = "") -> str:
+    """Mark a failed query's output so it cannot read as a real answer.
+
+    Any non-zero exit is a failed query, stderr or not. The danger is not the
+    empty answer — it is the partial one, which reads like a result and gets
+    scored as a verification outcome.
+    """
+    if returncode == 0:
+        return output
+    output += f"\n[exit {returncode}]"
+    if stderr:
+        output += f"\n[stderr]: {stderr}"
+    return output
+
+
+def _timed_out(exc: subprocess.TimeoutExpired, timeout: int) -> tuple[str, int]:
+    """Render a hung CLI in the same shape as any other failed query."""
+    partial = exc.stdout or ""
+    if isinstance(partial, bytes):
+        # POSIX attaches raw, untranslated bytes even under text=True.
+        partial = partial.decode(errors="replace")
+    return (
+        _annotate_failure(partial, TIMEOUT_EXIT, f"timed out after {timeout}s"),
+        TIMEOUT_EXIT,
+    )
 
 
 def mcp_server_command(branch: str | None) -> list[str]:
@@ -108,15 +143,12 @@ def run_gemini_query(
             # Output wasn't JSON; keep the raw stdout text as-is.
             pass
 
-        # Any non-zero exit is a failed query, stderr or not. The danger is
-        # not the empty answer — it is the partial one, which reads like a
-        # real result and gets scored as a verification outcome.
-        if result.returncode != 0:
-            output += f"\n[exit {result.returncode}]"
-            if result.stderr:
-                output += f"\n[stderr]: {result.stderr}"
-
-        return output, result.returncode
+        return (
+            _annotate_failure(output, result.returncode, result.stderr),
+            result.returncode,
+        )
+    except subprocess.TimeoutExpired as exc:
+        return _timed_out(exc, timeout)
     finally:
         shutil.rmtree(workdir, ignore_errors=True)
 
@@ -181,16 +213,12 @@ def run_claude_query(
             check=False,
         )
 
-        output = result.stdout
-        # Any non-zero exit is a failed query, stderr or not. The danger is
-        # not the empty answer — it is the partial one, which reads like a
-        # real result and gets scored as a verification outcome.
-        if result.returncode != 0:
-            output += f"\n[exit {result.returncode}]"
-            if result.stderr:
-                output += f"\n[stderr]: {result.stderr}"
-
-        return output, result.returncode
+        return (
+            _annotate_failure(result.stdout, result.returncode, result.stderr),
+            result.returncode,
+        )
+    except subprocess.TimeoutExpired as exc:
+        return _timed_out(exc, timeout)
     finally:
         config_file.unlink(missing_ok=True)
 

--- a/tests/uat/stories/scripts/ha_query.py
+++ b/tests/uat/stories/scripts/ha_query.py
@@ -55,8 +55,9 @@ def run_gemini_query(
 ) -> tuple[str, int]:
     """Run a query via Gemini CLI with MCP tools.
 
-    Returns the answer text and the CLI's exit code, so callers can tell an
-    empty answer apart from a failed query.
+    Returns the answer text and the CLI's exit code, so callers can tell a
+    failed query apart from a real answer — the text alone cannot, since a
+    failing CLI may still have printed a partial one.
     """
     workdir = Path(tempfile.mkdtemp(prefix="ha_query_gemini_"))
     try:
@@ -107,8 +108,9 @@ def run_gemini_query(
             # Output wasn't JSON; keep the raw stdout text as-is.
             pass
 
-        # Any non-zero exit is a failed query, stderr or not — a silent
-        # failure would otherwise be consumed as a real (empty) answer.
+        # Any non-zero exit is a failed query, stderr or not. The danger is
+        # not the empty answer — it is the partial one, which reads like a
+        # real result and gets scored as a verification outcome.
         if result.returncode != 0:
             output += f"\n[exit {result.returncode}]"
             if result.stderr:
@@ -128,8 +130,9 @@ def run_claude_query(
 ) -> tuple[str, int]:
     """Run a query via Claude CLI with MCP tools.
 
-    Returns the answer text and the CLI's exit code, so callers can tell an
-    empty answer apart from a failed query.
+    Returns the answer text and the CLI's exit code, so callers can tell a
+    failed query apart from a real answer — the text alone cannot, since a
+    failing CLI may still have printed a partial one.
     """
     cmd = mcp_server_command(branch)
     config = {
@@ -179,8 +182,9 @@ def run_claude_query(
         )
 
         output = result.stdout
-        # Any non-zero exit is a failed query, stderr or not — a silent
-        # failure would otherwise be consumed as a real (empty) answer.
+        # Any non-zero exit is a failed query, stderr or not. The danger is
+        # not the empty answer — it is the partial one, which reads like a
+        # real result and gets scored as a verification outcome.
         if result.returncode != 0:
             output += f"\n[exit {result.returncode}]"
             if result.stderr:

--- a/tests/uat/stories/test_stories.py
+++ b/tests/uat/stories/test_stories.py
@@ -137,6 +137,7 @@ def _run_bat_scenario(scenario: dict, agent: str, ha_url: str, ha_token: str) ->
             f"Stdout: {result.stdout[-1000:]}\n"
             f"Stderr: {result.stderr[-2000:]}"
         )
+        return None  # py/mixed-returns: unreachable, pytest.fail always raises
 
 
 def _evaluate_result(story: dict, result: dict, agent: str) -> None:

--- a/tests/uat/stories/test_stories.py
+++ b/tests/uat/stories/test_stories.py
@@ -144,8 +144,10 @@ def _evaluate_result(story: dict, result: dict, agent: str) -> None:
     """Evaluate BAT results against story expectations."""
     agent_result = result.get("agents", {}).get(agent, {})
 
-    if not agent_result.get("available", False):
-        pytest.skip(f"Agent '{agent}' not available")
+    # No "agent unavailable" skip here: the caller resolved the agent through
+    # shutil.which before running, and run_uat exits non-zero (now a failure,
+    # above) when the single agent it was asked for is missing. An exit-0 run
+    # therefore cannot report the agent as unavailable.
 
     # Basic pass: agent completed without errors
     all_passed = agent_result.get("all_passed", False)

--- a/tests/uat/stories/test_stories.py
+++ b/tests/uat/stories/test_stories.py
@@ -118,16 +118,25 @@ def _run_bat_scenario(scenario: dict, agent: str, ha_url: str, ha_token: str) ->
     )
 
     if result.returncode != 0:
-        logger.error(f"BAT runner failed: {result.stderr}")
+        # run_uat.py exits 1 without emitting JSON when the agent CLI it was
+        # asked for isn't installed. That is the only non-zero exit that means
+        # "unavailable" rather than "broken", so it keeps the skip path.
+        if "No agents available" in result.stderr:
+            return {"agents": {agent: {"available": False, "all_passed": False}}}
+        pytest.fail(
+            f"BAT runner exited {result.returncode}.\n"
+            f"Stderr: {result.stderr[-2000:]}\n"
+            f"Stdout: {result.stdout[-1000:]}"
+        )
 
     try:
         return json.loads(result.stdout)
     except json.JSONDecodeError:
-        return {
-            "agents": {agent: {"available": False, "all_passed": False}},
-            "raw_stdout": result.stdout,
-            "raw_stderr": result.stderr,
-        }
+        pytest.fail(
+            f"BAT runner exited 0 but its stdout is not JSON.\n"
+            f"Stdout: {result.stdout[-1000:]}\n"
+            f"Stderr: {result.stderr[-2000:]}"
+        )
 
 
 def _evaluate_result(story: dict, result: dict, agent: str) -> None:

--- a/tests/uat/stories/test_stories.py
+++ b/tests/uat/stories/test_stories.py
@@ -118,11 +118,11 @@ def _run_bat_scenario(scenario: dict, agent: str, ha_url: str, ha_token: str) ->
     )
 
     if result.returncode != 0:
-        # run_uat.py exits 1 without emitting JSON when the agent CLI it was
-        # asked for isn't installed. That is the only non-zero exit that means
-        # "unavailable" rather than "broken", so it keeps the skip path.
-        if "No agents available" in result.stderr:
-            return {"agents": {agent: {"available": False, "all_passed": False}}}
+        # run_uat.py never exits after emitting its summary, so a non-zero exit
+        # means no result was produced. Its one "agent unavailable" exit cannot
+        # reach us either: the caller already resolved the agent through the
+        # same shutil.which check the runner uses. So this is a broken run —
+        # surface it instead of degrading it into a skip.
         pytest.fail(
             f"BAT runner exited {result.returncode}.\n"
             f"Stderr: {result.stderr[-2000:]}\n"

--- a/tests/uat/test_openai_agent.py
+++ b/tests/uat/test_openai_agent.py
@@ -22,14 +22,22 @@ class TestArgParsing:
     """Test CLI argument parsing."""
 
     def test_missing_required_args_exits(self):
-        """Script exits with error when required args are missing."""
+        """Script exits with argparse's usage error when required args are missing."""
         result = subprocess.run(
             [sys.executable, str(AGENT_SCRIPT)],
             capture_output=True,
             text=True,
             check=False,
         )
-        assert result.returncode != 0
+        # 2 is argparse's usage-error code; any other non-zero exit means the
+        # script got past parsing and died somewhere else.
+        assert result.returncode == 2, f"stderr: {result.stderr}"
+        # The usage line names every flag, so pin the missing-argument message
+        # itself — otherwise any argparse error satisfies the flag assertions.
+        assert "the following arguments are required" in result.stderr
+        assert "--prompt" in result.stderr
+        assert "--mcp-config" in result.stderr
+        assert "--base-url" in result.stderr
 
     def test_help_flag(self):
         """Script shows help text."""

--- a/tests/uat/test_openai_agent.py
+++ b/tests/uat/test_openai_agent.py
@@ -30,7 +30,8 @@ class TestArgParsing:
             check=False,
         )
         # 2 is argparse's usage-error code; any other non-zero exit means the
-        # script got past parsing and died somewhere else.
+        # script failed somewhere other than argument validation — before it
+        # (an import or startup error) or after it.
         assert result.returncode == 2, f"stderr: {result.stderr}"
         # The usage line names every flag, so pin the missing-argument message
         # itself — otherwise any argparse error satisfies the flag assertions.

--- a/tests/uat/test_openai_agent.py
+++ b/tests/uat/test_openai_agent.py
@@ -33,12 +33,15 @@ class TestArgParsing:
         # script failed somewhere other than argument validation — before it
         # (an import or startup error) or after it.
         assert result.returncode == 2, f"stderr: {result.stderr}"
-        # The usage line names every flag, so pin the missing-argument message
-        # itself — otherwise any argparse error satisfies the flag assertions.
-        assert "the following arguments are required" in result.stderr
-        assert "--prompt" in result.stderr
-        assert "--mcp-config" in result.stderr
-        assert "--base-url" in result.stderr
+        # Match the whole missing-arguments list in one assertion. Substring
+        # checks per flag would not discriminate: the usage block above the
+        # error prints every flag either way, so dropping required=True from
+        # one of them still leaves its name in stderr — as "[--base-url URL]".
+        # argparse emits this line unwrapped, so an exact match is safe.
+        assert (
+            "the following arguments are required: "
+            "--prompt, --mcp-config, --base-url" in result.stderr
+        ), f"stderr: {result.stderr}"
 
     def test_help_flag(self):
         """Script shows help text."""


### PR DESCRIPTION
## What does this PR do?

Follow-ups from a post-merge review of #2102 (the ruff pylint-rules sweep): two lint-config gaps, plus a set of subprocess assertions the sweep touched that could pass vacuously. Verifying one of those assertions surfaced a real defect in the shipped server, fixed here too.

**Server fix**
- `Settings.model_config` declared `env_file=".env"` relative, which pydantic-settings resolves against the process's **working directory** at instantiation. That made it a second, independent dotenv read alongside the `load_dotenv` at import — and one `HAMCP_ENV_FILE` could not govern, since pydantic never looks at that variable. So launching the server from a directory holding an unrelated `.env` silently supplied values for any key matching a field name (the un-prefixed ones — `timeout`, `debug`, `log_level`, `environment`, `max_retries`, `verify_ssl` — are exactly what other projects' `.env` files carry), and pointing `HAMCP_ENV_FILE` at a custom file did not stop it. Real environment variables still won, so this only filled in values the operator had not set another way. The fallback is now resolved once at import and `model_config` gets that absolute path, so both readers agree on one file. No documented workflow relies on the cwd read: the install guides never mention `.env`, the Dockerfile's `WORKDIR /app` holds none, and the add-on passes configuration as env vars.

**Lint config**
- Scope the temporary PLC0207/PLR5501 per-file-ignore to the four exact files that need it, in both webhook-proxy trees. The `-dev` entries name where a reset-dev-from-stable run puts the two still-unfixed stable files, so the auto-opened reset PR lints clean; keeping the ignore per-file and per-rule means both rules stay live everywhere else in the `-dev` tree, which is where all new webhook-proxy code is authored under dev-first/promote-only. All four go away at the next promote.
- Add `packaging/` to the CI ruff scope in `pr.yml`. Lefthook already lints it via `**/*.py` on commit, but CI enumerates directories by hand and this one was never added. `tests/src/unit/test_ruff_scope_covers_the_tree.py` now pins that list to the tree so the next directory cannot go missing the same way (verified non-vacuous: removing `packaging/` again makes it fail by name). Also adds `maxsplit=1` to the docstring first-line split in `generate_manifest.py`, matching the sweep's pattern.

**Vacuous-pass / silent-failure hardening**
- `run_story.py::get_git_info`: `check=True` on both git lookups, and log the failure instead of a bare `pass`. The `except` exists to keep the `"unknown"` default, but with `check=False` a git that runs and exits non-zero recorded empty strings in every results row — silently.
- `test_config.py`: the credential subprocess tests could not create the missing-credentials scenario on a machine with the repo's documented `.env` — `config.py` loads it by absolute path, so popping the variables from the child environment is not enough (an *existing but empty* `HAMCP_ENV_FILE` is; a missing one falls back to `.env`). Adds a `child_env` fixture used across the class. The assertions now anchor on the dynamic `"  - VAR"` missing-list entries: both reachable startup banners name both variables, so the bare-name matches proved nothing, and the two single-variable tests were green for the wrong reason.
- `test_docker_build.py::test_uv_not_in_runtime`: assert exit code 1 (`which` not-found) instead of any non-zero — a container that never started (125/126) or a missing `which` (127) previously passed as "uv absent".
- `test_openai_agent.py::test_missing_required_args_exits`: assert argparse's exit 2 and match the whole `the following arguments are required: --prompt, --mcp-config, --base-url` list. A bare non-zero exit also matches a post-parsing traceback, and per-flag substring checks match the usage block above the error — which names every flag whether required or not, so dropping `required=True` from one would not have been caught.
- `test_stories.py::_run_bat_scenario`: a runner crash now fails the test with the captured output instead of converting into `pytest.skip("Agent not available")`. Exit 0 with non-JSON stdout fails too.
- `ha_query.py`: a query CLI exiting non-zero is now a failure regardless of stderr — previously a failure with empty stderr was consumed as a real answer by the story-verification leg, and the dangerous case is the *partial* answer, which reads like a result and gets scored. The answer text still prints to stdout unchanged; the script then exits 1. `tests/src/unit/test_ha_query_exit_contract.py` pins the `(text, exit_code)` contract and the exit status of `main()`.
- `/bat-story-eval` SKILL.md + evaluation-protocol.md: the only consumer of `ha_query.py` defined three outcomes (confirmed / denied / unclear) and no failure state, which would have mapped the new non-zero exit straight back onto a scored "unclear".

## Type of change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [x] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent — not applicable, no LLM-facing tool behavior changed
- [x] All automated tests pass (`uv run pytest`) — with one scope caveat, below
- [x] Code follows style guidelines (`uv run ruff check`) — `ruff check` over the full CI directory list including the newly added `packaging/`, plus `ruff format --check` on all touched files

CI covers the server fix and its regression test, the changes to `test_config.py` and `test_docker_build.py` (Unit Tests / Docker & Add-on Validation), and both new unit test files, which were also run locally.

The remaining edits — `test_openai_agent.py`, `test_stories.py`, `run_story.py`, `ha_query.py` — live under `tests/uat/`, which **no workflow runs**. That is why the `ha_query.py` contract is pinned from `tests/src/unit/` rather than beside the script: placed there it actually gates. The three `tests/uat/` assertion changes themselves remain unexecuted, verified by reading against their targets (`openai_agent.py`'s three `required=True` flags; `run_uat.py` never exiting after it emits its JSON summary).

## Checklist
- [x] I have updated documentation if needed
