### PR TITLE
Automate Dependabot approvals

### DIFF
--- a/.github/workflows/codeql-quality.yml
+++ b/.github/workflows/codeql-quality.yml
@@ -18,9 +18,7 @@ name: CodeQL Code Quality
 #   - javascript  scans the JS/TS family (.js/.mjs/.cjs/.ts/.tsx/.jsx) across the
 #                 whole tree — first-party src/, the Astro site's .mjs config,
 #                 and test JS; the same PATHS_IGNORE drops the vendored fixture
-#                 tree. (CodeQL does not extract .astro component scripts, but
-#                 .astro is in the path triggers below so site/ edits still run
-#                 the gate.)
+#                 tree. (CodeQL does not extract .astro component scripts.)
 #
 # Why a custom workflow instead of GitHub's Code Quality page:
 #   - GitHub Code Quality (Preview) is gated to Team/Enterprise Cloud org plans;
@@ -37,17 +35,6 @@ permissions:
 on:
   pull_request:
     branches: [ master ]
-    paths:
-      - '**.py'
-      - '**.js'
-      - '**.mjs'
-      - '**.cjs'
-      - '**.jsx'
-      - '**.ts'
-      - '**.tsx'
-      - '**.astro'
-      - '.github/workflows/codeql-quality.yml'
-      - 'scripts/codeql_quality_gate.py'
   push:
     branches: [ master ]
     paths:
@@ -128,3 +115,12 @@ jobs:
 
       - name: Gate on findings
         run: python scripts/codeql_quality_gate.py quality.sarif
+
+  code-quality-gate:
+    name: CodeQL Gate
+    if: ${{ always() }}
+    needs: code-quality
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require every CodeQL analysis to pass
+        run: test "${{ needs.code-quality.result }}" = "success"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -8,7 +8,10 @@ permissions:
 
 jobs:
   dependabot:
-    if: github.actor == 'dependabot[bot]'
+    if: >-
+      github.actor == 'dependabot[bot]' &&
+      github.event.pull_request.user.login == 'dependabot[bot]' &&
+      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
       - name: Fetch Dependabot metadata
@@ -16,6 +19,20 @@ jobs:
         uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Approve eligible Dependabot PR
+        if: ${{ steps.metadata.outputs.update-type == 'security-update' || contains(fromJson('["version-update:semver-minor","version-update:semver-patch"]'), steps.metadata.outputs.update-type) }}
+        run: |
+          gh api --method POST \
+            "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/reviews" \
+            -f event=APPROVE \
+            -f commit_id="$HEAD_SHA" \
+            -f body="Automated approval: verified Dependabot update; required checks remain authoritative."
+        env:
+          # This must be a Dependabot secret owned by a maintainers-team member.
+          GH_TOKEN: ${{ secrets.DEPENDABOT_APPROVAL_TOKEN }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
 
       - name: Enable auto-merge for Dependabot PRs
         if: ${{ steps.metadata.outputs.update-type == 'security-update' || contains(fromJson('["version-update:semver-minor","version-update:semver-patch"]'), steps.metadata.outputs.update-type) }}

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -22,7 +22,7 @@ jobs:
           alert-lookup: true
 
       - name: Approve eligible Dependabot PR
-        if: ${{ steps.metadata.outputs.alert-state == 'OPEN' || contains(fromJson('["version-update:semver-minor","version-update:semver-patch"]'), steps.metadata.outputs.update-type) }}
+        if: ${{ (steps.metadata.outputs.alert-state == 'OPEN' && !contains(steps.metadata.outputs.dependency-names, ',')) || contains(fromJson('["version-update:semver-minor","version-update:semver-patch"]'), steps.metadata.outputs.update-type) }}
         run: |
           gh api --method POST \
             "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/reviews" \
@@ -36,7 +36,7 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
 
       - name: Enable auto-merge for Dependabot PRs
-        if: ${{ steps.metadata.outputs.alert-state == 'OPEN' || contains(fromJson('["version-update:semver-minor","version-update:semver-patch"]'), steps.metadata.outputs.update-type) }}
+        if: ${{ (steps.metadata.outputs.alert-state == 'OPEN' && !contains(steps.metadata.outputs.dependency-names, ',')) || contains(fromJson('["version-update:semver-minor","version-update:semver-patch"]'), steps.metadata.outputs.update-type) }}
         run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -18,10 +18,11 @@ jobs:
         id: metadata
         uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3
         with:
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          github-token: "${{ secrets.DEPENDABOT_APPROVAL_TOKEN }}"
+          alert-lookup: true
 
       - name: Approve eligible Dependabot PR
-        if: ${{ steps.metadata.outputs.update-type == 'security-update' || contains(fromJson('["version-update:semver-minor","version-update:semver-patch"]'), steps.metadata.outputs.update-type) }}
+        if: ${{ steps.metadata.outputs.alert-state == 'OPEN' || contains(fromJson('["version-update:semver-minor","version-update:semver-patch"]'), steps.metadata.outputs.update-type) }}
         run: |
           gh api --method POST \
             "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/reviews" \
@@ -35,7 +36,7 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
 
       - name: Enable auto-merge for Dependabot PRs
-        if: ${{ steps.metadata.outputs.update-type == 'security-update' || contains(fromJson('["version-update:semver-minor","version-update:semver-patch"]'), steps.metadata.outputs.update-type) }}
+        if: ${{ steps.metadata.outputs.alert-state == 'OPEN' || contains(fromJson('["version-update:semver-minor","version-update:semver-patch"]'), steps.metadata.outputs.update-type) }}
         run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}

