### PR TITLE
feat: Add update_information action to ha_manage_hacs

### DIFF
--- a/src/ha_mcp/tools/hacs_registration.py
+++ b/src/ha_mcp/tools/hacs_registration.py
@@ -160,6 +160,11 @@ HACS_ADD_REGISTRATION_TIMEOUT = 10.0
 # lookup ~3x faster.
 HACS_RESOLVE_REGISTRATION_TIMEOUT = 10.0
 
+# hacs/repository/refresh re-fetches release data from GitHub before
+# returning, so it gets the same 60 s budget as download/remove (#1623):
+# a slow GitHub past the 30 s default would report a false failure.
+HACS_REFRESH_TIMEOUT = 60.0
+
 
 async def _find_repo_in_list_by_full_name(
     ws_client: Any, full_name_lower: str
@@ -391,3 +396,19 @@ async def wait_for_repo_registration(
             # unsubscribe has already been dispatched; allow the
             # cancellation to propagate.
             raise
+
+
+async def send_hacs_repository_refresh(
+    ws_client: Any, repository_id: str
+) -> dict[str, Any]:
+    """Send HACS's "Update information" force-refresh for one repository.
+
+    NOTE: HACS's WS API is asymmetric — refresh takes ``repository`` (like
+    remove), not ``repository_id`` (like info).
+    """
+    response: dict[str, Any] = await ws_client.send_command(
+        "hacs/repository/refresh",
+        repository=repository_id,
+        _wait_timeout=HACS_REFRESH_TIMEOUT,
+    )
+    return response

--- a/src/ha_mcp/tools/helpers.py
+++ b/src/ha_mcp/tools/helpers.py
@@ -353,7 +353,14 @@ def _classify_by_message(
         # Honor caller-supplied context like the type-based TimeoutError
         # branch does — a hardcoded 30 here misreported calls that run on a
         # longer budget (e.g. the 60 s HACS refresh/remove round-trips).
-        operation = context.get("operation", "operation") if context else "operation"
+        # WS callers name the call ``command`` rather than ``operation``, so
+        # fall back to it: without that the message reads "Operation
+        # 'operation' timed out" and never names what actually timed out.
+        operation = (
+            (context.get("operation") or context.get("command") or "operation")
+            if context
+            else "operation"
+        )
         timeout_seconds = context.get("timeout_seconds", 30) if context else 30
         result = create_timeout_error(
             operation, timeout_seconds, details=error_msg, context=context

--- a/src/ha_mcp/tools/helpers.py
+++ b/src/ha_mcp/tools/helpers.py
@@ -350,8 +350,13 @@ def _classify_by_message(
                 ErrorCode.RESOURCE_NOT_FOUND, error_msg, context=context
             )
     elif "timeout" in error_str:
+        # Honor caller-supplied context like the type-based TimeoutError
+        # branch does — a hardcoded 30 here misreported calls that run on a
+        # longer budget (e.g. the 60 s HACS refresh/remove round-trips).
+        operation = context.get("operation", "operation") if context else "operation"
+        timeout_seconds = context.get("timeout_seconds", 30) if context else 30
         result = create_timeout_error(
-            "operation", 30, details=error_msg, context=context
+            operation, timeout_seconds, details=error_msg, context=context
         )
     elif "connection" in error_str or "connect" in error_str:
         result = create_connection_error(error_msg, context=context)

--- a/src/ha_mcp/tools/tools_hacs.py
+++ b/src/ha_mcp/tools/tools_hacs.py
@@ -23,6 +23,7 @@ from .hacs_registration import (
     HACS_ADD_REGISTRATION_TIMEOUT,
     HACS_RESOLVE_REGISTRATION_TIMEOUT,
     _filter_and_score_repos,
+    send_hacs_repository_refresh,
     wait_for_repo_registration,
 )
 from .helpers import (
@@ -120,7 +121,7 @@ class HacsTools:
     read path keeps ``readOnlyHint`` and is never flagged ``destructive``:
 
     - ``ha_get_hacs_info`` (read): ``search`` the store / ``info`` for one repo.
-    - ``ha_manage_hacs`` (write): ``download`` install/update / ``remove`` / ``add_repository``.
+    - ``ha_manage_hacs`` (write): ``download`` install/update / ``remove`` / ``add_repository`` / ``update_information`` refresh.
     """
 
     def __init__(self, client: Any) -> None:
@@ -243,11 +244,13 @@ class HacsTools:
     async def ha_manage_hacs(
         self,
         action: Annotated[
-            Literal["download", "add_repository", "remove"],
+            Literal["download", "add_repository", "remove", "update_information"],
             Field(
                 description=(
                     "'download' to install/update, 'add_repository' to register "
-                    "a custom repo, or 'remove' to uninstall a downloaded repo"
+                    "a custom repo, 'remove' to uninstall a downloaded repo, or "
+                    "'update_information' to refresh a repository's release data "
+                    "from GitHub"
                 )
             ),
         ],
@@ -256,7 +259,7 @@ class HacsTools:
             Field(
                 description=(
                     "Numeric HACS ID or 'owner/repo' path "
-                    "(action='download' / action='remove')"
+                    "(action='download' / 'remove' / 'update_information')"
                 )
             ),
         ] = None,
@@ -282,20 +285,26 @@ class HacsTools:
         ``action="remove"`` to uninstall a downloaded repository, or
         ``action="add_repository"`` to register a custom GitHub repository with HACS. This
         tool performs writes; to search the store or read repository details use
-        ``ha_get_hacs_info``.
+        ``ha_get_hacs_info``. Use ``action="update_information"`` to run the HACS UI's
+        "Update information" action — a forced re-fetch of one repository's release data
+        from GitHub, so a pending update becomes visible to HACS and its update entity
+        immediately.
 
         **Examples:**
         - Install latest: ha_manage_hacs(action="download", repository_id="441028036")
         - Install a version: ha_manage_hacs(action="download", repository_id="piitaya/lovelace-mushroom", version="v4.0.0")
         - Remove: ha_manage_hacs(action="remove", repository_id="owner/repo")
         - Add a custom repo: ha_manage_hacs(action="add_repository", repository="owner/repo", category="lovelace")
+        - Refresh release data: ha_manage_hacs(action="update_information", repository_id="owner/repo")
 
         **Caveats:** Installing an integration usually needs a Home Assistant restart to
         activate; new Lovelace cards need a browser cache clear. ``repository_id`` accepts a
         numeric HACS ID or an ``owner/repo`` path; ``add_repository`` requires ``owner/repo``
         format plus a matching ``category``. Removing an integration deletes its files but
         the loaded module persists until the next Home Assistant restart — delete its config
-        entries first (``ha_remove_helpers_integrations``).
+        entries first (``ha_remove_helpers_integrations``). HACS refreshes custom
+        repositories on its own only about every 48 hours, so ``update_information`` is the
+        way to surface a just-published release.
         """
         try:
             # Reject parameters that don't belong to the chosen action rather
@@ -312,6 +321,11 @@ class HacsTools:
                     "category": category,
                 },
                 add_repository={"repository_id": repository_id, "version": version},
+                update_information={
+                    "version": version,
+                    "repository": repository,
+                    "category": category,
+                },
             )
 
             if action == "download":
@@ -319,6 +333,9 @@ class HacsTools:
 
             if action == "remove":
                 return await self._hacs_remove(repository_id)
+
+            if action == "update_information":
+                return await self._hacs_update_information(repository_id)
 
             # action == "add_repository"
             repository = validate_identifier_not_empty(
@@ -345,7 +362,7 @@ class HacsTools:
                 context={"tool": "ha_manage_hacs", "action": action},
                 suggestions=[
                     "Verify HACS is installed: https://hacs.xyz/",
-                    "For action='download' or action='remove', pass a valid repository_id (use ha_get_hacs_info(action='search') to find it)",
+                    "For action='download', 'remove', or 'update_information', pass a valid repository_id (use ha_get_hacs_info(action='search') to find it)",
                     "For action='add_repository', use 'owner/repo' format and a matching category",
                 ],
             )
@@ -686,6 +703,55 @@ class HacsTools:
                 "note": (
                     "Files are deleted, but an already-loaded integration "
                     "module persists until the next Home Assistant restart."
+                ),
+                "data": response.get("result", {}),
+            },
+        )
+        return {"success": True, **wrapped}
+
+    async def _hacs_update_information(
+        self, repository_id: str | None
+    ) -> dict[str, Any]:
+        # Same up-front guard as ``_hacs_download``: an empty identifier must
+        # fail before any backend call.
+        repository_id = validate_identifier_not_empty(
+            repository_id,
+            "repository_id",
+            suggestions=[
+                "Use ha_get_hacs_info(action='search') to find valid repository IDs",
+                "Or pass a GitHub path like 'owner/repo' to refresh by name",
+            ],
+        )
+        await _assert_hacs_available()
+
+        from ..client.websocket_client import get_websocket_client
+
+        ws_client = await get_websocket_client()
+
+        actual_id, repo_name = await _resolve_hacs_repo_id(ws_client, repository_id)
+
+        response = await send_hacs_repository_refresh(ws_client, actual_id)
+
+        if not response.get("success"):
+            exception_to_structured_error(
+                Exception(f"HACS refresh request failed: {response}"),
+                context={
+                    "command": "hacs/repository/refresh",
+                    "repository_id": repository_id,
+                },
+                raise_error=True,
+            )
+
+        wrapped = await add_timezone_metadata(
+            self._client,
+            {
+                "repository_id": actual_id,
+                "repository": repo_name,
+                "message": f"Refreshed repository information for {repo_name}",
+                "note": (
+                    "HACS re-fetched this repository's release data from GitHub; "
+                    "a pending update is now visible in HACS and on its update "
+                    "entity."
                 ),
                 "data": response.get("result", {}),
             },

--- a/src/ha_mcp/tools/tools_hacs.py
+++ b/src/ha_mcp/tools/tools_hacs.py
@@ -21,6 +21,7 @@ from ..errors import ErrorCode, create_error_response
 from .hacs_registration import (
     CATEGORY_MAP,
     HACS_ADD_REGISTRATION_TIMEOUT,
+    HACS_REFRESH_TIMEOUT,
     HACS_RESOLVE_REGISTRATION_TIMEOUT,
     _filter_and_score_repos,
     send_hacs_repository_refresh,
@@ -279,7 +280,7 @@ class HacsTools:
             Field(description="Repository category (action='add_repository')"),
         ] = None,
     ) -> dict[str, Any]:
-        """Manage HACS (Home Assistant Community Store) — install/update, remove, or add custom repositories.
+        """Manage HACS (Home Assistant Community Store) — install/update, remove, add custom repositories, or refresh repository information.
 
         Use ``action="download"`` to install or update a repository,
         ``action="remove"`` to uninstall a downloaded repository, or
@@ -662,6 +663,7 @@ class HacsTools:
                 context={
                     "command": "hacs/repository/remove",
                     "repository_id": repository_id,
+                    "timeout_seconds": 60.0,
                 },
                 suggestions=[
                     "The removal may still have completed on the HACS side — "
@@ -730,7 +732,25 @@ class HacsTools:
 
         actual_id, repo_name = await _resolve_hacs_repo_id(ws_client, repository_id)
 
-        response = await send_hacs_repository_refresh(ws_client, actual_id)
+        # Without the explicit timeout context, the generic classifier reports
+        # its 30 s default — a false claim against this call's 60 s budget.
+        # The refresh is idempotent, so unlike remove no unknown-outcome
+        # warning is needed: retrying a completed refresh is harmless.
+        try:
+            response = await send_hacs_repository_refresh(ws_client, actual_id)
+        except HomeAssistantCommandTimeout as timeout_err:
+            exception_to_structured_error(
+                timeout_err,
+                context={
+                    "command": "hacs/repository/refresh",
+                    "repository_id": repository_id,
+                    "timeout_seconds": HACS_REFRESH_TIMEOUT,
+                },
+                suggestions=[
+                    "GitHub may be slow; the refresh is safe to retry",
+                ],
+                raise_error=True,
+            )
 
         if not response.get("success"):
             exception_to_structured_error(
@@ -749,9 +769,9 @@ class HacsTools:
                 "repository": repo_name,
                 "message": f"Refreshed repository information for {repo_name}",
                 "note": (
-                    "HACS re-fetched this repository's release data from GitHub; "
-                    "a pending update is now visible in HACS and on its update "
-                    "entity."
+                    "HACS re-fetched this repository's release data from GitHub. "
+                    "If a newer release exists, HACS now shows it (and, for "
+                    "downloaded repositories, so does the update entity)."
                 ),
                 "data": response.get("result", {}),
             },

--- a/src/ha_mcp/tools/tools_hacs.py
+++ b/src/ha_mcp/tools/tools_hacs.py
@@ -465,10 +465,23 @@ class HacsTools:
         # If repository_id contains a slash, it's a GitHub path - look up numeric ID
         actual_id, _ = await _resolve_hacs_repo_id(ws_client, repository_id)
 
-        # Get repository info via WebSocket using numeric ID
-        response = await ws_client.send_command(
-            "hacs/repository/info", repository_id=actual_id
-        )
+        # Get repository info via WebSocket using numeric ID. The WS client
+        # RAISES on a failed result frame, so that — not the dict branch
+        # below, which serves stubbed clients — is where a real HACS failure
+        # lands; keep the command context attached (mirrors ``_hacs_remove``).
+        try:
+            response = await ws_client.send_command(
+                "hacs/repository/info", repository_id=actual_id
+            )
+        except HomeAssistantCommandError as cmd_err:
+            exception_to_structured_error(
+                cmd_err,
+                context={
+                    "command": "hacs/repository/info",
+                    "repository_id": repository_id,
+                },
+                raise_error=True,
+            )
 
         if not response.get("success"):
             exception_to_structured_error(
@@ -553,9 +566,40 @@ class HacsTools:
         # Download/install the repository. Same 60 s budget as remove: HACS
         # refreshes from GitHub before acting, and a slow GitHub past the
         # 30 s default reports a false failure for work that completes.
-        response = await ws_client.send_command(
-            "hacs/repository/download", _wait_timeout=60.0, **download_kwargs
-        )
+        try:
+            response = await ws_client.send_command(
+                "hacs/repository/download", _wait_timeout=60.0, **download_kwargs
+            )
+        except HomeAssistantCommandTimeout as timeout_err:
+            # Same false-failure shape remove documents: HACS finishes the
+            # download regardless, so name the real 60 s budget (the generic
+            # classifier would claim 30) and say the outcome is unknown
+            # instead of inviting a blind retry.
+            exception_to_structured_error(
+                timeout_err,
+                context={
+                    "command": "hacs/repository/download",
+                    "repository_id": repository_id,
+                    "version": version,
+                    "timeout_seconds": 60.0,
+                },
+                suggestions=[
+                    "The download may still have completed on the HACS side — "
+                    "verify with ha_get_hacs_info(action='info', "
+                    f"repository_id='{actual_id}') before retrying",
+                ],
+                raise_error=True,
+            )
+        except HomeAssistantCommandError as cmd_err:
+            exception_to_structured_error(
+                cmd_err,
+                context={
+                    "command": "hacs/repository/download",
+                    "repository_id": repository_id,
+                    "version": version,
+                },
+                raise_error=True,
+            )
 
         if not response.get("success"):
             exception_to_structured_error(
@@ -749,6 +793,22 @@ class HacsTools:
                 suggestions=[
                     "GitHub may be slow; the refresh is safe to retry",
                 ],
+                raise_error=True,
+            )
+        except HomeAssistantCommandError as cmd_err:
+            # The WS client RAISES on a failed result frame (it never returns
+            # success=False), so this — not the dict branch below, which
+            # serves stubbed clients — is where a real HACS refresh failure
+            # lands. ``timeout_seconds`` rides along because a HACS-side
+            # message containing "timeout" routes to the by-message timeout
+            # branch, which would otherwise claim 30 s against this budget.
+            exception_to_structured_error(
+                cmd_err,
+                context={
+                    "command": "hacs/repository/refresh",
+                    "repository_id": repository_id,
+                    "timeout_seconds": HACS_REFRESH_TIMEOUT,
+                },
                 raise_error=True,
             )
 

--- a/src/ha_mcp/tools/tools_hacs.py
+++ b/src/ha_mcp/tools/tools_hacs.py
@@ -597,6 +597,7 @@ class HacsTools:
                     "command": "hacs/repository/download",
                     "repository_id": repository_id,
                     "version": version,
+                    "timeout_seconds": 60.0,
                 },
                 raise_error=True,
             )
@@ -726,6 +727,7 @@ class HacsTools:
                 context={
                     "command": "hacs/repository/remove",
                     "repository_id": repository_id,
+                    "timeout_seconds": 60.0,
                 },
                 raise_error=True,
             )

