### PR TITLE
fix: validate entity area IDs

### DIFF
--- a/src/ha_mcp/tools/tools_config_helpers.py
+++ b/src/ha_mcp/tools/tools_config_helpers.py
@@ -1232,7 +1232,7 @@ def _raise_if_unknown_labels(
             )
 
 
-async def _validate_registry_ids(
+async def validate_registry_ids(
     client: Any,
     area_id: str | None,
     labels: list[str] | None,
@@ -2070,7 +2070,7 @@ async def _handle_flow_helper(
         )
 
     # Bug 16 (issue #1150): validate registry IDs BEFORE creating the config entry.
-    await _validate_registry_ids(client, area_id, labels_list, category)
+    await validate_registry_ids(client, area_id, labels_list, category)
 
     if action == "create":
         # Validate against EITHER the top-level `name` arg OR `config_dict["name"]`.
@@ -4741,7 +4741,7 @@ class HelperConfigTools:
                 )
 
             # Bug 16 (issue #1150): validate area_id / labels / category exist.
-            await _validate_registry_ids(self._client, area_id, labels, category)
+            await validate_registry_ids(self._client, area_id, labels, category)
 
             # Bug 13/17 (issue #1150): pre-validate per-type schema constraints.
             _validate_pre_dispatch_params(

--- a/src/ha_mcp/tools/tools_config_helpers.py
+++ b/src/ha_mcp/tools/tools_config_helpers.py
@@ -1232,11 +1232,27 @@ def _raise_if_unknown_labels(
             )
 
 
+def _raise_if_area_lookup_failed(
+    ok: bool, area_id: str | None, fail_closed_area: bool
+) -> None:
+    """Fail entity area assignment when its registry cannot be read."""
+    if fail_closed_area and not ok:
+        raise_tool_error(
+            create_error_response(
+                ErrorCode.CONNECTION_FAILED,
+                "Could not validate area_id because the area registry is unavailable.",
+                context={"area_id": area_id},
+            )
+        )
+
+
 async def validate_registry_ids(
     client: Any,
     area_id: str | None,
     labels: list[str] | None,
     category: str | None,
+    *,
+    fail_closed_area: bool = False,
 ) -> None:
     """Validate that area_id, labels, and category reference existing registry entries.
 
@@ -1252,6 +1268,8 @@ async def validate_registry_ids(
 
     Raises VALIDATION_INVALID_PARAMETER on the first unknown ID encountered, with
     the available IDs included in the suggestions list so the caller can correct.
+    ``fail_closed_area`` also rejects an unavailable area registry; entity
+    assignments use it because HA otherwise persists dangling area references.
     """
     needs_area = area_id is not None and area_id != ""
     needs_labels = bool(labels)
@@ -1287,6 +1305,7 @@ async def validate_registry_ids(
 
     if needs_area:
         ok, areas = by_param["area"]
+        _raise_if_area_lookup_failed(ok, area_id, fail_closed_area)
         valid_area_ids = _registry_id_values(areas, "area_id")
         if ok and area_id not in valid_area_ids:
             raise_tool_error(

--- a/src/ha_mcp/tools/tools_entities.py
+++ b/src/ha_mcp/tools/tools_entities.py
@@ -35,6 +35,7 @@ from .helpers import (
     register_tool_methods,
     validate_identifier_not_empty,
 )
+from .tools_config_helpers import validate_registry_ids
 from .tools_voice_assistant import KNOWN_ASSISTANTS
 from .util_helpers import (
     JSON_STRING_COERCION,
@@ -1775,6 +1776,7 @@ class EntityTools:
                     )
                 )
 
+            await validate_registry_ids(self._client, area_id, None, None)
             _validate_enabled_constraint(enabled, entity_ids)
 
             parsed_aliases = _parse_string_list_field(aliases, "aliases")

--- a/src/ha_mcp/tools/tools_entities.py
+++ b/src/ha_mcp/tools/tools_entities.py
@@ -1062,6 +1062,12 @@ class EntityTools:
         original_entity_id = entity_id
 
         # Phase 3: Send entity registry update (covers all fields except expose_to)
+        # Repeat the preflight immediately before this write: Home Assistant
+        # accepts unknown area IDs, so a deleted area must not slip through
+        # after the earlier validation while preparing the update.
+        await validate_registry_ids(
+            self._client, area_id, None, None, fail_closed_area=True
+        )
         (
             entity_id,
             entity_entry,
@@ -1776,7 +1782,9 @@ class EntityTools:
                     )
                 )
 
-            await validate_registry_ids(self._client, area_id, None, None)
+            await validate_registry_ids(
+                self._client, area_id, None, None, fail_closed_area=True
+            )
             _validate_enabled_constraint(enabled, entity_ids)
 
             parsed_aliases = _parse_string_list_field(aliases, "aliases")

--- a/tests/src/e2e/workflows/entities/test_entity_management.py
+++ b/tests/src/e2e/workflows/entities/test_entity_management.py
@@ -604,6 +604,18 @@ class TestSetEntityNegativeInputs:
         assert not data.get("success", False)
         assert data["error"]["code"] == "VALIDATION_INVALID_PARAMETER"
 
+    async def test_set_entity_invalid_area_id_rejected(self, mcp_client) -> None:
+        """Rejects unknown areas instead of creating a dangling assignment."""
+        data = await safe_call_tool(
+            mcp_client,
+            "ha_set_entity",
+            {"entity_id": "light.test", "area_id": "unknown_area_id"},
+        )
+
+        assert not data.get("success", False)
+        assert data["error"]["code"] == "VALIDATION_INVALID_PARAMETER"
+        assert data["area_id"] == "unknown_area_id"
+
     async def test_set_entity_automation_disable_rejected(self, mcp_client) -> None:
         """Rejects registry-disabling an automation entity.
 

--- a/tests/src/unit/test_helper_registry_id_validation.py
+++ b/tests/src/unit/test_helper_registry_id_validation.py
@@ -273,7 +273,7 @@ class TestPhantomRejectedAgainstEmptyRegistry:
     """Pin the (ok=True, items=[]) contract: phantom IDs must be rejected even
     when the registry is genuinely empty.
 
-    The ``_validate_registry_ids`` helper returns a (ok, items) tuple to
+    The ``validate_registry_ids`` helper returns a (ok, items) tuple to
     distinguish a successful-but-empty lookup from a lookup failure. Without
     explicit coverage, a future refactor that fails open on empty results
     would silently regress phantom-ID rejection."""

--- a/tests/src/unit/test_helper_registry_id_validation.py
+++ b/tests/src/unit/test_helper_registry_id_validation.py
@@ -273,10 +273,11 @@ class TestPhantomRejectedAgainstEmptyRegistry:
     """Pin the (ok=True, items=[]) contract: phantom IDs must be rejected even
     when the registry is genuinely empty.
 
-    The ``validate_registry_ids`` helper returns a (ok, items) tuple to
-    distinguish a successful-but-empty lookup from a lookup failure. Without
-    explicit coverage, a future refactor that fails open on empty results
-    would silently regress phantom-ID rejection."""
+    ``validate_registry_ids`` returns ``None`` for valid input and raises
+    ``ToolError`` for invalid input. The underlying registry lookup returns
+    ``(ok, items)`` to distinguish a successful-but-empty lookup from a lookup
+    failure. Without explicit coverage, a future refactor that fails open on
+    empty results would silently regress phantom-ID rejection."""
 
     async def test_phantom_area_rejected_against_empty_area_registry(
         self, register_tools, mock_client

--- a/tests/src/unit/test_helper_response_shape.py
+++ b/tests/src/unit/test_helper_response_shape.py
@@ -269,7 +269,7 @@ class TestUniformResponseShape:
         A regression that re-nests this string under ``data``, or drops the
         ``warnings.append`` entirely, would slip past the category test —
         this fills that gap. The ``area.kitchen`` is registered (so the
-        upstream ``_validate_registry_ids`` lookup passes) and the failure
+        upstream ``validate_registry_ids`` lookup passes) and the failure
         happens at the post-create registry-update step itself.
         """
 

--- a/tests/src/unit/test_tools_entities.py
+++ b/tests/src/unit/test_tools_entities.py
@@ -198,6 +198,50 @@ class TestHaSetEntityLabels:
             (({"type": "config/area_registry/list"},), {})
         ]
 
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "area_lookup",
+        [
+            {"success": False, "error": {"message": "registry unavailable"}},
+            RuntimeError("connection lost"),
+        ],
+    )
+    async def test_area_registry_lookup_failure_rejects_entity_update(
+        self, set_entity_tool, mock_client, area_lookup
+    ):
+        """Area assignment fails closed when its registry cannot be read."""
+        mock_client.send_websocket_message.side_effect = area_lookup
+
+        with pytest.raises(ToolError) as exc_info:
+            await set_entity_tool(entity_id="light.test", area_id="living_room")
+
+        error_data = json.loads(str(exc_info.value))
+        assert error_data["error"]["code"] == "CONNECTION_FAILED"
+        assert error_data["area_id"] == "living_room"
+        assert mock_client.send_websocket_message.call_args_list == [
+            (({"type": "config/area_registry/list"},), {})
+        ]
+
+    @pytest.mark.asyncio
+    async def test_area_id_revalidated_immediately_before_registry_update(
+        self, set_entity_tool, mock_client
+    ):
+        """An area deleted after preflight is not submitted to HA."""
+        mock_client.send_websocket_message.side_effect = [
+            {"success": True, "result": [{"area_id": "living_room"}]},
+            {"success": True, "result": []},
+        ]
+
+        with pytest.raises(ToolError) as exc_info:
+            await set_entity_tool(entity_id="light.test", area_id="living_room")
+
+        error_data = json.loads(str(exc_info.value))
+        assert error_data["error"]["code"] == "VALIDATION_INVALID_PARAMETER"
+        assert mock_client.send_websocket_message.call_args_list == [
+            (({"type": "config/area_registry/list"},), {}),
+            (({"type": "config/area_registry/list"},), {}),
+        ]
+
 
 class TestHaSetEntityExposeTo:
     """Test ha_set_entity expose_to parameter."""

--- a/tests/src/unit/test_tools_entities.py
+++ b/tests/src/unit/test_tools_entities.py
@@ -178,6 +178,26 @@ class TestHaSetEntityLabels:
         call_args = mock_client.send_websocket_message.call_args[0][0]
         assert "labels" not in call_args
 
+    @pytest.mark.asyncio
+    async def test_invalid_area_id_rejected_before_registry_update(
+        self, set_entity_tool, mock_client
+    ):
+        """Unknown area IDs must not create dangling entity assignments."""
+        mock_client.send_websocket_message.return_value = {
+            "success": True,
+            "result": [{"area_id": "living_room"}],
+        }
+
+        with pytest.raises(ToolError) as exc_info:
+            await set_entity_tool(entity_id="light.test", area_id="extérieur nord")
+
+        error_data = json.loads(str(exc_info.value))
+        assert error_data["error"]["code"] == "VALIDATION_INVALID_PARAMETER"
+        assert error_data["area_id"] == "extérieur nord"
+        assert mock_client.send_websocket_message.call_args_list == [
+            (({"type": "config/area_registry/list"},), {})
+        ]
+
 
 class TestHaSetEntityExposeTo:
     """Test ha_set_entity expose_to parameter."""


### PR DESCRIPTION
## What does this PR do?

Fixes #2159.

Validate non-empty `area_id` values before `ha_set_entity` updates the entity registry.

Home Assistant accepts unknown area IDs in its entity-registry WebSocket command, which previously let the tool create dangling assignments. The tool now reuses the existing registry-ID validator and returns `VALIDATION_INVALID_PARAMETER` with valid IDs when the requested area does not exist. Entity area assignment now fails closed when the area registry cannot be read and revalidates immediately before the registry update.

## Type of change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing

- [ ] I have tested these changes with a LLM agent
- [ ] All automated tests pass (`uv run pytest`) — the full suite was not run.
- [x] Code follows style guidelines (`uv run ruff check`)

Focused validation passed: 72 unit tests and the E2E regression test against Home Assistant 2026.8.0.

## Checklist

- [ ] I have updated documentation if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for area assignments when updating entities.
  * Invalid or deleted area IDs are now rejected before changes are applied.
  * Area-registry connection failures now return clear connection errors in fail-closed scenarios.
  * Error responses preserve the affected area ID for easier troubleshooting.

* **Tests**
  * Added coverage for invalid areas, registry failures, and areas removed during an update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->