### PR TITLE
chore: let CodeRabbit review draft PRs

### DIFF
--- a/.claude/skills/contrib-pr-review/SKILL.md
+++ b/.claude/skills/contrib-pr-review/SKILL.md
@@ -39,6 +39,10 @@ Review PR #$ARGUMENTS from external contributor for safety, quality, and readine
 # --paginate: both endpoints page at 30, and an iterating PR outruns that.
 gh api --paginate /repos/homeassistant-ai/ha-mcp/pulls/$ARGUMENTS/reviews --jq '.[] | select(.user.login == "chatgpt-codex-connector[bot]" or .user.login == "coderabbitai[bot]") | {author: .user.login, state: .state, body: .body}'
 gh api --paginate /repos/homeassistant-ai/ha-mcp/pulls/$ARGUMENTS/comments --jq '.[] | select(.user.login == "chatgpt-codex-connector[bot]" or .user.login == "coderabbitai[bot]") | {author: .user.login, path: .path, line: .line, body: .body}'
+# CodeRabbit posts its walkthrough and summary as a top-level comment, which
+# neither endpoint above returns — fetch that channel by author too.
+gh api --paginate /repos/homeassistant-ai/ha-mcp/issues/$ARGUMENTS/comments --jq '.[] | select(.user.login == "chatgpt-codex-connector[bot]" or .user.login == "coderabbitai[bot]") | {author: .user.login, body: .body}'
+# Keyword scan stays, for humans raising security concerns in conversation.
 gh pr view $ARGUMENTS --repo homeassistant-ai/ha-mcp --json comments --jq '.comments[] | select(.body | contains("security") or contains("Security")) | {author: .author.login, body: .body}'
 ```
 

--- a/.claude/skills/contrib-pr-review/SKILL.md
+++ b/.claude/skills/contrib-pr-review/SKILL.md
@@ -28,25 +28,26 @@ Review PR #$ARGUMENTS from external contributor for safety, quality, and readine
 
 ## Review Protocol
 
-### 1. Check Codex's Security Review
+### 1. Check the Bot Security Reviews
 
-**Note:** Codex reviews PRs automatically (posts as `chatgpt-codex-connector[bot]`). Check if Codex flagged any security concerns.
+**Note:** Codex (`chatgpt-codex-connector[bot]`) and CodeRabbit (`coderabbitai[bot]`) both review PRs automatically. Check whether either flagged security concerns.
 
 ```bash
-# Check Codex's reviews and any security-related comments.
-# Codex findings can be inline-only, so also fetch the pull review comments
+# Check both bots' reviews and any security-related comments.
+# Their findings can be inline-only, so also fetch the pull review comments
 # endpoint — review bodies and conversation comments alone can miss them.
-gh api /repos/homeassistant-ai/ha-mcp/pulls/$ARGUMENTS/reviews --jq '.[] | select(.user.login == "chatgpt-codex-connector[bot]") | {state: .state, body: .body}'
-gh api /repos/homeassistant-ai/ha-mcp/pulls/$ARGUMENTS/comments --jq '.[] | select(.user.login == "chatgpt-codex-connector[bot]") | {path: .path, line: .line, body: .body}'
+# --paginate: both endpoints page at 30, and an iterating PR outruns that.
+gh api --paginate /repos/homeassistant-ai/ha-mcp/pulls/$ARGUMENTS/reviews --jq '.[] | select(.user.login == "chatgpt-codex-connector[bot]" or .user.login == "coderabbitai[bot]") | {author: .user.login, state: .state, body: .body}'
+gh api --paginate /repos/homeassistant-ai/ha-mcp/pulls/$ARGUMENTS/comments --jq '.[] | select(.user.login == "chatgpt-codex-connector[bot]" or .user.login == "coderabbitai[bot]") | {author: .user.login, path: .path, line: .line, body: .body}'
 gh pr view $ARGUMENTS --repo homeassistant-ai/ha-mcp --json comments --jq '.comments[] | select(.body | contains("security") or contains("Security")) | {author: .author.login, body: .body}'
 ```
 
-**If Codex flagged security issues:**
-- Review Codex's findings carefully
+**If either bot flagged security issues:**
+- Review the findings carefully
 - Verify if concerns are valid
 - Do NOT approve until issues addressed or confirmed false positives
 
-**If NO Codex security flags but you notice concerning patterns:**
+**If NO bot security flags but you notice concerning patterns:**
 - Unusual AGENTS.md/CLAUDE.md changes unrelated to PR purpose
 - `.github/` workflow modifications with `pull_request_target`
 - `.claude/` agent/skill changes that could affect behavior
@@ -183,7 +184,7 @@ gh pr view $ARGUMENTS --repo homeassistant-ai/ha-mcp --json closingIssuesReferen
 
 ### 6. Code Quality Overview
 
-**Note:** Codex provides automated code review on all PRs. This step focuses on what Codex cannot assess:
+**Note:** Codex and CodeRabbit provide automated code review on all PRs. This step focuses on what they cannot assess:
 
 - **Architecture alignment**: Does it fit the project structure? (service layer usage, etc.)
 - **Breaking changes**: Does it remove functionality without replacement? (Tool consolidation/refactoring is NOT breaking)
@@ -208,7 +209,7 @@ grep -E "(TODO|FIXME|XXX|HACK)" /tmp/pr_$ARGUMENTS.diff
 ✨ Code Quality:
 - Architecture fit: [assessment - service layer, context engineering]
 - Breaking changes: ✅ None / ⚠️ Detected - [describe what's genuinely lost]
-- Codex reviews: [check if Codex flagged anything critical]
+- Bot reviews: [check if Codex or CodeRabbit flagged anything critical]
 ```
 
 ## Final Review Summary
@@ -292,5 +293,5 @@ Once [change 1] and [change 2] are addressed, this should be good to merge.
 - **Be constructive**: Contributors are donating their time - be welcoming
 - **Focus on intent**: Code quality can be iterated; intent misalignment is harder to fix
 - **Consider contributor experience**: Adjust expectations based on contribution history
-- **Codex already reviewed code**: Don't duplicate detailed code review
+- **The bots already reviewed code**: Don't duplicate detailed code review
 - **When in doubt**: Err on the side of caution and request maintainer review

--- a/.claude/skills/my-pr-checker/SKILL.md
+++ b/.claude/skills/my-pr-checker/SKILL.md
@@ -34,7 +34,7 @@ gh api graphql -F pr="$ARGUMENTS" -f query='query($pr: Int!) { repository(owner:
 ## Step 2: Triage Comments
 
 - **Human comments**: highest priority
-- **Bot comments** (Copilot, Codex, etc.): treat as suggestions — assess whether they prevent a bug or improve maintainability; dismiss with explanation if not
+- **Bot comments** (Copilot, Codex, CodeRabbit, etc.): treat as suggestions — assess whether they prevent a bug or improve maintainability; dismiss with explanation if not
 
 Accept if: prevents a bug, improves clarity for future maintainers, aligns with project conventions, addresses security.
 Dismiss if: incorrect suggestion, reduces readability, conflicts with project patterns, already handled elsewhere.

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -12,8 +12,8 @@ reviews:
     # 2 for busy branches. Taken anyway because running out is loud and cheap —
     # a rate-limited push gets a comment plus a deliberately-passing "Review
     # rate limited" check, never blocks merge, and neither consumes a review nor
