### PR TITLE
fix: close truncated fences with their own delimiter and warn on empty extracts

### DIFF
--- a/.github/workflows/hotfix-release.yml
+++ b/.github/workflows/hotfix-release.yml
@@ -118,6 +118,10 @@ jobs:
         # (an over-long body is a 422 that strands the already-pushed tag).
         python3 scripts/extract_release_notes.py --version "$VERSION" --out release_notes.md
         if [ ! -s release_notes.md ]; then
+          # An empty extract means either no "## v${VERSION}" heading or an
+          # empty section, and the file cannot tell those apart — so warn
+          # instead of letting a one-line release body pass for a normal run.
+          echo "::warning::no changelog section extracted for v${VERSION} — releasing with fallback notes"
           echo "Hotfix Release v${VERSION}" > release_notes.md
           echo "" >> release_notes.md
           echo "Critical bug fix - see PR #${{ github.event.pull_request.number }}" >> release_notes.md

--- a/.github/workflows/semver-release.yml
+++ b/.github/workflows/semver-release.yml
@@ -175,6 +175,10 @@ jobs:
         # (an over-long body is a 422 that strands the already-pushed tag).
         python3 scripts/extract_release_notes.py --version "$VERSION" --out release_notes.md
         if [ ! -s release_notes.md ]; then
+          # An empty extract means either no "## v${VERSION}" heading or an
+          # empty section, and the file cannot tell those apart — so warn
+          # instead of letting a one-line release body pass for a normal run.
+          echo "::warning::no changelog section extracted for v${VERSION} — releasing with fallback notes"
           echo "Release v${VERSION}" > release_notes.md
         fi
 

--- a/scripts/extract_release_notes.py
+++ b/scripts/extract_release_notes.py
@@ -47,7 +47,11 @@ _NEXT_SECTION_RE = re.compile(r"^## v\d")
 # after it. Closing a ````-fence with ```, or mistaking a second ```python for
 # a closer, leaves it open -- and everything after the cut, the truncation
 # notice included, then renders as code.
-_FENCE_RE = re.compile(r"^\s*(`{3,}|~{3,})(.*)$")
+#
+# At most three spaces of indentation: four or more makes the line indented
+# code, not a fence, so treating it as one would open a fence that never
+# closes and silence `<details>` tracking behind it.
+_FENCE_RE = re.compile(r"^ {0,3}(`{3,}|~{3,})(.*)$")
 
 _DETAILS_TAG_RE = re.compile(r"</?details>")
 

--- a/scripts/extract_release_notes.py
+++ b/scripts/extract_release_notes.py
@@ -64,7 +64,7 @@ def _heading_re(version: str) -> re.Pattern[str]:
     `## v8.0.01`) and also `-` / `+`, so a stable version never matches a
     prerelease or build-metadata heading like `## v8.0.0-rc.1`.
     """
-    return re.compile(rf"^## v{re.escape(version.lstrip('v'))}(?![\w.+-])")
+    return re.compile(rf"^## v{re.escape(version.removeprefix('v'))}(?![\w.+-])")
 
 
 def extract_section(changelog: str, version: str) -> str:
@@ -95,7 +95,7 @@ def extract_section(changelog: str, version: str) -> str:
 
 
 def _truncation_notice(repo: str, version: str, limit: int) -> str:
-    url = f"https://github.com/{repo}/blob/v{version.lstrip('v')}/CHANGELOG.md"
+    url = f"https://github.com/{repo}/blob/v{version.removeprefix('v')}/CHANGELOG.md"
     return (
         "\n\n---\n\n"
         f"_Release notes truncated to fit GitHub's {limit:,}-character release-body "
@@ -228,7 +228,9 @@ def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
     try:
         changelog = args.changelog.read_text(encoding="utf-8")
-    except OSError as e:
+    except (OSError, UnicodeDecodeError) as e:
+        # UnicodeDecodeError subclasses ValueError, not OSError, so a changelog
+        # with a bad byte would otherwise exit on a raw traceback.
         print(f"extract_release_notes: {e}", file=sys.stderr)
         return 1
 
@@ -240,7 +242,13 @@ def main(argv: list[str] | None = None) -> int:
         except ValueError as e:
             print(f"extract_release_notes: {e}", file=sys.stderr)
             return 1
-    args.out.write_text(body, encoding="utf-8")
+    try:
+        # newline="\n" so the file on disk matches the character budget the cap
+        # was computed against, on any platform rather than only on the runner.
+        args.out.write_text(body, encoding="utf-8", newline="\n")
+    except OSError as e:
+        print(f"extract_release_notes: {e}", file=sys.stderr)
+        return 1
     return 0
 
 

--- a/scripts/extract_release_notes.py
+++ b/scripts/extract_release_notes.py
@@ -13,8 +13,11 @@ reachable stable tag into a single section). So this script does the same
 extraction, then truncates on a line boundary and appends a pointer to the full
 changelog rather than letting the API reject the whole release.
 
-Prints nothing on success; writes the notes to --out. An absent version yields
-an empty file, which is the signal for the caller's own fallback text.
+Prints nothing on success; writes the notes to --out. A version that is absent
+-- or present with an empty section, which two released versions in this repo's
+own changelog are -- yields an empty file, which is the signal for the caller's
+own fallback text. The caller cannot tell those two apart, so it warns rather
+than treating the fallback as routine.
 """
 
 from __future__ import annotations
@@ -25,16 +28,22 @@ import re
 import sys
 from pathlib import Path
 
-# GitHub's documented maximum for a release body. Characters, not bytes --
-# the changelog carries emoji in headings, so a byte-based cut would be wrong.
+# GitHub's maximum for a release body. The API validates a character count,
+# not a byte count -- its rejection reads "body is too long (maximum is 125000
+# characters)" -- so the cut below is made in characters to match.
 GITHUB_RELEASE_BODY_LIMIT = 125_000
 
-# Section headings look like "## v8.0.0 (2026-08-02)". The negative lookahead
-# keeps "8.0.0" from also matching "## v8.0.01", which a bare prefix match
-# (what the old awk did) accepts.
+# Section headings look like "## v8.0.0 (2026-08-02)", emitted by
+# templates/CHANGELOG.md.j2. This pattern only has to find where the current
+# section ends, so it deliberately matches any version heading; `_heading_re`
+# below is the one that has to match a single exact version.
 _NEXT_SECTION_RE = re.compile(r"^## v\d")
 
-_FENCE_RE = re.compile(r"^\s*```")
+# A fence opens with three or more backticks or tildes. The delimiter is
+# captured because a fence can only be closed by the same character, repeated
+# at least as many times -- closing a ````-fence with ``` leaves it open, and
+# everything after the cut (including the truncation notice) renders as code.
+_FENCE_RE = re.compile(r"^\s*(`{3,}|~{3,})")
 
 # Truncation can land inside a block the changelog template opened: a fenced
 # code block, or the `<details><summary>Internal Changes</summary>` element
