### PR TITLE
feat: add MCP Prompts layer (safety, troubleshooting, automation, status, security)

### DIFF
--- a/src/ha_mcp/prompts/__init__.py
+++ b/src/ha_mcp/prompts/__init__.py
@@ -1,0 +1,33 @@
+"""MCP Prompts layer for Home Assistant.
+
+Provides reusable, parameterized prompts that guide LLMs through
+structured workflows for safety, troubleshooting, automation,
+status checks, and security-sensitive operations.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from fastmcp import FastMCP
+
+from .automation import register_automation_prompts
+from .safety import register_safety_prompts
+from .security import register_security_prompts
+from .status import register_status_prompts
+from .troubleshooting import register_troubleshooting_prompts
+
+logger = logging.getLogger(__name__)
+
+
+def register_all_prompts(mcp: FastMCP) -> None:
+    """Register all prompt modules with the MCP server."""
+    register_safety_prompts(mcp)
+    register_troubleshooting_prompts(mcp)
+    register_automation_prompts(mcp)
+    register_status_prompts(mcp)
+    register_security_prompts(mcp)
+    logger.info(
+        "Registered MCP prompt modules "
+        "(safety, troubleshooting, automation, status, security)"
+    )

--- a/src/ha_mcp/prompts/automation.py
+++ b/src/ha_mcp/prompts/automation.py
@@ -1,0 +1,62 @@
+"""Automation workflow prompts — guided creation, review, and validation flows."""
+
+from __future__ import annotations
+
+from fastmcp import FastMCP
+
+
+def register_automation_prompts(mcp: FastMCP) -> None:
+    """Register automation creation and review prompts."""
+
+    @mcp.prompt()
+    async def create_automation(description: str) -> str:
+        """Full automation creation workflow: discover entities → draft YAML → validate → reload."""
+        text = (
+            f"Creating automation: **{description}**\n\n"
+            "**Step 1 — Entity Discovery**\n"
+            "Before writing any YAML, find all relevant entities:\n"
+            "- Use `ha_search_entities` to find entities by room or device type\n"
+            "- Confirm entity_ids exist and are not `unavailable`\n"
+            "- Prefer `entity_id` over `device_id` in all triggers and actions\n\n"
+            "**Step 2 — YAML Draft (conventions)**\n"
+            "Write the automation YAML following these rules:\n"
+            "- `mode`: restart for motion/timeout, queued for sequential, single for one-shot\n"
+            "- `continue_on_error: true` on all non-critical action steps\n"
+            "- Native constructs first (numeric_state, time conditions) before Jinja2 templates\n"
+            "- Use `script.smart_announcement_universal_notifier` for any announcements\n"
+            "- Ask if a room-hold boolean should gate the automation\n\n"
+            "**Step 3 — Show YAML and Get Confirmation**\n"
+            "Present the full YAML to the user. Wait for explicit approval before writing.\n\n"
+            "**Step 4 — Apply and Validate**\n"
+            "Call `ha_config_set_automation` with the approved YAML.\n"
+            "Then call `ha_check_config` — abort and show errors if validation fails.\n\n"
+            "**Step 5 — Reload**\n"
+            "Call `ha_reload_config` (automations domain). Confirm the automation appears in HA."
+        )
+        return text
+
+    @mcp.prompt()
+    async def review_automation(automation_id: str) -> str:
+        """Review an existing automation: read config + traces → check against conventions."""
+        text = (
+            f"Reviewing automation: `{automation_id}`\n\n"
+            "**Step 1 — Read Current Config**\n"
+            f"Call `ha_config_get_automation` with automation_id=`{automation_id}`.\n"
+            "Store the full YAML for analysis.\n\n"
+            "**Step 2 — Check Recent Traces**\n"
+            f"Call `ha_get_automation_traces` with automation_id=`{automation_id}`, limit=3.\n"
+            "Note: did it run as expected? Any errors?\n\n"
+            "**Step 3 — Convention Checklist**\n"
+            "Review the YAML against these rules:\n"
+            "- [ ] `mode` is explicitly set and appropriate\n"
+            "- [ ] `continue_on_error: true` on non-critical steps\n"
+            "- [ ] No `device_id` in triggers/actions (except Z2M device triggers)\n"
+            "- [ ] No `wait_template` where `wait_for_trigger` would be better\n"
+            "- [ ] TTS routed through `script.smart_announcement_universal_notifier`\n"
+            "- [ ] Tuya entities use `tuya_local` domain, not `tuya` cloud\n"
+            "- [ ] Motion lights use `mode: restart` not `mode: single`\n\n"
+            "**Step 4 — Report**\n"
+            "List: issues found / conventions violated / suggested improvements. "
+            "Show the corrected YAML only if changes are needed."
+        )
+        return text

--- a/src/ha_mcp/prompts/safety.py
+++ b/src/ha_mcp/prompts/safety.py
@@ -1,0 +1,83 @@
+"""Safety prompts — guard rails before executing dangerous, bulk, or irreversible actions.
+
+Enforces read-before-write, quiet-hours awareness, and bulk-action confirmation
+to prevent accidental HA state changes.
+"""
+
+from __future__ import annotations
+
+from fastmcp import FastMCP
+
+
+def register_safety_prompts(mcp: FastMCP) -> None:
+    """Register safety-guard prompts."""
+
+    @mcp.prompt()
+    async def confirm_action(action: str, entity_id: str) -> str:
+        """Read current state and confirm before executing any write or delete action."""
+        text = (
+            f"You are about to execute **{action}** on `{entity_id}`.\n\n"
+            "**SAFETY PROTOCOL — complete every step in order:**\n\n"
+            f"1. **Read current state** — call `ha_get_entity` with entity_id=`{entity_id}` "
+            "and note: state, friendly_name, available/unavailable.\n"
+            f"2. **Verify** — does `{action}` make sense given the current state?\n"
+            "3. **Side-effects** — will this affect other entities or automations? "
+            "(e.g. turning off a light: is someone in the room?)\n"
+            "4. **Destructive check** — if this action deletes or resets data, "
+            "present a one-sentence summary to the user and wait for explicit confirmation.\n"
+            f"5. **Execute** — only after steps 1–4 pass, proceed with `{action}` on `{entity_id}`.\n\n"
+            "Do NOT skip the state-read step. Skipping it has caused unintended overrides before."
+        )
+        return text
+
+    @mcp.prompt()
+    async def quiet_hours_check(entity_id: str, purpose: str) -> str:
+        """Before triggering TTS, announcements, or lights — check quiet hours and occupancy."""
+        text = (
+            f"Before triggering `{entity_id}` for **{purpose}**:\n\n"
+            "**Quiet-Hours Protocol:**\n\n"
+            "1. **Check time** — get `sensor.time` or evaluate `now().hour`.\n"
+            "   - Quiet hours: **22:00–07:00**. If active, skip to step 3.\n"
+            "2. **Check occupancy** — are any family members sleeping in nearby rooms?\n"
+            "   - Check: `binary_sensor.*_occupancy` or `person.*` states.\n"
+            "3. **Route accordingly:**\n"
+            "   - Normal hours + no sleeping: proceed with `script.smart_announcement_universal_notifier`\n"
+            "   - Quiet hours + non-urgent: use silent mobile push only "
+            "(`notify.mobile_app_sharon_mobile` or `notify.parentsmobile`)\n"
+            "   - Emergency (fire, intrusion, flood): use `script.emergency_alert_all_channels` "
+            "(bypasses DND, max volume)\n\n"
+            "Never call TTS directly. Always route through the Universal Notifier unless emergency."
+        )
+        return text
+
+    @mcp.prompt()
+    async def read_before_write(entity_id: str) -> str:
+        """Read current entity state and config before modifying anything."""
+        text = (
+            f"Before modifying `{entity_id}`:\n\n"
+            "**Read-Before-Write Checklist:**\n\n"
+            f"1. Call `ha_get_entity` with entity_id=`{entity_id}` — record: state, attributes, last_changed.\n"
+            "2. If modifying automation/script config: call `ha_config_get_automation` or "
+            "`ha_config_get_script` to get the current YAML.\n"
+            "3. Show the current state/config to the user before presenting your proposed change.\n"
+            "4. Only after user confirms the diff, apply the change.\n\n"
+            "This prevents overwriting recent manual edits made directly in the HA UI."
+        )
+        return text
+
+    @mcp.prompt()
+    async def bulk_action_review(entities: str, action: str) -> str:
+        """Guard rail before executing the same action across multiple entities."""
+        text = (
+            f"You are about to execute **{action}** on multiple entities:\n`{entities}`\n\n"
+            "**Bulk Action Review Protocol:**\n\n"
+            "1. **Count** — how many entities are targeted? List them explicitly.\n"
+            "2. **Sample-check** — read the current state of the first 3 entities with `ha_get_state`.\n"
+            "3. **Confirm intent** — present the full entity list and proposed action to the user.\n"
+            f"   Ask: *'Confirm: run {action} on all N entities above?'*\n"
+            "4. **Execute sequentially** — do NOT fire all service calls in parallel; "
+            "use one call at a time and log any failures.\n"
+            "5. **Report** — after completion, summarize: succeeded / failed / skipped.\n\n"
+            "Bulk actions on the wrong entity set have caused widespread unintended state changes."
+        )
+        return text

--- a/src/ha_mcp/prompts/security.py
+++ b/src/ha_mcp/prompts/security.py
@@ -1,0 +1,64 @@
+"""Security prompts — lock and alarm workflows with explicit confirmation steps."""
+
+from __future__ import annotations
+
+from fastmcp import FastMCP
+
+
+def register_security_prompts(mcp: FastMCP) -> None:
+    """Register lock and alarm security workflow prompts."""
+
+    @mcp.prompt()
+    async def lock_workflow(entity_id: str, action: str) -> str:
+        """Safe lock/unlock workflow with state verification and explicit confirmation."""
+        text = (
+            f"**Lock Workflow: {action} on `{entity_id}`**\n\n"
+            "**Step 1 — Verify Entity**\n"
+            f"Call `ha_get_entity` with entity_id=`{entity_id}`.\n"
+            "Confirm: domain is `lock`, entity is not `unavailable`.\n\n"
+            "**Step 2 — Read Current State**\n"
+            "Record current state: `locked` / `unlocked` / `jammed` / `locking` / `unlocking`.\n"
+            f"If already in target state: report 'already {action}ed, no action needed.'\n\n"
+            "**Step 3 — Confirm with User**\n"
+            f"Present: 'Lock `{entity_id}` is currently [state]. Confirm: {action} it?'\n"
+            "Wait for explicit user confirmation before proceeding.\n\n"
+            "**Step 4 — Execute**\n"
+            f"Call `lock.{action}` service with entity_id=`{entity_id}`.\n\n"
+            "**Step 5 — Verify**\n"
+            "Wait 3 seconds, then call `ha_get_entity` again.\n"
+            f"Confirm state changed to `{action}ed`. If not, report failure and check error logs."
+        )
+        return text
+
+    @mcp.prompt()
+    async def alarm_workflow(
+        entity_id: str, action: str, code: str = ""
+    ) -> str:
+        """Safe alarm control panel workflow with code validation and explicit confirmation."""
+        code_note = (
+            f"Code `{code}` provided. Verify it matches `code_arm_required` attribute before use."
+            if code
+            else "**No code provided.** Check `code_arm_required` attribute — if True, a code is mandatory."
+        )
+        text = (
+            f"**Alarm Workflow: {action} on `{entity_id}`**\n\n"
+            "**Step 1 — Verify Panel**\n"
+            f"Call `ha_get_entity` with entity_id=`{entity_id}`.\n"
+            "Confirm: domain is `alarm_control_panel`, entity is not `unavailable`.\n"
+            "Record attributes: `code_arm_required`, `changed_by`, current state.\n\n"
+            "**Step 2 — Code Check**\n"
+            f"{code_note}\n\n"
+            "**Step 3 — Validate Action**\n"
+            "Valid actions: `arm_home`, `arm_away`, `arm_night`, `arm_vacation`, `disarm`.\n"
+            f"Check if `{action}` is valid from the current panel state.\n\n"
+            "**Step 4 — Explicit User Confirmation**\n"
+            f"Present: 'Alarm `{entity_id}` is [state]. Confirm: {action}?'\n"
+            "For `disarm`: also ask 'Is this intentional? The system will be unprotected.'\n"
+            "Wait for user confirmation.\n\n"
+            "**Step 5 — Execute**\n"
+            f"Call `alarm_control_panel.{action}` with entity_id=`{entity_id}`"
+            + (f" and code=`{code}`" if code else "") + ".\n\n"
+            "**Step 6 — Verify**\n"
+            "Wait 5 seconds, confirm panel transitioned to expected state. Report result."
+        )
+        return text

--- a/src/ha_mcp/prompts/status.py
+++ b/src/ha_mcp/prompts/status.py
@@ -1,0 +1,60 @@
+"""Status prompts — system overview, health checks, and area-level status reports."""
+
+from __future__ import annotations
+
+from fastmcp import FastMCP
+
+
+def register_status_prompts(mcp: FastMCP) -> None:
+    """Register system and area status prompts."""
+
+    @mcp.prompt()
+    async def system_status() -> str:
+        """Full system health overview: entities → updates → errors → recommendations."""
+        text = (
+            "**Home Assistant System Status Check**\n\n"
+            "Run these steps in order and compile a summary report:\n\n"
+            "**1. Overview**\n"
+            "Call `ha_get_system_info` — record HA version, uptime, location name.\n\n"
+            "**2. Unavailable Entities**\n"
+            "Call `ha_search_entities` with query='unavailable' or use `ha_get_state` in bulk.\n"
+            "List all entities with state=`unavailable` or `unknown` grouped by integration.\n\n"
+            "**3. Pending Updates**\n"
+            "Call `ha_get_updates` — list HA core, OS, supervisor, and HACS updates pending.\n\n"
+            "**4. Recent Errors**\n"
+            "Call `ha_get_logs` with level=ERROR, limit=20.\n"
+            "Group by source component. Highlight anything firing >10 times.\n\n"
+            "**5. Report**\n"
+            "Present a structured summary:\n"
+            "- System: version / uptime\n"
+            "- Unavailable: N entities (list top offenders)\n"
+            "- Updates: N pending\n"
+            "- Errors: top 3 recurring issues with suggested action\n"
+            "- Overall health: ✅ Green / ⚠️ Yellow / ❌ Red"
+        )
+        return text
+
+    @mcp.prompt()
+    async def area_status(area_name: str) -> str:
+        """Deep-dive status for a single area: all devices, entities, and active automations."""
+        text = (
+            f"**Area Status: {area_name}**\n\n"
+            "**Step 1 — Entity Inventory**\n"
+            f"Call `ha_search_entities` with query=`{area_name}` or use area registry tools.\n"
+            f"List all entities in `{area_name}` grouped by domain "
+            "(lights, sensors, switches, climate, media_player).\n\n"
+            "**Step 2 — Current States**\n"
+            "For each entity found: call `ha_get_state` and note current value.\n"
+            "Flag any that are `unavailable` or `unknown`.\n\n"
+            "**Step 3 — Active Automations**\n"
+            f"Search for automations referencing `{area_name.lower()}` via `ha_deep_search`.\n"
+            "List which are enabled vs disabled.\n\n"
+            "**Step 4 — Summary**\n"
+            f"Report for {area_name}:\n"
+            "- Lights: on/off count\n"
+            "- Climate: current temp / setpoint\n"
+            "- Sensors: motion / occupancy state\n"
+            "- Issues: unavailable devices\n"
+            "- Automations: active count"
+        )
+        return text

--- a/src/ha_mcp/prompts/troubleshooting.py
+++ b/src/ha_mcp/prompts/troubleshooting.py
@@ -1,0 +1,61 @@
+"""Troubleshooting prompts — structured diagnostic chains for broken automations and entities.
+
+Chains ha_get_automation_traces → ha_get_logs → ha_get_state for root-cause analysis.
+"""
+
+from __future__ import annotations
+
+from fastmcp import FastMCP
+
+
+def register_troubleshooting_prompts(mcp: FastMCP) -> None:
+    """Register troubleshooting diagnostic prompts."""
+
+    @mcp.prompt()
+    async def diagnose_automation(automation_id: str) -> str:
+        """Structured diagnostic chain: traces → logs → entity states → root cause."""
+        text = (
+            f"Diagnosing automation: `{automation_id}`\n\n"
+            "**Step 1 — Execution Traces**\n"
+            f"Call `ha_get_automation_traces` with automation_id=`{automation_id}`, limit=5.\n"
+            "Look for:\n"
+            "- Last run timestamp and trigger that fired\n"
+            "- Which step failed (error message, condition that blocked)\n"
+            "- Whether it ran at all (if not: trigger never fired)\n\n"
+            "**Step 2 — Error Logs**\n"
+            f"Call `ha_get_logs` with search=`{automation_id}`, level=ERROR, limit=20.\n"
+            "Also search for any entity_ids referenced in the automation.\n\n"
+            "**Step 3 — Entity States**\n"
+            "For every entity referenced in the automation:\n"
+            "- Call `ha_get_entity` — check if state is `unavailable` or `unknown`\n"
+            "- Note last_changed vs expected trigger time\n\n"
+            "**Step 4 — Root Cause Summary**\n"
+            "Based on steps 1–3, identify: trigger issue / condition blocking / "
+            "entity unavailable / service call failure / YAML error. "
+            "Report the specific cause and the fix needed."
+        )
+        return text
+
+    @mcp.prompt()
+    async def diagnose_entity(entity_id: str) -> str:
+        """Diagnose why an entity is unavailable, unknown, or behaving unexpectedly."""
+        text = (
+            f"Diagnosing entity: `{entity_id}`\n\n"
+            "**Step 1 — Current State**\n"
+            f"Call `ha_get_entity` with entity_id=`{entity_id}`.\n"
+            "Record: state, attributes, last_changed, last_updated, device_class, integration.\n\n"
+            "**Step 2 — Integration Logs**\n"
+            "Extract the integration name from the entity_id prefix (e.g. `tuya_local`, `zigbee2mqtt`).\n"
+            f"Call `ha_get_logs` with search=`{entity_id}`, level=WARNING, limit=30.\n"
+            "Also search by integration name.\n\n"
+            "**Step 3 — Device Registry**\n"
+            "If unavailable: check if the parent device is reachable.\n"
+            "For Tuya devices: prefer `tuya_local` entity over `tuya` cloud entity.\n"
+            "For Zigbee: check Z2M bridge state (`sensor.zigbee2mqtt_bridge_state`).\n\n"
+            "**Step 4 — Fix Path**\n"
+            "- `unavailable`: device offline → check network/power\n"
+            "- `unknown`: integration restarting → wait or reload integration\n"
+            "- Wrong value: calibration or unit issue → check device attributes\n"
+            "- Missing entity: check entity registry, may need re-pairing"
+        )
+        return text

--- a/src/ha_mcp/server.py
+++ b/src/ha_mcp/server.py
@@ -194,6 +194,9 @@ class HomeAssistantSmartMCPServer:
         # Register tools
         self.tools_registry.register_all_tools()
 
+        # Register MCP prompts (safety, troubleshooting, automation, status, security)
+        self._initialize_prompts()
+
         # Register bundled skills as MCP resources
         self._register_skills()
 
@@ -284,6 +287,30 @@ class HomeAssistantSmartMCPServer:
         # so it is innermost: its result scan sees the raw tool output before
         # any other middleware transforms it.
         self._apply_visibility_outbound_middleware()
+
+    def _initialize_prompts(self) -> None:
+        """Register all MCP prompt modules with the server.
+
+        Prompts are reusable, parameterized conversation-starters that guide
+        LLMs through structured workflows: safety guards, troubleshooting
+        chains, automation creation, status reports, and security-sensitive
+        operations.
+
+        Failures are logged and swallowed: prompts are additive guidance, so a
+        broken prompt module must never take the tool surface down with it.
+        """
+        try:
+            from .prompts import register_all_prompts
+
+            register_all_prompts(self.mcp)
+            logger.info(
+                "Registered MCP prompts "
+                "(safety, troubleshooting, automation, status, security)"
+            )
+        except Exception:
+            logger.exception(
+                "Failed to register MCP prompts — server will start without prompts"
+            )
 
     def _get_skills_dir(self) -> Path | None:
         """Return the bundled skills directory if it exists.

