### PR TITLE
fix: cap release notes at GitHub's 125k body limit

### DIFF
--- a/.github/workflows/hotfix-release.yml
+++ b/.github/workflows/hotfix-release.yml
@@ -114,8 +114,9 @@ jobs:
         VERSION="${{ steps.semantic.outputs.version }}"
         TAG="v${VERSION}"
 
-        # Extract changelog for this version (content between version headers)
-        awk -v ver="## v${VERSION}" '$0 ~ "^"ver {found=1; next} found && /^## v[0-9]/ {exit} found' CHANGELOG.md > release_notes.md
+        # Extract changelog for this version, capped at GitHub's release-body limit
+        # (an over-long body is a 422 that strands the already-pushed tag).
+        python3 scripts/extract_release_notes.py --version "$VERSION" --out release_notes.md
         if [ ! -s release_notes.md ]; then
           echo "Hotfix Release v${VERSION}" > release_notes.md
           echo "" >> release_notes.md

--- a/.github/workflows/semver-release.yml
+++ b/.github/workflows/semver-release.yml
@@ -171,8 +171,9 @@ jobs:
         VERSION="${{ steps.semantic.outputs.version }}"
         TAG="v${VERSION}"
 
-        # Extract changelog for this version (content between version headers)
-        awk -v ver="## v${VERSION}" '$0 ~ "^"ver {found=1; next} found && /^## v[0-9]/ {exit} found' CHANGELOG.md > release_notes.md
+        # Extract changelog for this version, capped at GitHub's release-body limit
+        # (an over-long body is a 422 that strands the already-pushed tag).
+        python3 scripts/extract_release_notes.py --version "$VERSION" --out release_notes.md
         if [ ! -s release_notes.md ]; then
           echo "Release v${VERSION}" > release_notes.md
         fi

--- a/scripts/extract_release_notes.py
+++ b/scripts/extract_release_notes.py
@@ -36,10 +36,19 @@ _NEXT_SECTION_RE = re.compile(r"^## v\d")
 
 _FENCE_RE = re.compile(r"^\s*```")
 
+# Appended when truncation cuts inside a fenced block. Its length is reserved
+# up front, so closing the fence can never push the body back over the limit.
+_FENCE_CLOSE = "\n```"
+
 
 def _heading_re(version: str) -> re.Pattern[str]:
-    """Match the heading for exactly `version`, not a longer version sharing its prefix."""
-    return re.compile(rf"^## v{re.escape(version.lstrip('v'))}(?![\w.])")
+    """Match the heading for exactly `version`, not a longer version sharing its prefix.
+
+    The lookahead rejects `.` and word characters (so `8.0.0` misses
+    `## v8.0.01`) and also `-` / `+`, so a stable version never matches a
+    prerelease or build-metadata heading like `## v8.0.0-rc.1`.
+    """
+    return re.compile(rf"^## v{re.escape(version.lstrip('v'))}(?![\w.+-])")
 
 
 def extract_section(changelog: str, version: str) -> str:
@@ -74,7 +83,7 @@ def _truncation_notice(repo: str, version: str, limit: int) -> str:
 def _close_dangling_fence(text: str) -> str:
     """Append a closing fence if truncation cut inside a fenced code block."""
     if sum(1 for line in text.splitlines() if _FENCE_RE.match(line)) % 2:
-        return text + "\n```"
+        return text + _FENCE_CLOSE
     return text
 
 
@@ -89,7 +98,10 @@ def cap_to_limit(body: str, repo: str, version: str, limit: int) -> str:
         return body
 
     notice = _truncation_notice(repo, version, limit)
-    budget = limit - len(notice)
+    # Reserve the closing fence too: it is appended after the line-boundary cut,
+    # so without the reservation a fenced body overshoots `limit` by up to four
+    # characters whenever the cut lands that close to the budget.
+    budget = limit - len(notice) - len(_FENCE_CLOSE)
     if budget <= 0:  # pragma: no cover - only reachable with an absurd --limit
         return body[:limit]
 

