### PR TITLE
fix: observe the shutdown cleanup task result

### DIFF
--- a/src/ha_mcp/__main__.py
+++ b/src/ha_mcp/__main__.py
@@ -1005,13 +1005,18 @@ def _get_http_runtime(default_port: int = 8086) -> tuple[str, int, str]:
     ignored — ``MCP_HOST`` is the only env var that affects bind host
     for ha-mcp's CLI entry points.
 
-    The ``0.0.0.0`` bind combined with the default ``/mcp`` path is the
-    documented posture, not an oversight. SECURITY.md § "Local network is
-    the trusted zone for standard mode" makes the LAN the trusted zone, and
-    its Scope section excludes both "LAN-peer access to standard-mode HTTP
-    endpoints" and anything "only exploitable due to a misconfigured
-    deployment (e.g. ... a network-reachable HTTP entrypoint using the
-    default ``MCP_SECRET_PATH``)".
+    The ``0.0.0.0`` default is deliberate and documented: SECURITY.md
+    § "Local network is the trusted zone for standard mode" states that the
+    HTTP entrypoints bind to all interfaces so LAN peers can reach them, and
+    its Scope section excludes "LAN-peer access to standard-mode HTTP
+    endpoints".
+
+    The default ``/mcp`` path is *not* blessed the same way once the bind
+    leaves loopback. That combination is what ``_warn_if_default_path_exposed``
+    warns about, and SECURITY.md's Scope classes it under "a misconfigured
+    deployment" — meaning such reports are declined, not that the
+    configuration is endorsed. Operators on a non-loopback bind are still
+    expected to set a high-entropy ``MCP_SECRET_PATH``.
     """
 
     host = os.getenv("MCP_HOST", "0.0.0.0")
@@ -1028,9 +1033,9 @@ def _get_http_runtime(default_port: int = 8086) -> tuple[str, int, str]:
 # Default ``MCP_SECRET_PATH`` value, shared by ``_get_http_runtime`` (the
 # read-from-env fallback) and ``_warn_if_default_path_exposed`` (the
 # hardening-nudge predicate). Single source of truth so the two sites
-# can't drift. Leaving this at ``/mcp`` on a non-loopback bind is an
-# accepted, documented posture — see the Scope exclusions quoted in
-# ``_get_http_runtime`` above.
+# can't drift. Safe on a loopback bind; on a non-loopback bind it is the
+# misconfiguration ``_warn_if_default_path_exposed`` flags, which SECURITY.md
+# declines to action without endorsing — see ``_get_http_runtime`` above.
 DEFAULT_MCP_PATH = "/mcp"
 
 # Hostname literals (not IP addresses) treated as loopback by

--- a/src/ha_mcp/__main__.py
+++ b/src/ha_mcp/__main__.py
@@ -609,6 +609,25 @@ async def _cleanup_resources() -> None:
     logger.info("Server resources cleaned up")
 
 
+def _log_cleanup_result(task: "asyncio.Future[None]") -> None:
+    """Consume the cleanup task's outcome so a failure is never silent.
+
+    ``asyncio.wait`` does not retrieve results, and the timeout path
+    deliberately abandons rather than awaits (see the ``finally`` block), so
+    without this nothing observes ``cleanup_task``. An exception left
+    unretrieved this close to loop teardown surfaces only as a GC-time "Task
+    exception was never retrieved" error, which is unstructured and not
+    guaranteed to be emitted before exit. Mirrors what ``_cancel_tasks`` does
+    for the tasks it reaps. Cancellation is the expected abandoned-timeout
+    outcome and stays silent.
+    """
+    if task.cancelled():
+        return
+    exc = task.exception()
+    if exc is not None:
+        logger.warning(f"Resource cleanup raised: {exc!r}")
+
+
 async def _cancel_tasks(*tasks: asyncio.Task) -> None:
     """Cancel tasks and wait for completion, bounding the wait.
 
@@ -697,6 +716,7 @@ async def _run_with_shutdown(server_coro: Coroutine[Any, Any, Any]) -> None:
         # guard), so a hung close handshake could block shutdown past the
         # budget. A straggler is left to the runner's own task sweep.
         cleanup_task = asyncio.ensure_future(_cleanup_resources())
+        cleanup_task.add_done_callback(_log_cleanup_result)
         _done, cleanup_pending = await asyncio.wait(
             {cleanup_task}, timeout=SHUTDOWN_TIMEOUT_SECONDS
         )

--- a/src/ha_mcp/__main__.py
+++ b/src/ha_mcp/__main__.py
@@ -1004,6 +1004,14 @@ def _get_http_runtime(default_port: int = 8086) -> tuple[str, int, str]:
     ``run_async``, any ``FASTMCP_HOST`` value in the environment is
     ignored — ``MCP_HOST`` is the only env var that affects bind host
     for ha-mcp's CLI entry points.