--- a/tests/src/e2e/workflows/hacs/test_hacs.py
+++ b/tests/src/e2e/workflows/hacs/test_hacs.py
@@ -709,6 +709,48 @@ class TestHacsWriteOperations:
 
 
 @pytest.mark.hacs
+async def test_hacs_update_information(mcp_client):
+    """ha_manage_hacs(action="update_information") refreshes a repository's
+    release data (the HACS UI "Update information" action)."""
+    logger.info("Testing ha_manage_hacs update_information...")
+
+    search_data = await safe_hacs_call(
+        mcp_client,
+        "ha_get_hacs_info",
+        {"action": "search", "max_results": 1},
+    )
+
+    unavailable, reason = is_hacs_unavailable(search_data)
+    if unavailable:
+        pytest.skip(f"HACS not available: {reason}")
+
+    results = search_data.get("results") or []
+    if not results:
+        pytest.skip("HACS returned no repositories to refresh")
+    repo_id = str(results[0]["id"])
+
+    logger.info(f"Refreshing repository information for: {repo_id}")
+
+    data = await safe_hacs_call(
+        mcp_client,
+        "ha_manage_hacs",
+        {"action": "update_information", "repository_id": repo_id},
+    )
+
+    if not data.get("success"):
+        # The refresh re-fetches from GitHub, so an unreachable / rate-limited
+        # GitHub is an environment limitation, not a tool failure.
+        unavailable, reason = is_hacs_unavailable(data)
+        if unavailable:
+            pytest.skip(f"HACS not available: {reason}")
+
+    assert data.get("success") is True, f"Refresh failed: {data.get('error')}"
+    assert data.get("repository_id"), "Response should include repository_id"
+
+    logger.info("Update information test passed")
+
+
+@pytest.mark.hacs
 async def test_hacs_discovery(mcp_client):
     """
     Test: Basic HACS discovery

--- a/tests/src/e2e/workflows/hacs/test_hacs.py
+++ b/tests/src/e2e/workflows/hacs/test_hacs.py
@@ -739,10 +739,14 @@ async def test_hacs_update_information(mcp_client):
 
     if not data.get("success"):
         # The refresh re-fetches from GitHub, so an unreachable / rate-limited
-        # GitHub is an environment limitation, not a tool failure.
+        # GitHub is an environment limitation, not a tool failure. Only those
+        # reasons may skip: the broad is_hacs_unavailable matcher classifies
+        # EVERY INTERNAL_ERROR as unavailable, which would silently skip past
+        # an implementation defect (the search probe above already covered
+        # HACS availability itself).
         unavailable, reason = is_hacs_unavailable(data)
-        if unavailable:
-            pytest.skip(f"HACS not available: {reason}")
+        if unavailable and reason in ("GitHub rate limit", "GitHub access issue"):
+            pytest.skip(f"GitHub not reachable from HACS: {reason}")
 
     assert data.get("success") is True, f"Refresh failed: {data.get('error')}"
     assert data.get("repository_id"), "Response should include repository_id"

--- a/tests/src/unit/test_hacs_actions.py
+++ b/tests/src/unit/test_hacs_actions.py
@@ -92,6 +92,20 @@ class TestGetHacsInfo:
         ws.send_command.assert_awaited_once()
         assert ws.send_command.await_args.args[0] == "hacs/repository/info"
 
+    async def test_info_command_error_keeps_command_context(self, tools):
+        from ha_mcp.client.rest_client import HomeAssistantCommandError
+
+        ws = AsyncMock()
+        ws.send_command = AsyncMock(
+            side_effect=HomeAssistantCommandError(
+                "Command failed: kaboom", "unknown_error"
+            )
+        )
+        with _patched_hacs(ws), pytest.raises(ToolError) as excinfo:
+            await tools.ha_get_hacs_info(action="info", repository_id="441028036")
+        assert "kaboom" in str(excinfo.value)
+        assert "hacs/repository/info" in str(excinfo.value)
+
 
 class TestManageHacsDownload:
     async def test_download_defaults_version_to_latest(self, tools):
@@ -133,6 +147,37 @@ class TestManageHacsDownload:
             wait_mock.await_args.kwargs.get("timeout")
             == HACS_RESOLVE_REGISTRATION_TIMEOUT
         )
+
+    async def test_download_timeout_reports_the_real_budget(self, tools):
+        # Download runs on the same 60 s budget as remove/refresh; without its
+        # own timeout context the classifier claims the 30 s default, and a
+        # false failure invites a blind retry of work HACS finishes anyway.
+        from ha_mcp.client.rest_client import HomeAssistantCommandTimeout
+
+        ws = AsyncMock()
+        ws.send_command = AsyncMock(
+            side_effect=HomeAssistantCommandTimeout("Command timeout")
+        )
+        with _patched_hacs(ws), pytest.raises(ToolError) as excinfo:
+            await tools.ha_manage_hacs(action="download", repository_id="441028036")
+        msg = str(excinfo.value)
+        assert "60" in msg
+        assert "Operation 'hacs/repository/download'" in msg
+        assert "may still have completed" in msg
+
+    async def test_download_command_error_keeps_command_context(self, tools):
+        from ha_mcp.client.rest_client import HomeAssistantCommandError
+
+        ws = AsyncMock()
+        ws.send_command = AsyncMock(
+            side_effect=HomeAssistantCommandError(
+                "Command failed: kaboom", "unknown_error"
+            )
+        )
+        with _patched_hacs(ws), pytest.raises(ToolError) as excinfo:
+            await tools.ha_manage_hacs(action="download", repository_id="441028036")
+        assert "kaboom" in str(excinfo.value)
+        assert "hacs/repository/download" in str(excinfo.value)
 
 
 class TestManageHacsAddRepository:
@@ -511,6 +556,28 @@ class TestManageHacsUpdateInformation:
                 action="update_information", repository_id="441028036"
             )
         assert "60" in str(excinfo.value)
+        assert "hacs/repository/refresh" in str(excinfo.value)
+        # The rendered message must name the command that timed out. Without
+        # the command fallback in the classifier it reads "Operation
+        # 'operation' timed out", which no other assertion here would catch.
+        assert "Operation 'hacs/repository/refresh'" in str(excinfo.value)
+
+    async def test_update_information_command_error_keeps_command_context(self, tools):
+        # The raised path is the one real HACS failures take; the dict branch
+        # below it only serves stubbed clients.
+        from ha_mcp.client.rest_client import HomeAssistantCommandError
+
+        ws = AsyncMock()
+        ws.send_command = AsyncMock(
+            side_effect=HomeAssistantCommandError(
+                "Command failed: kaboom", "unknown_error"
+            )
+        )
+        with _patched_hacs(ws), pytest.raises(ToolError) as excinfo:
+            await tools.ha_manage_hacs(
+                action="update_information", repository_id="441028036"
+            )
+        assert "kaboom" in str(excinfo.value)
         assert "hacs/repository/refresh" in str(excinfo.value)
 
     async def test_update_information_failed_response_raises(self, tools):

--- a/tests/src/unit/test_hacs_actions.py
+++ b/tests/src/unit/test_hacs_actions.py
@@ -497,6 +497,22 @@ class TestManageHacsUpdateInformation:
         assert "do not apply" in str(excinfo.value)
         ws.send_command.assert_not_awaited()
 
+    async def test_update_information_timeout_reports_the_real_budget(self, tools):
+        # The generic timeout classifier defaults to a 30 s message; the
+        # refresh handler must attach its actual 60 s budget instead.
+        from ha_mcp.client.rest_client import HomeAssistantCommandTimeout
+
+        ws = AsyncMock()
+        ws.send_command = AsyncMock(
+            side_effect=HomeAssistantCommandTimeout("Command timeout")
+        )
+        with _patched_hacs(ws), pytest.raises(ToolError) as excinfo:
+            await tools.ha_manage_hacs(
+                action="update_information", repository_id="441028036"
+            )
+        assert "60" in str(excinfo.value)
+        assert "hacs/repository/refresh" in str(excinfo.value)
+
     async def test_update_information_failed_response_raises(self, tools):
         ws = AsyncMock()
         ws.send_command = AsyncMock(

--- a/tests/src/unit/test_hacs_actions.py
+++ b/tests/src/unit/test_hacs_actions.py
@@ -1,10 +1,11 @@
 """Unit tests for the consolidated HACS action tools.
 
 Exercise the per-action handler success paths (``_hacs_info`` /
-``_hacs_download`` / ``_hacs_remove`` / ``_hacs_add_repository``) and the
-dispatcher's error-routing with a mocked WebSocket client. Complements the
-validation-guard tests in ``test_identifier_validation_family.py`` and the
-ctx/progress test in ``test_context_injection.py``.
+``_hacs_download`` / ``_hacs_remove`` / ``_hacs_update_information`` /
+``_hacs_add_repository``) and the dispatcher's error-routing with a mocked
+WebSocket client. Complements the validation-guard tests in
+``test_identifier_validation_family.py`` and the ctx/progress test in
+``test_context_injection.py``.
 """
 
 from contextlib import contextmanager
@@ -424,6 +425,91 @@ class TestManageHacsRemove:
         assert result["success"] is True
         assert result["data"]["repository_id"] == "401454435"
         assert "metadata" in result
+
+
+class TestManageHacsUpdateInformation:
+    async def test_update_information_numeric_id_sends_refresh(self, tools):
+        ws = _ws({})
+        with _patched_hacs(ws):
+            result = await tools.ha_manage_hacs(
+                action="update_information", repository_id="441028036"
+            )
+
+        assert result["success"] is True
+        # A numeric id needs no resolution round-trip — exactly one WS call.
+        ws.send_command.assert_awaited_once()
+        assert ws.send_command.await_args.args[0] == "hacs/repository/refresh"
+        # HACS's WS API is asymmetric: refresh takes repository (like remove),
+        # not repository_id (like info). The 60 s budget covers HACS's forced
+        # GitHub re-fetch, which the 30 s default would report as a false
+        # failure.
+        assert ws.send_command.await_args.kwargs["repository"] == "441028036"
+        assert ws.send_command.await_args.kwargs["_wait_timeout"] == 60.0
+
+    async def test_update_information_path_resolves_then_refreshes(self, tools):
+        ws = _ws({})
+        registered = {"id": 123, "name": "lovelace-mushroom"}
+        with (
+            _patched_hacs(ws),
+            patch(
+                "ha_mcp.tools.tools_hacs.wait_for_repo_registration",
+                new_callable=AsyncMock,
+            ) as wait_mock,
+        ):
+            wait_mock.return_value = registered
+            result = await tools.ha_manage_hacs(
+                action="update_information",
+                repository_id="piitaya/lovelace-mushroom",
+            )
+
+        assert result["success"] is True
+        assert result["repository"] == "lovelace-mushroom"  # resolved display name
+        assert ws.send_command.await_args.args[0] == "hacs/repository/refresh"
+        # The resolved numeric id, not the owner/repo path, reaches HACS.
+        assert ws.send_command.await_args.kwargs["repository"] == "123"
+
+    async def test_update_information_empty_id_raises(self, tools):
+        ws = _ws({})
+        with _patched_hacs(ws), pytest.raises(ToolError) as excinfo:
+            await tools.ha_manage_hacs(action="update_information", repository_id="")
+        assert "repository_id" in str(excinfo.value)
+        ws.send_command.assert_not_awaited()
+
+    async def test_update_information_missing_id_raises(self, tools):
+        ws = _ws({})
+        with _patched_hacs(ws), pytest.raises(ToolError) as excinfo:
+            await tools.ha_manage_hacs(action="update_information")
+        assert "repository_id" in str(excinfo.value)
+        ws.send_command.assert_not_awaited()
+
+    async def test_update_information_rejects_foreign_params(self, tools):
+        # update_information takes only repository_id; a download-only
+        # parameter must fail loudly rather than be silently dropped.
+        ws = _ws({})
+        with _patched_hacs(ws), pytest.raises(ToolError) as excinfo:
+            await tools.ha_manage_hacs(
+                action="update_information",
+                repository_id="1",
+                version="v1.0.0",
+            )
+        assert "VALIDATION_INVALID_PARAMETER" in str(excinfo.value)
+        assert "version" in str(excinfo.value)
+        assert "do not apply" in str(excinfo.value)
+        ws.send_command.assert_not_awaited()
+
+    async def test_update_information_failed_response_raises(self, tools):
+        ws = AsyncMock()
+        ws.send_command = AsyncMock(
+            return_value={"success": False, "error": {"message": "boom"}}
+        )
+        with _patched_hacs(ws), pytest.raises(ToolError) as excinfo:
+            await tools.ha_manage_hacs(
+                action="update_information", repository_id="441028036"
+            )
+        # HACS's own error text must survive the wrap, alongside the command
+        # context that names which call failed.
+        assert "boom" in str(excinfo.value)
+        assert "hacs/repository/refresh" in str(excinfo.value)
 
 
 class TestDispatcherErrorRouting:

--- a/tests/src/unit/test_hacs_actions.py
+++ b/tests/src/unit/test_hacs_actions.py
@@ -179,6 +179,22 @@ class TestManageHacsDownload:
         assert "kaboom" in str(excinfo.value)
         assert "hacs/repository/download" in str(excinfo.value)
 
+    async def test_download_command_timeout_error_reports_real_budget(self, tools):
+        from ha_mcp.client.rest_client import HomeAssistantCommandError
+
+        ws = AsyncMock()
+        ws.send_command = AsyncMock(
+            side_effect=HomeAssistantCommandError(
+                "Command failed: backend timeout", "unknown_error"
+            )
+        )
+        with _patched_hacs(ws), pytest.raises(ToolError) as excinfo:
+            await tools.ha_manage_hacs(action="download", repository_id="441028036")
+        assert (
+            "Operation 'hacs/repository/download' timed out after 60.0s"
+            in str(excinfo.value)
+        )
+
 
 class TestManageHacsAddRepository:
     async def test_add_repository_translates_category_and_returns_registered_id(
@@ -382,6 +398,25 @@ class TestManageHacsRemove:
             await tools.ha_manage_hacs(action="remove", repository_id="401454435")
         assert "kaboom" in str(excinfo.value)
         assert "hacs/repository/remove" in str(excinfo.value)
+
+    async def test_remove_command_timeout_error_reports_real_budget(self, tools):
+        from ha_mcp.client.rest_client import HomeAssistantCommandError
+
+        ws = AsyncMock()
+        ws.send_command = AsyncMock(
+            side_effect=[
+                {"success": True, "result": {"installed": True}},
+                HomeAssistantCommandError(
+                    "Command failed: backend timeout", "unknown_error"
+                ),
+            ]
+        )
+        with _patched_hacs(ws), pytest.raises(ToolError) as excinfo:
+            await tools.ha_manage_hacs(action="remove", repository_id="401454435")
+        assert (
+            "Operation 'hacs/repository/remove' timed out after 60.0s"
+            in str(excinfo.value)
+        )
 
     async def test_remove_timeout_says_outcome_is_unknown(self, tools):
         # HACS force-refreshes from GitHub before uninstalling; when that

--- a/tests/src/unit/test_hacs_actions.py
+++ b/tests/src/unit/test_hacs_actions.py
@@ -190,9 +190,8 @@ class TestManageHacsDownload:
         )
         with _patched_hacs(ws), pytest.raises(ToolError) as excinfo:
             await tools.ha_manage_hacs(action="download", repository_id="441028036")
-        assert (
-            "Operation 'hacs/repository/download' timed out after 60.0s"
-            in str(excinfo.value)
+        assert "Operation 'hacs/repository/download' timed out after 60.0s" in str(
+            excinfo.value
         )
 
 
@@ -413,9 +412,8 @@ class TestManageHacsRemove:
         )
         with _patched_hacs(ws), pytest.raises(ToolError) as excinfo:
             await tools.ha_manage_hacs(action="remove", repository_id="401454435")
-        assert (
-            "Operation 'hacs/repository/remove' timed out after 60.0s"
-            in str(excinfo.value)
+        assert "Operation 'hacs/repository/remove' timed out after 60.0s" in str(
+            excinfo.value
         )
 
     async def test_remove_timeout_says_outcome_is_unknown(self, tools):

--- a/tests/src/unit/test_identifier_validation_family.py
+++ b/tests/src/unit/test_identifier_validation_family.py
@@ -1259,6 +1259,20 @@ class TestHacsActionValidation:
         tools._client.send_websocket_message.assert_not_called()
 
     @pytest.mark.parametrize("bad", [None, "", "   "])
+    async def test_manage_hacs_update_information_rejects_empty_repository_id(
+        self, tools, bad
+    ):
+        # ``update_information`` shares the download/remove up-front guard:
+        # an empty id must fail before the HACS availability check or any
+        # WS round-trip, not fall through ``_resolve_hacs_repo_id`` into a
+        # lookup miss.
+        with pytest.raises(ToolError) as excinfo:
+            await tools.ha_manage_hacs(action="update_information", repository_id=bad)
+        _assert_invalid_param(excinfo)
+        assert '"parameter": "repository_id"' in str(excinfo.value), str(excinfo.value)
+        tools._client.send_websocket_message.assert_not_called()
+
+    @pytest.mark.parametrize("bad", [None, "", "   "])
     async def test_get_hacs_info_requires_repository_id(self, tools, bad):
         # ``info`` has nothing to act on without a repository_id — the
         # dispatcher must reject None / empty / whitespace before any HACS


### PR DESCRIPTION
## What does this PR do?

Adds an `update_information` action to `ha_manage_hacs`, exposing the HACS
UI's "Update information" repository action (WebSocket command
`hacs/repository/refresh`). It forces HACS to re-fetch one repository's
release data from GitHub, so a just-published release becomes visible to
HACS and its update entity immediately instead of waiting out HACS's
~48-hour custom-repository refresh cycle.

- The refresh sender lives in `hacs_registration.py` so the stacked
  follow-up PR (automatic refresh on server updates) can reuse it.
- Unit tests pin the WS contract: the command takes `repository` (not
  `repository_id` — the same asymmetry the remove path documents) and gets
  the same 60 s budget as download/remove.
- E2E test follows the existing HACS patterns (clean skip when HACS is
  unavailable).

## Type of change
- [x] ✨ New feature

## Testing
- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

## Checklist
- [x] I have updated documentation if needed (tool docs regenerate on merge)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an HACS action to refresh repository information.
  * Supports repository IDs and owner/repository paths.
  * Returns refreshed repository details, including timezone information.
  * Provides clearer validation and error messages for invalid requests.

* **Bug Fixes**
  * Improved handling of unavailable HACS or GitHub services.
  * Added clearer command-error and timeout reporting for HACS operations.

* **Tests**
  * Added coverage for successful refreshes, invalid parameters, timeouts, failed responses, and backend errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->