### PR TITLE
fix: keep hardcoded config-entry titles untranslated too

### DIFF
--- a/.github/workflows/locale-sync.yml
+++ b/.github/workflows/locale-sync.yml
@@ -19,7 +19,7 @@ name: Locale Sync
 #
 # Verification is three layers. (1) Every returned string is validated
 # before it is written (placeholder, markup, formatting-tag and panel-link
-# parity, plus the config flow's hardcoded option labels, in the script).
+# parity, plus the on-screen names Python hardcodes, in the script).
 # (2) After a clean run, the content-completeness checks that PR CI
 # skips run here under LOCALE_COMPLETENESS_CHECKS=1; a failure means the
 # output may be corrupt (the engine pasted English back, parity broke) and

--- a/custom_components/ha_mcp_tools/translations/nl.json
+++ b/custom_components/ha_mcp_tools/translations/nl.json
@@ -152,8 +152,8 @@
     "oauth_select_legacy_mode": "Stel de authenticatiemodus hierboven in op legacy OAuth en sla op om een Client ID en Client Secret te genereren.",
     "panel_hint": "Open het [HA-MCP instellingenpaneel](/ha-mcp) voor toolbeheer en serverinstellingen.",
     "tools_module_installed": "Bèta/geavanceerde bestands- & YAML-tools module (optioneel): Geïnstalleerd",
-    "tools_module_not_installed": "Bèta/geavanceerde bestands- & YAML-tools module (optioneel): Niet geïnstalleerd — druk op \"Entiteit toevoegen\" op de pagina van deze integratie en kies \"HA-MCP Bestands- & YAML-tools\" om deze toe te voegen",
-    "tools_module_not_loaded": "Bèta/geavanceerde bestands- & YAML-tools module (optioneel): Geïnstalleerd maar niet geladen — schakel de \"HA-MCP Bestands- & YAML-tools\" entiteit op de pagina van deze integratie in of herlaad deze",
+    "tools_module_not_installed": "Bèta/geavanceerde bestands- & YAML-tools module (optioneel): Niet geïnstalleerd — druk op \"Item toevoegen\" op de pagina van deze integratie en kies \"HA-MCP File & YAML Tools\" om deze toe te voegen",
+    "tools_module_not_loaded": "Bèta/geavanceerde bestands- & YAML-tools module (optioneel): Geïnstalleerd maar niet geladen — schakel het \"HA-MCP File & YAML Tools\" item op de pagina van deze integratie in of herlaad het",
     "version_line": "Component {component_version} - Server ha-mcp {server_version} ({channel} kanaal)",
     "version_not_installed": "nog niet geïnstalleerd",
     "version_unknown": "onbekend"

--- a/scripts/translate_locales.py
+++ b/scripts/translate_locales.py
@@ -452,7 +452,18 @@ def _hardcoded_ui_names() -> tuple[str, ...]:
 
 
 def _untranslatable_name_dropped(english: str, translated: str) -> str | None:
-    """The hardcoded on-screen name this translation localised away, if any."""
+    """The hardcoded on-screen name this translation localised away, if any.
+
+    Single quotes are matched against the known names rather than paired like
+    the other marks: English prose spells the apostrophe with the same
+    character, so pairing on it shifts every quote in a sentence containing one
+    and loses the real candidate. Measured on the shipped catalogs, adding `'`
+    to the paired class drops one of the two live violations.
+    """
+    for name in _hardcoded_ui_names():
+        if any(f"{q}{name}{q2}" in english for q, q2 in (("'", "'"), ("‘", "’"))):
+            if name not in translated:
+                return name
     quoted_texts: list[str] = _QUOTED_RE.findall(english)
     for quoted in quoted_texts:
         for name in _hardcoded_ui_names():

--- a/scripts/translate_locales.py
+++ b/scripts/translate_locales.py
@@ -26,8 +26,8 @@ down is a HUMAN: hand-edit the translations, run
 run sees nothing stale and no-ops. Hand-edits always win; the machine only
 touches strings whose English changed.
 Every returned string is validated (placeholder parity, the settings UI markup
-allowlist, formatting-tag parity, panel-link parity, and the config flow's
-hardcoded option labels staying untranslated) before it is written; a failure
+allowlist, formatting-tag parity, panel-link parity, and the on-screen names
+Python hardcodes staying untranslated) before it is written; a failure
 leaves that string unwritten and the run red rather than shipping a broken
 translation.
 