-    # delays the next one. `@coderabbitai rate limit` reports what is left
-    # without spending a review. OSS projects sit on a 1-10/hour band that
+    # delays the next one. The `rate limit` command reports whether reviews are
+    # available without spending one. OSS projects sit on a 1-10/hour band that
     # varies with project popularity, so the real headroom here is unknown.
     auto_pause_after_reviewed_commits: 0
     # Dependency and automation PRs go unreviewed today, but nothing configured

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -16,20 +16,22 @@ reviews:
     # available without spending one. OSS projects sit on a 1-10/hour band that
     # varies with project popularity, so the real headroom here is unknown.
     auto_pause_after_reviewed_commits: 0
-    # Dependency-update PRs go unreviewed today, but nothing configured says
-    # so — `@coderabbitai configuration` reports every value as coming from
-    # defaults, so the current behaviour rests on undocumented CodeRabbit
-    # bot-author handling. Stated explicitly here so it survives a change to
-    # that handling. Exact, case-sensitive logins — no wildcards.
-    #
-    # Deliberately the same two logins as the Codex skip list in
-    # pr-codex-review-request.yml, and nothing more. github-actions[bot] is
-    # absent on purpose: that login authors the webhook-proxy promote PRs,
-    # which are reviewed today (Codex reviewed #1936/#2037, humans approved
-    # them, and #1977 folded in real fixes) and must stay reviewed.
+    # Bot-authored PRs are knowingly excluded from automatic review. Nothing
+    # configured produced today's skips — `@coderabbitai configuration`
+    # reports all defaults — so they rested on undocumented bot-author
+    # handling; stated explicitly here so they survive a change to it.
+    # dependabot/renovate PRs have never been reviewed. github-actions[bot]
+    # authors the webhook-proxy promote PRs: dev -> stable copies whose
+    # content was already reviewed in the dev PRs, so an automatic second
+    # pass duplicates it. A promote that folds in more than a version bump
+    # (the #1977 case) gets `@coderabbitai review` on demand — this key only
+    # gates auto_review. Mirrors the Codex auto-admission skip list in
+    # pr-codex-review-request.yml (pinned by test_coderabbit_config.py).
+    # Exact, case-sensitive logins — no wildcards.
     ignore_usernames:
       - "dependabot[bot]"
       - "ha-mcp-renovate[bot]"
+      - "github-actions[bot]"
 knowledge_base:
   code_guidelines:
     # AGENTS.md is auto-detected; a guideline file is scoped to its own

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+reviews:
+  auto_review:
+    drafts: true
+    # Drafts here iterate push -> CI -> fix, which blows past the default
+    # 5-commit pause and leaves the PR silently unreviewed. 0 disables the
+    # pause so review keeps running until it stops finding anything.
+    auto_pause_after_reviewed_commits: 0
+    # Dependency and automation PRs are not reviewed today, and this file must
+    # say so to keep it that way: repo YAML replaces the UI settings wholesale
+    # rather than merging with them, so an omitted ignore_usernames resolves to
+    # the schema default of [] and CodeRabbit would start reviewing every
+    # Dependabot, Renovate, and release-automation PR. Exact, case-sensitive
+    # logins — no wildcards.
+    ignore_usernames:
+      - "dependabot[bot]"
+      - "ha-mcp-renovate[bot]"
+      - "github-actions[bot]"
+knowledge_base:
+  code_guidelines:
+    # AGENTS.md is auto-detected; a guideline file is scoped to its own
+    # directory tree, so the styleguide needs an explicit applyTo to reach
+    # anything outside .gemini/. Three patterns, because minimatch defaults to
+    # dot: false and a bare ** therefore skips every dotted name: non-dot paths,
+    # dotfiles at any depth (.coderabbit.yaml, tests/.env.test), and the
+    # contents of dot-directories (.github/, .claude/, .gemini/).
+    filePatterns:
+      - files: ".gemini/styleguide.md"
+        applyTo: "**,**/.*,**/.*/**"

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -5,6 +5,16 @@ reviews:
     # Drafts here iterate push -> CI -> fix, which blows past the default
     # 5-commit pause and leaves the PR silently unreviewed. 0 disables the
     # pause so review keeps running until it stops finding anything.
+    #
+    # The documented cost, accepted deliberately: incremental reviews draw on
+    # the same per-developer hourly allowance as manual ones, and 0 "can make
+    # active branches use review allowance quickly"; CodeRabbit recommends 1 or
+    # 2 for busy branches. Taken anyway because running out is loud and cheap —
+    # a rate-limited push gets a comment plus a deliberately-passing "Review
+    # rate limited" check, never blocks merge, and neither consumes a review nor
+    # delays the next one. `@coderabbitai rate limit` reports what is left
+    # without spending a review. OSS projects sit on a 1-10/hour band that
+    # varies with project popularity, so the real headroom here is unknown.
     auto_pause_after_reviewed_commits: 0
     # Dependency and automation PRs go unreviewed today, but nothing configured
     # says so — `@coderabbitai configuration` reports every value as coming from

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -6,12 +6,11 @@ reviews:
     # 5-commit pause and leaves the PR silently unreviewed. 0 disables the
     # pause so review keeps running until it stops finding anything.
     auto_pause_after_reviewed_commits: 0
-    # Dependency and automation PRs are not reviewed today, and this file must
-    # say so to keep it that way: repo YAML replaces the UI settings wholesale
-    # rather than merging with them, so an omitted ignore_usernames resolves to
-    # the schema default of [] and CodeRabbit would start reviewing every
-    # Dependabot, Renovate, and release-automation PR. Exact, case-sensitive
-    # logins — no wildcards.
+    # Dependency and automation PRs go unreviewed today, but nothing configured
+    # says so — `@coderabbitai configuration` reports every value as coming from
+    # defaults, so the current behaviour rests on undocumented CodeRabbit
+    # bot-author handling. Stated explicitly here so it survives a change to
+    # that handling. Exact, case-sensitive logins — no wildcards.
     ignore_usernames:
       - "dependabot[bot]"
       - "ha-mcp-renovate[bot]"

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -16,15 +16,20 @@ reviews:
     # available without spending one. OSS projects sit on a 1-10/hour band that
     # varies with project popularity, so the real headroom here is unknown.
     auto_pause_after_reviewed_commits: 0
-    # Dependency and automation PRs go unreviewed today, but nothing configured
-    # says so — `@coderabbitai configuration` reports every value as coming from
+    # Dependency-update PRs go unreviewed today, but nothing configured says
+    # so — `@coderabbitai configuration` reports every value as coming from
     # defaults, so the current behaviour rests on undocumented CodeRabbit
     # bot-author handling. Stated explicitly here so it survives a change to
     # that handling. Exact, case-sensitive logins — no wildcards.
+    #
+    # Deliberately the same two logins as the Codex skip list in
+    # pr-codex-review-request.yml, and nothing more. github-actions[bot] is
+    # absent on purpose: that login authors the webhook-proxy promote PRs,
+    # which are reviewed today (Codex reviewed #1936/#2037, humans approved
+    # them, and #1977 folded in real fixes) and must stay reviewed.
     ignore_usernames:
       - "dependabot[bot]"
       - "ha-mcp-renovate[bot]"
