### PR TITLE
docs: document settings-UI and OIDC trust properties in SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -328,6 +328,24 @@ deployments (see [docs/oidc.md](docs/oidc.md)). The settings-UI caveat above
 applies identically: `MCP_SETTINGS_SECRET_PATH`, not the OIDC token, is what
 gates it.
 
+Three further properties of the mode:
+
+- **OIDC is an access gate, not per-user authorization.** Every authenticated
+  user shares the one server-side `HOMEASSISTANT_TOKEN`, so all requests act as
+  the same Home Assistant identity. As in standard mode, there is no per-user
+  isolation — reports assuming user A cannot reach user B's data do not apply.
+  Per-user Home Assistant credentials exist only in OAuth mode.
+- **The token audience is not checked by default.** With `OIDC_AUDIENCE` unset
+  and `OIDC_VERIFY_ID_TOKEN` off, FastMCP's JWT verifier checks issuer,
+  signature, and expiry but not `aud`. That is fine on an IdP dedicated to
+  ha-mcp, and weaker on a shared one, where a token another client obtained
+  from the same issuer would also pass. Set `OIDC_AUDIENCE` on a shared IdP.
+- **Sessions persist across restarts, and revocation is rotation.** When
+  `OIDC_JWT_SIGNING_KEY` is unset, the session signing key is derived
+  deterministically from `OIDC_CLIENT_SECRET`, so a restart does not log users
+  out. To invalidate every outstanding session, rotate whichever secret the key
+  derives from.
+
 ## Reporting a Vulnerability
 
 Use the private reporting page at:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -273,6 +273,13 @@ the proxy returns 503 whenever the server is not running.
 - DNS rebinding against the HTTP entrypoints: fastmcp's Host/Origin guard is off
   by default; URL-path secrecy is the boundary and the local network is the
   trusted zone (see [Threat Model](#threat-model) above).
+- The web settings UI not being gated by the OAuth/OIDC token: fastmcp custom
+  routes bypass the auth middleware by design, so a dedicated secret path gates
+  it instead (see [OAuth Mode](#oauth-mode--beta-warning) below). Reports
+  placing the settings routes at `<MCP_SECRET_PATH>/settings` in OAuth or OIDC
+  mode describe pre-7.14.0 behavior, and the Supervisor-backed operations they
+  reach (add-on restart, add-on option writes) require `SUPERVISOR_TOKEN` and
+  return 400 outside add-on mode.
 - OAuth token containing an encoded LLAT: this is the Bearer token design
   (see [Threat Model](#threat-model) above).
 - OAuth token revocation not preventing further HA API access: revoke the LLAT
@@ -295,6 +302,15 @@ and carries a larger attack surface than the standard LLAT setup.
 - Requires explicit opt-in (`ha-mcp-oauth`); the default entrypoint is unaffected
 - CVEs were published and fixed in v7.x (XSS: GHSA-pf93-j98v-25pv;
   SSRF: GHSA-fmfg-9g7c-3vq7). Upgrade to the latest release before deploying.
+- The web settings UI is **not** gated by the OAuth token. It is served as
+  fastmcp custom routes, which bypass `RequireAuthMiddleware`, so `mcp.auth`
+  covers the MCP protocol endpoints only. Since 7.14.0 the UI is mounted under
+  its own dedicated secret path — auto-generated as `/private_<token>` unless
+  `MCP_SETTINGS_SECRET_PATH` is set, never advertised to MCP clients, and
+  printed only in the startup log (GHSA-mx64-982r-65vg). Treat that path as a
+  credential, or set `HA_MCP_DISABLE_SETTINGS_UI` to not serve the UI at all.
+  Standard mode and the add-on differ: there the UI sits under the MCP secret
+  path, which is already the auth boundary for the tool surface.
 
 If you choose to run OAuth mode, restrict the consent endpoint to trusted
 networks and place it behind a TLS-terminating reverse proxy.
@@ -308,7 +324,9 @@ and, like OAuth mode, exposes dynamic client registration (DCR) to any
 client that can reach the discovery endpoints. The same TLS/reverse-proxy
 recommendations apply, and
 `OIDC_ALLOWED_CLIENT_REDIRECT_URIS` should be set for internet-facing
-deployments (see [docs/oidc.md](docs/oidc.md)).
+deployments (see [docs/oidc.md](docs/oidc.md)). The settings-UI caveat above
+applies identically: `MCP_SETTINGS_SECRET_PATH`, not the OIDC token, is what
+gates it.
 
 ## Reporting a Vulnerability
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -277,9 +277,7 @@ the proxy returns 503 whenever the server is not running.
   routes bypass the auth middleware by design, so a dedicated secret path gates
   it instead (see [OAuth Mode](#oauth-mode--beta-warning) below). Reports
   placing the settings routes at `<MCP_SECRET_PATH>/settings` in OAuth or OIDC
-  mode describe pre-7.14.0 behavior, and the Supervisor-backed operations they
-  reach (add-on restart, add-on option writes) require `SUPERVISOR_TOKEN` and
-  return 400 outside add-on mode.
+  mode describe pre-7.14.0 behavior.
 - OAuth token containing an encoded LLAT: this is the Bearer token design
   (see [Threat Model](#threat-model) above).
 - OAuth token revocation not preventing further HA API access: revoke the LLAT
@@ -307,10 +305,16 @@ and carries a larger attack surface than the standard LLAT setup.
   covers the MCP protocol endpoints only. Since 7.14.0 the UI is mounted under
   its own dedicated secret path — auto-generated as `/private_<token>` unless
   `MCP_SETTINGS_SECRET_PATH` is set, never advertised to MCP clients, and
-  printed only in the startup log (GHSA-mx64-982r-65vg). Treat that path as a
-  credential, or set `HA_MCP_DISABLE_SETTINGS_UI` to not serve the UI at all.
-  Standard mode and the add-on differ: there the UI sits under the MCP secret
-  path, which is already the auth boundary for the tool surface.
+  printed only in the startup log (GHSA-mx64-982r-65vg). That path is a
+  credential: the surface behind it edits feature flags (including
+  `read_only_mode` and the filesystem tools), tool configuration, the
+  tool-security policy and entity visibility, and can restore or delete
+  backups. Set `HA_MCP_DISABLE_SETTINGS_UI` to not serve the UI at all.
+  Standard mode instead mounts the UI under the MCP secret path, which already
+  gates the tool surface. The add-on mounts it twice: under that secret path
+  for direct access, and at the bare root for Home Assistant ingress, where the
+  routes admit only the Supervisor peer (`172.30.32.2`) and 403 every other
+  caller.
 
 If you choose to run OAuth mode, restrict the consent endpoint to trusted
 networks and place it behind a TLS-terminating reverse proxy.
@@ -343,8 +347,8 @@ Three further properties of the mode:
 - **Sessions persist across restarts, and revocation is rotation.** When
   `OIDC_JWT_SIGNING_KEY` is unset, the session signing key is derived
   deterministically from `OIDC_CLIENT_SECRET`, so a restart does not log users
-  out. To invalidate every outstanding session, rotate whichever secret the key
-  derives from.
+  out. To invalidate every outstanding session, rotate `OIDC_JWT_SIGNING_KEY`
+  if it is set, and `OIDC_CLIENT_SECRET` otherwise.
 
 ## Reporting a Vulnerability
 


### PR DESCRIPTION
## What does this PR do?

SECURITY.md was missing several trust properties that only appear in
docs/OAUTH.md and docs/oidc.md. SECURITY.md is what a reporter reads before
filing, and the settings-UI gap in particular has produced repeated duplicate
advisories against the already-fixed GHSA-mx64-982r-65vg.

Adds, to the sections that already cover these modes:

- **OAuth Mode** — the web settings UI is not gated by the OAuth token
  (fastmcp custom routes bypass `RequireAuthMiddleware`); since 7.14.0 it is
  mounted under its own dedicated secret path, with `MCP_SETTINGS_SECRET_PATH`
  and `HA_MCP_DISABLE_SETTINGS_UI`.
- **OIDC Mode** — the same settings-UI caveat, plus three properties documented
  only in docs/oidc.md: OIDC is a shared-credential access gate with no
  per-user HA isolation; `aud` is unverified unless `OIDC_AUDIENCE` is set;
  and sessions persist across restarts because the signing key derives from
  `OIDC_CLIENT_SECRET`.
- **Scope** — a matching bullet for the settings-UI question.

Documentation only — no code or behaviour changes.

## Type of change
- [x] 📚 Documentation

## Testing
- [ ] I have tested these changes with a LLM agent
- [ ] All automated tests pass (`uv run pytest`)
- [ ] Code follows style guidelines (`uv run ruff check`)

## Checklist
- [x] I have updated documentation if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Documented authentication behavior for the web settings interface.
  * Added guidance on configuring, disclosing, and disabling the dedicated settings secret.
  * Clarified OIDC authorization identity, optional audience validation, and session-key persistence and rotation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->