### PR TITLE
docs: document Webhook Proxy ha_auth as an access gate, not per-user authorization

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -239,6 +239,50 @@ re-validates that the session still maps to an active admin. The loopback secret
 path is never exposed to the browser and no token or secret is placed in a URL;
 the proxy returns 503 whenever the server is not running.
 
+### Webhook Proxy add-on (`ha_mcp_webhook_proxy`)
+
+In the add-on's `ha_auth` mode the Home Assistant login is the credential, not
+the webhook URL. The URL without a Bearer gets a 401, and the URL is not
+withheld: as in any OAuth mode, the RFC 9728 protected-resource document
+advertises it at a fixed unauthenticated path so clients can discover the
+endpoint. (This is the difference from the add-on's default posture with OAuth
+disabled, where the URL is withheld because it alone is the credential.)
+
+**`ha_auth` is an access gate, not per-user authorization.** It validates the
+inbound Bearer against Home Assistant core and accepts any token core still
+honors, without inspecting the backing account: administrators,
+non-administrators, and system-generated accounts are all accepted alike. (Home
+Assistant core itself rejects a deactivated user's tokens, so deactivation does
+revoke proxy access.) The in-process entry above, by contrast, accepts only
+active human administrators. The caller's Bearer is never forwarded upstream:
+the ha-mcp add-on services every request with its own
+Supervisor/`homeassistant_api` privileges regardless of which account
+authenticated. A caller holding a credential Home Assistant core honors is a
+trusted principal per "MCP clients are trusted principals" above, which draws
+the line at possession of a working credential — not at holding any particular
+Home Assistant role.
+
+Treat a Home Assistant account on this instance as admin-equivalent wherever the
+add-on runs `ha_auth`: every account that can sign in reaches the same tool
+surface. Because the gate never inspects the account's role, demoting a user out
+of the administrator group does not revoke their access through the proxy —
+deactivate the account, which Home Assistant honors immediately by dropping that
+user's refresh tokens. Turning the add-on's OAuth mode off revokes nobody, and
+loosens the boundary: the webhook id persists across the switch, so that posture
+falls back to treating as the sole credential a URL every `ha_auth` client
+already holds — and one that was advertised anonymously the whole time `ha_auth`
+was on. Treat any webhook id that has served `ha_auth` as public, and rotate it
+(add-on DOCS.md, "Rotating the webhook URL") when moving to the URL-secret
+posture. The in-process entry's admin restriction is a property of that entry,
+not a guarantee of the add-on.
+
+The add-on's `legacy` mode carries the same properties as the in-process
+`legacy` mode described above — the component's implementation was ported from
+this add-on's — including the static `client_id`/`client_secret` as the sole
+boundary, admin-equivalent access, self-issued HMAC bearers, and revocation by
+credential rotation plus a restart. Only one of the two may own the root
+`/authorize` and `/token` routes per Home Assistant instance.
+
 ## Scope
 
 **In scope** — please report these:
@@ -287,6 +331,14 @@ the proxy returns 503 whenever the server is not running.
   data — and `run_saved` executes with the caller's own HA token, granting no
   access the caller lacks. Any client that can reach ha-mcp is a trusted
   principal (see [Threat Model](#threat-model) above).
+- Any Home Assistant account being accepted by the Webhook Proxy add-on's
+  `ha_auth` mode — non-administrators and system-generated accounts alike:
+  holding a credential Home Assistant core honors makes a caller a trusted
+  principal (see [Threat Model](#threat-model) above), which is the bar that
+  mode sets.
+  `ha_auth` is an access gate, not per-user authorization; the in-process
+  entry's admin restriction is a property of that entry, not a guarantee of the
+  add-on.
 - Vulnerabilities that are only exploitable due to a misconfigured deployment
   (e.g., standard-mode instance exposed to the internet without TLS, or a
   network-reachable HTTP entrypoint using the default `MCP_SECRET_PATH`).


### PR DESCRIPTION
## What does this PR do?

Documents the Webhook Proxy add-on's `ha_auth` posture in SECURITY.md. The
threat model previously covered only the in-process `ha_mcp_tools` entry, so the
add-on — which shares the `ha_auth` mode name but not its admin restriction —
had no documented posture.

Records that the add-on's `ha_auth` gate validates the inbound Bearer against HA
core without inspecting the backing account, so administrators,
non-administrators, and system-generated accounts are accepted alike, and that
the caller's Bearer is never forwarded upstream — the ha-mcp add-on services
every request with its own privileges. Anyone completing the Home Assistant
login is a trusted principal under the existing "MCP clients are trusted
principals" rule, which draws the line at completing the OAuth flow rather than
at holding a particular HA role.

Also states the revocation consequence: demoting a user out of the administrator
group does not revoke proxy access, since the gate never inspects role.
Deactivation does revoke it (HA core rejects an inactive user's tokens).

Adds the matching Scope exclusion.

## Type of change
- [x] 📚 Documentation

## Testing
- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added threat-model guidance for Webhook Proxy authentication modes.
  * Clarified Home Assistant login authentication, webhook URL discovery, accepted account types, and add-on privileges.
  * Documented trusted-principal behavior, access revocation, URL rotation requirements, and legacy mode’s static credentials and restart-dependent revocation.
  * Clarified which non-administrator and system-generated accounts are outside vulnerability scope.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->