-      - "github-actions[bot]"
 knowledge_base:
   code_guidelines:
     # AGENTS.md is auto-detected; a guideline file is scoped to its own

--- a/.github/workflows/pr-codex-review-request.yml
+++ b/.github/workflows/pr-codex-review-request.yml
@@ -24,7 +24,7 @@ jobs:
       ${{
         (github.event_name == 'pull_request_target' &&
           !contains(
-            fromJSON('["dependabot[bot]", "ha-mcp-renovate[bot]"]'),
+            fromJSON('["dependabot[bot]", "ha-mcp-renovate[bot]", "github-actions[bot]"]'),
             github.event.pull_request.user.login
           )) ||
         (github.event_name == 'issue_comment' &&

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,6 +117,15 @@ PR making it: on open-source repos CodeRabbit honours only the base branch's
 config, so the PR reports `Configuration used: defaults` and the change takes
 effect on merge.
 
+**Bot-authored PRs are excluded from automatic review by both tools** —
+Dependabot, Renovate, and the `github-actions[bot]` webhook-proxy promote PRs
+(dev → stable copies whose content was already reviewed in their dev PRs).
+Enforced in `.coderabbit.yaml` `ignore_usernames` and the `pull_request_target`
+admission list in `pr-codex-review-request.yml`, pinned to each other by
+`test_coderabbit_config.py`. A maintainer can still summon a review on a
+promote PR: `@coderabbitai review`, or `/review` for Codex — the `issue_comment`
+admission list deliberately omits `github-actions[bot]` to keep that lever.
+
 **Division of Labor:**
 - **Codex (automatic)**: Code quality, test coverage, generic security, MCP conventions
 - **CodeRabbit (automatic, drafts included)**: Line-level review against `AGENTS.md` and `.gemini/styleguide.md`, PR walkthrough and summary

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,7 +103,11 @@ at it explicitly, and the Claude review skills below apply it.
 
 **CodeRabbit** (GitHub app, posts as `coderabbitai[bot]`) reviews drafts too —
 `.coderabbit.yaml` sets `reviews.auto_review.drafts: true`, since every PR here
-opens as a draft. It auto-detects `AGENTS.md` as review criteria;
+opens as a draft, and `auto_pause_after_reviewed_commits: 0` so it keeps
+reviewing every push instead of going quiet after five. That spends the
+per-developer hourly review allowance faster; a rate-limited push says so in a
+comment and never blocks merge, and `@coderabbitai rate limit` reports what is
+left without consuming a review. It auto-detects `AGENTS.md` as review criteria;
 `.gemini/styleguide.md` is added through
 `knowledge_base.code_guidelines.filePatterns` (see the comment there). Repo YAML
 outranks the UI settings (only org/workspace Global Overrides beat it) and does

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,7 +90,7 @@ When implementing features or debugging, consult these resources:
 
 ## Issue & PR Management
 
-### Automated Code Review (Codex)
+### Automated Code Review
 
 **Codex** reviews PRs automatically (`pr-codex-review-request.yml` /
 `pr-codex-review-delivery.yml`; posts as `chatgpt-codex-connector[bot]`).
@@ -101,8 +101,21 @@ document (code quality, test coverage, security patterns, MCP conventions,
 safety annotation accuracy): the `@codex review` request comment points Codex
 at it explicitly, and the Claude review skills below apply it.
 
+**CodeRabbit** (GitHub app, posts as `coderabbitai[bot]`) reviews drafts too —
+`.coderabbit.yaml` sets `reviews.auto_review.drafts: true`, since every PR here
+opens as a draft. It auto-detects `AGENTS.md` as review criteria;
+`.gemini/styleguide.md` is added through
+`knowledge_base.code_guidelines.filePatterns` (see the comment there). Repo YAML
+outranks the UI settings (only org/workspace Global Overrides beat it) and does
+not merge with them — any key it omits falls back to CodeRabbit's schema
+defaults, not to UI values. A change to `.coderabbit.yaml` never applies to the
+PR making it: on open-source repos CodeRabbit honours only the base branch's
+config, so the PR reports `Configuration used: defaults` and the change takes
+effect on merge.
+
 **Division of Labor:**
 - **Codex (automatic)**: Code quality, test coverage, generic security, MCP conventions
+- **CodeRabbit (automatic, drafts included)**: Line-level review against `AGENTS.md` and `.gemini/styleguide.md`, PR walkthrough and summary
 - **Claude `/contrib-pr-review` (on-demand)**: Repo-specific security (AGENTS.md, .github/, .claude/), detailed test analysis, PR size assessment, issue linkage
 - **Claude `/my-pr-checker` (lifecycle)**: Resolve threads, fix issues, monitor CI, create improvement PRs
 
@@ -161,7 +174,7 @@ gh issue list --state open --json number,title,labels --jq '.[] | select(.labels
 ### PR Review Comments
 
 **Always check for comments after pushing to a PR.** They come from bots
-(Codex, Copilot) or humans. Address human comments with highest
+(Codex, CodeRabbit, Copilot) or humans. Address human comments with highest
 priority; treat bot comments as suggestions to assess, not commands.
 
 **Reply, then resolve.** After addressing an inline comment, reply on its

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,8 +123,9 @@ Dependabot, Renovate, and the `github-actions[bot]` webhook-proxy promote PRs
 Enforced in `.coderabbit.yaml` `ignore_usernames` and the `pull_request_target`
 admission list in `pr-codex-review-request.yml`, pinned to each other by
 `test_coderabbit_config.py`. A maintainer can still summon a review on a
-promote PR: `@coderabbitai review`, or `/review` for Codex — the `issue_comment`
-admission list deliberately omits `github-actions[bot]` to keep that lever.
+promote PR: `@coderabbitai review`, or for Codex a comment that is exactly
+`/review` (or `@ghhamcp review`) — the `issue_comment` admission list
+deliberately omits `github-actions[bot]` to keep that lever.
 
 **Division of Labor:**
 - **Codex (automatic)**: Code quality, test coverage, generic security, MCP conventions

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,8 +106,8 @@ at it explicitly, and the Claude review skills below apply it.
 opens as a draft, and `auto_pause_after_reviewed_commits: 0` so it keeps
 reviewing every push instead of going quiet after five. That spends the
 per-developer hourly review allowance faster; a rate-limited push says so in a
-comment and never blocks merge, and `@coderabbitai rate limit` reports what is
-left without consuming a review. It auto-detects `AGENTS.md` as review criteria;
+comment and never blocks merge, and CodeRabbit's `rate limit` command reports
+whether reviews are available without consuming one. It auto-detects `AGENTS.md` as review criteria;
 `.gemini/styleguide.md` is added through
 `knowledge_base.code_guidelines.filePatterns` (see the comment there). Repo YAML
 outranks the UI settings (only org/workspace Global Overrides beat it) and does

--- a/tests/src/unit/test_coderabbit_config.py
+++ b/tests/src/unit/test_coderabbit_config.py
@@ -43,6 +43,16 @@ BOT_AUTHORS = {
     "github-actions[bot]",
 }
 
+# The issue_comment `/review` admission list is DELIBERATELY narrower than
+# BOT_AUTHORS: github-actions[bot] must stay off it, or a maintainer loses the
+# on-demand Codex lever on promote PRs — the escape hatch the auto-exclusion
+# rationale rests on. Harmonising the two lists would read as tidying while
+# quietly turning "excluded from automatic review" into "not reviewed at all".
+COMMENT_PATH_SKIPS = {
+    "dependabot[bot]",
+    "ha-mcp-renovate[bot]",
+}
+
 # ``applyTo`` has to keep the styleguide repo-wide, and minimatch's ``dot:
 # false`` means each class of path needs its own pattern. Asserted separately
 # rather than as one exact string: dropping any single one silently removes a
@@ -191,6 +201,43 @@ def test_codex_auto_skip_matches_the_coderabbit_ignore_list() -> None:
         f"{CODEX_REQUEST.name}'s auto-admission skip list {sorted(auto_admission)} "
         f"differs from .coderabbit.yaml's ignore_usernames {sorted(BOT_AUTHORS)} — "
         "the two tools would again disagree on which bot PRs get automatic review."
+    )
+
+
+def test_the_manual_review_escape_hatch_survives() -> None:
+    """The `/review` comment path must keep admitting promote PRs.
+
+    The auto-exclusion of ``github-actions[bot]`` is defensible only because a
+    maintainer can still summon Codex on a promote PR with `/review` — which
+    works solely because the ``issue_comment`` admission list omits that login.
+    The two ``fromJSON`` lists sit six lines apart and differ by one entry, so
+    an edit harmonising them would read as tidying while removing the lever.
+    This pins the comment-path list to its own expected set, making the
+    asymmetry a recorded decision.
+    """
+    text = CODEX_REQUEST.read_text("utf-8")
+    comment_anchor = "github.event_name == 'issue_comment'"
+    assert comment_anchor in text, (
+        f"{CODEX_REQUEST.name} no longer has an issue_comment branch — rebind "
+        "this test to the new structure."
+    )
+    comment_branch = text.split(comment_anchor, 1)[1]
+    raw_lists = [
+        raw
+        for raw in re.findall(r"fromJSON\('(\[[^']*\])'\)", comment_branch)
+        if "[bot]" in raw
+    ]
+    assert len(raw_lists) == 1, (
+        f"expected exactly one bot skip list in {CODEX_REQUEST.name}'s "
+        f"issue_comment branch, found {len(raw_lists)}"
+    )
+
+    comment_skips = set(json.loads(raw_lists[0]))
+    assert comment_skips == COMMENT_PATH_SKIPS, (
+        f"{CODEX_REQUEST.name}'s issue_comment skip list {sorted(comment_skips)} "
+        f"no longer matches COMMENT_PATH_SKIPS {sorted(COMMENT_PATH_SKIPS)}. "
+        "Adding github-actions[bot] here removes the manual /review lever on "
+        "promote PRs that the auto-exclusion rationale depends on."
     )
 
 

--- a/tests/src/unit/test_coderabbit_config.py
+++ b/tests/src/unit/test_coderabbit_config.py
@@ -27,12 +27,16 @@ AGENTS_MD = REPO_ROOT / "AGENTS.md"
 CODEX_DELIVERY = REPO_ROOT / ".github" / "workflows" / "pr-codex-review-delivery.yml"
 STYLEGUIDE = ".gemini/styleguide.md"
 
-# Bot identities whose PRs have never been reviewed. Exact logins: CodeRabbit
-# matches ``ignore_usernames`` case-sensitively with no wildcard support.
+# The exact skip list, mirroring the Codex list in
+# pr-codex-review-request.yml. Dependency-update PRs are the one class that
+# genuinely goes unreviewed. github-actions[bot] must NOT appear here: it
+# authors the webhook-proxy promote PRs, which are reviewed today (Codex and
+# humans; #1977 folded in real fixes) — ignoring the login would silently
+# extend the dependency-PR policy to them. Exact logins: CodeRabbit matches
+# ``ignore_usernames`` case-sensitively with no wildcard support.
 BOT_AUTHORS = {
     "dependabot[bot]",
     "ha-mcp-renovate[bot]",
-    "github-actions[bot]",
 }
 
 # ``applyTo`` has to keep the styleguide repo-wide, and minimatch's ``dot:
@@ -119,22 +123,31 @@ def test_draft_reviews_are_enabled() -> None:
 
 
 def test_bot_authors_stay_unreviewed() -> None:
-    """Dependency and automation PRs were never reviewed; keep it that way.
+    """The skip list is exact in both directions.
 
-    Nothing configured produces that today — the resolved config is entirely
-    defaults — so it rests on undocumented CodeRabbit bot-author handling.
-    Pinning the logins here makes the intent explicit and independent of that
-    behaviour, and ``ignore_usernames`` defaults to ``[]``, so dropping the key
-    would leave nothing standing between a handling change and a flood of
-    reviews on every Dependabot, Renovate, and release-automation PR.
+    Dropping a login floods dependency PRs with reviews: nothing configured
+    produces today's skip — the resolved config is entirely defaults — so it
+    rests on undocumented CodeRabbit bot-author handling, and
+    ``ignore_usernames`` defaults to ``[]``.
+
+    Adding a login silently widens the policy: ``github-actions[bot]`` was
+    listed here once, which would have excluded the webhook-proxy promote PRs
+    that Codex and humans actually review. An addition must change
+    ``BOT_AUTHORS`` too, where the comment forces the promote-PR question.
     """
     configured = set(_config()["reviews"]["auto_review"]["ignore_usernames"])
-    missing = BOT_AUTHORS - configured
 
+    missing = BOT_AUTHORS - configured
     assert not missing, (
         f"ignore_usernames no longer covers {sorted(missing)} — those PRs would "
         "start getting reviewed. Matching is exact and case-sensitive, so the "
         "login must include the `[bot]` suffix."
+    )
+    extras = configured - BOT_AUTHORS
+    assert not extras, (
+        f"ignore_usernames gained {sorted(extras)} — every PR that login "
+        "authors silently loses CodeRabbit review. If that is intended, add "
+        "it to BOT_AUTHORS with the rationale recorded in the comment there."
     )
 
 

--- a/tests/src/unit/test_coderabbit_config.py
+++ b/tests/src/unit/test_coderabbit_config.py
@@ -27,11 +27,6 @@ AGENTS_MD = REPO_ROOT / "AGENTS.md"
 CODEX_DELIVERY = REPO_ROOT / ".github" / "workflows" / "pr-codex-review-delivery.yml"
 STYLEGUIDE = ".gemini/styleguide.md"
 
-# ``applyTo`` has to keep the styleguide repo-wide, and minimatch's ``dot:
-# false`` means each class of path needs its own pattern. Asserted separately
-# rather than as one exact string: dropping any single one silently removes a
-# whole class of files from the styleguide's scope, and that is the failure
-# worth naming. Adding further patterns is fine.
 # Bot identities whose PRs have never been reviewed. Exact logins: CodeRabbit
 # matches ``ignore_usernames`` case-sensitively with no wildcard support.
 BOT_AUTHORS = {
@@ -40,6 +35,11 @@ BOT_AUTHORS = {
     "github-actions[bot]",
 }
 
+# ``applyTo`` has to keep the styleguide repo-wide, and minimatch's ``dot:
+# false`` means each class of path needs its own pattern. Asserted separately
+# rather than as one exact string: dropping any single one silently removes a
+# whole class of files from the styleguide's scope, and that is the failure
+# worth naming. Adding further patterns is fine.
 REQUIRED_SCOPE = {
     "**": "non-dot paths at any depth",
     "**/.*": "dotfiles at any depth, including the repo root",
@@ -53,19 +53,50 @@ def _config() -> dict[str, Any]:
     return loaded
 
 
-def _agents_md_subsection(title: str) -> str:
-    """The body of one ``### `` subsection of AGENTS.md.
+def _subsection(text: str, title: str) -> str | None:
+    """The body of one ``### `` subsection, or ``None`` when absent.
 
-    Scoped rather than grepping the whole file, for the reason given in
+    Scoped rather than grepping the whole document, for the reason given in
     ``test_locale_parity.py::_agents_md_section``: a whole-file grep answers a
     question about the file, not about the section it claims to guard.
+
+    Terminates on any heading of level 1-3 or end of input. Both bounds matter:
+    stopping only at ``##``/``###`` would report a section that ends the file as
+    missing, and would run a following ``#`` section's text into the body, so a
+    value assertion could pass on prose from somewhere else entirely. ``####``
+    and deeper stay inside the body, being parts of this section.
     """
-    text = AGENTS_MD.read_text("utf-8")
     match = re.search(
-        rf"^### {re.escape(title)}$(.*?)(?=^#{{2,3}} )", text, re.MULTILINE | re.DOTALL
+        rf"^### {re.escape(title)}$(.*?)(?=^#{{1,3}} |\Z)",
+        text,
+        re.MULTILINE | re.DOTALL,
     )
-    assert match, f"AGENTS.md has no '### {title}' section — this test guards it"
-    return match.group(1)
+    return match.group(1) if match else None
+
+
+def _agents_md_subsection(title: str) -> str:
+    """``_subsection`` against AGENTS.md, asserting the section exists."""
+    body = _subsection(AGENTS_MD.read_text("utf-8"), title)
+    assert body is not None, (
+        f"AGENTS.md has no '### {title}' section — this test guards it"
+    )
+    return body
+
+
+def test_subsection_bounds_hold_at_every_edge() -> None:
+    """The extractor decides what every prose assertion below is reading."""
+    assert _subsection("### A\nbody\n### B\nother\n", "A") == "\nbody\n"
+    assert _subsection("### A\nbody\n## B\nother\n", "A") == "\nbody\n"
+    # A following h1 must terminate it — otherwise the next top-level section's
+    # prose lands in the body and a value assertion can pass on the wrong text.
+    assert _subsection("### A\nbody\n# B\nother\n", "A") == "\nbody\n"
+    # Last section in the file: the ##/###-only bound reported this as missing.
+    assert _subsection("### A\nbody\n", "A") == "\nbody\n"
+    # Deeper headings belong to the section.
+    assert _subsection("### A\nbody\n#### A1\nmore\n### B\n", "A") == (
+        "\nbody\n#### A1\nmore\n"
+    )
+    assert _subsection("### A\nbody\n", "Missing") is None
 
 
 def test_draft_reviews_are_enabled() -> None:

--- a/tests/src/unit/test_coderabbit_config.py
+++ b/tests/src/unit/test_coderabbit_config.py
@@ -166,14 +166,27 @@ def test_codex_auto_skip_matches_the_coderabbit_ignore_list() -> None:
     dispatches Codex (the on-demand lever the exclusion rationale relies on).
     """
     text = CODEX_REQUEST.read_text("utf-8")
-    bot_lists = [
-        set(json.loads(raw))
-        for raw in re.findall(r"fromJSON\('(\[[^']*\])'\)", text)
+    # Bound to the pull_request_target branch structurally, not by position.
+    # Anchored on the event_name comparisons — the bare event names also
+    # appear in the `on:` trigger block, which holds no skip list at all.
+    auto_anchor = "github.event_name == 'pull_request_target'"
+    comment_anchor = "github.event_name == 'issue_comment'"
+    assert auto_anchor in text and comment_anchor in text, (
+        f"{CODEX_REQUEST.name} no longer has the two admission branches this "
+        "test expects — rebind the extraction below to the new structure."
+    )
+    auto_branch = text.split(auto_anchor, 1)[1].split(comment_anchor, 1)[0]
+    raw_lists = [
+        raw
+        for raw in re.findall(r"fromJSON\('(\[[^']*\])'\)", auto_branch)
         if "[bot]" in raw
     ]
-    assert bot_lists, f"no bot skip list found in {CODEX_REQUEST.name}"
+    assert len(raw_lists) == 1, (
+        f"expected exactly one bot skip list in {CODEX_REQUEST.name}'s "
+        f"pull_request_target branch, found {len(raw_lists)}"
+    )
 
-    auto_admission = bot_lists[0]
+    auto_admission = set(json.loads(raw_lists[0]))
     assert auto_admission == BOT_AUTHORS, (
         f"{CODEX_REQUEST.name}'s auto-admission skip list {sorted(auto_admission)} "
         f"differs from .coderabbit.yaml's ignore_usernames {sorted(BOT_AUTHORS)} — "

--- a/tests/src/unit/test_coderabbit_config.py
+++ b/tests/src/unit/test_coderabbit_config.py
@@ -1,0 +1,179 @@
+"""``.coderabbit.yaml`` must stay valid and match what AGENTS.md claims.
+
+Nothing in CI parses this file — no yamllint, no schema check — and every key
+it omits falls back to CodeRabbit's schema defaults rather than to any UI
+setting. ``reviews.auto_review.drafts`` defaults to ``false``, so a typo'd key
+or a bad indent silently restores the exact behaviour the file exists to
+change, with no signal anywhere. The guideline paths have the same shape of
+failure: rename ``.gemini/styleguide.md`` and both CodeRabbit and the Codex
+review request point at nothing, quietly.
+
+Same pattern as ``test_ruff_scope_covers_the_tree.py`` (pins a tool's config to
+the tree) and ``test_locale_parity.py::test_agents_md_states_the_current_ceilings``
+(pins AGENTS.md prose to the real values).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+CODERABBIT_YAML = REPO_ROOT / ".coderabbit.yaml"
+AGENTS_MD = REPO_ROOT / "AGENTS.md"
+CODEX_DELIVERY = REPO_ROOT / ".github" / "workflows" / "pr-codex-review-delivery.yml"
+STYLEGUIDE = ".gemini/styleguide.md"
+
+# ``applyTo`` has to keep the styleguide repo-wide, and minimatch's ``dot:
+# false`` means each class of path needs its own pattern. Asserted separately
+# rather than as one exact string: dropping any single one silently removes a
+# whole class of files from the styleguide's scope, and that is the failure
+# worth naming. Adding further patterns is fine.
+# Bot identities whose PRs have never been reviewed. Exact logins: CodeRabbit
+# matches ``ignore_usernames`` case-sensitively with no wildcard support.
+BOT_AUTHORS = {
+    "dependabot[bot]",
+    "ha-mcp-renovate[bot]",
+    "github-actions[bot]",
+}
+
+REQUIRED_SCOPE = {
+    "**": "non-dot paths at any depth",
+    "**/.*": "dotfiles at any depth, including the repo root",
+    "**/.*/**": "contents of dot-directories (.github/, .claude/, .gemini/)",
+}
+
+
+def _config() -> dict[str, Any]:
+    loaded = yaml.safe_load(CODERABBIT_YAML.read_text("utf-8"))
+    assert isinstance(loaded, dict), f"{CODERABBIT_YAML.name} must parse to a mapping"
+    return loaded
+
+
+def _agents_md_subsection(title: str) -> str:
+    """The body of one ``### `` subsection of AGENTS.md.
+
+    Scoped rather than grepping the whole file, for the reason given in
+    ``test_locale_parity.py::_agents_md_section``: a whole-file grep answers a
+    question about the file, not about the section it claims to guard.
+    """
+    text = AGENTS_MD.read_text("utf-8")
+    match = re.search(
+        rf"^### {re.escape(title)}$(.*?)(?=^#{{2,3}} )", text, re.MULTILINE | re.DOTALL
+    )
+    assert match, f"AGENTS.md has no '### {title}' section — this test guards it"
+    return match.group(1)
+
+
+def test_draft_reviews_are_enabled() -> None:
+    """The whole point of the file; CodeRabbit's own default is ``false``."""
+    auto_review = _config()["reviews"]["auto_review"]
+
+    assert auto_review["drafts"] is True, (
+        "reviews.auto_review.drafts must be true — every PR here opens as a "
+        "draft (AGENTS.md § Git & PR Policies), and CodeRabbit skips drafts by "
+        "default, so a false value means no PR gets reviewed until it is readied."
+    )
+    pause = auto_review["auto_pause_after_reviewed_commits"]
+    # Schema type is integer, and `== 0` alone would accept YAML `false` (bool
+    # is an int subclass) or `0.0`, either of which CodeRabbit would reject.
+    assert isinstance(pause, int) and not isinstance(pause, bool) and pause == 0, (
+        "auto_pause_after_reviewed_commits must be integer 0 — drafts here "
+        "iterate push -> CI -> fix and blow past CodeRabbit's default 5-commit "
+        f"pause, which stops review with no signal. Found {pause!r}."
+    )
+
+
+def test_bot_authors_stay_unreviewed() -> None:
+    """Dependency and automation PRs were never reviewed; keep it that way.
+
+    Repo YAML replaces the UI settings rather than merging with them, so this
+    key has to be present: dropping it resolves ``ignore_usernames`` to the
+    schema default of ``[]`` and every Dependabot, Renovate, and
+    release-automation PR starts getting reviewed.
+    """
+    configured = set(_config()["reviews"]["auto_review"]["ignore_usernames"])
+    missing = BOT_AUTHORS - configured
+
+    assert not missing, (
+        f"ignore_usernames no longer covers {sorted(missing)} — those PRs would "
+        "start getting reviewed. Matching is exact and case-sensitive, so the "
+        "login must include the `[bot]` suffix."
+    )
+
+
+def test_agents_md_documents_the_real_draft_setting() -> None:
+    """The prose is where a contributor learns the behaviour; pin it."""
+    section = _agents_md_subsection("Automated Code Review")
+    drafts = _config()["reviews"]["auto_review"]["drafts"]
+
+    assert f"reviews.auto_review.drafts: {str(drafts).lower()}" in section, (
+        "AGENTS.md § Automated Code Review must state the drafts value that "
+        f"`.coderabbit.yaml` actually sets ({drafts!r}). Update the prose."
+    )
+
+
+def test_every_guideline_path_resolves() -> None:
+    """A renamed styleguide would no-op the entry with no error anywhere."""
+    patterns = _config()["knowledge_base"]["code_guidelines"]["filePatterns"]
+    assert patterns, "filePatterns is empty — the styleguide entry went missing"
+
+    for entry in patterns:
+        files = entry["files"] if isinstance(entry, dict) else entry
+        for pattern in (part.strip() for part in files.split(",")):
+            assert list(REPO_ROOT.glob(pattern)), (
+                f"`.coderabbit.yaml` points code_guidelines at {pattern!r}, "
+                "which matches no file. A guideline path that resolves to "
+                "nothing is silently ignored by CodeRabbit."
+            )
+
+
+def test_styleguide_applies_to_the_whole_tree() -> None:
+    """A narrowed ``applyTo`` scopes the styleguide to nothing, silently.
+
+    Path resolution alone does not catch it: the entry keeps pointing at a real
+    file while governing no reviewed code, because a guideline is otherwise
+    scoped to its own directory tree and ``.gemini/`` holds no source.
+    """
+    entries = [
+        entry
+        for entry in _config()["knowledge_base"]["code_guidelines"]["filePatterns"]
+        if isinstance(entry, dict) and entry.get("files") == STYLEGUIDE
+    ]
+    assert len(entries) == 1, (
+        f"expected exactly one code_guidelines entry for {STYLEGUIDE}, found "
+        f"{len(entries)} — a string entry would scope it to `.gemini/` only."
+    )
+
+    scope = {part.strip() for part in entries[0]["applyTo"].split(",")}
+    missing = {p: why for p, why in REQUIRED_SCOPE.items() if p not in scope}
+
+    assert not missing, (
+        f"{STYLEGUIDE} no longer applies to: "
+        + "; ".join(f"{why} (pattern {p!r})" for p, why in missing.items())
+        + ". CodeRabbit drops those files from the styleguide's scope with no error."
+    )
+
+
+def test_codex_review_request_points_at_a_real_styleguide() -> None:
+    """The same path is hard-coded in the Codex request comment."""
+    referenced = set(
+        re.findall(
+            rf"[\w./-]*{re.escape(STYLEGUIDE)}", CODEX_DELIVERY.read_text("utf-8")
+        )
+    )
+    # The exact path, not merely something ending in it: a `vendor/` copy would
+    # otherwise satisfy both this and the existence check below while the
+    # workflow no longer pointed at the repo's own styleguide.
+    assert STYLEGUIDE in referenced, (
+        f"{CODEX_DELIVERY.name} no longer names {STYLEGUIDE} (found "
+        f"{sorted(referenced)}) — if the review request moved, update this test "
+        "alongside it."
+    )
+    for path in referenced:
+        assert (REPO_ROOT / path).is_file(), (
+            f"{CODEX_DELIVERY.name} points Codex at {path!r}, which does not exist."
+        )

--- a/tests/src/unit/test_coderabbit_config.py
+++ b/tests/src/unit/test_coderabbit_config.py
@@ -208,12 +208,14 @@ def test_the_manual_review_escape_hatch_survives() -> None:
     """The `/review` comment path must keep admitting promote PRs.
 
     The auto-exclusion of ``github-actions[bot]`` is defensible only because a
-    maintainer can still summon Codex on a promote PR with `/review` — which
-    works solely because the ``issue_comment`` admission list omits that login.
-    The two ``fromJSON`` lists sit six lines apart and differ by one entry, so
-    an edit harmonising them would read as tidying while removing the lever.
-    This pins the comment-path list to its own expected set, making the
-    asymmetry a recorded decision.
+    maintainer can still summon Codex on a promote PR with `/review`.
+    Admission is a several-way conjunction; this test pins one piece of it —
+    the ``issue_comment`` list omitting that login — because it is the piece
+    that can die silently: the two ``fromJSON`` lists sit six lines apart and
+    differ by one entry, so harmonising them reads as tidying. The other
+    conjuncts (the trigger, the command literal, the author gate) are shared,
+    repo-wide machinery whose breakage is loud on the next `/review` anywhere,
+    and are deliberately not pinned here.
     """
     text = CODEX_REQUEST.read_text("utf-8")
     comment_anchor = "github.event_name == 'issue_comment'"
@@ -233,11 +235,19 @@ def test_the_manual_review_escape_hatch_survives() -> None:
     )
 
     comment_skips = set(json.loads(raw_lists[0]))
-    assert comment_skips == COMMENT_PATH_SKIPS, (
-        f"{CODEX_REQUEST.name}'s issue_comment skip list {sorted(comment_skips)} "
-        f"no longer matches COMMENT_PATH_SKIPS {sorted(COMMENT_PATH_SKIPS)}. "
-        "Adding github-actions[bot] here removes the manual /review lever on "
-        "promote PRs that the auto-exclusion rationale depends on."
+
+    extras = comment_skips - COMMENT_PATH_SKIPS
+    assert not extras, (
+        f"{CODEX_REQUEST.name}'s issue_comment skip list gained {sorted(extras)} "
+        "— that removes the manual /review lever on those authors' PRs, which "
+        "for github-actions[bot] is the escape hatch the auto-exclusion "
+        "rationale depends on."
+    )
+    missing = COMMENT_PATH_SKIPS - comment_skips
+    assert not missing, (
+        f"{CODEX_REQUEST.name}'s issue_comment skip list no longer covers "
+        f"{sorted(missing)} — a maintainer /review on those bots' dependency "
+        "PRs would start dispatching Codex."
     )
 
 

--- a/tests/src/unit/test_coderabbit_config.py
+++ b/tests/src/unit/test_coderabbit_config.py
@@ -107,14 +107,25 @@ def test_bot_authors_stay_unreviewed() -> None:
     )
 
 
-def test_agents_md_documents_the_real_draft_setting() -> None:
-    """The prose is where a contributor learns the behaviour; pin it."""
-    section = _agents_md_subsection("Automated Code Review")
-    drafts = _config()["reviews"]["auto_review"]["drafts"]
+def test_agents_md_documents_the_real_auto_review_settings() -> None:
+    """The prose is where a contributor learns the behaviour; pin it.
 
-    assert f"reviews.auto_review.drafts: {str(drafts).lower()}" in section, (
-        "AGENTS.md § Automated Code Review must state the drafts value that "
-        f"`.coderabbit.yaml` actually sets ({drafts!r}). Update the prose."
+    Both settings, not just ``drafts``: the pause is the one carrying an
+    operational cost (it spends the per-developer review allowance), so prose
+    that documented only ``drafts`` described the cheaper half of the change.
+    """
+    section = _agents_md_subsection("Automated Code Review")
+    auto_review = _config()["reviews"]["auto_review"]
+    documented = {
+        f"reviews.auto_review.drafts: {str(auto_review['drafts']).lower()}",
+        f"auto_pause_after_reviewed_commits: "
+        f"{auto_review['auto_pause_after_reviewed_commits']}",
+    }
+    missing = {claim for claim in documented if claim not in section}
+
+    assert not missing, (
+        "AGENTS.md § Automated Code Review must state the values "
+        f"`.coderabbit.yaml` actually sets. Missing: {sorted(missing)}."
     )
 
 

--- a/tests/src/unit/test_coderabbit_config.py
+++ b/tests/src/unit/test_coderabbit_config.py
@@ -15,6 +15,7 @@ the tree) and ``test_locale_parity.py::test_agents_md_states_the_current_ceiling
 
 from __future__ import annotations
 