+
+    The ``0.0.0.0`` bind combined with the default ``/mcp`` path is the
+    documented posture, not an oversight. SECURITY.md § "Local network is
+    the trusted zone for standard mode" makes the LAN the trusted zone, and
+    its Scope section excludes both "LAN-peer access to standard-mode HTTP
+    endpoints" and anything "only exploitable due to a misconfigured
+    deployment (e.g. ... a network-reachable HTTP entrypoint using the
+    default ``MCP_SECRET_PATH``)".
     """
 
     host = os.getenv("MCP_HOST", "0.0.0.0")
@@ -1020,7 +1028,9 @@ def _get_http_runtime(default_port: int = 8086) -> tuple[str, int, str]:
 # Default ``MCP_SECRET_PATH`` value, shared by ``_get_http_runtime`` (the
 # read-from-env fallback) and ``_warn_if_default_path_exposed`` (the
 # hardening-nudge predicate). Single source of truth so the two sites
-# can't drift.
+# can't drift. Leaving this at ``/mcp`` on a non-loopback bind is an
+# accepted, documented posture — see the Scope exclusions quoted in
+# ``_get_http_runtime`` above.
 DEFAULT_MCP_PATH = "/mcp"
 
 # Hostname literals (not IP addresses) treated as loopback by

--- a/src/ha_mcp/settings_ui/__init__.py
+++ b/src/ha_mcp/settings_ui/__init__.py
@@ -566,6 +566,15 @@ def register_settings_routes(
     and serve the "Open Web UI" button. Stdio transports use a separate
     side-process sidecar instead — see :mod:`ha_mcp.stdio_settings_sidecar`.
 
+    The ``RequireAuthMiddleware`` bypass is the documented posture, not an
+    oversight: SECURITY.md § "OAuth Mode — Beta Warning" states that the
+    settings UI "is **not** gated by the OAuth token", and its Scope section
+    excludes "The web settings UI not being gated by the OAuth/OIDC token".
+    OAuth and OIDC modes compensate by passing a *dedicated* secret path here
+    rather than the client-known MCP path (GHSA-mx64-982r-65vg); standard mode
+    and the add-on pass the MCP secret path, which already gates the whole
+    tool surface.
+
     Args:
         mcp: The FastMCP instance to register routes on.
         server: The HomeAssistantSmartMCPServer wrapping ``mcp``.

--- a/src/ha_mcp/tools/tools_code.py
+++ b/src/ha_mcp/tools/tools_code.py
@@ -53,8 +53,18 @@ logger = logging.getLogger(__name__)
 # boundary.
 #
 # WARNING: This is shared across all clients in the same server process.
-# In multi-user modes (OAuth, HTTP), one user's saved tools are visible to
-# all other users. Scope to per-session/user before multi-user support.
+# In multi-user modes (OAuth, HTTP), one user's saved tools are listable and
+# runnable by every other user, and ``save_as`` overwrites by name without an
+# ownership check.
+#
+# That exposure is accepted design, not a pending TODO — SECURITY.md § Scope
+# excludes "Saved custom tools (code mode, off by default) visible to other
+# clients of the same server process", on the grounds that they are shared
+# scaffolding rather than per-user data, that ``run_saved`` executes with the
+# caller's own HA token (granting no access the caller lacks), and that any
+# client which can reach ha-mcp is a trusted principal (SECURITY.md § "MCP
+# clients are trusted principals"). Scoping per session/user would be a
+# feature, not a security fix.
 _saved_tools: dict[str, dict[str, str]] = {}
 
 # Tools that sandbox code must not call. Includes ``ha_manage_custom_tool``

--- a/src/ha_mcp/tools/tools_code.py
+++ b/src/ha_mcp/tools/tools_code.py
@@ -53,9 +53,11 @@ logger = logging.getLogger(__name__)
 # boundary.
 #
 # WARNING: This is shared across all clients in the same server process.
-# In multi-user modes (OAuth, HTTP), one user's saved tools are listable and
-# runnable by every other user, and ``save_as`` overwrites by name without an
-# ownership check.
+# One client's saved tools are listable and runnable by every other client,
+# and ``save_as`` overwrites by name without an ownership check. OAuth is the
+# only mode with distinct per-user credentials for that to cross; standard,
+# OIDC and add-on modes are single-tenant already (SECURITY.md § "Standard
+# mode is single-tenant"), so every caller there shares one HA token anyway.
 #
 # That exposure is accepted design, not a pending TODO — SECURITY.md § Scope
 # excludes "Saved custom tools (code mode, off by default) visible to other

--- a/src/ha_mcp/transport_security.py
+++ b/src/ha_mcp/transport_security.py
@@ -23,6 +23,12 @@ exactly the pre-3.4.3 behaviour without giving up the protection that matters.
 Operators who front ha-mcp differently can re-enable the guard (and pin their
 own allow-lists) via ``FASTMCP_HTTP_HOST_ORIGIN_PROTECTION=true`` plus
 ``FASTMCP_HTTP_ALLOWED_HOSTS`` / ``FASTMCP_HTTP_ALLOWED_ORIGINS``.
+
+Turning the guard off is the documented posture, not an oversight: it has its
+own SECURITY.md section, § "Host/Origin validation (DNS-rebinding guard) is off
+by default", and the Scope section there excludes "DNS rebinding against the
+HTTP entrypoints" on the grounds that URL-path secrecy is the boundary and the
+local network is already the trusted zone.
 """
 
 from __future__ import annotations

