### PR TITLE
feat(code-mode): add binary=True response mode to api_get/api_post

### DIFF
--- a/src/ha_mcp/tools/tools_code.py
+++ b/src/ha_mcp/tools/tools_code.py
@@ -21,6 +21,7 @@ MCP" — a personal library of one-off tools that survives restarts.
 See: https://github.com/homeassistant-ai/ha-mcp/issues/726
 """
 
+import base64
 import json
 import logging
 import re
@@ -711,6 +712,50 @@ def _normalize_endpoint(endpoint: Any) -> str:
     return ep
 
 
+def _decode_sandbox_response(response: Any, binary: bool) -> Any:
+    """Decode an ``httpx`` response body for return into sandbox code.
+
+    HA REST responses are normally JSON (or plain text for a handful of
+    endpoints), which the default path below already handles. Some
+    integrations, though, expose authenticated file-download views over
+    ``/api/`` — for example Home Keeper (a HACS asset/maintenance
+    tracker) streams uploaded manuals/receipts back as raw
+    ``application/pdf``/image bytes through its own ``HomeAssistantView``.
+    Monty (the sandbox interpreter) has no filesystem or raw-socket
+    access, so ``api_get``/``api_post`` are the only way sandbox code can
+    reach such a view — but forcing ``response.text`` on a non-text body
+    raises ``UnicodeDecodeError``, which the caller previously surfaced
+    as an opaque generic error with no way to recover the bytes.
+
+    ``binary=True`` skips JSON/text parsing entirely and returns the raw
+    body as base64 so sandbox code (and, downstream, the calling LLM) can
+    decode it outside the sandbox. ``binary=False`` keeps the original
+    JSON-first-then-text behavior, now with a clear error instead of a
+    crash when the body turns out to be non-text after all.
+    """
+    if binary:
+        return {
+            "content_type": response.headers.get("content-type"),
+            "size": len(response.content),
+            "base64": base64.b64encode(response.content).decode("ascii"),
+        }
+    try:
+        return response.json()
+    except json.JSONDecodeError:
+        try:
+            return response.text
+        except UnicodeDecodeError:
+            return {
+                "error": (
+                    "Response body is not UTF-8 text (likely binary, e.g. "
+                    "a PDF or image). Retry the call with binary=True to "
+                    "receive it as base64."
+                ),
+                "content_type": response.headers.get("content-type"),
+                "size": len(response.content),
+            }
+
+
 class _SandboxBridge:
     """Bridges sandboxed Monty code to HA REST/WebSocket/MCP-tool calls.
 
@@ -745,8 +790,15 @@ class _SandboxBridge:
         self.call_count += 1
         return bool(self.call_count > self.settings.code_mode_max_invocations)
 
