### PR TITLE
chore: Enable CodeRabbit auto-review on non-default base branches

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -2,6 +2,8 @@
 reviews:
   auto_review:
     drafts: true
+    base_branches:
+      - ".*"
     # Drafts here iterate push -> CI -> fix, which blows past the default
     # 5-commit pause and leaves the PR silently unreviewed. 0 disables the
     # pause so review keeps running until it stops finding anything.


### PR DESCRIPTION
## What does this PR do?

Sets `reviews.auto_review.base_branches: [".*"]` in `.coderabbit.yaml`.

The key defaults to `[]`, which restricts automatic review to PRs targeting
the default branch. A PR opened against any other base gets an "Auto reviews
are disabled on base/target branches other than the default branch" notice
instead of a review.

`base_branches` is additive — per the auto-review docs, "The default branch is
always included. `base_branches` extends the set of reviewed branches; it does
not replace the default branch." So PRs onto `master` are unaffected. `.*` is
the schema's documented match-all; an allowlist has nothing stable to
enumerate, since stack branch names are invented per PR.

Cost: those reviews draw on the same per-developer hourly allowance that
`auto_pause_after_reviewed_commits: 0` already spends faster.

Note: a `.coderabbit.yaml` change never applies to the PR making it —
CodeRabbit reads only the base branch's config on OSS repos, so this PR will
report `Configuration used: defaults` and the change takes effect on merge.

## Type of change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [x] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [ ] All automated tests pass (`uv run pytest`)
- [ ] Code follows style guidelines (`uv run ruff check`)

Config-only change, no Python touched. Verified the key name, type and
default against the schema `.coderabbit.yaml` pins
(`coderabbit.ai/integrations/schema.v2.json`), and that the file still parses.
`tests/src/unit/test_coderabbit_config.py` parses the file in CI.

## Checklist
- [ ] I have updated documentation if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Automatic code reviews now apply to pull requests targeting any base branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->