--- a/tests/src/unit/test_prompts_registration.py
+++ b/tests/src/unit/test_prompts_registration.py
@@ -1,0 +1,83 @@
+"""Unit tests for the MCP prompts layer.
+
+Two contracts are locked here.
+
+**Every module reaches the server.** ``register_all_prompts`` is the single
+entry point ``HomeAssistantSmartMCPServer._initialize_prompts`` calls, and that
+call is wrapped in a ``try/except`` that logs and continues — a prompt module
+that stopped registering would therefore fail silently in production. The count
+check is what makes that failure loud here instead.
+
+**Every prompt still renders.** This is a regression test for a real break: the
+prompts were originally written against an older FastMCP that accepted a
+``list[PromptMessage]`` return. FastMCP 3.4.4 rejects it at *render* time with
+``messages[0] must be Message or str, got PromptMessage`` — so registration and
+``list_prompts`` both kept passing while every actual invocation raised. Only
+rendering catches it, which is why each prompt is rendered rather than merely
+counted.
+"""
+
+import pytest
+from fastmcp import FastMCP
+
+from ha_mcp.prompts import register_all_prompts
+
+# Minimal valid arguments per prompt. Keyed by name so an added prompt that is
+# not listed here fails ``test_every_prompt_renders_a_user_message`` by KeyError
+# rather than being silently skipped.
+PROMPT_ARGUMENTS: dict[str, dict[str, str]] = {
+    "confirm_action": {"action": "turn_off", "entity_id": "light.kitchen"},
+    "quiet_hours_check": {"entity_id": "light.kitchen", "purpose": "cleaning"},
+    "read_before_write": {"entity_id": "light.kitchen"},
+    "bulk_action_review": {"entities": "light.a, light.b", "action": "turn_off"},
+    "diagnose_automation": {"automation_id": "automation.morning"},
+    "diagnose_entity": {"entity_id": "light.kitchen"},
+    "create_automation": {"description": "turn on lights at sunset"},
+    "review_automation": {"automation_id": "automation.morning"},
+    "system_status": {},
+    "area_status": {"area_name": "kitchen"},
+    "lock_workflow": {"entity_id": "lock.front_door", "action": "lock"},
+    "alarm_workflow": {"entity_id": "alarm_control_panel.home", "action": "arm", "code": "1234"},
+}
+
+
+@pytest.fixture
+def server() -> FastMCP:
+    mcp = FastMCP("test-prompts")
+    register_all_prompts(mcp)
+    return mcp
+
+
+@pytest.mark.asyncio
+async def test_all_prompt_modules_register(server: FastMCP) -> None:
+    """Every prompt across the five modules is registered exactly once."""
+    registered = {prompt.name for prompt in await server.list_prompts()}
+    assert registered == set(PROMPT_ARGUMENTS), (
+        "prompt registration drifted from the expected set — a module either "
+        "stopped registering (silently swallowed by _initialize_prompts) or a "
+        "new prompt was added without arguments in PROMPT_ARGUMENTS"
+    )
+
+
+@pytest.mark.asyncio
+async def test_every_prompt_renders_a_user_message(server: FastMCP) -> None:
+    """Rendering is what catches an unsupported return type, not registration."""
+    for prompt in await server.list_prompts():
+        result = await server.render_prompt(prompt.name, PROMPT_ARGUMENTS[prompt.name])
+
+        assert len(result.messages) == 1, f"{prompt.name} should yield one message"
+        message = result.messages[0]
+        assert message.role == "user", f"{prompt.name} should address the user"
+        assert message.content.text.strip(), f"{prompt.name} rendered empty text"
+
+
+@pytest.mark.asyncio
+async def test_prompt_arguments_are_interpolated(server: FastMCP) -> None:
+    """A prompt echoes its arguments, so callers get entity-specific guidance."""
+    result = await server.render_prompt(
+        "confirm_action", {"action": "turn_off", "entity_id": "light.kitchen"}
+    )
+
+    text = result.messages[0].content.text
+    assert "turn_off" in text
+    assert "light.kitchen" in text