@@ -43,7 +52,6 @@ _FENCE_RE = re.compile(r"^\s*```")
 # into a collapsed section, so a reader sees no sign the notes are incomplete.
 # Their lengths are reserved before lines are selected, so closing them can
 # never push the body back over the limit.
-_FENCE_CLOSE = "\n```"
 _DETAILS_CLOSE = "\n</details>"
 
 
@@ -58,10 +66,17 @@ def _heading_re(version: str) -> re.Pattern[str]:
 
 
 def extract_section(changelog: str, version: str) -> str:
-    """Return the changelog body for `version`, or "" when the version is absent.
+    """Return the changelog body for `version`, or "" when there is none to return.
 
     The body is everything after the version's heading up to the next version
     heading (or end of file), with surrounding blank lines stripped.
+
+    "" covers two cases the caller cannot distinguish: no heading for `version`
+    at all, and a heading whose section is empty (`## v4.8.0` and `## v1.0.0`
+    in this repo's changelog both are). Both want the caller's fallback text,
+    so the ambiguity is harmless here -- but it means an empty result is not
+    evidence that the heading was missing, and callers should say so in their
+    logs rather than shipping fallback notes silently.
     """
     heading = _heading_re(version)
     lines = changelog.splitlines(keepends=True)
@@ -90,14 +105,29 @@ class _OpenBlocks:
     """Tracks which markdown blocks are still open as lines are consumed."""
 
     def __init__(self) -> None:
-        self.in_fence = False
+        # The delimiter of the open fence ("```", "````", "~~~"), or None.
+        self.fence: str | None = None
         self.details_depth = 0
 
+    def clone(self) -> _OpenBlocks:
+        """A detached copy, for testing whether a line would still fit."""
+        twin = _OpenBlocks()
+        twin.fence, twin.details_depth = self.fence, self.details_depth
+        return twin
+
     def feed(self, line: str) -> None:
-        if _FENCE_RE.match(line):
-            self.in_fence = not self.in_fence
+        match = _FENCE_RE.match(line)
+        if match:
+            delimiter = match.group(1)
+            if self.fence is None:
+                self.fence = delimiter
+                return
+            # Only the same character, repeated at least as often, closes it;
+            # anything else is just content sitting inside the open fence.
+            if delimiter[0] == self.fence[0] and len(delimiter) >= len(self.fence):
+                self.fence = None
             return
-        if self.in_fence:  # `<details>` inside a code block is text, not markup
+        if self.fence:  # `<details>` inside a code block is text, not markup
             return
         self.details_depth += line.count("<details>") - line.count("</details>")
         self.details_depth = max(self.details_depth, 0)
@@ -105,7 +135,7 @@ class _OpenBlocks:
     @property
     def closers(self) -> str:
         """The suffix that closes everything still open, innermost first."""
-        fence = _FENCE_CLOSE if self.in_fence else ""
+        fence = f"\n{self.fence}" if self.fence else ""
         return fence + _DETAILS_CLOSE * self.details_depth
 
 
@@ -117,9 +147,11 @@ def cap_to_limit(body: str, repo: str, version: str, limit: int) -> str:
     leaves open are charged against the budget before the line is accepted, so
     the result never exceeds `limit`.
 
-    Raises ValueError when `limit` cannot even hold the truncation notice.
-    Silently emitting a notice-free body there would hand GitHub a release that
-    looks complete but is not, so an unusable --limit fails loudly instead.
+    Raises ValueError when `limit` leaves no room for any content beyond the
+    truncation notice. Silently emitting a notice-free body there would hand
+    GitHub a release that looks complete but is not, and a body consisting of
+    nothing but "these notes were truncated" is not worth publishing either, so
+    an unusable --limit fails loudly instead.
     """
     if len(body) <= limit:
         return body
@@ -136,11 +168,7 @@ def cap_to_limit(body: str, repo: str, version: str, limit: int) -> str:
     kept: list[str] = []
     used = 0
     for line in body.splitlines(keepends=True):
-        candidate = _OpenBlocks()
-        candidate.in_fence, candidate.details_depth = (
-            open_blocks.in_fence,
-            open_blocks.details_depth,
-        )
+        candidate = open_blocks.clone()
         candidate.feed(line)
         if used + len(line) + len(candidate.closers) > budget:
             break

--- a/scripts/extract_release_notes.py
+++ b/scripts/extract_release_notes.py
@@ -16,8 +16,9 @@ changelog rather than letting the API reject the whole release.
 Prints nothing on success; writes the notes to --out. A version that is absent
 -- or present with an empty section, which two released versions in this repo's
 own changelog are -- yields an empty file, which is the signal for the caller's
-own fallback text. The caller cannot tell those two apart, so it warns rather
-than treating the fallback as routine.
+own fallback text. Which of the two happened is reported on stderr, so the run
+log distinguishes a version we failed to find from one that genuinely shipped
+an empty section.
 """
 
 from __future__ import annotations
@@ -26,6 +27,7 @@ import argparse
 import os
 import re
 import sys
+from dataclasses import dataclass, replace
 from pathlib import Path
 
 # GitHub's maximum for a release body. The API validates a character count,
@@ -67,25 +69,24 @@ def _heading_re(version: str) -> re.Pattern[str]:
     return re.compile(rf"^## v{re.escape(version.removeprefix('v'))}(?![\w.+-])")
 
 
-def extract_section(changelog: str, version: str) -> str:
-    """Return the changelog body for `version`, or "" when there is none to return.
+def extract_section(changelog: str, version: str) -> str | None:
+    """Return the changelog body for `version`, or None when it has no heading.
 
     The body is everything after the version's heading up to the next version
     heading (or end of file), with surrounding blank lines stripped.
 
-    "" covers two cases the caller cannot distinguish: no heading for `version`
-    at all, and a heading whose section is empty (`## v4.8.0` and `## v1.0.0`
-    in this repo's changelog both are). Both want the caller's fallback text,
-    so the ambiguity is harmless here -- but it means an empty result is not
-    evidence that the heading was missing, and callers should say so in their
-    logs rather than shipping fallback notes silently.
+    None and "" are different answers: None means no `## v<version>` heading
+    exists, "" means the heading is there but its section is empty (`## v4.8.0`
+    and `## v1.0.0` in this repo's changelog both are). Both leave the caller
+    writing fallback notes, but only the first says the extractor failed to
+    find the release -- so they are reported differently.
     """
     heading = _heading_re(version)
     lines = changelog.splitlines(keepends=True)
 
     start = next((i for i, line in enumerate(lines) if heading.match(line)), None)
     if start is None:
-        return ""
+        return None
 
     body = lines[start + 1 :]
     end = next((i for i, line in enumerate(body) if _NEXT_SECTION_RE.match(line)), None)
@@ -103,27 +104,26 @@ def _truncation_notice(repo: str, version: str, limit: int) -> str:
     )
 
 