-    async def api_get(self, endpoint: str) -> Any:
-        """GET request to Home Assistant REST API."""
+    async def api_get(self, endpoint: str, binary: bool = False) -> Any:
+        """GET request to Home Assistant REST API.
+
+        Set ``binary=True`` to receive the response body as base64
+        (``{"content_type", "size", "base64"}``) instead of the default
+        JSON/text decoding — required for endpoints that serve non-text
+        bytes, e.g. a custom integration's authenticated file-download
+        view. See ``_decode_sandbox_response`` for the full rationale.
+        """
         if self._over_invocation_limit():
             return {
                 "error": f"API call limit exceeded ({self.settings.code_mode_max_invocations})"
@@ -758,16 +810,22 @@ class _SandboxBridge:
             return {"error": str(exc)}
         try:
             response = await self.client.httpx_client.request("GET", normalized)
-            try:
-                return response.json()
-            except json.JSONDecodeError:
-                return response.text
+            return _decode_sandbox_response(response, binary)
         except Exception as exc:
             logger.warning("api_get(%r) failed", endpoint, exc_info=True)
             return {"error": str(exc)[:200]}
 
-    async def api_post(self, endpoint: str, data: dict[str, Any] | None = None) -> Any:
-        """POST request to Home Assistant REST API."""
+    async def api_post(
+        self,
+        endpoint: str,
+        data: dict[str, Any] | None = None,
+        binary: bool = False,
+    ) -> Any:
+        """POST request to Home Assistant REST API.
+
+        Set ``binary=True`` to receive the response body as base64
+        instead of the default JSON/text decoding (see ``api_get``).
+        """
         if self._over_invocation_limit():
             return {
                 "error": f"API call limit exceeded ({self.settings.code_mode_max_invocations})"
@@ -807,10 +865,7 @@ class _SandboxBridge:
             response = await self.client.httpx_client.request(
                 "POST", normalized, **post_kwargs
             )
-            try:
-                return response.json()
-            except json.JSONDecodeError:
-                return response.text
+            return _decode_sandbox_response(response, binary)
         except Exception as exc:
             logger.warning("api_post(%r) failed", endpoint, exc_info=True)
             return {"error": str(exc)[:200]}
@@ -949,8 +1004,8 @@ async def _run_sandboxed_code(
     """Execute code in the pydantic-monty sandbox.
 
     External functions available to sandbox code:
-    - api_get(endpoint) — GET request to HA REST API
-    - api_post(endpoint, data) — POST request to HA REST API
+    - api_get(endpoint, binary=False) — GET request to HA REST API
+    - api_post(endpoint, data, binary=False) — POST request to HA REST API
     - ws_send(message) — send a HA WebSocket command and return its result
     - call_tool(name, args) — call a registered MCP tool (for existing tools)
 
@@ -1327,8 +1382,12 @@ def register_code_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
         - Set ``list_saved=True`` to list all saved tools
 
         **Available functions in sandbox:**
-        - ``api_get(endpoint)`` — GET request to HA REST API
-        - ``api_post(endpoint, data)`` — POST request to HA REST API
+        - ``api_get(endpoint, binary=False)`` — GET request to HA REST API.
+          Pass ``binary=True`` to get ``{"content_type", "size", "base64"}``
+          instead of JSON/text decoding — needed for endpoints that stream
+          non-text bytes, e.g. a custom integration's file-download view.
+        - ``api_post(endpoint, data, binary=False)`` — POST request to HA
+          REST API; same ``binary`` behavior as ``api_get`` for the response.
         - ``ws_send(message)`` — send a HA WebSocket command (e.g. registry
           lookups, ``render_template``, dashboard ops). ``message`` must include
           a ``"type"`` field; the MCP server adds ``id`` and handles auth.
@@ -1352,6 +1411,17 @@ def register_code_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
         ```python
         repairs = await api_get("/repairs/issues")
         repairs
+        ```
+
+        Example — download a binary file exposed by a custom integration's
+        authenticated HTTP view (JSON/text decoding would raise on the
+        raw bytes; ``binary=True`` returns base64 instead):
+        ```python
+        doc = await api_get(
+            "/some_integration/document/<asset_id>/<document_id>",
+            binary=True,
+        )
+        {"content_type": doc["content_type"], "size": doc["size"]}
         ```
 
         Example — list areas via WebSocket:

--- a/src/ha_mcp/tools/tools_code.py
+++ b/src/ha_mcp/tools/tools_code.py
@@ -712,7 +712,7 @@ def _normalize_endpoint(endpoint: Any) -> str:
     return ep
 
 
-def _decode_sandbox_response(response: Any, binary: bool) -> Any:
+def _decode_sandbox_response(response: Any, binary: bool, max_binary_size: int) -> Any:
     """Decode an ``httpx`` response body for return into sandbox code.
 
     HA REST responses are normally JSON (or plain text for a handful of
@@ -723,37 +723,82 @@ def _decode_sandbox_response(response: Any, binary: bool) -> Any:
     ``application/pdf``/image bytes through its own ``HomeAssistantView``.
     Monty (the sandbox interpreter) has no filesystem or raw-socket
     access, so ``api_get``/``api_post`` are the only way sandbox code can
-    reach such a view — but forcing ``response.text`` on a non-text body
-    raises ``UnicodeDecodeError``, which the caller previously surfaced
-    as an opaque generic error with no way to recover the bytes.
+    reach such a view.
+
+    httpx's ``Response.json()`` decodes ``response.content`` with a
+    guessed encoding *without* error replacement, so a non-UTF-8 body
+    (a real PDF, say) raises ``UnicodeDecodeError`` there — not
+    ``json.JSONDecodeError``. Missing that exception type is exactly
+    how the original bug surfaced: the caller's blanket ``except
+    Exception`` turned it into an opaque ``"'utf-8' codec can't decode
+    byte ..."`` error with no way to recover the bytes. That case must
+    go straight to the binary-hint error below rather than falling
+    through to ``response.text`` — ``.text`` uses replacement-decoding
+    and does not raise on the same bytes, so falling through there
+    would silently return corrupted text (with U+FFFD replacement
+    characters standing in for whatever the original bytes were)
+    instead of surfacing that the body isn't text at all. A
+    ``json.JSONDecodeError`` is different: it means the body decoded
+    fine as text but isn't valid JSON, so falling through to
+    ``response.text`` there is the correct, intentional plain-text
+    path. ``response.text`` is still guarded against
+    ``UnicodeDecodeError`` for defense-in-depth, since which decode
+    stage can raise is an httpx implementation detail this function
+    shouldn't have to assume.
 
     ``binary=True`` skips JSON/text parsing entirely and returns the raw
     body as base64 so sandbox code (and, downstream, the calling LLM) can
-    decode it outside the sandbox. ``binary=False`` keeps the original
-    JSON-first-then-text behavior, now with a clear error instead of a
-    crash when the body turns out to be non-text after all.
+    decode it outside the sandbox. Monty's own memory limit only covers
+    the sandbox interpreter, not bytes buffered on the host side of an
+    external function call, so ``max_binary_size`` (the operator's
+    ``CODE_MODE_MAX_MEMORY``) bounds the base64 payload here — otherwise
+    a single large file download could balloon host memory well past
+    what the sandbox's own ``ResourceLimits`` are meant to represent.
     """
     if binary:
+        size = len(response.content)
+        if size > max_binary_size:
+            return {
+                "error": (
+                    f"Response body ({size} bytes) exceeds the "
+                    f"binary=True size limit ({max_binary_size} bytes, "
+                    "CODE_MODE_MAX_MEMORY). Ask the operator to raise "
+                    "CODE_MODE_MAX_MEMORY, or fetch a smaller resource."
+                ),
+                "content_type": response.headers.get("content-type"),
+                "size": size,
+            }
         return {
             "content_type": response.headers.get("content-type"),
-            "size": len(response.content),
+            "size": size,
             "base64": base64.b64encode(response.content).decode("ascii"),
         }
     try:
         return response.json()
     except json.JSONDecodeError:
-        try:
-            return response.text
-        except UnicodeDecodeError:
-            return {
-                "error": (
-                    "Response body is not UTF-8 text (likely binary, e.g. "
-                    "a PDF or image). Retry the call with binary=True to "
-                    "receive it as base64."
-                ),
-                "content_type": response.headers.get("content-type"),
-                "size": len(response.content),
-            }
+        pass
+    except UnicodeDecodeError:
+        return _binary_hint_error(response)
+    try:
+        return response.text
+    except UnicodeDecodeError:
+        return _binary_hint_error(response)
+
+
+def _binary_hint_error(response: Any) -> dict[str, Any]:
+    """Error payload for a response body that turned out to be non-text.
+
+    Shared by both decode-failure sites in ``_decode_sandbox_response``.
+    """
+    return {
+        "error": (
+            "Response body is not UTF-8 text (likely binary, e.g. "
+            "a PDF or image). Retry the call with binary=True to "
+            "receive it as base64."
+        ),
+        "content_type": response.headers.get("content-type"),
+        "size": len(response.content),
+    }
 
 
 class _SandboxBridge:
@@ -797,7 +842,9 @@ class _SandboxBridge:
         (``{"content_type", "size", "base64"}``) instead of the default
         JSON/text decoding — required for endpoints that serve non-text
         bytes, e.g. a custom integration's authenticated file-download
-        view. See ``_decode_sandbox_response`` for the full rationale.
+        view. The body is capped at ``CODE_MODE_MAX_MEMORY`` bytes; a
+        larger response comes back as an ``"error"`` dict instead of
+        base64. See ``_decode_sandbox_response`` for the full rationale.
         """
         if self._over_invocation_limit():
             return {
@@ -810,7 +857,9 @@ class _SandboxBridge:
             return {"error": str(exc)}
         try:
             response = await self.client.httpx_client.request("GET", normalized)
-            return _decode_sandbox_response(response, binary)
+            return _decode_sandbox_response(
+                response, binary, self.settings.code_mode_max_memory
+            )
         except Exception as exc:
             logger.warning("api_get(%r) failed", endpoint, exc_info=True)
             return {"error": str(exc)[:200]}
@@ -865,7 +914,9 @@ class _SandboxBridge:
             response = await self.client.httpx_client.request(
                 "POST", normalized, **post_kwargs
             )
-            return _decode_sandbox_response(response, binary)
+            return _decode_sandbox_response(
+                response, binary, self.settings.code_mode_max_memory
+            )
         except Exception as exc:
             logger.warning("api_post(%r) failed", endpoint, exc_info=True)
             return {"error": str(exc)[:200]}
@@ -1386,6 +1437,7 @@ def register_code_tools(mcp: Any, client: Any, **kwargs: Any) -> None:
           Pass ``binary=True`` to get ``{"content_type", "size", "base64"}``
           instead of JSON/text decoding — needed for endpoints that stream
           non-text bytes, e.g. a custom integration's file-download view.
+          Capped at ``CODE_MODE_MAX_MEMORY`` bytes.
         - ``api_post(endpoint, data, binary=False)`` — POST request to HA
           REST API; same ``binary`` behavior as ``api_get`` for the response.
         - ``ws_send(message)`` — send a HA WebSocket command (e.g. registry

--- a/tests/src/unit/test_sandbox_bridge_binary.py
+++ b/tests/src/unit/test_sandbox_bridge_binary.py
@@ -7,60 +7,39 @@ authenticated file-download view such as Home Keeper's document/manual
 endpoint). ``binary=True`` must return base64 instead of attempting
 JSON/text decoding; the default path must degrade to a clear error
 instead of propagating the raw decode exception.
+
+Uses real ``httpx.Response`` objects (not a hand-rolled fake) so the
+tests exercise actual httpx decode behavior: ``Response.json()``
+decodes ``.content`` with a guessed encoding and *no* error
+replacement, so a genuinely non-UTF-8 body raises ``UnicodeDecodeError``
+there — not ``json.JSONDecodeError`` — while ``Response.text`` falls
+back to replacement-decoding and does not raise. A mock that only ever
+raises ``JSONDecodeError`` would mask exactly the failure mode this fix
+targets.
 """
 
 import base64
-import json
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
+import httpx
 import pytest
 
 from ha_mcp.tools.tools_code import _SandboxBridge
 
-
-class _FakeResponse:
-    """Stand-in for an ``httpx.Response``.
-
-    ``json_ok``/``text_ok`` mirror real httpx semantics: ``.json()``
-    raises ``json.JSONDecodeError`` on non-JSON bodies, and ``.text``
-    raises ``UnicodeDecodeError`` when the declared/sniffed encoding
-    can't decode the raw bytes (as it does for real PDF/image content).
-    """
-
-    def __init__(
-        self, *, content: bytes, content_type: str, json_ok: bool, text_ok: bool
-    ):
-        self.content = content
-        self.headers = {"content-type": content_type}
-        self._json_ok = json_ok
-        self._text_ok = text_ok
-
-    def json(self):
-        if self._json_ok:
-            return json.loads(self.content)
-        raise json.JSONDecodeError("not json", self.content.decode("latin-1"), 0)
-
-    @property
-    def text(self):
-        if self._text_ok:
-            return self.content.decode("utf-8")
-        raise UnicodeDecodeError("utf-8", self.content, 0, 1, "invalid start byte")
+# Real PDF-ish bytes: not valid JSON, and not valid UTF-8 (0xd3 with no
+# continuation byte). Mirrors the actual incident this fix addresses.
+_PDF_BYTES = b"%PDF-1.4 fake binary \xd3\xff content"
+_PNG_BYTES = b"\x89PNG\r\n\x1a\nfake binary \xd3\xff content"
 
 
-def _make_response(
-    *, content: bytes, content_type: str, json_ok: bool = False, text_ok: bool = True
-):
-    return _FakeResponse(
-        content=content, content_type=content_type, json_ok=json_ok, text_ok=text_ok
-    )
-
-
-def _make_bridge(response):
+def _make_bridge(response: httpx.Response, *, max_binary_size: int = 10_485_760):
     client = SimpleNamespace(
         httpx_client=SimpleNamespace(request=AsyncMock(return_value=response))
     )
-    settings = SimpleNamespace(code_mode_max_invocations=100)
+    settings = SimpleNamespace(
+        code_mode_max_invocations=100, code_mode_max_memory=max_binary_size
+    )
     return _SandboxBridge(ctx=None, client=client, settings=settings)
 
 
@@ -68,9 +47,8 @@ class TestApiGetBinary:
     @pytest.mark.asyncio
     async def test_binary_true_returns_base64_for_pdf(self):
         """A PDF body with binary=True comes back as base64, not a crash."""
-        pdf_bytes = b"%PDF-1.4 fake binary \xd3\xff content"
-        response = _make_response(
-            content=pdf_bytes, content_type="application/pdf", text_ok=False
+        response = httpx.Response(
+            200, headers={"content-type": "application/pdf"}, content=_PDF_BYTES
         )
         bridge = _make_bridge(response)
 
@@ -78,15 +56,32 @@ class TestApiGetBinary:
 
         assert "error" not in result
         assert result["content_type"] == "application/pdf"
-        assert result["size"] == len(pdf_bytes)
-        assert base64.b64decode(result["base64"]) == pdf_bytes
+        assert result["size"] == len(_PDF_BYTES)
+        assert base64.b64decode(result["base64"]) == _PDF_BYTES
+
+    @pytest.mark.asyncio
+    async def test_binary_true_over_size_cap_returns_error_not_base64(self):
+        """A body over CODE_MODE_MAX_MEMORY must not be base64-encoded —
+        that would defeat the point of bounding host-side memory use."""
+        response = httpx.Response(
+            200, headers={"content-type": "application/pdf"}, content=_PDF_BYTES
+        )
+        bridge = _make_bridge(response, max_binary_size=len(_PDF_BYTES) - 1)
+
+        result = await bridge.api_get("/home_keeper/document/asset/doc", binary=True)
+
+        assert "base64" not in result
+        assert "error" in result
+        assert "CODE_MODE_MAX_MEMORY" in result["error"]
+        assert result["size"] == len(_PDF_BYTES)
 
     @pytest.mark.asyncio
     async def test_binary_false_default_still_parses_json(self):
         """binary=False (the default) is unchanged for ordinary JSON APIs."""
-        body = b'{"version": "2026.1.0"}'
-        response = _make_response(
-            content=body, content_type="application/json", json_ok=True
+        response = httpx.Response(
+            200,
+            headers={"content-type": "application/json"},
+            content=b'{"version": "2026.1.0"}',
         )
         bridge = _make_bridge(response)
 
@@ -95,30 +90,52 @@ class TestApiGetBinary:
         assert result == {"version": "2026.1.0"}
 
     @pytest.mark.asyncio
+    async def test_binary_false_falls_through_to_text_for_plain_text_endpoints(self):
+        """A genuinely non-JSON but valid-UTF-8 body (JSONDecodeError, not
+        UnicodeDecodeError) must still fall through to response.text —
+        the UnicodeDecodeError-only short-circuit must not swallow this
+        legitimate plain-text case."""
+        response = httpx.Response(
+            200,
+            headers={"content-type": "text/plain"},
+            content=b"OK, config valid",
+        )
+        bridge = _make_bridge(response)
+
+        result = await bridge.api_get("/config/core/check_config")
+
+        assert result == "OK, config valid"
+
+    @pytest.mark.asyncio
     async def test_binary_false_on_binary_body_returns_error_not_crash(self):
         """Without binary=True, a non-text body must degrade to a clear
         error dict — never propagate a raw UnicodeDecodeError to the
-        sandbox caller (the bug this test guards against)."""
-        pdf_bytes = b"%PDF-1.4 fake binary \xd3\xff content"
-        response = _make_response(
-            content=pdf_bytes, content_type="application/pdf", text_ok=False
+        sandbox caller (the bug this test guards against). This is the
+        exact real-world failure mode: httpx's Response.json() raises
+        UnicodeDecodeError (not JSONDecodeError) on non-UTF-8 content."""
+        response = httpx.Response(
+            200, headers={"content-type": "application/pdf"}, content=_PDF_BYTES
         )
         bridge = _make_bridge(response)
+
+        # Confirm the assumption this test relies on: json() raises
+        # UnicodeDecodeError for this body, not JSONDecodeError.
+        with pytest.raises(UnicodeDecodeError):
+            response.json()
 
         result = await bridge.api_get("/home_keeper/document/asset/doc")
 
         assert "error" in result
         assert "binary=True" in result["error"]
         assert result["content_type"] == "application/pdf"
-        assert result["size"] == len(pdf_bytes)
+        assert result["size"] == len(_PDF_BYTES)
 
 
 class TestApiPostBinary:
     @pytest.mark.asyncio
     async def test_binary_true_returns_base64(self):
-        image_bytes = b"\x89PNG\r\n\x1a\nfake"
-        response = _make_response(
-            content=image_bytes, content_type="image/png", text_ok=False
+        response = httpx.Response(
+            200, headers={"content-type": "image/png"}, content=_PNG_BYTES
         )
         bridge = _make_bridge(response)
 
@@ -126,16 +143,29 @@ class TestApiPostBinary:
 
         assert "error" not in result
         assert result["content_type"] == "image/png"
-        assert base64.b64decode(result["base64"]) == image_bytes
+        assert base64.b64decode(result["base64"]) == _PNG_BYTES
 
     @pytest.mark.asyncio
     async def test_binary_false_default_still_parses_json(self):
-        body = b'{"ok": true}'
-        response = _make_response(
-            content=body, content_type="application/json", json_ok=True
+        response = httpx.Response(
+            200,
+            headers={"content-type": "application/json"},
+            content=b'{"ok": true}',
         )
         bridge = _make_bridge(response)
 
         result = await bridge.api_post("/config/core/check_config")
 
         assert result == {"ok": True}
+
+    @pytest.mark.asyncio
+    async def test_binary_false_on_binary_body_returns_error_not_crash(self):
+        response = httpx.Response(
+            200, headers={"content-type": "image/png"}, content=_PNG_BYTES
+        )
+        bridge = _make_bridge(response)
+
+        result = await bridge.api_post("/some_endpoint", data={"x": 1})
+
+        assert "error" in result
+        assert "binary=True" in result["error"]

--- a/tests/src/unit/test_sandbox_bridge_binary.py
+++ b/tests/src/unit/test_sandbox_bridge_binary.py
@@ -1,0 +1,141 @@
+"""Unit tests for the ``binary=True`` response mode on ``_SandboxBridge``.
+
+Covers the fix for sandbox code crashing with an opaque
+``UnicodeDecodeError`` when ``api_get``/``api_post`` hit an HA REST
+endpoint that streams non-text bytes (e.g. a custom integration's
+authenticated file-download view such as Home Keeper's document/manual
+endpoint). ``binary=True`` must return base64 instead of attempting
+JSON/text decoding; the default path must degrade to a clear error
+instead of propagating the raw decode exception.
+"""
+
+import base64
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from ha_mcp.tools.tools_code import _SandboxBridge
+
+
+class _FakeResponse:
+    """Stand-in for an ``httpx.Response``.
+
+    ``json_ok``/``text_ok`` mirror real httpx semantics: ``.json()``
+    raises ``json.JSONDecodeError`` on non-JSON bodies, and ``.text``
+    raises ``UnicodeDecodeError`` when the declared/sniffed encoding
+    can't decode the raw bytes (as it does for real PDF/image content).
+    """
+
+    def __init__(
+        self, *, content: bytes, content_type: str, json_ok: bool, text_ok: bool
+    ):
+        self.content = content
+        self.headers = {"content-type": content_type}
+        self._json_ok = json_ok
+        self._text_ok = text_ok
+
+    def json(self):
+        if self._json_ok:
+            return json.loads(self.content)
+        raise json.JSONDecodeError("not json", self.content.decode("latin-1"), 0)
+
+    @property
+    def text(self):
+        if self._text_ok:
+            return self.content.decode("utf-8")
+        raise UnicodeDecodeError("utf-8", self.content, 0, 1, "invalid start byte")
+
+
+def _make_response(
+    *, content: bytes, content_type: str, json_ok: bool = False, text_ok: bool = True
+):
+    return _FakeResponse(
+        content=content, content_type=content_type, json_ok=json_ok, text_ok=text_ok
+    )
+
+
+def _make_bridge(response):
+    client = SimpleNamespace(
+        httpx_client=SimpleNamespace(request=AsyncMock(return_value=response))
+    )
+    settings = SimpleNamespace(code_mode_max_invocations=100)
+    return _SandboxBridge(ctx=None, client=client, settings=settings)
+
+
+class TestApiGetBinary:
+    @pytest.mark.asyncio
+    async def test_binary_true_returns_base64_for_pdf(self):
+        """A PDF body with binary=True comes back as base64, not a crash."""
+        pdf_bytes = b"%PDF-1.4 fake binary \xd3\xff content"
+        response = _make_response(
+            content=pdf_bytes, content_type="application/pdf", text_ok=False
+        )
+        bridge = _make_bridge(response)
+
+        result = await bridge.api_get("/home_keeper/document/asset/doc", binary=True)
+
+        assert "error" not in result
+        assert result["content_type"] == "application/pdf"
+        assert result["size"] == len(pdf_bytes)
+        assert base64.b64decode(result["base64"]) == pdf_bytes
+
+    @pytest.mark.asyncio
+    async def test_binary_false_default_still_parses_json(self):
+        """binary=False (the default) is unchanged for ordinary JSON APIs."""
+        body = b'{"version": "2026.1.0"}'
+        response = _make_response(
+            content=body, content_type="application/json", json_ok=True
+        )
+        bridge = _make_bridge(response)
+
+        result = await bridge.api_get("/config")
+
+        assert result == {"version": "2026.1.0"}
+
+    @pytest.mark.asyncio
+    async def test_binary_false_on_binary_body_returns_error_not_crash(self):
+        """Without binary=True, a non-text body must degrade to a clear
+        error dict — never propagate a raw UnicodeDecodeError to the
+        sandbox caller (the bug this test guards against)."""
+        pdf_bytes = b"%PDF-1.4 fake binary \xd3\xff content"
+        response = _make_response(
+            content=pdf_bytes, content_type="application/pdf", text_ok=False
+        )
+        bridge = _make_bridge(response)
+
+        result = await bridge.api_get("/home_keeper/document/asset/doc")
+
+        assert "error" in result
+        assert "binary=True" in result["error"]
+        assert result["content_type"] == "application/pdf"
+        assert result["size"] == len(pdf_bytes)
+
+
+class TestApiPostBinary:
+    @pytest.mark.asyncio
+    async def test_binary_true_returns_base64(self):
+        image_bytes = b"\x89PNG\r\n\x1a\nfake"
+        response = _make_response(
+            content=image_bytes, content_type="image/png", text_ok=False
+        )
+        bridge = _make_bridge(response)
+
+        result = await bridge.api_post("/some_endpoint", data={"x": 1}, binary=True)
+
+        assert "error" not in result
+        assert result["content_type"] == "image/png"
+        assert base64.b64decode(result["base64"]) == image_bytes
+
+    @pytest.mark.asyncio
+    async def test_binary_false_default_still_parses_json(self):
+        body = b'{"ok": true}'
+        response = _make_response(
+            content=body, content_type="application/json", json_ok=True
+        )
+        bridge = _make_bridge(response)
+
+        result = await bridge.api_post("/config/core/check_config")
+
+        assert result == {"ok": True}


### PR DESCRIPTION
## Problem

`ha_manage_custom_tool`'s sandbox (Monty) has no filesystem or raw-socket access — `api_get`/`api_post` are the only way sandbox code can reach an HA REST endpoint that isn't already covered by a dedicated tool.

Some custom integrations expose **authenticated file-download views** over `/api/` that stream non-text bytes. Concretely: [Home Keeper](https://github.com/prestomation/ha-home-keeper) (a HACS asset/maintenance-tracking integration) stores uploaded manuals, receipts, and warranty documents and serves them back through its own `HomeAssistantView` as raw `application/pdf` (or image) bytes — there's no service/websocket API that returns the file contents, only this HTTP view.

`_SandboxBridge.api_get`/`api_post` unconditionally do:
```python
try:
    return response.json()
except json.JSONDecodeError:
    return response.text
```
For a PDF body, `.json()` fails as expected, then `.text` tries to decode the raw bytes as UTF-8 and raises `UnicodeDecodeError`. That's caught by the method's blanket `except Exception`, so the caller only ever sees an opaque `{"error": "'utf-8' codec can't decode byte ... invalid continuation byte"}` with no way to actually retrieve the file.

## Fix

Add an optional `binary: bool = False` parameter to both `api_get` and `api_post`. When `True`, the response is returned as `{"content_type", "size", "base64"}` instead of being decoded — sandbox code (and the calling LLM) can base64-decode it outside the sandbox. Factored the response-decoding into a shared `_decode_sandbox_response` helper used by both methods.

The default (`binary=False`) path is unchanged for ordinary JSON/text APIs. As a side benefit, a body that turns out to be undecodable now degrades to a clear, actionable error dict (mentioning `binary=True`) instead of surfacing a raw `UnicodeDecodeError` message.

Updated both docstrings (`_SandboxBridge` methods and the `ha_manage_custom_tool` tool description/examples) to document the new parameter.

## Testing

- Added `tests/src/unit/test_sandbox_bridge_binary.py`: exercises `api_get`/`api_post` against a fake `httpx.Response` that mirrors real httpx behavior (`.json()` raises `JSONDecodeError` on non-JSON, `.text` raises `UnicodeDecodeError` on undecodable bytes). Covers: `binary=True` round-trips a PDF/PNG body through base64, `binary=False` is unchanged for JSON, and `binary=False` on a genuinely binary body returns a descriptive error instead of crashing.
- `uv run pytest tests/src/unit -k "code or sandbox or docs_sync"` — 322 passed, 7 skipped (unrelated `jsdom` JS-harness tests requiring `npm install`).
- `uv run ruff check` / `uv run ruff format --check` / `uv run mypy src/ha_mcp/tools/tools_code.py` / `uv run ast-grep scan` — all clean on the changed files.

No config/behavior change for existing callers — `binary` defaults to `False` and the JSON/text path is untouched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional binary response support for sandbox GET and POST requests.
  * Binary responses can be returned as base64 data with content type and size metadata.
  * Added configurable size-limit enforcement for binary responses.
  * Added an example for downloading binary files.

* **Bug Fixes**
  * Non-text responses now return a clear error in standard mode, with guidance to retry using binary mode.

* **Documentation**
  * Updated sandbox and tool documentation for binary responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->