### PR TITLE
feat: add the Polish (pl) locale across all four translated surfaces

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -755,7 +755,7 @@ identity holds by construction.
 
 A language ships on all four surfaces or not at all —
 `tests/src/unit/test_locale_parity.py` enforces it. One Home Assistant language
-code (`de`, `es`, `fr`, `it`, `nl`, `ru`, `zh-Hans`) names every file:
+code (`de`, `es`, `fr`, `it`, `nl`, `pl`, `ru`, `zh-Hans`) names every file:
 `src/ha_mcp/settings_ui/locales/<code>.json`,
 `custom_components/ha_mcp_tools/translations/<code>.json`, and
 `homeassistant-addon{,-dev}/translations/<code>.yaml`.

--- a/custom_components/ha_mcp_tools/translations/pl.json
+++ b/custom_components/ha_mcp_tools/translations/pl.json
@@ -1,0 +1,5 @@
+{
+  "common": {
+    "oauth_not_serving": "Legacy OAuth jeszcze ich nie udostępnia — uruchom ponownie Home Assistant, gdy pojawi się taka prośba, aby je aktywować."
+  }
+}

--- a/custom_components/ha_mcp_tools/translations/pl.json
+++ b/custom_components/ha_mcp_tools/translations/pl.json
@@ -1,5 +1,5 @@
 {
   "common": {
-    "oauth_not_serving": "Legacy OAuth jeszcze ich nie udostępnia — uruchom ponownie Home Assistant, gdy pojawi się taka prośba, aby je aktywować."
+    "oauth_not_serving": "Legacy OAuth jeszcze ich nie udostępnia — uruchom ponownie Home Assistanta, gdy pojawi się taka prośba, aby je aktywować."
   }
 }