+@dataclass(frozen=True)
 class _OpenBlocks:
-    """Tracks which markdown blocks are still open as lines are consumed."""
+    """Which markdown blocks are still open after consuming some lines.
 
-    def __init__(self) -> None:
-        # The delimiter of the open fence ("```", "````", "~~~"), or None.
-        self.fence: str | None = None
-        self.details_depth = 0
+    Immutable so that `feed` can be used to ask "what would the state be if I
+    took this line?" without committing to it -- which is exactly what the
+    budget check in `cap_to_limit` needs.
+    """
 
-    def clone(self) -> _OpenBlocks:
-        """A detached copy, for testing whether a line would still fit."""
-        twin = _OpenBlocks()
-        twin.fence, twin.details_depth = self.fence, self.details_depth
-        return twin
+    # The delimiter of the open fence ("```", "````", "~~~"), or None.
+    fence: str | None = None
+    details_depth: int = 0
 
-    def feed(self, line: str) -> None:
+    def feed(self, line: str) -> _OpenBlocks:
+        """The state after `line`, leaving this instance untouched."""
         match = _FENCE_RE.match(line)
         if match:
             delimiter, trailing = match.group(1), match.group(2)
             if self.fence is None:
-                self.fence = delimiter
-                return
+                return replace(self, fence=delimiter)
             # Only the same character, repeated at least as often and carrying
             # nothing but whitespace, closes it. A closing fence cannot have an
             # info string, so ```python inside a ```-block is ordinary content.
@@ -132,12 +132,12 @@ class _OpenBlocks:
                 and len(delimiter) >= len(self.fence)
                 and not trailing.strip()
             ):
-                self.fence = None
-            return
+                return replace(self, fence=None)
+            return self
         if self.fence:  # `<details>` inside a code block is text, not markup
-            return
-        self.details_depth += line.count("<details>") - line.count("</details>")
-        self.details_depth = max(self.details_depth, 0)
+            return self
+        opened = line.count("<details>") - line.count("</details>")
+        return replace(self, details_depth=max(self.details_depth + opened, 0))
 
     @property
     def closers(self) -> str:
@@ -177,8 +177,7 @@ def cap_to_limit(body: str, repo: str, version: str, limit: int) -> str:
     kept: list[str] = []
     used = 0
     for line in body.splitlines(keepends=True):
-        candidate = open_blocks.clone()
-        candidate.feed(line)
+        candidate = open_blocks.feed(line)
         if used + len(line) + len(candidate.closers) > budget:
             break
         kept.append(line)
@@ -234,11 +233,23 @@ def main(argv: list[str] | None = None) -> int:
         print(f"extract_release_notes: {e}", file=sys.stderr)
         return 1
 
-    body = extract_section(changelog, args.version)
-    if body:
+    version = args.version.removeprefix("v")
+    section = extract_section(changelog, args.version)
+    body = ""
+    if section is None:
+        print(
+            f"extract_release_notes: no '## v{version}' heading in {args.changelog}",
+            file=sys.stderr,
+        )
+    elif not section:
+        print(
+            f"extract_release_notes: the '## v{version}' section is empty",
+            file=sys.stderr,
+        )
+    else:
         try:
             # Cap the trailing newline too, so the written file never exceeds --limit.
-            body = cap_to_limit(body + "\n", args.repo, args.version, args.limit)
+            body = cap_to_limit(section + "\n", args.repo, args.version, args.limit)
         except ValueError as e:
             print(f"extract_release_notes: {e}", file=sys.stderr)
             return 1

--- a/scripts/extract_release_notes.py
+++ b/scripts/extract_release_notes.py
@@ -51,7 +51,7 @@ _NEXT_SECTION_RE = re.compile(r"^## v\d")
 # At most three spaces of indentation: four or more makes the line indented
 # code, not a fence, so treating it as one would open a fence that never
 # closes and silence `<details>` tracking behind it.
-_FENCE_RE = re.compile(r"^ {0,3}(`{3,}|~{3,})(.*)$")
+_FENCE_RE = re.compile(r"^( {0,3})(`{3,}|~{3,})(.*)$")
 
 _DETAILS_TAG_RE = re.compile(r"</?details>")
 
