### PR TITLE
fix: Schedule the HACS refresh nudge via the FastMCP lifespan

### DIFF
--- a/scripts/codeql_quality_gate.py
+++ b/scripts/codeql_quality_gate.py
@@ -78,6 +78,15 @@ ALLOWLIST: tuple[tuple[str, str, str, str], ...] = (
         "completion, which is the required shutdown-sequencing effect.",
     ),
     (
+        "py/ineffectual-statement",
+        "src/ha_mcp/hacs_auto_refresh.py",
+        "This statement has no effect",
+        "False positive on the bare 'await task' inside contextlib.suppress "
+        "in hacs_refresh_lifespan: awaiting the cancelled nudge task IS the "
+        "effect (it waits for the task to finish unwinding before the server "
+        "lifespan exits).",
+    ),
+    (
         "py/unused-global-variable",
         "src/ha_mcp/__main__.py",
         "_shutdown_in_progress",

--- a/scripts/codeql_quality_gate.py
+++ b/scripts/codeql_quality_gate.py
@@ -105,6 +105,16 @@ ALLOWLIST: tuple[tuple[str, str, str, str, str], ...] = (
         "lifespan exits).",
     ),
     (
+        "py/ineffectual-statement",
+        "tests/src/e2e/workflows/hacs/test_auto_refresh_startup.py",
+        "This statement has no effect",
+        "await task",
+        "False positive on the bare 'await task' inside contextlib.suppress "
+        "in _HttpLauncher.wait_for_lifespan_started: awaiting the cancelled "
+        "racer IS the effect (it drives the loser of the started-vs-exited "
+        "race to completion before returning).",
+    ),
+    (
         "py/unused-global-variable",
         "src/ha_mcp/__main__.py",
         "_shutdown_in_progress",

--- a/scripts/codeql_quality_gate.py
+++ b/scripts/codeql_quality_gate.py
@@ -24,6 +24,7 @@ import json
 import os
 import sys
 from collections import Counter, defaultdict
+from functools import lru_cache
 from pathlib import Path
 from typing import Any
 
@@ -41,30 +42,36 @@ PATHS_IGNORE: tuple[str, ...] = (
 
 # Per-finding allowlist for verified false positives and intentional patterns
 # that cannot be cleared without breaking or contorting correct code. Each entry
-# is (rule_id, path_fragment, message_substring, reason). A finding is suppressed
-# only when all three of rule/path/message match — keep this list tight and the
+# is (rule_id, path_fragment, message_substring, code_substring, reason). A
+# finding is suppressed only when rule/path/message all match and — when
+# ``code_substring`` is non-empty — the flagged line's own text in the checkout
+# contains it ("" means no statement scoping). Keep this list tight and the
 # reason current. Suppressed findings are reported (not silently dropped). Scope
 # every entry to a specific file + message signature so a genuinely new finding
 # of the same rule elsewhere still fails the gate.
-ALLOWLIST: tuple[tuple[str, str, str, str], ...] = (
+ALLOWLIST: tuple[tuple[str, str, str, str, str], ...] = (
     (
         "py/unused-global-variable",
         "tests/src/unit/_embedded_stubs.py",
         "_INSTALLED",
+        "",
         "Cross-invocation use: install() sets the module-level flag under a "
         "'global' declaration so a second call returns early. CodeQL's "
         "single-pass dead-store analysis misses the next-call read at the top "
         "of install(), so the assignment looks dead.",
     ),
     # NOTE: CodeQL emits the same generic message for every instance of
-    # py/ineffectual-statement, so the two entries below are PATH-WIDE for
-    # that rule (a future genuinely-dead statement in these files would be
-    # suppressed too). Accepted: both files are small and the rationale
-    # names the exact suppressed statements - re-audit if either file grows.
+    # py/ineffectual-statement, so the entries below carry a code substring:
+    # the gate reads the flagged line out of the checkout and suppresses only
+    # when that line contains the named statement. Any OTHER ineffectual
+    # statement in these files still fails the gate. The match is on the
+    # statement's text rather than its line number, so edits above it do not
+    # churn the allowlist.
     (
         "py/ineffectual-statement",
         "custom_components/ha_mcp_tools/embedded_entry.py",
         "This statement has no effect",
+        "await task",
         "False positive on a bare 'await task' inside contextlib.suppress: "
         "awaiting a cancelled task IS the effect (it waits for the task to "
         "finish unwinding before teardown continues).",
@@ -73,6 +80,16 @@ ALLOWLIST: tuple[tuple[str, str, str, str], ...] = (
         "py/ineffectual-statement",
         "custom_components/ha_mcp_tools/embedded_server.py",
         "This statement has no effect",
+        "await serve_task",
+        "False positive on bare 'await serve_task' / 'await stop_task' inside "
+        "contextlib.suppress: the await drives the cancelled task to "
+        "completion, which is the required shutdown-sequencing effect.",
+    ),
+    (
+        "py/ineffectual-statement",
+        "custom_components/ha_mcp_tools/embedded_server.py",
+        "This statement has no effect",
+        "await stop_task",
         "False positive on bare 'await serve_task' / 'await stop_task' inside "
         "contextlib.suppress: the await drives the cancelled task to "
         "completion, which is the required shutdown-sequencing effect.",
@@ -81,6 +98,7 @@ ALLOWLIST: tuple[tuple[str, str, str, str], ...] = (
         "py/ineffectual-statement",
         "src/ha_mcp/hacs_auto_refresh.py",
         "This statement has no effect",
+        "await task",
         "False positive on the bare 'await task' inside contextlib.suppress "
         "in hacs_refresh_lifespan: awaiting the cancelled nudge task IS the "
         "effect (it waits for the task to finish unwinding before the server "
@@ -90,6 +108,7 @@ ALLOWLIST: tuple[tuple[str, str, str, str], ...] = (
         "py/unused-global-variable",
         "src/ha_mcp/__main__.py",
         "_shutdown_in_progress",
+        "",
         "Cross-invocation use: set True on the first signal, read on the next to "
         "force-exit. CodeQL's single-pass dead-store analysis misses the "
         "second-signal read, so the assignment looks dead.",
@@ -98,6 +117,7 @@ ALLOWLIST: tuple[tuple[str, str, str, str], ...] = (
         "py/unused-global-variable",
         "custom_components/ha_mcp_tools/embedded_server.py",
         "_PENDING_INSTALL_DONE",
+        "",
         "Cross-method use: _async_run_tracked_install_job registers/clears the "
         "slot under a 'global' declaration and _async_wait_for_pending_install "
         "reads it on the NEXT bring-up (a different coroutine). CodeQL's "
@@ -108,6 +128,7 @@ ALLOWLIST: tuple[tuple[str, str, str, str], ...] = (
         "py/unused-global-variable",
         "homeassistant-addon-webhook-proxy/mcp_proxy/__init__.py",
         "_LOGGER_LEVEL_RAISED",
+        "",
         "Cross-invocation use: set when the debug toggle raises the logger to "
         "INFO on one async_setup_entry, then read on a later one (a config-entry "
         "reload) to undo only our own raise. CodeQL's single-pass dead-store "
@@ -117,6 +138,7 @@ ALLOWLIST: tuple[tuple[str, str, str, str], ...] = (
         "py/unused-global-variable",
         "homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/__init__.py",
         "_LOGGER_LEVEL_RAISED",
+        "",
         "Cross-invocation use (dev flavor, identical code to stable): set when "
         "the debug toggle raises the logger to INFO on one async_setup_entry, "
         "then read on a later one (a config-entry reload) to undo only our own "
@@ -127,6 +149,7 @@ ALLOWLIST: tuple[tuple[str, str, str, str], ...] = (
         "py/unused-global-variable",
         "src/ha_mcp/settings_ui/_tools_meta.py",
         "_VALID_STATES",
+        "",
         "Cross-module use: _tools_meta.py is a leaf module in the settings_ui "
         "split, so this frozenset is imported and read by _handlers_tools.py's "
         "_coerce_tool_states. CodeQL's single-file analysis misses the "
@@ -136,6 +159,7 @@ ALLOWLIST: tuple[tuple[str, str, str, str], ...] = (
         "py/unused-global-variable",
         "src/ha_mcp/tools/util_helpers.py",
         "_SERVICE_TO_STATE",
+        "",
         "Cross-module use: util_helpers is the leaf module that owns the single "
         "_SERVICE_TO_STATE map, imported and read by tools_service.py (ha_call_service) "
         "and device_control.py (ha_bulk_control) as the confirmation-state hint. "
@@ -146,6 +170,7 @@ ALLOWLIST: tuple[tuple[str, str, str, str], ...] = (
         "py/unused-global-variable",
         "src/ha_mcp/tools/best_practice_result.py",
         "_DEFAULT_SKILL_PREFIX",
+        "",
         "Cross-module use: best_practice_result.py is the leaf module the "
         "best_practice_* checks import to emit a warning, so this default is "
         "read by best_practice_checker.py as the skill_prefix parameter "
@@ -156,6 +181,7 @@ ALLOWLIST: tuple[tuple[str, str, str, str], ...] = (
         "py/unused-import",
         "packaging/binary/pyinstaller_hooks/runtime_hook.py",
         "idna",
+        "",
         "Intentional side-effect import: registers the idna codec at startup and "
         "forces PyInstaller to bundle it. Rewriting it risks the binary build.",
     ),
@@ -163,6 +189,7 @@ ALLOWLIST: tuple[tuple[str, str, str, str], ...] = (
         "py/unused-import",
         "packaging/binary/pyinstaller_hooks/runtime_hook.py",
         "encodings",
+        "",
         "Intentional side-effect import: registers the stdlib encodings.idna "
         "codec at startup. Rewriting it risks the binary build.",
     ),
@@ -170,6 +197,7 @@ ALLOWLIST: tuple[tuple[str, str, str, str], ...] = (
         "py/catch-base-exception",
         "homeassistant-addon/start.py",
         "BaseException",
+        "",
         "Intentional top-level supervisor handler: must catch SystemExit to emit "
         "a clean add-on exit code; KeyboardInterrupt is handled by the clause "
         "above. Matches how the codebase suppresses other deliberate catches.",
@@ -178,6 +206,7 @@ ALLOWLIST: tuple[tuple[str, str, str, str], ...] = (
         "py/catch-base-exception",
         "src/ha_mcp/__main__.py",
         "BaseException",
+        "",
         "Intentional: the stdio exit routing must see BaseExceptions (e.g. the "
         "re-raised CancelledError from the #1544 hard-stop path) so they leave "
         "via _force_exit — reaching interpreter finalization with the SDK's "
@@ -192,6 +221,7 @@ ALLOWLIST: tuple[tuple[str, str, str, str], ...] = (
         "py/mixed-returns",
         "src/ha_mcp/server.py",
         "Mixing implicit and explicit returns",
+        "",
         "False positive on _skill_guide_degraded_response and "
         "_read_skill_file_content's success-branch-vs-raise shape: the non-return "
         "branch in each always goes through raise_tool_error, typed '-> NoReturn' "
@@ -205,6 +235,7 @@ ALLOWLIST: tuple[tuple[str, str, str, str], ...] = (
         "py/mixed-returns",
         "src/ha_mcp/tools/backup.py",
         "Mixing implicit and explicit returns",
+        "",
         "False positive on _finalize_backup_timeout and _perform_restore's "
         "success-branch-vs-raise shape (helpers extracted from the C901 "
         "refactor, issue #925): the non-return branch in each always goes "
@@ -224,6 +255,7 @@ ALLOWLIST: tuple[tuple[str, str, str, str], ...] = (
         "py/clear-text-logging-sensitive-data",
         "custom_components/ha_mcp_tools/embedded_setup.py",
         "as clear text",
+        "",
         "Deliberate admin-only connect instructions: the startup log prints the "
         "legacy-OAuth Client ID/Secret so the admin can paste them into an MCP "
         "client. The SECURITY note from the #1880 review in this file governs "
@@ -234,6 +266,7 @@ ALLOWLIST: tuple[tuple[str, str, str, str], ...] = (
         "py/clear-text-logging-sensitive-data",
         "homeassistant-addon-webhook-proxy/mcp_proxy/__init__.py",
         "as clear text",
+        "",
         "False positive: the log line emits oauth_provider.client_id_masked(), "
         "not the raw value; CodeQL tracks taint through the masking helper.",
     ),
@@ -241,6 +274,7 @@ ALLOWLIST: tuple[tuple[str, str, str, str], ...] = (
         "py/clear-text-logging-sensitive-data",
         "homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/__init__.py",
         "as clear text",
+        "",
         "False positive (dev flavor, identical code to stable): the log line "
         "emits client_id_masked(), not the raw value; CodeQL tracks taint "
         "through the masking helper.",
@@ -249,6 +283,7 @@ ALLOWLIST: tuple[tuple[str, str, str, str], ...] = (
         "py/clear-text-logging-sensitive-data",
         "homeassistant-addon-webhook-proxy/start.py",
         "as clear text",
+        "",
         "Deliberate add-on startup log: prints the connect URL and legacy-OAuth "
         "credentials to the Supervisor add-on log (admin-only) as the user's "
         "setup instructions — the add-on-side mirror of embedded_setup.py's "
@@ -258,6 +293,7 @@ ALLOWLIST: tuple[tuple[str, str, str, str], ...] = (
         "py/clear-text-logging-sensitive-data",
         "homeassistant-addon-webhook-proxy-dev/start.py",
         "as clear text",
+        "",
         "Deliberate add-on startup log (dev flavor, identical code to stable): "
         "prints the connect URL and legacy-OAuth credentials to the Supervisor "
         "add-on log (admin-only) as the user's setup instructions.",
@@ -266,6 +302,7 @@ ALLOWLIST: tuple[tuple[str, str, str, str], ...] = (
         "py/clear-text-logging-sensitive-data",
         "src/ha_mcp/stdio_settings_sidecar.py",
         "as clear text",
+        "",
         "Deliberate: logs the sidecar's own loopback settings URL "
         "(http://127.0.0.1:<port><secret_path>/settings) so the local operator "
         "can open it. Local-process log/stderr only; the URL is unreachable off "
@@ -275,6 +312,7 @@ ALLOWLIST: tuple[tuple[str, str, str, str], ...] = (
         "py/clear-text-logging-sensitive-data",
         "src/ha_mcp/__main__.py",
         "as clear text",
+        "",
         "Deliberate: _log_settings_url prints the settings-UI URL (which "
         "includes the secret path) to the server's own startup log so the "
         "operator can find the page. Startup log only — the path is never "
@@ -285,6 +323,7 @@ ALLOWLIST: tuple[tuple[str, str, str, str], ...] = (
         "py/clear-text-logging-sensitive-data",
         "src/ha_mcp/settings_ui/__init__.py",
         "as clear text",
+        "",
         "Deliberate: names the misconfigured secret path in a startup ERROR "
         "when it contains route-template characters (an invalid, non-working "
         "value) so the operator can fix it. Startup log only; the routes are "
@@ -294,6 +333,7 @@ ALLOWLIST: tuple[tuple[str, str, str, str], ...] = (
         "py/clear-text-logging-sensitive-data",
         "tests/test_env_manager.py",
         "as clear text",
+        "",
         "Interactive test-environment helper printing the seeded throwaway "
         "credentials of the disposable HA test container (tests/test_constants.py). "
         "Printing them for copy-paste is the tool's purpose.",
@@ -302,6 +342,7 @@ ALLOWLIST: tuple[tuple[str, str, str, str], ...] = (
         "py/clear-text-storage-sensitive-data",
         "homeassistant-addon-webhook-proxy/mcp_proxy/oauth.py",
         "as clear text",
+        "",
         "Warned fallback: the primary path writes the signing key via "
         "_atomic_write_0600; the flagged plain write only runs when the "
         "filesystem cannot honor 0600 and it logs a warning. Persisting the key "
@@ -311,6 +352,7 @@ ALLOWLIST: tuple[tuple[str, str, str, str], ...] = (
         "py/clear-text-storage-sensitive-data",
         "homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/oauth.py",
         "as clear text",
+        "",
         "Warned fallback (dev flavor, identical code to stable): plain write of "
         "the signing key only when the filesystem cannot honor 0600, with a "
         "warning. Persistence is the feature.",
@@ -319,6 +361,7 @@ ALLOWLIST: tuple[tuple[str, str, str, str], ...] = (
         "py/clear-text-storage-sensitive-data",
         "homeassistant-addon-webhook-proxy/start.py",
         "as clear text",
+        "",
         "Warned fallbacks: both the creds file and the proxy-config handoff "
         "file write via _atomic_write_0600; the flagged plain writes only run "
         "when the filesystem cannot honor 0600 and each logs a warning. "
@@ -328,6 +371,7 @@ ALLOWLIST: tuple[tuple[str, str, str, str], ...] = (
         "py/clear-text-storage-sensitive-data",
         "homeassistant-addon-webhook-proxy-dev/start.py",
         "as clear text",
+        "",
         "Warned fallbacks (dev flavor): both the creds file and the "
         "proxy-config handoff file write via _atomic_write_0600; the flagged "
         "plain writes only run when the filesystem cannot honor 0600 and each "
@@ -337,6 +381,7 @@ ALLOWLIST: tuple[tuple[str, str, str, str], ...] = (
         "py/weak-sensitive-data-hashing",
         "custom_components/ha_mcp_tools/oauth_legacy.py",
         "hashing algorithm (SHA256)",
+        "",
         "Not password storage: SHA256 builds a change-detection fingerprint of "
         "the OAuth identity bound to the root views (machine-generated client "
         "secret + 256-bit signing key) to decide when routes must be rebound. "
@@ -347,6 +392,7 @@ ALLOWLIST: tuple[tuple[str, str, str, str], ...] = (
         "py/weak-sensitive-data-hashing",
         "homeassistant-addon-webhook-proxy/mcp_proxy/__init__.py",
         "hashing algorithm (SHA256)",
+        "",
         "Not password storage: same _oauth_route_fingerprint helper as "
         "oauth_legacy.py — a SHA256 change-detection fingerprint of "
         "machine-generated high-entropy credentials, not a stored password hash.",
@@ -355,6 +401,7 @@ ALLOWLIST: tuple[tuple[str, str, str, str], ...] = (
         "py/weak-sensitive-data-hashing",
         "homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/__init__.py",
         "hashing algorithm (SHA256)",
+        "",
         "Not password storage (dev flavor, identical code to stable): SHA256 "
         "change-detection fingerprint of machine-generated high-entropy "
         "credentials, not a stored password hash.",
@@ -363,6 +410,7 @@ ALLOWLIST: tuple[tuple[str, str, str, str], ...] = (
         "py/bad-tag-filter",
         "tests/src/unit/_js_harness.py",
         "does not match upper case",
+        "",
         "Not a sanitizer: the JSDOM harness extracts <script> bodies from "
         "repo-authored, lowercase templates for parse/behaviour testing; "
         "untrusted HTML never flows through it.",
@@ -371,6 +419,7 @@ ALLOWLIST: tuple[tuple[str, str, str, str], ...] = (
         "py/incomplete-url-substring-sanitization",
         "tests/src/unit/test_best_practice_checker.py",
         "may be at an arbitrary position",
+        "",
         "Test assertion, not URL validation: checks that a warning message "
         "mentions the configured skill-prefix host.",
     ),
@@ -378,6 +427,7 @@ ALLOWLIST: tuple[tuple[str, str, str, str], ...] = (
         "py/incomplete-url-substring-sanitization",
         "tests/src/unit/test_browser_landing.py",
         "may be at an arbitrary position",
+        "",
         "Test assertion, not URL validation: checks that the landing page's "
         "help copy mentions dash.cloudflare.com.",
     ),
@@ -385,6 +435,7 @@ ALLOWLIST: tuple[tuple[str, str, str, str], ...] = (
         "py/incomplete-url-substring-sanitization",
         "tests/src/unit/test_oauth.py",
         "may be at an arbitrary position",
+        "",
         "Test assertion, not URL validation: checks that the consent HTML "
         "displays the redirect host to the user.",
     ),
@@ -392,17 +443,57 @@ ALLOWLIST: tuple[tuple[str, str, str, str], ...] = (
         "py/incomplete-url-substring-sanitization",
         "tests/src/unit/test_oauth_legacy_component.py",
         "may be at an arbitrary position",
+        "",
         "Test assertion, not URL validation: the XSS-escape test checks the "
         "redirect host appears (escaped) in the response body.",
     ),
 )
 
 
-def _allowlist_reason(file: str, rule_id: str, message: str) -> str | None:
-    """Return the allowlist reason if this finding is a verified suppression."""
-    for rule, path, substr, reason in ALLOWLIST:
-        if rule_id == rule and path in file and substr in message:
-            return reason
+@lru_cache(maxsize=32)
+def _source_lines(file: str) -> tuple[str, ...] | None:
+    """Return the checkout's lines for ``file``, or None if it cannot be read.
+
+    The path comes from the SARIF ``artifactLocation.uri`` and is used as-is:
+    CodeQL emits repo-root-relative paths and the gate runs from the checkout
+    root.
+    """
+    try:
+        text = Path(file).read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return None
+    return tuple(text.splitlines())
+
+
+def _source_line(file: str, line: int) -> str | None:
+    """Return the text of 1-based ``line`` in ``file``, or None if unreadable."""
+    if line < 1:
+        return None
+    lines = _source_lines(file)
+    if lines is None:
+        return None
+    try:
+        return lines[line - 1]
+    except IndexError:
+        return None
+
+
+def _allowlist_reason(file: str, line: int, rule_id: str, message: str) -> str | None:
+    """Return the allowlist reason if this finding is a verified suppression.
+
+    An entry carrying a code substring also has to match the flagged line's own
+    text, which pins the suppression to that one statement instead of the whole
+    file. It fails closed: a line the gate cannot read does not match, because a
+    gate must not suppress what it cannot verify.
+    """
+    for rule, path, substr, code, reason in ALLOWLIST:
+        if rule_id != rule or path not in file or substr not in message:
+            continue
+        if code:
+            source = _source_line(file, line)
+            if source is None or code not in source:
+                continue
+        return reason
     return None
 
 
@@ -450,7 +541,7 @@ def classify(
             if any(file.startswith(prefix) for prefix in PATHS_IGNORE):
                 continue
             message = ((result.get("message") or {}).get("text") or "").strip()
-            if reason := _allowlist_reason(file, rule_id, message):
+            if reason := _allowlist_reason(file, line, rule_id, message):
                 suppressed.append((file, line, rule_id, message, reason))
                 continue
             findings.append((file, line, rule_id, message))

--- a/src/ha_mcp/__main__.py
+++ b/src/ha_mcp/__main__.py
@@ -666,13 +666,6 @@ async def _run_with_shutdown(server_coro: Coroutine[Any, Any, Any]) -> None:
     server_task = asyncio.create_task(server_coro)
     shutdown_task = asyncio.create_task(_shutdown_event.wait())
 
-    # Fire-and-forget: ask HACS to surface a paired component update after a
-    # server update (advisory; see hacs_auto_refresh). Not in the wait set —
-    # its completion must not stop the server.
-    from ha_mcp.hacs_auto_refresh import maybe_refresh_hacs_after_update
-
-    hacs_refresh_task = asyncio.create_task(maybe_refresh_hacs_after_update())
-
     try:
         done, pending = await asyncio.wait(
             [server_task, shutdown_task],
@@ -732,7 +725,7 @@ async def _run_with_shutdown(server_coro: Coroutine[Any, Any, Any]) -> None:
             logger.warning("Resource cleanup timed out")
 
         try:
-            await _cancel_tasks(server_task, shutdown_task, hacs_refresh_task)
+            await _cancel_tasks(server_task, shutdown_task)
         except Exception as e:
             # Teardown must never mask the exception being propagated from the
             # try block (Python drops the original if finally raises).

--- a/src/ha_mcp/hacs_auto_refresh.py
+++ b/src/ha_mcp/hacs_auto_refresh.py
@@ -226,6 +226,17 @@ async def maybe_refresh_hacs_after_update() -> None:
         if not _nudge_due(current, info, marker):
             return
 
+        # The one unconditional line a due pass emits BEFORE any WebSocket
+        # work: it proves the launcher scheduled the nudge even where HACS
+        # is absent and the pass ends silently — the observable the HAOS
+        # add-on lane greps for, and the line whose absence exposed the
+        # launcher gap this module's lifespan wiring closed.
+        logger.info(
+            "HACS auto-refresh: startup pass due (server %s); "
+            "asking HACS for repository state",
+            current,
+        )
+
         result = await _refresh_with_retries()
         if result is None:
             logger.debug(

--- a/src/ha_mcp/hacs_auto_refresh.py
+++ b/src/ha_mcp/hacs_auto_refresh.py
@@ -224,6 +224,15 @@ async def maybe_refresh_hacs_after_update() -> None:
         info = await asyncio.to_thread(get_update_info)
         marker = await asyncio.to_thread(_read_marker, ha_url)
         if not _nudge_due(current, info, marker):
+            # DEBUG, not INFO: the not-due return is the per-conversation
+            # stdio hot path and must stay quiet at default levels. The line
+            # exists so a DEBUG-level launcher (the HAOS add-on lane) can
+            # prove scheduling even when a completed earlier pass makes every
+            # later boot legitimately not due.
+            logger.debug(
+                "HACS auto-refresh: pass not due (marker current for server %s)",
+                current,
+            )
             return
 
         # The one unconditional line a due pass emits BEFORE any WebSocket

--- a/src/ha_mcp/hacs_auto_refresh.py
+++ b/src/ha_mcp/hacs_auto_refresh.py
@@ -25,6 +25,8 @@ import asyncio
 import hashlib
 import json
 import logging
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager, suppress
 from pathlib import Path
 from typing import Any
 
@@ -250,3 +252,26 @@ async def maybe_refresh_hacs_after_update() -> None:
         raise
     except Exception:
         logger.debug("HACS auto-refresh nudge skipped", exc_info=True)
+
+
+@asynccontextmanager
+async def hacs_refresh_lifespan(_server: Any) -> AsyncIterator[dict[str, Any]]:
+    """Schedule the startup nudge for the lifetime of any server run.
+
+    Attached as the FastMCP ``lifespan`` so it runs on EVERY launcher —
+    stdio, the HTTP CLI entry points, and the add-on's ``start.py``, which
+    calls ``mcp.run()`` directly and never passes through ``__main__``'s
+    ``_run_with_shutdown`` (the wiring this replaces; the add-on gap was
+    found live, not by CI, because the e2e suites launch via the CLI
+    entry points).
+    """
+    task = asyncio.create_task(maybe_refresh_hacs_after_update())
+    try:
+        yield {}
+    finally:
+        # The nudge may be mid-retry-sleep; a cancelled task must not
+        # stall shutdown. maybe_refresh_hacs_after_update re-raises
+        # CancelledError by design, so this await returns promptly.
+        task.cancel()
+        with suppress(asyncio.CancelledError):
+            await task

--- a/src/ha_mcp/server.py
+++ b/src/ha_mcp/server.py
@@ -20,6 +20,7 @@ from pydantic import Field
 
 from .config import _PACKAGE_VERSION, get_global_settings
 from .errors import ErrorCode, create_error_response
+from .hacs_auto_refresh import hacs_refresh_lifespan
 from .tools.helpers import raise_tool_error
 from .transforms import DEFAULT_PINNED_TOOLS
 
@@ -142,6 +143,7 @@ class HomeAssistantSmartMCPServer:
             version=server_version,
             icons=SERVER_ICONS,
             instructions=instructions,
+            lifespan=hacs_refresh_lifespan,
         )
 
         # Register all tools and expert prompts

--- a/tests/src/e2e/basic/test_backend_dispatch_smoke.py
+++ b/tests/src/e2e/basic/test_backend_dispatch_smoke.py
@@ -85,7 +85,7 @@ _SKIP_CEILING_PER_LANE = {
     # Entries below are CI-observed item counts, bumped only for intentional
     # marker-gated additions rather than runtime skips.
     "container": 73,  # was 72; +1 inaddon startup-nudge e2e (haos_only + inaddon_only)
-    "haos": 48,  # was 47; +1 embedded HACS-nudge skip e2e (container_only), +1 inaddon startup-nudge e2e (inaddon_only)
+    "haos": 48,  # was 46; +1 embedded HACS-nudge skip e2e (container_only), +1 inaddon startup-nudge e2e (inaddon_only)
     "haos_inaddon": 76,  # was 75; +1 embedded HACS-nudge skip e2e (container_only)
     # Embedded backend (#1527, E2E_BACKEND=embedded). Skips exactly the container
     # lane's marker-skips PLUS two embedded-specific additions:

--- a/tests/src/e2e/basic/test_backend_dispatch_smoke.py
+++ b/tests/src/e2e/basic/test_backend_dispatch_smoke.py
@@ -84,9 +84,9 @@ _SKIP_CEILING_PER_LANE = {
     # gain 10; container is unchanged because the tests run there.
     # Entries below are CI-observed item counts, bumped only for intentional
     # marker-gated additions rather than runtime skips.
-    "container": 72,  # was 71; +1 Puppet-management test (haos_only + inaddon_only)
-    "haos": 46,  # was 45; +1 py3.14 invalidate_caches recovery e2e (container_only)
-    "haos_inaddon": 75,  # was 74; +1 inline dashboard_resource auto-backup e2e (external_only, #2060)
+    "container": 73,  # was 72; +1 inaddon startup-nudge e2e (haos_only + inaddon_only)
+    "haos": 48,  # was 47; +1 embedded HACS-nudge skip e2e (container_only), +1 inaddon startup-nudge e2e (inaddon_only)
+    "haos_inaddon": 76,  # was 75; +1 embedded HACS-nudge skip e2e (container_only)
     # Embedded backend (#1527, E2E_BACKEND=embedded). Skips exactly the container
     # lane's marker-skips PLUS two embedded-specific additions:
     #   - haos_only + inaddon_only tests skip on embedded just like on container
@@ -100,7 +100,7 @@ _SKIP_CEILING_PER_LANE = {
     # 1) + not_on_embedded 2 = 101. Initially set to 115 as a buffer for
     # parametrize item-inflation; round 6 (run 28709196071) observed the exact
     # item count and the entry below is pinned to it.
-    "embedded": 130,  # was 129; +1 inline dashboard_resource auto-backup e2e (external_only, #2060)
+    "embedded": 132,  # was 130; +1 embedded HACS-nudge skip e2e (not_on_embedded), +1 inaddon startup-nudge e2e (haos_only + inaddon_only)
     # HAOS embedded backend (#1527, HAOS_TEST_MODE=embedded). A HAOS lane, so it
     # skips the SAME set as the external HAOS lane (container_only + inaddon_only)
     # PLUS two haos_embedded-specific additions:
@@ -118,7 +118,7 @@ _SKIP_CEILING_PER_LANE = {
     # lanes show (haos def 30 → ~35 observed; haos_inaddon def 50 → ~58) gives
     # ~84; initially set to 90 with a small buffer, and round 8 observed
     # exactly 90 — the entry below is pinned to the observed count.
-    "haos_embedded": 104,  # was 103; +1 inline dashboard_resource auto-backup e2e (external_only, #2060)
+    "haos_embedded": 106,  # was 104; +1 embedded HACS-nudge skip e2e (container_only), +1 inaddon startup-nudge e2e (inaddon_only)
 }
 
 

--- a/tests/src/e2e/haos_only/test_inaddon_startup_nudge.py
+++ b/tests/src/e2e/haos_only/test_inaddon_startup_nudge.py
@@ -29,8 +29,9 @@ import httpx
 import pytest
 from fastmcp import Client
 from fastmcp.client.transports import StreamableHttpTransport
+from fastmcp.exceptions import ToolError
 
-from ..utilities.assertions import MCPAssertions, parse_mcp_result, safe_call_tool
+from ..utilities.assertions import MCPAssertions, parse_mcp_result
 from ..utilities.wait_helpers import _POLLING_TRANSIENT_ERRORS
 
 LOG = logging.getLogger(__name__)
@@ -106,23 +107,29 @@ async def _restore_info_level(settings_advanced: str, settings_restart: str) -> 
 async def _warm_shared_client(mcp_client: Any) -> None:
     """Warm the SHARED session client back up after the self-restarts.
 
-    safe_call_tool: a ToolError raised mid-bounce is not in the transient
-    set and would escape the loop; break only on a successful payload.
+    Any completed round-trip — success or ToolError — proves the session
+    is usable again; only transport-level transients keep the loop going.
     """
     deadline = time.monotonic() + _WARM_TIMEOUT
+    last: object = None
     while True:
         try:
-            payload = await safe_call_tool(mcp_client, "ha_get_overview", {})
-            if payload.get("success", True) and "error" not in payload:
-                return
-        except _RESTORE_TRANSIENT:
+            await mcp_client.call_tool("ha_get_overview", {})
+            return
+        except ToolError:
+            # Warm-up only cares that the shared session round-trips again;
+            # a tool-level failure IS a completed round-trip. (Payload
+            # inspection here proved harmful: it kept the loop spinning on a
+            # healthy session — the two prior CI failures.)
+            return
+        except _RESTORE_TRANSIENT as err:
             # Transient while the addon bounces underneath us; the deadline
             # check below bounds the retries.
-            pass
+            last = err
         if time.monotonic() >= deadline:
             raise AssertionError(
                 "Shared mcp_client never warmed back up after the restore "
-                f"restart within {_WARM_TIMEOUT}s"
+                f"restart within {_WARM_TIMEOUT}s (last={last!r})"
             )
         await asyncio.sleep(_POLL_INTERVAL)
 
@@ -176,11 +183,18 @@ async def test_addon_launcher_schedules_the_startup_nudge(
                         "search": NUDGE_LOG_SIGNATURE,
                     },
                 )
-                if payload.get("success") and payload.get("returned_lines", 0) > 0:
+                log_text = payload.get("log", "")
+                # Post-filter for the two REAL per-boot phrases: at DEBUG the
+                # addon logs this probe's own tool calls, whose search
+                # argument contains the bare signature — matching only the
+                # signature would let the probe confirm itself.
+                if payload.get("success") and (
+                    "startup pass due" in log_text or "pass not due" in log_text
+                ):
                     found = True
                     LOG.info(
                         "Nudge per-boot line found after restart: %s",
-                        payload.get("log", "")[:200],
+                        log_text[:200],
                     )
                     break
                 last = f"no match yet in {payload.get('total_lines', 0)} lines"

--- a/tests/src/e2e/haos_only/test_inaddon_startup_nudge.py
+++ b/tests/src/e2e/haos_only/test_inaddon_startup_nudge.py
@@ -12,10 +12,10 @@ prove scheduling; which one fires depends on marker state, which this test
 must NOT assume: the add-on's ``/data`` persists across restarts, and once
 an early boot lives ~8.5 minutes its HACS-absent pass completes and writes
 the marker, making every later boot legitimately not due (observed live in
-CI — 50 boots, one due-line). So the test drives the add-on to DEBUG via
-the settings API (the ``test_addon_debug_log_level`` flow), restarts it,
-and searches the fresh boot's log for the shared ``"HACS auto-refresh:"``
-prefix, restoring INFO afterwards.
+CI — 50 boots, one due-line). So the test drives the add-on to DEBUG via the
+settings API (the ``test_addon_debug_log_level`` flow), records the current
+process identity, restarts it, and requires the replacement process's own
+startup diagnostics to contain a per-boot line, restoring INFO afterwards.
 """
 
 from __future__ import annotations
@@ -30,22 +30,19 @@ import pytest
 from fastmcp import Client
 from fastmcp.client.transports import StreamableHttpTransport
 
-from ..utilities.assertions import MCPAssertions, parse_mcp_result, safe_call_tool
+from ..utilities.assertions import parse_mcp_result, safe_call_tool
 from ..utilities.wait_helpers import _POLLING_TRANSIENT_ERRORS
 
 LOG = logging.getLogger(__name__)
 
-DEV_ADDON_NAME = "Home Assistant MCP Server (Dev)"
-
 # Matches BOTH the due (INFO) and not-due (DEBUG) per-boot lines — either
 # proves the launcher scheduled the nudge. Keep in lockstep with
 # src/ha_mcp/hacs_auto_refresh.py.
-NUDGE_LOG_SIGNATURE = "HACS auto-refresh:"
+NUDGE_LOGGER = "ha_mcp.hacs_auto_refresh"
 NUDGE_BOOT_LOG_PHRASES = (
     "HACS auto-refresh: startup pass due",
     "HACS auto-refresh: pass not due",
 )
-_NUDGE_LOG_LIMIT = 500
 
 # Same transient sets as test_addon_debug_log_level (see its comments).
 _TRANSIENT = (*_POLLING_TRANSIENT_ERRORS, httpx.HTTPError)
@@ -83,27 +80,35 @@ async def _call_tool_fresh(addon_url: str, tool: str, args: dict[str, Any]) -> A
     return parse_mcp_result(raw)
 
 
-def _nudge_log_args(slug: str) -> dict[str, Any]:
-    """Build the widest bounded search for the nudge log signature."""
-    return {
-        "source": "supervisor",
-        "slug": slug,
-        "search": NUDGE_LOG_SIGNATURE,
-        "limit": _NUDGE_LOG_LIMIT,
-    }
-
-
-async def _fetch_nudge_logs(addon_url: str, slug: str) -> dict[str, Any]:
-    """Fetch nudge logs over a restart-safe fresh connection."""
-    return await _call_tool_fresh(addon_url, "ha_get_logs", _nudge_log_args(slug))
-
-
-def _nudge_boot_line_count(log_text: str) -> int:
-    """Count real per-boot nudge lines, excluding search-argument echoes."""
-    return sum(
-        any(phrase in line for phrase in NUDGE_BOOT_LOG_PHRASES)
-        for line in log_text.splitlines()
+async def _get_instance_id(settings_info_url: str) -> str:
+    """Read the settings endpoint's per-process identity."""
+    async with httpx.AsyncClient(timeout=30.0) as http:
+        resp = await http.get(settings_info_url)
+    assert resp.status_code == 200, (
+        f"GET {settings_info_url} returned {resp.status_code}: {resp.text[:500]}"
     )
+    data = resp.json()
+    assert isinstance(data, dict), (
+        f"GET {settings_info_url} returned non-object JSON: {data!r}"
+    )
+    instance_id = data.get("instance_id")
+    assert isinstance(instance_id, str) and instance_id, (
+        f"GET {settings_info_url} returned no process instance_id: {data!r}"
+    )
+    return instance_id
+
+
+def _find_nudge_startup_record(startup_logs: object) -> dict[str, Any] | None:
+    """Find a real per-boot nudge record in process-local startup logs."""
+    if not isinstance(startup_logs, list):
+        return None
+    for entry in startup_logs:
+        if not isinstance(entry, dict) or entry.get("logger") != NUDGE_LOGGER:
+            continue
+        message = entry.get("message")
+        if isinstance(message, str) and message.startswith(NUDGE_BOOT_LOG_PHRASES):
+            return entry
+    return None
 
 
 async def _post_log_level(settings_advanced_url: str, level: str) -> None:
@@ -185,34 +190,15 @@ async def test_addon_launcher_schedules_the_startup_nudge(
     addon_url = ha_container_with_fresh_config.get("addon_mcp_url")
     assert addon_url, "inaddon container_info has no addon_mcp_url"
     base = addon_url.split("/mcp", 1)[0]
+    settings_info = f"{base}{HA_MCP_TEST_SECRET_PATH}/api/settings/info"
     settings_advanced = f"{base}{HA_MCP_TEST_SECRET_PATH}/api/settings/advanced"
     settings_restart = f"{base}{HA_MCP_TEST_SECRET_PATH}/api/settings/restart"
 
-    # Resolve the dev addon's Supervisor slug while the shared client is
-    # still live (pre-restart). call_tool_success per the test conventions:
-    # a failed listing reports itself instead of reading as a missing addon.
-    async with MCPAssertions(mcp_client) as mcp:
-        data = await mcp.call_tool_success("ha_get_addon", {})
-    addons = data.get("addons") or []
-    dev_addon = next((a for a in addons if a.get("name") == DEV_ADDON_NAME), None)
-    assert dev_addon is not None, (
-        f"Dev addon {DEV_ADDON_NAME!r} not in ha_get_addon listing: "
-        f"{[a.get('name') for a in addons]}"
-    )
-    slug = dev_addon["slug"]
-
-    # Supervisor logs survive add-on restarts. Record the exact per-boot phrase
-    # count on the already-proven shared client so an older boot cannot satisfy
-    # this restart; fresh connections are reserved for the post-restart retry.
-    async with MCPAssertions(mcp_client) as mcp:
-        baseline_payload = await mcp.call_tool_success(
-            "ha_get_logs", _nudge_log_args(slug)
-        )
-    baseline_count = _nudge_boot_line_count(baseline_payload.get("log", ""))
-    LOG.info(
-        "Recorded %d nudge per-boot lines before the restart",
-        baseline_count,
-    )
+    # The settings identity changes only when the add-on process does. Binding
+    # this baseline to ha_report_issue's process-local startup records avoids
+    # stale matches and rollover races in Supervisor's bounded log window.
+    baseline_instance_id = await _get_instance_id(settings_info)
+    LOG.info("Recorded pre-restart process %s", baseline_instance_id)
 
     LOG.info("Flipping the dev add-on to DEBUG for a fresh, provable boot...")
     await _post_log_level(settings_advanced, "DEBUG")
@@ -225,36 +211,65 @@ async def test_addon_launcher_schedules_the_startup_nudge(
         while time.monotonic() < deadline:
             try:
                 url = wait_for_addon_mcp_ready(timeout=30.0)
-                payload = await _fetch_nudge_logs(url, slug)
-                log_text = payload.get("log", "")
-                # Post-filter for the two REAL per-boot phrases: at DEBUG the
-                # addon logs this probe's own tool calls, whose search
-                # argument contains the bare signature — matching only the
-                # signature would let the probe confirm itself.
-                current_count = _nudge_boot_line_count(log_text)
-                if payload.get("success") and current_count > baseline_count:
-                    found = True
-                    LOG.info(
-                        "Nudge per-boot line count grew from %d to %d after "
-                        "restart: %s",
-                        baseline_count,
-                        current_count,
-                        log_text[:200],
-                    )
-                    break
-                last = (
-                    f"per-boot line count {current_count} has not grown beyond "
-                    f"the pre-restart baseline {baseline_count} in "
-                    f"{payload.get('total_lines', 0)} matching lines"
+                payload = await _call_tool_fresh(
+                    url,
+                    "ha_report_issue",
+                    {
+                        "tool_call_count": 1,
+                        "fields": ["diagnostic_info", "startup_logs"],
+                    },
                 )
+                if not isinstance(payload, dict) or not payload.get("success"):
+                    last = f"unexpected ha_report_issue payload: {payload!r}"
+                else:
+                    diagnostic_info = payload.get("diagnostic_info")
+                    instance = (
+                        diagnostic_info.get("instance")
+                        if isinstance(diagnostic_info, dict)
+                        else None
+                    )
+                    current_instance_id = (
+                        instance.get("instance_id")
+                        if isinstance(instance, dict)
+                        else None
+                    )
+                    if current_instance_id == baseline_instance_id:
+                        last = (
+                            f"still reached pre-restart process {baseline_instance_id}"
+                        )
+                    elif not isinstance(current_instance_id, str) or not (
+                        current_instance_id
+                    ):
+                        last = f"ha_report_issue omitted process identity: {instance!r}"
+                    else:
+                        startup_logs = payload.get("startup_logs")
+                        record = _find_nudge_startup_record(startup_logs)
+                        if record is not None:
+                            found = True
+                            LOG.info(
+                                "Replacement process %s captured nudge startup "
+                                "record: %s",
+                                current_instance_id,
+                                record,
+                            )
+                            break
+                        startup_log_count = (
+                            len(startup_logs)
+                            if isinstance(startup_logs, list)
+                            else f"invalid {type(startup_logs).__name__}"
+                        )
+                        last = (
+                            f"replacement process {current_instance_id} has no "
+                            f"nudge record among {startup_log_count} startup logs"
+                        )
             except _TRANSIENT as err:
                 last = err
             await asyncio.sleep(_POLL_INTERVAL)
 
         assert found, (
-            "A DEBUG-level fresh boot did not add a new "
-            f"{NUDGE_LOG_SIGNATURE!r} per-boot line within {_PROBE_TIMEOUT}s "
-            f"of the self-restart (last={last!r}) — "
+            "A DEBUG-level replacement process did not capture a per-boot "
+            f"nudge startup record within {_PROBE_TIMEOUT}s of the self-restart "
+            f"(pre-restart instance={baseline_instance_id}, last={last!r}) — "
             "the add-on launcher did not schedule the startup nudge (neither "
             "the due INFO line nor the not-due DEBUG line appeared). This is "
             "the exact regression the lifespan wiring exists to prevent: "

--- a/tests/src/e2e/haos_only/test_inaddon_startup_nudge.py
+++ b/tests/src/e2e/haos_only/test_inaddon_startup_nudge.py
@@ -1,69 +1,161 @@
 """Add-on-lane regression test for the HACS startup nudge scheduling.
 
-The launcher gap this branch fixes was SPECIFIC to the add-on: `start.py`
+The launcher gap this branch fixes was SPECIFIC to the add-on: ``start.py``
 calls ``mcp.run()`` directly, so the nudge scheduled from ``__main__``'s
 ``_run_with_shutdown`` never ran there, and no CI lane noticed. This test
 closes that lane: the inaddon tier runs the real dev add-on built from this
 PR's source, and a due startup pass emits one unconditional INFO line
 *before* any WebSocket work (``hacs_auto_refresh.py``), so the line appears
 even though the HAOS VM ships no HACS (where the pass then retries quietly
-and ends silently). Grepping the add-on's own logs for that line proves the
+and ends silently). Finding that line in the add-on's own logs proves the
 real add-on launcher entered the server lifespan and started the nudge —
 exactly what was silently missing before.
+
+The test self-restarts the add-on first (the ``test_addon_debug_log_level``
+pattern) because the line is a one-shot BOOT line: by the time this test
+runs, the boot that emitted it sits thousands of request-log lines back,
+beyond even the expanded journald search window
+(``SUPERVISOR_SEARCH_WINDOW_LINES``). A fresh boot is still due — the HAOS
+VM has no HACS, so no earlier pass ever completed and wrote a marker — and
+puts the line in the fresh tail where the search window sees it.
 """
 
 from __future__ import annotations
 
+import asyncio
 import logging
+import time
 from typing import Any
 
+import httpx
 import pytest
+from fastmcp import Client
+from fastmcp.client.transports import StreamableHttpTransport
 
 from ..utilities.assertions import parse_mcp_result
-from ..utilities.wait_helpers import wait_for_condition
+from ..utilities.wait_helpers import _POLLING_TRANSIENT_ERRORS
 
 LOG = logging.getLogger(__name__)
 
-# Slug of the dev add-on the inaddon tier boots (see test_inaddon_source_refresh).
 DEV_ADDON_NAME = "Home Assistant MCP Server (Dev)"
 
 NUDGE_LOG_SIGNATURE = "HACS auto-refresh: startup pass due"
 
+# Same transient set as test_addon_debug_log_level: the MCP-client polling
+# tuple plus httpx transport errors from connections dying mid-restart.
+# Bugs (TypeError, KeyError, AssertionError) must propagate.
+_TRANSIENT = (*_POLLING_TRANSIENT_ERRORS, httpx.HTTPError)
+
+# The warm-up loop additionally rides out the HTTP-status asserts the
+# restart helper makes while the addon is still bouncing.
+_RESTORE_TRANSIENT = (*_TRANSIENT, AssertionError)
+
+# Addon restart = container stop + start; CI runners take 5-25s.
+_RECOVERY_TIMEOUT = 180.0
+_POLL_INTERVAL = 3.0
+
+
+async def _call_tool_fresh(addon_url: str, tool: str, args: dict[str, Any]) -> Any:
+    """Call an MCP tool over a fresh streamable-HTTP connection.
+
+    The server is stateless, so a new client per call is cheap and — unlike a
+    long-lived session — immune to the addon restarting between calls.
+    """
+    client = Client(StreamableHttpTransport(url=addon_url))
+    async with client:
+        raw = await client.call_tool(tool, args)
+    return parse_mcp_result(raw)
+
+
+async def _restart_self(settings_restart_url: str) -> None:
+    """Self-restart via the settings restart endpoint (empty body → self)."""
+    async with httpx.AsyncClient(timeout=30.0) as http:
+        resp = await http.post(settings_restart_url, json={})
+    assert resp.status_code == 200, (
+        f"self-restart POST returned {resp.status_code}: {resp.text[:300]}"
+    )
+
 
 @pytest.mark.inaddon_only
-async def test_addon_launcher_schedules_the_startup_nudge(mcp_client: Any) -> None:
-    """The running dev add-on's logs must carry the nudge's startup line.
+@pytest.mark.addon_disruptive
+async def test_addon_launcher_schedules_the_startup_nudge(
+    mcp_client: Any,
+    ha_container_with_fresh_config: dict[str, Any],
+) -> None:
+    """A fresh add-on boot must log the nudge's due-pass line.
 
-    A fresh bake has no marker, so the pass is always due on the add-on's
-    first boot; the INFO line lands before any WebSocket work, so HACS
-    being absent from the VM cannot suppress it.
+    A fresh boot is always due here (no marker: the VM has no HACS, so no
+    prior pass ever completed), and the INFO line lands before any WebSocket
+    work, so HACS being absent cannot suppress it.
     """
-    LOG.info("Looking up the dev add-on slug...")
-    raw = await mcp_client.call_tool("ha_get_addon", {})
-    data = parse_mcp_result(raw)
+    from haos_runtime import HA_MCP_TEST_SECRET_PATH, wait_for_addon_mcp_ready
+
+    addon_url = ha_container_with_fresh_config.get("addon_mcp_url")
+    assert addon_url, "inaddon container_info has no addon_mcp_url"
+    base = addon_url.split("/mcp", 1)[0]
+    settings_restart = f"{base}{HA_MCP_TEST_SECRET_PATH}/api/settings/restart"
+
+    # Resolve the dev addon's Supervisor slug while the shared client is
+    # still live (pre-restart).
+    data = parse_mcp_result(await mcp_client.call_tool("ha_get_addon", {}))
     addons = data.get("addons") or []
     dev_addon = next((a for a in addons if a.get("name") == DEV_ADDON_NAME), None)
-    assert dev_addon, f"Dev add-on {DEV_ADDON_NAME!r} not installed: {addons}"
+    assert dev_addon is not None, (
+        f"Dev addon {DEV_ADDON_NAME!r} not in ha_get_addon listing: "
+        f"{[a.get('name') for a in addons]}"
+    )
     slug = dev_addon["slug"]
 
-    async def nudge_line_logged() -> bool:
-        raw_logs = await mcp_client.call_tool(
-            "ha_get_logs",
-            {"source": "supervisor", "slug": slug, "search": NUDGE_LOG_SIGNATURE},
-        )
-        payload = parse_mcp_result(raw_logs)
-        return bool(payload.get("success")) and payload.get("returned_lines", 0) > 0
+    LOG.info("Restarting the dev add-on to get a fresh boot in the log tail...")
+    try:
+        await _restart_self(settings_restart)
 
-    found = await wait_for_condition(
-        nudge_line_logged,
-        timeout=60,
-        condition_name="startup nudge INFO line in the dev add-on logs",
-    )
-    assert found, (
-        f"The dev add-on's logs never showed {NUDGE_LOG_SIGNATURE!r} — the "
-        "add-on launcher did not schedule the startup nudge. This is the "
-        "exact regression the lifespan wiring exists to prevent: start.py "
-        "runs mcp.run() directly, so only a server-attached lifespan reaches "
-        "the add-on."
-    )
+        deadline = time.monotonic() + _RECOVERY_TIMEOUT
+        last: object = None
+        found = False
+        while time.monotonic() < deadline:
+            try:
+                url = wait_for_addon_mcp_ready(timeout=30.0)
+                payload = await _call_tool_fresh(
+                    url,
+                    "ha_get_logs",
+                    {
+                        "source": "supervisor",
+                        "slug": slug,
+                        "search": NUDGE_LOG_SIGNATURE,
+                    },
+                )
+                if payload.get("success") and payload.get("returned_lines", 0) > 0:
+                    found = True
+                    LOG.info(
+                        "Due-pass line found after restart: %s",
+                        payload.get("log", "")[:200],
+                    )
+                    break
+                last = f"no match yet in {payload.get('total_lines', 0)} lines"
+            except _TRANSIENT as err:
+                last = err
+            await asyncio.sleep(_POLL_INTERVAL)
+
+        assert found, (
+            f"The dev add-on's fresh boot never logged {NUDGE_LOG_SIGNATURE!r} "
+            f"within {_RECOVERY_TIMEOUT}s of the self-restart (last={last!r}) — "
+            "the add-on launcher did not schedule the startup nudge. This is "
+            "the exact regression the lifespan wiring exists to prevent: "
+            "start.py runs mcp.run() directly, so only a server-attached "
+            "lifespan reaches the add-on."
+        )
+    finally:
+        # The self-restart dropped the SHARED session mcp_client's connection.
+        # Warm it back up so later tests on this worker get a live session.
+        warm_deadline = time.monotonic() + _RECOVERY_TIMEOUT
+        while True:
+            try:
+                await mcp_client.call_tool("ha_get_overview", {})
+                break
+            except _RESTORE_TRANSIENT:
+                if time.monotonic() >= warm_deadline:
+                    raise
+                await asyncio.sleep(_POLL_INTERVAL)
+
     LOG.info("Add-on launcher scheduled the startup nudge")

--- a/tests/src/e2e/haos_only/test_inaddon_startup_nudge.py
+++ b/tests/src/e2e/haos_only/test_inaddon_startup_nudge.py
@@ -30,7 +30,7 @@ import pytest
 from fastmcp import Client
 from fastmcp.client.transports import StreamableHttpTransport
 
-from ..utilities.assertions import MCPAssertions, parse_mcp_result
+from ..utilities.assertions import MCPAssertions, parse_mcp_result, safe_call_tool
 from ..utilities.wait_helpers import _POLLING_TRANSIENT_ERRORS
 
 LOG = logging.getLogger(__name__)
@@ -84,6 +84,43 @@ async def _restart_self(settings_restart_url: str) -> None:
     assert resp.status_code == 200, (
         f"self-restart POST returned {resp.status_code}: {resp.text[:300]}"
     )
+
+
+async def _restore_info_level(settings_advanced: str, settings_restart: str) -> None:
+    """Restore log_level=INFO and bounce, retried as a set (leaked DEBUG
+    would flood every later test's addon log)."""
+    deadline = time.monotonic() + _RESTORE_TIMEOUT
+    while True:
+        try:
+            await _post_log_level(settings_advanced, "INFO")
+            await _restart_self(settings_restart)
+            return
+        except _RESTORE_TRANSIENT:
+            if time.monotonic() >= deadline:
+                raise
+            await asyncio.sleep(_POLL_INTERVAL)
+
+
+async def _warm_shared_client(mcp_client: Any) -> None:
+    """Warm the SHARED session client back up after the self-restarts.
+
+    safe_call_tool: a ToolError raised mid-bounce is not in the transient
+    set and would escape the loop; break only on a successful payload.
+    """
+    deadline = time.monotonic() + _WARM_TIMEOUT
+    while True:
+        try:
+            payload = await safe_call_tool(mcp_client, "ha_get_overview", {})
+            if payload.get("success", True) and "error" not in payload:
+                return
+        except _RESTORE_TRANSIENT:
+            pass
+        if time.monotonic() >= deadline:
+            raise AssertionError(
+                "Shared mcp_client never warmed back up after the restore "
+                f"restart within {_WARM_TIMEOUT}s"
+            )
+        await asyncio.sleep(_POLL_INTERVAL)
 
 
 @pytest.mark.inaddon_only
@@ -156,30 +193,7 @@ async def test_addon_launcher_schedules_the_startup_nudge(
             "lifespan reaches the add-on."
         )
     finally:
-        # Restore INFO for the rest of the session — retried as a set, like
-        # the debug-log-level test (a leaked DEBUG level would flood every
-        # later test's addon log).
-        restore_deadline = time.monotonic() + _RESTORE_TIMEOUT
-        while True:
-            try:
-                await _post_log_level(settings_advanced, "INFO")
-                await _restart_self(settings_restart)
-                break
-            except _RESTORE_TRANSIENT:
-                if time.monotonic() >= restore_deadline:
-                    raise
-                await asyncio.sleep(_POLL_INTERVAL)
-        # The self-restarts dropped the SHARED session mcp_client's
-        # connection. Warm it back up so later tests on this worker get a
-        # live session.
-        warm_deadline = time.monotonic() + _WARM_TIMEOUT
-        while True:
-            try:
-                await mcp_client.call_tool("ha_get_overview", {})
-                break
-            except _RESTORE_TRANSIENT:
-                if time.monotonic() >= warm_deadline:
-                    raise
-                await asyncio.sleep(_POLL_INTERVAL)
+        await _restore_info_level(settings_advanced, settings_restart)
+        await _warm_shared_client(mcp_client)
 
     LOG.info("Add-on launcher scheduled the startup nudge")

--- a/tests/src/e2e/haos_only/test_inaddon_startup_nudge.py
+++ b/tests/src/e2e/haos_only/test_inaddon_startup_nudge.py
@@ -1,0 +1,69 @@
+"""Add-on-lane regression test for the HACS startup nudge scheduling.
+
+The launcher gap this branch fixes was SPECIFIC to the add-on: `start.py`
+calls ``mcp.run()`` directly, so the nudge scheduled from ``__main__``'s
+``_run_with_shutdown`` never ran there, and no CI lane noticed. This test
+closes that lane: the inaddon tier runs the real dev add-on built from this
+PR's source, and a due startup pass emits one unconditional INFO line
+*before* any WebSocket work (``hacs_auto_refresh.py``), so the line appears
+even though the HAOS VM ships no HACS (where the pass then retries quietly
+and ends silently). Grepping the add-on's own logs for that line proves the
+real add-on launcher entered the server lifespan and started the nudge —
+exactly what was silently missing before.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import pytest
+
+from ..utilities.assertions import parse_mcp_result
+from ..utilities.wait_helpers import wait_for_condition
+
+LOG = logging.getLogger(__name__)
+
+# Slug of the dev add-on the inaddon tier boots (see test_inaddon_source_refresh).
+DEV_ADDON_NAME = "Home Assistant MCP Server (Dev)"
+
+NUDGE_LOG_SIGNATURE = "HACS auto-refresh: startup pass due"
+
+
+@pytest.mark.inaddon_only
+async def test_addon_launcher_schedules_the_startup_nudge(mcp_client: Any) -> None:
+    """The running dev add-on's logs must carry the nudge's startup line.
+
+    A fresh bake has no marker, so the pass is always due on the add-on's
+    first boot; the INFO line lands before any WebSocket work, so HACS
+    being absent from the VM cannot suppress it.
+    """
+    LOG.info("Looking up the dev add-on slug...")
+    raw = await mcp_client.call_tool("ha_get_addon", {})
+    data = parse_mcp_result(raw)
+    addons = data.get("addons") or []
+    dev_addon = next((a for a in addons if a.get("name") == DEV_ADDON_NAME), None)
+    assert dev_addon, f"Dev add-on {DEV_ADDON_NAME!r} not installed: {addons}"
+    slug = dev_addon["slug"]
+
+    async def nudge_line_logged() -> bool:
+        raw_logs = await mcp_client.call_tool(
+            "ha_get_logs",
+            {"source": "supervisor", "slug": slug, "search": NUDGE_LOG_SIGNATURE},
+        )
+        payload = parse_mcp_result(raw_logs)
+        return bool(payload.get("success")) and payload.get("returned_lines", 0) > 0
+
+    found = await wait_for_condition(
+        nudge_line_logged,
+        timeout=60,
+        condition_name="startup nudge INFO line in the dev add-on logs",
+    )
+    assert found, (
+        f"The dev add-on's logs never showed {NUDGE_LOG_SIGNATURE!r} — the "
+        "add-on launcher did not schedule the startup nudge. This is the "
+        "exact regression the lifespan wiring exists to prevent: start.py "
+        "runs mcp.run() directly, so only a server-attached lifespan reaches "
+        "the add-on."
+    )
+    LOG.info("Add-on launcher scheduled the startup nudge")

--- a/tests/src/e2e/haos_only/test_inaddon_startup_nudge.py
+++ b/tests/src/e2e/haos_only/test_inaddon_startup_nudge.py
@@ -29,9 +29,8 @@ import httpx
 import pytest
 from fastmcp import Client
 from fastmcp.client.transports import StreamableHttpTransport
-from fastmcp.exceptions import ToolError
 
-from ..utilities.assertions import MCPAssertions, parse_mcp_result
+from ..utilities.assertions import MCPAssertions, parse_mcp_result, safe_call_tool
 from ..utilities.wait_helpers import _POLLING_TRANSIENT_ERRORS
 
 LOG = logging.getLogger(__name__)
@@ -121,28 +120,28 @@ async def _warm_shared_client(mcp_client: Any) -> None:
     """
     deadline = time.monotonic() + _WARM_TIMEOUT
     last: object = None
-    while True:
+    while (remaining := deadline - time.monotonic()) > 0:
         try:
-            # Bounded like the fresh calls: an unbounded read on the shared
-            # session mid-bounce parks the loop past every deadline.
-            await asyncio.wait_for(mcp_client.call_tool("ha_get_overview", {}), 30)
-            return
-        except ToolError:
-            # Warm-up only cares that the shared session round-trips again;
-            # a tool-level failure IS a completed round-trip. (Payload
+            # safe_call_tool: a returned dict — success OR ToolError shape —
+            # is a completed round-trip, which is all warm-up needs. (Payload
             # inspection here proved harmful: it kept the loop spinning on a
-            # healthy session — the two prior CI failures.)
+            # healthy session — two prior CI failures.) wait_for bounds the
+            # exchange, capped to the remaining budget so the last iteration
+            # cannot overshoot the deadline.
+            await asyncio.wait_for(
+                safe_call_tool(mcp_client, "ha_get_overview", {}),
+                timeout=min(30.0, remaining),
+            )
             return
         except _RESTORE_TRANSIENT as err:
-            # Transient while the addon bounces underneath us; the deadline
-            # check below bounds the retries.
+            # Transient while the addon bounces underneath us; the loop
+            # condition bounds the retries.
             last = err
-        if time.monotonic() >= deadline:
-            raise AssertionError(
-                "Shared mcp_client never warmed back up after the restore "
-                f"restart within {_WARM_TIMEOUT}s (last={last!r})"
-            )
-        await asyncio.sleep(_POLL_INTERVAL)
+        await asyncio.sleep(min(_POLL_INTERVAL, max(deadline - time.monotonic(), 0)))
+    raise AssertionError(
+        "Shared mcp_client never warmed back up after the restore "
+        f"restart within {_WARM_TIMEOUT}s (last={last!r})"
+    )
 
 
 @pytest.mark.inaddon_only

--- a/tests/src/e2e/haos_only/test_inaddon_startup_nudge.py
+++ b/tests/src/e2e/haos_only/test_inaddon_startup_nudge.py
@@ -32,7 +32,7 @@ import pytest
 from fastmcp import Client
 from fastmcp.client.transports import StreamableHttpTransport
 
-from ..utilities.assertions import parse_mcp_result
+from ..utilities.assertions import MCPAssertions, parse_mcp_result
 from ..utilities.wait_helpers import _POLLING_TRANSIENT_ERRORS
 
 LOG = logging.getLogger(__name__)
@@ -96,8 +96,10 @@ async def test_addon_launcher_schedules_the_startup_nudge(
     settings_restart = f"{base}{HA_MCP_TEST_SECRET_PATH}/api/settings/restart"
 
     # Resolve the dev addon's Supervisor slug while the shared client is
-    # still live (pre-restart).
-    data = parse_mcp_result(await mcp_client.call_tool("ha_get_addon", {}))
+    # still live (pre-restart). call_tool_success per the test conventions:
+    # a failed listing reports itself instead of reading as a missing addon.
+    async with MCPAssertions(mcp_client) as mcp:
+        data = await mcp.call_tool_success("ha_get_addon", {})
     addons = data.get("addons") or []
     dev_addon = next((a for a in addons if a.get("name") == DEV_ADDON_NAME), None)
     assert dev_addon is not None, (

--- a/tests/src/e2e/haos_only/test_inaddon_startup_nudge.py
+++ b/tests/src/e2e/haos_only/test_inaddon_startup_nudge.py
@@ -83,18 +83,19 @@ async def _call_tool_fresh(addon_url: str, tool: str, args: dict[str, Any]) -> A
     return parse_mcp_result(raw)
 
 
+def _nudge_log_args(slug: str) -> dict[str, Any]:
+    """Build the widest bounded search for the nudge log signature."""
+    return {
+        "source": "supervisor",
+        "slug": slug,
+        "search": NUDGE_LOG_SIGNATURE,
+        "limit": _NUDGE_LOG_LIMIT,
+    }
+
+
 async def _fetch_nudge_logs(addon_url: str, slug: str) -> dict[str, Any]:
-    """Fetch the widest bounded search result for the nudge log signature."""
-    return await _call_tool_fresh(
-        addon_url,
-        "ha_get_logs",
-        {
-            "source": "supervisor",
-            "slug": slug,
-            "search": NUDGE_LOG_SIGNATURE,
-            "limit": _NUDGE_LOG_LIMIT,
-        },
-    )
+    """Fetch nudge logs over a restart-safe fresh connection."""
+    return await _call_tool_fresh(addon_url, "ha_get_logs", _nudge_log_args(slug))
 
 
 def _nudge_boot_line_count(log_text: str) -> int:
@@ -200,21 +201,22 @@ async def test_addon_launcher_schedules_the_startup_nudge(
     )
     slug = dev_addon["slug"]
 
+    # Supervisor logs survive add-on restarts. Record the exact per-boot phrase
+    # count on the already-proven shared client so an older boot cannot satisfy
+    # this restart; fresh connections are reserved for the post-restart retry.
+    async with MCPAssertions(mcp_client) as mcp:
+        baseline_payload = await mcp.call_tool_success(
+            "ha_get_logs", _nudge_log_args(slug)
+        )
+    baseline_count = _nudge_boot_line_count(baseline_payload.get("log", ""))
+    LOG.info(
+        "Recorded %d nudge per-boot lines before the restart",
+        baseline_count,
+    )
+
     LOG.info("Flipping the dev add-on to DEBUG for a fresh, provable boot...")
     await _post_log_level(settings_advanced, "DEBUG")
     try:
-        # Supervisor logs survive add-on restarts. Record the exact per-boot
-        # phrase count first so an older boot cannot satisfy this restart.
-        baseline_payload = await _fetch_nudge_logs(addon_url, slug)
-        assert baseline_payload.get("success"), (
-            f"Could not record the pre-restart nudge-log baseline: {baseline_payload}"
-        )
-        baseline_count = _nudge_boot_line_count(baseline_payload.get("log", ""))
-        LOG.info(
-            "Recorded %d nudge per-boot lines before the restart",
-            baseline_count,
-        )
-
         await _restart_self(settings_restart)
 
         deadline = time.monotonic() + _PROBE_TIMEOUT

--- a/tests/src/e2e/haos_only/test_inaddon_startup_nudge.py
+++ b/tests/src/e2e/haos_only/test_inaddon_startup_nudge.py
@@ -41,6 +41,11 @@ DEV_ADDON_NAME = "Home Assistant MCP Server (Dev)"
 # proves the launcher scheduled the nudge. Keep in lockstep with
 # src/ha_mcp/hacs_auto_refresh.py.
 NUDGE_LOG_SIGNATURE = "HACS auto-refresh:"
+NUDGE_BOOT_LOG_PHRASES = (
+    "HACS auto-refresh: startup pass due",
+    "HACS auto-refresh: pass not due",
+)
+_NUDGE_LOG_LIMIT = 500
 
 # Same transient sets as test_addon_debug_log_level (see its comments).
 _TRANSIENT = (*_POLLING_TRANSIENT_ERRORS, httpx.HTTPError)
@@ -76,6 +81,28 @@ async def _call_tool_fresh(addon_url: str, tool: str, args: dict[str, Any]) -> A
 
     raw = await asyncio.wait_for(_exchange(), timeout=30)
     return parse_mcp_result(raw)
+
+
+async def _fetch_nudge_logs(addon_url: str, slug: str) -> dict[str, Any]:
+    """Fetch the widest bounded search result for the nudge log signature."""
+    return await _call_tool_fresh(
+        addon_url,
+        "ha_get_logs",
+        {
+            "source": "supervisor",
+            "slug": slug,
+            "search": NUDGE_LOG_SIGNATURE,
+            "limit": _NUDGE_LOG_LIMIT,
+        },
+    )
+
+
+def _nudge_boot_line_count(log_text: str) -> int:
+    """Count real per-boot nudge lines, excluding search-argument echoes."""
+    return sum(
+        any(phrase in line for phrase in NUDGE_BOOT_LOG_PHRASES)
+        for line in log_text.splitlines()
+    )
 
 
 async def _post_log_level(settings_advanced_url: str, level: str) -> None:
@@ -176,6 +203,18 @@ async def test_addon_launcher_schedules_the_startup_nudge(
     LOG.info("Flipping the dev add-on to DEBUG for a fresh, provable boot...")
     await _post_log_level(settings_advanced, "DEBUG")
     try:
+        # Supervisor logs survive add-on restarts. Record the exact per-boot
+        # phrase count first so an older boot cannot satisfy this restart.
+        baseline_payload = await _fetch_nudge_logs(addon_url, slug)
+        assert baseline_payload.get("success"), (
+            f"Could not record the pre-restart nudge-log baseline: {baseline_payload}"
+        )
+        baseline_count = _nudge_boot_line_count(baseline_payload.get("log", ""))
+        LOG.info(
+            "Recorded %d nudge per-boot lines before the restart",
+            baseline_count,
+        )
+
         await _restart_self(settings_restart)
 
         deadline = time.monotonic() + _PROBE_TIMEOUT
@@ -184,37 +223,36 @@ async def test_addon_launcher_schedules_the_startup_nudge(
         while time.monotonic() < deadline:
             try:
                 url = wait_for_addon_mcp_ready(timeout=30.0)
-                payload = await _call_tool_fresh(
-                    url,
-                    "ha_get_logs",
-                    {
-                        "source": "supervisor",
-                        "slug": slug,
-                        "search": NUDGE_LOG_SIGNATURE,
-                    },
-                )
+                payload = await _fetch_nudge_logs(url, slug)
                 log_text = payload.get("log", "")
                 # Post-filter for the two REAL per-boot phrases: at DEBUG the
                 # addon logs this probe's own tool calls, whose search
                 # argument contains the bare signature — matching only the
                 # signature would let the probe confirm itself.
-                if payload.get("success") and (
-                    "startup pass due" in log_text or "pass not due" in log_text
-                ):
+                current_count = _nudge_boot_line_count(log_text)
+                if payload.get("success") and current_count > baseline_count:
                     found = True
                     LOG.info(
-                        "Nudge per-boot line found after restart: %s",
+                        "Nudge per-boot line count grew from %d to %d after "
+                        "restart: %s",
+                        baseline_count,
+                        current_count,
                         log_text[:200],
                     )
                     break
-                last = f"no match yet in {payload.get('total_lines', 0)} lines"
+                last = (
+                    f"per-boot line count {current_count} has not grown beyond "
+                    f"the pre-restart baseline {baseline_count} in "
+                    f"{payload.get('total_lines', 0)} matching lines"
+                )
             except _TRANSIENT as err:
                 last = err
             await asyncio.sleep(_POLL_INTERVAL)
 
         assert found, (
-            f"A DEBUG-level fresh boot never logged {NUDGE_LOG_SIGNATURE!r} "
-            f"within {_PROBE_TIMEOUT}s of the self-restart (last={last!r}) — "
+            "A DEBUG-level fresh boot did not add a new "
+            f"{NUDGE_LOG_SIGNATURE!r} per-boot line within {_PROBE_TIMEOUT}s "
+            f"of the self-restart (last={last!r}) — "
             "the add-on launcher did not schedule the startup nudge (neither "
             "the due INFO line nor the not-due DEBUG line appeared). This is "
             "the exact regression the lifespan wiring exists to prevent: "

--- a/tests/src/e2e/haos_only/test_inaddon_startup_nudge.py
+++ b/tests/src/e2e/haos_only/test_inaddon_startup_nudge.py
@@ -63,10 +63,19 @@ async def _call_tool_fresh(addon_url: str, tool: str, args: dict[str, Any]) -> A
 
     The server is stateless, so a new client per call is cheap and — unlike a
     long-lived session — immune to the addon restarting between calls.
+    asyncio.wait_for bounds the whole exchange: a half-open connection to a
+    bouncing addon otherwise parks the await indefinitely — the event loop
+    sat idle at selector.select past the 600 s pytest-timeout with none of
+    this test's own deadlines ever re-evaluated (round-4 CI failure).
+    TimeoutError is in the polling transient set, so a bound trip is retried.
     """
-    client = Client(StreamableHttpTransport(url=addon_url))
-    async with client:
-        raw = await client.call_tool(tool, args)
+
+    async def _exchange() -> Any:
+        client = Client(StreamableHttpTransport(url=addon_url))
+        async with client:
+            return await client.call_tool(tool, args)
+
+    raw = await asyncio.wait_for(_exchange(), timeout=30)
     return parse_mcp_result(raw)
 
 
@@ -114,7 +123,9 @@ async def _warm_shared_client(mcp_client: Any) -> None:
     last: object = None
     while True:
         try:
-            await mcp_client.call_tool("ha_get_overview", {})
+            # Bounded like the fresh calls: an unbounded read on the shared
+            # session mid-bounce parks the loop past every deadline.
+            await asyncio.wait_for(mcp_client.call_tool("ha_get_overview", {}), 30)
             return
         except ToolError:
             # Warm-up only cares that the shared session round-trips again;

--- a/tests/src/e2e/haos_only/test_inaddon_startup_nudge.py
+++ b/tests/src/e2e/haos_only/test_inaddon_startup_nudge.py
@@ -46,13 +46,15 @@ NUDGE_LOG_SIGNATURE = "HACS auto-refresh:"
 _TRANSIENT = (*_POLLING_TRANSIENT_ERRORS, httpx.HTTPError)
 _RESTORE_TRANSIENT = (*_TRANSIENT, AssertionError)
 
-# Budgets sized to fit inside pytest-timeout's 300 s per-test cap even on
-# the all-loops-exhausted path: probe 120 + restore 60 + warm 60 (+ restarts
-# at 5-25 s each) stays under it. The probe's happy path is a few seconds.
-_PROBE_TIMEOUT = 120.0
-_RESTORE_TIMEOUT = 60.0
-_WARM_TIMEOUT = 60.0
+# Real-world HAOS budgets (a 60 s warm-up starved in CI: two back-to-back
+# container restarts, and DEBUG-level logging makes every log fetch heavy).
+# The per-test pytest.mark.timeout below is sized to the phase sum plus
+# restart margin, following the other HAOS long-runners' precedent.
+_PROBE_TIMEOUT = 180.0
+_RESTORE_TIMEOUT = 120.0
+_WARM_TIMEOUT = 180.0
 _POLL_INTERVAL = 3.0
+_TEST_TIMEOUT_S = 600
 
 
 async def _call_tool_fresh(addon_url: str, tool: str, args: dict[str, Any]) -> Any:
@@ -127,6 +129,7 @@ async def _warm_shared_client(mcp_client: Any) -> None:
 
 @pytest.mark.inaddon_only
 @pytest.mark.addon_disruptive
+@pytest.mark.timeout(_TEST_TIMEOUT_S)
 async def test_addon_launcher_schedules_the_startup_nudge(
     mcp_client: Any,
     ha_container_with_fresh_config: dict[str, Any],

--- a/tests/src/e2e/haos_only/test_inaddon_startup_nudge.py
+++ b/tests/src/e2e/haos_only/test_inaddon_startup_nudge.py
@@ -114,6 +114,8 @@ async def _warm_shared_client(mcp_client: Any) -> None:
             if payload.get("success", True) and "error" not in payload:
                 return
         except _RESTORE_TRANSIENT:
+            # Transient while the addon bounces underneath us; the deadline
+            # check below bounds the retries.
             pass
         if time.monotonic() >= deadline:
             raise AssertionError(

--- a/tests/src/e2e/haos_only/test_inaddon_startup_nudge.py
+++ b/tests/src/e2e/haos_only/test_inaddon_startup_nudge.py
@@ -3,21 +3,19 @@
 The launcher gap this branch fixes was SPECIFIC to the add-on: ``start.py``
 calls ``mcp.run()`` directly, so the nudge scheduled from ``__main__``'s
 ``_run_with_shutdown`` never ran there, and no CI lane noticed. This test
-closes that lane: the inaddon tier runs the real dev add-on built from this
-PR's source, and a due startup pass emits one unconditional INFO line
-*before* any WebSocket work (``hacs_auto_refresh.py``), so the line appears
-even though the HAOS VM ships no HACS (where the pass then retries quietly
-and ends silently). Finding that line in the add-on's own logs proves the
-real add-on launcher entered the server lifespan and started the nudge —
-exactly what was silently missing before.
+closes that lane by proving the real add-on launcher enters the server
+lifespan and starts the nudge.
 
-The test self-restarts the add-on first (the ``test_addon_debug_log_level``
-pattern) because the line is a one-shot BOOT line: by the time this test
-runs, the boot that emitted it sits thousands of request-log lines back,
-beyond even the expanded journald search window
-(``SUPERVISOR_SEARCH_WINDOW_LINES``). A fresh boot is still due — the HAOS
-VM has no HACS, so no earlier pass ever completed and wrote a marker — and
-puts the line in the fresh tail where the search window sees it.
+The observable is one of the nudge's own per-boot lines: ``"startup pass
+due"`` (INFO, first boot) or ``"pass not due"`` (DEBUG, later boots). Both
+prove scheduling; which one fires depends on marker state, which this test
+must NOT assume: the add-on's ``/data`` persists across restarts, and once
+an early boot lives ~8.5 minutes its HACS-absent pass completes and writes
+the marker, making every later boot legitimately not due (observed live in
+CI — 50 boots, one due-line). So the test drives the add-on to DEBUG via
+the settings API (the ``test_addon_debug_log_level`` flow), restarts it,
+and searches the fresh boot's log for the shared ``"HACS auto-refresh:"``
+prefix, restoring INFO afterwards.
 """
 
 from __future__ import annotations
@@ -39,19 +37,21 @@ LOG = logging.getLogger(__name__)
 
 DEV_ADDON_NAME = "Home Assistant MCP Server (Dev)"
 
-NUDGE_LOG_SIGNATURE = "HACS auto-refresh: startup pass due"
+# Matches BOTH the due (INFO) and not-due (DEBUG) per-boot lines — either
+# proves the launcher scheduled the nudge. Keep in lockstep with
+# src/ha_mcp/hacs_auto_refresh.py.
+NUDGE_LOG_SIGNATURE = "HACS auto-refresh:"
 
-# Same transient set as test_addon_debug_log_level: the MCP-client polling
-# tuple plus httpx transport errors from connections dying mid-restart.
-# Bugs (TypeError, KeyError, AssertionError) must propagate.
+# Same transient sets as test_addon_debug_log_level (see its comments).
 _TRANSIENT = (*_POLLING_TRANSIENT_ERRORS, httpx.HTTPError)
-
-# The warm-up loop additionally rides out the HTTP-status asserts the
-# restart helper makes while the addon is still bouncing.
 _RESTORE_TRANSIENT = (*_TRANSIENT, AssertionError)
 
-# Addon restart = container stop + start; CI runners take 5-25s.
-_RECOVERY_TIMEOUT = 180.0
+# Budgets sized to fit inside pytest-timeout's 300 s per-test cap even on
+# the all-loops-exhausted path: probe 120 + restore 60 + warm 60 (+ restarts
+# at 5-25 s each) stays under it. The probe's happy path is a few seconds.
+_PROBE_TIMEOUT = 120.0
+_RESTORE_TIMEOUT = 60.0
+_WARM_TIMEOUT = 60.0
 _POLL_INTERVAL = 3.0
 
 
@@ -65,6 +65,16 @@ async def _call_tool_fresh(addon_url: str, tool: str, args: dict[str, Any]) -> A
     async with client:
         raw = await client.call_tool(tool, args)
     return parse_mcp_result(raw)
+
+
+async def _post_log_level(settings_advanced_url: str, level: str) -> None:
+    """Write ``log_level`` through the settings advanced API."""
+    async with httpx.AsyncClient(timeout=30.0) as http:
+        resp = await http.post(settings_advanced_url, json={"log_level": level})
+    assert resp.status_code == 200, (
+        f"POST {{'log_level': {level!r}}} to {settings_advanced_url} returned "
+        f"{resp.status_code}: {resp.text[:500]}"
+    )
 
 
 async def _restart_self(settings_restart_url: str) -> None:
@@ -82,17 +92,13 @@ async def test_addon_launcher_schedules_the_startup_nudge(
     mcp_client: Any,
     ha_container_with_fresh_config: dict[str, Any],
 ) -> None:
-    """A fresh add-on boot must log the nudge's due-pass line.
-
-    A fresh boot is always due here (no marker: the VM has no HACS, so no
-    prior pass ever completed), and the INFO line lands before any WebSocket
-    work, so HACS being absent cannot suppress it.
-    """
+    """A DEBUG-level fresh boot must log one of the nudge's per-boot lines."""
     from haos_runtime import HA_MCP_TEST_SECRET_PATH, wait_for_addon_mcp_ready
 
     addon_url = ha_container_with_fresh_config.get("addon_mcp_url")
     assert addon_url, "inaddon container_info has no addon_mcp_url"
     base = addon_url.split("/mcp", 1)[0]
+    settings_advanced = f"{base}{HA_MCP_TEST_SECRET_PATH}/api/settings/advanced"
     settings_restart = f"{base}{HA_MCP_TEST_SECRET_PATH}/api/settings/restart"
 
     # Resolve the dev addon's Supervisor slug while the shared client is
@@ -108,11 +114,12 @@ async def test_addon_launcher_schedules_the_startup_nudge(
     )
     slug = dev_addon["slug"]
 
-    LOG.info("Restarting the dev add-on to get a fresh boot in the log tail...")
+    LOG.info("Flipping the dev add-on to DEBUG for a fresh, provable boot...")
+    await _post_log_level(settings_advanced, "DEBUG")
     try:
         await _restart_self(settings_restart)
 
-        deadline = time.monotonic() + _RECOVERY_TIMEOUT
+        deadline = time.monotonic() + _PROBE_TIMEOUT
         last: object = None
         found = False
         while time.monotonic() < deadline:
@@ -130,7 +137,7 @@ async def test_addon_launcher_schedules_the_startup_nudge(
                 if payload.get("success") and payload.get("returned_lines", 0) > 0:
                     found = True
                     LOG.info(
-                        "Due-pass line found after restart: %s",
+                        "Nudge per-boot line found after restart: %s",
                         payload.get("log", "")[:200],
                     )
                     break
@@ -140,17 +147,32 @@ async def test_addon_launcher_schedules_the_startup_nudge(
             await asyncio.sleep(_POLL_INTERVAL)
 
         assert found, (
-            f"The dev add-on's fresh boot never logged {NUDGE_LOG_SIGNATURE!r} "
-            f"within {_RECOVERY_TIMEOUT}s of the self-restart (last={last!r}) — "
-            "the add-on launcher did not schedule the startup nudge. This is "
+            f"A DEBUG-level fresh boot never logged {NUDGE_LOG_SIGNATURE!r} "
+            f"within {_PROBE_TIMEOUT}s of the self-restart (last={last!r}) — "
+            "the add-on launcher did not schedule the startup nudge (neither "
+            "the due INFO line nor the not-due DEBUG line appeared). This is "
             "the exact regression the lifespan wiring exists to prevent: "
             "start.py runs mcp.run() directly, so only a server-attached "
             "lifespan reaches the add-on."
         )
     finally:
-        # The self-restart dropped the SHARED session mcp_client's connection.
-        # Warm it back up so later tests on this worker get a live session.
-        warm_deadline = time.monotonic() + _RECOVERY_TIMEOUT
+        # Restore INFO for the rest of the session — retried as a set, like
+        # the debug-log-level test (a leaked DEBUG level would flood every
+        # later test's addon log).
+        restore_deadline = time.monotonic() + _RESTORE_TIMEOUT
+        while True:
+            try:
+                await _post_log_level(settings_advanced, "INFO")
+                await _restart_self(settings_restart)
+                break
+            except _RESTORE_TRANSIENT:
+                if time.monotonic() >= restore_deadline:
+                    raise
+                await asyncio.sleep(_POLL_INTERVAL)
+        # The self-restarts dropped the SHARED session mcp_client's
+        # connection. Warm it back up so later tests on this worker get a
+        # live session.
+        warm_deadline = time.monotonic() + _WARM_TIMEOUT
         while True:
             try:
                 await mcp_client.call_tool("ha_get_overview", {})

--- a/tests/src/e2e/workflows/embedded/test_embedded_server.py
+++ b/tests/src/e2e/workflows/embedded/test_embedded_server.py
@@ -593,9 +593,13 @@ class TestEmbeddedServerEndToEnd:
         def marker_files() -> list[Path]:
             return list(data_dir.glob(f"{MARKER_FILENAME_PREFIX}_*.json"))
 
+        # 10 s: the container ships a loaded HACS, so a regressed
+        # is_embedded gate completes its pass (and writes the marker) on the
+        # immediate first attempt — this window is over the completion time,
+        # not the retry schedule, which only starts when that attempt fails.
         appeared = await wait_for_condition(
             marker_files,
-            timeout=5,
+            timeout=10,
             condition_name=(
                 "(not expected) HACS refresh marker in the in-process server's data dir"
             ),

--- a/tests/src/e2e/workflows/embedded/test_embedded_server.py
+++ b/tests/src/e2e/workflows/embedded/test_embedded_server.py
@@ -49,7 +49,10 @@ import pytest
 import requests
 from test_constants import HA_TEST_IMAGE, TEST_TOKEN
 
+from ha_mcp.hacs_auto_refresh import MARKER_FILENAME_PREFIX
+
 from ...utilities.streamable_http import parse_mcp_response
+from ...utilities.wait_helpers import wait_for_condition
 
 # ``not_on_embedded``: this test boots its OWN dedicated in-process MCP server container to
 # prove the install method end to end. The embedded backend (E2E_BACKEND=embedded)
@@ -73,6 +76,12 @@ _ENTRY_ID = "e2e_test_ha_mcp_server_entry"
 _WEBHOOK_ID = "mcp_e2e_ha_mcp_server_0123456789abcdef"
 _SECRET_PATH = "/private_e2e_ha_mcp_server_secret"
 _SERVER_PORT = 9584
+# Where the in-process server keeps its data dir: the component points
+# HA_MCP_CONFIG_DIR at ``hass.config.path(SERVER_CONFIG_SUBDIR)``, so it lands
+# under the bind-mounted /config and is readable from the host. Duplicated from
+# custom_components/ha_mcp_tools/const.py (SERVER_CONFIG_SUBDIR), same as
+# conftest's _EMBEDDED_SERVER_CONFIG_SUBDIR.
+_SERVER_CONFIG_SUBDIR = ".ha_mcp"
 
 # The whole fastmcp dependency tree is runtime-installed on first bring-up.
 _READY_TIMEOUT_S = 600
@@ -545,3 +554,57 @@ class TestEmbeddedServerEndToEnd:
                 # component's tool-search mode).
                 assert stamps["ha_search"]["pinned"] is True
                 assert stamps["ha_get_state"]["pinned"] is False
+
+    async def test_embedded_server_skips_the_startup_nudge(self, embedded_ha):
+        """The in-process server must NOT run the HACS startup nudge.
+
+        ``hacs_refresh_lifespan`` is attached to the server itself, so the
+        in-process server runs it too (``embedded_server`` enters
+        ``mcp._lifespan_manager()`` around uvicorn). The nudge inside it must
+        return at the ``is_embedded()`` gate: the component ships its own
+        ``hacs_nudge``, and running both would double HACS's GitHub fetches.
+        The negative lanes' positive counterparts live in
+        tests/src/e2e/workflows/hacs/test_auto_refresh_startup.py.
+
+        Readiness is the ``embedded_ha`` fixture itself — it only yields once
+        MCP ``initialize`` succeeded, which is past server start and so past
+        the lifespan.
+
+        NOTE (skip-ceiling coupling): see
+        ``test_invalidate_caches_recovers_from_editable_finder_keyerror``
+        above — this module is ``container_only`` + ``not_on_embedded``, so
+        adding a test here bumps the haos, haos_inaddon, haos_embedded and
+        embedded ceilings in
+        tests/src/e2e/basic/test_backend_dispatch_smoke.py by one.
+        """
+        _base_url, _session_id, config_path, _container = embedded_ha
+        data_dir = config_path / _SERVER_CONFIG_SUBDIR
+
+        # The component creates this dir during bring-up; the test seeds
+        # nothing into it. Its absence would mean the glob below is pointed at
+        # the wrong path, which would make "no marker" prove nothing.
+        assert data_dir.is_dir(), (
+            f"{data_dir} does not exist, so the in-process server's data dir "
+            "is not where this test looks — check SERVER_CONFIG_SUBDIR in "
+            "custom_components/ha_mcp_tools/const.py. /config contents: "
+            f"{sorted(p.name for p in config_path.iterdir())}"
+        )
+
+        def marker_files() -> list[Path]:
+            return list(data_dir.glob(f"{MARKER_FILENAME_PREFIX}_*.json"))
+
+        appeared = await wait_for_condition(
+            marker_files,
+            timeout=5,
+            condition_name=(
+                "(not expected) HACS refresh marker in the in-process server's data dir"
+            ),
+        )
+        assert not appeared, (
+            "The in-process server wrote a HACS refresh marker "
+            f"({[p.name for p in marker_files()]}), but the embedded install "
+            "skips the nudge by design — the component's own hacs_nudge covers "
+            "it, and running both doubles HACS's GitHub fetches. The "
+            "is_embedded() gate in maybe_refresh_hacs_after_update is what "
+            "must hold here."
+        )

--- a/tests/src/e2e/workflows/hacs/test_auto_refresh_startup.py
+++ b/tests/src/e2e/workflows/hacs/test_auto_refresh_startup.py
@@ -34,9 +34,10 @@ in ``tests/src/e2e/workflows/embedded/test_embedded_server.py`` (the
 credentials at startup and exits without them (``_validate_standard_credentials``
 in ``__main__``), so it has no sentinel state to prove, and its run path is the
 same ``_run_with_shutdown(mcp.run_async(**_http_run_kwargs(...)))`` call the web
-lane already drives. The HAOS add-on lane is covered structurally rather than by
-a marker of its own — the unit suite pins the lifespan wiring, and the add-on's
-``start.py`` calls ``mcp.run()`` on this same server instance.
+lane already drives. The HAOS add-on lane is covered directly in
+``tests/src/e2e/haos_only/test_inaddon_startup_nudge.py``, which restarts the
+real add-on and requires a per-boot nudge line from that restart; the unit suite
+separately pins the shared lifespan wiring.
 """
 
 import asyncio

--- a/tests/src/e2e/workflows/hacs/test_auto_refresh_startup.py
+++ b/tests/src/e2e/workflows/hacs/test_auto_refresh_startup.py
@@ -21,11 +21,30 @@ one real launcher proving the chain runs end to end, plus the unit-level wiring
 pin, covers the others. The e2e container ships HACS in ``custom_components``
 but has neither candidate repository downloaded, so the pass completes on the
 first attempt with no GitHub traffic and writes the marker immediately.
+
+The lane matrix: stdio and ``ha-mcp-web`` are the POSITIVE lanes — the nudge
+completes a pass and writes its marker (the HTTP lifespan fires at uvicorn
+startup, so the web lane needs no client connection at all). ``ha-mcp-oauth``
+is a NEGATIVE lane: OAuth mode holds no server-level HA credential, so
+``maybe_refresh_hacs_after_update`` must return at the ``OAUTH_MODE_TOKEN``
+gate instead of burning its whole retry schedule on auth failures every boot.
+The embedded server is the other negative lane, pinned next to its own bring-up
+in ``tests/src/e2e/workflows/embedded/test_embedded_server.py`` (the
+``is_embedded`` gate). ``ha-mcp-oidc`` has no lane here: it validates HA
+credentials at startup and exits without them (``_validate_standard_credentials``
+in ``__main__``), so it has no sentinel state to prove, and its run path is the
+same ``_run_with_shutdown(mcp.run_async(**_http_run_kwargs(...)))`` call the web
+lane already drives. The HAOS add-on lane is covered structurally rather than by
+a marker of its own — the unit suite pins the lifespan wiring, and the add-on's
+``start.py`` calls ``mcp.run()`` on this same server instance.
 """
 
+import asyncio
 import json
 import logging
 import os
+from contextlib import suppress
+from pathlib import Path
 
 import pytest
 from fastmcp import Client
@@ -64,7 +83,10 @@ async def test_stdio_launcher_runs_the_startup_nudge(
         "HA_MCP_CONFIG_DIR": str(tmp_path),
     }
 
-    transport = StdioTransport(command="ha-mcp", args=[], env=env)
+    # keep_alive=False: the pinned FastMCP defaults to keeping the stdio
+    # subprocess alive past the client context, which would leak a server
+    # per test run and skip the lifespan's cancellation path on exit.
+    transport = StdioTransport(command="ha-mcp", args=[], env=env, keep_alive=False)
 
     def marker_files():
         return list(tmp_path.glob(f"{MARKER_FILENAME_PREFIX}_*.json"))
@@ -109,3 +131,259 @@ async def test_stdio_launcher_runs_the_startup_nudge(
     )
 
     logger.info("Stdio launcher startup nudge test passed")
+
+
+# Uvicorn logs both of these only AFTER the ASGI lifespan's startup half has
+# finished, so either line proves ``hacs_refresh_lifespan`` ran in the launcher's
+# own process and created the nudge task. The negative lane below needs that
+# proof: without it, "no marker appeared" could just mean the server never
+# started.
+_LIFESPAN_STARTED_LOG_FRAGMENTS = (
+    "Application startup complete",
+    "Uvicorn running on",
+)
+
+# Log fragments ``hacs_auto_refresh`` emits only once a pass has gone PAST the
+# gates — the per-attempt failure, the give-up line, and the success line. None
+# of them can come from a pass that returned at the OAuth sentinel gate.
+_NUDGE_RAN_LOG_FRAGMENTS = (
+    "HACS repository refresh attempt failed",
+    "Could not reach HACS to refresh the component repository",
+    "Asked HACS to refresh component repository info",
+)
+
+
+def _http_launcher_env(ha_url: str, config_dir: Path) -> dict[str, str]:
+    """Env shared by the HTTP launcher lanes, minus each lane's credentials.
+
+    Same shape as the stdio test's env (including the deliberate absence of
+    HA_MCP_DISABLE_UPDATE_CHECK, which would return the nudge early) plus the
+    HTTP knobs: loopback bind on an ephemeral port and a throwaway secret path,
+    because nothing ever connects to these servers — the lifespan fires at
+    uvicorn startup on its own.
+    """
+    return {
+        "HOMEASSISTANT_URL": ha_url,
+        "PATH": os.environ.get("PATH", ""),
+        "HOME": os.environ.get("HOME", ""),
+        "HA_MAX_RETRIES": "1",
+        "ENABLE_STRICT_MANDATORY_BPS": "false",
+        "HA_MCP_CONFIG_DIR": str(config_dir),
+        "MCP_HOST": "127.0.0.1",
+        "MCP_PORT": "0",
+        "MCP_SECRET_PATH": "/e2e-nudge-probe",
+    }
+
+
+class _HttpLauncher:
+    """A real ha-mcp HTTP launcher subprocess whose output is drained live.
+
+    stdout and stderr are merged into one pipe that a background task keeps
+    reading. That is not just for diagnostics: a launcher whose pipe buffer
+    filled would block inside its own log write, which could stall it before or
+    inside the lifespan and make both assertions below meaningless.
+    """
+
+    def __init__(self, proc: asyncio.subprocess.Process) -> None:
+        self._proc = proc
+        self._lines: list[str] = []
+        self._lifespan_started = asyncio.Event()
+        self._drain_task = asyncio.create_task(self._drain())
+
+    async def _drain(self) -> None:
+        assert self._proc.stdout is not None
+        buffer = ""
+        while True:
+            # Chunked reads rather than ``readline()``: a line longer than the
+            # stream reader's limit makes ``readline`` raise instead of
+            # returning, and a server banner is not a size we control.
+            chunk = await self._proc.stdout.read(4096)
+            if not chunk:
+                if buffer:
+                    self._record(buffer)
+                return
+            buffer += chunk.decode("utf-8", errors="replace")
+            *complete, buffer = buffer.split("\n")
+            for line in complete:
+                self._record(line)
+
+    def _record(self, line: str) -> None:
+        self._lines.append(line)
+        if any(f in line for f in _LIFESPAN_STARTED_LOG_FRAGMENTS):
+            self._lifespan_started.set()
+
+    async def wait_for_lifespan_started(self, timeout: float = 30) -> bool:
+        """True once the launcher reports a completed ASGI lifespan startup.
+
+        Raced against the process exiting so a launcher that died on a config
+        error reports back immediately instead of costing the whole timeout.
+        """
+        started = asyncio.ensure_future(self._lifespan_started.wait())
+        exited = asyncio.ensure_future(self._proc.wait())
+        try:
+            done, _pending = await asyncio.wait(
+                {started, exited},
+                timeout=timeout,
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+        finally:
+            for task in (started, exited):
+                task.cancel()
+                with suppress(asyncio.CancelledError):
+                    await task
+        return started in done
+
+    def lines_matching(self, fragments: tuple[str, ...]) -> list[str]:
+        return [line for line in self._lines if any(f in line for f in fragments)]
+
+    def output(self, limit: int = 40) -> str:
+        """The tail of the launcher's merged output, for failure messages."""
+        return "\n".join(self._lines[-limit:]) or "<no output captured>"
+
+    async def aclose(self) -> None:
+        """Stop the launcher and its drain — never leave an orphaned process."""
+        if self._proc.returncode is None:
+            self._proc.terminate()
+            try:
+                await asyncio.wait_for(self._proc.wait(), timeout=10)
+            except TimeoutError:
+                self._proc.kill()
+                await self._proc.wait()
+        self._drain_task.cancel()
+        with suppress(asyncio.CancelledError):
+            await self._drain_task
+
+
+async def _spawn_http_launcher(command: str, env: dict[str, str]) -> _HttpLauncher:
+    """Spawn ``command`` (an ha-mcp HTTP console script) with a drained pipe.
+
+    Not StdioTransport: these entry points speak HTTP, not MCP-over-stdio, so
+    the test drives the process directly.
+    """
+    proc = await asyncio.create_subprocess_exec(
+        command,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.STDOUT,
+        env=env,
+    )
+    return _HttpLauncher(proc)
+
+
+@pytest.mark.hacs
+async def test_web_launcher_runs_the_startup_nudge(
+    ha_container_with_fresh_config, tmp_path
+):
+    """A real ha-mcp-web subprocess must complete the nudge with no client."""
+    logger.info("Testing the HACS startup nudge through the ha-mcp-web launcher...")
+
+    container_info = ha_container_with_fresh_config
+    env = _http_launcher_env(container_info["base_url"], tmp_path)
+    env["HOMEASSISTANT_TOKEN"] = TEST_TOKEN
+
+    def marker_files():
+        return list(tmp_path.glob(f"{MARKER_FILENAME_PREFIX}_*.json"))
+
+    launcher = await _spawn_http_launcher("ha-mcp-web", env)
+    try:
+        # The marker IS the readiness signal: it can only be written after
+        # uvicorn ran the lifespan and the nudge completed a pass. Nothing
+        # connects to the HTTP endpoint at any point in this test.
+        found = await wait_for_condition(
+            marker_files,
+            timeout=30,
+            condition_name="HACS refresh marker written by the web launcher",
+        )
+        markers = marker_files()
+        output = launcher.output()
+    finally:
+        await launcher.aclose()
+
+    assert found, (
+        "No HACS refresh marker appeared in the web launcher's data dir within "
+        "30s — the HTTP lifespan is likely not scheduling "
+        "maybe_refresh_hacs_after_update. Data dir contents: "
+        f"{sorted(p.name for p in tmp_path.iterdir())}. Launcher output:\n{output}"
+    )
+    assert len(markers) == 1, (
+        "The nudge writes one marker per HA target and this run had exactly "
+        f"one, got: {[p.name for p in markers]}"
+    )
+
+    marker = json.loads(markers[0].read_text(encoding="utf-8"))
+    logger.info(f"Marker written by the web launcher: {marker}")
+
+    assert marker["hacs"] == "present", (
+        f"Marker reports hacs={marker['hacs']!r}, but the e2e container ships "
+        "HACS in custom_components — the pass did not reach a loaded HACS."
+    )
+    server_version = marker["server_version"]
+    assert isinstance(server_version, str) and server_version, (
+        "Marker must record the running server version so the next startup can "
+        f"detect an update, got {server_version!r}"
+    )
+
+    logger.info("Web launcher startup nudge test passed")
+
+
+@pytest.mark.hacs
+async def test_oauth_launcher_skips_the_startup_nudge(
+    ha_container_with_fresh_config, tmp_path
+):
+    """A real ha-mcp-oauth subprocess must return at the OAuth sentinel gate.
+
+    Per-user OAuth mode holds no server-level HA credential, so
+    ``maybe_refresh_hacs_after_update`` returns before touching the WebSocket.
+    A regression that dropped the gate would nudge with the sentinel token and
+    burn the whole ~8-minute retry schedule on auth failures on every single
+    boot — and it would still write no marker, so marker absence alone cannot
+    detect it. Hence the two assertions: nothing that only a past-the-gate pass
+    logs, and no marker.
+    """
+    logger.info("Testing the HACS startup nudge gate on the ha-mcp-oauth launcher...")
+
+    container_info = ha_container_with_fresh_config
+    env = _http_launcher_env(container_info["base_url"], tmp_path)
+    # No HOMEASSISTANT_TOKEN: main_oauth substitutes OAUTH_MODE_TOKEN for it,
+    # which is exactly the state under test. MCP_BASE_URL is only echoed into
+    # the OAuth metadata URLs — HomeAssistantOAuthProvider never fetches it —
+    # so a reserved .invalid host keeps that side of the run entirely offline.
+    env["MCP_BASE_URL"] = "https://e2e-oauth-probe.invalid"
+    # The nudge's own attempt/give-up lines are DEBUG; without this the
+    # past-the-gate assertion below could not see them.
+    env["LOG_LEVEL"] = "DEBUG"
+
+    def marker_files():
+        return list(tmp_path.glob(f"{MARKER_FILENAME_PREFIX}_*.json"))
+
+    launcher = await _spawn_http_launcher("ha-mcp-oauth", env)
+    try:
+        started = await launcher.wait_for_lifespan_started(timeout=30)
+        assert started, (
+            "The ha-mcp-oauth launcher never reported a completed ASGI lifespan "
+            "startup within 30s, so the assertions below would prove nothing "
+            f"about the gate. Launcher output:\n{launcher.output()}"
+        )
+        appeared = await wait_for_condition(
+            marker_files,
+            timeout=5,
+            condition_name="(not expected) HACS refresh marker from the oauth launcher",
+        )
+        markers = marker_files()
+        ran = launcher.lines_matching(_NUDGE_RAN_LOG_FRAGMENTS)
+        output = launcher.output()
+    finally:
+        await launcher.aclose()
+
+    assert not ran, (
+        "The oauth launcher logged a HACS refresh pass, so the nudge ran past "
+        "the OAUTH_MODE_TOKEN gate with sentinel credentials — every boot would "
+        "spend its retry schedule failing auth. Lines:\n" + "\n".join(ran)
+    )
+    assert not appeared, (
+        "The oauth launcher wrote a HACS refresh marker "
+        f"({[p.name for p in markers]}), but OAuth mode has no server-level HA "
+        "credential — the nudge must return at the OAUTH_MODE_TOKEN gate. "
+        f"Launcher output:\n{output}"
+    )
+
+    logger.info("OAuth launcher startup nudge gate test passed")

--- a/tests/src/e2e/workflows/hacs/test_auto_refresh_startup.py
+++ b/tests/src/e2e/workflows/hacs/test_auto_refresh_startup.py
@@ -363,9 +363,13 @@ async def test_oauth_launcher_skips_the_startup_nudge(
             "startup within 30s, so the assertions below would prove nothing "
             f"about the gate. Launcher output:\n{launcher.output()}"
         )
+        # 10 s window as belt-and-braces only: a regressed gate with sentinel
+        # credentials fails auth and never writes a marker at ANY timeout,
+        # which is why the log assertion below — not marker absence — is the
+        # deterministic proof for this lane.
         appeared = await wait_for_condition(
             marker_files,
-            timeout=5,
+            timeout=10,
             condition_name="(not expected) HACS refresh marker from the oauth launcher",
         )
         markers = marker_files()

--- a/tests/src/e2e/workflows/hacs/test_auto_refresh_startup.py
+++ b/tests/src/e2e/workflows/hacs/test_auto_refresh_startup.py
@@ -1,0 +1,111 @@
+"""Launcher-lane regression test for the HACS startup nudge (the add-on gap).
+
+The nudge that asks HACS to refresh the paired component's release data used to
+be scheduled by ``__main__``'s ``_run_with_shutdown``, so any launcher that
+calls ``mcp.run()`` directly — the add-on's ``start.py`` above all — never got
+it. The fix moves the scheduling into the server's FastMCP ``lifespan``
+(``hacs_refresh_lifespan`` in ``src/ha_mcp/hacs_auto_refresh.py``), which every
+launcher runs because it is attached to the server itself, not to one entry
+point.
+
+The unit suite pins that wiring (the lifespan is attached, the task is created
+and cancelled). What it cannot show is the runtime chain completing in a real
+process, which is precisely what the add-on gap broke — and why CI stayed green
+through it. So this test boots the real ``ha-mcp`` stdio binary (the same
+``main()`` → ``run_async`` path real launchers hit) and watches for the
+observable end of the chain: process start → lifespan → task → admin WebSocket
+→ HACS repository list → marker file in the ha-mcp data dir.
+
+Stdio stands in for every launcher here because the lifespan is transport-level:
+one real launcher proving the chain runs end to end, plus the unit-level wiring
+pin, covers the others. The e2e container ships HACS in ``custom_components``
+but has neither candidate repository downloaded, so the pass completes on the
+first attempt with no GitHub traffic and writes the marker immediately.
+"""
+
+import json
+import logging
+import os
+
+import pytest
+from fastmcp import Client
+from fastmcp.client.transports import StdioTransport
+from test_constants import TEST_TOKEN
+
+from ha_mcp.hacs_auto_refresh import MARKER_FILENAME_PREFIX
+
+from ...utilities.wait_helpers import wait_for_condition
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.mark.hacs
+async def test_stdio_launcher_runs_the_startup_nudge(
+    ha_container_with_fresh_config, tmp_path
+):
+    """A real ha-mcp subprocess must complete the nudge and write its marker."""
+    logger.info("Testing the HACS startup nudge through the stdio launcher...")
+
+    container_info = ha_container_with_fresh_config
+
+    # Mirrors the ``stdio_mcp_client`` fixture's env — that fixture is
+    # session-scoped and shares one subprocess, so this test spawns its own —
+    # plus HA_MCP_CONFIG_DIR, which puts the subprocess's data dir (and so the
+    # marker the nudge writes) inside this test's tmp dir. The subprocess
+    # inherits nothing, so HA_MCP_DISABLE_UPDATE_CHECK — which would return the
+    # nudge early — is deliberately absent.
+    env = {
+        "HOMEASSISTANT_URL": container_info["base_url"],
+        "HOMEASSISTANT_TOKEN": TEST_TOKEN,
+        "PATH": os.environ.get("PATH", ""),
+        "HOME": os.environ.get("HOME", ""),
+        "HA_MAX_RETRIES": "1",
+        "ENABLE_STRICT_MANDATORY_BPS": "false",
+        "HA_MCP_CONFIG_DIR": str(tmp_path),
+    }
+
+    transport = StdioTransport(command="ha-mcp", args=[], env=env)
+
+    def marker_files():
+        return list(tmp_path.glob(f"{MARKER_FILENAME_PREFIX}_*.json"))
+
+    async with Client(transport):
+        # Poll INSIDE the client context: leaving it terminates the subprocess,
+        # and the lifespan cancels the nudge task on the way out.
+        found = await wait_for_condition(
+            marker_files,
+            timeout=30,
+            condition_name="HACS refresh marker written by the stdio launcher",
+        )
+        markers = marker_files()
+
+    assert found, (
+        "No HACS refresh marker appeared in the subprocess data dir within 30s "
+        "— the startup nudge never completed a pass, so the server lifespan is "
+        "likely not scheduling maybe_refresh_hacs_after_update. Data dir "
+        f"contents: {sorted(p.name for p in tmp_path.iterdir())}"
+    )
+    assert len(markers) == 1, (
+        "The nudge writes one marker per HA target and this run had exactly "
+        f"one, got: {[p.name for p in markers]}"
+    )
+
+    marker = json.loads(markers[0].read_text(encoding="utf-8"))
+    logger.info(f"Marker written by the stdio launcher: {marker}")
+
+    # A completed pass against this container must have SEEN HACS. "absent" is
+    # written only after the retry schedule runs out, which would mean the
+    # WebSocket reached HA but HACS never answered.
+    assert marker["hacs"] == "present", (
+        f"Marker reports hacs={marker['hacs']!r}, but the e2e container ships "
+        "HACS in custom_components — the pass did not reach a loaded HACS."
+    )
+    # ``latest`` is intentionally not asserted: it is None or a version string
+    # depending on whether PyPI is reachable from the runner, and both are fine.
+    server_version = marker["server_version"]
+    assert isinstance(server_version, str) and server_version, (
+        "Marker must record the running server version so the next startup can "
+        f"detect an update, got {server_version!r}"
+    )
+
+    logger.info("Stdio launcher startup nudge test passed")

--- a/tests/src/unit/test_codeql_quality_gate.py
+++ b/tests/src/unit/test_codeql_quality_gate.py
@@ -48,6 +48,32 @@ def _result(rule_id: str | None, uri: str, line: int, text: str) -> dict:
     return result
 
 
+_SCOPED_REASON = "Awaiting the cancelled task is the effect."
+
+
+def _ineffectual_allowlist(
+    path_fragment: str, code_substring: str
+) -> tuple[tuple[str, str, str, str, str], ...]:
+    """A one-entry ALLOWLIST for the rule whose message is always generic."""
+    return (
+        (
+            "py/ineffectual-statement",
+            path_fragment,
+            "This statement has no effect",
+            code_substring,
+            _SCOPED_REASON,
+        ),
+    )
+
+
+@pytest.fixture(autouse=True)
+def _clear_source_cache():
+    """Source lines are cached per path; keep reads from leaking between tests."""
+    gate._source_lines.cache_clear()
+    yield
+    gate._source_lines.cache_clear()
+
+
 def test_load_findings_sorted_and_parsed(tmp_path: Path) -> None:
     path = _write_sarif(
         tmp_path,
@@ -251,6 +277,149 @@ def test_allowlist_wrong_path_is_not_suppressed(tmp_path: Path) -> None:
     findings, suppressed = gate.classify(path)
     assert len(findings) == 1
     assert not suppressed
+
+
+def test_code_scoped_entry_suppresses_the_named_statement(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """An entry with a code substring matches against the flagged line's text."""
+    source = tmp_path / "teardown.py"
+    source.write_text(
+        "async def teardown(task):\n"
+        "    with contextlib.suppress(asyncio.CancelledError):\n"
+        "        await task\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        gate, "ALLOWLIST", _ineffectual_allowlist(source.name, "await task")
+    )
+    path = _write_sarif(
+        tmp_path,
+        [
+            _result(
+                "py/ineffectual-statement",
+                str(source),
+                3,
+                "This statement has no effect.",
+            )
+        ],
+    )
+    findings, suppressed = gate.classify(path)
+    assert not findings
+    assert [(f[1], f[4]) for f in suppressed] == [(3, _SCOPED_REASON)]
+
+
+def test_other_ineffectual_statement_in_same_file_still_gates(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """Scoping is per statement: a second dead statement in the file still fails.
+
+    Same rule, same file, same generic message as the allowlisted one — only the
+    flagged line's text differs, which is all the gate has to tell them apart.
+    """
+    source = tmp_path / "teardown.py"
+    source.write_text(
+        "async def teardown(task, x):\n"
+        "    with contextlib.suppress(asyncio.CancelledError):\n"
+        "        await task\n"
+        "    x == 1\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        gate, "ALLOWLIST", _ineffectual_allowlist(source.name, "await task")
+    )
+    path = _write_sarif(
+        tmp_path,
+        [
+            _result(
+                "py/ineffectual-statement",
+                str(source),
+                3,
+                "This statement has no effect.",
+            ),
+            _result(
+                "py/ineffectual-statement",
+                str(source),
+                4,
+                "This statement has no effect.",
+            ),
+        ],
+    )
+    findings, suppressed = gate.classify(path)
+    assert [f[1] for f in findings] == [4]
+    assert [f[1] for f in suppressed] == [3]
+    assert gate.main(["prog", str(path)]) == 1
+
+
+def test_code_scoped_entry_fails_closed_when_source_is_unreadable(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """A gate must not suppress a statement it cannot read back from the tree."""
+    missing = tmp_path / "gone.py"
+    monkeypatch.setattr(
+        gate, "ALLOWLIST", _ineffectual_allowlist(missing.name, "await task")
+    )
+    path = _write_sarif(
+        tmp_path,
+        [
+            _result(
+                "py/ineffectual-statement",
+                str(missing),
+                3,
+                "This statement has no effect.",
+            )
+        ],
+    )
+    findings, suppressed = gate.classify(path)
+    assert len(findings) == 1
+    assert not suppressed
+
+
+def test_code_scoped_entry_fails_closed_without_a_line_number(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """No region.startLine means no statement to verify, so no suppression."""
+    source = tmp_path / "teardown.py"
+    source.write_text("        await task\n", encoding="utf-8")
+    monkeypatch.setattr(
+        gate, "ALLOWLIST", _ineffectual_allowlist(source.name, "await task")
+    )
+    path = _write_sarif(
+        tmp_path,
+        [
+            _result(
+                "py/ineffectual-statement",
+                str(source),
+                0,
+                "This statement has no effect.",
+            )
+        ],
+    )
+    findings, suppressed = gate.classify(path)
+    assert len(findings) == 1
+    assert not suppressed
+
+
+def test_empty_code_substring_suppresses_without_reading_the_source(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """An entry with "" keeps the rule/path/message-only behavior."""
+    missing = tmp_path / "gone.py"
+    monkeypatch.setattr(gate, "ALLOWLIST", _ineffectual_allowlist(missing.name, ""))
+    path = _write_sarif(
+        tmp_path,
+        [
+            _result(
+                "py/ineffectual-statement",
+                str(missing),
+                3,
+                "This statement has no effect.",
+            )
+        ],
+    )
+    findings, suppressed = gate.classify(path)
+    assert not findings
+    assert [f[4] for f in suppressed] == [_SCOPED_REASON]
 
 
 def test_result_without_location_still_gates(tmp_path: Path) -> None:

--- a/tests/src/unit/test_graceful_shutdown.py
+++ b/tests/src/unit/test_graceful_shutdown.py
@@ -14,20 +14,6 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 
-@pytest.fixture(autouse=True)
-def _no_startup_hacs_nudge():
-    """Keep the startup HACS nudge out of these tests.
-
-    ``_run_with_shutdown`` fires it as a background task; left real it would
-    reach PyPI and the Home Assistant WebSocket from a unit test.
-    """
-    with patch(
-        "ha_mcp.hacs_auto_refresh.maybe_refresh_hacs_after_update",
-        new=AsyncMock(return_value=None),
-    ):
-        yield
-
-
 class TestSignalHandlerSetup:
     """Tests for signal handler registration."""
 

--- a/tests/src/unit/test_hacs_auto_refresh.py
+++ b/tests/src/unit/test_hacs_auto_refresh.py
@@ -324,13 +324,14 @@ class TestMaybeRefreshHacsAfterUpdate:
         assert mocks.refresh.await_count == 2
         assert _written_marker(data_dir) is None
 
-    async def test_unreachable_hacs_leaves_the_marker_unwritten(self, data_dir):
+    async def test_unreachable_hacs_leaves_the_marker_unwritten(self, data_dir, caplog):
         # Nothing was determined, so the next startup must retry — which is
         # exactly what an absent marker does. RETRY_DELAYS is emptied so the
         # test cannot sleep through the real ~8 minute schedule.
         ws = _ws(error=HomeAssistantConnectionError("websocket down"))
 
         with (
+            caplog.at_level(logging.INFO),
             _server(ws, info=_info()) as mocks,
             patch.object(hacs_auto_refresh, "RETRY_DELAYS", ()),
         ):
@@ -339,6 +340,10 @@ class TestMaybeRefreshHacsAfterUpdate:
         assert ws.send_command.await_count == 1
         mocks.refresh.assert_not_awaited()
         assert _written_marker(data_dir) is None
+        # The due-pass line still logged although every WS attempt failed —
+        # the strongest form of "before any WebSocket work", and the property
+        # the HAOS add-on lane depends on (its VM has no HACS to answer).
+        assert "HACS auto-refresh: startup pass due" in caplog.text
 
     async def test_websocket_closure_is_retried(self, data_dir):
         # send_command re-raises raw websocket exceptions on a mid-send

--- a/tests/src/unit/test_hacs_auto_refresh.py
+++ b/tests/src/unit/test_hacs_auto_refresh.py
@@ -371,12 +371,15 @@ class TestMaybeRefreshHacsAfterUpdate:
         )
         ws = _ws([_repo(123, MIRROR)])
 
-        with caplog.at_level(logging.INFO), _server(ws, info=_info()) as mocks:
+        with caplog.at_level(logging.DEBUG), _server(ws, info=_info()) as mocks:
             await hacs_auto_refresh.maybe_refresh_hacs_after_update()
 
         mocks.get_websocket_client.assert_not_awaited()
         mocks.refresh.assert_not_awaited()
         assert "startup pass due" not in caplog.text
+        # The not-due DEBUG line is contract too: it is what the HAOS add-on
+        # lane greps for once an earlier completed pass makes boots not due.
+        assert "pass not due" in caplog.text
 
 
 class TestLifespanWiring:

--- a/tests/src/unit/test_hacs_auto_refresh.py
+++ b/tests/src/unit/test_hacs_auto_refresh.py
@@ -238,6 +238,9 @@ class TestMaybeRefreshHacsAfterUpdate:
         with caplog.at_level(logging.INFO), _server(ws, info=_info()) as mocks:
             await hacs_auto_refresh.maybe_refresh_hacs_after_update()
 
+        # The due-pass line logs BEFORE any WS work — the observable the
+        # HAOS add-on lane greps for, so it is contract, not decoration.
+        assert "HACS auto-refresh: startup pass due" in caplog.text
         # Both entries the component can be tracked under, and nothing else.
         assert _refreshed_ids(mocks) == ["123", "456"]
         assert _written_marker(data_dir) == {
@@ -355,19 +358,20 @@ class TestMaybeRefreshHacsAfterUpdate:
         mocks.refresh.assert_not_awaited()
         assert _written_marker(data_dir) is None
 
-    async def test_matching_marker_skips_the_websocket(self, data_dir):
+    async def test_matching_marker_skips_the_websocket(self, data_dir, caplog):
         # The stdio hot path: a per-conversation spawn on an unchanged version
-        # costs one file read and no WebSocket traffic.
+        # costs one file read, no WebSocket traffic, and no log noise.
         hacs_auto_refresh._marker_path(HA_URL).write_text(
             json.dumps(_marker(latest="1.1.0", hacs="present"))
         )
         ws = _ws([_repo(123, MIRROR)])
 
-        with _server(ws, info=_info()) as mocks:
+        with caplog.at_level(logging.INFO), _server(ws, info=_info()) as mocks:
             await hacs_auto_refresh.maybe_refresh_hacs_after_update()
 
         mocks.get_websocket_client.assert_not_awaited()
         mocks.refresh.assert_not_awaited()
+        assert "startup pass due" not in caplog.text
 
 
 class TestLifespanWiring:

--- a/tests/src/unit/test_hacs_auto_refresh.py
+++ b/tests/src/unit/test_hacs_auto_refresh.py
@@ -379,7 +379,13 @@ class TestMaybeRefreshHacsAfterUpdate:
         assert "startup pass due" not in caplog.text
         # The not-due DEBUG line is contract too: it is what the HAOS add-on
         # lane greps for once an earlier completed pass makes boots not due.
-        assert "pass not due" in caplog.text
+        not_due_records = [
+            record
+            for record in caplog.records
+            if "HACS auto-refresh: pass not due" in record.getMessage()
+        ]
+        assert len(not_due_records) == 1
+        assert not_due_records[0].levelno == logging.DEBUG
 
 
 class TestLifespanWiring:

--- a/tests/src/unit/test_hacs_auto_refresh.py
+++ b/tests/src/unit/test_hacs_auto_refresh.py
@@ -12,6 +12,7 @@ schedule empties it first.
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 from contextlib import contextmanager
@@ -21,7 +22,6 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from ha_mcp import hacs_auto_refresh
-from ha_mcp.__main__ import _run_with_shutdown
 from ha_mcp.client.rest_client import (
     HomeAssistantCommandError,
     HomeAssistantCommandTimeout,
@@ -370,21 +370,51 @@ class TestMaybeRefreshHacsAfterUpdate:
         mocks.refresh.assert_not_awaited()
 
 
-class TestStartupWiring:
-    async def test_run_with_shutdown_fires_the_nudge(self):
-        # The task is created but deliberately kept out of the wait set, so
-        # the server's own exit is what ends _run_with_shutdown.
-        nudge = AsyncMock(return_value=None)
+class TestLifespanWiring:
+    async def test_lifespan_schedules_and_cancels_the_nudge(self):
+        # Entering the lifespan starts the task; exiting cancels it, so a
+        # nudge parked in a retry sleep cannot stall shutdown.
+        started = asyncio.Event()
+        cancelled = False
 
-        async def clean_server():
-            return None
+        async def never_finishes():
+            nonlocal cancelled
+            started.set()
+            try:
+                await asyncio.Event().wait()
+            except asyncio.CancelledError:
+                cancelled = True
+                raise
+
+        with patch(
+            "ha_mcp.hacs_auto_refresh.maybe_refresh_hacs_after_update",
+            new=never_finishes,
+        ):
+            async with hacs_auto_refresh.hacs_refresh_lifespan(object()):
+                # The lifespan hands the task to the loop; wait on the flag
+                # the fake sets rather than sleeping.
+                await started.wait()
+
+        assert cancelled, "exiting the lifespan must cancel the pending nudge"
+
+    async def test_server_attaches_the_lifespan(self):
+        # The built server's FastMCP instance carries the lifespan — the pin
+        # that catches a future constructor change dropping it, which is the
+        # sibling of the add-on gap this wiring replaced.
+        from ha_mcp.server import HomeAssistantSmartMCPServer
 
         with (
+            patch("ha_mcp.server.get_global_settings") as get_settings,
+            patch("ha_mcp.server.HomeAssistantSmartMCPServer._initialize_server"),
             patch(
-                "ha_mcp.hacs_auto_refresh.maybe_refresh_hacs_after_update", new=nudge
+                "ha_mcp.server.HomeAssistantSmartMCPServer._build_skills_instructions",
+                return_value=None,
             ),
-            patch("ha_mcp.__main__._cleanup_resources", new=AsyncMock()),
         ):
-            await _run_with_shutdown(clean_server())
+            settings = get_settings.return_value
+            settings.mcp_server_name = "test"
+            settings.mcp_server_version = "0.0.1"
+            settings.read_only_mode = False
+            server = HomeAssistantSmartMCPServer()
 
-        nudge.assert_awaited_once()
+        assert server.mcp._lifespan is hacs_auto_refresh.hacs_refresh_lifespan

--- a/tests/src/unit/test_http_run_kwargs.py
+++ b/tests/src/unit/test_http_run_kwargs.py
@@ -7,25 +7,10 @@ alongside it, since the kwargs it builds are what that server task starts from.
 """
 
 import asyncio
-from unittest.mock import AsyncMock, patch
 
 import pytest
 
 from ha_mcp.__main__ import _http_run_kwargs, _run_with_shutdown
-
-
-@pytest.fixture(autouse=True)
-def _no_startup_hacs_nudge():
-    """Keep the startup HACS nudge out of these tests.
-
-    ``_run_with_shutdown`` fires it as a background task; left real it would
-    reach PyPI and the Home Assistant WebSocket from a unit test.
-    """
-    with patch(
-        "ha_mcp.hacs_auto_refresh.maybe_refresh_hacs_after_update",
-        new=AsyncMock(return_value=None),
-    ):
-        yield
 
 
 def test_kwargs_request_stateless_streamable_http():


### PR DESCRIPTION
## What does this PR do?

Fixes the startup HACS-refresh nudge (#2166) never running on the HA
add-on. It was scheduled in `__main__`'s `_run_with_shutdown`, which the
CLI entry points share — but the add-on's `start.py` calls `mcp.run()`
directly and never passes through it, so the nudge was inert on the
deployment it was built for. Found by live-testing on a HAOS instance
(the add-on booted the merged code with zero nudge activity in its
logs); CI could not catch it because the e2e suites launch via the CLI
entry points.

The task is now attached as the server's FastMCP `lifespan`: the
lifespan manager is entered by every transport runner (stdio and the
HTTP app factories), ref-counted to fire once per run — one site covers
stdio, web, oauth, oidc, and the add-on launcher, so no launcher can
bypass it again. Exit cancels a nudge parked in a retry sleep, replacing
the `_cancel_tasks` wiring.

Tests: unit coverage pins the lifespan schedule/cancel contract and that
the built server carries the lifespan; a new launcher-lane e2e test
boots the real `ha-mcp` stdio binary against the container and asserts
the full chain completes (process → lifespan → task → WebSocket → HACS
→ marker file) — the regression shape that stayed invisible when the
scheduling site was launcher-specific.

## Type of change
- [x] 🐛 Bug fix

## Testing
- [x] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

## Checklist
- [x] I have updated documentation if needed (docstrings only)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HACS startup refresh reliability across supported launchers and add-ons.
  * Ensured refresh tasks shut down cleanly.
  * Prevented refresh attempts when OAuth credentials are unavailable.
  * Embedded servers now skip unsupported HACS startup refresh behavior.
  * Added clearer logging when refresh checks run or are skipped.

* **Tests**
  * Expanded coverage for launchers, add-ons, version recording, marker suppression, OAuth handling, embedded servers, and shutdown behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->