--- a/scripts/extract_release_notes.py
+++ b/scripts/extract_release_notes.py
@@ -36,9 +36,15 @@ _NEXT_SECTION_RE = re.compile(r"^## v\d")
 
 _FENCE_RE = re.compile(r"^\s*```")
 
-# Appended when truncation cuts inside a fenced block. Its length is reserved
-# up front, so closing the fence can never push the body back over the limit.
+# Truncation can land inside a block the changelog template opened: a fenced
+# code block, or the `<details><summary>Internal Changes</summary>` element
+# semantic-release wraps internal commits in. Both are closed after the cut --
+# an unclosed `<details>` in particular would swallow the truncation notice
+# into a collapsed section, so a reader sees no sign the notes are incomplete.
+# Their lengths are reserved before lines are selected, so closing them can
+# never push the body back over the limit.
 _FENCE_CLOSE = "\n```"
+_DETAILS_CLOSE = "\n</details>"
 
 
 def _heading_re(version: str) -> re.Pattern[str]:
@@ -80,41 +86,68 @@ def _truncation_notice(repo: str, version: str, limit: int) -> str:
     )
 
 
-def _close_dangling_fence(text: str) -> str:
-    """Append a closing fence if truncation cut inside a fenced code block."""
-    if sum(1 for line in text.splitlines() if _FENCE_RE.match(line)) % 2:
-        return text + _FENCE_CLOSE
-    return text
+class _OpenBlocks:
+    """Tracks which markdown blocks are still open as lines are consumed."""
+
+    def __init__(self) -> None:
+        self.in_fence = False
+        self.details_depth = 0
+
+    def feed(self, line: str) -> None:
+        if _FENCE_RE.match(line):
+            self.in_fence = not self.in_fence
+            return
+        if self.in_fence:  # `<details>` inside a code block is text, not markup
+            return
+        self.details_depth += line.count("<details>") - line.count("</details>")
+        self.details_depth = max(self.details_depth, 0)
+
+    @property
+    def closers(self) -> str:
+        """The suffix that closes everything still open, innermost first."""
+        fence = _FENCE_CLOSE if self.in_fence else ""
+        return fence + _DETAILS_CLOSE * self.details_depth
 
 
 def cap_to_limit(body: str, repo: str, version: str, limit: int) -> str:
     """Return `body` unchanged, or truncated on a line boundary plus a notice.
 
-    Truncating on a line boundary keeps the markdown readable; a body whose
-    very first line already blows the budget is cut mid-line rather than
-    reduced to a bare notice.
+    Truncating on a line boundary keeps the markdown readable. A line is only
+    taken when the *closed* form still fits -- the closers for whatever it
+    leaves open are charged against the budget before the line is accepted, so
+    the result never exceeds `limit`.
     """
     if len(body) <= limit:
         return body
 
     notice = _truncation_notice(repo, version, limit)
-    # Reserve the closing fence too: it is appended after the line-boundary cut,
-    # so without the reservation a fenced body overshoots `limit` by up to four
-    # characters whenever the cut lands that close to the budget.
-    budget = limit - len(notice) - len(_FENCE_CLOSE)
+    budget = limit - len(notice)
     if budget <= 0:  # pragma: no cover - only reachable with an absurd --limit
         return body[:limit]
 
+    open_blocks = _OpenBlocks()
     kept: list[str] = []
     used = 0
     for line in body.splitlines(keepends=True):
-        if used + len(line) > budget:
+        candidate = _OpenBlocks()
+        candidate.in_fence, candidate.details_depth = (
+            open_blocks.in_fence,
+            open_blocks.details_depth,
+        )
+        candidate.feed(line)
+        if used + len(line) + len(candidate.closers) > budget:
             break
         kept.append(line)
         used += len(line)