+import json
 import re
 from pathlib import Path
 from typing import Any
@@ -25,18 +26,21 @@ REPO_ROOT = Path(__file__).resolve().parents[3]
 CODERABBIT_YAML = REPO_ROOT / ".coderabbit.yaml"
 AGENTS_MD = REPO_ROOT / "AGENTS.md"
 CODEX_DELIVERY = REPO_ROOT / ".github" / "workflows" / "pr-codex-review-delivery.yml"
+CODEX_REQUEST = REPO_ROOT / ".github" / "workflows" / "pr-codex-review-request.yml"
 STYLEGUIDE = ".gemini/styleguide.md"
 
-# The exact skip list, mirroring the Codex list in
-# pr-codex-review-request.yml. Dependency-update PRs are the one class that
-# genuinely goes unreviewed. github-actions[bot] must NOT appear here: it
-# authors the webhook-proxy promote PRs, which are reviewed today (Codex and
-# humans; #1977 folded in real fixes) — ignoring the login would silently
-# extend the dependency-PR policy to them. Exact logins: CodeRabbit matches
-# ``ignore_usernames`` case-sensitively with no wildcard support.
+# The exact auto-review skip list, mirrored by the Codex auto-admission list
+# in pr-codex-review-request.yml. dependabot/renovate PRs have never been
+# reviewed. github-actions[bot] authors the webhook-proxy promote PRs — dev ->
+# stable copies whose content was already reviewed in the dev PRs — excluded
+# knowingly (maintainer decision on #2118); a promote that folds in more than
+# a version bump still gets `@coderabbitai review` on demand. Exact logins:
+# CodeRabbit matches ``ignore_usernames`` case-sensitively with no wildcard
+# support.
 BOT_AUTHORS = {
     "dependabot[bot]",
     "ha-mcp-renovate[bot]",
+    "github-actions[bot]",
 }
 
 # ``applyTo`` has to keep the styleguide repo-wide, and minimatch's ``dot:
@@ -125,15 +129,15 @@ def test_draft_reviews_are_enabled() -> None:
 def test_bot_authors_stay_unreviewed() -> None:
     """The skip list is exact in both directions.
 
-    Dropping a login floods dependency PRs with reviews: nothing configured
+    Dropping a login floods that bot's PRs with reviews: nothing configured
     produces today's skip — the resolved config is entirely defaults — so it
     rests on undocumented CodeRabbit bot-author handling, and
     ``ignore_usernames`` defaults to ``[]``.
 
-    Adding a login silently widens the policy: ``github-actions[bot]`` was
-    listed here once, which would have excluded the webhook-proxy promote PRs
-    that Codex and humans actually review. An addition must change
-    ``BOT_AUTHORS`` too, where the comment forces the promote-PR question.
+    Adding a login silently widens the policy — every PR that author opens
+    loses automatic review. Each entry here is a recorded decision (see the
+    ``BOT_AUTHORS`` comment); an addition must change both places, which is
+    what forces the rationale to be written down.
     """
     configured = set(_config()["reviews"]["auto_review"]["ignore_usernames"])
 
@@ -148,6 +152,32 @@ def test_bot_authors_stay_unreviewed() -> None:
         f"ignore_usernames gained {sorted(extras)} — every PR that login "
         "authors silently loses CodeRabbit review. If that is intended, add "
         "it to BOT_AUTHORS with the rationale recorded in the comment there."