--- a/tests/src/unit/test_graceful_shutdown.py
+++ b/tests/src/unit/test_graceful_shutdown.py
@@ -300,6 +300,54 @@ class TestGracefulShutdownIntegration:
             assert cleanup_called.is_set(), "Cleanup was not called"
 
     @pytest.mark.asyncio
+    async def test_cleanup_exception_is_logged_not_left_unretrieved(self, caplog):
+        """An exception escaping cleanup must be logged, not left unretrieved.
+
+        ``asyncio.wait`` does not retrieve results and the timeout path
+        abandons rather than awaits, so without the done callback nothing
+        observes ``cleanup_task``: the failure would surface only as a
+        GC-time "Task exception was never retrieved" error, which is
+        unstructured and may never be emitted before the process exits.
+        """
+        import ha_mcp.__main__ as main_module
+
+        async def failing_cleanup():
+            raise RuntimeError("websocket close blew up")
+
+        mock_mcp = MagicMock()
+
+        async def mock_run_async(show_banner=True):
+            await asyncio.sleep(100)
+
+        mock_mcp.run_async = mock_run_async
+
+        with (
+            patch.object(main_module, "_get_mcp", return_value=mock_mcp),
+            patch.object(
+                main_module, "_cleanup_resources", side_effect=failing_cleanup
+            ),
+            caplog.at_level(logging.WARNING),
+        ):
+            main_module._shutdown_event = None
+            main_module._shutdown_in_progress = False
+
+            server_task = asyncio.create_task(main_module._run_with_graceful_shutdown())
+            await asyncio.sleep(0.1)
+
+            if main_module._shutdown_event:
+                main_module._shutdown_event.set()
+
+            try:
+                await asyncio.wait_for(server_task, timeout=3.0)
+            except (TimeoutError, asyncio.CancelledError):
+                pass
+
+        assert "Resource cleanup raised" in caplog.text, (
+            "Cleanup exception was not observed"
+        )
+        assert "websocket close blew up" in caplog.text
+
+    @pytest.mark.asyncio
     async def test_cleanup_that_swallows_cancellation_is_abandoned(
         self, monkeypatch, caplog
     ):

--- a/tests/src/unit/test_graceful_shutdown.py
+++ b/tests/src/unit/test_graceful_shutdown.py
@@ -340,6 +340,9 @@ class TestGracefulShutdownIntegration:
             try:
                 await asyncio.wait_for(server_task, timeout=3.0)
             except (TimeoutError, asyncio.CancelledError):
+                # Either outcome is acceptable here: the assertion below is
+                # about the cleanup exception being observed, not about how
+                # the server task itself ended.
                 pass
 
         assert "Resource cleanup raised" in caplog.text, (


### PR DESCRIPTION
## What does this PR do?

Four code sites have each drawn repeat security reports that SECURITY.md
already covers — the `0.0.0.0`/`/mcp` defaults (4 reports), the DNS-rebinding
guard, the settings-UI auth bypass (2), and code-mode saved tools (2).
Scanners read the code, not SECURITY.md, so the annotation has to be where
they land.

Adds a short note at each site naming and quoting the governing SECURITY.md
section and Scope exclusion, following the pattern already used in
`utils/python_sandbox.py` (which has never been re-reported).

Also rewrites the `tools_code.py` note that read "Scope to per-session/user
before multi-user support" — that phrasing describes accepted design as a
pending TODO, and the most recent report quoted that exact line as its
evidence. The WARNING is retained and extended with the `save_as`
overwrite-by-name behaviour.

**Boy Scout fix, surfaced during review of this PR:** the shutdown path never
observed `cleanup_task`. `asyncio.wait` does not retrieve results and the
timeout path deliberately abandons rather than awaits, so an exception
escaping `_cleanup_resources` surfaced only as a GC-time "Task exception was
never retrieved" — unstructured, and not guaranteed to be emitted before the
process exits. `_cancel_tasks` already retrieves and logs exceptions from the
tasks it reaps; `cleanup_task` was the one task in that function exempt.
Fixed with a single `add_done_callback` attached at task creation, which
covers both the completed and abandoned paths without awaiting a
possibly-hung cleanup. Regression test verified to fail without the callback
and pass with it.

## Type of change
- [x] 🐛 Bug fix
- [x] 📚 Documentation

## Testing
- [ ] I have tested these changes with a LLM agent
- [ ] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

## Checklist
- [x] I have updated documentation if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Cleanup failures during shutdown are now logged as warnings instead of being silently ignored.
  * Expected cancellation events no longer generate unnecessary warnings.

* **Documentation**
  * Clarified HTTP binding, secret-path security, settings UI authentication behavior, custom tool visibility, and DNS-rebinding protections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->