@@ -418,38 +418,46 @@ def build_plan(module: Any) -> Plan:
 
 
 _CONFIG_FLOW_PATH = REPO_ROOT / "custom_components" / "ha_mcp_tools" / "config_flow.py"
+_CONST_PATH = REPO_ROOT / "custom_components" / "ha_mcp_tools" / "const.py"
 _SELECTOR_LABEL_RE = re.compile(r'label="([^"]+)"')
+_ENTRY_TITLE_RE = re.compile(r'^_?[A-Z][A-Z_]*TITLE\s*=\s*"([^"]+)"', re.M)
 # English sources quote with straight or typographic marks — both already occur
-# in the shipped catalogs — and the label check has to see the quoted text
-# either way, or the spelling of a quote silently decides whether it applies.
+# in the shipped catalogs — and the check has to see the quoted text either
+# way, or the spelling of a quote silently decides whether it applies.
 _QUOTED_RE = re.compile(r'["“”«»„]([^"“”«»„]+)["“”«»„]')
 
 
 @lru_cache(maxsize=1)
-def _hardcoded_option_labels() -> tuple[str, ...]:
-    """Config-flow selector labels, which read English on every reader's form.
+def _hardcoded_ui_names() -> tuple[str, ...]:
+    """On-screen names Python hardcodes, which read English to every reader.
 
     Quoting alone does not say whether a string may be translated: catalogs
     correctly translate quoted cross-references to their own option labels,
     and Home Assistant translates its own buttons ("Add entry"). What must
-    survive verbatim is the narrower class this returns — labels our config
-    flow hardcodes in Python, so no catalog can localise them and a reader
-    told to pick a translated one goes looking for an option that is not on
-    the form. Read from the source instead of listed here so a rename cannot
+    survive verbatim is the narrower class this returns — names our own code
+    fixes in Python, so no catalog can localise them and a reader told to pick
+    a translated one goes looking for something that is not on the screen.
+
+    Two kinds, one rule. Config-flow selector labels name a dropdown option;
+    entry titles name the config entry a reader is told to click. Both are
+    read from the source rather than listed here, so renaming one cannot
     strand a stale copy; ``test_connect_local_lan_quotes_the_bind_host_option``