@@ -119,27 +119,37 @@ class _OpenBlocks:
     budget check in `cap_to_limit` needs.
     """
 
-    # The delimiter of the open fence ("```", "````", "~~~"), or None.
+    # The delimiter of the open fence ("```", "````", "~~~"), or None, and the
+    # indentation it opened at -- the closer has to reproduce that indentation
+    # or it leaves the container the fence lives in instead of closing it.
     fence: str | None = None
+    fence_indent: str = ""
     details_depth: int = 0
 
     def feed(self, line: str) -> _OpenBlocks:
         """The state after `line`, leaving this instance untouched."""
         match = _FENCE_RE.match(line)
         if match:
-            delimiter, trailing = match.group(1), match.group(2)
-            if self.fence is None:
-                return replace(self, fence=delimiter)
-            # Only the same character, repeated at least as often and carrying
-            # nothing but whitespace, closes it. A closing fence cannot have an
-            # info string, so ```python inside a ```-block is ordinary content.
-            if (
-                delimiter[0] == self.fence[0]
-                and len(delimiter) >= len(self.fence)
-                and not trailing.strip()
-            ):
-                return replace(self, fence=None)
-            return self
+            indent, delimiter, trailing = match.group(1), match.group(2), match.group(3)
+            if self.fence is not None:
+                # Only the same character, repeated at least as often and
+                # carrying nothing but whitespace, closes it. A closing fence
+                # cannot have an info string, so ```python inside a ```-block
+                # is ordinary content.
+                if (
+                    delimiter[0] == self.fence[0]
+                    and len(delimiter) >= len(self.fence)
+                    and not trailing.strip()
+                ):
+                    return replace(self, fence=None, fence_indent="")
+                return self
+            # A backtick fence's info string may not itself contain a backtick.
+            # GFM reads such a line as ordinary text, so opening a fence here
+            # would make the closer emitted later read as a new opening fence
+            # and swallow everything after it, the notice included.
+            if delimiter[0] != "`" or "`" not in trailing:
+                return replace(self, fence=delimiter, fence_indent=indent)
+            # Not a fence after all -- fall through and treat it as text.
         if self.fence:  # `<details>` inside a code block is text, not markup
             return self
         # Left to right, clamping after each close, rather than netting the
@@ -153,7 +163,7 @@ class _OpenBlocks:
     @property
     def closers(self) -> str:
         """The suffix that closes everything still open, innermost first."""
-        fence = f"\n{self.fence}" if self.fence else ""
+        fence = f"\n{self.fence_indent}{self.fence}" if self.fence else ""
         return fence + _DETAILS_CLOSE * self.details_depth
 
 

--- a/scripts/extract_release_notes.py
+++ b/scripts/extract_release_notes.py
@@ -49,6 +49,8 @@ _NEXT_SECTION_RE = re.compile(r"^## v\d")
 # notice included, then renders as code.
 _FENCE_RE = re.compile(r"^\s*(`{3,}|~{3,})(.*)$")
 
+_DETAILS_TAG_RE = re.compile(r"</?details>")
+
 # Truncation can land inside a block the changelog template opened: a fenced
 # code block, or the `<details><summary>Internal Changes</summary>` element
 # semantic-release wraps internal commits in. Both are closed after the cut --
@@ -136,8 +138,13 @@ class _OpenBlocks:
             return self
         if self.fence:  # `<details>` inside a code block is text, not markup
             return self
-        opened = line.count("<details>") - line.count("</details>")
-        return replace(self, details_depth=max(self.details_depth + opened, 0))
+        # Left to right, clamping after each close, rather than netting the
+        # line's tags: `</details><details>` nets to zero but really leaves one
+        # open, and its closer would then be dropped.
+        depth = self.details_depth
+        for tag in _DETAILS_TAG_RE.findall(line):
+            depth = depth + 1 if tag == "<details>" else max(depth - 1, 0)
+        return replace(self, details_depth=depth)
 
     @property
     def closers(self) -> str:

--- a/scripts/extract_release_notes.py
+++ b/scripts/extract_release_notes.py
@@ -39,11 +39,13 @@ GITHUB_RELEASE_BODY_LIMIT = 125_000
 # below is the one that has to match a single exact version.
 _NEXT_SECTION_RE = re.compile(r"^## v\d")
 
-# A fence opens with three or more backticks or tildes. The delimiter is
-# captured because a fence can only be closed by the same character, repeated
-# at least as many times -- closing a ````-fence with ``` leaves it open, and
-# everything after the cut (including the truncation notice) renders as code.
-_FENCE_RE = re.compile(r"^\s*(`{3,}|~{3,})")
+# A fence opens with three or more backticks or tildes, optionally followed by
+# an info string. Both parts are captured: a fence can only be closed by the
+# same character repeated at least as many times *and* nothing but whitespace
+# after it. Closing a ````-fence with ```, or mistaking a second ```python for
+# a closer, leaves it open -- and everything after the cut, the truncation
+# notice included, then renders as code.
+_FENCE_RE = re.compile(r"^\s*(`{3,}|~{3,})(.*)$")
 
 # Truncation can land inside a block the changelog template opened: a fenced
 # code block, or the `<details><summary>Internal Changes</summary>` element
@@ -118,13 +120,18 @@ class _OpenBlocks:
     def feed(self, line: str) -> None:
         match = _FENCE_RE.match(line)
         if match:
-            delimiter = match.group(1)
+            delimiter, trailing = match.group(1), match.group(2)
             if self.fence is None:
                 self.fence = delimiter
                 return
-            # Only the same character, repeated at least as often, closes it;
-            # anything else is just content sitting inside the open fence.
-            if delimiter[0] == self.fence[0] and len(delimiter) >= len(self.fence):
+            # Only the same character, repeated at least as often and carrying
+            # nothing but whitespace, closes it. A closing fence cannot have an
+            # info string, so ```python inside a ```-block is ordinary content.
+            if (
+                delimiter[0] == self.fence[0]
+                and len(delimiter) >= len(self.fence)
+                and not trailing.strip()
+            ):
                 self.fence = None
             return
         if self.fence:  # `<details>` inside a code block is text, not markup
@@ -147,11 +154,13 @@ def cap_to_limit(body: str, repo: str, version: str, limit: int) -> str:
     leaves open are charged against the budget before the line is accepted, so
     the result never exceeds `limit`.
 
-    Raises ValueError when `limit` leaves no room for any content beyond the
-    truncation notice. Silently emitting a notice-free body there would hand
-    GitHub a release that looks complete but is not, and a body consisting of
-    nothing but "these notes were truncated" is not worth publishing either, so
-    an unusable --limit fails loudly instead.
+    Raises ValueError when `limit` leaves no room for the truncation notice, or
+    no room for even the first complete line beyond it. Silently emitting a
+    notice-free body would hand GitHub a release that looks complete but is
+    not; a body of nothing but "these notes were truncated" is not worth
+    publishing; and a mid-line cut would strand an opening fence or `<details>`
+    with no closer, swallowing the notice. An unusable --limit fails loudly
+    instead of producing any of the three.
     """
     if len(body) <= limit:
         return body
@@ -176,8 +185,15 @@ def cap_to_limit(body: str, repo: str, version: str, limit: int) -> str:
         used += len(line)
         open_blocks = candidate
 
-    head = "".join(kept).rstrip() if kept else body[:budget].rstrip()
-    closers = open_blocks.closers if kept else ""
+    if not kept:
+        raise ValueError(
+            f"--limit {limit} cannot retain even the first complete line of the "
+            "notes; cutting mid-line would leave any opening fence or <details> "
+            "unclosed and swallow the truncation notice"
+        )
+
+    head = "".join(kept).rstrip()
+    closers = open_blocks.closers
     # Defensive clamp: rstrip only shortens, so this should already hold.
     overflow = len(head) + len(closers) + len(notice) - limit
     if overflow > 0:  # pragma: no cover - budget accounting makes this unreachable

--- a/tests/src/unit/test_extract_release_notes.py
+++ b/tests/src/unit/test_extract_release_notes.py
@@ -112,9 +112,15 @@ def test_the_heading_pattern_still_matches_the_real_changelog() -> None:
     version = pyproject["project"]["version"]
     changelog = (_REPO_ROOT / "CHANGELOG.md").read_text(encoding="utf-8")
 