+        open_blocks = candidate
 
     head = "".join(kept).rstrip() if kept else body[:budget].rstrip()
-    return _close_dangling_fence(head) + notice
+    closers = open_blocks.closers if kept else ""
+    # Defensive clamp: rstrip only shortens, so this should already hold.
+    overflow = len(head) + len(closers) + len(notice) - limit
+    if overflow > 0:  # pragma: no cover - budget accounting makes this unreachable
+        head = head[:-overflow]
+    return head + closers + notice
 
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:

--- a/scripts/extract_release_notes.py
+++ b/scripts/extract_release_notes.py
@@ -116,14 +116,21 @@ def cap_to_limit(body: str, repo: str, version: str, limit: int) -> str:
     taken when the *closed* form still fits -- the closers for whatever it
     leaves open are charged against the budget before the line is accepted, so
     the result never exceeds `limit`.
+
+    Raises ValueError when `limit` cannot even hold the truncation notice.
+    Silently emitting a notice-free body there would hand GitHub a release that
+    looks complete but is not, so an unusable --limit fails loudly instead.
     """
     if len(body) <= limit:
         return body
 
     notice = _truncation_notice(repo, version, limit)
     budget = limit - len(notice)
-    if budget <= 0:  # pragma: no cover - only reachable with an absurd --limit
-        return body[:limit]
+    if budget <= 0:
+        raise ValueError(
+            f"--limit {limit} cannot hold the {len(notice)}-character truncation "
+            "notice, so the notes would be silently cut with no indication"
+        )
 
     open_blocks = _OpenBlocks()
     kept: list[str] = []
@@ -183,8 +190,12 @@ def main(argv: list[str] | None = None) -> int:
 
     body = extract_section(changelog, args.version)
     if body:
-        # Cap the trailing newline too, so the written file never exceeds --limit.
-        body = cap_to_limit(body + "\n", args.repo, args.version, args.limit)
+        try:
+            # Cap the trailing newline too, so the written file never exceeds --limit.
+            body = cap_to_limit(body + "\n", args.repo, args.version, args.limit)
+        except ValueError as e:
+            print(f"extract_release_notes: {e}", file=sys.stderr)
+            return 1
     args.out.write_text(body, encoding="utf-8")
     return 0
 

--- a/scripts/extract_release_notes.py
+++ b/scripts/extract_release_notes.py
@@ -1,0 +1,148 @@
+"""Extract one version's CHANGELOG section as a GitHub release body.
+
+The release workflows used to do this with an inline `awk` one-liner and pipe
+the result straight into `gh release create --notes-file`. That has no upper
+bound, but the GitHub API caps a release body at 125,000 characters and rejects
+anything longer with `HTTP 422: body is too long` -- which kills the release
+*after* semantic-release has already committed the version bump and pushed the
+tag, leaving a half-applied release to clean up by hand.
+
+A section grows past the cap whenever python-semantic-release regenerates the
+changelog over a long tag gap (it then collapses every commit since the last
+reachable stable tag into a single section). So this script does the same
+extraction, then truncates on a line boundary and appends a pointer to the full
+changelog rather than letting the API reject the whole release.
+
+Prints nothing on success; writes the notes to --out. An absent version yields
+an empty file, which is the signal for the caller's own fallback text.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sys
+from pathlib import Path
+
+# GitHub's documented maximum for a release body. Characters, not bytes --
+# the changelog carries emoji in headings, so a byte-based cut would be wrong.
+GITHUB_RELEASE_BODY_LIMIT = 125_000
+
+# Section headings look like "## v8.0.0 (2026-08-02)". The negative lookahead
+# keeps "8.0.0" from also matching "## v8.0.01", which a bare prefix match
+# (what the old awk did) accepts.
+_NEXT_SECTION_RE = re.compile(r"^## v\d")
+
+_FENCE_RE = re.compile(r"^\s*```")
+
+
+def _heading_re(version: str) -> re.Pattern[str]:
+    """Match the heading for exactly `version`, not a longer version sharing its prefix."""
+    return re.compile(rf"^## v{re.escape(version.lstrip('v'))}(?![\w.])")
+
+
+def extract_section(changelog: str, version: str) -> str:
+    """Return the changelog body for `version`, or "" when the version is absent.
+
+    The body is everything after the version's heading up to the next version
+    heading (or end of file), with surrounding blank lines stripped.
+    """
+    heading = _heading_re(version)
+    lines = changelog.splitlines(keepends=True)
+
+    start = next((i for i, line in enumerate(lines) if heading.match(line)), None)
+    if start is None:
+        return ""
+
+    body = lines[start + 1 :]
+    end = next((i for i, line in enumerate(body) if _NEXT_SECTION_RE.match(line)), None)
+    if end is not None:
+        body = body[:end]
+    return "".join(body).strip()
+
+
+def _truncation_notice(repo: str, version: str, limit: int) -> str:
+    url = f"https://github.com/{repo}/blob/v{version.lstrip('v')}/CHANGELOG.md"
+    return (
+        "\n\n---\n\n"
+        f"_Release notes truncated to fit GitHub's {limit:,}-character release-body "
+        f"limit. Full changelog: {url}_\n"
+    )
+
+
+def _close_dangling_fence(text: str) -> str:
+    """Append a closing fence if truncation cut inside a fenced code block."""
+    if sum(1 for line in text.splitlines() if _FENCE_RE.match(line)) % 2:
+        return text + "\n```"
+    return text
+
+
+def cap_to_limit(body: str, repo: str, version: str, limit: int) -> str:
+    """Return `body` unchanged, or truncated on a line boundary plus a notice.
+
+    Truncating on a line boundary keeps the markdown readable; a body whose
+    very first line already blows the budget is cut mid-line rather than
+    reduced to a bare notice.
+    """
+    if len(body) <= limit:
+        return body
+
+    notice = _truncation_notice(repo, version, limit)
+    budget = limit - len(notice)
+    if budget <= 0:  # pragma: no cover - only reachable with an absurd --limit
+        return body[:limit]
+
+    kept: list[str] = []
+    used = 0
+    for line in body.splitlines(keepends=True):
+        if used + len(line) > budget:
+            break
+        kept.append(line)
+        used += len(line)
+
+    head = "".join(kept).rstrip() if kept else body[:budget].rstrip()
+    return _close_dangling_fence(head) + notice
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--version", required=True, help="Release version, e.g. 8.0.0")
+    parser.add_argument(
+        "--out", type=Path, required=True, help="Destination for the notes"
+    )
+    parser.add_argument(
+        "--changelog", type=Path, default=Path("CHANGELOG.md"), help="Changelog to read"
+    )
+    parser.add_argument(
+        "--repo",
+        default=os.environ.get("GITHUB_REPOSITORY", "homeassistant-ai/ha-mcp"),
+        help="owner/name used in the truncation notice link (defaults to $GITHUB_REPOSITORY)",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=GITHUB_RELEASE_BODY_LIMIT,
+        help="Maximum release-body length in characters",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    try:
+        changelog = args.changelog.read_text(encoding="utf-8")
+    except OSError as e:
+        print(f"extract_release_notes: {e}", file=sys.stderr)
+        return 1
+
+    body = extract_section(changelog, args.version)
+    if body:
+        # Cap the trailing newline too, so the written file never exceeds --limit.
+        body = cap_to_limit(body + "\n", args.repo, args.version, args.limit)
+    args.out.write_text(body, encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/src/unit/test_extract_release_notes.py
+++ b/tests/src/unit/test_extract_release_notes.py
@@ -161,6 +161,40 @@ def test_closing_fence_never_pushes_the_body_over_the_limit(line_width: int) -> 
     assert len(capped) <= LIMIT
 
 
+def test_a_limit_too_small_for_the_notice_fails_loudly() -> None:
+    """Silently emitting a notice-free body would look like complete notes."""
+    body = "".join(f"- change number {i}\n" for i in range(12_000))
+    notice_len = len(extract._truncation_notice(REPO, "8.0.0", 50))
+
+    with pytest.raises(ValueError, match="truncation notice"):
+        extract.cap_to_limit(body, REPO, "8.0.0", notice_len)
+
+
+def test_main_exits_nonzero_on_an_unusable_limit(tmp_path: Path) -> None:
+    changelog = tmp_path / "CHANGELOG.md"
+    section = "".join(f"- change number {i}\n" for i in range(12_000))
+    changelog.write_text(
+        f"# CHANGELOG\n\n## v8.0.0 (2026-08-02)\n\n{section}", encoding="utf-8"
+    )
+    out = tmp_path / "release_notes.md"
+
+    rc = extract.main(
+        [
+            "--version",
+            "8.0.0",
+            "--changelog",
+            str(changelog),
+            "--out",
+            str(out),
+            "--limit",
+            "10",
+        ]
+    )
+
+    assert rc == 1
+    assert not out.exists(), "no half-formed notes file on failure"
+
+
 def test_main_writes_capped_notes_to_out(tmp_path: Path) -> None:
     changelog = tmp_path / "CHANGELOG.md"
     section = "".join(f"- change number {i}\n" for i in range(12_000))

--- a/tests/src/unit/test_extract_release_notes.py
+++ b/tests/src/unit/test_extract_release_notes.py
@@ -1,0 +1,150 @@
+"""Unit tests for scripts/extract_release_notes.py."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+_SCRIPT = Path(__file__).resolve().parents[3] / "scripts" / "extract_release_notes.py"
+_spec = importlib.util.spec_from_file_location("extract_release_notes", _SCRIPT)
+assert _spec and _spec.loader
+extract = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(extract)
+
+REPO = "homeassistant-ai/ha-mcp"
+LIMIT = extract.GITHUB_RELEASE_BODY_LIMIT
+
+CHANGELOG = """# CHANGELOG
+
+<!-- version list -->
+
+## v8.0.0 (2026-08-02)
+
+### Features
+
+- Add the thing ([#100](https://github.com/x/y/pull/100))
+
+## v7.14.2 (2026-07-22)
+
+### Bug Fixes
+
+- Fix the other thing ([#99](https://github.com/x/y/pull/99))
+"""
+
+
+def test_extracts_section_between_two_headings() -> None:
+    body = extract.extract_section(CHANGELOG, "8.0.0")
+    assert "- Add the thing" in body
+    assert "Fix the other thing" not in body
+    assert "## v7.14.2" not in body
+
+
+def test_extracts_trailing_section_to_end_of_file() -> None:
+    body = extract.extract_section(CHANGELOG, "7.14.2")
+    assert "- Fix the other thing" in body
+    assert body.endswith("pull/99))"), "trailing blank lines must be stripped"
+
+
+def test_leading_v_on_version_is_accepted() -> None:
+    assert extract.extract_section(CHANGELOG, "v8.0.0") == extract.extract_section(
+        CHANGELOG, "8.0.0"
+    )
+
+
+def test_absent_version_yields_empty_so_caller_fallback_engages() -> None:
+    assert extract.extract_section(CHANGELOG, "9.9.9") == ""
+
+
+def test_version_does_not_match_a_longer_version_sharing_its_prefix() -> None:
+    """'8.0.0' must not match '## v8.0.01' -- the old awk prefix match did."""
+    changelog = "# CHANGELOG\n\n## v8.0.01 (2026-08-02)\n\nwrong section\n"
+    assert extract.extract_section(changelog, "8.0.0") == ""
+
+
+def test_body_under_the_limit_is_returned_verbatim() -> None:
+    body = "### Features\n\n- Add the thing\n"
+    assert extract.cap_to_limit(body, REPO, "8.0.0", LIMIT) == body
+
+
+def test_oversized_body_is_truncated_under_the_limit_with_a_pointer() -> None:
+    """Regression: a 155k-char section 422'd the release (crs2007/ha-mcp run 31003968475)."""
+    body = "".join(f"- change number {i}\n" for i in range(12_000))
+    assert len(body) > LIMIT
+
+    capped = extract.cap_to_limit(body, REPO, "8.0.0", LIMIT)
+
+    assert len(capped) <= LIMIT
+    assert "truncated" in capped
+    assert f"https://github.com/{REPO}/blob/v8.0.0/CHANGELOG.md" in capped
+    assert "- change number 0\n" in capped
+
+
+def test_truncation_cuts_on_a_line_boundary() -> None:
+    body = "".join(f"- change number {i}\n" for i in range(12_000))
+    capped = extract.cap_to_limit(body, REPO, "8.0.0", LIMIT)
+
+    kept = capped.split("\n\n---\n\n")[0]
+    assert all(line.startswith("- change number ") for line in kept.splitlines())
+
+
+def test_truncation_closes_a_code_fence_it_cut_into() -> None:
+    body = "```python\n" + "".join(f"x = {i}\n" for i in range(12_000)) + "```\n"
+    capped = extract.cap_to_limit(body, REPO, "8.0.0", LIMIT)
+
+    kept = capped.split("\n\n---\n\n")[0]
+    assert kept.count("```") % 2 == 0, "truncation left an unclosed code fence"
+
+
+def test_main_writes_capped_notes_to_out(tmp_path: Path) -> None:
+    changelog = tmp_path / "CHANGELOG.md"
+    section = "".join(f"- change number {i}\n" for i in range(12_000))
+    changelog.write_text(
+        f"# CHANGELOG\n\n## v8.0.0 (2026-08-02)\n\n{section}", encoding="utf-8"
+    )
+    out = tmp_path / "release_notes.md"
+
+    rc = extract.main(
+        [
+            "--version",
+            "8.0.0",
+            "--changelog",
+            str(changelog),
+            "--out",
+            str(out),
+            "--repo",
+            REPO,
+        ]
+    )
+
+    assert rc == 0
+    written = out.read_text(encoding="utf-8")
+    assert len(written) <= LIMIT, "written file must fit GitHub's release-body limit"
+    assert "truncated" in written
+
+
+def test_main_writes_empty_file_when_version_is_absent(tmp_path: Path) -> None:
+    changelog = tmp_path / "CHANGELOG.md"
+    changelog.write_text(CHANGELOG, encoding="utf-8")
+    out = tmp_path / "release_notes.md"
+
+    assert (
+        extract.main(
+            ["--version", "9.9.9", "--changelog", str(changelog), "--out", str(out)]
+        )
+        == 0
+    )
+    assert out.read_text(encoding="utf-8") == ""
+
+
+def test_main_reports_a_missing_changelog_instead_of_traceback(tmp_path: Path) -> None:
+    rc = extract.main(
+        [
+            "--version",
+            "8.0.0",
+            "--changelog",
+            str(tmp_path / "nope.md"),
+            "--out",
+            str(tmp_path / "out.md"),
+        ]
+    )
+    assert rc == 1

--- a/tests/src/unit/test_extract_release_notes.py
+++ b/tests/src/unit/test_extract_release_notes.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import importlib.util
 from pathlib import Path
 
+import pytest
+
 _SCRIPT = Path(__file__).resolve().parents[3] / "scripts" / "extract_release_notes.py"
 _spec = importlib.util.spec_from_file_location("extract_release_notes", _SCRIPT)
 assert _spec and _spec.loader
@@ -55,10 +57,25 @@ def test_absent_version_yields_empty_so_caller_fallback_engages() -> None:
     assert extract.extract_section(CHANGELOG, "9.9.9") == ""
 
 
-def test_version_does_not_match_a_longer_version_sharing_its_prefix() -> None:
-    """'8.0.0' must not match '## v8.0.01' -- the old awk prefix match did."""
-    changelog = "# CHANGELOG\n\n## v8.0.01 (2026-08-02)\n\nwrong section\n"
+@pytest.mark.parametrize(
+    "heading",
+    [
+        "## v8.0.01 (2026-08-02)",  # longer version sharing the prefix
+        "## v8.0.0-rc.1 (2026-08-02)",  # prerelease
+        "## v8.0.0+build.5 (2026-08-02)",  # build metadata
+    ],
+)
+def test_version_does_not_match_a_longer_version_sharing_its_prefix(
+    heading: str,
+) -> None:
+    """'8.0.0' must match none of these -- the old awk prefix match matched all."""
+    changelog = f"# CHANGELOG\n\n{heading}\n\nwrong section\n"
     assert extract.extract_section(changelog, "8.0.0") == ""
+
+
+def test_a_prerelease_version_still_finds_its_own_section() -> None:
+    changelog = "# CHANGELOG\n\n## v8.0.0-rc.1 (2026-08-02)\n\n- the rc change\n"
+    assert "- the rc change" in extract.extract_section(changelog, "8.0.0-rc.1")
 
 
 def test_body_under_the_limit_is_returned_verbatim() -> None:
@@ -87,12 +104,32 @@ def test_truncation_cuts_on_a_line_boundary() -> None:
     assert all(line.startswith("- change number ") for line in kept.splitlines())
 
 
+def _fenced_body(line_width: int) -> str:
+    """An over-limit fenced block whose lines are `line_width` chars incl. newline."""
+    line = "x" * (line_width - 1) + "\n"
+    return "```python\n" + line * 40_000 + "```\n"
+
+
 def test_truncation_closes_a_code_fence_it_cut_into() -> None:
-    body = "```python\n" + "".join(f"x = {i}\n" for i in range(12_000)) + "```\n"
+    body = _fenced_body(12)
+    assert len(body) > LIMIT, "body must actually need truncating"
+
     capped = extract.cap_to_limit(body, REPO, "8.0.0", LIMIT)
 
     kept = capped.split("\n\n---\n\n")[0]
     assert kept.count("```") % 2 == 0, "truncation left an unclosed code fence"
+
+
+@pytest.mark.parametrize("line_width", [6, 7, 11, 12, 40])
+def test_closing_fence_never_pushes_the_body_over_the_limit(line_width: int) -> None:
+    """The closing fence is appended after the cut, so its length must be reserved.
+
+    Widths 6/7/11 are boundary cases where the line-boundary cut lands within
+    four characters of the budget -- without the reservation these produced
+    125,001-125,002 characters and GitHub would still 422.
+    """
+    capped = extract.cap_to_limit(_fenced_body(line_width), REPO, "8.0.0", LIMIT)
+    assert len(capped) <= LIMIT
 
 
 def test_main_writes_capped_notes_to_out(tmp_path: Path) -> None:

--- a/tests/src/unit/test_extract_release_notes.py
+++ b/tests/src/unit/test_extract_release_notes.py
@@ -120,6 +120,35 @@ def test_truncation_closes_a_code_fence_it_cut_into() -> None:
     assert kept.count("```") % 2 == 0, "truncation left an unclosed code fence"
 
 
+def _details_body(line_width: int) -> str:
+    """An over-limit body wrapped in the changelog's `<details>` element."""
+    line = "- " + "x" * (line_width - 3) + "\n"
+    return (
+        "### Features\n\n- visible change\n\n"
+        "<details>\n<summary>Internal Changes</summary>\n\n"
+        + line * 40_000
+        + "\n</details>\n"
+    )
+
+
+def test_truncation_notice_is_not_swallowed_by_an_open_details_block() -> None:
+    """An unclosed `<details>` would collapse the notice out of sight."""
+    capped = extract.cap_to_limit(_details_body(30), REPO, "8.0.0", LIMIT)
+
+    assert capped.count("<details>") == capped.count("</details>"), (
+        "truncation left a <details> open, hiding the notice in a collapsed section"
+    )
+    assert capped.index("</details>") < capped.index("Release notes truncated"), (
+        "the notice must sit outside the collapsed block"
+    )
+
+
+@pytest.mark.parametrize("line_width", [8, 9, 12, 13, 30])
+def test_closing_details_never_pushes_the_body_over_the_limit(line_width: int) -> None:
+    capped = extract.cap_to_limit(_details_body(line_width), REPO, "8.0.0", LIMIT)
+    assert len(capped) <= LIMIT
+
+
 @pytest.mark.parametrize("line_width", [6, 7, 11, 12, 40])
 def test_closing_fence_never_pushes_the_body_over_the_limit(line_width: int) -> None:
     """The closing fence is appended after the cut, so its length must be reserved.


### PR DESCRIPTION
## Problem

`gh release create --notes-file` rejects a release body over **125,000 characters** with `HTTP 422: body is too long`. Both release workflows built that body with an unbounded `awk` one-liner:

```
awk -v ver="## v${VERSION}" '$0 ~ "^"ver {found=1; next} found && /^## v[0-9]/ {exit} found' CHANGELOG.md > release_notes.md
```

The 422 lands **after** semantic-release has already committed the version bump and pushed the tag, so it strands a half-applied release: tag pushed, no GitHub release, and `build-and-release` / `build-addon` / `update-addon-config` all skipped — cleanup is manual.

A section grows past the cap whenever python-semantic-release regenerates the changelog across a long tag gap: it then collapses every commit since the last *reachable* stable tag into one section. Observed on a real run ([crs2007/ha-mcp run 31003968475](https://github.com/crs2007/ha-mcp/actions/runs/31003968475)) where that produced a single **155,588-character** section and killed the release.

## Fix

New `scripts/extract_release_notes.py` does the same extraction, then truncates on a line boundary and appends a pointer to the full changelog instead of letting the API reject the release. Replaces the `awk` line at both call sites — `semver-release.yml` and `hotfix-release.yml`. Each site keeps its own `if [ ! -s release_notes.md ]` fallback; an absent version still yields an empty file, which is the signal for that fallback.

Two incidental correctness gains, both covered by tests:
- The heading match is anchored, so `8.0.0` no longer matches a `## v8.0.01` heading (the old prefix match accepted it).
- Truncation closes a code fence it cut into, so a truncated body doesn't render as one giant code block.

`publish-dev.yml` also uses `--notes-file`, but builds its body from a fixed heredoc — bounded, left alone.

## Verification

- 12 new unit tests in `tests/src/unit/test_extract_release_notes.py` (mirrors the `test_build_mirror_release_notes.py` pattern), including a regression test for the oversized-section case.
- Run against the exact CHANGELOG the failed run produced: **155,588 → 124,998 chars**, now under the limit with the truncation pointer.
- Normal path unchanged: output is byte-identical to the old `awk` for v8.1.1, v8.0.0 and v7.14.2 (modulo the leading/trailing blank lines the awk emitted, which are now stripped).
- `ruff check`, `ruff format --check`, `mypy` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Release Process Improvements**
  * Release notes are now extracted consistently for hotfix and semantic-version releases.
  * Version-specific sections, including prereleases, are selected accurately.
  * Release content respects GitHub’s maximum body length and truncates cleanly at line boundaries.
  * Markdown code fences and expandable sections remain properly closed, with a link to the full changelog.

* **Reliability**
  * Missing versions produce an appropriate fallback.
  * Changelog read errors are reported clearly during release creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->