### PR TITLE
feat: Automatically surface component updates in HACS after a server update

### DIFF
--- a/custom_components/ha_mcp_tools/hacs_nudge.py
+++ b/custom_components/ha_mcp_tools/hacs_nudge.py
@@ -151,9 +151,11 @@ async def _async_force_hacs_repo_refresh(hass: HomeAssistant) -> bool:
     if not installed_candidates:
         return False
 
-    # Every installed candidate, not just the first: a user migrating
-    # legacy->mirror can have BOTH entries installed, each with its own update
-    # entity, and refreshing only the mirror left the legacy one stale.
+    # Every installed candidate, not just the first. Two entries read
+    # installed when the mirror was downloaded without removing the legacy
+    # record — HACS blocks adding the same repository twice but not two
+    # repositories sharing a domain — and each carries its own update entity,
+    # so refreshing only the first left the other stale.
     refreshed_any = False
     for repository in installed_candidates:
         # The repository's "Update information" menu action: re-fetch its

--- a/custom_components/ha_mcp_tools/hacs_nudge.py
+++ b/custom_components/ha_mcp_tools/hacs_nudge.py
@@ -26,7 +26,7 @@ change would otherwise warn forever about an advisory nicety.
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from .const import (
     DOMAIN,
@@ -113,14 +113,15 @@ async def async_nudge_hacs_refresh(hass: HomeAssistant, target_version: str) -> 
 
 
 async def _async_force_hacs_repo_refresh(hass: HomeAssistant) -> bool:
-    """Run HACS's "Update information" force-refresh for this component's repo.
+    """Run HACS's "Update information" force-refresh for this component's repos.
 
-    Returns True when a tracked repository was found and its refresh completed,
-    False when there is nothing to refresh (no HACS, or no INSTALLED repository
-    under either candidate name). Reaches into HACS internals —
-    the top-level lookups are ``getattr``-guarded so a wholly different HACS
-    shape returns False cleanly; anything deeper that changes shape raises and is
-    swallowed by :func:`async_nudge_hacs_refresh`.
+    Returns True when at least one INSTALLED tracked repository completed its
+    refresh, False when there was nothing to refresh (no HACS, or no installed
+    repository under either candidate name) or every candidate's refresh
+    failed. Reaches into HACS internals — the top-level lookups are
+    ``getattr``-guarded so a wholly different HACS shape returns False cleanly;
+    anything deeper that changes shape raises and is swallowed by
+    :func:`async_nudge_hacs_refresh`.
     """
     hacs = hass.data.get("hacs")
     if hacs is None:
@@ -133,7 +134,7 @@ async def _async_force_hacs_repo_refresh(hass: HomeAssistant) -> bool:
     if get_by_full_name is None:
         return False
 
-    repository = None
+    installed_candidates: list[Any] = []
     for full_name in _CANDIDATE_REPO_FULL_NAMES:
         candidate = get_by_full_name(full_name)
         if candidate is None:
@@ -146,20 +147,39 @@ async def _async_force_hacs_repo_refresh(hass: HomeAssistant) -> bool:
         # only an installed candidate counts (review finding).
         if not getattr(getattr(candidate, "data", None), "installed", False):
             continue
-        repository = candidate
-        break
-    if repository is None:
+        installed_candidates.append(candidate)
+    if not installed_candidates:
         return False
 
-    # The repository's "Update information" menu action: re-fetch its release
-    # data ignoring cached state, then push the fresh data to HACS's own update
-    # entity so Home Assistant advertises the component update immediately.
-    await repository.update_repository(ignore_issues=True, force=True)
-    # The refresh is complete at this point; the listener push below only
-    # re-publishes the fresh data to HACS's update entity sooner. Guarded
-    # separately so a HACS shape change here cannot void the completed
-    # refresh's throttle and re-run the network fetch every pass (review
-    # finding).
+    # Every installed candidate, not just the first: a user migrating
+    # legacy->mirror can have BOTH entries installed, each with its own update
+    # entity, and refreshing only the mirror left the legacy one stale.
+    refreshed_any = False
+    for repository in installed_candidates:
+        # The repository's "Update information" menu action: re-fetch its
+        # release data ignoring cached state.
+        try:
+            await repository.update_repository(ignore_issues=True, force=True)
+        except Exception:
+            # One candidate's failure must not skip the other's refresh.
+            _LOGGER.debug(
+                "HA-MCP: HACS refresh failed for one candidate repository",
+                exc_info=True,
+            )
+            continue
+        refreshed_any = True
+        _poke_hacs_update_entity(hacs, repository)
+    return refreshed_any
+
+
+def _poke_hacs_update_entity(hacs: Any, repository: Any) -> None:
+    """Push the freshly fetched data to HACS's own update entity.
+
+    The refresh is already complete when this runs; the push only makes Home
+    Assistant advertise the component update sooner. Guarded separately so a
+    HACS shape change here cannot void the completed refresh's throttle and
+    re-run the network fetch every pass (review finding).
+    """
     try:
         coordinators = getattr(hacs, "coordinators", None) or {}
         category = getattr(getattr(repository, "data", None), "category", None)
@@ -171,4 +191,3 @@ async def _async_force_hacs_repo_refresh(hass: HomeAssistant) -> bool:
             "HA-MCP: HACS listener push after the repository refresh failed",
             exc_info=True,
         )
-    return True

--- a/src/ha_mcp/__main__.py
+++ b/src/ha_mcp/__main__.py
@@ -666,6 +666,13 @@ async def _run_with_shutdown(server_coro: Coroutine[Any, Any, Any]) -> None:
     server_task = asyncio.create_task(server_coro)
     shutdown_task = asyncio.create_task(_shutdown_event.wait())
 
+    # Fire-and-forget: ask HACS to surface a paired component update after a
+    # server update (advisory; see hacs_auto_refresh). Not in the wait set —
+    # its completion must not stop the server.
+    from ha_mcp.hacs_auto_refresh import maybe_refresh_hacs_after_update
+
+    hacs_refresh_task = asyncio.create_task(maybe_refresh_hacs_after_update())
+
     try:
         done, pending = await asyncio.wait(
             [server_task, shutdown_task],
@@ -725,7 +732,7 @@ async def _run_with_shutdown(server_coro: Coroutine[Any, Any, Any]) -> None:
             logger.warning("Resource cleanup timed out")
 
         try:
-            await _cancel_tasks(server_task, shutdown_task)
+            await _cancel_tasks(server_task, shutdown_task, hacs_refresh_task)
         except Exception as e:
             # Teardown must never mask the exception being propagated from the
             # try block (Python drops the original if finally raises).

--- a/src/ha_mcp/hacs_auto_refresh.py
+++ b/src/ha_mcp/hacs_auto_refresh.py
@@ -1,0 +1,207 @@
+"""Ask HACS to surface the paired component update after a server update.
+
+HACS refreshes a *custom* repository's release data from GitHub only about
+every 48 hours, and the ha_mcp_tools component ships in lockstep with each
+server release — so a freshly updated server can sit for two days next to a
+component update HACS has not noticed yet. The component's own nudge
+(``custom_components/ha_mcp_tools/hacs_nudge.py``) closes that gap only for the
+embedded server, which is where it runs; add-on, Docker, pip and stdio installs
+had no trigger at all. This module is that trigger, server-side.
+
+On startup, when the server version changed since the last recorded nudge (the
+just-updated case) or a newer release is pending, it sends HACS's "Update
+information" refresh (``hacs/repository/refresh``) over the existing admin
+WebSocket for every INSTALLED candidate repository entry.
+
+Fully advisory: every failure degrades to a debug log and nothing here can
+fault startup. A marker file in the data dir records the state the last
+completed pass ran against, so the common case — a per-conversation stdio
+spawn on an unchanged version — costs one file read and no WebSocket traffic.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+from ._version import get_version, is_embedded
+from .client.rest_client import (
+    HomeAssistantCommandError,
+    HomeAssistantConnectionError,
+)
+from .update_check import UpdateInfo, get_update_info, is_update_check_disabled
+from .utils.data_paths import get_data_dir
+
+logger = logging.getLogger(__name__)
+
+# The repository full_names HACS may track the ha_mcp_tools component under —
+# the dedicated mirror first, the legacy main-repo path second. Values are
+# duplicated from custom_components/ha_mcp_tools/const.py (HACS_MIRROR_ /
+# HACS_LEGACY_REPO_FULL_NAME): the server package cannot import the component.
+CANDIDATE_REPO_FULL_NAMES = (
+    "homeassistant-ai/ha-mcp-integration",
+    "homeassistant-ai/ha-mcp",
+)
+
+# Marker file (in the ha-mcp data dir) recording the state the last completed
+# nudge ran against. Written only on a completed pass, so a failed pass (HA
+# still booting, HACS not loaded yet) is retried on the next startup.
+MARKER_FILENAME = "hacs_refresh_marker.json"
+
+# The add-on can start before HA Core finishes booting (and before HACS is
+# loaded), so the first attempts may fail; spread retries over ~8 minutes,
+# then give up until the next startup (the unwritten marker retries then).
+RETRY_DELAYS = (30.0, 60.0, 120.0, 300.0)
+
+
+def _marker_path() -> Path:
+    return get_data_dir() / MARKER_FILENAME
+
+
+def _read_marker() -> dict[str, Any] | None:
+    """Return the last completed pass's marker, or None when there isn't one."""
+    path = _marker_path()
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return None
+    except (OSError, ValueError) as err:
+        logger.debug("Ignoring unreadable HACS refresh marker %s: %s", path, err)
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def _write_marker(marker: dict[str, Any]) -> None:
+    """Record the state this pass ran against; an unwritable dir just retries."""
+    path = _marker_path()
+    try:
+        path.write_text(json.dumps(marker), encoding="utf-8")
+    except OSError as err:
+        logger.debug("Could not write HACS refresh marker %s: %s", path, err)
+
+
+def _nudge_due(
+    current_version: str, info: UpdateInfo | None, marker: dict[str, Any] | None
+) -> bool:
+    """Decide whether this startup should ask HACS for a refresh."""
+    if marker is None:
+        # First run ever, or no pass has ever completed.
+        return True
+    if marker.get("server_version") != current_version:
+        # The server was just updated, and the paired component release is
+        # exactly what HACS needs to surface.
+        return True
+    # A release appeared while this build sat idle — surface its component side.
+    return bool(
+        info is not None
+        and info.update_available
+        and marker.get("latest") != info.latest
+    )
+
+
+async def _refresh_installed_candidates() -> dict[str, Any] | None:
+    """Refresh every installed candidate repository; one attempt, no retries.
+
+    Returns the pass result (``hacs`` presence plus the full_names refreshed),
+    or None when the outcome could not be determined.
+    """
+    from .client.websocket_client import get_websocket_client
+    from .tools.hacs_registration import send_hacs_repository_refresh
+
+    ws_client = await get_websocket_client()
+    try:
+        response = await ws_client.send_command("hacs/repositories/list")
+    except HomeAssistantCommandError as err:
+        # HACS not installed at all — HA rejects its commands as unknown. Same
+        # detection as ``_assert_hacs_available`` in tools/tools_hacs.py. Any
+        # other command failure is a real error: let the retry loop see it.
+        if err.code == "unknown_command" or "unknown command" in str(err).lower():
+            return {"hacs": "absent", "refreshed": []}
+        raise
+
+    wanted = {name.lower() for name in CANDIDATE_REPO_FULL_NAMES}
+    refreshed: list[str] = []
+    for repo in response.get("result", []):
+        full_name = (repo.get("full_name") or "").lower()
+        # HACS keeps a record for every ADDED repo but only creates an update
+        # entity for downloaded ones, so refreshing an uninstalled record
+        # lights up nothing.
+        if full_name not in wanted or not repo.get("installed"):
+            continue
+        try:
+            await send_hacs_repository_refresh(ws_client, str(repo["id"]))
+        except Exception as err:
+            # A user mid legacy->mirror migration has both entries installed;
+            # one failing must not cost the other its refresh.
+            logger.debug("HACS refresh failed for %s: %s", full_name, err)
+            continue
+        refreshed.append(full_name)
+    return {"hacs": "present", "refreshed": refreshed}
+
+
+async def _refresh_with_retries() -> dict[str, Any] | None:
+    """Run the refresh pass, retrying transport failures over ``RETRY_DELAYS``."""
+    result: dict[str, Any] | None = None
+    for delay in (0.0, *RETRY_DELAYS):
+        if delay:
+            await asyncio.sleep(delay)
+        try:
+            result = await _refresh_installed_candidates()
+        except (
+            HomeAssistantConnectionError,
+            HomeAssistantCommandError,
+            OSError,
+        ) as err:
+            logger.debug("HACS repository refresh attempt failed: %s", err)
+            continue
+        if result is not None:
+            break
+    return result
+
+
+async def maybe_refresh_hacs_after_update() -> None:
+    """Nudge HACS once per startup when the update picture changed."""
+    try:
+        if is_embedded():
+            # The component's own hacs_nudge already covers embedded installs;
+            # running both would double HACS's GitHub fetches.
+            return
+        if is_update_check_disabled():
+            return
+
+        current = get_version()
+        # Normally a cache hit — the startup banner warms the lru_cache — but
+        # offloaded anyway so a cold call can never touch the event loop.
+        info = await asyncio.to_thread(get_update_info)
+        marker = await asyncio.to_thread(_read_marker)
+        if not _nudge_due(current, info, marker):
+            return
+
+        result = await _refresh_with_retries()
+        if result is None:
+            logger.debug(
+                "Could not reach HACS to refresh the component repository; "
+                "giving up until next startup"
+            )
+            return
+
+        await asyncio.to_thread(
+            _write_marker,
+            {
+                "server_version": current,
+                "latest": info.latest if info else None,
+                "hacs": result["hacs"],
+            },
+        )
+        if result["refreshed"]:
+            logger.info(
+                "Asked HACS to refresh component repository info: %s",
+                ", ".join(result["refreshed"]),
+            )
+    except asyncio.CancelledError:
+        raise
+    except Exception:
+        logger.debug("HACS auto-refresh nudge skipped", exc_info=True)

--- a/src/ha_mcp/hacs_auto_refresh.py
+++ b/src/ha_mcp/hacs_auto_refresh.py
@@ -22,11 +22,13 @@ spawn on an unchanged version — costs one file read and no WebSocket traffic.
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import json
 import logging
 from pathlib import Path
 from typing import Any
 
+from ._vendor import websockets
 from ._version import get_version, is_embedded
 from .client.rest_client import (
     HomeAssistantCommandError,
@@ -50,8 +52,11 @@ CANDIDATE_REPO_FULL_NAMES = (
 
 # Marker file (in the ha-mcp data dir) recording the state the last completed
 # nudge ran against. Written only on a completed pass, so a failed pass (HA
-# still booting, HACS not loaded yet) is retried on the next startup.
-MARKER_FILENAME = "hacs_refresh_marker.json"
+# still booting, HACS not loaded yet) is retried on the next startup. One file
+# PER Home Assistant target: server configs sharing a data dir but pointing at
+# different instances must neither suppress each other's nudge nor invalidate
+# each other's marker on every alternating spawn (review finding).
+MARKER_FILENAME_PREFIX = "hacs_refresh_marker"
 
 # The add-on can start before HA Core finishes booting (and before HACS is
 # loaded), so the first attempts may fail; spread retries over ~8 minutes,
@@ -59,13 +64,14 @@ MARKER_FILENAME = "hacs_refresh_marker.json"
 RETRY_DELAYS = (30.0, 60.0, 120.0, 300.0)
 
 
-def _marker_path() -> Path:
-    return get_data_dir() / MARKER_FILENAME
+def _marker_path(ha_url: str) -> Path:
+    digest = hashlib.sha256(ha_url.rstrip("/").encode()).hexdigest()[:12]
+    return get_data_dir() / f"{MARKER_FILENAME_PREFIX}_{digest}.json"
 
 
-def _read_marker() -> dict[str, Any] | None:
+def _read_marker(ha_url: str) -> dict[str, Any] | None:
     """Return the last completed pass's marker, or None when there isn't one."""
-    path = _marker_path()
+    path = _marker_path(ha_url)
     try:
         payload = json.loads(path.read_text(encoding="utf-8"))
     except FileNotFoundError:
@@ -76,9 +82,9 @@ def _read_marker() -> dict[str, Any] | None:
     return payload if isinstance(payload, dict) else None
 
 
-def _write_marker(marker: dict[str, Any]) -> None:
+def _write_marker(ha_url: str, marker: dict[str, Any]) -> None:
     """Record the state this pass ran against; an unwritable dir just retries."""
-    path = _marker_path()
+    path = _marker_path(ha_url)
     try:
         path.write_text(json.dumps(marker), encoding="utf-8")
     except OSError as err:
@@ -87,22 +93,20 @@ def _write_marker(marker: dict[str, Any]) -> None:
 
 def _nudge_due(
     current_version: str,
-    ha_url: str,
     info: UpdateInfo | None,
     marker: dict[str, Any] | None,
 ) -> bool:
-    """Decide whether this startup should ask HACS for a refresh."""
+    """Decide whether this startup should ask HACS for a refresh.
+
+    Instance scoping lives in the marker PATH (one file per HA target), so a
+    marker handed in here always describes the current instance.
+    """
     if marker is None:
-        # First run ever, or no pass has ever completed.
+        # First run ever, or no pass has ever completed for this HA target.
         return True
     if marker.get("server_version") != current_version:
         # The server was just updated, and the paired component release is
         # exactly what HACS needs to surface.
-        return True
-    if marker.get("ha_url") != ha_url:
-        # Same data dir, different Home Assistant target (multi-instance
-        # setups, or a changed HOMEASSISTANT_URL): the recorded pass says
-        # nothing about THIS instance's HACS.
         return True
     # A release appeared while this build sat idle — surface its component side.
     return bool(
@@ -171,6 +175,10 @@ async def _refresh_with_retries() -> dict[str, Any] | None:
             HomeAssistantConnectionError,
             HomeAssistantCommandError,
             HomeAssistantCommandTimeout,
+            # send_command deliberately re-raises the ORIGINAL exception when
+            # the socket closes mid-send (ambiguous-write contract), so raw
+            # websocket closures reach this loop unwrapped (review finding).
+            websockets.exceptions.WebSocketException,
             OSError,
         ) as err:
             logger.debug("HACS repository refresh attempt failed: %s", err)
@@ -209,8 +217,8 @@ async def maybe_refresh_hacs_after_update() -> None:
         # Normally a cache hit — the startup banner warms the lru_cache — but
         # offloaded anyway so a cold call can never touch the event loop.
         info = await asyncio.to_thread(get_update_info)
-        marker = await asyncio.to_thread(_read_marker)
-        if not _nudge_due(current, ha_url, info, marker):
+        marker = await asyncio.to_thread(_read_marker, ha_url)
+        if not _nudge_due(current, info, marker):
             return
 
         result = await _refresh_with_retries()
@@ -223,9 +231,9 @@ async def maybe_refresh_hacs_after_update() -> None:
 
         await asyncio.to_thread(
             _write_marker,
+            ha_url,
             {
                 "server_version": current,
-                "ha_url": ha_url,
                 "latest": info.latest if info else None,
                 "hacs": result["hacs"],
             },

--- a/src/ha_mcp/hacs_auto_refresh.py
+++ b/src/ha_mcp/hacs_auto_refresh.py
@@ -150,8 +150,11 @@ async def _refresh_installed_candidates() -> dict[str, Any] | None:
         try:
             await send_hacs_repository_refresh(ws_client, str(repo["id"]))
         except Exception as err:
-            # A user mid legacy->mirror migration has both entries installed;
-            # one failing must not cost the other its refresh.
+            # Both entries read installed only when someone downloaded the
+            # mirror without removing the legacy record — HACS guards against
+            # adding the same repository twice but not against two
+            # repositories sharing a domain. Rare, but one failing must not
+            # cost the other its refresh.
             logger.debug("HACS refresh failed for %s: %s", full_name, err)
             continue
         refreshed.append(full_name)

--- a/src/ha_mcp/hacs_auto_refresh.py
+++ b/src/ha_mcp/hacs_auto_refresh.py
@@ -30,8 +30,10 @@ from typing import Any
 from ._version import get_version, is_embedded
 from .client.rest_client import (
     HomeAssistantCommandError,
+    HomeAssistantCommandTimeout,
     HomeAssistantConnectionError,
 )
+from .config import OAUTH_MODE_TOKEN, get_global_settings
 from .update_check import UpdateInfo, get_update_info, is_update_check_disabled
 from .utils.data_paths import get_data_dir
 
@@ -84,7 +86,10 @@ def _write_marker(marker: dict[str, Any]) -> None:
 
 
 def _nudge_due(
-    current_version: str, info: UpdateInfo | None, marker: dict[str, Any] | None
+    current_version: str,
+    ha_url: str,
+    info: UpdateInfo | None,
+    marker: dict[str, Any] | None,
 ) -> bool:
     """Decide whether this startup should ask HACS for a refresh."""
     if marker is None:
@@ -93,6 +98,11 @@ def _nudge_due(
     if marker.get("server_version") != current_version:
         # The server was just updated, and the paired component release is
         # exactly what HACS needs to surface.
+        return True
+    if marker.get("ha_url") != ha_url:
+        # Same data dir, different Home Assistant target (multi-instance
+        # setups, or a changed HOMEASSISTANT_URL): the recorded pass says
+        # nothing about THIS instance's HACS.
         return True
     # A release appeared while this build sat idle — surface its component side.
     return bool(
@@ -124,6 +134,7 @@ async def _refresh_installed_candidates() -> dict[str, Any] | None:
 
     wanted = {name.lower() for name in CANDIDATE_REPO_FULL_NAMES}
     refreshed: list[str] = []
+    attempted = 0
     for repo in response.get("result", []):
         full_name = (repo.get("full_name") or "").lower()
         # HACS keeps a record for every ADDED repo but only creates an update
@@ -131,6 +142,7 @@ async def _refresh_installed_candidates() -> dict[str, Any] | None:
         # lights up nothing.
         if full_name not in wanted or not repo.get("installed"):
             continue
+        attempted += 1
         try:
             await send_hacs_repository_refresh(ws_client, str(repo["id"]))
         except Exception as err:
@@ -139,12 +151,17 @@ async def _refresh_installed_candidates() -> dict[str, Any] | None:
             logger.debug("HACS refresh failed for %s: %s", full_name, err)
             continue
         refreshed.append(full_name)
+    if attempted and not refreshed:
+        # Every attempted refresh failed — the pass is undetermined, not
+        # complete. Returning a result here would write the marker and cancel
+        # the retry schedule and the next startup's pass (review finding).
+        return None
     return {"hacs": "present", "refreshed": refreshed}
 
 
 async def _refresh_with_retries() -> dict[str, Any] | None:
     """Run the refresh pass, retrying transport failures over ``RETRY_DELAYS``."""
-    result: dict[str, Any] | None = None
+    absent_result: dict[str, Any] | None = None
     for delay in (0.0, *RETRY_DELAYS):
         if delay:
             await asyncio.sleep(delay)
@@ -153,13 +170,22 @@ async def _refresh_with_retries() -> dict[str, Any] | None:
         except (
             HomeAssistantConnectionError,
             HomeAssistantCommandError,
+            HomeAssistantCommandTimeout,
             OSError,
         ) as err:
             logger.debug("HACS repository refresh attempt failed: %s", err)
             continue
-        if result is not None:
-            break
-    return result
+        if result is None:
+            continue
+        if result["hacs"] == "absent":
+            # ``unknown_command`` also happens while HA is still booting,
+            # before HACS registers its WS handlers — indistinguishable from
+            # no HACS at all. Keep retrying; record absence only once the
+            # schedule is exhausted (review finding).
+            absent_result = result
+            continue
+        return result
+    return absent_result
 
 
 async def maybe_refresh_hacs_after_update() -> None:
@@ -172,12 +198,19 @@ async def maybe_refresh_hacs_after_update() -> None:
         if is_update_check_disabled():
             return
 
+        settings = get_global_settings()
+        if settings.homeassistant_token == OAUTH_MODE_TOKEN:
+            # Per-user OAuth mode holds no server-level HA credential — the
+            # nudge would only burn its retry schedule on auth failures.
+            return
+        ha_url = settings.homeassistant_url
+
         current = get_version()
         # Normally a cache hit — the startup banner warms the lru_cache — but
         # offloaded anyway so a cold call can never touch the event loop.
         info = await asyncio.to_thread(get_update_info)
         marker = await asyncio.to_thread(_read_marker)
-        if not _nudge_due(current, info, marker):
+        if not _nudge_due(current, ha_url, info, marker):
             return
 
         result = await _refresh_with_retries()
@@ -192,6 +225,7 @@ async def maybe_refresh_hacs_after_update() -> None:
             _write_marker,
             {
                 "server_version": current,
+                "ha_url": ha_url,
                 "latest": info.latest if info else None,
                 "hacs": result["hacs"],
             },

--- a/src/ha_mcp/update_check.py
+++ b/src/ha_mcp/update_check.py
@@ -79,6 +79,16 @@ def _is_disabled() -> bool:
     return os.environ.get(DISABLE_ENV, "").strip().lower() in _TRUTHY
 
 
+def is_update_check_disabled() -> bool:
+    """Public accessor for the HA_MCP_DISABLE_UPDATE_CHECK opt-out.
+
+    The HACS auto-refresh nudge gates on the same switch: an operator who
+    opted out of update phone-home should not get update-driven side
+    effects either.
+    """
+    return _is_disabled()
+
+
 def _is_newer(latest: str, current: str) -> bool:
     """Return True only when ``latest`` is a strictly higher PEP 440 release.
 

--- a/tests/src/unit/test_graceful_shutdown.py
+++ b/tests/src/unit/test_graceful_shutdown.py
@@ -14,6 +14,20 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 
+@pytest.fixture(autouse=True)
+def _no_startup_hacs_nudge():
+    """Keep the startup HACS nudge out of these tests.
+
+    ``_run_with_shutdown`` fires it as a background task; left real it would
+    reach PyPI and the Home Assistant WebSocket from a unit test.
+    """
+    with patch(
+        "ha_mcp.hacs_auto_refresh.maybe_refresh_hacs_after_update",
+        new=AsyncMock(return_value=None),
+    ):
+        yield
+
+
 class TestSignalHandlerSetup:
     """Tests for signal handler registration."""
 

--- a/tests/src/unit/test_hacs_auto_refresh.py
+++ b/tests/src/unit/test_hacs_auto_refresh.py
@@ -1,0 +1,281 @@
+"""Unit tests for the server-side HACS auto-refresh nudge.
+
+On a startup where the version picture changed, the server asks HACS to
+re-fetch the ha_mcp_tools component's repository info so an external install
+(add-on / Docker / pip / stdio) surfaces the paired component update instead of
+waiting out HACS's ~48h custom-repository cache.
+
+The WebSocket layer is mocked and the marker file is redirected at a tmp dir;
+HACS itself is never involved. No test may sleep — the one covering the retry
+schedule empties it first.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from contextlib import contextmanager
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from ha_mcp import hacs_auto_refresh
+from ha_mcp.__main__ import _run_with_shutdown
+from ha_mcp.client.rest_client import (
+    HomeAssistantCommandError,
+    HomeAssistantConnectionError,
+)
+from ha_mcp.update_check import UpdateInfo
+
+MIRROR, LEGACY = hacs_auto_refresh.CANDIDATE_REPO_FULL_NAMES
+
+
+def _info(latest="1.1.0", *, update_available=True, current="1.0.0"):
+    return UpdateInfo(current=current, latest=latest, update_available=update_available)
+
+
+def _repo(repo_id, full_name, *, installed=True):
+    """One entry of HACS's ``hacs/repositories/list`` result."""
+    return {"id": repo_id, "full_name": full_name, "installed": installed}
+
+
+def _ws(repos=(), error=None):
+    """A WS client whose ``hacs/repositories/list`` returns ``repos``, or raises."""
+    ws = AsyncMock()
+    if error is not None:
+        ws.send_command = AsyncMock(side_effect=error)
+    else:
+        ws.send_command = AsyncMock(
+            return_value={"success": True, "result": list(repos)}
+        )
+    return ws
+
+
+@contextmanager
+def _server(ws, *, info=None, version="1.0.0", embedded=False, disabled=False):
+    """Patch the startup gates, the WS client factory and the HACS refresh call."""
+    get_ws = AsyncMock(return_value=ws)
+    refresh = AsyncMock(return_value={"success": True})
+    with (
+        patch("ha_mcp.hacs_auto_refresh.is_embedded", return_value=embedded),
+        patch(
+            "ha_mcp.hacs_auto_refresh.is_update_check_disabled", return_value=disabled
+        ),
+        patch("ha_mcp.hacs_auto_refresh.get_version", return_value=version),
+        patch("ha_mcp.hacs_auto_refresh.get_update_info", return_value=info),
+        patch(
+            "ha_mcp.tools.hacs_registration.send_hacs_repository_refresh", new=refresh
+        ),
+        patch("ha_mcp.client.websocket_client.get_websocket_client", new=get_ws),
+    ):
+        yield SimpleNamespace(get_websocket_client=get_ws, refresh=refresh)
+
+
+@pytest.fixture
+def data_dir(tmp_path):
+    """Redirect the marker file at a tmp dir (patched at the module's import site)."""
+    with patch("ha_mcp.hacs_auto_refresh.get_data_dir", return_value=tmp_path):
+        yield tmp_path
+
+
+def _written_marker(data_dir):
+    path = data_dir / hacs_auto_refresh.MARKER_FILENAME
+    return json.loads(path.read_text()) if path.exists() else None
+
+
+def _refreshed_ids(mocks):
+    return [call.args[1] for call in mocks.refresh.await_args_list]
+
+
+class TestNudgeDue:
+    def test_no_marker_is_due(self):
+        assert hacs_auto_refresh._nudge_due("1.0.0", _info(), None) is True
+
+    def test_changed_server_version_is_due(self):
+        # The just-updated case: the paired component release is what HACS
+        # needs to surface.
+        marker = {"server_version": "0.9.0", "latest": "1.1.0"}
+        assert hacs_auto_refresh._nudge_due("1.0.0", _info(), marker) is True
+
+    def test_same_version_without_an_update_is_not_due(self):
+        marker = {"server_version": "1.0.0", "latest": "1.0.0"}
+        info = _info(latest="1.0.0", update_available=False)
+        assert hacs_auto_refresh._nudge_due("1.0.0", info, marker) is False
+
+    def test_release_appearing_since_the_last_pass_is_due(self):
+        marker = {"server_version": "1.0.0", "latest": "1.0.0"}
+        info = _info(latest="1.1.0")
+
+        assert hacs_auto_refresh._nudge_due("1.0.0", info, marker) is True
+
+    def test_already_recorded_latest_is_not_due(self):
+        marker = {"server_version": "1.0.0", "latest": "1.1.0"}
+        info = _info(latest="1.1.0")
+
+        assert hacs_auto_refresh._nudge_due("1.0.0", info, marker) is False
+
+    def test_missing_update_info_on_the_same_version_is_not_due(self):
+        marker = {"server_version": "1.0.0", "latest": None}
+        assert hacs_auto_refresh._nudge_due("1.0.0", None, marker) is False
+
+
+class TestMarkerFile:
+    def test_roundtrip(self, data_dir):
+        marker = {"server_version": "1.0.0", "latest": "1.1.0", "hacs": "present"}
+        hacs_auto_refresh._write_marker(marker)
+
+        assert hacs_auto_refresh._read_marker() == marker
+
+    def test_missing_file_reads_as_none(self, data_dir):
+        assert hacs_auto_refresh._read_marker() is None
+
+    def test_corrupt_file_reads_as_none(self, data_dir):
+        (data_dir / hacs_auto_refresh.MARKER_FILENAME).write_text("{not json")
+
+        assert hacs_auto_refresh._read_marker() is None
+
+    def test_non_dict_payload_reads_as_none(self, data_dir):
+        (data_dir / hacs_auto_refresh.MARKER_FILENAME).write_text('["nope"]')
+
+        assert hacs_auto_refresh._read_marker() is None
+
+
+class TestMaybeRefreshHacsAfterUpdate:
+    async def test_embedded_server_is_a_no_op(self, data_dir):
+        # The component's own hacs_nudge covers the embedded server; running
+        # both would double HACS's GitHub fetches.
+        with (
+            _server(_ws(), info=_info(), embedded=True) as mocks,
+            patch("ha_mcp.hacs_auto_refresh._read_marker") as read_marker,
+        ):
+            await hacs_auto_refresh.maybe_refresh_hacs_after_update()
+
+        read_marker.assert_not_called()
+        mocks.get_websocket_client.assert_not_awaited()
+
+    async def test_disabled_update_check_is_a_no_op(self, data_dir):
+        with (
+            _server(_ws(), info=_info(), disabled=True) as mocks,
+            patch("ha_mcp.hacs_auto_refresh._read_marker") as read_marker,
+        ):
+            await hacs_auto_refresh.maybe_refresh_hacs_after_update()
+
+        read_marker.assert_not_called()
+        mocks.get_websocket_client.assert_not_awaited()
+
+    async def test_both_installed_candidates_are_refreshed(self, data_dir, caplog):
+        ws = _ws([_repo(123, MIRROR), _repo(456, LEGACY), _repo(789, "other/repo")])
+
+        with caplog.at_level(logging.INFO), _server(ws, info=_info()) as mocks:
+            await hacs_auto_refresh.maybe_refresh_hacs_after_update()
+
+        # Both entries the component can be tracked under, and nothing else.
+        assert _refreshed_ids(mocks) == ["123", "456"]
+        assert _written_marker(data_dir) == {
+            "server_version": "1.0.0",
+            "latest": "1.1.0",
+            "hacs": "present",
+        }
+        # The one info line is the operator-visible signal for this feature.
+        assert f"{MIRROR}, {LEGACY}" in caplog.text
+
+    async def test_uninstalled_candidate_is_skipped(self, data_dir):
+        # Migration limbo: the mirror record is added but not downloaded, so
+        # only the legacy entry has an update entity to light up.
+        ws = _ws([_repo(123, MIRROR, installed=False), _repo(456, LEGACY)])
+
+        with _server(ws, info=_info()) as mocks:
+            await hacs_auto_refresh.maybe_refresh_hacs_after_update()
+
+        assert _refreshed_ids(mocks) == ["456"]
+
+    async def test_no_installed_candidate_still_records_the_pass(self, data_dir):
+        ws = _ws([_repo(789, "other/repo")])
+
+        with _server(ws, info=_info()) as mocks:
+            await hacs_auto_refresh.maybe_refresh_hacs_after_update()
+
+        mocks.refresh.assert_not_awaited()
+        # "nothing to refresh" is a completed pass, so the next startup on this
+        # same version does not re-ask HACS.
+        assert _written_marker(data_dir)["hacs"] == "present"
+
+    async def test_one_failing_refresh_does_not_skip_the_other(self, data_dir):
+        ws = _ws([_repo(123, MIRROR), _repo(456, LEGACY)])
+
+        with _server(ws, info=_info()) as mocks:
+            mocks.refresh.side_effect = [
+                HomeAssistantCommandError("Command failed: repository not found"),
+                {"success": True},
+            ]
+            await hacs_auto_refresh.maybe_refresh_hacs_after_update()
+
+        assert _refreshed_ids(mocks) == ["123", "456"]
+        assert _written_marker(data_dir)["hacs"] == "present"
+
+    async def test_absent_hacs_is_recorded(self, data_dir):
+        ws = _ws(
+            error=HomeAssistantCommandError(
+                "Command failed: unknown command: hacs/repositories/list",
+                "unknown_command",
+            )
+        )
+
+        with _server(ws, info=_info()) as mocks:
+            await hacs_auto_refresh.maybe_refresh_hacs_after_update()
+
+        mocks.refresh.assert_not_awaited()
+        assert _written_marker(data_dir)["hacs"] == "absent"
+
+    async def test_unreachable_hacs_leaves_the_marker_unwritten(self, data_dir):
+        # Nothing was determined, so the next startup must retry — which is
+        # exactly what an absent marker does. RETRY_DELAYS is emptied so the
+        # test cannot sleep through the real ~8 minute schedule.
+        ws = _ws(error=HomeAssistantConnectionError("websocket down"))
+
+        with (
+            _server(ws, info=_info()) as mocks,
+            patch.object(hacs_auto_refresh, "RETRY_DELAYS", ()),
+        ):
+            await hacs_auto_refresh.maybe_refresh_hacs_after_update()
+
+        assert ws.send_command.await_count == 1
+        mocks.refresh.assert_not_awaited()
+        assert _written_marker(data_dir) is None
+
+    async def test_matching_marker_skips_the_websocket(self, data_dir):
+        # The stdio hot path: a per-conversation spawn on an unchanged version
+        # costs one file read and no WebSocket traffic.
+        (data_dir / hacs_auto_refresh.MARKER_FILENAME).write_text(
+            json.dumps(
+                {"server_version": "1.0.0", "latest": "1.1.0", "hacs": "present"}
+            )
+        )
+        ws = _ws([_repo(123, MIRROR)])
+
+        with _server(ws, info=_info()) as mocks:
+            await hacs_auto_refresh.maybe_refresh_hacs_after_update()
+
+        mocks.get_websocket_client.assert_not_awaited()
+        mocks.refresh.assert_not_awaited()
+
+
+class TestStartupWiring:
+    async def test_run_with_shutdown_fires_the_nudge(self):
+        # The task is created but deliberately kept out of the wait set, so
+        # the server's own exit is what ends _run_with_shutdown.
+        nudge = AsyncMock(return_value=None)
+
+        async def clean_server():
+            return None
+
+        with (
+            patch(
+                "ha_mcp.hacs_auto_refresh.maybe_refresh_hacs_after_update", new=nudge
+            ),
+            patch("ha_mcp.__main__._cleanup_resources", new=AsyncMock()),
+        ):
+            await _run_with_shutdown(clean_server())
+
+        nudge.assert_awaited_once()

--- a/tests/src/unit/test_hacs_auto_refresh.py
+++ b/tests/src/unit/test_hacs_auto_refresh.py
@@ -91,8 +91,8 @@ def data_dir(tmp_path):
         yield tmp_path
 
 
-def _written_marker(data_dir):
-    path = data_dir / hacs_auto_refresh.MARKER_FILENAME
+def _written_marker(data_dir, ha_url=HA_URL):
+    path = hacs_auto_refresh._marker_path(ha_url)
     return json.loads(path.read_text()) if path.exists() else None
 
 
@@ -100,57 +100,52 @@ def _refreshed_ids(mocks):
     return [call.args[1] for call in mocks.refresh.await_args_list]
 
 
-def _marker(version="1.0.0", latest="1.0.0", ha_url=HA_URL, **extra):
-    return {"server_version": version, "latest": latest, "ha_url": ha_url, **extra}
+def _marker(version="1.0.0", latest="1.0.0", **extra):
+    return {"server_version": version, "latest": latest, **extra}
 
 
 class TestNudgeDue:
     def test_no_marker_is_due(self):
-        assert hacs_auto_refresh._nudge_due("1.0.0", HA_URL, _info(), None) is True
+        assert hacs_auto_refresh._nudge_due("1.0.0", _info(), None) is True
 
     def test_changed_server_version_is_due(self):
         # The just-updated case: the paired component release is what HACS
         # needs to surface.
         marker = _marker(version="0.9.0", latest="1.1.0")
-        assert hacs_auto_refresh._nudge_due("1.0.0", HA_URL, _info(), marker) is True
-
-    def test_changed_ha_instance_is_due(self):
-        # Shared data dir, different HA target (or a changed
-        # HOMEASSISTANT_URL): one instance's pass must not suppress the
-        # other's nudge.
-        marker = _marker(latest="1.1.0")
-        due = hacs_auto_refresh._nudge_due(
-            "1.0.0", "http://other-ha:8123", _info(), marker
-        )
-        assert due is True
+        assert hacs_auto_refresh._nudge_due("1.0.0", _info(), marker) is True
 
     def test_same_version_without_an_update_is_not_due(self):
         marker = _marker()
         info = _info(latest="1.0.0", update_available=False)
-        assert hacs_auto_refresh._nudge_due("1.0.0", HA_URL, info, marker) is False
+        assert hacs_auto_refresh._nudge_due("1.0.0", info, marker) is False
 
     def test_release_appearing_since_the_last_pass_is_due(self):
         marker = _marker()
         info = _info(latest="1.1.0")
 
-        assert hacs_auto_refresh._nudge_due("1.0.0", HA_URL, info, marker) is True
+        assert hacs_auto_refresh._nudge_due("1.0.0", info, marker) is True
 
     def test_already_recorded_latest_is_not_due(self):
         marker = _marker(latest="1.1.0")
         info = _info(latest="1.1.0")
 
-        assert hacs_auto_refresh._nudge_due("1.0.0", HA_URL, info, marker) is False
+        assert hacs_auto_refresh._nudge_due("1.0.0", info, marker) is False
 
     def test_missing_update_info_on_the_same_version_is_not_due(self):
         marker = _marker(latest=None)
-        assert hacs_auto_refresh._nudge_due("1.0.0", HA_URL, None, marker) is False
+        assert hacs_auto_refresh._nudge_due("1.0.0", None, marker) is False
 
 
 def test_candidate_names_match_the_component_constants():
     # CANDIDATE_REPO_FULL_NAMES duplicates the component's constants (the
     # server package cannot import the component at runtime); this pins the
     # two sources together so a rename cannot silently strand the server
-    # refresh on stale repository names.
+    # refresh on stale repository names. The component package pulls
+    # homeassistant on import, so stub it first (same as test_hacs_nudge).
+    from ._embedded_stubs import install
+
+    install()
+
     from custom_components.ha_mcp_tools.const import (
         HACS_LEGACY_REPO_FULL_NAME,
         HACS_MIRROR_REPO_FULL_NAME,
@@ -165,22 +160,41 @@ def test_candidate_names_match_the_component_constants():
 class TestMarkerFile:
     def test_roundtrip(self, data_dir):
         marker = {"server_version": "1.0.0", "latest": "1.1.0", "hacs": "present"}
-        hacs_auto_refresh._write_marker(marker)
+        hacs_auto_refresh._write_marker(HA_URL, marker)
 
-        assert hacs_auto_refresh._read_marker() == marker
+        assert hacs_auto_refresh._read_marker(HA_URL) == marker
 
     def test_missing_file_reads_as_none(self, data_dir):
-        assert hacs_auto_refresh._read_marker() is None
+        assert hacs_auto_refresh._read_marker(HA_URL) is None
 
     def test_corrupt_file_reads_as_none(self, data_dir):
-        (data_dir / hacs_auto_refresh.MARKER_FILENAME).write_text("{not json")
+        hacs_auto_refresh._marker_path(HA_URL).write_text("{not json")
 
-        assert hacs_auto_refresh._read_marker() is None
+        assert hacs_auto_refresh._read_marker(HA_URL) is None
 
     def test_non_dict_payload_reads_as_none(self, data_dir):
-        (data_dir / hacs_auto_refresh.MARKER_FILENAME).write_text('["nope"]')
+        hacs_auto_refresh._marker_path(HA_URL).write_text('["nope"]')
 
-        assert hacs_auto_refresh._read_marker() is None
+        assert hacs_auto_refresh._read_marker(HA_URL) is None
+
+    def test_markers_are_scoped_per_ha_target(self, data_dir):
+        # Two server configs sharing one data dir but targeting different
+        # instances keep independent markers — neither suppresses the other's
+        # nudge nor invalidates the other's marker on alternating spawns.
+        hacs_auto_refresh._write_marker(HA_URL, {"server_version": "1.0.0"})
+        other = "http://other-ha:8123"
+
+        assert hacs_auto_refresh._read_marker(other) is None
+        hacs_auto_refresh._write_marker(other, {"server_version": "2.0.0"})
+        assert hacs_auto_refresh._read_marker(HA_URL) == {"server_version": "1.0.0"}
+        assert hacs_auto_refresh._read_marker(other) == {"server_version": "2.0.0"}
+
+    def test_trailing_slash_is_the_same_target(self, data_dir):
+        hacs_auto_refresh._write_marker(HA_URL, {"server_version": "1.0.0"})
+
+        assert hacs_auto_refresh._read_marker(HA_URL + "/") == {
+            "server_version": "1.0.0"
+        }
 
 
 class TestMaybeRefreshHacsAfterUpdate:
@@ -228,7 +242,6 @@ class TestMaybeRefreshHacsAfterUpdate:
         assert _refreshed_ids(mocks) == ["123", "456"]
         assert _written_marker(data_dir) == {
             "server_version": "1.0.0",
-            "ha_url": HA_URL,
             "latest": "1.1.0",
             "hacs": "present",
         }
@@ -324,10 +337,28 @@ class TestMaybeRefreshHacsAfterUpdate:
         mocks.refresh.assert_not_awaited()
         assert _written_marker(data_dir) is None
 
+    async def test_websocket_closure_is_retried(self, data_dir):
+        # send_command re-raises raw websocket exceptions on a mid-send
+        # closure (ambiguous-write contract), so they arrive here unwrapped —
+        # they must consume a retry, not escape to the outer advisory catch.
+        from ha_mcp._vendor import websockets
+
+        ws = _ws(error=websockets.exceptions.WebSocketException("closed"))
+
+        with (
+            _server(ws, info=_info()) as mocks,
+            patch.object(hacs_auto_refresh, "RETRY_DELAYS", (0.001,)),
+        ):
+            await hacs_auto_refresh.maybe_refresh_hacs_after_update()
+
+        assert ws.send_command.await_count == 2
+        mocks.refresh.assert_not_awaited()
+        assert _written_marker(data_dir) is None
+
     async def test_matching_marker_skips_the_websocket(self, data_dir):
         # The stdio hot path: a per-conversation spawn on an unchanged version
         # costs one file read and no WebSocket traffic.
-        (data_dir / hacs_auto_refresh.MARKER_FILENAME).write_text(
+        hacs_auto_refresh._marker_path(HA_URL).write_text(
             json.dumps(_marker(latest="1.1.0", hacs="present"))
         )
         ws = _ws([_repo(123, MIRROR)])

--- a/tests/src/unit/test_hacs_auto_refresh.py
+++ b/tests/src/unit/test_hacs_auto_refresh.py
@@ -24,8 +24,10 @@ from ha_mcp import hacs_auto_refresh
 from ha_mcp.__main__ import _run_with_shutdown
 from ha_mcp.client.rest_client import (
     HomeAssistantCommandError,
+    HomeAssistantCommandTimeout,
     HomeAssistantConnectionError,
 )
+from ha_mcp.config import OAUTH_MODE_TOKEN
 from ha_mcp.update_check import UpdateInfo
 
 MIRROR, LEGACY = hacs_auto_refresh.CANDIDATE_REPO_FULL_NAMES
@@ -52,16 +54,26 @@ def _ws(repos=(), error=None):
     return ws
 
 
+HA_URL = "http://ha.local:8123"
+
+
 @contextmanager
-def _server(ws, *, info=None, version="1.0.0", embedded=False, disabled=False):
+def _server(
+    ws, *, info=None, version="1.0.0", embedded=False, disabled=False, oauth=False
+):
     """Patch the startup gates, the WS client factory and the HACS refresh call."""
     get_ws = AsyncMock(return_value=ws)
     refresh = AsyncMock(return_value={"success": True})
+    settings = SimpleNamespace(
+        homeassistant_token=OAUTH_MODE_TOKEN if oauth else "a-real-llat",
+        homeassistant_url=HA_URL,
+    )
     with (
         patch("ha_mcp.hacs_auto_refresh.is_embedded", return_value=embedded),
         patch(
             "ha_mcp.hacs_auto_refresh.is_update_check_disabled", return_value=disabled
         ),
+        patch("ha_mcp.hacs_auto_refresh.get_global_settings", return_value=settings),
         patch("ha_mcp.hacs_auto_refresh.get_version", return_value=version),
         patch("ha_mcp.hacs_auto_refresh.get_update_info", return_value=info),
         patch(
@@ -88,36 +100,66 @@ def _refreshed_ids(mocks):
     return [call.args[1] for call in mocks.refresh.await_args_list]
 
 
+def _marker(version="1.0.0", latest="1.0.0", ha_url=HA_URL, **extra):
+    return {"server_version": version, "latest": latest, "ha_url": ha_url, **extra}
+
+
 class TestNudgeDue:
     def test_no_marker_is_due(self):
-        assert hacs_auto_refresh._nudge_due("1.0.0", _info(), None) is True
+        assert hacs_auto_refresh._nudge_due("1.0.0", HA_URL, _info(), None) is True
 
     def test_changed_server_version_is_due(self):
         # The just-updated case: the paired component release is what HACS
         # needs to surface.
-        marker = {"server_version": "0.9.0", "latest": "1.1.0"}
-        assert hacs_auto_refresh._nudge_due("1.0.0", _info(), marker) is True
+        marker = _marker(version="0.9.0", latest="1.1.0")
+        assert hacs_auto_refresh._nudge_due("1.0.0", HA_URL, _info(), marker) is True
+
+    def test_changed_ha_instance_is_due(self):
+        # Shared data dir, different HA target (or a changed
+        # HOMEASSISTANT_URL): one instance's pass must not suppress the
+        # other's nudge.
+        marker = _marker(latest="1.1.0")
+        due = hacs_auto_refresh._nudge_due(
+            "1.0.0", "http://other-ha:8123", _info(), marker
+        )
+        assert due is True
 
     def test_same_version_without_an_update_is_not_due(self):
-        marker = {"server_version": "1.0.0", "latest": "1.0.0"}
+        marker = _marker()
         info = _info(latest="1.0.0", update_available=False)
-        assert hacs_auto_refresh._nudge_due("1.0.0", info, marker) is False
+        assert hacs_auto_refresh._nudge_due("1.0.0", HA_URL, info, marker) is False
 
     def test_release_appearing_since_the_last_pass_is_due(self):
-        marker = {"server_version": "1.0.0", "latest": "1.0.0"}
+        marker = _marker()
         info = _info(latest="1.1.0")
 
-        assert hacs_auto_refresh._nudge_due("1.0.0", info, marker) is True
+        assert hacs_auto_refresh._nudge_due("1.0.0", HA_URL, info, marker) is True
 
     def test_already_recorded_latest_is_not_due(self):
-        marker = {"server_version": "1.0.0", "latest": "1.1.0"}
+        marker = _marker(latest="1.1.0")
         info = _info(latest="1.1.0")
 
-        assert hacs_auto_refresh._nudge_due("1.0.0", info, marker) is False
+        assert hacs_auto_refresh._nudge_due("1.0.0", HA_URL, info, marker) is False
 
     def test_missing_update_info_on_the_same_version_is_not_due(self):
-        marker = {"server_version": "1.0.0", "latest": None}
-        assert hacs_auto_refresh._nudge_due("1.0.0", None, marker) is False
+        marker = _marker(latest=None)
+        assert hacs_auto_refresh._nudge_due("1.0.0", HA_URL, None, marker) is False
+
+
+def test_candidate_names_match_the_component_constants():
+    # CANDIDATE_REPO_FULL_NAMES duplicates the component's constants (the
+    # server package cannot import the component at runtime); this pins the
+    # two sources together so a rename cannot silently strand the server
+    # refresh on stale repository names.
+    from custom_components.ha_mcp_tools.const import (
+        HACS_LEGACY_REPO_FULL_NAME,
+        HACS_MIRROR_REPO_FULL_NAME,
+    )
+
+    assert hacs_auto_refresh.CANDIDATE_REPO_FULL_NAMES == (
+        HACS_MIRROR_REPO_FULL_NAME,
+        HACS_LEGACY_REPO_FULL_NAME,
+    )
 
 
 class TestMarkerFile:
@@ -164,6 +206,18 @@ class TestMaybeRefreshHacsAfterUpdate:
         read_marker.assert_not_called()
         mocks.get_websocket_client.assert_not_awaited()
 
+    async def test_oauth_mode_is_a_no_op(self, data_dir):
+        # Per-user OAuth mode holds no server-level HA credential; the nudge
+        # would only burn its retry schedule on auth failures.
+        with (
+            _server(_ws(), info=_info(), oauth=True) as mocks,
+            patch("ha_mcp.hacs_auto_refresh._read_marker") as read_marker,
+        ):
+            await hacs_auto_refresh.maybe_refresh_hacs_after_update()
+
+        read_marker.assert_not_called()
+        mocks.get_websocket_client.assert_not_awaited()
+
     async def test_both_installed_candidates_are_refreshed(self, data_dir, caplog):
         ws = _ws([_repo(123, MIRROR), _repo(456, LEGACY), _repo(789, "other/repo")])
 
@@ -174,6 +228,7 @@ class TestMaybeRefreshHacsAfterUpdate:
         assert _refreshed_ids(mocks) == ["123", "456"]
         assert _written_marker(data_dir) == {
             "server_version": "1.0.0",
+            "ha_url": HA_URL,
             "latest": "1.1.0",
             "hacs": "present",
         }
@@ -214,7 +269,11 @@ class TestMaybeRefreshHacsAfterUpdate:
         assert _refreshed_ids(mocks) == ["123", "456"]
         assert _written_marker(data_dir)["hacs"] == "present"
 
-    async def test_absent_hacs_is_recorded(self, data_dir):
+    async def test_absent_hacs_is_recorded_only_after_retries_exhaust(self, data_dir):
+        # unknown_command is also what a still-booting HA returns before HACS
+        # registers its WS handlers, so absence must survive the whole retry
+        # schedule before it is recorded. RETRY_DELAYS is trimmed (not
+        # emptied) so the test proves the re-attempt without sleeping long.
         ws = _ws(
             error=HomeAssistantCommandError(
                 "Command failed: unknown command: hacs/repositories/list",
@@ -222,11 +281,32 @@ class TestMaybeRefreshHacsAfterUpdate:
             )
         )
 
-        with _server(ws, info=_info()) as mocks:
+        with (
+            _server(ws, info=_info()) as mocks,
+            patch.object(hacs_auto_refresh, "RETRY_DELAYS", (0.001,)),
+        ):
             await hacs_auto_refresh.maybe_refresh_hacs_after_update()
 
+        # Immediate attempt + one retry: absence was NOT accepted first try.
+        assert ws.send_command.await_count == 2
         mocks.refresh.assert_not_awaited()
         assert _written_marker(data_dir)["hacs"] == "absent"
+
+    async def test_all_refreshes_failing_leaves_the_marker_unwritten(self, data_dir):
+        # list succeeded but every installed candidate's refresh failed — an
+        # undetermined pass must not write the marker, or the retry schedule
+        # and the next startup's pass are both cancelled.
+        ws = _ws([_repo(123, MIRROR), _repo(456, LEGACY)])
+
+        with (
+            _server(ws, info=_info()) as mocks,
+            patch.object(hacs_auto_refresh, "RETRY_DELAYS", ()),
+        ):
+            mocks.refresh.side_effect = HomeAssistantCommandTimeout("no answer")
+            await hacs_auto_refresh.maybe_refresh_hacs_after_update()
+
+        assert mocks.refresh.await_count == 2
+        assert _written_marker(data_dir) is None
 
     async def test_unreachable_hacs_leaves_the_marker_unwritten(self, data_dir):
         # Nothing was determined, so the next startup must retry — which is
@@ -248,9 +328,7 @@ class TestMaybeRefreshHacsAfterUpdate:
         # The stdio hot path: a per-conversation spawn on an unchanged version
         # costs one file read and no WebSocket traffic.
         (data_dir / hacs_auto_refresh.MARKER_FILENAME).write_text(
-            json.dumps(
-                {"server_version": "1.0.0", "latest": "1.1.0", "hacs": "present"}
-            )
+            json.dumps(_marker(latest="1.1.0", hacs="present"))
         )
         ws = _ws([_repo(123, MIRROR)])
 

--- a/tests/src/unit/test_hacs_nudge.py
+++ b/tests/src/unit/test_hacs_nudge.py
@@ -1,9 +1,10 @@
 """Unit tests for the HACS refresh nudge (#1783/#1785 follow-up).
 
 When the component detects that a newer custom component exists — the auto-update
-hold or the component-outdated repair — it asks HACS to force-refresh this
-component's repository so HACS surfaces the update promptly instead of waiting
-out its ~48h custom-repository cache. The interaction reaches into HACS internals
+hold or the component-outdated repair — it asks HACS to force-refresh every
+repository entry this component is installed under, so HACS surfaces the update
+promptly instead of waiting out its ~48h custom-repository cache. The
+interaction reaches into HACS internals
 and is advisory: any failure degrades to a debug log and never faults the caller.
 
 HACS is faked in ``hass.data["hacs"]``; HACS itself is never imported. Home
@@ -74,7 +75,7 @@ class TestNudge:
         # ...then the update entity's coordinator is nudged to re-publish.
         coordinator.async_update_listeners.assert_called_once()
 
-    async def test_falls_back_to_legacy_repo_name(self):
+    async def test_legacy_only_install_is_refreshed(self):
         hass = _make_hass()
         repo = _fake_repo()
         hacs, _ = _fake_hacs(repos={HACS_LEGACY_REPO_FULL_NAME: repo})
@@ -86,6 +87,78 @@ class TestNudge:
         tried = [c.args[0] for c in hacs.repositories.get_by_full_name.call_args_list]
         assert tried == [HACS_MIRROR_REPO_FULL_NAME, HACS_LEGACY_REPO_FULL_NAME]
         repo.update_repository.assert_awaited_once()
+
+    async def test_both_installed_candidates_are_refreshed(self):
+        # A legacy->mirror migration can leave BOTH records installed, each
+        # with its own update entity — refreshing only the mirror left the
+        # legacy entry stale.
+        hass = _make_hass()
+        mirror = _fake_repo(category="integration")
+        legacy = _fake_repo(category="integration")
+        hacs, coordinator = _fake_hacs(
+            repos={
+                HACS_MIRROR_REPO_FULL_NAME: mirror,
+                HACS_LEGACY_REPO_FULL_NAME: legacy,
+            },
+            category="integration",
+        )
+        hass.data["hacs"] = hacs
+
+        await nudge.async_nudge_hacs_refresh(hass, "1.2.0")
+
+        for repo in (mirror, legacy):
+            repo.update_repository.assert_awaited_once_with(
+                ignore_issues=True, force=True
+            )
+        # One poke per refreshed candidate (both share the integration
+        # category, so both land on the same coordinator).
+        assert coordinator.async_update_listeners.call_count == 2
+        assert "1.2.0" in hass.data[DOMAIN][nudge._DATA_HACS_NUDGED_VERSIONS]
+
+    async def test_one_failing_candidate_does_not_skip_the_other(self):
+        hass = _make_hass()
+        mirror = _fake_repo()
+        mirror.update_repository = AsyncMock(side_effect=RuntimeError("github down"))
+        legacy = _fake_repo()
+        hacs, _ = _fake_hacs(
+            repos={
+                HACS_MIRROR_REPO_FULL_NAME: mirror,
+                HACS_LEGACY_REPO_FULL_NAME: legacy,
+            }
+        )
+        hass.data["hacs"] = hacs
+
+        await nudge.async_nudge_hacs_refresh(hass, "1.2.0")
+
+        legacy.update_repository.assert_awaited_once_with(
+            ignore_issues=True, force=True
+        )
+        # One completed refresh is enough to throttle this version.
+        assert "1.2.0" in hass.data[DOMAIN][nudge._DATA_HACS_NUDGED_VERSIONS]
+
+    async def test_every_candidate_failing_leaves_the_throttle_unset(self):
+        # Nothing was refreshed, so a later pass for this same version must
+        # still get its one refresh.
+        hass = _make_hass()
+        mirror = _fake_repo()
+        mirror.update_repository = AsyncMock(side_effect=RuntimeError("github down"))
+        legacy = _fake_repo()
+        legacy.update_repository = AsyncMock(side_effect=RuntimeError("github down"))
+        hacs, _ = _fake_hacs(
+            repos={
+                HACS_MIRROR_REPO_FULL_NAME: mirror,
+                HACS_LEGACY_REPO_FULL_NAME: legacy,
+            }
+        )
+        hass.data["hacs"] = hacs
+
+        await nudge.async_nudge_hacs_refresh(hass, "1.2.0")
+
+        mirror.update_repository.assert_awaited_once()
+        legacy.update_repository.assert_awaited_once()
+        assert "1.2.0" not in hass.data.get(DOMAIN, {}).get(
+            nudge._DATA_HACS_NUDGED_VERSIONS, set()
+        )
 
     async def test_uninstalled_mirror_falls_through_to_installed_legacy(self):
         # Legacy->mirror migration limbo: the mirror repo has been ADDED to

--- a/tests/src/unit/test_http_run_kwargs.py
+++ b/tests/src/unit/test_http_run_kwargs.py
@@ -7,10 +7,25 @@ alongside it, since the kwargs it builds are what that server task starts from.
 """
 
 import asyncio
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
 from ha_mcp.__main__ import _http_run_kwargs, _run_with_shutdown
+
+
+@pytest.fixture(autouse=True)
+def _no_startup_hacs_nudge():
+    """Keep the startup HACS nudge out of these tests.
+
+    ``_run_with_shutdown`` fires it as a background task; left real it would
+    reach PyPI and the Home Assistant WebSocket from a unit test.
+    """
+    with patch(
+        "ha_mcp.hacs_auto_refresh.maybe_refresh_hacs_after_update",
+        new=AsyncMock(return_value=None),
+    ):
+        yield
 
 
 def test_kwargs_request_stateless_streamable_http():


### PR DESCRIPTION
## What does this PR do?

Makes the paired custom-component update visible in HACS automatically
whenever the server updates. Today the server update gets detected
(Supervisor / PyPI), but the component update stays invisible for up to
~48 hours unless the user runs HACS's "Update information" by hand.

**Server side** (new `src/ha_mcp/hacs_auto_refresh.py`, started from
`_run_with_shutdown`, covering all entrypoints):
- On startup, when the server version changed since the last recorded pass
  (the just-updated case) or the boot-time update check reports a pending
  release, it sends `hacs/repository/refresh` for every **installed**
  candidate repository entry — the dedicated mirror
  (`homeassistant-ai/ha-mcp-integration`) and the legacy main-repo path
  (`homeassistant-ai/ha-mcp`).
- Fully advisory: every failure degrades to a debug log; retries spread
  over ~8 minutes cover HA/HACS still booting; a marker file in the data
  dir throttles repeat passes, so a per-conversation stdio spawn on an
  unchanged version costs one file read and no WebSocket traffic; embedded
  installs are skipped (the component's own nudge covers them);
  `HA_MCP_DISABLE_UPDATE_CHECK` opts out of this as well.

**Component side:**
- `hacs_nudge.py` now refreshes **all** installed candidate repositories
  instead of only the first match, so a legacy-path install is refreshed
  even when the mirror entry is also present.
- No component version bump: pending 1.3.3 already leads stable 1.3.2, and
  no services/arguments changed, so no `MIN_COMPONENT_VERSION` change.

Stacked on #2165 — reuses its `send_hacs_repository_refresh` helper.

## Type of change
- [x] ✨ New feature

## Testing
- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

## Checklist
- [x] I have updated documentation if needed (module docstrings; no
  user-docs change needed)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic HACS repository refresh after server startup when update checks detect a relevant change.
  * Refreshes all eligible installed repositories, including legacy installations.
  * Retries temporary connection issues and notifies Home Assistant after successful refreshes.

* **Bug Fixes**
  * A failed repository refresh no longer prevents other repositories from being refreshed.
  * HACS refresh failures no longer interrupt server startup or shutdown.
  * Refresh state is tracked separately for each Home Assistant installation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->