+    )
+
+
+def test_codex_auto_skip_matches_the_coderabbit_ignore_list() -> None:
+    """One auto-review skip policy, two enforcement points; no silent drift.
+
+    The lists were unequal once — Codex admitted the webhook-proxy promote
+    PRs that CodeRabbit ignored — and the divergence was invisible until a
+    reviewer diffed the two files by hand. Only the ``pull_request_target``
+    admission list must match: the ``issue_comment`` list stays narrower on
+    purpose, so a maintainer's explicit `/review` on a promote PR still
+    dispatches Codex (the on-demand lever the exclusion rationale relies on).
+    """
+    text = CODEX_REQUEST.read_text("utf-8")
+    bot_lists = [
+        set(json.loads(raw))
+        for raw in re.findall(r"fromJSON\('(\[[^']*\])'\)", text)
+        if "[bot]" in raw
+    ]
+    assert bot_lists, f"no bot skip list found in {CODEX_REQUEST.name}"
+
+    auto_admission = bot_lists[0]
+    assert auto_admission == BOT_AUTHORS, (
+        f"{CODEX_REQUEST.name}'s auto-admission skip list {sorted(auto_admission)} "
+        f"differs from .coderabbit.yaml's ignore_usernames {sorted(BOT_AUTHORS)} — "
+        "the two tools would again disagree on which bot PRs get automatic review."
     )
 
 

