### PR TITLE
feat: add the Dutch (nl) locale across all four translated surfaces

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -755,7 +755,7 @@ identity holds by construction.
 
 A language ships on all four surfaces or not at all —
 `tests/src/unit/test_locale_parity.py` enforces it. One Home Assistant language
-code (`de`, `es`, `fr`, `it`, `ru`, `zh-Hans`) names every file:
+code (`de`, `es`, `fr`, `it`, `nl`, `ru`, `zh-Hans`) names every file:
 `src/ha_mcp/settings_ui/locales/<code>.json`,
 `custom_components/ha_mcp_tools/translations/<code>.json`, and
 `homeassistant-addon{,-dev}/translations/<code>.yaml`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -773,6 +773,15 @@ spells the backend literal counts as untranslated), so does
 into, and at least one translated key must have English that addresses the
 reader in the second person, which is where `scripts/translate_locales.py`
 reads the catalog's address register.
+`policies.operators.exists_long` is the trap in that list: the condition editor
+renders it as its own dropdown label, but it is UI-only rather than a
+`PredicateOp` member, so no enum-derived check asks for it and a catalog
+without it reads English there until the sync fills it. Each surface reads that
+register from its own catalog, so a component catalog left at a key or two
+rests on whichever of them addresses the reader — losing it costs the engine
+the register for every later string of that language and says so only on
+stderr, which is why
+`test_every_shipped_component_catalog_gets_reader_addressing_samples` pins it.
 `src/ha_mcp/settings_ui/locales/README.md` names the tests — including the one
 that skips locally until `tests/js/` has its npm dependencies.
 

--- a/custom_components/ha_mcp_tools/const.py
+++ b/custom_components/ha_mcp_tools/const.py
@@ -25,7 +25,7 @@ DOMAIN = "ha_mcp_tools"
 # in CI. The
 # capability negotiation — not this version — gates each WS command (see
 # ``websocket_api.CAPABILITIES``).
-COMPONENT_VERSION = "1.3.2"
+COMPONENT_VERSION = "1.3.3"
 
 # Config-entry discriminator (``entry.data[CONF_ENTRY_TYPE]``). A missing value
 # means "tools" so the pre-existing services entry keeps working across the

--- a/custom_components/ha_mcp_tools/manifest.json
+++ b/custom_components/ha_mcp_tools/manifest.json
@@ -22,5 +22,5 @@
     "requirements": [
         "ruamel.yaml>=0.18.0"
     ],
-    "version": "1.3.2"
+    "version": "1.3.3"
 }

--- a/custom_components/ha_mcp_tools/translations/nl.json
+++ b/custom_components/ha_mcp_tools/translations/nl.json
@@ -1,0 +1,5 @@
+{
+  "common": {
+    "oauth_not_serving": "Legacy OAuth levert deze nog niet — start Home Assistant opnieuw op wanneer je daarom wordt gevraagd, om ze te activeren."
+  }
+}

