### PR TITLE
fix: reject blank locale catalog values instead of rendering them

### DIFF
--- a/scripts/translate_locales.py
+++ b/scripts/translate_locales.py
@@ -465,10 +465,13 @@ def _style_sample_keys(
     right-hand side into the prompt, so the pair it contributes shows the model
     nothing to imitate while still counting against the sample budget — and on
     a catalog whose register rests on a single key, that is the whole signal.
-    Nothing upstream stops it reaching here: an engine answer this shape is
-    rejected (`_validate`), but a hand-committed one is only type-checked
-    (`_validate_string_map`), and the parity ceilings count a key untranslated
-    only when it equals the English or is absent, so `""` reads as translated.
+    An engine answer this shape is rejected (`_validate`), and a hand-committed
+    one no longer survives a catalog load (`_validate_string_map`) — but this
+    script reads the catalogs with `json.loads` rather than through
+    `load_catalogs`, so one still reaches here out of a working tree the app has
+    not loaded. The parity ceilings would not object either: they count a key
+    untranslated only when it equals the English or is absent, so `""` reads
+    there as translated.
     """
     return sorted(
         (

--- a/src/ha_mcp/settings_ui/_i18n.py
+++ b/src/ha_mcp/settings_ui/_i18n.py
@@ -23,7 +23,18 @@ _PLACEHOLDER_RE = re.compile(r"\{([a-zA-Z_][a-zA-Z0-9_]*)\}")
 
 
 def _validate_string_map(value: Any, *, context: str) -> dict[str, str]:
-    """Return a validated ``str -> str`` catalog section."""
+    """Return a validated ``str -> str`` catalog section.
+
+    A blank value is rejected rather than stored. English is the per-key
+    fallback, but only for a key that is ABSENT: ``t()`` and ``tHtml()`` pick
+    the catalog value with ``hasOwnProperty``, so a present-but-empty string
+    wins over English and renders as nothing at all. Omitting a key and
+    emptying it therefore look identical in the JSON and behave oppositely on
+    screen, which is the kind of difference no reviewer catches by reading.
+    Nothing else covers it either — the parity ceilings count a key
+    untranslated only when it equals the English or is missing, so ``""``
+    reads there as translated.
+    """
     if value is None:
         return {}
     if not isinstance(value, dict):
@@ -32,6 +43,11 @@ def _validate_string_map(value: Any, *, context: str) -> dict[str, str]:
     for key, text in value.items():
         if not isinstance(key, str) or not isinstance(text, str):
             raise ValueError(f"{context} must contain only string keys and values")
+        if not text.strip():
+            raise ValueError(
+                f"{context}.{key} is blank — omit the key instead, so English "
+                "renders as the fallback"
+            )
         result[key] = text
     return result
 
@@ -53,6 +69,13 @@ def _validate_tools(value: Any, *, context: str) -> dict[str, dict[str, str]]:
                 continue
             if not isinstance(field_value, str):
                 raise ValueError(f"{context}.{tool_name}.{field} must be a string")
+            # Same rule as _validate_string_map: blank loses to nothing, an
+            # omitted field falls back to the tool's own English metadata.
+            if not field_value.strip():
+                raise ValueError(
+                    f"{context}.{tool_name}.{field} is blank — omit the field "
+                    "instead, so the English tool metadata renders"
+                )
             translated[field] = field_value
         unknown = set(tool_values) - {"title", "description"}
         if unknown:

--- a/src/ha_mcp/settings_ui/_i18n.py
+++ b/src/ha_mcp/settings_ui/_i18n.py
@@ -45,8 +45,9 @@ def _validate_string_map(value: Any, *, context: str) -> dict[str, str]:
             raise ValueError(f"{context} must contain only string keys and values")
         if not text.strip():
             raise ValueError(
-                f"{context}.{key} is blank — omit the key instead, so English "
-                "renders as the fallback"
+                f"{context}.{key} is blank — English renders only for an "
+                "absent key, so translate it, or leave the key out where the "
+                "section allows a missing one"
             )
         result[key] = text
     return result

--- a/src/ha_mcp/settings_ui/locales/README.md
+++ b/src/ha_mcp/settings_ui/locales/README.md
@@ -66,7 +66,10 @@ or constructed — needs no pipeline change.
   rejected when the catalog loads, because the runtime resolves by key
   presence, so an empty value would win over English and render as nothing.
 - `tool_groups`: one entry per renderable MCP tool tag, keyed by the English
-  tag. Not optional, and exact: no key more and none fewer.
+  tag. Not optional, and exact: no key more and none fewer. Blank is rejected
+  here too, but dropping the key is not the escape hatch it is for `messages` —
+  the exact key set forbids that. A heading you have not translated yet keeps
+  the English tag as its value.
 - `tools`: `title` and `description` per tool, keyed by the stable MCP tool
   name. The key set is not optional and exact in the same way; either field on
   its own may be left out, but a missing one counts as untranslated against the

--- a/src/ha_mcp/settings_ui/locales/README.md
+++ b/src/ha_mcp/settings_ui/locales/README.md
@@ -61,13 +61,16 @@ or constructed — needs no pipeline change.
   rejected when the catalog loads.
 - `messages`: interface labels, help text, notices, and runtime messages. Keys
   may be omitted — English is the per-key fallback at runtime — but see the
-  share limit below before leaving a catalog half-finished.
+  share limit below before leaving a catalog half-finished. Omitting is the
+  only way to say "not translated yet": a key that is present but blank is
+  rejected when the catalog loads, because the runtime resolves by key
+  presence, so an empty value would win over English and render as nothing.
 - `tool_groups`: one entry per renderable MCP tool tag, keyed by the English
   tag. Not optional, and exact: no key more and none fewer.
 - `tools`: `title` and `description` per tool, keyed by the stable MCP tool
   name. The key set is not optional and exact in the same way; either field on
   its own may be left out, but a missing one counts as untranslated against the
-  share limit below.
+  share limit below. Blank is rejected here too, for the same reason.
 
 Keep the keys and `{placeholders}` unchanged in every section.
 

--- a/tests/src/unit/test_settings_ui_i18n.py
+++ b/tests/src/unit/test_settings_ui_i18n.py
@@ -257,8 +257,9 @@ def test_blank_catalog_value_is_rejected(
         load_catalogs(tmp_path)
 
 
+@pytest.mark.parametrize("blank", ["", " ", "\n\t "])
 @pytest.mark.parametrize("field", ["title", "description"])
-def test_blank_tool_field_is_rejected(tmp_path: Path, field: str) -> None:
+def test_blank_tool_field_is_rejected(tmp_path: Path, field: str, blank: str) -> None:
     """Same rule on the per-tool surface, which validates separately."""
     (tmp_path / "en.json").write_text(
         json.dumps(
@@ -266,7 +267,7 @@ def test_blank_tool_field_is_rejected(tmp_path: Path, field: str) -> None:
                 "meta": {"native_name": "English", "dir": "ltr"},
                 "messages": {},
                 "tool_groups": {},
-                "tools": {"ha_get_state": {field: "  "}},
+                "tools": {"ha_get_state": {field: blank}},
             }
         ),
         encoding="utf-8",

--- a/tests/src/unit/test_settings_ui_i18n.py
+++ b/tests/src/unit/test_settings_ui_i18n.py
@@ -230,6 +230,54 @@ def test_catalog_without_a_native_name_is_rejected(tmp_path: Path) -> None:
         load_catalogs(tmp_path)
 
 
+@pytest.mark.parametrize("blank", ["", " ", "\n\t "])
+@pytest.mark.parametrize("section", ["messages", "tool_groups"])
+def test_blank_catalog_value_is_rejected(
+    tmp_path: Path, section: str, blank: str
+) -> None:
+    """Blank and absent look the same in JSON and behave oppositely on screen.
+
+    English is the per-key fallback only for a key that is ABSENT: `t()` and
+    `tHtml()` resolve with `hasOwnProperty`, so an empty string wins over the
+    English source and renders as nothing. A translator emptying a value to
+    mean "not translated yet" would silently blank that piece of UI, and no
+    other check objects — the parity ceilings count a key untranslated only
+    when it equals the English or is missing.
+    """
+    catalog = {
+        "meta": {"native_name": "English", "dir": "ltr"},
+        "messages": {},
+        "tool_groups": {},
+        "tools": {},
+    }
+    catalog[section] = {"a": blank}
+    (tmp_path / "en.json").write_text(json.dumps(catalog), encoding="utf-8")
+
+    with pytest.raises(ValueError, match=re.escape(f"en.json.{section}.a is blank")):
+        load_catalogs(tmp_path)
+
+
+@pytest.mark.parametrize("field", ["title", "description"])
+def test_blank_tool_field_is_rejected(tmp_path: Path, field: str) -> None:
+    """Same rule on the per-tool surface, which validates separately."""
+    (tmp_path / "en.json").write_text(
+        json.dumps(
+            {
+                "meta": {"native_name": "English", "dir": "ltr"},
+                "messages": {},
+                "tool_groups": {},
+                "tools": {"ha_get_state": {field: "  "}},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(
+        ValueError, match=re.escape(f"en.json.tools.ha_get_state.{field} is blank")
+    ):
+        load_catalogs(tmp_path)
+
+
 def test_inline_payload_escapes_script_breakout() -> None:
     serialized = serialize_payload({"messages": {"unsafe": "</script><b>&"}})
 

--- a/tests/src/unit/test_translate_locales.py
+++ b/tests/src/unit/test_translate_locales.py
@@ -162,8 +162,9 @@ class TestStyleSamples:
 
     @pytest.mark.parametrize("blank", ["", " ", "\n\t "])
     def test_skips_keys_whose_translation_is_blank(self, blank: str) -> None:
-        """A blank value is a present key with nothing in it, and the sampler is
-        the only thing that looks: `_validate_string_map` type-checks, and the
+        """A blank value is a present key with nothing in it, and this sampler
+        is where one still turns up: `_validate_string_map` rejects it at load,
+        but this script reads the catalogs with `json.loads` instead, and the
         parity ceilings count a key untranslated only when it equals the English
         or is missing, so `""` reads there as translated. Sampled, it spends one
         of three slots on a pair whose target side is empty — and a catalog


### PR DESCRIPTION
## What does this PR do?

Rejects blank values in the settings-UI locale catalogs at load time, instead of
letting them render.

English is the per-key fallback only for a key that is **absent**. `t()` and
`tHtml()` (`settings.js`) resolve with `hasOwnProperty` rather than truthiness,
so a present-but-empty string wins over the English source and renders as
nothing at all. Omitting a key and emptying it therefore look nearly identical
in the JSON and behave oppositely on screen — a translator clearing a value to
mean "not translated yet" silently blanks that piece of UI.

Nothing objected to it. `_validate_string_map` and `_validate_tools` checked the
type and stopped; the parity ceilings count a key untranslated only when it
equals the English or is missing (`_untranslated_keys`), so `""` read there as
translated. Placeholder parity did catch the subset whose English carries a
placeholder, which is why this stayed invisible — though that subset is smaller
than it sounds: 66 of 443 `messages` keys carry one, and neither `tool_groups`
nor the tool fields were covered at all.

Both validators now reject a blank value the way their caller `load_catalogs`
already rejects a blank `meta.native_name`, and the message names the mechanism:
English renders only for an absent key. Measured before changing anything:
**0 blank values across 4,985 shipped ones** (messages, tool_groups, tools and
the component catalogs), so this rejects nothing that exists today.

The locale README gains the rule in each section that carries one. Under
`messages` and `tools`, omitting is now the only way to express "not translated
yet". Under `tool_groups` it is not available at all — that key set is exact, so
an untranslated heading keeps the English tag as its value.

## Type of change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

Each guard is pinned separately rather than as a pair: breaking the
`messages`/`tool_groups` condition fails those six parametrizations while the
six tool-field cases stay green, and breaking the tool-field condition inverts
that exactly. A single combined revert would not have discriminated between
them.

`tests/src/unit` at cb2cab89, with `pytest.ini`'s `--maxfail=3` overridden so
the run completes: 9,620 passed, 69 skipped, no failures, and 5 errors that are
environmental rather than branch-caused — `test_relay_timeout_upstream_contract.py`
introspects the real `aiohttp`, which my environment lacks.

## Checklist
- [x] I have updated documentation if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved localization validation to reject blank or whitespace-only translation values.
  * Added clearer error details identifying the affected catalog section, tool, or field.
  * Preserved English fallback behavior when translation keys or fields are omitted.
  * Applied validation consistently to message text, tool groups, titles, and descriptions.

* **Documentation**
  * Clarified catalog rules for omitted translations, fallback behavior, exact tool-group keys, and untranslated content limits.
  * Documented handling of blank values during translation checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