-    assert extract.extract_section(changelog, version) != "", (
-        f"no changelog section extracted for the current version {version} — "
-        "the heading format and the extractor's regexes have drifted apart"
+    section = extract.extract_section(changelog, version)
+
+    # Truthiness, not `!= ""`: a missing heading returns None, and `None != ""`
+    # is true, so the looser assertion stayed green in the exact scenario this
+    # test exists to catch.
+    assert section, (
+        f"no changelog section extracted for the current version {version} "
+        f"(got {section!r}) — the heading format and the extractor's regexes "
+        "have drifted apart"
     )
 
 
@@ -253,13 +259,34 @@ def test_an_info_string_line_does_not_close_an_open_fence() -> None:
     assert _after("```python\n", "```python\n", "```   \n").closers == ""
 
 
+def test_a_backtick_info_string_containing_a_backtick_is_not_a_fence() -> None:
+    """GFM forbids backticks in a backtick fence's info string.
+
+    Opening a fence on such a line means the closer emitted later reads as a
+    *new* opening fence, putting the truncation notice inside code to EOF.
+    """
+    assert _after("```py`x\n").closers == "", "opened a fence GFM would not open"
+    assert _after("```py\n").closers == "\n```"
+    # The restriction is specific to backticks; tilde info strings may hold them.
+    assert _after("~~~py`x\n").closers == "\n~~~"
+
+
+def test_a_closer_reproduces_the_indentation_its_fence_opened_at() -> None:
+    """An unindented closer exits the list container instead of closing the fence."""
+    assert _after("  ~~~\n").closers == "\n  ~~~"
+    assert _after("   ```py\n").closers == "\n   ```"
+    assert _after("```py\n").closers == "\n```"
+
+
 def test_four_space_indentation_is_indented_code_not_a_fence() -> None:
     """GFM allows at most three spaces before a fence; four makes it a code block.
 
     Treating an indented code sample as a fence opens one that never closes,
     which also silences `<details>` tracking for everything behind it.
     """
-    assert _after("   ```python\n").closers == "\n```", "three spaces is still a fence"
+    assert _after("   ```python\n").closers == "\n   ```", (
+        "three spaces is still a fence, and its closer keeps that indentation"
+    )
     assert _after("    ```python\n").closers == "", "four spaces is indented code"
     assert _after("\t```python\n").closers == "", "a tab indents past the fence limit"
 

--- a/tests/src/unit/test_extract_release_notes.py
+++ b/tests/src/unit/test_extract_release_notes.py
@@ -253,6 +253,20 @@ def test_an_info_string_line_does_not_close_an_open_fence() -> None:
     assert _after("```python\n", "```python\n", "```   \n").closers == ""
 
 
+def test_four_space_indentation_is_indented_code_not_a_fence() -> None:
+    """GFM allows at most three spaces before a fence; four makes it a code block.
+
+    Treating an indented code sample as a fence opens one that never closes,
+    which also silences `<details>` tracking for everything behind it.
+    """
+    assert _after("   ```python\n").closers == "\n```", "three spaces is still a fence"
+    assert _after("    ```python\n").closers == "", "four spaces is indented code"
+    assert _after("\t```python\n").closers == "", "a tab indents past the fence limit"
+
+    # An indented look-alike must not close a fence that is genuinely open.
+    assert _after("```python\n", "    ```\n").closers == "\n```"
+
+
 def test_details_tags_on_one_line_are_counted_in_source_order() -> None:
     """Netting a line's tags hides an opener that follows a closer."""
     assert _after("</details><details>\n").closers == "\n</details>", (

--- a/tests/src/unit/test_extract_release_notes.py
+++ b/tests/src/unit/test_extract_release_notes.py
@@ -253,6 +253,15 @@ def test_an_info_string_line_does_not_close_an_open_fence() -> None:
     assert _after("```python\n", "```python\n", "```   \n").closers == ""
 
 
+def test_details_tags_on_one_line_are_counted_in_source_order() -> None:
+    """Netting a line's tags hides an opener that follows a closer."""
+    assert _after("</details><details>\n").closers == "\n</details>", (
+        "a close-then-open line nets to zero but really leaves one open"
+    )
+    assert _after("<details></details>\n").closers == ""
+    assert _after("<details>\n", "</details><details>\n").closers == "\n</details>"
+
+
 def test_feed_leaves_the_instance_it_was_called_on_untouched() -> None:
     """`cap_to_limit` peeks at the next state before deciding to take a line."""
     outside = extract._OpenBlocks()

--- a/tests/src/unit/test_extract_release_notes.py
+++ b/tests/src/unit/test_extract_release_notes.py
@@ -3,11 +3,13 @@
 from __future__ import annotations
 
 import importlib.util
+import tomllib
 from pathlib import Path
 
 import pytest
 
-_SCRIPT = Path(__file__).resolve().parents[3] / "scripts" / "extract_release_notes.py"
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_SCRIPT = _REPO_ROOT / "scripts" / "extract_release_notes.py"
 _spec = importlib.util.spec_from_file_location("extract_release_notes", _SCRIPT)
 assert _spec and _spec.loader
 extract = importlib.util.module_from_spec(_spec)
@@ -76,6 +78,29 @@ def test_version_does_not_match_a_longer_version_sharing_its_prefix(
 def test_a_prerelease_version_still_finds_its_own_section() -> None:
     changelog = "# CHANGELOG\n\n## v8.0.0-rc.1 (2026-08-02)\n\n- the rc change\n"
     assert "- the rc change" in extract.extract_section(changelog, "8.0.0-rc.1")
+
+
+def test_the_heading_pattern_still_matches_the_real_changelog() -> None:
+    """Pin the regexes to the heading `templates/CHANGELOG.md.j2` actually emits.
+
+    Every other test builds its own `## vX.Y.Z` fixture, so a change to that
+    template or to semantic-release's `tag_format` would leave the whole file
+    green while `extract_section` returned "" for every real release — the
+    workflows would then ship `Release vX.Y.Z` as the entire release body,
+    indefinitely and with CI green. `pyproject.toml`'s version is bumped by
+    semantic-release in the same commit that writes the changelog section, so
+    the two are always in sync on any branch.
+    """
+    pyproject = tomllib.loads(
+        (_REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8")
+    )
+    version = pyproject["project"]["version"]
+    changelog = (_REPO_ROOT / "CHANGELOG.md").read_text(encoding="utf-8")
+
+    assert extract.extract_section(changelog, version) != "", (
+        f"no changelog section extracted for the current version {version} — "
+        "the heading format and the extractor's regexes have drifted apart"
+    )
 
 
 def test_body_under_the_limit_is_returned_verbatim() -> None:
@@ -159,6 +184,41 @@ def test_closing_fence_never_pushes_the_body_over_the_limit(line_width: int) -> 
     """
     capped = extract.cap_to_limit(_fenced_body(line_width), REPO, "8.0.0", LIMIT)
     assert len(capped) <= LIMIT
+
+
+@pytest.mark.parametrize("delimiter", ["```", "````", "~~~", "~~~~"])
+def test_truncation_closes_a_fence_with_the_delimiter_it_was_opened_with(
+    delimiter: str,
+) -> None:
+    """Closing a ````-fence with ``` leaves it open — and eats the notice.
+
+    Markdown only ends a fence on the same character repeated at least as many
+    times, so a fixed three-backtick closer renders the truncation notice and
+    the full-changelog link as code instead of as the warning they are.
+    """
+    body = f"{delimiter}python\n" + ("x" * 11 + "\n") * 40_000 + f"{delimiter}\n"
+    assert len(body) > LIMIT, "body must actually need truncating"
+
+    capped = extract.cap_to_limit(body, REPO, "8.0.0", LIMIT)
+
+    kept = capped.split("\n\n---\n\n")[0]
+    assert kept.splitlines()[-1] == delimiter, (
+        "fence closed with a delimiter that cannot close it"
+    )
+    assert len(capped) <= LIMIT
+
+
+def test_a_shorter_or_foreign_fence_line_does_not_close_an_open_fence() -> None:
+    blocks = extract._OpenBlocks()
+    blocks.feed("````python\n")
+    assert blocks.closers == "\n````"
+
+    blocks.feed("```\n")  # too short to close it
+    blocks.feed("~~~\n")  # wrong character
+    assert blocks.closers == "\n````", "an open fence was closed by a line that can't"
+
+    blocks.feed("`````\n")  # same character, longer — closes it
+    assert blocks.closers == ""
 
 
 def test_a_limit_too_small_for_the_notice_fails_loudly() -> None:

--- a/tests/src/unit/test_extract_release_notes.py
+++ b/tests/src/unit/test_extract_release_notes.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import importlib.util
+import sys
 import tomllib
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -13,6 +15,9 @@ _SCRIPT = _REPO_ROOT / "scripts" / "extract_release_notes.py"
 _spec = importlib.util.spec_from_file_location("extract_release_notes", _SCRIPT)
 assert _spec and _spec.loader
 extract = importlib.util.module_from_spec(_spec)
+# Register before exec: @dataclass resolves its class through
+# sys.modules[cls.__module__], which module_from_spec alone does not populate.
+sys.modules[_spec.name] = extract
 _spec.loader.exec_module(extract)
 
 REPO = "homeassistant-ai/ha-mcp"
@@ -55,8 +60,18 @@ def test_leading_v_on_version_is_accepted() -> None:
     )
 
 
-def test_absent_version_yields_empty_so_caller_fallback_engages() -> None:
-    assert extract.extract_section(CHANGELOG, "9.9.9") == ""
+def test_absent_version_yields_none_so_caller_fallback_engages() -> None:
+    assert extract.extract_section(CHANGELOG, "9.9.9") is None
+
+
+def test_a_present_but_empty_section_is_distinguishable_from_an_absent_one() -> None:
+    """`## v4.8.0` and `## v1.0.0` are real released versions with empty sections."""
+    changelog = (
+        "# CHANGELOG\n\n## v4.8.0 (2025-12-01)\n\n\n## v4.7.7 (2025-12-01)\n\n- x\n"
+    )
+
+    assert extract.extract_section(changelog, "4.8.0") == ""
+    assert extract.extract_section(changelog, "4.9.0") is None
 
 
 @pytest.mark.parametrize(
@@ -72,7 +87,7 @@ def test_version_does_not_match_a_longer_version_sharing_its_prefix(
 ) -> None:
     """'8.0.0' must match none of these -- the old awk prefix match matched all."""
     changelog = f"# CHANGELOG\n\n{heading}\n\nwrong section\n"
-    assert extract.extract_section(changelog, "8.0.0") == ""
+    assert extract.extract_section(changelog, "8.0.0") is None
 
 
 def test_a_prerelease_version_still_finds_its_own_section() -> None:
@@ -208,29 +223,43 @@ def test_truncation_closes_a_fence_with_the_delimiter_it_was_opened_with(
     assert len(capped) <= LIMIT
 
 
-def test_a_shorter_or_foreign_fence_line_does_not_close_an_open_fence() -> None:
+def _after(*lines: str) -> Any:
+    """The block state after feeding `lines` through a fresh tracker."""
     blocks = extract._OpenBlocks()
-    blocks.feed("````python\n")
-    assert blocks.closers == "\n````"
+    for line in lines:
+        blocks = blocks.feed(line)
+    return blocks
 
-    blocks.feed("```\n")  # too short to close it
-    blocks.feed("~~~\n")  # wrong character
-    assert blocks.closers == "\n````", "an open fence was closed by a line that can't"
 
-    blocks.feed("`````\n")  # same character, longer — closes it
-    assert blocks.closers == ""
+def test_a_shorter_or_foreign_fence_line_does_not_close_an_open_fence() -> None:
+    assert _after("````python\n").closers == "\n````"
+
+    # too short to close it, then the wrong character
+    assert _after("````python\n", "```\n", "~~~\n").closers == "\n````", (
+        "an open fence was closed by a line that can't close it"
+    )
+
+    # same character, longer — closes it
+    assert _after("````python\n", "`````\n").closers == ""
 
 
 def test_an_info_string_line_does_not_close_an_open_fence() -> None:
     """A closing fence carries no info string, so ```python is content, not a closer."""
-    blocks = extract._OpenBlocks()
-    blocks.feed("```python\n")
-    blocks.feed("```python\n")
+    assert _after("```python\n", "```python\n").closers == "\n```", (
+        "an info-string line was treated as a closer"
+    )
 
-    assert blocks.closers == "\n```", "an info-string line was treated as a closer"
+    # delimiter plus whitespace only — a real closer
+    assert _after("```python\n", "```python\n", "```   \n").closers == ""
 
-    blocks.feed("```   \n")  # delimiter plus whitespace only — a real closer
-    assert blocks.closers == ""
+
+def test_feed_leaves_the_instance_it_was_called_on_untouched() -> None:
+    """`cap_to_limit` peeks at the next state before deciding to take a line."""
+    outside = extract._OpenBlocks()
+    inside = outside.feed("```python\n")
+
+    assert outside.closers == "", "feed mutated the state it was asked about"
+    assert inside.closers == "\n```"
 
 
 def test_truncation_closes_a_fence_whose_content_looks_like_a_fence() -> None:

--- a/tests/src/unit/test_extract_release_notes.py
+++ b/tests/src/unit/test_extract_release_notes.py
@@ -221,6 +221,40 @@ def test_a_shorter_or_foreign_fence_line_does_not_close_an_open_fence() -> None:
     assert blocks.closers == ""
 
 
+def test_an_info_string_line_does_not_close_an_open_fence() -> None:
+    """A closing fence carries no info string, so ```python is content, not a closer."""
+    blocks = extract._OpenBlocks()
+    blocks.feed("```python\n")
+    blocks.feed("```python\n")
+
+    assert blocks.closers == "\n```", "an info-string line was treated as a closer"
+
+    blocks.feed("```   \n")  # delimiter plus whitespace only — a real closer
+    assert blocks.closers == ""
+
+
+def test_truncation_closes_a_fence_whose_content_looks_like_a_fence() -> None:
+    """Interior ```python lines keep the block open, so the cut still needs a closer."""
+    body = "```python\n" + ("```python\n" + "x" * 9 + "\n") * 20_000
+    assert len(body) > LIMIT, "body must actually need truncating"
+
+    capped = extract.cap_to_limit(body, REPO, "8.0.0", LIMIT)
+
+    kept = capped.split("\n\n---\n\n")[0]
+    assert kept.splitlines()[-1] == "```", "the still-open fence was left unclosed"
+    assert len(capped) <= LIMIT
+
+
+def test_a_limit_too_small_for_the_first_line_fails_loudly() -> None:
+    """A mid-line cut would strand an opening fence and swallow the notice."""
+    limit = 200
+    body = "```" + "z" * 300 + "\n" + "x" * 300 + "\n"
+    assert len(body) > limit
+
+    with pytest.raises(ValueError, match="first complete line"):
+        extract.cap_to_limit(body, REPO, "8.0.0", limit)
+
+
 def test_a_limit_too_small_for_the_notice_fails_loudly() -> None:
     """Silently emitting a notice-free body would look like complete notes."""
     body = "".join(f"- change number {i}\n" for i in range(12_000))

--- a/tests/src/unit/test_release_notes_wiring_shape.py
+++ b/tests/src/unit/test_release_notes_wiring_shape.py
@@ -44,7 +44,12 @@ def _release_step_run(workflow: str) -> str:
     assert len(steps) == 1, f"{workflow} must have exactly one {_STEP!r} step"
     run = steps[0].get("run")
     assert run, f"{workflow}'s {_STEP!r} step has no run body"
-    return _RUNS_OF_BLANKS.sub(" ", run)
+    # Comment lines are dropped first: the step is commented, and a commented-out
+    # command must not be able to satisfy an assertion about what it does.
+    active = "\n".join(
+        line for line in run.splitlines() if not line.lstrip().startswith("#")
+    )
+    return _RUNS_OF_BLANKS.sub(" ", active)
 
 
 def test_the_extractor_the_workflows_call_exists() -> None:

--- a/tests/src/unit/test_release_notes_wiring_shape.py
+++ b/tests/src/unit/test_release_notes_wiring_shape.py
@@ -1,0 +1,62 @@
+"""Pin the release workflows to the release-note extractor they call.
+
+``semver-release.yml`` and ``hotfix-release.yml`` cannot run in PR CI, so
+nothing else checks that the three filenames in each release step still agree:
+the script's ``--out``, the ``[ ! -s ... ]`` emptiness guard, and ``gh release
+create --notes-file``. A missing script is loud (the step runs under ``bash
+-e``), but a drifting ``--out`` name is silent — the guard finds no file, the
+fallback fires, and the release ships ``Release vX.Y.Z`` as its entire body on
+a green run, for that release and every one after it. These tests catch that
+before merge, the only coverage a workflow that cannot run pre-merge can have.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_SCRIPT = "scripts/extract_release_notes.py"
+_WORKFLOWS = ["semver-release.yml", "hotfix-release.yml"]
+
+
+def _workflow(name: str) -> str:
+    return (_REPO_ROOT / ".github" / "workflows" / name).read_text(encoding="utf-8")
+
+
+def test_the_extractor_the_workflows_call_exists() -> None:
+    assert (_REPO_ROOT / _SCRIPT).is_file(), (
+        f"{_SCRIPT} is gone, but the release workflows still invoke it"
+    )
+
+
+@pytest.mark.parametrize("workflow", _WORKFLOWS)
+def test_the_release_step_calls_the_extractor(workflow: str) -> None:
+    assert re.search(rf"python3\s+{re.escape(_SCRIPT)}\s", _workflow(workflow)), (
+        f"{workflow} no longer calls {_SCRIPT}"
+    )
+
+
+@pytest.mark.parametrize("workflow", _WORKFLOWS)
+def test_out_guard_and_notes_file_all_name_the_same_file(workflow: str) -> None:
+    text = _workflow(workflow)
+    out = re.search(r"extract_release_notes\.py[^\n]*--out\s+(\S+)", text)
+    assert out, f"{workflow} does not pass --out to the extractor"
+    notes = out.group(1)
+
+    assert re.search(rf"\[\s*!\s*-s\s+{re.escape(notes)}\s*\]", text), (
+        f"{workflow} writes notes to {notes} but its emptiness guard checks something else"
+    )
+    assert re.search(rf"--notes-file\s+{re.escape(notes)}\b", text), (
+        f"{workflow} writes notes to {notes} but publishes something else"
+    )
+
+
+@pytest.mark.parametrize("workflow", _WORKFLOWS)
+def test_the_empty_extract_fallback_warns(workflow: str) -> None:
+    """Without the warning, a degraded release reads exactly like a healthy one."""
+    assert "::warning::no changelog section extracted" in _workflow(workflow), (
+        f"{workflow} falls back to generic notes without saying so in the run log"
+    )

--- a/tests/src/unit/test_release_notes_wiring_shape.py
+++ b/tests/src/unit/test_release_notes_wiring_shape.py
@@ -1,29 +1,50 @@
 """Pin the release workflows to the release-note extractor they call.
 
 ``semver-release.yml`` and ``hotfix-release.yml`` cannot run in PR CI, so
-nothing else checks that the three filenames in each release step still agree:
-the script's ``--out``, the ``[ ! -s ... ]`` emptiness guard, and ``gh release
-create --notes-file``. A missing script is loud (the step runs under ``bash
--e``), but a drifting ``--out`` name is silent — the guard finds no file, the
-fallback fires, and the release ships ``Release vX.Y.Z`` as its entire body on
-a green run, for that release and every one after it. These tests catch that
-before merge, the only coverage a workflow that cannot run pre-merge can have.
+nothing else checks that the filenames in each release step still agree: the
+script's ``--out``, the ``[ ! -s ... ]`` emptiness guard, the fallback write,
+and ``gh release create --notes-file``. A missing script is loud (the step runs
+under ``bash -e``), but a drifting ``--out`` name is silent — the guard finds no
+file, the fallback fires, and the release ships ``Release vX.Y.Z`` as its entire
+body on a green run, for that release and every one after it. These tests catch
+that before merge, the only coverage a workflow that cannot run pre-merge can
+have.
+
+The assertions are scoped to the one step that builds and publishes the body,
+so a match somewhere else in the file cannot stand in for that step's wiring.
 """
 
 from __future__ import annotations
 
 import re
 from pathlib import Path
+from typing import Any
 
 import pytest
+import yaml
 
 _REPO_ROOT = Path(__file__).resolve().parents[3]
+_WORKFLOW_DIR = _REPO_ROOT / ".github" / "workflows"
 _SCRIPT = "scripts/extract_release_notes.py"
+_STEP = "Create draft GitHub release"
 _WORKFLOWS = ["semver-release.yml", "hotfix-release.yml"]
+_OUT_RE = re.compile(r"extract_release_notes\.py[^\n]*--out\s+(\S+)")
+_RUNS_OF_BLANKS = re.compile(r"[ \t]+")
 
 
-def _workflow(name: str) -> str:
-    return (_REPO_ROOT / ".github" / "workflows" / name).read_text(encoding="utf-8")
+def _release_step_run(workflow: str) -> str:
+    """The `run` body of the single step that writes and publishes the notes."""
+    data: Any = yaml.safe_load((_WORKFLOW_DIR / workflow).read_text(encoding="utf-8"))
+    steps = [
+        step
+        for job in data["jobs"].values()
+        for step in job.get("steps", [])
+        if step.get("name") == _STEP
+    ]
+    assert len(steps) == 1, f"{workflow} must have exactly one {_STEP!r} step"
+    run = steps[0].get("run")
+    assert run, f"{workflow}'s {_STEP!r} step has no run body"
+    return _RUNS_OF_BLANKS.sub(" ", run)
 
 
 def test_the_extractor_the_workflows_call_exists() -> None:
@@ -33,30 +54,25 @@ def test_the_extractor_the_workflows_call_exists() -> None:
 
 
 @pytest.mark.parametrize("workflow", _WORKFLOWS)
-def test_the_release_step_calls_the_extractor(workflow: str) -> None:
-    assert re.search(rf"python3\s+{re.escape(_SCRIPT)}\s", _workflow(workflow)), (
-        f"{workflow} no longer calls {_SCRIPT}"
-    )
+def test_the_release_step_wires_one_filename_end_to_end(workflow: str) -> None:
+    run = _release_step_run(workflow)
 
-
-@pytest.mark.parametrize("workflow", _WORKFLOWS)
-def test_out_guard_and_notes_file_all_name_the_same_file(workflow: str) -> None:
-    text = _workflow(workflow)
-    out = re.search(r"extract_release_notes\.py[^\n]*--out\s+(\S+)", text)
-    assert out, f"{workflow} does not pass --out to the extractor"
+    out = _OUT_RE.search(run)
+    assert out, f"{workflow}'s {_STEP!r} step does not call {_SCRIPT} with --out"
     notes = out.group(1)
 
-    assert re.search(rf"\[\s*!\s*-s\s+{re.escape(notes)}\s*\]", text), (
-        f"{workflow} writes notes to {notes} but its emptiness guard checks something else"
-    )
-    assert re.search(rf"--notes-file\s+{re.escape(notes)}\b", text), (
-        f"{workflow} writes notes to {notes} but publishes something else"
-    )
+    stages = [
+        (f"python3 {_SCRIPT}", "call the extractor"),
+        (f"[ ! -s {notes} ]", f"guard {notes} for emptiness"),
+        ("::warning::no changelog section extracted", "warn when the extract is empty"),
+        (f"> {notes}", f"write its fallback body to {notes}"),
+        (f"--notes-file {notes}", f"publish {notes}"),
+    ]
+    for needle, what in stages:
+        assert needle in run, f"{workflow}'s {_STEP!r} step does not {what}"
 
-
-@pytest.mark.parametrize("workflow", _WORKFLOWS)
-def test_the_empty_extract_fallback_warns(workflow: str) -> None:
-    """Without the warning, a degraded release reads exactly like a healthy one."""
-    assert "::warning::no changelog section extracted" in _workflow(workflow), (
-        f"{workflow} falls back to generic notes without saying so in the run log"
+    positions = [run.index(needle) for needle, _ in stages]
+    assert positions == sorted(positions), (
+        f"{workflow}'s {_STEP!r} step must extract, guard the empty file, warn, "
+        "write the fallback, then publish that same file — in that order"
     )


### PR DESCRIPTION
## What does this PR do?

Fixes the gaps left in `scripts/extract_release_notes.py` and the two release workflows it feeds, on top of #2154.

**Truncation could leave a fence open, swallowing its own warning.** `_FENCE_RE` matched any run of three or more backticks but `closers` always appended exactly three, so a ` ````python ` block stayed open; `~~~` fences weren't tracked at all; and a second ` ```python ` inside an open block was treated as a closer, though a closing fence carries no info string. The opening delimiter is now captured, and a fence closes only on the same character, repeated at least as many times, followed by whitespace only. Otherwise the truncation notice and the full-changelog link render as code instead of as the warning they are.

**The no-line-fits fallback cut mid-line with no closers.** It sliced `body[:budget]`, which could strand an opening fence or `<details>` around the notice and contradicted the documented line-boundary guarantee. It now raises, so the guarantee holds unconditionally.

**An empty extract looked exactly like a healthy release.** Both workflows fall back to a one-line body but only wrote the file, so a degraded release and a normal one were indistinguishable in the run log. Each fallback now emits a `::warning::`. `extract_section` also conflated "no such heading" with "heading present, section empty" — two real cases here (`## v4.8.0`, `## v1.0.0`) — so it returns `None` for the former and the script prints which one happened.

**Error paths.** `UnicodeDecodeError` subclasses `ValueError`, so a changelog with a bad byte escaped the `OSError` handler and exited on a traceback; the write was unguarded while the read was not; `write_text` used platform line endings, so the file on disk didn't match the character budget the cap was computed against; and `lstrip('v')` strips a character set rather than a prefix.

**`_OpenBlocks` was a mutable class whose only caller hand-copied its fields** to peek at the next state — a field added later would have been dropped silently by that copy. It's now a frozen dataclass whose `feed()` returns the next state.

**Two comments described things that aren't true.** The 125,000 cap was justified by "the changelog carries emoji in headings" — it carries none; the real reason is that the API's own rejection counts characters. And the "negative lookahead" comment sat on `_NEXT_SECTION_RE`, which has no lookahead; it's the section terminator, and the lookahead it described lives in `_heading_re`.

**Two pins, because neither release workflow can run in PR CI.** One asserts the heading regexes still match the real `CHANGELOG.md` for `pyproject.toml`'s current version — every other test uses a synthetic fixture, so a change to `templates/CHANGELOG.md.j2` or `tag_format` would leave them green while every release shipped `Release vX.Y.Z` as its entire body. The other scopes to the single `Create draft GitHub release` step and pins extract → emptiness guard → warning → fallback write → `--notes-file`, all naming one filename, in that order; verified non-vacuous by mutation.

Codex's P3 on #2154 — accept `--limit` exactly equal to the notice length — is not taken: the only possible output there is a body containing nothing but "these notes were truncated". The docstring that promised otherwise is corrected instead.

## Type of change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [ ] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

Ran `test_extract_release_notes.py`, `test_release_notes_wiring_shape.py` and `test_build_mirror_release_notes.py` locally — 51 passed — plus `ruff check`, `ruff format --check` (0.16.1, the uv.lock pin) and `mypy`. Also exercised the script against a changelog with an absent version, a present-but-empty section and a normal section, confirming the three distinct run-log outcomes. Full suite is CI's.

## Checklist
- [x] I have updated documentation if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release-note generation when changelog content is missing or empty by issuing a warning and providing fallback notes.
  * Improved formatting preservation for code blocks and other structured content.
  * Clarified release-description size limits and truncation behavior to prevent incomplete content.
  * Improved handling of changelog encoding and line endings.

* **Tests**
  * Added coverage for missing and empty sections, formatting edge cases, fallback behavior, size limits, and release workflow configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->