--- a/homeassistant-addon-dev/translations/pl.yaml
+++ b/homeassistant-addon-dev/translations/pl.yaml
@@ -1,0 +1,258 @@
+---
+# GENERATED FILE — do not edit. Translations live in
+# src/ha_mcp/settings_ui/locales/pl.json (keys addon.*, features.*,
+# addon_dev.*); regenerate with: python scripts/generate_locales.py
+configuration:
+  backup_hint:
+    name: Full-HA snapshot suggestion level (LLM-facing)
+    description: 'Tunes the wording of the hint the LLM sees in the
+
+      `ha_manage_backup(scope=''snapshot'')` tool description for when to
+
+      suggest a full Home Assistant tarball backup before risky operations
+
+      (e.g. mass device deletes). Affects ONLY this one LLM-facing prompt
+
+      sentence.
+
+
+      For per-edit automatic snapshots of automations / scripts / helpers /
+
+      etc., use the separate **Enable auto-backup of edits** toggle below.'
+  secret_path:
+    name: Secret path override
+    description: 'Optional custom HTTP path for the MCP server. Leave empty to use
+      the auto-generated secure path.
+
+      '
+  enable_tool_search:
+    name: Enable tool search
+    description: 'Replace the full tool catalog with search-based discovery. Reduces
+      idle context by roughly 90%, to about 5K tokens. ⚠️ Do NOT enable this in clients
+      with their own built-in tool search / deferred tools (claude.ai, Claude Desktop,
+      Claude Code) — the two search layers conflict, and the client''s built-in tool
+      search is the better choice there; leave this off. Whether tools are deferred
+      depends on your client and model combination: use this when your setup loads
+      the full catalog up front — models without native deferred tools (e.g. Gemini,
+      OpenAI-compatible local models, Claude Haiku), clients that inline all tool
+      schemas regardless of model (e.g. GitHub Copilot CLI), or smaller context windows.
+      Some Codex models and ChatGPT include deferred tools too — check your client/model
+      directly to confirm its features so you don''t leave this enabled unnecessarily.
+      Tools are found via ha_search_tools and executed via categorized proxies (read/write/delete).
+      Requires restart to take effect.'
+  enable_tool_security_policies:
+    name: Enable Tool Security Policies (advanced)
+    description: Gate high-stakes tool calls (lock/alarm control, automation writes,
+      etc.) behind user approval. When a guarded tool is called, the agent tells the
+      user to open the Tool Security Policies tab in the web UI and click Approve
+      before the call proceeds. Per-tool rules with optional argument conditions are
+      configured in the Tool Security Policies tab. Off by default. Requires restart
+      to take effect.
+  enable_security_policy_tool:
+    name: Let AI agents edit tool security policies
+    description: 'Registers the ha_manage_security_policy tool, which lets connected
+      AI agents read and rewrite the tool security policies — including removing approval
+      gates. Off by default. Independent of the Tool Security Policies option above:
+      this controls who can edit the rules, not whether they are enforced. The tool
+      cannot see or decide pending approvals. To keep a human in the loop, gate the
+      tool before enabling it: switch on "security gated" for Manage Security Policy
+      in the Tools tab of the web UI. Requires restart to take effect.'
+  read_only_mode:
+    name: Read Only Mode
+    description: Toggles all write tools off, and removes ability for tools to make
+      any write or destructive calls. Mixed read/write tools (backups, add-ons, energy
+      preferences, voice pipelines, and code mode when enabled) stay available with
+      their write operations blocked. Same toggle as the web UI Tools tab. Off by
+      default. Requires restart to take effect.
+  redact_secrets:
+    name: Redact Secrets
+    description: Redacts secrets from tool responses before they reach the AI assistant.
+      Add-on options and integration fields marked as passwords are replaced with
+      a set/empty marker (so "is this credential configured?" stays answerable), and
+      other tool responses are scrubbed of secret values the server has already seen
+      (values shorter than 6 characters are skipped, since replacing tiny fragments
+      would corrupt unrelated output). Fields not marked as passwords by their schema
+      cannot be detected. Off by default.
+  enable_beta_features:
+    name: Enable beta features (master)
+    description: ⚠ DANGER — these tools can PERMANENTLY DAMAGE your Home Assistant
+      installation. They write to your YAML config, your filesystem, install custom
+      components, run arbitrary sandboxed Python, and edit tool docstrings the AI
+      sees. There is no warranty and no support guarantee — you enable them at your
+      OWN RISK. Take a Home Assistant backup before turning this on, and never enable
+      in production without one. Master gate for the 5 experimental sub-flags below;
+      sub-flags are ignored at runtime while this master is off, even when explicitly
+      set to true. The same toggle is also surfaced in the web settings UI under "Beta
+      features (dangerous)" — either surface reflects the other on restart.
+  enable_yaml_config_editing:
+    name: Enable YAML config editing (beta)
+    description: Beta feature. Allows AI assistants to add, replace, or remove top-level
+      keys in configuration.yaml and packages/*.yaml. Only whitelisted keys are allowed
+      (e.g., template, sensor, command_line, mqtt, knx); core keys like homeassistant,
+      http, and recorder are blocked. Each edit validates YAML syntax, runs a config
+      check, and creates an automatic backup. Changes to most keys require a full
+      HA restart to take effect. See docs/beta.md for known limitations. Dedicated
+      tools (automations, scripts, scenes, helpers, template sensors) should be preferred
+      when available. REQUIRES the master "Enable beta features" toggle above (and
+      in the web UI) to be on — otherwise this sub-flag is ignored at runtime regardless
+      of its value here.
+  enable_yaml_packages_automation:
+    name: Allow automation in packages/*.yaml
+    description: Sub-toggle of YAML config editing. When on, ha_config_set_yaml accepts
+      yaml_path='automation' inside packages/*.yaml. When off, the call is rejected
+      both client-side and server-side. The storage-mode tool (ha_config_set_automation)
+      is unaffected. Default OFF; only takes effect when "Enable YAML config editing"
+      above is also on.
+  enable_yaml_packages_script:
+    name: Allow script in packages/*.yaml
+    description: Sub-toggle of YAML config editing. When on, ha_config_set_yaml accepts
+      yaml_path='script' inside packages/*.yaml. When off, the call is rejected both
+      client-side and server-side. The storage-mode tool (ha_config_set_script) is
+      unaffected. Default OFF; only takes effect when "Enable YAML config editing"
+      above is also on.
+  enable_yaml_packages_scene:
+    name: Allow scene in packages/*.yaml
+    description: Sub-toggle of YAML config editing. When on, ha_config_set_yaml accepts
+      yaml_path='scene' inside packages/*.yaml. When off, the call is rejected both
+      client-side and server-side. The storage-mode tool (ha_config_set_scene) is
+      unaffected. Default OFF; only takes effect when "Enable YAML config editing"
+      above is also on.
+  enable_yaml_edit_confirm:
+    name: Require confirmation for YAML edits (diff preview)
+    description: 'Sub-toggle of YAML config editing, ON by default (recommended).
+      The first ha_config_set_yaml call returns a unified diff of exactly what would
+      change on disk plus a confirm token and writes nothing; the edit only lands
+      when the call is repeated with that token. Exists so unintended changes outside
+      the requested edit are caught before they reach disk (issue #1720). Turn off
+      only to save one round-trip per edit.'
+  enable_code_mode:
+    name: Enable custom tool sandbox (beta)
+    description: Beta feature. Enables the ha_manage_custom_tool tool, which lets
+      AI assistants create, run, save, and delete custom Python code in a secure sandbox
+      when no built-in tool can handle the request. Code runs in an isolated interpreter
+      with no filesystem or arbitrary network access. Sandbox code can hit the HA
+      REST API (api_get/api_post), send WebSocket commands (ws_send), call existing
+      MCP tools (call_tool), or remove a saved tool (delete_saved_tool). Saved tools
+      persist to /data/saved_tools.json by default so they survive add-on restarts,
+      and are visible to any client that can connect. See docs/beta.md for known limitations.
+      Requires restart to take effect. REQUIRES the master "Enable beta features"
+      toggle above (and in the web UI) to be on — otherwise this sub-flag is ignored
+      at runtime regardless of its value here.
+  enable_lite_docstrings:
+    name: Enable lite tool docstrings (beta)
+    description: 'Beta feature. Replaces the docstrings on a handful of heavy ha-mcp
+      tools (automations, scripts, scenes, helpers, dashboards, ha_call_service, ha_config_set_yaml)
+      with shorter variants that defer schema and example detail to the ha_get_skill_guide
+      tool (or its skill:// resource). WARNING: this reduces idle token usage, but
+      may degrade LLM performance — the trimmed descriptions rely on the LLM actually
+      calling the skill tool or reading the skill resource for detail, which is not
+      guaranteed (some models will skip the extra tool call and end up with less guidance
+      than they had before). Best paired with a client that supports MCP resources
+      or with enable_tool_search. Requires restart to take effect. REQUIRES the master
+      "Enable beta features" toggle above (and in the web UI) to be on — otherwise
+      this sub-flag is ignored at runtime regardless of its value here.'
+  enable_mandatory_bps:
+    name: Attach best-practice skills on writes
+    description: 'Master switch for the write-tool skill content delivery feature
+      (issue #1182). When enabled (default), the six config write tools (automations,
+      scripts, scenes, helpers, dashboards, raw YAML) attach the canonical Home Assistant
+      best-practice reference files under `skill_content` on every successful write,
+      plus auto-embed any reference sections cited by best-practice warnings. Each
+      tool also exposes a per-call `MandatoryBPS` parameter the agent can set to false
+      on subsequent calls once it has the content. When this master switch is off,
+      NO skill_content goes out regardless of the per-call parameter or BP warnings.
+      Recommended ON as the first choice; disable only for models with very small
+      context windows. Turning this off may degrade write accuracy. Requires restart
+      to take effect.'
+  enable_strict_mandatory_bps:
+    name: Strict best-practices mode
+    description: 'Strict mode: prevents the client from using the tool until it can
+      prove that it read the best practices. While on, the six best-practice write
+      tools (automations, scripts, scenes, helpers, dashboards, raw YAML) are blocked
+      and return an error directing the client to read the best-practices skill via
+      ha_get_skill_guide and pass back the acknowledgment key it obtains there. While
+      on, the ha_get_skill_guide tool is locked enabled — it is the only publisher
+      of the acknowledgment key. Child of the "Attach best-practice skills on writes"
+      option above and inert while that parent is off. Requires restart to take effect.'
+  enable_filesystem_tools:
+    name: Enable filesystem tools (beta)
+    description: 'Sets HAMCP_ENABLE_FILESYSTEM_TOOLS=true. Enables direct file read/write
+      access to your Home Assistant filesystem. WARNING: This gives the MCP server
+      sensitive direct file access to your system. Only enable if you trust the AI
+      assistant with file operations. Requires restart to take effect. REQUIRES the
+      master "Enable beta features" toggle above (and in the web UI) to be on — otherwise
+      this sub-flag is ignored at runtime regardless of its value here.'
+  enable_dashboard_screenshot:
+    name: Enable dashboard screenshot mode (beta)
+    description: Beta feature — disabled by default. Adds the ha_get_dashboard_screenshot
+      tool plus include_screenshot / return_screenshot options on the dashboard get/set
+      tools, so AI assistants can inspect one or more responsive Lovelace images (e.g.
+      to verify a dashboard they just created). Supports stable named views, mobile/tablet/desktop
+      batches, and PNG/JPEG/WebP/BMP output. Rendering runs in a separate, opt-in
+      engine — balloob's "Puppet" add-on (headless Chromium) — which you install once
+      (add balloob's add-on repository, then install "Puppet") and give a long-lived
+      access token; on Docker/Container deployments you run that engine as a sidecar
+      and set HAMCP_DASHBOARD_SCREENSHOT_ENGINE_URL. Nothing heavy is installed unless
+      you both enable this and install the engine. Requires restart to take effect.
+      REQUIRES the master "Enable beta features" toggle above (and in the web UI)
+      to be on — otherwise this sub-flag is ignored at runtime regardless of its value
+      here.
+  enable_auto_backup:
+    name: Enable auto-backup of edits
+    description: Captures a per-entity snapshot before every wrapped write/destructive
+      MCP tool call (automation, script, scene, helper, dashboard, label, category,
+      group, zone, area, calendar, todo, entity, integration, and sibling remove/delete
+      tools). Snapshots are saved as YAML files under /data/ha_mcp_backups/ (override
+      via HAMCP_BACKUP_DIR) and listed, restored, or deleted via the Backups tab in
+      the web settings UI or via ha_manage_backup(scope='edits', ...). Best-effort
+      — failures log a WARNING but never block the underlying write. On by default;
+      uncheck to opt out. Requires restart to take effect.
+  auto_backup_throttle_minutes:
+    name: Auto-backup throttle (minutes)
+    description: Per-entity throttle window. 0 (default) captures a snapshot on every
+      wrapped write. N>0 captures at most one snapshot per N minutes per entity. Range
+      0–1440.
+  auto_backup_retain_per_entity:
+    name: Auto-backup retention (per entity)
+    description: Maximum number of snapshots kept per entity. Older snapshots beyond
+      this cap are rotated out on each successful capture. Default 100, range 1–10000.
+  enable_snapshot_delete:
+    name: Allow snapshot deletion
+    description: Lets ha_manage_backup delete full HA snapshot tarballs (scope='snapshot',
+      action='delete'). Off by default — a snapshot may be the last recovery point
+      after a mistaken change, so a human must opt in here. Even when on, scheduled
+      backups, the newest remaining snapshot, and anything younger than the age floor
+      below stay protected.
+  snapshot_delete_min_age_days:
+    name: Minimum snapshot age to delete (days)
+    description: A snapshot must be at least this old before it can be deleted. Range
+      0–365; 0 disables the floor (the newest-snapshot and scheduled-backup protections
+      still apply). Default 7.
+  tool_search_max_results:
+    name: Tool search max results
+    description: 'Maximum number of tools returned by ha_search_tools when tool search
+      is enabled. Lower values (2-3) save context tokens but may miss relevant tools.
+      Range: 2-10. Requires restart.'
+  disabled_tools:
+    name: Disabled tools (comma-separated)
+    description: Tools listed here are forced off and locked in the web Settings UI
+      (Tools tab) — they cannot be re-enabled there without unsetting this option
+      first. A small set of mandatory tools (ha_search, ha_get_overview, ha_get_state,
+      ha_report_issue, ha_manage_backup) cannot be disabled and keep running even
+      if listed here. ha_get_skill_guide can be disabled only while strict best-practices
+      mode (enable_strict_mandatory_bps) is off. Comma-separated tool names (e.g.
+      ha_call_event,ha_eval_template).
+  pinned_tools:
+    name: Pinned tools (comma-separated)
+    description: Tools listed here are locked pinned — they appear at the top of the
+      Tools tab and cannot be unpinned from the web Settings UI without unsetting
+      this option first. Useful in combination with Tool Search. Comma-separated tool
+      names.
+  verify_ssl:
+    name: Verify TLS certificate
+    description: Verify the Home Assistant server's TLS certificate. The add-on connects
+      via the Supervisor proxy, so this normally has no effect and should stay enabled.
+      Disable only if you've reconfigured the add-on to talk to HA over a public HTTPS
+      hostname with a self-signed certificate or hostname mismatch. Disabling weakens
+      transport security — leave on unless you know you need it. Requires restart
+      to take effect.

--- a/homeassistant-addon/translations/pl.yaml
+++ b/homeassistant-addon/translations/pl.yaml
@@ -1,0 +1,160 @@
+---
+# GENERATED FILE — do not edit. Translations live in
+# src/ha_mcp/settings_ui/locales/pl.json (keys addon.*, features.*,
+# addon_stable.*); regenerate with: python scripts/generate_locales.py
+configuration:
+  backup_hint:
+    name: Full-HA snapshot suggestion level (LLM-facing)
+    description: 'Tunes the wording of the hint the LLM sees in the
+
+      `ha_manage_backup(scope=''snapshot'')` tool description for when to
+
+      suggest a full Home Assistant tarball backup before risky operations
+
+      (e.g. mass device deletes). Affects ONLY this one LLM-facing prompt
+
+      sentence.
+
+
+      For per-edit automatic snapshots of automations / scripts / helpers /
+
+      etc., use the separate **Enable auto-backup of edits** toggle below.'
+  secret_path:
+    name: Secret path override
+    description: 'Optional custom HTTP path for the MCP server. Leave empty to use
+      the auto-generated secure path.
+
+      '
+  enable_tool_search:
+    name: Enable tool search
+    description: 'Replace the full tool catalog with search-based discovery. Reduces
+      idle context by roughly 90%, to about 5K tokens. ⚠️ Do NOT enable this in clients
+      with their own built-in tool search / deferred tools (claude.ai, Claude Desktop,
+      Claude Code) — the two search layers conflict, and the client''s built-in tool
+      search is the better choice there; leave this off. Whether tools are deferred
+      depends on your client and model combination: use this when your setup loads
+      the full catalog up front — models without native deferred tools (e.g. Gemini,
+      OpenAI-compatible local models, Claude Haiku), clients that inline all tool
+      schemas regardless of model (e.g. GitHub Copilot CLI), or smaller context windows.
+      Some Codex models and ChatGPT include deferred tools too — check your client/model
+      directly to confirm its features so you don''t leave this enabled unnecessarily.
+      Tools are found via ha_search_tools and executed via categorized proxies (read/write/delete).
+      Requires an add-on restart to take effect — then reconnect or refresh the MCP
+      server in your AI client so it reloads the tool list. Restarting the add-on
+      alone does NOT refresh a client''s cached tool list; this applies after changing
+      any setting here.'
+  tool_search_max_results:
+    name: Tool search max results
+    description: 'Maximum number of tools returned by ha_search_tools when tool search
+      is enabled. Lower values (2-3) save context tokens but may miss relevant tools.
+      Range: 2-10. Requires restart.'
+  enable_tool_security_policies:
+    name: Enable Tool Security Policies (advanced)
+    description: Gate high-stakes tool calls (lock/alarm control, automation writes,
+      etc.) behind user approval. When a guarded tool is called, the agent tells the
+      user to open the Tool Security Policies tab in the web UI and click Approve
+      before the call proceeds. Per-tool rules with optional argument conditions are
+      configured in the Tool Security Policies tab. Off by default. Requires restart
+      to take effect.
+  enable_security_policy_tool:
+    name: Let AI agents edit tool security policies
+    description: 'Registers the ha_manage_security_policy tool, which lets connected
+      AI agents read and rewrite the tool security policies — including removing approval
+      gates. Off by default. Independent of the Tool Security Policies option above:
+      this controls who can edit the rules, not whether they are enforced. The tool
+      cannot see or decide pending approvals. To keep a human in the loop, gate the
+      tool before enabling it: switch on "security gated" for Manage Security Policy
+      in the Tools tab of the web UI. Requires restart to take effect.'
+  read_only_mode:
+    name: Read Only Mode
+    description: Toggles all write tools off, and removes ability for tools to make
+      any write or destructive calls. Mixed read/write tools (backups, add-ons, energy
+      preferences, voice pipelines, and code mode when enabled) stay available with
+      their write operations blocked. Same toggle as the web UI Tools tab. Off by
+      default. Requires restart to take effect.
+  redact_secrets:
+    name: Redact Secrets
+    description: Redacts secrets from tool responses before they reach the AI assistant.
+      Add-on options and integration fields marked as passwords are replaced with
+      a set/empty marker (so "is this credential configured?" stays answerable), and
+      other tool responses are scrubbed of secret values the server has already seen
+      (values shorter than 6 characters are skipped, since replacing tiny fragments
+      would corrupt unrelated output). Fields not marked as passwords by their schema
+      cannot be detected. Off by default.
+  enable_mandatory_bps:
+    name: Attach best-practice skills on writes
+    description: 'Master switch for the write-tool skill content delivery feature
+      (issue #1182). When enabled (default), the six config write tools (automations,
+      scripts, scenes, helpers, dashboards, raw YAML) attach the canonical Home Assistant
+      best-practice reference files under `skill_content` on every successful write,
+      plus auto-embed any reference sections cited by best-practice warnings. Each
+      tool also exposes a per-call `MandatoryBPS` parameter the agent can set to false
+      on subsequent calls once it has the content. When this master switch is off,
+      NO skill_content goes out regardless of the per-call parameter or BP warnings.
+      Recommended ON as the first choice; disable only for models with very small
+      context windows. Turning this off may degrade write accuracy. Requires restart
+      to take effect.'
+  enable_strict_mandatory_bps:
+    name: Strict best-practices mode
+    description: 'Strict mode: prevents the client from using the tool until it can
+      prove that it read the best practices. While on, the six best-practice write
+      tools (automations, scripts, scenes, helpers, dashboards, raw YAML) are blocked
+      and return an error directing the client to read the best-practices skill via
+      ha_get_skill_guide and pass back the acknowledgment key it obtains there. While
+      on, the ha_get_skill_guide tool is locked enabled — it is the only publisher
+      of the acknowledgment key. Child of the "Attach best-practice skills on writes"
+      option above and inert while that parent is off. Requires restart to take effect.'
+  disabled_tools:
+    name: Disabled tools (comma-separated)
+    description: Tools listed here are forced off and locked in the web Settings UI
+      (Tools tab) — they cannot be re-enabled there without unsetting this option
+      first. A small set of mandatory tools (ha_search, ha_get_overview, ha_get_state,
+      ha_report_issue, ha_manage_backup) cannot be disabled and keep running even
+      if listed here. ha_get_skill_guide can be disabled only while strict best-practices
+      mode (enable_strict_mandatory_bps) is off. Comma-separated tool names (e.g.
+      ha_call_event,ha_eval_template).
+  pinned_tools:
+    name: Pinned tools (comma-separated)
+    description: Tools listed here are locked pinned — they appear at the top of the
+      Tools tab and cannot be unpinned from the web Settings UI without unsetting
+      this option first. Useful in combination with Tool Search. Comma-separated tool
+      names.
+  enable_auto_backup:
+    name: Enable auto-backup of edits
+    description: Captures a per-entity snapshot before every wrapped write/destructive
+      MCP tool call (automation, script, scene, helper, dashboard, label, category,
+      group, zone, area, calendar, todo, entity, integration, and sibling remove/delete
+      tools). Snapshots are saved as YAML files under /data/ha_mcp_backups/ (override
+      via HAMCP_BACKUP_DIR) and listed, restored, or deleted via the Backups tab in
+      the web settings UI or via ha_manage_backup(scope='edits', ...). Best-effort
+      — failures log a WARNING but never block the underlying write. On by default;
+      uncheck to opt out. Requires restart to take effect.
+  auto_backup_throttle_minutes:
+    name: Auto-backup throttle (minutes)
+    description: Per-entity throttle window. 0 (default) captures a snapshot on every
+      wrapped write. N>0 captures at most one snapshot per N minutes per entity. Range
+      0–1440.
+  auto_backup_retain_per_entity:
+    name: Auto-backup retention (per entity)
+    description: Maximum number of snapshots kept per entity. Older snapshots beyond
+      this cap are rotated out on each successful capture. Default 100, range 1–10000.
+  enable_snapshot_delete:
+    name: Allow snapshot deletion
+    description: Lets ha_manage_backup delete full HA snapshot tarballs (scope='snapshot',
+      action='delete'). Off by default — a snapshot may be the last recovery point
+      after a mistaken change, so a human must opt in here. Even when on, scheduled
+      backups, the newest remaining snapshot, and anything younger than the age floor
+      below stay protected.
+  snapshot_delete_min_age_days:
+    name: Minimum snapshot age to delete (days)
+    description: A snapshot must be at least this old before it can be deleted. Range
+      0–365; 0 disables the floor (the newest-snapshot and scheduled-backup protections
+      still apply). Default 7.
+  verify_ssl:
+    name: Verify TLS certificate
+    description: Verify the Home Assistant server's TLS certificate. The add-on connects
+      via the Supervisor proxy, so this normally has no effect and should stay enabled.
+      Disable only if you've reconfigured the add-on to talk to HA over a public HTTPS
+      hostname with a self-signed certificate or hostname mismatch. Disabling weakens
+      transport security — leave on unless you know you need it. Requires restart
+      to take effect.

--- a/src/ha_mcp/settings_ui/locales/pl.json
+++ b/src/ha_mcp/settings_ui/locales/pl.json
@@ -1,0 +1,22 @@
+{
+  "meta": {
+    "native_name": "Polski",
+    "dir": "ltr"
+  },
+  "messages": {
+    "policies.pending.decision.approved": "zatwierdzone",
+    "policies.pending.decision.denied": "odrzucone",
+    "policies.operators.exists": "istnieje",
+    "policies.operators.eq": "równa się",
+    "policies.operators.neq": "NIE równa się",
+    "policies.operators.in": "jest jednym z",
+    "policies.operators.not_in": "NIE jest jednym z",
+    "policies.operators.contains": "zawiera",
+    "policies.operators.regex": "pasuje do wyrażenia regularnego",
+    "policies.operators.gt": "jest większe niż",
+    "policies.operators.lt": "jest mniejsze niż",
+    "accessibility.storage_blocked": "Twoja przeglądarka blokuje przechowywanie danych witryny; wybrane opcje obowiązują tylko w tej sesji.",
+    "policies.pending.already_decided": "To zatwierdzenie zostało już {decision}, prawdopodobnie przez inną kartę lub sesję.",
+    "policies.operators.exists_long": "jest obecne (dowolna wartość)"
+  }
+}


### PR DESCRIPTION
## What does this PR do?

Adds Polish on all four translated surfaces: the canonical settings store, the component config-flow catalog, and both add-on YAML flavors.

Polish is the largest untranslated language by installation base after Dutch. Home Assistant collects no language statistic — the public analytics snapshot carries country codes, not languages — so the ranking is derived from country installations with multilingual countries weighted, which puts pl at roughly 16k estimated installations, ahead of sv at roughly 14k.

The two authored catalogs carry the fourteen keys the ungated checks demand, plus `policies.operators.exists_long`, which no check asks for: it is the condition editor's own dropdown label rather than a `PredicateOp` member, so a catalog without it reads English there until the sync fills it. The demanded keys are the eleven `Decision` and `PredicateOp` words, the `policies.pending.already_decided` host sentence they interpolate into, and one reader-addressing anchor per surface. Both add-on YAMLs are `generate_locales.py` output, regenerated against current master, which is why they carry the `redact_secrets` option that landed after this work started. The remaining 736 strings are the post-merge sync's job, so the gated completeness checks fail for pl until that run, exactly as they did for nl.

Register is measured, not assumed. Across all 9708 Polish strings in frontend wheel 20260729.6 there is no formal address marker at all against 92 informal possessives, so the two strings that address a reader use the ty-form; the other thirteen are impersonal third person, matching the English and every other shipped catalog. The operator words render the concept instead of the backend's spelling — `in` reads "jest jednym z" — and a value left as the backend's own word is what the check reds on.

## Type of change
- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

No agent testing: this adds catalog data and one documentation line, neither of which an agent exercises at runtime.

Beyond the suite:

- Of the 13 parametrized IDs that carry `[pl]`, 4 run in PR CI and pass; the other 9 are the completeness checks, which skip until the sync sets their flag.
- A count of IDs understates the coverage, because several checks iterate every shipped catalog instead of being parametrized. Confirmed by injection instead: spelling `policies.operators.in` as the backend operator reds `test_every_predicate_operator_has_a_catalog_word`, and the suite is green again once the word is restored.
- The sync planner reports 736 items, all `pl`, and none of the authored keys — so the machine fill will not overwrite the hand-written anchors. That also held empirically for nl, whose authored operator words are unchanged after its own fill.
- `generate_locales.py` reports no further updates after the regeneration, so the projections are byte-exact generator output.
- The anchors were cross-read before marking ready, and one finding adopted: `common.oauth_not_serving` left the product name in the nominative after an imperative, where Home Assistant's own Polish declines it — `ui.panel.config.hardware.restart_homeassistant` reads "Uruchom ponownie Home Assistanta".

## Checklist
- [x] I have updated documentation if needed

## Summary by CodeRabbit

* **New Features**
  * Added Polish translations for Home Assistant add-on settings, including security, backup, tool, YAML editing, and TLS options.
  * Added Polish messages for approval decisions, accessibility restrictions, and OAuth status notifications.
* **Documentation**
  * Updated the shipped-locale documentation to include Italian.
  * Added localized descriptions covering configuration defaults, safeguards, and operational behavior in the development add-on.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