--- a/tests/src/unit/test_codeql_workflow_shape.py
+++ b/tests/src/unit/test_codeql_workflow_shape.py
@@ -1,0 +1,29 @@
+"""Guard the always-reported CodeQL merge gate."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_WORKFLOW = _REPO_ROOT / ".github" / "workflows" / "codeql-quality.yml"
+
+
+def _workflow() -> dict[str, Any]:
+    return yaml.safe_load(_WORKFLOW.read_text(encoding="utf-8"))
+
+
+def test_pull_requests_always_emit_codeql_gate() -> None:
+    workflow = _workflow()
+    pull_request = workflow[True]["pull_request"]
+    gate = workflow["jobs"]["code-quality-gate"]
+
+    assert "paths" not in pull_request
+    assert gate["name"] == "CodeQL Gate"
+    assert gate["needs"] == "code-quality"
+    assert gate["if"] == "${{ always() }}"
+    assert gate["steps"][0]["run"] == (
+        'test "${{ needs.code-quality.result }}" = "success"'
+    )

--- a/tests/src/unit/test_dependabot_auto_merge_shape.py
+++ b/tests/src/unit/test_dependabot_auto_merge_shape.py
@@ -15,12 +15,33 @@ def _workflow() -> dict[str, Any]:
     return yaml.safe_load(_WORKFLOW.read_text(encoding="utf-8"))
 
 
+def _normalize(value: str) -> str:
+    return " ".join(value.split())
+
+
 def test_metadata_fetches_security_alert_state_with_approval_token() -> None:
-    steps = _workflow()["jobs"]["dependabot"]["steps"]
+    job = _workflow()["jobs"]["dependabot"]
+    steps = job["steps"]
     metadata = next(step for step in steps if step.get("id") == "metadata")
 
+    assert _normalize(job["if"]) == _normalize(
+        "github.actor == 'dependabot[bot]' && "
+        "github.event.pull_request.user.login == 'dependabot[bot]' && "
+        "github.event.pull_request.head.repo.full_name == github.repository"
+    )
     assert metadata["with"]["alert-lookup"] is True
     assert metadata["with"]["github-token"] == (
+        "${{ secrets.DEPENDABOT_APPROVAL_TOKEN }}"
+    )
+
+
+def test_approval_is_bound_to_the_current_head_and_dedicated_token() -> None:
+    steps = _workflow()["jobs"]["dependabot"]["steps"]
+    approval = next(step for step in steps if step["name"].startswith("Approve"))
+
+    assert '-f commit_id="$HEAD_SHA"' in approval["run"]
+    assert approval["env"]["HEAD_SHA"] == "${{ github.event.pull_request.head.sha }}"
+    assert approval["env"]["GH_TOKEN"] == (
         "${{ secrets.DEPENDABOT_APPROVAL_TOKEN }}"
     )
 
@@ -30,10 +51,10 @@ def test_approval_and_auto_merge_share_security_aware_eligibility() -> None:
     gated = [step for step in steps if step["name"].startswith(("Approve", "Enable"))]
 
     assert len(gated) == 2
-    conditions = {step["if"] for step in gated}
-    assert len(conditions) == 1
-    condition = conditions.pop()
-    assert "outputs.alert-state == 'OPEN'" in condition
-    assert "security-update" not in condition
-    assert "version-update:semver-minor" in condition
-    assert "version-update:semver-patch" in condition
+    expected = (
+        "${{ steps.metadata.outputs.alert-state == 'OPEN' || "
+        "contains(fromJson('[\"version-update:semver-minor\","
+        "\"version-update:semver-patch\"]'), "
+        "steps.metadata.outputs.update-type) }}"
+    )
+    assert {_normalize(step["if"]) for step in gated} == {_normalize(expected)}

--- a/tests/src/unit/test_dependabot_auto_merge_shape.py
+++ b/tests/src/unit/test_dependabot_auto_merge_shape.py
@@ -37,7 +37,9 @@ def test_metadata_fetches_security_alert_state_with_approval_token() -> None:
 
 def test_approval_is_bound_to_the_current_head_and_dedicated_token() -> None:
     steps = _workflow()["jobs"]["dependabot"]["steps"]
-    approval = next(step for step in steps if step["name"].startswith("Approve"))
+    approval = next(
+        step for step in steps if step["name"] == "Approve eligible Dependabot PR"
+    )
 
     assert '-f commit_id="$HEAD_SHA"' in approval["run"]
     assert approval["env"]["HEAD_SHA"] == "${{ github.event.pull_request.head.sha }}"
@@ -46,13 +48,22 @@ def test_approval_is_bound_to_the_current_head_and_dedicated_token() -> None:
 
 def test_approval_and_auto_merge_share_security_aware_eligibility() -> None:
     steps = _workflow()["jobs"]["dependabot"]["steps"]
-    gated = [step for step in steps if step["name"].startswith(("Approve", "Enable"))]
+    metadata = next(step for step in steps if step.get("id") == "metadata")
+    approval = next(
+        step for step in steps if step["name"] == "Approve eligible Dependabot PR"
+    )
+    auto_merge = next(
+        step for step in steps if step["name"] == "Enable auto-merge for Dependabot PRs"
+    )
 
-    assert len(gated) == 2
+    assert steps.index(metadata) < steps.index(approval)
+    assert steps.index(metadata) < steps.index(auto_merge)
     expected = (
         "${{ steps.metadata.outputs.alert-state == 'OPEN' || "
         'contains(fromJson(\'["version-update:semver-minor",'
         '"version-update:semver-patch"]\'), '
         "steps.metadata.outputs.update-type) }}"
     )
-    assert {_normalize(step["if"]) for step in gated} == {_normalize(expected)}
+    assert {_normalize(approval["if"]), _normalize(auto_merge["if"])} == {
+        _normalize(expected)
+    }

--- a/tests/src/unit/test_dependabot_auto_merge_shape.py
+++ b/tests/src/unit/test_dependabot_auto_merge_shape.py
@@ -59,7 +59,8 @@ def test_approval_and_auto_merge_share_security_aware_eligibility() -> None:
     assert steps.index(metadata) < steps.index(approval)
     assert steps.index(metadata) < steps.index(auto_merge)
     expected = (
-        "${{ steps.metadata.outputs.alert-state == 'OPEN' || "
+        "${{ (steps.metadata.outputs.alert-state == 'OPEN' && "
+        "!contains(steps.metadata.outputs.dependency-names, ',')) || "
         'contains(fromJson(\'["version-update:semver-minor",'
         '"version-update:semver-patch"]\'), '
         "steps.metadata.outputs.update-type) }}"

--- a/tests/src/unit/test_dependabot_auto_merge_shape.py
+++ b/tests/src/unit/test_dependabot_auto_merge_shape.py
@@ -41,9 +41,7 @@ def test_approval_is_bound_to_the_current_head_and_dedicated_token() -> None:
 
     assert '-f commit_id="$HEAD_SHA"' in approval["run"]
     assert approval["env"]["HEAD_SHA"] == "${{ github.event.pull_request.head.sha }}"
-    assert approval["env"]["GH_TOKEN"] == (
-        "${{ secrets.DEPENDABOT_APPROVAL_TOKEN }}"
-    )
+    assert approval["env"]["GH_TOKEN"] == ("${{ secrets.DEPENDABOT_APPROVAL_TOKEN }}")
 
 
 def test_approval_and_auto_merge_share_security_aware_eligibility() -> None:
@@ -53,8 +51,8 @@ def test_approval_and_auto_merge_share_security_aware_eligibility() -> None:
     assert len(gated) == 2
     expected = (
         "${{ steps.metadata.outputs.alert-state == 'OPEN' || "
-        "contains(fromJson('[\"version-update:semver-minor\","
-        "\"version-update:semver-patch\"]'), "
+        'contains(fromJson(\'["version-update:semver-minor",'
+        '"version-update:semver-patch"]\'), '
         "steps.metadata.outputs.update-type) }}"
     )
     assert {_normalize(step["if"]) for step in gated} == {_normalize(expected)}

--- a/tests/src/unit/test_dependabot_auto_merge_shape.py
+++ b/tests/src/unit/test_dependabot_auto_merge_shape.py
@@ -1,0 +1,39 @@
+"""Guard the security-sensitive wiring of Dependabot auto-merge."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_WORKFLOW = _REPO_ROOT / ".github" / "workflows" / "dependabot-auto-merge.yml"
+
+
+def _workflow() -> dict[str, Any]:
+    return yaml.safe_load(_WORKFLOW.read_text(encoding="utf-8"))
+
+
+def test_metadata_fetches_security_alert_state_with_approval_token() -> None:
+    steps = _workflow()["jobs"]["dependabot"]["steps"]
+    metadata = next(step for step in steps if step.get("id") == "metadata")
+
+    assert metadata["with"]["alert-lookup"] is True
+    assert metadata["with"]["github-token"] == (
+        "${{ secrets.DEPENDABOT_APPROVAL_TOKEN }}"
+    )
+
+
+def test_approval_and_auto_merge_share_security_aware_eligibility() -> None:
+    steps = _workflow()["jobs"]["dependabot"]["steps"]
+    gated = [step for step in steps if step["name"].startswith(("Approve", "Enable"))]
+
+    assert len(gated) == 2
+    conditions = {step["if"] for step in gated}
+    assert len(conditions) == 1
+    condition = conditions.pop()
+    assert "outputs.alert-state == 'OPEN'" in condition
+    assert "security-update" not in condition
+    assert "version-update:semver-minor" in condition
+    assert "version-update:semver-patch" in condition