-    guards the rename against the catalogs.
+    guards the selector rename against the catalogs.
     """
-    labels: list[str] = _SELECTOR_LABEL_RE.findall(_CONFIG_FLOW_PATH.read_text("utf-8"))
-    return tuple(labels)
+    flow = _CONFIG_FLOW_PATH.read_text("utf-8")
+    const = _CONST_PATH.read_text("utf-8")
+    labels: list[str] = _SELECTOR_LABEL_RE.findall(flow)
+    titles: list[str] = _ENTRY_TITLE_RE.findall(flow) + _ENTRY_TITLE_RE.findall(const)
+    return tuple(labels + titles)
 
 
-def _untranslatable_label_dropped(english: str, translated: str) -> str | None:
-    """The hardcoded label this translation localised away, if any."""
+def _untranslatable_name_dropped(english: str, translated: str) -> str | None:
+    """The hardcoded on-screen name this translation localised away, if any."""
     quoted_texts: list[str] = _QUOTED_RE.findall(english)
     for quoted in quoted_texts:
-        for label in _hardcoded_option_labels():
+        for name in _hardcoded_ui_names():
             if (
-                label == quoted or label.startswith(f"{quoted} ")
+                name == quoted or name.startswith(f"{quoted} ")
             ) and quoted not in translated:
                 return quoted
     return None
@@ -459,10 +467,10 @@ def _validate(item: WorkItem, translated: Any) -> str | None:
     """The reason a translation is unusable for this item, or None."""
     if not isinstance(translated, str) or not translated.strip():
         return "empty or non-string translation"
-    dropped = _untranslatable_label_dropped(item.english, translated)
+    dropped = _untranslatable_name_dropped(item.english, translated)
     if dropped is not None:
         return (
-            f"the on-screen option {dropped!r} is hardcoded in the config flow "
+            f"the on-screen name {dropped!r} is hardcoded in Python "
             "and has to stay untranslated"
         )
     if set(_PLACEHOLDER_RE.findall(item.english)) != set(

--- a/tests/src/unit/test_translate_locales.py
+++ b/tests/src/unit/test_translate_locales.py
@@ -172,6 +172,29 @@ class TestHardcodedOptionLabels:
         assert _validate(_item(section="component", english=english), localised)
         assert _validate(_item(section="component", english=english), kept) is None
 
+    def test_rejects_a_localised_name_in_single_quotes(self) -> None:
+        # Shipped English at options.step.init.data_description.enable_llm_api
+        # spells this one with apostrophes rather than double quotes. Single
+        # quotes are matched against the known names instead of being paired
+        # like the other marks: the apostrophe in "integration's" is the same
+        # character, so pairing on it shifts every quote in such a sentence —
+        # measured on the shipped catalogs, pairing loses a live violation.
+        english = "agents can select 'HA-MCP Server' under Control Home Assistant"
+        localised = "agenten kunnen 'HA-MCP Servidor' kiezen onder Bediening"
+        kept = "agenten kunnen 'HA-MCP Server' kiezen onder Bediening"
+        assert _validate(_item(section="component", english=english), localised)
+        assert _validate(_item(section="component", english=english), kept) is None
+
+    def test_apostrophes_do_not_hide_a_double_quoted_name(self) -> None:
+        # The regression the obvious repair would have caused: this English
+        # carries an apostrophe before the quoted title.
+        english = (
+            'press "Add entry" on this integration\'s page and choose '
+            '"HA-MCP File & YAML Tools" to add it'
+        )
+        localised = 'druk op "Item toevoegen" en kies "HA-MCP Bestands-tools"'
+        assert _validate(_item(section="component", english=english), localised)
+
     def test_leaves_other_quoted_text_translatable(self) -> None:
         # "Add entry" is Home Assistant's own button: HA translates it, so
         # every shipped catalog translates the quote too. Only labels the

--- a/tests/src/unit/test_translate_locales.py
+++ b/tests/src/unit/test_translate_locales.py
@@ -119,18 +119,25 @@ class TestValidate:
 
 
 class TestHardcodedOptionLabels:
-    """The config flow hardcodes a couple of selector labels in Python, so
-    Home Assistant shows them in English whatever the reader's language is.
-    A catalog that localises one sends the reader looking for an option that
-    is not on the form — the failure that stopped a whole sync run, since the
-    engine only had a prose rule telling it not to."""
+    """Python hardcodes a handful of on-screen names — selector labels and the
+    titles of the config entries themselves — so Home Assistant shows them in
+    English whatever the reader's language is. A catalog that localises one
+    sends the reader looking for something that is not on the screen: the
+    failure that stopped a whole sync run, since the engine only had a prose
+    rule telling it not to."""
 
-    def test_the_label_set_is_read_from_the_config_flow(self) -> None:
-        # Without this the check degrades silently: an empty label set accepts
-        # every translation and still reports a clean run.
-        labels = translate_locales._hardcoded_option_labels()
-        assert labels, "no selector labels found — the config flow was restructured"
-        assert any(label.startswith("Local network") for label in labels)
+    def test_the_name_set_is_read_from_the_source(self) -> None:
+        # Without this the check degrades silently: an empty name set accepts
+        # every translation and still reports a clean run. Both kinds are
+        # asserted because either regex can stop matching on its own.
+        names = translate_locales._hardcoded_ui_names()
+        assert names, "no on-screen names found — the sources were restructured"
+        assert any(name.startswith("Local network") for name in names), (
+            "no selector label found — check the config flow's selector syntax"
+        )
+        assert "HA-MCP File & YAML Tools" in names, (
+            "no config-entry title found — check the *_ENTRY_TITLE constants"
+        )
 
     def test_rejects_a_localised_hardcoded_label(self) -> None:
         english = 'Local/LAN (when Network access is "Local network"): {url}'
@@ -145,6 +152,25 @@ class TestHardcodedOptionLabels:
         english = "Local/LAN (when Network access is “Local network”): {url}"
         localised = 'Lokaal/LAN (wanneer Netwerktoegang "Lokaal netwerk" is): {url}'
         assert _validate(_item(section="component", english=english), localised)
+
+    def test_rejects_a_localised_entry_title(self) -> None:
+        # The exact string the 2026-08-08 nl fill shipped: the reader is sent
+        # to an entry whose title the integration hardcodes, under a name that
+        # entry never has.
+        english = (
+            'Not installed — press "Add entry" on this integration\'s page and '
+            'choose "HA-MCP File & YAML Tools" to add it'
+        )
+        localised = (
+            'Niet geïnstalleerd — druk op "Item toevoegen" op de pagina van deze '
+            'integratie en kies "HA-MCP Bestands- & YAML-tools" om deze toe te voegen'
+        )
+        kept = (
+            'Niet geïnstalleerd — druk op "Item toevoegen" op de pagina van deze '
+            'integratie en kies "HA-MCP File & YAML Tools" om deze toe te voegen'
+        )
+        assert _validate(_item(section="component", english=english), localised)
+        assert _validate(_item(section="component", english=english), kept) is None
 
     def test_leaves_other_quoted_text_translatable(self) -> None:
         # "Add entry" is Home Assistant's own button: HA translates it, so


### PR DESCRIPTION
## What does this PR do?

#2170 taught the locale validator that the config flow's selector labels are hardcoded in Python and must survive translation. That is half the class. The integration also hardcodes the titles of the config entries, and two component strings tell the reader to click one of them by name — so those titles are just as untranslatable, and nothing was checking them.

The gap is not theoretical. The `nl` fill on 2026-08-08, which ran *after* #2170 merged, localised the title in both strings:

| | |
|---|---|
| English | choose `"HA-MCP File & YAML Tools"` to add it |
| `nl` on master | kies `"HA-MCP Bestands- & YAML-tools"` om deze toe te voegen |
| The entry that exists | `TOOLS_ENTRY_TITLE` = `"HA-MCP File & YAML Tools"` (`const.py:40`) |

A Dutch reader is sent to an entry that does not exist under that name — the same failure #2170 was opened for, one string away from where it was looked for.

**The change.** The protected set becomes selector labels **plus** config-entry titles, both still read from the source at runtime rather than listed in the script, so renaming one cannot strand a stale copy here. Names quoted with apostrophes are recognised as well — one shipped English string spells `'HA-MCP Server'` that way — but by matching the known names rather than by pairing on `'`, because English prose spells the apostrophe with the same character and pairing on it re-partitions every quote in such a sentence. It covers all three hardcoded titles, not only the two that catalogs quote today: scoping the guard to current quoting practice would mean acquiring the protection only once the mistake had already shipped, which is precisely how this defect arrived.

`nl` is corrected in both strings. The button name goes with it: the fill rendered "Add entry" as "Entiteit toevoegen", which is Home Assistant's entity picker; Home Assistant's own Dutch calls that button "Item toevoegen" at `ui.panel.config.integrations.integration_page.add_entry`. Neither key's English changed, so the baseline still matches and the next sync will not retranslate over these corrections.

The module docstring and the workflow header both enumerate what the script validates, so both now say "the on-screen names Python hardcodes" instead of naming only the config flow's labels. That comment is the entire `.github/` diff — no permissions, secrets, triggers or steps are touched.

## Type of change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

No agent testing: this changes a build-time validation script and two catalog strings, neither of which an agent exercises at runtime.

The unit suite reports 9619 passed, 0 failed, 288 skipped. Five collection errors come from `test_relay_timeout_upstream_contract.py`, which this PR does not touch — they are a missing optional dependency in my local environment, not a result; CI is the authority on those.

Beyond the suite:

- The extended check rejects exactly the two strings shipped on master today and accepts their corrections. That is the discriminating measurement — it fires on the defect that actually occurred, not only on a constructed one.
- The nine catalogs carry 4383 English/translation pairs between them. Run against master as it stands, the check rejects exactly those two, both `nl`; run against this branch it rejects none. The "none" is therefore a property of this branch, not of master.
- Removing the entry-title pattern turns both new tests red (`test_the_name_set_is_read_from_the_source`, `test_rejects_a_localised_entry_title`); the suite is green again once it is restored. The name-set test asserts one example of *each* kind, because either pattern can stop matching on its own and an empty set would accept every translation while still reporting a clean run.
- `mypy` over `src/`, `custom_components/`, `homeassistant-addon/` and `scripts/` is clean.

## Checklist
- [x] I have updated documentation if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Localization**
  - Updated Dutch File & YAML Tools status messages with clearer, more consistent terminology.
  - Standardized references to the English module name.

- **Bug Fixes**
  - Improved translation validation to preserve required English names and titles in the interface.
  - Prevented localized configuration titles from replacing designated hardcoded labels.

- **Tests**
  - Expanded coverage for selector labels, configuration titles, and hardcoded names to help prevent future localization regressions.

- **Documentation**
  - Clarified that localization validation checks parity with hardcoded on-screen names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->