--- a/tests/src/unit/test_coderabbit_config.py
+++ b/tests/src/unit/test_coderabbit_config.py
@@ -90,10 +90,12 @@ def test_draft_reviews_are_enabled() -> None:
 def test_bot_authors_stay_unreviewed() -> None:
     """Dependency and automation PRs were never reviewed; keep it that way.
 
-    Repo YAML replaces the UI settings rather than merging with them, so this
-    key has to be present: dropping it resolves ``ignore_usernames`` to the
-    schema default of ``[]`` and every Dependabot, Renovate, and
-    release-automation PR starts getting reviewed.
+    Nothing configured produces that today — the resolved config is entirely
+    defaults — so it rests on undocumented CodeRabbit bot-author handling.
+    Pinning the logins here makes the intent explicit and independent of that
+    behaviour, and ``ignore_usernames`` defaults to ``[]``, so dropping the key
+    would leave nothing standing between a handling change and a flood of
+    reviews on every Dependabot, Renovate, and release-automation PR.
     """
     configured = set(_config()["reviews"]["auto_review"]["ignore_usernames"])
     missing = BOT_AUTHORS - configured


### PR DESCRIPTION
## What does this PR do?

Adds `.coderabbit.yaml` so CodeRabbit reviews draft PRs, and points it at
`.gemini/styleguide.md` as review criteria.

