### PR TITLE
fix: keep hardcoded config-flow labels untranslated

### DIFF
--- a/.github/workflows/locale-sync.yml
+++ b/.github/workflows/locale-sync.yml
@@ -18,8 +18,9 @@ name: Locale Sync
 # which is what tells the bot the changed English is already covered).
 #
 # Verification is three layers. (1) Every returned string is validated
-# before it is written (placeholder, markup and panel-link parity, in the
-# script). (2) After a clean run, the content-completeness checks that PR CI
+# before it is written (placeholder, markup and panel-link parity, plus the
+# config flow's hardcoded option labels, in the script). (2) After a clean
+# run, the content-completeness checks that PR CI
 # skips run here under LOCALE_COMPLETENESS_CHECKS=1; a failure means the
 # output may be corrupt (the engine pasted English back, parity broke) and
 # BLOCKS the push — machine translations are recomputable, so dropping them

--- a/.github/workflows/locale-sync.yml
+++ b/.github/workflows/locale-sync.yml
@@ -18,9 +18,9 @@ name: Locale Sync
 # which is what tells the bot the changed English is already covered).
 #
 # Verification is three layers. (1) Every returned string is validated
-# before it is written (placeholder, markup and panel-link parity, plus the
-# config flow's hardcoded option labels, in the script). (2) After a clean
-# run, the content-completeness checks that PR CI
+# before it is written (placeholder, markup, formatting-tag and panel-link
+# parity, plus the config flow's hardcoded option labels, in the script).
+# (2) After a clean run, the content-completeness checks that PR CI
 # skips run here under LOCALE_COMPLETENESS_CHECKS=1; a failure means the
 # output may be corrupt (the engine pasted English back, parity broke) and
 # BLOCKS the push — machine translations are recomputable, so dropping them

--- a/custom_components/ha_mcp_tools/translations/nl.json
+++ b/custom_components/ha_mcp_tools/translations/nl.json
@@ -1,5 +1,6 @@
 {
   "common": {
+    "connect_local_lan": "Lokaal/LAN (wanneer Netwerktoegang \"Local network\" is): {url}",
     "oauth_not_serving": "Legacy OAuth levert deze nog niet — start Home Assistant opnieuw op wanneer je daarom wordt gevraagd, om ze te activeren."
   }
 }

--- a/scripts/translate_locales.py
+++ b/scripts/translate_locales.py
@@ -419,7 +419,10 @@ def build_plan(module: Any) -> Plan:
 
 _CONFIG_FLOW_PATH = REPO_ROOT / "custom_components" / "ha_mcp_tools" / "config_flow.py"
 _SELECTOR_LABEL_RE = re.compile(r'label="([^"]+)"')
-_QUOTED_RE = re.compile(r'"([^"]+)"')
+# English sources quote with straight or typographic marks — both already occur
+# in the shipped catalogs — and the label check has to see the quoted text
+# either way, or the spelling of a quote silently decides whether it applies.
+_QUOTED_RE = re.compile(r'["“”«»„]([^"“”«»„]+)["“”«»„]')
 
 
 @lru_cache(maxsize=1)

--- a/scripts/translate_locales.py
+++ b/scripts/translate_locales.py
@@ -26,9 +26,10 @@ down is a HUMAN: hand-edit the translations, run
 run sees nothing stale and no-ops. Hand-edits always win; the machine only
 touches strings whose English changed.
 Every returned string is validated (placeholder parity, the settings UI markup
-allowlist, formatting-tag parity, panel-link parity) before it is written; a
-failure leaves that string unwritten and the run red rather than shipping a
-broken translation.
+allowlist, formatting-tag parity, panel-link parity, and the config flow's
+hardcoded option labels staying untranslated) before it is written; a failure
+leaves that string unwritten and the run red rather than shipping a broken
+translation.
 
 Rate limits and outages: requests are paced under the free-tier rate and
 retry transient errors with backoff; a persistently failing batch marks its
@@ -56,6 +57,7 @@ import time
 from collections import Counter
 from collections.abc import Container
 from dataclasses import dataclass, field
+from functools import lru_cache
 from pathlib import Path
 from typing import Any, Literal, NamedTuple
 
@@ -415,10 +417,49 @@ def build_plan(module: Any) -> Plan:
     return plan
 
 
