### PR TITLE
feat: add the Swedish (sv) locale across all four translated surfaces

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -755,7 +755,7 @@ identity holds by construction.
 
 A language ships on all four surfaces or not at all —
 `tests/src/unit/test_locale_parity.py` enforces it. One Home Assistant language
-code (`de`, `es`, `fr`, `it`, `nl`, `pl`, `ru`, `zh-Hans`) names every file:
+code (`de`, `es`, `fr`, `it`, `nl`, `pl`, `ru`, `sv`, `zh-Hans`) names every file:
 `src/ha_mcp/settings_ui/locales/<code>.json`,
 `custom_components/ha_mcp_tools/translations/<code>.json`, and
 `homeassistant-addon{,-dev}/translations/<code>.yaml`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -754,8 +754,8 @@ are different projections of the one store, and cross-surface wording
 identity holds by construction.
 
 A language ships on all four surfaces or not at all —
-`tests/src/unit/test_locale_parity.py` enforces it. One Home Assistant language
-code (`de`, `es`, `fr`, `it`, `nl`, `pl`, `ru`, `sv`, `zh-Hans`) names every file:
+`tests/src/unit/test_locale_parity.py` enforces it. The same Home Assistant
+language code (`de`, `es`, `fr`, `it`, `nl`, `pl`, `ru`, `sv`, `zh-Hans`) names every file:
 `src/ha_mcp/settings_ui/locales/<code>.json`,
 `custom_components/ha_mcp_tools/translations/<code>.json`, and
 `homeassistant-addon{,-dev}/translations/<code>.yaml`.

--- a/custom_components/ha_mcp_tools/translations/sv.json
+++ b/custom_components/ha_mcp_tools/translations/sv.json
@@ -1,0 +1,5 @@
+{
+  "common": {
+    "oauth_not_serving": "Legacy OAuth tillhandahåller dem inte ännu — starta om Home Assistant när du blir ombedd, så aktiveras de."
+  }
+}