Every PR here opens as a draft, and CodeRabbit skips drafts by default, so it
posted "Review skipped — Draft detected" and only reviewed once a PR was
readied. The repo had no `.coderabbit.yaml` at all; recent PRs report
`Configuration used: defaults`.

**Config:**
- `reviews.auto_review.drafts: true` — the actual fix.
- `auto_pause_after_reviewed_commits: 0` — the default is 5, and drafts here
  iterate push → CI → fix, so review would go quiet partway through with no
  signal. That is the window this PR exists to cover. The documented cost:
  incremental reviews draw on the same per-developer hourly allowance as manual
  ones, and CodeRabbit recommends 1-2 for busy branches. Taken anyway because
  running out is loud and cheap — a rate-limited push gets a comment and a
  deliberately-passing check, blocks nothing, and neither consumes a review nor
  delays the next.
- `ignore_usernames` — Dependabot, Renovate, and release-automation PRs go
  unreviewed today, but nothing configured causes that (`@coderabbitai
  configuration` reports every value as a default), so it rests on undocumented
  bot handling. Listed explicitly to make the intent survive a change to it.
- `knowledge_base.code_guidelines.filePatterns` — adds `.gemini/styleguide.md`.
  `AGENTS.md` needs no entry; it is auto-detected. The `applyTo` object form is
  required rather than stylistic: a guideline file is scoped to its own
  directory tree, so a bare string entry would scope the styleguide to
  `.gemini/` and silently never apply. `applyTo` also carries a second pattern
  for dot-directories, which a bare `**` does not match under minimatch's
  default `dot: false` — that would otherwise skip `.github/` and `.claude/`.

**Follow-through, because the review tooling didn't know CodeRabbit existed:**
- `/contrib-pr-review` filtered PR feedback through an exact-match allowlist of
  `chatgpt-codex-connector[bot]` on both the reviews and comments endpoints, so
  it discarded everything CodeRabbit posts — on PRs where unresolved threads
  block merge. Both `select()` clauses now take either bot and emit `author:`.
- The bot lists in `AGENTS.md` and `/my-pr-checker` named only Codex and Copilot.
- `tests/src/unit/test_coderabbit_config.py` pins the config: `drafts`, the
  pause value, that AGENTS.md's prose matches the real setting, and that every
  guideline path resolves. `.gemini/styleguide.md` is now hard-coded in both
  `.coderabbit.yaml` and `pr-codex-review-delivery.yml`, and nothing asserted it
  exists — renaming it would have quietly disabled the styleguide for both bots.
  Same pattern as `test_ruff_scope_covers_the_tree.py`.

**Worth knowing before merge:** repo YAML outranks the CodeRabbit UI settings and
does not merge with them, so any key this file omits resolves to CodeRabbit's
schema defaults rather than to a dashboard value. Nothing is lost today — the
resolved config was already defaults — but the dashboard stops being the place
to configure this repo. `@coderabbitai configuration` on a PR prints the
resolved config annotated by source.

## Type of change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [x] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [ ] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

Ran `tests/src/unit/test_coderabbit_config.py` only — 8 passed. Every assertion
was mutation-checked rather than merely run: flipping `drafts`, setting the pause
to `5` / YAML `false`, narrowing `applyTo`, dropping a scope pattern, removing a
bot login, renaming the styleguide, and contradicting the AGENTS.md prose each
redden the intended test. `ruff format` + `ruff check` clean. Full suite left to CI.

Config keys and defaults verified against
`https://coderabbit.ai/integrations/schema.v2.json`.

This PR cannot exercise the config. CodeRabbit replies: "Ignoring CodeRabbit
configuration file changes. For security, only the configuration from the base
branch is applied for open source repositories." So it reports `Configuration
used: defaults` here by design, and the settings take effect on merge.

## Checklist
- [x] I have updated documentation if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Enabled automated CodeRabbit reviews for draft pull requests.
  * Applied shared style guidance across repository files, including hidden files and directories.
  * Excluded Dependabot, Renovate, and GitHub Actions pull requests from automated reviews.
  * Kept automated review processing active without automatic pausing.
  * Expanded automated review handling to include pull-request and issue comments from Codex and CodeRabbit.

* **Documentation**
  * Updated review guidance, responsibilities, escalation rules, and comment handling.

* **Tests**
  * Added validation for review settings, documentation, bot exclusions, and styleguide coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