+_CONFIG_FLOW_PATH = REPO_ROOT / "custom_components" / "ha_mcp_tools" / "config_flow.py"
+_SELECTOR_LABEL_RE = re.compile(r'label="([^"]+)"')
+_QUOTED_RE = re.compile(r'"([^"]+)"')
+
+
+@lru_cache(maxsize=1)
+def _hardcoded_option_labels() -> tuple[str, ...]:
+    """Config-flow selector labels, which read English on every reader's form.
+
+    Quoting alone does not say whether a string may be translated: catalogs
+    correctly translate quoted cross-references to their own option labels,
+    and Home Assistant translates its own buttons ("Add entry"). What must
+    survive verbatim is the narrower class this returns — labels our config
+    flow hardcodes in Python, so no catalog can localise them and a reader
+    told to pick a translated one goes looking for an option that is not on
+    the form. Read from the source instead of listed here so a rename cannot
+    strand a stale copy; ``test_connect_local_lan_quotes_the_bind_host_option``
+    guards the rename against the catalogs.
+    """
+    return tuple(_SELECTOR_LABEL_RE.findall(_CONFIG_FLOW_PATH.read_text("utf-8")))
+
+
+def _untranslatable_label_dropped(english: str, translated: str) -> str | None:
+    """The hardcoded label this translation localised away, if any."""
+    for quoted in _QUOTED_RE.findall(english):
+        for label in _hardcoded_option_labels():
+            if (
+                label == quoted or label.startswith(f"{quoted} ")
+            ) and quoted not in translated:
+                return quoted
+    return None
+
+
 def _validate(item: WorkItem, translated: Any) -> str | None:
     """The reason a translation is unusable for this item, or None."""
     if not isinstance(translated, str) or not translated.strip():
         return "empty or non-string translation"
+    dropped = _untranslatable_label_dropped(item.english, translated)
+    if dropped is not None:
+        return (
+            f"the on-screen option {dropped!r} is hardcoded in the config flow "
+            "and has to stay untranslated"
+        )
     if set(_PLACEHOLDER_RE.findall(item.english)) != set(
         _PLACEHOLDER_RE.findall(translated)
     ):