--- a/homeassistant-addon-dev/translations/sv.yaml
+++ b/homeassistant-addon-dev/translations/sv.yaml
@@ -1,0 +1,258 @@
+---
+# GENERATED FILE — do not edit. Translations live in
+# src/ha_mcp/settings_ui/locales/sv.json (keys addon.*, features.*,
+# addon_dev.*); regenerate with: python scripts/generate_locales.py
+configuration:
+  backup_hint:
+    name: Full-HA snapshot suggestion level (LLM-facing)
+    description: 'Tunes the wording of the hint the LLM sees in the
+
+      `ha_manage_backup(scope=''snapshot'')` tool description for when to
+
+      suggest a full Home Assistant tarball backup before risky operations
+
+      (e.g. mass device deletes). Affects ONLY this one LLM-facing prompt
+
+      sentence.
+
+
+      For per-edit automatic snapshots of automations / scripts / helpers /
+
+      etc., use the separate **Enable auto-backup of edits** toggle below.'
+  secret_path:
+    name: Secret path override
+    description: 'Optional custom HTTP path for the MCP server. Leave empty to use
+      the auto-generated secure path.
+
+      '
+  enable_tool_search:
+    name: Enable tool search
+    description: 'Replace the full tool catalog with search-based discovery. Reduces
+      idle context by roughly 90%, to about 5K tokens. ⚠️ Do NOT enable this in clients
+      with their own built-in tool search / deferred tools (claude.ai, Claude Desktop,
+      Claude Code) — the two search layers conflict, and the client''s built-in tool
+      search is the better choice there; leave this off. Whether tools are deferred
+      depends on your client and model combination: use this when your setup loads
+      the full catalog up front — models without native deferred tools (e.g. Gemini,
+      OpenAI-compatible local models, Claude Haiku), clients that inline all tool
+      schemas regardless of model (e.g. GitHub Copilot CLI), or smaller context windows.
+      Some Codex models and ChatGPT include deferred tools too — check your client/model
+      directly to confirm its features so you don''t leave this enabled unnecessarily.
+      Tools are found via ha_search_tools and executed via categorized proxies (read/write/delete).
+      Requires restart to take effect.'
+  enable_tool_security_policies:
+    name: Enable Tool Security Policies (advanced)
+    description: Gate high-stakes tool calls (lock/alarm control, automation writes,
+      etc.) behind user approval. When a guarded tool is called, the agent tells the
+      user to open the Tool Security Policies tab in the web UI and click Approve
+      before the call proceeds. Per-tool rules with optional argument conditions are
+      configured in the Tool Security Policies tab. Off by default. Requires restart
+      to take effect.
+  enable_security_policy_tool:
+    name: Let AI agents edit tool security policies
+    description: 'Registers the ha_manage_security_policy tool, which lets connected
+      AI agents read and rewrite the tool security policies — including removing approval
+      gates. Off by default. Independent of the Tool Security Policies option above:
+      this controls who can edit the rules, not whether they are enforced. The tool
+      cannot see or decide pending approvals. To keep a human in the loop, gate the
+      tool before enabling it: switch on "security gated" for Manage Security Policy
+      in the Tools tab of the web UI. Requires restart to take effect.'
+  read_only_mode:
+    name: Read Only Mode
+    description: Toggles all write tools off, and removes ability for tools to make
+      any write or destructive calls. Mixed read/write tools (backups, add-ons, energy
+      preferences, voice pipelines, and code mode when enabled) stay available with
+      their write operations blocked. Same toggle as the web UI Tools tab. Off by
+      default. Requires restart to take effect.
+  redact_secrets:
+    name: Redact Secrets
+    description: Redacts secrets from tool responses before they reach the AI assistant.
+      Add-on options and integration fields marked as passwords are replaced with
+      a set/empty marker (so "is this credential configured?" stays answerable), and
+      other tool responses are scrubbed of secret values the server has already seen
+      (values shorter than 6 characters are skipped, since replacing tiny fragments
+      would corrupt unrelated output). Fields not marked as passwords by their schema
+      cannot be detected. Off by default.
+  enable_beta_features:
+    name: Enable beta features (master)
+    description: ⚠ DANGER — these tools can PERMANENTLY DAMAGE your Home Assistant
+      installation. They write to your YAML config, your filesystem, install custom
+      components, run arbitrary sandboxed Python, and edit tool docstrings the AI
+      sees. There is no warranty and no support guarantee — you enable them at your
+      OWN RISK. Take a Home Assistant backup before turning this on, and never enable
+      in production without one. Master gate for the 5 experimental sub-flags below;
+      sub-flags are ignored at runtime while this master is off, even when explicitly
+      set to true. The same toggle is also surfaced in the web settings UI under "Beta
+      features (dangerous)" — either surface reflects the other on restart.
+  enable_yaml_config_editing:
+    name: Enable YAML config editing (beta)
+    description: Beta feature. Allows AI assistants to add, replace, or remove top-level
+      keys in configuration.yaml and packages/*.yaml. Only whitelisted keys are allowed
+      (e.g., template, sensor, command_line, mqtt, knx); core keys like homeassistant,
+      http, and recorder are blocked. Each edit validates YAML syntax, runs a config
+      check, and creates an automatic backup. Changes to most keys require a full
+      HA restart to take effect. See docs/beta.md for known limitations. Dedicated
+      tools (automations, scripts, scenes, helpers, template sensors) should be preferred
+      when available. REQUIRES the master "Enable beta features" toggle above (and
+      in the web UI) to be on — otherwise this sub-flag is ignored at runtime regardless
+      of its value here.
+  enable_yaml_packages_automation:
+    name: Allow automation in packages/*.yaml
+    description: Sub-toggle of YAML config editing. When on, ha_config_set_yaml accepts
+      yaml_path='automation' inside packages/*.yaml. When off, the call is rejected
+      both client-side and server-side. The storage-mode tool (ha_config_set_automation)
+      is unaffected. Default OFF; only takes effect when "Enable YAML config editing"
+      above is also on.
+  enable_yaml_packages_script:
+    name: Allow script in packages/*.yaml
+    description: Sub-toggle of YAML config editing. When on, ha_config_set_yaml accepts
+      yaml_path='script' inside packages/*.yaml. When off, the call is rejected both
+      client-side and server-side. The storage-mode tool (ha_config_set_script) is
+      unaffected. Default OFF; only takes effect when "Enable YAML config editing"
+      above is also on.
+  enable_yaml_packages_scene:
+    name: Allow scene in packages/*.yaml
+    description: Sub-toggle of YAML config editing. When on, ha_config_set_yaml accepts
+      yaml_path='scene' inside packages/*.yaml. When off, the call is rejected both
+      client-side and server-side. The storage-mode tool (ha_config_set_scene) is
+      unaffected. Default OFF; only takes effect when "Enable YAML config editing"
+      above is also on.
+  enable_yaml_edit_confirm:
+    name: Require confirmation for YAML edits (diff preview)
+    description: 'Sub-toggle of YAML config editing, ON by default (recommended).
+      The first ha_config_set_yaml call returns a unified diff of exactly what would
+      change on disk plus a confirm token and writes nothing; the edit only lands
+      when the call is repeated with that token. Exists so unintended changes outside
+      the requested edit are caught before they reach disk (issue #1720). Turn off
+      only to save one round-trip per edit.'
+  enable_code_mode:
+    name: Enable custom tool sandbox (beta)
+    description: Beta feature. Enables the ha_manage_custom_tool tool, which lets
+      AI assistants create, run, save, and delete custom Python code in a secure sandbox
+      when no built-in tool can handle the request. Code runs in an isolated interpreter
+      with no filesystem or arbitrary network access. Sandbox code can hit the HA
+      REST API (api_get/api_post), send WebSocket commands (ws_send), call existing
+      MCP tools (call_tool), or remove a saved tool (delete_saved_tool). Saved tools
+      persist to /data/saved_tools.json by default so they survive add-on restarts,
+      and are visible to any client that can connect. See docs/beta.md for known limitations.
+      Requires restart to take effect. REQUIRES the master "Enable beta features"
+      toggle above (and in the web UI) to be on — otherwise this sub-flag is ignored
+      at runtime regardless of its value here.
+  enable_lite_docstrings:
+    name: Enable lite tool docstrings (beta)
+    description: 'Beta feature. Replaces the docstrings on a handful of heavy ha-mcp
+      tools (automations, scripts, scenes, helpers, dashboards, ha_call_service, ha_config_set_yaml)
+      with shorter variants that defer schema and example detail to the ha_get_skill_guide
+      tool (or its skill:// resource). WARNING: this reduces idle token usage, but
+      may degrade LLM performance — the trimmed descriptions rely on the LLM actually
+      calling the skill tool or reading the skill resource for detail, which is not
+      guaranteed (some models will skip the extra tool call and end up with less guidance
+      than they had before). Best paired with a client that supports MCP resources
+      or with enable_tool_search. Requires restart to take effect. REQUIRES the master
+      "Enable beta features" toggle above (and in the web UI) to be on — otherwise
+      this sub-flag is ignored at runtime regardless of its value here.'
+  enable_mandatory_bps:
+    name: Attach best-practice skills on writes
+    description: 'Master switch for the write-tool skill content delivery feature
+      (issue #1182). When enabled (default), the six config write tools (automations,
+      scripts, scenes, helpers, dashboards, raw YAML) attach the canonical Home Assistant
+      best-practice reference files under `skill_content` on every successful write,
+      plus auto-embed any reference sections cited by best-practice warnings. Each
+      tool also exposes a per-call `MandatoryBPS` parameter the agent can set to false
+      on subsequent calls once it has the content. When this master switch is off,
+      NO skill_content goes out regardless of the per-call parameter or BP warnings.
+      Recommended ON as the first choice; disable only for models with very small
+      context windows. Turning this off may degrade write accuracy. Requires restart
+      to take effect.'
+  enable_strict_mandatory_bps:
+    name: Strict best-practices mode
+    description: 'Strict mode: prevents the client from using the tool until it can
+      prove that it read the best practices. While on, the six best-practice write
+      tools (automations, scripts, scenes, helpers, dashboards, raw YAML) are blocked
+      and return an error directing the client to read the best-practices skill via
+      ha_get_skill_guide and pass back the acknowledgment key it obtains there. While
+      on, the ha_get_skill_guide tool is locked enabled — it is the only publisher
+      of the acknowledgment key. Child of the "Attach best-practice skills on writes"
+      option above and inert while that parent is off. Requires restart to take effect.'
+  enable_filesystem_tools:
+    name: Enable filesystem tools (beta)
+    description: 'Sets HAMCP_ENABLE_FILESYSTEM_TOOLS=true. Enables direct file read/write
+      access to your Home Assistant filesystem. WARNING: This gives the MCP server
+      sensitive direct file access to your system. Only enable if you trust the AI
+      assistant with file operations. Requires restart to take effect. REQUIRES the
+      master "Enable beta features" toggle above (and in the web UI) to be on — otherwise
+      this sub-flag is ignored at runtime regardless of its value here.'
+  enable_dashboard_screenshot:
+    name: Enable dashboard screenshot mode (beta)
+    description: Beta feature — disabled by default. Adds the ha_get_dashboard_screenshot
+      tool plus include_screenshot / return_screenshot options on the dashboard get/set
+      tools, so AI assistants can inspect one or more responsive Lovelace images (e.g.
+      to verify a dashboard they just created). Supports stable named views, mobile/tablet/desktop
+      batches, and PNG/JPEG/WebP/BMP output. Rendering runs in a separate, opt-in
+      engine — balloob's "Puppet" add-on (headless Chromium) — which you install once
+      (add balloob's add-on repository, then install "Puppet") and give a long-lived
+      access token; on Docker/Container deployments you run that engine as a sidecar
+      and set HAMCP_DASHBOARD_SCREENSHOT_ENGINE_URL. Nothing heavy is installed unless
+      you both enable this and install the engine. Requires restart to take effect.
+      REQUIRES the master "Enable beta features" toggle above (and in the web UI)
+      to be on — otherwise this sub-flag is ignored at runtime regardless of its value
+      here.
+  enable_auto_backup:
+    name: Enable auto-backup of edits
+    description: Captures a per-entity snapshot before every wrapped write/destructive
+      MCP tool call (automation, script, scene, helper, dashboard, label, category,
+      group, zone, area, calendar, todo, entity, integration, and sibling remove/delete
+      tools). Snapshots are saved as YAML files under /data/ha_mcp_backups/ (override
+      via HAMCP_BACKUP_DIR) and listed, restored, or deleted via the Backups tab in
+      the web settings UI or via ha_manage_backup(scope='edits', ...). Best-effort
+      — failures log a WARNING but never block the underlying write. On by default;
+      uncheck to opt out. Requires restart to take effect.
+  auto_backup_throttle_minutes:
+    name: Auto-backup throttle (minutes)
+    description: Per-entity throttle window. 0 (default) captures a snapshot on every
+      wrapped write. N>0 captures at most one snapshot per N minutes per entity. Range
+      0–1440.
+  auto_backup_retain_per_entity:
+    name: Auto-backup retention (per entity)
+    description: Maximum number of snapshots kept per entity. Older snapshots beyond
+      this cap are rotated out on each successful capture. Default 100, range 1–10000.
+  enable_snapshot_delete:
+    name: Allow snapshot deletion
+    description: Lets ha_manage_backup delete full HA snapshot tarballs (scope='snapshot',
+      action='delete'). Off by default — a snapshot may be the last recovery point
+      after a mistaken change, so a human must opt in here. Even when on, scheduled
+      backups, the newest remaining snapshot, and anything younger than the age floor
+      below stay protected.
+  snapshot_delete_min_age_days:
+    name: Minimum snapshot age to delete (days)
+    description: A snapshot must be at least this old before it can be deleted. Range
+      0–365; 0 disables the floor (the newest-snapshot and scheduled-backup protections
+      still apply). Default 7.
+  tool_search_max_results:
+    name: Tool search max results
+    description: 'Maximum number of tools returned by ha_search_tools when tool search
+      is enabled. Lower values (2-3) save context tokens but may miss relevant tools.
+      Range: 2-10. Requires restart.'
+  disabled_tools:
+    name: Disabled tools (comma-separated)
+    description: Tools listed here are forced off and locked in the web Settings UI
+      (Tools tab) — they cannot be re-enabled there without unsetting this option
+      first. A small set of mandatory tools (ha_search, ha_get_overview, ha_get_state,
+      ha_report_issue, ha_manage_backup) cannot be disabled and keep running even
+      if listed here. ha_get_skill_guide can be disabled only while strict best-practices
+      mode (enable_strict_mandatory_bps) is off. Comma-separated tool names (e.g.
+      ha_call_event,ha_eval_template).
+  pinned_tools:
+    name: Pinned tools (comma-separated)
+    description: Tools listed here are locked pinned — they appear at the top of the
+      Tools tab and cannot be unpinned from the web Settings UI without unsetting
+      this option first. Useful in combination with Tool Search. Comma-separated tool
+      names.
+  verify_ssl:
+    name: Verify TLS certificate
+    description: Verify the Home Assistant server's TLS certificate. The add-on connects
+      via the Supervisor proxy, so this normally has no effect and should stay enabled.
+      Disable only if you've reconfigured the add-on to talk to HA over a public HTTPS
+      hostname with a self-signed certificate or hostname mismatch. Disabling weakens
+      transport security — leave on unless you know you need it. Requires restart
+      to take effect.

--- a/homeassistant-addon/translations/sv.yaml
+++ b/homeassistant-addon/translations/sv.yaml
@@ -1,0 +1,160 @@
+---
+# GENERATED FILE — do not edit. Translations live in
+# src/ha_mcp/settings_ui/locales/sv.json (keys addon.*, features.*,
+# addon_stable.*); regenerate with: python scripts/generate_locales.py
+configuration:
+  backup_hint:
+    name: Full-HA snapshot suggestion level (LLM-facing)
+    description: 'Tunes the wording of the hint the LLM sees in the
+
+      `ha_manage_backup(scope=''snapshot'')` tool description for when to
+
+      suggest a full Home Assistant tarball backup before risky operations
+
+      (e.g. mass device deletes). Affects ONLY this one LLM-facing prompt
+
+      sentence.
+
+
+      For per-edit automatic snapshots of automations / scripts / helpers /
+
+      etc., use the separate **Enable auto-backup of edits** toggle below.'
+  secret_path:
+    name: Secret path override
+    description: 'Optional custom HTTP path for the MCP server. Leave empty to use
+      the auto-generated secure path.
+
+      '
+  enable_tool_search:
+    name: Enable tool search
+    description: 'Replace the full tool catalog with search-based discovery. Reduces
+      idle context by roughly 90%, to about 5K tokens. ⚠️ Do NOT enable this in clients
+      with their own built-in tool search / deferred tools (claude.ai, Claude Desktop,
+      Claude Code) — the two search layers conflict, and the client''s built-in tool
+      search is the better choice there; leave this off. Whether tools are deferred
+      depends on your client and model combination: use this when your setup loads
+      the full catalog up front — models without native deferred tools (e.g. Gemini,
+      OpenAI-compatible local models, Claude Haiku), clients that inline all tool
+      schemas regardless of model (e.g. GitHub Copilot CLI), or smaller context windows.
+      Some Codex models and ChatGPT include deferred tools too — check your client/model
+      directly to confirm its features so you don''t leave this enabled unnecessarily.
+      Tools are found via ha_search_tools and executed via categorized proxies (read/write/delete).
+      Requires an add-on restart to take effect — then reconnect or refresh the MCP
+      server in your AI client so it reloads the tool list. Restarting the add-on
+      alone does NOT refresh a client''s cached tool list; this applies after changing
+      any setting here.'
+  tool_search_max_results:
+    name: Tool search max results
+    description: 'Maximum number of tools returned by ha_search_tools when tool search
+      is enabled. Lower values (2-3) save context tokens but may miss relevant tools.
+      Range: 2-10. Requires restart.'
+  enable_tool_security_policies:
+    name: Enable Tool Security Policies (advanced)
+    description: Gate high-stakes tool calls (lock/alarm control, automation writes,
+      etc.) behind user approval. When a guarded tool is called, the agent tells the
+      user to open the Tool Security Policies tab in the web UI and click Approve
+      before the call proceeds. Per-tool rules with optional argument conditions are
+      configured in the Tool Security Policies tab. Off by default. Requires restart
+      to take effect.
+  enable_security_policy_tool:
+    name: Let AI agents edit tool security policies
+    description: 'Registers the ha_manage_security_policy tool, which lets connected
+      AI agents read and rewrite the tool security policies — including removing approval
+      gates. Off by default. Independent of the Tool Security Policies option above:
+      this controls who can edit the rules, not whether they are enforced. The tool
+      cannot see or decide pending approvals. To keep a human in the loop, gate the
+      tool before enabling it: switch on "security gated" for Manage Security Policy
+      in the Tools tab of the web UI. Requires restart to take effect.'
+  read_only_mode:
+    name: Read Only Mode
+    description: Toggles all write tools off, and removes ability for tools to make
+      any write or destructive calls. Mixed read/write tools (backups, add-ons, energy
+      preferences, voice pipelines, and code mode when enabled) stay available with
+      their write operations blocked. Same toggle as the web UI Tools tab. Off by
+      default. Requires restart to take effect.
+  redact_secrets:
+    name: Redact Secrets
+    description: Redacts secrets from tool responses before they reach the AI assistant.
+      Add-on options and integration fields marked as passwords are replaced with
+      a set/empty marker (so "is this credential configured?" stays answerable), and
+      other tool responses are scrubbed of secret values the server has already seen
+      (values shorter than 6 characters are skipped, since replacing tiny fragments
+      would corrupt unrelated output). Fields not marked as passwords by their schema
+      cannot be detected. Off by default.
+  enable_mandatory_bps:
+    name: Attach best-practice skills on writes
+    description: 'Master switch for the write-tool skill content delivery feature
+      (issue #1182). When enabled (default), the six config write tools (automations,
+      scripts, scenes, helpers, dashboards, raw YAML) attach the canonical Home Assistant
+      best-practice reference files under `skill_content` on every successful write,
+      plus auto-embed any reference sections cited by best-practice warnings. Each
+      tool also exposes a per-call `MandatoryBPS` parameter the agent can set to false
+      on subsequent calls once it has the content. When this master switch is off,
+      NO skill_content goes out regardless of the per-call parameter or BP warnings.
+      Recommended ON as the first choice; disable only for models with very small
+      context windows. Turning this off may degrade write accuracy. Requires restart
+      to take effect.'
+  enable_strict_mandatory_bps:
+    name: Strict best-practices mode
+    description: 'Strict mode: prevents the client from using the tool until it can
+      prove that it read the best practices. While on, the six best-practice write
+      tools (automations, scripts, scenes, helpers, dashboards, raw YAML) are blocked
+      and return an error directing the client to read the best-practices skill via
+      ha_get_skill_guide and pass back the acknowledgment key it obtains there. While
+      on, the ha_get_skill_guide tool is locked enabled — it is the only publisher
+      of the acknowledgment key. Child of the "Attach best-practice skills on writes"
+      option above and inert while that parent is off. Requires restart to take effect.'
+  disabled_tools:
+    name: Disabled tools (comma-separated)
+    description: Tools listed here are forced off and locked in the web Settings UI
+      (Tools tab) — they cannot be re-enabled there without unsetting this option
+      first. A small set of mandatory tools (ha_search, ha_get_overview, ha_get_state,
+      ha_report_issue, ha_manage_backup) cannot be disabled and keep running even
+      if listed here. ha_get_skill_guide can be disabled only while strict best-practices
+      mode (enable_strict_mandatory_bps) is off. Comma-separated tool names (e.g.
+      ha_call_event,ha_eval_template).
+  pinned_tools:
+    name: Pinned tools (comma-separated)
+    description: Tools listed here are locked pinned — they appear at the top of the
+      Tools tab and cannot be unpinned from the web Settings UI without unsetting
+      this option first. Useful in combination with Tool Search. Comma-separated tool
+      names.
+  enable_auto_backup:
+    name: Enable auto-backup of edits
+    description: Captures a per-entity snapshot before every wrapped write/destructive
+      MCP tool call (automation, script, scene, helper, dashboard, label, category,
+      group, zone, area, calendar, todo, entity, integration, and sibling remove/delete
+      tools). Snapshots are saved as YAML files under /data/ha_mcp_backups/ (override
+      via HAMCP_BACKUP_DIR) and listed, restored, or deleted via the Backups tab in
+      the web settings UI or via ha_manage_backup(scope='edits', ...). Best-effort
+      — failures log a WARNING but never block the underlying write. On by default;
+      uncheck to opt out. Requires restart to take effect.
+  auto_backup_throttle_minutes:
+    name: Auto-backup throttle (minutes)
+    description: Per-entity throttle window. 0 (default) captures a snapshot on every
+      wrapped write. N>0 captures at most one snapshot per N minutes per entity. Range
+      0–1440.
+  auto_backup_retain_per_entity:
+    name: Auto-backup retention (per entity)
+    description: Maximum number of snapshots kept per entity. Older snapshots beyond
+      this cap are rotated out on each successful capture. Default 100, range 1–10000.
+  enable_snapshot_delete:
+    name: Allow snapshot deletion
+    description: Lets ha_manage_backup delete full HA snapshot tarballs (scope='snapshot',
+      action='delete'). Off by default — a snapshot may be the last recovery point
+      after a mistaken change, so a human must opt in here. Even when on, scheduled
+      backups, the newest remaining snapshot, and anything younger than the age floor
+      below stay protected.
+  snapshot_delete_min_age_days:
+    name: Minimum snapshot age to delete (days)
+    description: A snapshot must be at least this old before it can be deleted. Range
+      0–365; 0 disables the floor (the newest-snapshot and scheduled-backup protections
+      still apply). Default 7.
+  verify_ssl:
+    name: Verify TLS certificate
+    description: Verify the Home Assistant server's TLS certificate. The add-on connects
+      via the Supervisor proxy, so this normally has no effect and should stay enabled.
+      Disable only if you've reconfigured the add-on to talk to HA over a public HTTPS
+      hostname with a self-signed certificate or hostname mismatch. Disabling weakens
+      transport security — leave on unless you know you need it. Requires restart
+      to take effect.

--- a/src/ha_mcp/settings_ui/locales/sv.json
+++ b/src/ha_mcp/settings_ui/locales/sv.json
@@ -1,0 +1,22 @@
+{
+  "meta": {
+    "native_name": "Svenska",
+    "dir": "ltr"
+  },
+  "messages": {
+    "accessibility.storage_blocked": "Din webbläsare blockerar lagring för den här webbplatsen; dina val gäller bara den här sessionen.",
+    "policies.operators.exists": "finns",
+    "policies.operators.exists_long": "finns (valfritt värde)",
+    "policies.operators.eq": "är lika med",
+    "policies.operators.neq": "är INTE lika med",
+    "policies.operators.in": "är en av",
+    "policies.operators.not_in": "är INTE en av",
+    "policies.operators.contains": "innehåller",
+    "policies.operators.regex": "matchar reguljärt uttryck",
+    "policies.operators.gt": "är större än",
+    "policies.operators.lt": "är mindre än",
+    "policies.pending.already_decided": "Det här godkännandet är redan {decision}, möjligen i en annan flik eller session.",
+    "policies.pending.decision.approved": "godkänt",
+    "policies.pending.decision.denied": "nekat"
+  }
+}


### PR DESCRIPTION
## What does this PR do?

Adds Swedish as a shipped locale code: it names a file on each of the four translated surfaces — the canonical settings store, the component config-flow catalog, and both add-on YAML flavors.

What those files contain at this commit is the anchor set, not a translation. The settings catalog holds 14 of 453 keys, the component catalog 1 of 93, and both add-on YAMLs are still English throughout, because they project add-on keys the settings catalog does not carry yet. Filling the rest is the post-merge sync's job; this PR exists so the sync has a catalog to fill, and the gated completeness checks therefore fail for sv until that run — 7 of the 9, the same seven that failed for nl at its landing commit.

With Dutch and Polish shipping, Swedish is the largest untranslated language by installation base: roughly 14k estimated installations against cs at roughly 10k, read per Home Assistant language code as `AGENTS.md` does. Home Assistant collects no language statistic, so the ranking is derived from country installations.

The two authored catalogs carry the fourteen keys the ungated checks demand, plus `policies.operators.exists_long`, which no check asks for but which would otherwise read English in the condition editor until the sync fills it. The `AGENTS.md` change is two lines of one sentence: `sv` joins the list of shipped codes that `test_agents_md_lists_every_shipped_locale` pins, and "One Home Assistant language code" becomes "The same Home Assistant language code", because the sentence asserts that a language's code is identical across all four paths rather than how many codes exist.

Register and terminology are measured against Home Assistant's own Swedish. Across all 9847 Swedish strings in frontend wheel 20260729.6 there is no capitalised `Ni`, `Er` or `Eder` and exactly one lowercase ni-form possessive, against 489 lowercase `din`/`ditt`/`dina`. The wording follows the same corpus: `är lika med`, `innehåller`, `matchar`, `Reguljärt uttryck`, `flik`, `session`, `blockerar`, `Starta om Home Assistant`. The operator words render the concept instead of the backend's spelling, and the decision participles are neuter so they agree with `godkännandet` in the sentence they are substituted into.

## Type of change
- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

No agent testing: this adds catalog data and one documentation line, neither of which an agent exercises at runtime.

Beyond the suite:

- 13 parametrized IDs carry `[sv]`: 4 run without the completeness flag, and 9 are the completeness checks. PR CI installs the `tests/js` dependencies before running the unit directory, so two further sv-parametrized behaviour tests run there as well — six sv-specific tests in CI.
- Counting IDs still understates the coverage. Both anchors were confirmed by injection instead: spelling `policies.operators.contains` as the backend literal reds `test_every_predicate_operator_has_a_catalog_word`, and swapping the component catalog's single key for one whose English does not address the reader reds `test_every_shipped_component_catalog_gets_reader_addressing_samples[sv]`. Both suites are green again once restored.
- `generate_locales.py` reports no further updates after generating the two YAMLs, so the projections are byte-exact generator output.
- The anchors were cross-read by two independent models before committing, and two findings adopted, each confirmed against the shipped Swedish: "av en annan flik" became "i en annan flik" — that preposition occurs in the corpus, the original does not — and "levererar" became "tillhandahåller", the former appearing nowhere. One was declined on the same evidence: "matchar regex" would diverge from the "Reguljärt uttryck" the frontend already ships.

## Checklist
- [x] I have updated documentation if needed

## Summary by CodeRabbit

* **New Features**
  * Added Swedish translations for add-on configuration options, security settings, backups, tool management, and TLS verification.
  * Added Swedish messages for OAuth, storage warnings, policy operators, and approval decisions.

* **Documentation**
  * Clarified language-code documentation to indicate that each shipped language includes all required translation files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