### PR DESCRIPTION
## What does this PR do?

Automatically approves Dependabot minor and patch updates, plus single-dependency security updates when fetch-metadata can resolve an open alert, using a dedicated maintainer token. Major multi-dependency updates are deliberately excluded because alert-state describes only the first dependency; npm alert matching also has an upstream limitation and therefore fails safely when no alert is resolved. The approval is bound to the current pull request head SHA, while required status checks remain the authoritative merge gate. CodeQL now runs on every pull request and publishes an aggregate CodeQL Gate; the Master ruleset requires that gate along with every other deterministic regression check before merge.

The job verifies that the event actor and pull request author are `dependabot[bot]`, and that the head branch belongs to this repository. It does not check out or execute pull request content.

The token must be configured as a Dependabot secret named `DEPENDABOT_APPROVAL_TOKEN`. Its owner must belong to the `homeassistant-ai/maintainers` team so the review satisfies the ruleset. The fine-grained token needs `Pull requests: read and write` and `Dependabot alerts: read`. 

## Type of change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [x] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [ ] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

Additional targeted validation:
- `git diff --check`
- `npx --yes yaml-lint .github/workflows/dependabot-auto-merge.yml`

## Checklist
- [x] I have updated documentation if needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dependabot pull requests can now receive automated approval and auto-merge when they qualify through open security alerts or eligible minor/patch updates.
  * Automation is limited to Dependabot requests from the current repository.
  * Approval and merge actions apply to the specific pull request version under review.

* **Tests**
  * Added coverage for eligibility rules, security-alert detection, repository restrictions, and approval behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->