--- a/homeassistant-addon-dev/translations/nl.yaml
+++ b/homeassistant-addon-dev/translations/nl.yaml
@@ -1,0 +1,240 @@
+---
+# GENERATED FILE — do not edit. Translations live in
+# src/ha_mcp/settings_ui/locales/nl.json (keys addon.*, features.*,
+# addon_dev.*); regenerate with: python scripts/generate_locales.py
+configuration:
+  backup_hint:
+    name: Full-HA snapshot suggestion level (LLM-facing)
+    description: 'Tunes the wording of the hint the LLM sees in the
+
+      `ha_manage_backup(scope=''snapshot'')` tool description for when to
+
+      suggest a full Home Assistant tarball backup before risky operations
+
+      (e.g. mass device deletes). Affects ONLY this one LLM-facing prompt
+
+      sentence.
+
+
+      For per-edit automatic snapshots of automations / scripts / helpers /
+
+      etc., use the separate **Enable auto-backup of edits** toggle below.'
+  secret_path:
+    name: Secret path override
+    description: 'Optional custom HTTP path for the MCP server. Leave empty to use
+      the auto-generated secure path.
+
+      '
+  enable_tool_search:
+    name: Enable tool search
+    description: 'Replace the full tool catalog with search-based discovery. Reduces
+      idle context by roughly 90%, to about 5K tokens. ⚠️ Do NOT enable this in clients
+      with their own built-in tool search / deferred tools (claude.ai, Claude Desktop,
+      Claude Code) — the two search layers conflict, and the client''s built-in tool
+      search is the better choice there; leave this off. Whether tools are deferred
+      depends on your client and model combination: use this when your setup loads
+      the full catalog up front — models without native deferred tools (e.g. Gemini,
+      OpenAI-compatible local models, Claude Haiku), clients that inline all tool
+      schemas regardless of model (e.g. GitHub Copilot CLI), or smaller context windows.
+      Some Codex models and ChatGPT include deferred tools too — check your client/model
+      directly to confirm its features so you don''t leave this enabled unnecessarily.
+      Tools are found via ha_search_tools and executed via categorized proxies (read/write/delete).
+      Requires restart to take effect.'
+  enable_tool_security_policies:
+    name: Enable Tool Security Policies (advanced)
+    description: Gate high-stakes tool calls (lock/alarm control, automation writes,
+      etc.) behind user approval. When a guarded tool is called, the agent tells the
+      user to open the Tool Security Policies tab in the web UI and click Approve
+      before the call proceeds. Per-tool rules with optional argument conditions are
+      configured in the Tool Security Policies tab. Off by default. Requires restart
+      to take effect.
+  read_only_mode:
+    name: Read Only Mode
+    description: Toggles all write tools off, and removes ability for tools to make
+      any write or destructive calls. Mixed read/write tools (backups, add-ons, energy
+      preferences, voice pipelines, and code mode when enabled) stay available with
+      their write operations blocked. Same toggle as the web UI Tools tab. Off by
+      default. Requires restart to take effect.
+  enable_beta_features:
+    name: Enable beta features (master)
+    description: ⚠ DANGER — these tools can PERMANENTLY DAMAGE your Home Assistant
+      installation. They write to your YAML config, your filesystem, install custom
+      components, run arbitrary sandboxed Python, and edit tool docstrings the AI
+      sees. There is no warranty and no support guarantee — you enable them at your
+      OWN RISK. Take a Home Assistant backup before turning this on, and never enable
+      in production without one. Master gate for the 5 experimental sub-flags below;
+      sub-flags are ignored at runtime while this master is off, even when explicitly
+      set to true. The same toggle is also surfaced in the web settings UI under "Beta
+      features (dangerous)" — either surface reflects the other on restart.
+  enable_yaml_config_editing:
+    name: Enable YAML config editing (beta)
+    description: Beta feature. Allows AI assistants to add, replace, or remove top-level
+      keys in configuration.yaml and packages/*.yaml. Only whitelisted keys are allowed
+      (e.g., template, sensor, command_line, mqtt, knx); core keys like homeassistant,
+      http, and recorder are blocked. Each edit validates YAML syntax, runs a config
+      check, and creates an automatic backup. Changes to most keys require a full
+      HA restart to take effect. See docs/beta.md for known limitations. Dedicated
+      tools (automations, scripts, scenes, helpers, template sensors) should be preferred
+      when available. REQUIRES the master "Enable beta features" toggle above (and
+      in the web UI) to be on — otherwise this sub-flag is ignored at runtime regardless
+      of its value here.
+  enable_yaml_packages_automation:
+    name: Allow automation in packages/*.yaml
+    description: Sub-toggle of YAML config editing. When on, ha_config_set_yaml accepts
+      yaml_path='automation' inside packages/*.yaml. When off, the call is rejected
+      both client-side and server-side. The storage-mode tool (ha_config_set_automation)
+      is unaffected. Default OFF; only takes effect when "Enable YAML config editing"
+      above is also on.
+  enable_yaml_packages_script:
+    name: Allow script in packages/*.yaml
+    description: Sub-toggle of YAML config editing. When on, ha_config_set_yaml accepts
+      yaml_path='script' inside packages/*.yaml. When off, the call is rejected both
+      client-side and server-side. The storage-mode tool (ha_config_set_script) is
+      unaffected. Default OFF; only takes effect when "Enable YAML config editing"
+      above is also on.
+  enable_yaml_packages_scene:
+    name: Allow scene in packages/*.yaml
+    description: Sub-toggle of YAML config editing. When on, ha_config_set_yaml accepts
+      yaml_path='scene' inside packages/*.yaml. When off, the call is rejected both
+      client-side and server-side. The storage-mode tool (ha_config_set_scene) is
+      unaffected. Default OFF; only takes effect when "Enable YAML config editing"
+      above is also on.
+  enable_yaml_edit_confirm:
+    name: Require confirmation for YAML edits (diff preview)
+    description: 'Sub-toggle of YAML config editing, ON by default (recommended).
+      The first ha_config_set_yaml call returns a unified diff of exactly what would
+      change on disk plus a confirm token and writes nothing; the edit only lands
+      when the call is repeated with that token. Exists so unintended changes outside
+      the requested edit are caught before they reach disk (issue #1720). Turn off
+      only to save one round-trip per edit.'
+  enable_code_mode:
+    name: Enable custom tool sandbox (beta)
+    description: Beta feature. Enables the ha_manage_custom_tool tool, which lets
+      AI assistants create, run, save, and delete custom Python code in a secure sandbox
+      when no built-in tool can handle the request. Code runs in an isolated interpreter
+      with no filesystem or arbitrary network access. Sandbox code can hit the HA
+      REST API (api_get/api_post), send WebSocket commands (ws_send), call existing
+      MCP tools (call_tool), or remove a saved tool (delete_saved_tool). Saved tools
+      persist to /data/saved_tools.json by default so they survive add-on restarts,
+      and are visible to any client that can connect. See docs/beta.md for known limitations.
+      Requires restart to take effect. REQUIRES the master "Enable beta features"
+      toggle above (and in the web UI) to be on — otherwise this sub-flag is ignored
+      at runtime regardless of its value here.
+  enable_lite_docstrings:
+    name: Enable lite tool docstrings (beta)
+    description: 'Beta feature. Replaces the docstrings on a handful of heavy ha-mcp
+      tools (automations, scripts, scenes, helpers, dashboards, ha_call_service, ha_config_set_yaml)
+      with shorter variants that defer schema and example detail to the ha_get_skill_guide
+      tool (or its skill:// resource). WARNING: this reduces idle token usage, but
+      may degrade LLM performance — the trimmed descriptions rely on the LLM actually
+      calling the skill tool or reading the skill resource for detail, which is not
+      guaranteed (some models will skip the extra tool call and end up with less guidance
+      than they had before). Best paired with a client that supports MCP resources
+      or with enable_tool_search. Requires restart to take effect. REQUIRES the master
+      "Enable beta features" toggle above (and in the web UI) to be on — otherwise
+      this sub-flag is ignored at runtime regardless of its value here.'
+  enable_mandatory_bps:
+    name: Attach best-practice skills on writes
+    description: 'Master switch for the write-tool skill content delivery feature
+      (issue #1182). When enabled (default), the six config write tools (automations,
+      scripts, scenes, helpers, dashboards, raw YAML) attach the canonical Home Assistant
+      best-practice reference files under `skill_content` on every successful write,
+      plus auto-embed any reference sections cited by best-practice warnings. Each
+      tool also exposes a per-call `MandatoryBPS` parameter the agent can set to false
+      on subsequent calls once it has the content. When this master switch is off,
+      NO skill_content goes out regardless of the per-call parameter or BP warnings.
+      Recommended ON as the first choice; disable only for models with very small
+      context windows. Turning this off may degrade write accuracy. Requires restart
+      to take effect.'
+  enable_strict_mandatory_bps:
+    name: Strict best-practices mode
+    description: 'Strict mode: prevents the client from using the tool until it can
+      prove that it read the best practices. While on, the six best-practice write
+      tools (automations, scripts, scenes, helpers, dashboards, raw YAML) are blocked
+      and return an error directing the client to read the best-practices skill via
+      ha_get_skill_guide and pass back the acknowledgment key it obtains there. While
+      on, the ha_get_skill_guide tool is locked enabled — it is the only publisher
+      of the acknowledgment key. Child of the "Attach best-practice skills on writes"
+      option above and inert while that parent is off. Requires restart to take effect.'
+  enable_filesystem_tools:
+    name: Enable filesystem tools (beta)
+    description: 'Sets HAMCP_ENABLE_FILESYSTEM_TOOLS=true. Enables direct file read/write
+      access to your Home Assistant filesystem. WARNING: This gives the MCP server
+      sensitive direct file access to your system. Only enable if you trust the AI
+      assistant with file operations. Requires restart to take effect. REQUIRES the
+      master "Enable beta features" toggle above (and in the web UI) to be on — otherwise
+      this sub-flag is ignored at runtime regardless of its value here.'
+  enable_dashboard_screenshot:
+    name: Enable dashboard screenshot mode (beta)
+    description: Beta feature — disabled by default. Adds the ha_get_dashboard_screenshot
+      tool plus include_screenshot / return_screenshot options on the dashboard get/set
+      tools, so AI assistants can inspect one or more responsive Lovelace images (e.g.
+      to verify a dashboard they just created). Supports stable named views, mobile/tablet/desktop
+      batches, and PNG/JPEG/WebP/BMP output. Rendering runs in a separate, opt-in
+      engine — balloob's "Puppet" add-on (headless Chromium) — which you install once
+      (add balloob's add-on repository, then install "Puppet") and give a long-lived
+      access token; on Docker/Container deployments you run that engine as a sidecar
+      and set HAMCP_DASHBOARD_SCREENSHOT_ENGINE_URL. Nothing heavy is installed unless
+      you both enable this and install the engine. Requires restart to take effect.
+      REQUIRES the master "Enable beta features" toggle above (and in the web UI)
+      to be on — otherwise this sub-flag is ignored at runtime regardless of its value
+      here.
+  enable_auto_backup:
+    name: Enable auto-backup of edits
+    description: Captures a per-entity snapshot before every wrapped write/destructive
+      MCP tool call (automation, script, scene, helper, dashboard, label, category,
+      group, zone, area, calendar, todo, entity, integration, and sibling remove/delete
+      tools). Snapshots are saved as YAML files under /data/ha_mcp_backups/ (override
+      via HAMCP_BACKUP_DIR) and listed, restored, or deleted via the Backups tab in
+      the web settings UI or via ha_manage_backup(scope='edits', ...). Best-effort
+      — failures log a WARNING but never block the underlying write. On by default;
+      uncheck to opt out. Requires restart to take effect.
+  auto_backup_throttle_minutes:
+    name: Auto-backup throttle (minutes)
+    description: Per-entity throttle window. 0 (default) captures a snapshot on every
+      wrapped write. N>0 captures at most one snapshot per N minutes per entity. Range
+      0–1440.
+  auto_backup_retain_per_entity:
+    name: Auto-backup retention (per entity)
+    description: Maximum number of snapshots kept per entity. Older snapshots beyond
+      this cap are rotated out on each successful capture. Default 100, range 1–10000.
+  enable_snapshot_delete:
+    name: Allow snapshot deletion
+    description: Lets ha_manage_backup delete full HA snapshot tarballs (scope='snapshot',
+      action='delete'). Off by default — a snapshot may be the last recovery point
+      after a mistaken change, so a human must opt in here. Even when on, scheduled
+      backups, the newest remaining snapshot, and anything younger than the age floor
+      below stay protected.
+  snapshot_delete_min_age_days:
+    name: Minimum snapshot age to delete (days)
+    description: A snapshot must be at least this old before it can be deleted. Range
+      0–365; 0 disables the floor (the newest-snapshot and scheduled-backup protections
+      still apply). Default 7.
+  tool_search_max_results:
+    name: Tool search max results
+    description: 'Maximum number of tools returned by ha_search_tools when tool search
+      is enabled. Lower values (2-3) save context tokens but may miss relevant tools.
+      Range: 2-10. Requires restart.'
+  disabled_tools:
+    name: Disabled tools (comma-separated)
+    description: Tools listed here are forced off and locked in the web Settings UI
+      (Tools tab) — they cannot be re-enabled there without unsetting this option
+      first. A small set of mandatory tools (ha_search, ha_get_overview, ha_get_state,
+      ha_report_issue, ha_manage_backup) cannot be disabled and keep running even
+      if listed here. ha_get_skill_guide can be disabled only while strict best-practices
+      mode (enable_strict_mandatory_bps) is off. Comma-separated tool names (e.g.
+      ha_call_event,ha_eval_template).
+  pinned_tools:
+    name: Pinned tools (comma-separated)
+    description: Tools listed here are locked pinned — they appear at the top of the
+      Tools tab and cannot be unpinned from the web Settings UI without unsetting
+      this option first. Useful in combination with Tool Search. Comma-separated tool
+      names.
+  verify_ssl:
+    name: Verify TLS certificate
+    description: Verify the Home Assistant server's TLS certificate. The add-on connects
+      via the Supervisor proxy, so this normally has no effect and should stay enabled.
+      Disable only if you've reconfigured the add-on to talk to HA over a public HTTPS
+      hostname with a self-signed certificate or hostname mismatch. Disabling weakens
+      transport security — leave on unless you know you need it. Requires restart
+      to take effect.

--- a/homeassistant-addon/translations/nl.yaml
+++ b/homeassistant-addon/translations/nl.yaml
@@ -1,0 +1,142 @@
+---
+# GENERATED FILE — do not edit. Translations live in
+# src/ha_mcp/settings_ui/locales/nl.json (keys addon.*, features.*,
+# addon_stable.*); regenerate with: python scripts/generate_locales.py
+configuration:
+  backup_hint:
+    name: Full-HA snapshot suggestion level (LLM-facing)
+    description: 'Tunes the wording of the hint the LLM sees in the
+
+      `ha_manage_backup(scope=''snapshot'')` tool description for when to
+
+      suggest a full Home Assistant tarball backup before risky operations
+
+      (e.g. mass device deletes). Affects ONLY this one LLM-facing prompt
+
+      sentence.
+
+
+      For per-edit automatic snapshots of automations / scripts / helpers /
+
+      etc., use the separate **Enable auto-backup of edits** toggle below.'
+  secret_path:
+    name: Secret path override
+    description: 'Optional custom HTTP path for the MCP server. Leave empty to use
+      the auto-generated secure path.
+
+      '
+  enable_tool_search:
+    name: Enable tool search
+    description: 'Replace the full tool catalog with search-based discovery. Reduces
+      idle context by roughly 90%, to about 5K tokens. ⚠️ Do NOT enable this in clients
+      with their own built-in tool search / deferred tools (claude.ai, Claude Desktop,
+      Claude Code) — the two search layers conflict, and the client''s built-in tool
+      search is the better choice there; leave this off. Whether tools are deferred
+      depends on your client and model combination: use this when your setup loads
+      the full catalog up front — models without native deferred tools (e.g. Gemini,
+      OpenAI-compatible local models, Claude Haiku), clients that inline all tool
+      schemas regardless of model (e.g. GitHub Copilot CLI), or smaller context windows.
+      Some Codex models and ChatGPT include deferred tools too — check your client/model
+      directly to confirm its features so you don''t leave this enabled unnecessarily.
+      Tools are found via ha_search_tools and executed via categorized proxies (read/write/delete).
+      Requires an add-on restart to take effect — then reconnect or refresh the MCP
+      server in your AI client so it reloads the tool list. Restarting the add-on
+      alone does NOT refresh a client''s cached tool list; this applies after changing
+      any setting here.'
+  tool_search_max_results:
+    name: Tool search max results
+    description: 'Maximum number of tools returned by ha_search_tools when tool search
+      is enabled. Lower values (2-3) save context tokens but may miss relevant tools.
+      Range: 2-10. Requires restart.'
+  enable_tool_security_policies:
+    name: Enable Tool Security Policies (advanced)
+    description: Gate high-stakes tool calls (lock/alarm control, automation writes,
+      etc.) behind user approval. When a guarded tool is called, the agent tells the
+      user to open the Tool Security Policies tab in the web UI and click Approve
+      before the call proceeds. Per-tool rules with optional argument conditions are
+      configured in the Tool Security Policies tab. Off by default. Requires restart
+      to take effect.
+  read_only_mode:
+    name: Read Only Mode
+    description: Toggles all write tools off, and removes ability for tools to make
+      any write or destructive calls. Mixed read/write tools (backups, add-ons, energy
+      preferences, voice pipelines, and code mode when enabled) stay available with
+      their write operations blocked. Same toggle as the web UI Tools tab. Off by
+      default. Requires restart to take effect.
+  enable_mandatory_bps:
+    name: Attach best-practice skills on writes
+    description: 'Master switch for the write-tool skill content delivery feature
+      (issue #1182). When enabled (default), the six config write tools (automations,
+      scripts, scenes, helpers, dashboards, raw YAML) attach the canonical Home Assistant
+      best-practice reference files under `skill_content` on every successful write,
+      plus auto-embed any reference sections cited by best-practice warnings. Each
+      tool also exposes a per-call `MandatoryBPS` parameter the agent can set to false
+      on subsequent calls once it has the content. When this master switch is off,
+      NO skill_content goes out regardless of the per-call parameter or BP warnings.
+      Recommended ON as the first choice; disable only for models with very small
+      context windows. Turning this off may degrade write accuracy. Requires restart
+      to take effect.'
+  enable_strict_mandatory_bps:
+    name: Strict best-practices mode
+    description: 'Strict mode: prevents the client from using the tool until it can
+      prove that it read the best practices. While on, the six best-practice write
+      tools (automations, scripts, scenes, helpers, dashboards, raw YAML) are blocked
+      and return an error directing the client to read the best-practices skill via
+      ha_get_skill_guide and pass back the acknowledgment key it obtains there. While
+      on, the ha_get_skill_guide tool is locked enabled — it is the only publisher
+      of the acknowledgment key. Child of the "Attach best-practice skills on writes"
+      option above and inert while that parent is off. Requires restart to take effect.'
+  disabled_tools:
+    name: Disabled tools (comma-separated)
+    description: Tools listed here are forced off and locked in the web Settings UI
+      (Tools tab) — they cannot be re-enabled there without unsetting this option
+      first. A small set of mandatory tools (ha_search, ha_get_overview, ha_get_state,
+      ha_report_issue, ha_manage_backup) cannot be disabled and keep running even
+      if listed here. ha_get_skill_guide can be disabled only while strict best-practices
+      mode (enable_strict_mandatory_bps) is off. Comma-separated tool names (e.g.
+      ha_call_event,ha_eval_template).
+  pinned_tools:
+    name: Pinned tools (comma-separated)
+    description: Tools listed here are locked pinned — they appear at the top of the
+      Tools tab and cannot be unpinned from the web Settings UI without unsetting
+      this option first. Useful in combination with Tool Search. Comma-separated tool
+      names.
+  enable_auto_backup:
+    name: Enable auto-backup of edits
+    description: Captures a per-entity snapshot before every wrapped write/destructive
+      MCP tool call (automation, script, scene, helper, dashboard, label, category,
+      group, zone, area, calendar, todo, entity, integration, and sibling remove/delete
+      tools). Snapshots are saved as YAML files under /data/ha_mcp_backups/ (override
+      via HAMCP_BACKUP_DIR) and listed, restored, or deleted via the Backups tab in
+      the web settings UI or via ha_manage_backup(scope='edits', ...). Best-effort
+      — failures log a WARNING but never block the underlying write. On by default;
+      uncheck to opt out. Requires restart to take effect.
+  auto_backup_throttle_minutes:
+    name: Auto-backup throttle (minutes)
+    description: Per-entity throttle window. 0 (default) captures a snapshot on every
+      wrapped write. N>0 captures at most one snapshot per N minutes per entity. Range
+      0–1440.
+  auto_backup_retain_per_entity:
+    name: Auto-backup retention (per entity)
+    description: Maximum number of snapshots kept per entity. Older snapshots beyond
+      this cap are rotated out on each successful capture. Default 100, range 1–10000.
+  enable_snapshot_delete:
+    name: Allow snapshot deletion
+    description: Lets ha_manage_backup delete full HA snapshot tarballs (scope='snapshot',
+      action='delete'). Off by default — a snapshot may be the last recovery point
+      after a mistaken change, so a human must opt in here. Even when on, scheduled
+      backups, the newest remaining snapshot, and anything younger than the age floor
+      below stay protected.
+  snapshot_delete_min_age_days:
+    name: Minimum snapshot age to delete (days)
+    description: A snapshot must be at least this old before it can be deleted. Range
+      0–365; 0 disables the floor (the newest-snapshot and scheduled-backup protections
+      still apply). Default 7.
+  verify_ssl:
+    name: Verify TLS certificate
+    description: Verify the Home Assistant server's TLS certificate. The add-on connects
+      via the Supervisor proxy, so this normally has no effect and should stay enabled.
+      Disable only if you've reconfigured the add-on to talk to HA over a public HTTPS
+      hostname with a self-signed certificate or hostname mismatch. Disabling weakens
+      transport security — leave on unless you know you need it. Requires restart
+      to take effect.

--- a/scripts/translate_locales.py
+++ b/scripts/translate_locales.py
@@ -460,12 +460,22 @@ def _style_sample_keys(
     to imitate, and when the key is itself in the batch the model answers with
     the stale text it was just shown — which validates, gets written, and
     repins the baseline as if it were current.
+
+    A blank translation is skipped like a missing one. It renders as an empty
+    right-hand side into the prompt, so the pair it contributes shows the model
+    nothing to imitate while still counting against the sample budget — and on
+    a catalog whose register rests on a single key, that is the whole signal.
+    Nothing upstream stops it reaching here: an engine answer this shape is
+    rejected (`_validate`), but a hand-committed one is only type-checked
+    (`_validate_string_map`), and the parity ceilings count a key untranslated
+    only when it equals the English or is absent, so `""` reads as translated.
     """
     return sorted(
         (
             key
             for key, text in english.items()
             if key in translated
+            and translated[key].strip()
             and key not in exclude
             and _SECOND_PERSON_RE.search(text)
         ),

--- a/src/ha_mcp/settings_ui/locales/README.md
+++ b/src/ha_mcp/settings_ui/locales/README.md
@@ -38,9 +38,10 @@ entirely on whichever of them addresses the reader —
 `test_every_shipped_component_catalog_gets_reader_addressing_samples` pins that
 one. Leaving that catalog empty is fine, but the moment you author anything in
 it, at least one key must be one whose English addresses the reader in the
-second person. Most component strings do not, so starting at the top of the
-file leaves the catalog anchorless and that check red until you add one that
-does. To fill them in your own PR instead, run
+second person, and it must carry a non-empty translation — a key left blank is
+skipped like a missing one rather than sampled empty. Most component strings do
+not address the reader, so starting at the top of the file leaves the catalog
+anchorless and that check red until you add one that does. To fill them in your own PR instead, run
 `scripts/translate_locales.py` yourself and review its output like any
 other diff. Also add the new code to the locale list in the repository-root
 `AGENTS.md`

--- a/src/ha_mcp/settings_ui/locales/README.md
+++ b/src/ha_mcp/settings_ui/locales/README.md
@@ -29,7 +29,18 @@ and merge: the post-merge `locale-sync.yml` workflow machine-fills every string
 over its next daily runs. The component catalog may start as an empty object;
 this one needs `meta` (`native_name`, `dir`) plus the handful of `messages`
 keys the ungated checks below demand — a `meta`-only catalog is red in PR CI.
-To fill them in your own PR instead, run
+Two things that list will not lead you to: `policies.operators.exists_long` is
+the condition editor's own dropdown label rather than a `PredicateOp` member,
+so no check asks for it and a catalog without it reads English there until the
+sync fills it; and because each surface samples its own catalog for the address
+register the engine imitates, a component catalog left at a key or two rests
+entirely on whichever of them addresses the reader —
+`test_every_shipped_component_catalog_gets_reader_addressing_samples` pins that
+one. Leaving that catalog empty is fine, but the moment you author anything in
+it, at least one key must be one whose English addresses the reader in the
+second person. Most component strings do not, so starting at the top of the
+file leaves the catalog anchorless and that check red until you add one that
+does. To fill them in your own PR instead, run
 `scripts/translate_locales.py` yourself and review its output like any
 other diff. Also add the new code to the locale list in the repository-root
 `AGENTS.md`

--- a/src/ha_mcp/settings_ui/locales/nl.json
+++ b/src/ha_mcp/settings_ui/locales/nl.json
@@ -15,6 +15,8 @@
     "policies.operators.regex": "komt overeen met regex",
     "policies.operators.gt": "is groter dan",
     "policies.operators.lt": "is kleiner dan",
-    "accessibility.storage_blocked": "Je browser blokkeert opslag voor deze site; keuzes gelden alleen voor deze sessie."
+    "accessibility.storage_blocked": "Je browser blokkeert opslag voor deze site; keuzes gelden alleen voor deze sessie.",
+    "policies.pending.already_decided": "Deze goedkeuring was al {decision}, mogelijk door een ander tabblad of een andere sessie.",
+    "policies.operators.exists_long": "is aanwezig (elke waarde)"
   }
 }

--- a/src/ha_mcp/settings_ui/locales/nl.json
+++ b/src/ha_mcp/settings_ui/locales/nl.json
@@ -1,0 +1,20 @@
+{
+  "meta": {
+    "native_name": "Nederlands",
+    "dir": "ltr"
+  },
+  "messages": {
+    "policies.pending.decision.approved": "goedgekeurd",
+    "policies.pending.decision.denied": "geweigerd",
+    "policies.operators.exists": "bestaat",
+    "policies.operators.eq": "is gelijk aan",
+    "policies.operators.neq": "is NIET gelijk aan",
+    "policies.operators.in": "is een van",
+    "policies.operators.not_in": "is NIET een van",
+    "policies.operators.contains": "bevat",
+    "policies.operators.regex": "komt overeen met regex",
+    "policies.operators.gt": "is groter dan",
+    "policies.operators.lt": "is kleiner dan",
+    "accessibility.storage_blocked": "Je browser blokkeert opslag voor deze site; keuzes gelden alleen voor deze sessie."
+  }
+}

--- a/tests/src/unit/test_component_ws_search.py
+++ b/tests/src/unit/test_component_ws_search.py
@@ -779,7 +779,7 @@ class TestInfo:
                 _REPO_ROOT / "custom_components" / "ha_mcp_tools" / "manifest.json"
             ).read_text(encoding="utf-8")
         )
-        assert manifest["version"] == COMPONENT_VERSION == "1.3.2"
+        assert manifest["version"] == COMPONENT_VERSION == "1.3.3"
 
 
 # =============================================================================

--- a/tests/src/unit/test_translate_locales.py
+++ b/tests/src/unit/test_translate_locales.py
@@ -47,6 +47,17 @@ _TRANSLATED_LOCALES = sorted(
     for path in _SETTINGS_LOCALES.glob("*.json")
     if path.stem != "en" and json.loads(path.read_text("utf-8")).get("messages")
 )
+# The other authored surface samples its own catalog, never the settings one
+# (`_surface_catalogs`), so it needs its own list. Read the production constant
+# rather than rebuilding the path: a catalog this list misses is a catalog the
+# check below silently never runs on. An empty catalog is excluded for the same
+# reason as above — AGENTS.md § Translations lets a component catalog start
+# empty, and there is no wording in one to sample.
+_COMPONENT_LOCALES = sorted(
+    path.stem
+    for path in translate_locales.COMPONENT_DIR.glob("*.json")
+    if path.stem != "en" and _flatten(json.loads(path.read_text("utf-8")))
+)
 
 
 _SAMPLE_ENGLISH = {
@@ -208,6 +219,38 @@ class TestStyleSamples:
         assert all(
             translate_locales._SECOND_PERSON_RE.search(english[key]) for key in keys
         ), f"{locale}.json samples {keys} do not address the reader"
+
+    def test_the_component_catalogs_are_discovered(self) -> None:
+        """Same glob guard as above, for the other authored surface."""
+        assert _COMPONENT_LOCALES, "no component catalogs found to check samples for"
+
+    @pytest.mark.parametrize("locale", _COMPONENT_LOCALES)
+    def test_every_shipped_component_catalog_gets_reader_addressing_samples(
+        self, locale: str
+    ) -> None:
+        """The component surface carries the same guarantee and less margin.
+
+        A settings catalog samples from hundreds of keys, so one English string
+        losing its second person costs it one candidate. A component catalog
+        starts empty and is filled a key at a time, so early on the whole
+        surface can rest on a single shared key — today `nl` is exactly that,
+        one key. Lose the addressing there and the engine is told nothing about
+        how this language addresses its reader and falls back to its own
+        register for every later string, and the only trace is a line on
+        stderr inside an unattended workflow run. Goes through
+        ``_surface_catalogs`` on purpose: that it reads the component catalog
+        rather than the settings one is the property at issue.
+        """
+        english, translated = translate_locales._surface_catalogs(locale, "component")
+        keys = translate_locales._style_sample_keys(english, translated)
+
+        assert keys, (
+            f"component {locale}.json yields no style sample, so the engine "
+            "gets no signal about how this catalog addresses its reader"
+        )
+        assert all(
+            translate_locales._SECOND_PERSON_RE.search(english[key]) for key in keys
+        ), f"component {locale}.json samples {keys} do not address the reader"
 
 
 class TestPromptRegisterRule:

--- a/tests/src/unit/test_translate_locales.py
+++ b/tests/src/unit/test_translate_locales.py
@@ -160,6 +160,22 @@ class TestStyleSamples:
             "long"
         ]
 
+    @pytest.mark.parametrize("blank", ["", " ", "\n\t "])
+    def test_skips_keys_whose_translation_is_blank(self, blank: str) -> None:
+        """A blank value is a present key with nothing in it, and the sampler is
+        the only thing that looks: `_validate_string_map` type-checks, and the
+        parity ceilings count a key untranslated only when it equals the English
+        or is missing, so `""` reads there as translated. Sampled, it spends one
+        of three slots on a pair whose target side is empty — and a catalog
+        whose register rests on one key would hand the engine that and nothing
+        else. Whitespace counts as blank: it renders the same.
+        """
+        translated = dict.fromkeys(_SAMPLE_ENGLISH, "…") | {"short": blank}
+        assert translate_locales._style_sample_keys(_SAMPLE_ENGLISH, translated) == [
+            "middle",
+            "long",
+        ]
+
     def test_no_addressing_source_yields_no_samples(self) -> None:
         """Degenerate but defined: an English catalog that never addresses the
         reader gives the prompt no style block rather than a neutral one."""


### PR DESCRIPTION
## What does this PR do?

Adds Dutch (`nl`) on all four translated surfaces, as the catalog the post-merge
`locale-sync.yml` run fills.

Why Dutch next: Home Assistant publishes no language statistic — the analytics
integration collects a country code, not a locale — so the closest available
signal is the country table in `analytics.home-assistant.io/data.json`. Fetched
today, the Netherlands is the fourth-largest country by active installations
(~36.3k of ~662k), behind Germany, the US and the UK, and ahead of France.
Reading that table as languages, Dutch is the largest one ha-mcp does not ship:
English and German are ahead of it and both have catalogs, and the largest
language without one is Polish, at less than half Dutch's installed base.

**What is authored.** The settings catalog carries the fourteen strings that
cannot wait for the sync:

- A word for each decided `Decision` outcome and each `PredicateOp` operator,
  eleven in all, plus `policies.pending.already_decided`, the sentence those
  words are interpolated into. None of the twelve sit behind
  `LOCALE_COMPLETENESS_CHECKS`. The eleven are checked by
  `test_every_decided_outcome_has_a_catalog_word` and
  `test_every_predicate_operator_has_a_catalog_word`; the twelfth by
  `TestAlreadyDecidedCopy`, which reads the locale's own message map to build
  the sentence it expects, so a catalog carrying the word without its host
  sentence raises `KeyError` there. That check needs the JSDOM harness, which
  is why it is silent in a local run without it (see Testing).
- `policies.operators.exists_long`, the condition-editor dropdown label for
  `exists`. It is UI-only rather than a `PredicateOp` member, so the
  enum-derived checks never ask for it and the Dutch dropdown would read
  English until the sync filled it.
- One key whose English addresses the reader — see below.

The component catalog carries one string, for the same reason. The two add-on
YAMLs are generated (`scripts/generate_locales.py`) and project English until
the sync runs. `AGENTS.md` gains `nl` in its locale list, which
`test_agents_md_lists_every_shipped_locale` pins, and the component version
opens the next pending patch — the component catalog is a file under
`custom_components/ha_mcp_tools`, and master is level with the released stable:
the HACS mirror's latest stable release is v1.3.2. Without the bump the change
would ship under a number whose tag already exists, and the PR-time Component
Version Gate fails on manifest == released stable. That bump moves
`manifest.json`, `COMPONENT_VERSION` and the parity literal in
`test_component_ws_search.py` together to 1.3.3; `MIN_COMPONENT_VERSION` stays
at 1.2.0, since this adds no service or argument the server depends on.

**The address-register anchors are the load-bearing choice here.**
`scripts/translate_locales.py` picks a style sample per surface — a translated
key whose English addresses the reader — and tells the engine to imitate its
register. A surface without one gets no anchor and the engine falls back to its
own default, which is why the component catalog carries one too rather than
starting empty. Home Assistant's own Dutch frontend is informal: across the two
largest Dutch catalogs the shipped 20260729.5 wheel carries — 7,839 strings —
608 use `je`/`jij`/`jouw` and none use `u`/`uw`. Both sampled strings are
written informally to match,
and calling the sampler directly returns exactly them:
`accessibility.storage_blocked` for the settings surface,
`common.oauth_not_serving` for the component one.

**Added after review.** The anchor that paragraph rests on was not itself
pinned for the component surface: `test_every_shipped_catalog_gets_reader_addressing_samples`
globs the settings locales directory, and until this commit every
`COMPONENT_DIR` reference in that test file was monkeypatched to a fixture, so
nothing shipped was checking the surface that samples its own catalog. The
locale list added here is that file's first read of the production constant. A mirrored parametrization over the
shipped component catalogs now covers it — derived from the production
`COMPONENT_DIR` rather than a rebuilt path, and going through
`_surface_catalogs` so that it reads the component catalog rather than the
settings one is itself asserted. `AGENTS.md` § Translations and this
directory's README gain the two things this PR had to discover the hard way:
that `policies.operators.exists_long` needs authoring although no enum-derived
check asks for it, and that the permission to start a component catalog empty
stops being free at the first authored key.

A second review round then closed the other half of that anchor. The sampler
picked candidates from a key's presence and from the second person in its
English, never reading the translated value, so a key committed as `""` was
sampled and rendered as an empty pair while still consuming one of the three
sample slots — and on a one-key catalog that is the whole register signal.
Nothing else rejects it: `_validate` refuses a blank engine answer, but a
hand-committed one meets only `_validate_string_map`'s `isinstance` check, and
`_untranslated_keys` counts a key untranslated only when it equals the English
or is absent. `_style_sample_keys` now requires a non-blank translation, which
guards the unattended sync run as well as the checks, and the README's
procedure states that half of the rule too.

`scripts/translate_locales.py --dry-run` plans 721 strings for `nl` and no
orphan deletions. The gated completeness checks would fail against master
between this merge and the next sync run; they are gated out of PR CI and run
only inside `locale-sync.yml`, after its translate step, so nothing goes red in
that window — that is the flow the workflow documents, not a regression here.

## Type of change
- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [ ] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

`tests/src/unit` on this branch: 9,549 passed, 69 skipped, and 5 errors that
are environmental rather than branch-caused — `test_relay_timeout_upstream_contract.py`
introspects the real `aiohttp`, which my environment lacks. CI runs the full
suite, which is where the missing `policies.pending.already_decided` first
showed up: the JS behaviour tests skip unless `tests/js/` has its npm
dependencies installed, so that guard was silent locally and loud in CI. With
them installed, `test_settings_ui_js_behavior.py` runs 142 passed, 0 skipped.

## Checklist
- [x] I have updated documentation if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Dutch language support across the integration, add-on settings, and user interface.
  * Added Dutch translations for configuration options, policy labels, accessibility messages, backups, security, tool settings, and OAuth messaging.

* **Maintenance**
  * Updated the component version to 1.3.3.
  * Documented Dutch among supported Home Assistant languages and clarified translation guidance.
  * Improved validation for translated component catalogs and reader-facing language samples.
  * Excluded blank translations from localization style checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