### PR DESCRIPTION
## Summary

Adds an MCP **Prompts** layer — 12 parameterized, reusable prompts across five modules that guide an LLM through structured Home Assistant workflows. The server currently exposes tools and skills but no prompts; this fills that surface.

| Module | Prompts |
|---|---|
| `safety.py` | `confirm_action`, `quiet_hours_check`, `read_before_write`, `bulk_action_review` |
| `troubleshooting.py` | `diagnose_automation`, `diagnose_entity` |
| `automation.py` | `create_automation`, `review_automation` |
| `status.py` | `system_status`, `area_status` |
| `security.py` | `lock_workflow`, `alarm_workflow` |

## Wiring

`_initialize_server` gains one call to a new `_initialize_prompts` hook. Registration is wrapped in `try/except` that logs and continues — prompts are additive guidance and must never take the tool surface down with them.

## Note on the return type

The prompts return their text as a plain `str` rather than a `list[PromptMessage]`. FastMCP 3.4.4 rejects the latter at *render* time (`messages[0] must be Message or str, got PromptMessage`), while registration and `list_prompts` both keep passing — so the failure is invisible until a prompt is actually invoked. `test_every_prompt_renders_a_user_message` renders all 12 for exactly that reason.

## Test plan

- [x] `tests/src/unit/test_prompts_registration.py` — 3 tests: full registration set, every prompt renders a non-empty user message, arguments are interpolated
- [x] Full unit suite: 2195 passed (3 pre-existing Windows-only path-semantics failures in `test_custom_component_filesystem.py`, identical on clean master)
- [x] `ruff check src/ tests/` clean
- [x] `mypy src/` clean (4 pre-existing Windows-only `fcntl` errors, identical on clean master)

No new tools, so no locale-parity impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)