--- a/scripts/translate_locales.py
+++ b/scripts/translate_locales.py
@@ -436,12 +436,14 @@ def _hardcoded_option_labels() -> tuple[str, ...]:
     strand a stale copy; ``test_connect_local_lan_quotes_the_bind_host_option``
     guards the rename against the catalogs.
     """
-    return tuple(_SELECTOR_LABEL_RE.findall(_CONFIG_FLOW_PATH.read_text("utf-8")))
+    labels: list[str] = _SELECTOR_LABEL_RE.findall(_CONFIG_FLOW_PATH.read_text("utf-8"))
+    return tuple(labels)
 
 
 def _untranslatable_label_dropped(english: str, translated: str) -> str | None:
     """The hardcoded label this translation localised away, if any."""
-    for quoted in _QUOTED_RE.findall(english):
+    quoted_texts: list[str] = _QUOTED_RE.findall(english)
+    for quoted in quoted_texts:
         for label in _hardcoded_option_labels():
             if (
                 label == quoted or label.startswith(f"{quoted} ")

--- a/tests/src/unit/test_translate_locales.py
+++ b/tests/src/unit/test_translate_locales.py
@@ -118,6 +118,41 @@ class TestValidate:
         assert _validate(_item(english=english), wrong) is not None
 
 
+class TestHardcodedOptionLabels:
+    """The config flow hardcodes a couple of selector labels in Python, so
+    Home Assistant shows them in English whatever the reader's language is.
+    A catalog that localises one sends the reader looking for an option that
+    is not on the form — the failure that stopped a whole sync run, since the
+    engine only had a prose rule telling it not to."""
+
+    def test_the_label_set_is_read_from_the_config_flow(self) -> None:
+        # Without this the check degrades silently: an empty label set accepts
+        # every translation and still reports a clean run.
+        labels = translate_locales._hardcoded_option_labels()
+        assert labels, "no selector labels found — the config flow was restructured"
+        assert any(label.startswith("Local network") for label in labels)
+
+    def test_rejects_a_localised_hardcoded_label(self) -> None:
+        english = 'Local/LAN (when Network access is "Local network"): {url}'
+        localised = 'Lokaal/LAN (wanneer Netwerktoegang "Lokaal netwerk" is): {url}'
+        kept = 'Lokaal/LAN (wanneer Netwerktoegang "Local network" is): {url}'
+        assert _validate(_item(section="component", english=english), localised)
+        assert _validate(_item(section="component", english=english), kept) is None
+
+    def test_leaves_other_quoted_text_translatable(self) -> None:
+        # "Add entry" is Home Assistant's own button: HA translates it, so
+        # every shipped catalog translates the quote too. Only labels the
+        # config flow hardcodes are pinned to English.
+        english = 'Not installed — press "Add entry" on this integration\'s page'
+        assert (
+            _validate(
+                _item(section="component", english=english),
+                'Nicht installiert — klicke auf "Eintrag hinzufügen"',
+            )
+            is None
+        )
+
+
 class TestChunk:
     def test_splits_on_the_character_budget(self) -> None:
         big = "x" * (translate_locales._MAX_CHARS_PER_REQUEST - 10)

--- a/tests/src/unit/test_translate_locales.py
+++ b/tests/src/unit/test_translate_locales.py
@@ -139,6 +139,13 @@ class TestHardcodedOptionLabels:
         assert _validate(_item(section="component", english=english), localised)
         assert _validate(_item(section="component", english=english), kept) is None
 
+    def test_reads_the_label_through_typographic_quotes(self) -> None:
+        # Shipped English already quotes both ways, so which mark an author
+        # reached for must not decide whether the label is protected.
+        english = "Local/LAN (when Network access is “Local network”): {url}"
+        localised = 'Lokaal/LAN (wanneer Netwerktoegang "Lokaal netwerk" is): {url}'
+        assert _validate(_item(section="component", english=english), localised)
+
     def test_leaves_other_quoted_text_translatable(self) -> None:
         # "Add entry" is Home Assistant's own button: HA translates it, so
         # every shipped catalog translates the quote too. Only labels the


### PR DESCRIPTION
## What does this PR do?

`_validate` in `scripts/translate_locales.py` rejects a translation that localises a selector label the config flow hardcodes in Python, and the missing `nl` value for `common.connect_local_lan` is authored by hand.

The locale-sync run on 2026-08-08 failed its content-completeness verification and pushed nothing — for every language, not just the one at fault. Filling `nl` for the first time, the engine localised the on-screen option named in that key: `"Local network"` became `"Lokaal netwerk"`. That option label is hardcoded in `config_flow.py`, so it reads English on the form whatever language the reader has selected. The prompt already asked for the literal to survive; nothing enforced it.

Quoting alone is not the signal. Over the 3232 English/translation pairs shipped at the time, a naive "quoted text must stay English" check rejects 86 — 72 in the settings catalogs, where one setting's help text quotes another's title, and 6 in the component catalogs, where every locale that has the key translates `"Add entry"`, correctly, because Home Assistant translates that button itself. The discriminator is where the string comes from: labels the config flow hardcodes cannot be translated, everything else can. The label set is read from `config_flow.py` at runtime rather than duplicated, so a rename cannot strand a stale copy, and the quoted text is matched through straight and typographic marks alike.

The module docstring and the workflow header both enumerate what the script validates, so both name the new check; the header additionally picked up formatting-tag parity, which it had been missing against that same list. That comment is the entire `.github/` diff.

## Type of change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

No agent testing: this changes a build-time validation script and one catalog string, neither of which an agent exercises at runtime.

Beyond the suite:

- Four unit tests cover the rejection, the same rejection through typographic quotes, a check that other quoted material stays translatable, and one asserting the extracted label set is non-empty — without that last one, a rename in `config_flow.py` would degrade the check into a no-op that passes everything while still reporting a clean run.
- Each test was verified by mutating the condition it guards — not by deleting the call, which leaves an absence-assert green by construction — with each mutation naming exactly the assertion it should, and the suite green again after every restore.
- The content-completeness suites, which the sync gates on and PR CI skips, produce the same failure set on this branch as on the base commit without these changes.
- `generate_locales.py` reports no updates, so the projections stay consistent with the edited catalog.
- The `nl` key's English is unchanged since the last baseline repin, so the sync will not retranslate it and no repin is included. Repinning would also freeze the strings legitimately waiting for retranslation.

## Checklist
- [x] I have updated documentation if needed
