### PR TITLE
fix: allow updates to existing hyphenless dashboards

### DIFF
--- a/src/ha_mcp/backup_manager.py
+++ b/src/ha_mcp/backup_manager.py
@@ -1441,10 +1441,11 @@ async def _fetch_dashboard(client: Any, entity_id: str) -> Any:
     try:
         config, _config_hash = await _get_dashboard_config_internal(client, fetch_path)
     except ToolError as err:
-        # ToolError carries the structured failure payload; treat a
-        # missing/unknown dashboard as "nothing to back up" (also covers a
-        # brand-new dashboard on the create path). "Unknown config
-        # specified" is HA's message for an unresolved url_path.
+        # ToolError carries the structured failure payload, including HA's
+        # preserved ``config_not_found`` code; treat a missing/unknown
+        # dashboard as "nothing to back up" (also covers a brand-new dashboard
+        # on the create path). "Unknown config specified" is HA's message for
+        # an unresolved url_path.
         msg = str(err).lower()
         if "not_found" in msg or "config_not_found" in msg or "unknown config" in msg:
             return None

--- a/src/ha_mcp/tools/tools_config_dashboards.py
+++ b/src/ha_mcp/tools/tools_config_dashboards.py
@@ -40,7 +40,7 @@ from ..dashboard_screenshot.paths import (
     match_dashboard_view,
     resolve_dashboard_view,
 )
-from ..errors import ErrorCode, create_error_response
+from ..errors import ErrorCode, create_error_response, get_error_code, get_error_message
 from ..strict_bps import BestPracticeKeyParam
 from ..utils.config_hash import compute_config_hash
 from ..utils.python_sandbox import (
@@ -134,8 +134,9 @@ async def _get_dashboard_config_internal(
     ``tools_config_scenes.py``).
 
     Raises ``ToolError`` with ``ErrorCode.SERVICE_CALL_FAILED`` if the
-    WebSocket call reports failure or the response is not a dict; callers
-    can rely on the returned tuple being populated.
+    WebSocket call reports failure or the response is not a dict. HA's
+    upstream error code is preserved as ``ha_error_code`` when present, so
+    callers can distinguish confirmed absence from an unverifiable read.
     """
     get_data: dict[str, Any] = {"type": "lovelace/config", "force": True}
     if url_path:
@@ -144,14 +145,20 @@ async def _get_dashboard_config_internal(
     response = await client.send_websocket_message(get_data)
 
     if isinstance(response, dict) and not response.get("success", True):
-        error_msg = response.get("error", {})
-        if isinstance(error_msg, dict):
-            error_msg = error_msg.get("message", str(error_msg))
+        error_msg = get_error_message(response)
+        if error_msg is None:
+            error_msg = str(response.get("error", {}))
+        ha_error_code = response.get("error_code") or get_error_code(response)
+        error_context: dict[str, Any] = {"url_path": url_path}
+        if ha_error_code is not None:
+            # Preserve HA's code so downstream safety decisions do not have to
+            # infer an absent config from a multiply-prefixed message alone.
+            error_context["ha_error_code"] = str(ha_error_code)
         raise_tool_error(
             create_error_response(
                 ErrorCode.SERVICE_CALL_FAILED,
                 f"Dashboard fetch failed: {error_msg}",
-                context={"url_path": url_path},
+                context=error_context,
             )
         )
 
@@ -772,10 +779,37 @@ def _card_matches(
 # regresses silently to never firing — re-verify with major HA upgrades.
 _LAZY_RESOLVE_TRIGGER = "Unknown config specified"
 
+# Exact ``lovelace/config`` messages meaning that a storage dashboard exists
+# but has not been given a config yet. Mirrors smart_search/_deep.py and stays
+# deliberately narrower than ``_LAZY_RESOLVE_TRIGGER``: an unknown path or any
+# other pre-read failure must remain fail-closed before a full replacement.
+_NO_STORED_CONFIG_MESSAGES = frozenset(
+    {"No config found.", "Command failed: No config found."}
+)
+_DASHBOARD_FETCH_FAILED_PREFIX = "Dashboard fetch failed: "
+_HA_CONFIG_NOT_FOUND_CODE = "config_not_found"
+
 
 def _should_lazy_resolve(error_msg: str) -> bool:
     """Return True if a WS error message indicates the identifier needs resolving."""
     return _LAZY_RESOLVE_TRIGGER in error_msg
+
+
+def _is_no_stored_dashboard_config_error(exc: ToolError) -> bool:
+    """Return whether HA confirms that an existing dashboard has no config."""
+    try:
+        error_data = json.loads(str(exc))
+    except (json.JSONDecodeError, TypeError):
+        return False
+    if (
+        not isinstance(error_data, dict)
+        or error_data.get("ha_error_code") != _HA_CONFIG_NOT_FOUND_CODE
+    ):
+        return False
+    message = extract_tool_error_message(exc).removeprefix(
+        _DASHBOARD_FETCH_FAILED_PREFIX
+    )
+    return message in _NO_STORED_CONFIG_MESSAGES
 
 
 # The ha_mcp_tools/dashboards WS command: list / get / search over the live
@@ -3463,13 +3497,20 @@ class DashboardConfigTools:
 
         Omitting ``config_hash`` remains the force-replace path, but the current
         config must still be readable so strategy-dashboard protection can be
-        evaluated before any replacement write.
+        evaluated before any replacement write. The one exception is an existing
+        storage dashboard with no config yet and no supplied ``config_hash``:
+        there is no strategy state to protect, so its first full config may be
+        written. A supplied hash still conflicts with the now-absent config.
         """
         try:
             existing_config, existing_hash = await _get_dashboard_config_internal(
                 self._client, url_path
             )
         except ToolError as exc:
+            if _is_no_stored_dashboard_config_error(exc):
+                if config_hash is None:
+                    return None
+                self._raise_dashboard_hash_conflict(url_path)
             raise_tool_error(
                 create_error_response(
                     ErrorCode.SERVICE_CALL_FAILED,
@@ -3485,17 +3526,7 @@ class DashboardConfigTools:
 
         existing_config_size = len(json.dumps(existing_config))
         if config_hash is not None and existing_hash != config_hash:
-            raise_tool_error(
-                create_error_response(
-                    ErrorCode.SERVICE_CALL_FAILED,
-                    "Dashboard modified since last read (conflict)",
-                    suggestions=[
-                        "Call ha_config_get_dashboard() again",
-                        "Use the fresh config_hash, or omit config_hash to force replace",
-                    ],
-                    context={"action": "set", "url_path": url_path},
-                )
-            )
+            self._raise_dashboard_hash_conflict(url_path)
 
         self._validate_strategy_dashboard_replacement(
             url_path,
@@ -3510,6 +3541,21 @@ class DashboardConfigTools:
                 "Consider python_transform for targeted edits."
             )
         return None
+
+    @staticmethod
+    def _raise_dashboard_hash_conflict(url_path: str) -> NoReturn:
+        """Raise the shared optimistic-lock conflict for a full replacement."""
+        raise_tool_error(
+            create_error_response(
+                ErrorCode.SERVICE_CALL_FAILED,
+                "Dashboard modified since last read (conflict)",
+                suggestions=[
+                    "Call ha_config_get_dashboard() again",
+                    "Use the fresh config_hash, or omit config_hash to force replace",
+                ],
+                context={"action": "set", "url_path": url_path},
+            )
+        )
 
     @staticmethod
     def _validate_strategy_dashboard_replacement(

--- a/src/ha_mcp/tools/tools_config_dashboards.py
+++ b/src/ha_mcp/tools/tools_config_dashboards.py
@@ -8,7 +8,7 @@ import json
 import logging
 import re
 from dataclasses import dataclass, replace
-from typing import Annotated, Any, Literal, cast, overload
+from typing import Annotated, Any, Literal, NoReturn, cast, overload
 
 from fastmcp.exceptions import ToolError
 from fastmcp.tools import tool
@@ -1260,6 +1260,22 @@ async def fetch_dashboards_list(
         type(result).__name__,
     )
     return None
+
+
+def _raise_dashboard_registry_read_error(*, action: str, url_path: str) -> NoReturn:
+    """Raise the shared user-facing error for an unreadable dashboard registry."""
+    raise_tool_error(
+        create_error_response(
+            ErrorCode.SERVICE_CALL_FAILED,
+            "Failed to read the Home Assistant dashboard registry",
+            suggestions=[
+                "Retry the operation",
+                "Check the Home Assistant connection and logs",
+                "Use ha_config_get_dashboard(list_only=True) to verify registry access",
+            ],
+            context={"action": action, "url_path": url_path},
+        )
+    )
 
 
 async def _resolve_dashboard(
@@ -2972,7 +2988,12 @@ class DashboardConfigTools:
     async def _resolve_set_dashboard_url_path(
         self, url_path: str
     ) -> tuple[str, str | None, list[dict[str, Any]] | None]:
-        """Validate + canonicalize ``url_path`` for ``ha_config_set_dashboard``.
+        """Validate the set target and canonicalize supported dashboard identifiers.
+
+        Hyphenless input is allowed only when it exactly matches an existing
+        dashboard's ``url_path`` (plus the built-in ``lovelace`` alias case).
+        New dashboard paths must contain a hyphen. An internal-ID-only match may
+        still canonicalize to a different, hyphenated existing ``url_path``.
 
         Returns ``(url_path, pre_resolved_from, pre_fetched_dashboards)``:
         ``url_path`` is canonicalized (``"default"`` -> ``"lovelace"``, and an
@@ -3005,13 +3026,16 @@ class DashboardConfigTools:
             url_path = "lovelace"
 
         # Pre-resolve a hyphenless dashboard identifier before enforcing the
-        # creation-only hyphen rule below, so existing internal-id support is
-        # preserved. Only an exact url_path match establishes that the caller
-        # addressed an existing dashboard for purposes of that rule. An
-        # internal-id-only match may still canonicalize to a hyphenated path,
-        # but cannot exempt a different hyphenless path from validation.
+        # exact-url-path exception below. Internal-ID support is preserved when
+        # it canonicalizes to a hyphenated existing path, but an ID-only match
+        # cannot exempt a different hyphenless path from validation.
+        #
+        # This is still a create-or-update API: a caller intending to create a
+        # dashboard can target an existing one, either by exact url_path or by a
+        # supported internal-ID rewrite. ``action`` reports create vs update;
+        # ``resolved_from`` additionally reports only the latter rewrite.
         pre_resolved_from: str | None = None
-        existing_dashboard_resolved = False
+        exact_url_path_exists = False
         # When the pre-resolver fires and finds a match, ``_resolve_dashboard``
         # has already fetched ``lovelace/dashboards/list``. Capture that list
         # so the existence-check site below can reuse it instead of paying
@@ -3019,10 +3043,12 @@ class DashboardConfigTools:
         pre_fetched_dashboards: list[dict[str, Any]] | None = None
         if "-" not in url_path and url_path != "lovelace":
             resolved, dashboards = await _resolve_dashboard(self._client, url_path)
+            if dashboards is None:
+                _raise_dashboard_registry_read_error(action="set", url_path=url_path)
             if resolved is not None and resolved["url_path"]:
-                existing_dashboard_resolved = resolved["url_path"] == url_path
+                exact_url_path_exists = resolved["url_path"] == url_path
                 pre_fetched_dashboards = dashboards
-                if resolved["url_path"] != url_path:
+                if not exact_url_path_exists and "-" in resolved["url_path"]:
                     original_url_path = url_path
                     url_path = resolved["url_path"]
                     pre_resolved_from = original_url_path
@@ -3032,24 +3058,22 @@ class DashboardConfigTools:
                         url_path,
                     )
 
-        # Validate url_path contains a hyphen only when no existing dashboard
-        # was resolved. Existing dashboard paths predate this creation rule and
-        # must remain valid update targets unchanged.
+        # Existing exact url_path values may predate HA's creation rule and must
+        # remain valid update targets unchanged.
         # The built-in "lovelace" dashboard is exempt since it already exists
-        if (
-            not existing_dashboard_resolved
-            and "-" not in url_path
-            and url_path != "lovelace"
-        ):
+        if not exact_url_path_exists and "-" not in url_path and url_path != "lovelace":
+            suggestions = [
+                "Use format like 'my-dashboard' or 'mobile-view'",
+                "Use 'lovelace' or 'default' to edit the default dashboard",
+            ]
+            hyphenated_url_path = url_path.replace("_", "-")
+            if hyphenated_url_path != url_path:
+                suggestions.insert(0, f"Try '{hyphenated_url_path}' instead")
             raise_tool_error(
                 create_error_response(
                     ErrorCode.VALIDATION_INVALID_PARAMETER,
                     "url_path must contain a hyphen (-)",
-                    suggestions=[
-                        f"Try '{url_path.replace('_', '-')}' instead",
-                        "Use format like 'my-dashboard' or 'mobile-view'",
-                        "Use 'lovelace' or 'default' to edit the default dashboard",
-                    ],
+                    suggestions=suggestions,
                     context={"action": "set", "url_path": url_path},
                 )
             )
@@ -3102,6 +3126,7 @@ class DashboardConfigTools:
         url_path: str, python_transform: str, current_config: dict[str, Any]
     ) -> dict[str, Any]:
         """Run ``python_transform`` against ``current_config`` in the sandbox."""
+        was_strategy_dashboard = "strategy" in current_config
         try:
             transformed_config = safe_execute(python_transform, current_config)
         except PythonSandboxError as e:
@@ -3127,6 +3152,12 @@ class DashboardConfigTools:
                     context={"action": "python_transform", "url_path": url_path},
                 )
             )
+        DashboardConfigTools._validate_strategy_dashboard_replacement(
+            url_path,
+            was_strategy_dashboard=was_strategy_dashboard,
+            replacement_config=transformed_config,
+            action="python_transform",
+        )
         return transformed_config
 
     async def _save_dashboard_python_transform(
@@ -3255,7 +3286,10 @@ class DashboardConfigTools:
         if pre_fetched_dashboards is not None:
             existing_dashboards = pre_fetched_dashboards
         else:
-            existing_dashboards = await fetch_dashboards_list(self._client) or []
+            fetched_dashboards = await fetch_dashboards_list(self._client)
+            if fetched_dashboards is None:
+                _raise_dashboard_registry_read_error(action="set", url_path=url_path)
+            existing_dashboards = fetched_dashboards
         dashboard_exists = any(
             d.get("url_path") == url_path for d in existing_dashboards
         )
@@ -3344,7 +3378,7 @@ class DashboardConfigTools:
     ) -> tuple[str | None, bool, str | None]:
         """Update metadata for an existing dashboard if any metadata params were provided.
 
-        Returns ``(dashboard_id, metadata_updated, hint)``.
+        Returns ``(dashboard_id, metadata_updated, warning)``.
         """
         dashboard_id = None
         for dashboard in existing_dashboards:
@@ -3370,13 +3404,13 @@ class DashboardConfigTools:
         if metadata_update_fields and dashboard_id is None:
             # Dashboard ID not found in storage list (e.g. default lovelace on
             # fresh installs). Metadata update via lovelace/dashboards/update
-            # is not possible without a storage ID — config update still proceeds.
-            hint = (
+            # is not possible without a storage ID. The caller either proceeds
+            # with a requested config write or rejects the resulting no-op.
+            warning = (
                 "Metadata fields were provided but could not be applied: "
-                "dashboard has no storage ID (likely the built-in default dashboard). "
-                "Config changes were still saved."
+                "dashboard has no storage ID (likely the built-in default dashboard)."
             )
-            return dashboard_id, False, hint
+            return dashboard_id, False, warning
         return dashboard_id, False, None
 
     async def _ensure_dashboard_exists(
@@ -3391,7 +3425,7 @@ class DashboardConfigTools:
     ) -> tuple[bool, str | None, bool, str | None]:
         """Create the dashboard if missing, else update its metadata if requested.
 
-        Returns ``(dashboard_exists, dashboard_id, metadata_updated, hint)`` —
+        Returns ``(dashboard_exists, dashboard_id, metadata_updated, warning)`` —
         ``dashboard_exists`` reflects state *before* this call, so the caller
         can distinguish create vs update for the response's
         ``action``/``dashboard_created`` fields.
@@ -3409,7 +3443,7 @@ class DashboardConfigTools:
             )
             return dashboard_exists, dashboard_id, False, None
 
-        dashboard_id, metadata_updated, hint = await self._update_dashboard_metadata(
+        dashboard_id, metadata_updated, warning = await self._update_dashboard_metadata(
             url_path,
             existing_dashboards,
             title=title,
@@ -3417,12 +3451,15 @@ class DashboardConfigTools:
             require_admin=require_admin,
             show_in_sidebar=show_in_sidebar,
         )
-        return dashboard_exists, dashboard_id, metadata_updated, hint
+        return dashboard_exists, dashboard_id, metadata_updated, warning
 
     async def _check_dashboard_replace_hash(
-        self, url_path: str, config_hash: str | None
+        self,
+        url_path: str,
+        config_hash: str | None,
+        replacement_config: dict[str, Any],
     ) -> str | None:
-        """Optionally validate config_hash and warn on large full-config replacement.
+        """Validate replacement safety/hash and warn on large full-config replacement.
 
         Tolerates fetch failures — full replacement still proceeds even if the
         pre-read can't load the current state (force-replace path).
@@ -3454,12 +3491,42 @@ class DashboardConfigTools:
                 )
             )
 
+        self._validate_strategy_dashboard_replacement(
+            url_path,
+            was_strategy_dashboard="strategy" in existing_config,
+            replacement_config=replacement_config,
+            action="config",
+        )
+
         if existing_config_size >= 10000:
             return (
                 f"Replaced large config ({existing_config_size:,} bytes). "
                 "Consider python_transform for targeted edits."
             )
         return None
+
+    @staticmethod
+    def _validate_strategy_dashboard_replacement(
+        url_path: str,
+        *,
+        was_strategy_dashboard: bool,
+        replacement_config: dict[str, Any],
+        action: str,
+    ) -> None:
+        """Prevent this tool from taking control of a strategy dashboard."""
+        if not was_strategy_dashboard or "strategy" in replacement_config:
+            return
+        raise_tool_error(
+            create_error_response(
+                ErrorCode.VALIDATION_FAILED,
+                "Strategy dashboards cannot be converted to custom dashboards via this tool",
+                suggestions=[
+                    "Use 'Take Control' in the Home Assistant interface to convert it",
+                    "Keep a strategy configuration when updating this dashboard",
+                ],
+                context={"action": action, "url_path": url_path},
+            )
+        )
 
     async def _save_dashboard_config(
         self, url_path: str, config_dict: dict[str, Any]
@@ -3499,7 +3566,7 @@ class DashboardConfigTools:
     ) -> tuple[bool, str | None, dict[str, Any]]:
         """Parse + validate ``config`` and save it as a full replacement.
 
-        Returns ``(config_updated, hint, saved_config)``.
+        Returns ``(config_updated, warning, saved_config)``.
         """
         parsed_config = parse_json_param(config, "config")
         if parsed_config is None or not isinstance(parsed_config, dict):
@@ -3515,12 +3582,14 @@ class DashboardConfigTools:
             )
         config_dict = cast(dict[str, Any], parsed_config)
 
-        hint: str | None = None
+        warning: str | None = None
         if dashboard_exists:
-            hint = await self._check_dashboard_replace_hash(url_path, config_hash)
+            warning = await self._check_dashboard_replace_hash(
+                url_path, config_hash, config_dict
+            )
 
         await self._save_dashboard_config(url_path, config_dict)
-        return True, hint, config_dict
+        return True, warning, config_dict
 
     async def _run_dashboard_config_update(
         self,
@@ -3543,7 +3612,7 @@ class DashboardConfigTools:
             dashboard_exists,
             dashboard_id,
             metadata_updated,
-            hint,
+            metadata_warning,
         ) = await self._ensure_dashboard_exists(
             url_path,
             title=title,
@@ -3555,16 +3624,49 @@ class DashboardConfigTools:
 
         config_updated = False
         render_config: dict[str, Any] | None = None
+        warnings: list[str] = []
         if config is not None:
             (
                 config_updated,
-                config_hint,
+                config_warning,
                 render_config,
             ) = await self._apply_dashboard_config(
                 url_path, config, config_hash, dashboard_exists
             )
-            if config_hint:
-                hint = config_hint
+            if config_warning:
+                warnings.append(config_warning)
+
+        if dashboard_exists and not config_updated and not metadata_updated:
+            if metadata_warning is not None:
+                raise_tool_error(
+                    create_error_response(
+                        ErrorCode.SERVICE_CALL_FAILED,
+                        "No dashboard changes were applied",
+                        details=metadata_warning,
+                        suggestions=[
+                            "Use a storage-mode dashboard when changing metadata",
+                            "Provide config to replace the dashboard configuration",
+                        ],
+                        context={"action": "set", "url_path": url_path},
+                    )
+                )
+            raise_tool_error(
+                create_error_response(
+                    ErrorCode.VALIDATION_INVALID_PARAMETER,
+                    "No dashboard changes were requested",
+                    suggestions=[
+                        "Provide config or python_transform to change dashboard content",
+                        "Provide a metadata field such as title or icon",
+                        "Use ha_config_get_dashboard to read a dashboard without changing it",
+                    ],
+                    context={"action": "set", "url_path": url_path},
+                )
+            )
+
+        if metadata_warning:
+            if config_updated:
+                metadata_warning = f"{metadata_warning} Dashboard config was saved."
+            warnings.insert(0, metadata_warning)
 
         result_dict: dict[str, Any] = {
             "success": True,
@@ -3577,13 +3679,12 @@ class DashboardConfigTools:
             "message": f"Dashboard {url_path} {'created' if not dashboard_exists else 'updated'} successfully",
         }
 
-        if hint:
-            result_dict["hint"] = hint
+        if warnings:
+            result_dict["warnings"] = warnings
         if pre_resolved_from is not None:
-            # Caller passed an internal id; pre-resolver mapped it to
-            # the canonical url_path. Surface the original so a caller
-            # who *intended* to create a new dashboard can detect that
-            # an existing dashboard was updated instead.
+            # This marks identifier canonicalization only. Exact url_path
+            # matches deliberately omit it; callers use ``action`` to tell
+            # whether the create-or-update operation updated an existing target.
             result_dict["resolved_from"] = pre_resolved_from
 
         render_config = await _attach_dashboard_render_paths_after_write(
@@ -3651,6 +3752,8 @@ class DashboardConfigTools:
                 context={"action": "delete"},
             )
             resolved, dashboards = await _resolve_dashboard(self._client, url_path)
+            if dashboards is None:
+                _raise_dashboard_registry_read_error(action="delete", url_path=url_path)
             if resolved is None:
                 available_ids = [
                     d.get("url_path")

--- a/src/ha_mcp/tools/tools_config_dashboards.py
+++ b/src/ha_mcp/tools/tools_config_dashboards.py
@@ -3461,21 +3461,27 @@ class DashboardConfigTools:
     ) -> str | None:
         """Validate replacement safety/hash and warn on large full-config replacement.
 
-        Tolerates fetch failures — full replacement still proceeds even if the
-        pre-read can't load the current state (force-replace path).
+        Omitting ``config_hash`` remains the force-replace path, but the current
+        config must still be readable so strategy-dashboard protection can be
+        evaluated before any replacement write.
         """
         try:
             existing_config, existing_hash = await _get_dashboard_config_internal(
                 self._client, url_path
             )
-        except ToolError:
-            # Pre-read failure is non-fatal on the force-replace path: skip
-            # the optimistic-lock check and large-config warning and proceed
-            # with the replacement.
-            return None
-
-        if not isinstance(existing_config, dict):
-            return None
+        except ToolError as exc:
+            raise_tool_error(
+                create_error_response(
+                    ErrorCode.SERVICE_CALL_FAILED,
+                    "Cannot verify the current dashboard config before full replacement",
+                    details=extract_tool_error_message(exc),
+                    suggestions=[
+                        "Retry the operation",
+                        "Read the dashboard with ha_config_get_dashboard first",
+                    ],
+                    context={"action": "set", "url_path": url_path},
+                )
+            )
 
         existing_config_size = len(json.dumps(existing_config))
         if config_hash is not None and existing_hash != config_hash:
@@ -3756,9 +3762,7 @@ class DashboardConfigTools:
                 _raise_dashboard_registry_read_error(action="delete", url_path=url_path)
             if resolved is None:
                 available_ids = [
-                    d.get("url_path")
-                    for d in (dashboards or [])[:10]
-                    if d.get("url_path")
+                    d.get("url_path") for d in dashboards[:10] if d.get("url_path")
                 ]
                 raise_tool_error(
                     create_error_response(

--- a/src/ha_mcp/tools/tools_config_dashboards.py
+++ b/src/ha_mcp/tools/tools_config_dashboards.py
@@ -3005,21 +3005,11 @@ class DashboardConfigTools:
             url_path = "lovelace"
 
         # Pre-resolve a hyphenless dashboard identifier before enforcing the
-        # creation-only hyphen rule below, so callers may pass either an
-        # existing url_path or internal id. Only fires
-        # when the identifier looks like an internal id (no hyphen, not
-        # the built-in "lovelace") and matches a known dashboard.
-        #
-        # Caveat: if a caller passes a hyphenless identifier intending
-        # to *create* a new dashboard, but it happens to match an
-        # existing dashboard's id, the rewrite silently re-targets the
-        # operation onto that existing dashboard. Pre-PR they'd have
-        # hit the hyphen-validation error and known their input was
-        # invalid; now the create-vs-update distinction depends on
-        # whether the registry happens to contain a matching id.
-        # We log the rewrite and surface the original identifier as
-        # ``resolved_from`` on the success response so callers can
-        # detect this redirect.
+        # creation-only hyphen rule below, so existing internal-id support is
+        # preserved. Only an exact url_path match establishes that the caller
+        # addressed an existing dashboard for purposes of that rule. An
+        # internal-id-only match may still canonicalize to a hyphenated path,
+        # but cannot exempt a different hyphenless path from validation.
         pre_resolved_from: str | None = None
         existing_dashboard_resolved = False
         # When the pre-resolver fires and finds a match, ``_resolve_dashboard``
@@ -3030,7 +3020,7 @@ class DashboardConfigTools:
         if "-" not in url_path and url_path != "lovelace":
             resolved, dashboards = await _resolve_dashboard(self._client, url_path)
             if resolved is not None and resolved["url_path"]:
-                existing_dashboard_resolved = True
+                existing_dashboard_resolved = resolved["url_path"] == url_path
                 pre_fetched_dashboards = dashboards
                 if resolved["url_path"] != url_path:
                     original_url_path = url_path

--- a/src/ha_mcp/tools/tools_config_dashboards.py
+++ b/src/ha_mcp/tools/tools_config_dashboards.py
@@ -3004,8 +3004,9 @@ class DashboardConfigTools:
         if url_path == "default":
             url_path = "lovelace"
 
-        # Pre-resolve internal dashboard ID to url_path form before the
-        # hyphen check below, so callers may pass either form. Only fires
+        # Pre-resolve a hyphenless dashboard identifier before enforcing the
+        # creation-only hyphen rule below, so callers may pass either an
+        # existing url_path or internal id. Only fires
         # when the identifier looks like an internal id (no hyphen, not
         # the built-in "lovelace") and matches a known dashboard.
         #
@@ -3020,6 +3021,7 @@ class DashboardConfigTools:
         # ``resolved_from`` on the success response so callers can
         # detect this redirect.
         pre_resolved_from: str | None = None
+        existing_dashboard_resolved = False
         # When the pre-resolver fires and finds a match, ``_resolve_dashboard``
         # has already fetched ``lovelace/dashboards/list``. Capture that list
         # so the existence-check site below can reuse it instead of paying
@@ -3028,19 +3030,27 @@ class DashboardConfigTools:
         if "-" not in url_path and url_path != "lovelace":
             resolved, dashboards = await _resolve_dashboard(self._client, url_path)
             if resolved is not None and resolved["url_path"]:
-                original_url_path = url_path
-                url_path = resolved["url_path"]
-                pre_resolved_from = original_url_path
+                existing_dashboard_resolved = True
                 pre_fetched_dashboards = dashboards
-                logger.info(
-                    "ha_config_set_dashboard pre-resolver mapped %r -> %r",
-                    original_url_path,
-                    url_path,
-                )
+                if resolved["url_path"] != url_path:
+                    original_url_path = url_path
+                    url_path = resolved["url_path"]
+                    pre_resolved_from = original_url_path
+                    logger.info(
+                        "ha_config_set_dashboard pre-resolver mapped %r -> %r",
+                        original_url_path,
+                        url_path,
+                    )
 
-        # Validate url_path contains hyphen for new dashboards
+        # Validate url_path contains a hyphen only when no existing dashboard
+        # was resolved. Existing dashboard paths predate this creation rule and
+        # must remain valid update targets unchanged.
         # The built-in "lovelace" dashboard is exempt since it already exists
-        if "-" not in url_path and url_path != "lovelace":
+        if (
+            not existing_dashboard_resolved
+            and "-" not in url_path
+            and url_path != "lovelace"
+        ):
             raise_tool_error(
                 create_error_response(
                     ErrorCode.VALIDATION_INVALID_PARAMETER,

--- a/tests/src/e2e/workflows/dashboards/test_lifecycle.py
+++ b/tests/src/e2e/workflows/dashboards/test_lifecycle.py
@@ -207,6 +207,7 @@ class TestDashboardLifecycle:
     async def test_url_path_validation(self, mcp_client):
         """Test that 'lovelace' and 'default' are not rejected by hyphen validation (#591)."""
         logger.info("Starting default dashboard hyphen validation test")
+        mcp = MCPAssertions(mcp_client)
 
         # "lovelace" should NOT be rejected by the hyphen validation
         # (it may fail for other reasons on fresh HA, but not the hyphen check)
@@ -237,8 +238,7 @@ class TestDashboardLifecycle:
         # The seeded Map dashboard is a real storage dashboard whose url_path
         # predates the creation-only hyphen rule. Exact-path updates must work
         # without being reported as identifier canonicalization.
-        data = await safe_call_tool(
-            mcp_client,
+        data = await mcp.call_tool_success(
             "ha_config_set_dashboard",
             {"url_path": "map", "title": "Map"},
         )

--- a/tests/src/e2e/workflows/dashboards/test_lifecycle.py
+++ b/tests/src/e2e/workflows/dashboards/test_lifecycle.py
@@ -234,6 +234,20 @@ class TestDashboardLifecycle:
                 f"'default' should not be rejected by hyphen validation, got: {error_msg}"
             )
 
+        # The seeded Map dashboard is a real storage dashboard whose url_path
+        # predates the creation-only hyphen rule. Exact-path updates must work
+        # without being reported as identifier canonicalization.
+        data = await safe_call_tool(
+            mcp_client,
+            "ha_config_set_dashboard",
+            {"url_path": "map", "title": "Map"},
+        )
+        assert data["success"] is True
+        assert data["action"] == "update"
+        assert data["url_path"] == "map"
+        assert data["metadata_updated"] is True
+        assert "resolved_from" not in data
+
         # "nodash" (non-existent, no hyphen) SHOULD still be rejected
         data = await safe_call_tool(
             mcp_client,

--- a/tests/src/e2e/workflows/dashboards/test_lifecycle.py
+++ b/tests/src/e2e/workflows/dashboards/test_lifecycle.py
@@ -288,10 +288,18 @@ class TestDashboardLifecycle:
 
         logger.info("Partial metadata update test completed successfully")
 
-    async def test_dashboard_without_initial_config(self, mcp_client):
-        """Test creating dashboard without initial configuration."""
+    async def test_dashboard_without_initial_config_can_be_populated(self, mcp_client):
+        """A dashboard created without config accepts its first full config later."""
         logger.info("Starting dashboard without config test")
         mcp = MCPAssertions(mcp_client)
+        replacement = {
+            "views": [
+                {
+                    "title": "Populated",
+                    "cards": [{"type": "markdown", "content": "First config"}],
+                }
+            ]
+        }
 
         # Create dashboard without config
         create_data = await mcp.call_tool_success(
@@ -302,19 +310,31 @@ class TestDashboardLifecycle:
         dashboard_id = create_data.get("dashboard_id")
         assert dashboard_id is not None
 
-        # Verify it exists
-        list_data = await mcp.call_tool_success(
-            "ha_config_get_dashboard", {"list_only": True}
-        )
-        assert any(
-            d.get("url_path") == "test-no-config"
-            for d in list_data.get("dashboards", [])
-        )
+        try:
+            # Verify the metadata-only dashboard exists before its config does.
+            list_data = await mcp.call_tool_success(
+                "ha_config_get_dashboard", {"list_only": True}
+            )
+            assert any(
+                d.get("url_path") == "test-no-config"
+                for d in list_data.get("dashboards", [])
+            )
 
-        # Cleanup
-        await mcp.call_tool_success(
-            "ha_config_delete_dashboard", {"url_path": dashboard_id}
-        )
+            update_data = await mcp.call_tool_success(
+                "ha_config_set_dashboard",
+                {"url_path": "test-no-config", "config": replacement},
+            )
+            assert update_data["action"] == "update"
+            assert update_data["config_updated"] is True
+
+            get_data = await mcp.call_tool_success(
+                "ha_config_get_dashboard", {"url_path": "test-no-config"}
+            )
+            assert get_data["config"] == replacement
+        finally:
+            await mcp.call_tool_success(
+                "ha_config_delete_dashboard", {"url_path": dashboard_id}
+            )
 
         logger.info("Dashboard without config test completed successfully")
 

--- a/tests/src/unit/test_backup_manager.py
+++ b/tests/src/unit/test_backup_manager.py
@@ -17,6 +17,7 @@ import time
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 import yaml
@@ -370,6 +371,34 @@ class TestFetcherIdResolution:
         monkeypatch.setattr(dash, "_resolve_dashboard", fake_resolve)
         monkeypatch.setattr(dash, "_get_dashboard_config_internal", fake_get_internal)
         assert await bm._fetch_dashboard(_StubClient(), "x_dash") is None
+
+    async def test_fetch_dashboard_without_stored_config_returns_none(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A metadata-only dashboard has nothing to snapshot before first save."""
+        import ha_mcp.tools.tools_config_dashboards as dash
+
+        async def fake_resolve(_client: Any, identifier: str) -> Any:
+            return {"url_path": identifier, "id": "no_config"}, None
+
+        async def no_component_config(_client: Any, _url_path: str) -> None:
+            return None
+
+        client = MagicMock()
+        client.send_websocket_message = AsyncMock(
+            return_value={
+                "success": False,
+                "error": "Command failed: No config found.",
+                "error_code": "config_not_found",
+            }
+        )
+        monkeypatch.setattr(dash, "_resolve_dashboard", fake_resolve)
+        monkeypatch.setattr(dash, "_component_dashboard_config", no_component_config)
+
+        assert await bm._fetch_dashboard(client, "no-config") is None
+        client.send_websocket_message.assert_awaited_once_with(
+            {"type": "lovelace/config", "force": True, "url_path": "no-config"}
+        )
 
     async def test_fetch_dashboard_propagates_other_toolerror(
         self, monkeypatch: pytest.MonkeyPatch

--- a/tests/src/unit/test_error_code_consistency_1297.py
+++ b/tests/src/unit/test_error_code_consistency_1297.py
@@ -461,15 +461,10 @@ class TestDeleteDashboardNotFoundSurfacesAvailableIds:
             for s in _all_suggestions(error_data["error"])
         )
 
-    async def test_resolver_unexpected_shape_yields_empty_available_ids(
+    async def test_resolver_unexpected_shape_reports_registry_read_failure(
         self, delete_tool, mock_client
     ):
-        """When ``_resolve_dashboard`` returns ``(None, None)`` because the
-        WS response shape was unexpected, the structured raise still fires
-        with ``available_dashboard_ids: []`` — the ``(dashboards or [])[:10]``
-        guard at the raise site prevents a NoneType subscript while still
-        surfacing the canonical error shape.
-        """
+        """An unreadable registry is not misclassified as a missing dashboard."""
         # String response triggers the "unexpected shape" branch in
         # _fetch_dashboards_list, which causes _resolve_dashboard to return
         # (None, None).
@@ -479,8 +474,11 @@ class TestDeleteDashboardNotFoundSurfacesAvailableIds:
             await delete_tool(url_path="ghost-dash")
 
         error_data = json.loads(str(exc_info.value))
-        assert error_data["error"]["code"] == "RESOURCE_NOT_FOUND"
-        assert error_data.get("available_dashboard_ids") == []
+        assert error_data["error"]["code"] == "SERVICE_CALL_FAILED"
+        assert "dashboard registry" in error_data["error"]["message"]
+        assert "available_dashboard_ids" not in error_data
+        assert error_data["action"] == "delete"
+        assert error_data["url_path"] == "ghost-dash"
 
 
 class TestGetAutomationMissingSurfacesAvailableIds:

--- a/tests/src/unit/test_set_dashboard_metadata.py
+++ b/tests/src/unit/test_set_dashboard_metadata.py
@@ -486,6 +486,71 @@ class TestSetDashboardUrlPathCreationContract:
         assert save_call["config"] == replacement
 
     @pytest.mark.asyncio
+    async def test_create_then_write_config_to_dashboard_without_stored_config(
+        self, set_tool, mock_client
+    ):
+        replacement = {"views": [{"title": "Populated"}]}
+        no_config = {
+            "success": False,
+            "error": "Command failed: No config found.",
+            "error_code": "config_not_found",
+        }
+        mock_client.send_websocket_message.side_effect = [
+            {"result": []},
+            {"success": True, "result": {"id": "no_config"}},
+            no_config,
+            {"result": [{"url_path": "no-config", "id": "no_config"}]},
+            no_config,
+            {"success": True},
+            {"result": replacement},
+        ]
+
+        create_result = await set_tool(url_path="no-config", title="No Config")
+        assert create_result["success"] is True
+        assert create_result["action"] == "create"
+        assert any(
+            "No config found" in warning
+            for warning in create_result.get("warnings", [])
+        )
+
+        update_result = await set_tool(url_path="no-config", config=replacement)
+
+        assert update_result["success"] is True
+        assert update_result["action"] == "update"
+        assert update_result["config_updated"] is True
+        save_call = mock_client.send_websocket_message.call_args_list[5].args[0]
+        assert save_call["type"] == "lovelace/config/save"
+        assert save_call["config"] == replacement
+        assert mock_client.send_websocket_message.call_count == 7
+
+    @pytest.mark.asyncio
+    async def test_dashboard_without_stored_config_rejects_supplied_hash(
+        self, set_tool, mock_client
+    ):
+        no_config = {
+            "success": False,
+            "error": "Command failed: No config found.",
+            "error_code": "config_not_found",
+        }
+        mock_client.send_websocket_message.side_effect = [
+            {"result": [{"url_path": "no-config", "id": "no_config"}]},
+            no_config,
+        ]
+
+        with pytest.raises(ToolError) as exc_info:
+            await set_tool(
+                url_path="no-config",
+                config={"views": [{"title": "Populated"}]},
+                config_hash="stale-hash",
+            )
+
+        body = json.loads(str(exc_info.value))
+        assert body["error"]["code"] == "SERVICE_CALL_FAILED"
+        assert "conflict" in body["error"]["message"]
+        assert body["url_path"] == "no-config"
+        assert mock_client.send_websocket_message.call_count == 2
+
+    @pytest.mark.asyncio
     async def test_existing_hyphenless_dashboard_python_transform_is_allowed(
         self, set_tool, mock_client
     ):
@@ -529,13 +594,36 @@ class TestSetDashboardUrlPathCreationContract:
         assert "Take Control" in body["error"]["suggestion"]
         assert mock_client.send_websocket_message.call_count == 2
 
+    @pytest.mark.parametrize(
+        ("read_response", "read_error"),
+        [
+            (
+                {"success": False, "error": {"message": "temporary read failure"}},
+                "temporary read failure",
+            ),
+            (
+                {
+                    "success": False,
+                    "error": {
+                        "code": "config_not_found",
+                        "message": "Command failed: Unknown config specified: map",
+                    },
+                },
+                "Command failed: Unknown config specified: map",
+            ),
+            (
+                {"success": False, "error": "Command failed: No config found."},
+                "Command failed: No config found.",
+            ),
+        ],
+    )
     @pytest.mark.asyncio
     async def test_full_config_pre_read_failure_blocks_unverified_replacement(
-        self, set_tool, mock_client
+        self, set_tool, mock_client, read_response, read_error
     ):
         mock_client.send_websocket_message.side_effect = [
             {"result": [{"url_path": "map", "id": "map"}]},
-            {"success": False, "error": {"message": "temporary read failure"}},
+            read_response,
         ]
 
         with pytest.raises(ToolError) as exc_info:
@@ -544,7 +632,7 @@ class TestSetDashboardUrlPathCreationContract:
         body = json.loads(str(exc_info.value))
         assert body["error"]["code"] == "SERVICE_CALL_FAILED"
         assert "Cannot verify" in body["error"]["message"]
-        assert "temporary read failure" in body["error"]["details"]
+        assert read_error in body["error"]["details"]
         assert body["url_path"] == "map"
         assert mock_client.send_websocket_message.call_count == 2
 

--- a/tests/src/unit/test_set_dashboard_metadata.py
+++ b/tests/src/unit/test_set_dashboard_metadata.py
@@ -384,6 +384,22 @@ class TestSetDashboardUrlPathCreationContract:
         assert mock_client.send_websocket_message.call_count == 1
 
     @pytest.mark.asyncio
+    async def test_internal_id_match_cannot_exempt_other_hyphenless_path(
+        self, set_tool, mock_client
+    ):
+        mock_client.send_websocket_message.return_value = {
+            "result": [{"url_path": "map", "id": "map_internal"}]
+        }
+
+        with pytest.raises(ToolError) as exc_info:
+            await set_tool(url_path="map_internal", title="Updated Map")
+
+        body = json.loads(str(exc_info.value))
+        assert body["error"]["code"] == "VALIDATION_INVALID_PARAMETER"
+        assert "url_path must contain a hyphen" in body["error"]["message"]
+        assert mock_client.send_websocket_message.call_count == 1
+
+    @pytest.mark.asyncio
     async def test_new_hyphenated_dashboard_is_allowed(self, set_tool, mock_client):
         mock_client.send_websocket_message.side_effect = [
             {"result": []},

--- a/tests/src/unit/test_set_dashboard_metadata.py
+++ b/tests/src/unit/test_set_dashboard_metadata.py
@@ -7,6 +7,7 @@ import pytest
 from fastmcp.exceptions import ToolError
 
 from ha_mcp.tools.tools_config_dashboards import DashboardConfigTools
+from ha_mcp.utils.config_hash import compute_config_hash
 
 
 class TestSetDashboardMetadataUpdate:
@@ -51,26 +52,21 @@ class TestSetDashboardMetadataUpdate:
         assert meta_call["title"] == "New Title"
 
     @pytest.mark.asyncio
-    async def test_metadata_updated_false_when_no_metadata_params(
+    async def test_existing_dashboard_with_no_changes_is_rejected(
         self, set_tool, mock_client
     ):
-        """metadata_updated=False when no metadata params given for existing dashboard."""
-        mock_client.send_websocket_message.side_effect = [
-            self._make_dashboard_list("my-dashboard"),  # lovelace/dashboards/list
-            {"result": {"views": []}},  # post-write canonical render paths
-        ]
+        """An existing dashboard cannot report a successful update with no write."""
+        mock_client.send_websocket_message.return_value = self._make_dashboard_list(
+            "my-dashboard"
+        )
 
-        result = await set_tool(url_path="my-dashboard")
+        with pytest.raises(ToolError) as exc_info:
+            await set_tool(url_path="my-dashboard")
 
-        assert result["success"] is True
-        assert result["metadata_updated"] is False
-        # No metadata update; the second call fetches canonical render paths.
-        assert mock_client.send_websocket_message.call_count == 2
-        assert mock_client.send_websocket_message.call_args_list[1].args[0] == {
-            "type": "lovelace/config",
-            "force": True,
-            "url_path": "my-dashboard",
-        }
+        body = json.loads(str(exc_info.value))
+        assert body["error"]["code"] == "VALIDATION_INVALID_PARAMETER"
+        assert body["error"]["message"] == "No dashboard changes were requested"
+        assert mock_client.send_websocket_message.call_count == 1
 
     @pytest.mark.asyncio
     async def test_metadata_update_multiple_fields(self, set_tool, mock_client):
@@ -133,19 +129,47 @@ class TestSetDashboardMetadataUpdate:
         mock_client.send_websocket_message.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_metadata_update_skipped_when_dashboard_id_none(
+    async def test_metadata_only_update_without_dashboard_id_is_rejected(
         self, set_tool, mock_client
     ):
-        """When dashboard_id cannot be resolved, metadata update is skipped with a hint."""
+        """A skipped metadata write cannot report a successful dashboard update."""
         # Lovelace dashboard not in the list (fresh install scenario)
         mock_client.send_websocket_message.return_value = {"result": []}
 
-        result = await set_tool(url_path="lovelace", title="My Home")
+        with pytest.raises(ToolError) as exc_info:
+            await set_tool(url_path="lovelace", title="My Home")
+
+        body = json.loads(str(exc_info.value))
+        assert body["error"]["code"] == "SERVICE_CALL_FAILED"
+        assert body["error"]["message"] == "No dashboard changes were applied"
+        assert "no storage ID" in body["error"]["details"]
+        assert mock_client.send_websocket_message.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_config_write_with_unavailable_metadata_uses_warning(
+        self, set_tool, mock_client
+    ):
+        """A committed config write reports skipped metadata as a top-level warning."""
+        replacement = {"views": [{"title": "Home"}]}
+        mock_client.send_websocket_message.side_effect = [
+            {"result": []},  # default dashboard is absent from the registry
+            {"result": {"views": []}},  # replacement safety/hash pre-read
+            {"success": True},  # config save
+            {"result": replacement},  # authoritative post-write config
+        ]
+
+        result = await set_tool(
+            url_path="lovelace", title="My Home", config=replacement
+        )
 
         assert result["success"] is True
+        assert result["config_updated"] is True
         assert result["metadata_updated"] is False
-        assert "hint" in result
-        assert "no storage ID" in result["hint"]
+        assert "hint" not in result
+        metadata_warning = next(
+            warning for warning in result["warnings"] if "no storage ID" in warning
+        )
+        assert "Dashboard config was saved" in metadata_warning
 
     @pytest.mark.asyncio
     async def test_false_booleans_are_not_filtered_out(self, set_tool, mock_client):
@@ -288,27 +312,27 @@ class TestSetDashboardListCallDedup:
         assert self._list_call_count(mock_client) == 1
 
     @pytest.mark.asyncio
-    async def test_canonical_url_path_branch_warns_on_unexpected_shape(
+    async def test_canonical_url_path_branch_rejects_unreadable_registry(
         self, set_tool, mock_client, caplog
     ):
-        """Existence-check fallback fetch logs a warning on unexpected
-        response shapes, mirroring ``_resolve_dashboard``'s same-arm
-        behaviour. Without this parity, an HA-side shape change would go
-        silent on the canonical-url_path branch — the bug reports would
-        be wedged on ``dashboard_exists = False`` with no operator
-        signal."""
+        """An unexpected registry shape is not treated as an empty registry."""
         import logging
 
-        mock_client.send_websocket_message.side_effect = [
-            "unexpected string",  # response shape failure
-            {"success": True},  # create-dashboard call (still proceeds)
-        ]
+        mock_client.send_websocket_message.return_value = "unexpected string"
 
-        with caplog.at_level(
-            logging.WARNING, logger="ha_mcp.tools.tools_config_dashboards"
+        with (
+            caplog.at_level(
+                logging.WARNING, logger="ha_mcp.tools.tools_config_dashboards"
+            ),
+            pytest.raises(ToolError) as exc_info,
         ):
             await set_tool(url_path="my-dash", title="New")
 
+        body = json.loads(str(exc_info.value))
+        assert body["error"]["code"] == "SERVICE_CALL_FAILED"
+        assert "dashboard registry" in body["error"]["message"]
+        assert body["url_path"] == "my-dash"
+        assert mock_client.send_websocket_message.call_count == 1
         assert any(
             "unexpected shape" in rec.message and "type=str" in rec.message
             for rec in caplog.records
@@ -319,7 +343,7 @@ class TestSetDashboardListCallDedup:
 
 
 class TestSetDashboardUrlPathCreationContract:
-    """The hyphen requirement applies only when creating a dashboard."""
+    """Hyphenless input is exempt only for an exact existing url_path."""
 
     @pytest.fixture
     def mock_client(self):
@@ -381,6 +405,10 @@ class TestSetDashboardUrlPathCreationContract:
         body = json.loads(str(exc_info.value))
         assert body["error"]["code"] == "VALIDATION_INVALID_PARAMETER"
         assert "url_path must contain a hyphen" in body["error"]["message"]
+        assert all(
+            "Try 'newmap'" not in suggestion
+            for suggestion in body["error"]["suggestions"]
+        )
         assert mock_client.send_websocket_message.call_count == 1
 
     @pytest.mark.asyncio
@@ -397,7 +425,25 @@ class TestSetDashboardUrlPathCreationContract:
         body = json.loads(str(exc_info.value))
         assert body["error"]["code"] == "VALIDATION_INVALID_PARAMETER"
         assert "url_path must contain a hyphen" in body["error"]["message"]
+        assert body["url_path"] == "map_internal"
+        assert body["error"]["suggestion"] == "Try 'map-internal' instead"
+        assert "Try 'map' instead" not in body["error"]["suggestions"]
         assert mock_client.send_websocket_message.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_unreadable_registry_is_not_reported_as_bad_hyphenless_input(
+        self, set_tool, mock_client
+    ):
+        mock_client.send_websocket_message.return_value = "unexpected string"
+
+        with pytest.raises(ToolError) as exc_info:
+            await set_tool(url_path="map", title="Updated Map")
+
+        body = json.loads(str(exc_info.value))
+        assert body["error"]["code"] == "SERVICE_CALL_FAILED"
+        assert "dashboard registry" in body["error"]["message"]
+        assert "hyphen" not in body["error"]["message"]
+        assert body["url_path"] == "map"
 
     @pytest.mark.asyncio
     async def test_new_hyphenated_dashboard_is_allowed(self, set_tool, mock_client):
@@ -415,3 +461,92 @@ class TestSetDashboardUrlPathCreationContract:
         assert mock_client.send_websocket_message.call_args_list[1].args[0]["type"] == (
             "lovelace/dashboards/create"
         )
+
+    @pytest.mark.asyncio
+    async def test_existing_hyphenless_dashboard_full_config_update_is_allowed(
+        self, set_tool, mock_client
+    ):
+        replacement = {"views": [{"title": "Updated"}]}
+        mock_client.send_websocket_message.side_effect = [
+            {"result": [{"url_path": "panel", "id": "panel"}]},
+            {"result": {"views": []}},
+            {"success": True},
+            {"result": replacement},
+        ]
+
+        result = await set_tool(url_path="panel", config=replacement)
+
+        assert result["success"] is True
+        assert result["action"] == "update"
+        assert result["config_updated"] is True
+        assert "resolved_from" not in result
+        save_call = mock_client.send_websocket_message.call_args_list[2].args[0]
+        assert save_call["type"] == "lovelace/config/save"
+        assert save_call["config"] == replacement
+
+    @pytest.mark.asyncio
+    async def test_existing_hyphenless_dashboard_python_transform_is_allowed(
+        self, set_tool, mock_client
+    ):
+        current = {"views": []}
+        transformed = {"views": [{"title": "Added"}]}
+        mock_client.send_websocket_message.side_effect = [
+            {"result": [{"url_path": "panel", "id": "panel"}]},
+            {"result": current},
+            {"success": True},
+            {"result": transformed},
+        ]
+
+        result = await set_tool(
+            url_path="panel",
+            python_transform='config["views"].append({"title": "Added"})',
+            config_hash=compute_config_hash(current),
+        )
+
+        assert result["success"] is True
+        assert result["action"] == "python_transform"
+        assert "resolved_from" not in result
+        save_call = mock_client.send_websocket_message.call_args_list[2].args[0]
+        assert save_call["type"] == "lovelace/config/save"
+        assert save_call["config"] == transformed
+
+    @pytest.mark.asyncio
+    async def test_full_config_cannot_take_control_of_strategy_dashboard(
+        self, set_tool, mock_client
+    ):
+        mock_client.send_websocket_message.side_effect = [
+            {"result": [{"url_path": "map", "id": "map"}]},
+            {"result": {"strategy": {"type": "map"}}},
+        ]
+
+        with pytest.raises(ToolError) as exc_info:
+            await set_tool(url_path="map", config={"views": []})
+
+        body = json.loads(str(exc_info.value))
+        assert body["error"]["code"] == "VALIDATION_FAILED"
+        assert "cannot be converted" in body["error"]["message"]
+        assert "Take Control" in body["error"]["suggestion"]
+        assert mock_client.send_websocket_message.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_python_transform_cannot_take_control_of_strategy_dashboard(
+        self, set_tool, mock_client
+    ):
+        current = {"strategy": {"type": "map"}}
+        mock_client.send_websocket_message.side_effect = [
+            {"result": [{"url_path": "map", "id": "map"}]},
+            {"result": current},
+        ]
+
+        with pytest.raises(ToolError) as exc_info:
+            await set_tool(
+                url_path="map",
+                python_transform='config = {"views": []}',
+                config_hash=compute_config_hash(current),
+            )
+
+        body = json.loads(str(exc_info.value))
+        assert body["error"]["code"] == "VALIDATION_FAILED"
+        assert "cannot be converted" in body["error"]["message"]
+        assert body["action"] == "python_transform"
+        assert mock_client.send_websocket_message.call_count == 2

--- a/tests/src/unit/test_set_dashboard_metadata.py
+++ b/tests/src/unit/test_set_dashboard_metadata.py
@@ -444,6 +444,7 @@ class TestSetDashboardUrlPathCreationContract:
         assert "dashboard registry" in body["error"]["message"]
         assert "hyphen" not in body["error"]["message"]
         assert body["url_path"] == "map"
+        assert mock_client.send_websocket_message.call_count == 1
 
     @pytest.mark.asyncio
     async def test_new_hyphenated_dashboard_is_allowed(self, set_tool, mock_client):
@@ -526,6 +527,25 @@ class TestSetDashboardUrlPathCreationContract:
         assert body["error"]["code"] == "VALIDATION_FAILED"
         assert "cannot be converted" in body["error"]["message"]
         assert "Take Control" in body["error"]["suggestion"]
+        assert mock_client.send_websocket_message.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_full_config_pre_read_failure_blocks_unverified_replacement(
+        self, set_tool, mock_client
+    ):
+        mock_client.send_websocket_message.side_effect = [
+            {"result": [{"url_path": "map", "id": "map"}]},
+            {"success": False, "error": {"message": "temporary read failure"}},
+        ]
+
+        with pytest.raises(ToolError) as exc_info:
+            await set_tool(url_path="map", config={"views": []})
+
+        body = json.loads(str(exc_info.value))
+        assert body["error"]["code"] == "SERVICE_CALL_FAILED"
+        assert "Cannot verify" in body["error"]["message"]
+        assert "temporary read failure" in body["error"]["details"]
+        assert body["url_path"] == "map"
         assert mock_client.send_websocket_message.call_count == 2
 
     @pytest.mark.asyncio

--- a/tests/src/unit/test_set_dashboard_metadata.py
+++ b/tests/src/unit/test_set_dashboard_metadata.py
@@ -316,3 +316,86 @@ class TestSetDashboardListCallDedup:
             f"expected an 'unexpected shape' warning naming the response "
             f"type; got {[rec.message for rec in caplog.records]}"
         )
+
+
+class TestSetDashboardUrlPathCreationContract:
+    """The hyphen requirement applies only when creating a dashboard."""
+
+    @pytest.fixture
+    def mock_client(self):
+        client = MagicMock()
+        client.send_websocket_message = AsyncMock()
+        return client
+
+    @pytest.fixture
+    def set_tool(self, mock_client):
+        return DashboardConfigTools(mock_client).ha_config_set_dashboard
+
+    @pytest.mark.asyncio
+    async def test_existing_hyphenless_dashboard_update_is_allowed(
+        self, set_tool, mock_client
+    ):
+        mock_client.send_websocket_message.side_effect = [
+            {"result": [{"url_path": "map", "id": "map"}]},
+            {"success": True},
+            {"result": {"views": []}},
+        ]
+
+        result = await set_tool(url_path="map", title="Updated Map")
+
+        assert result["success"] is True
+        assert result["action"] == "update"
+        assert result["url_path"] == "map"
+        assert result["dashboard_created"] is False
+        assert "resolved_from" not in result
+        assert mock_client.send_websocket_message.call_args_list[1].args[0]["type"] == (
+            "lovelace/dashboards/update"
+        )
+
+    @pytest.mark.asyncio
+    async def test_existing_hyphenated_dashboard_update_is_allowed(
+        self, set_tool, mock_client
+    ):
+        mock_client.send_websocket_message.side_effect = [
+            {"result": [{"url_path": "floor-map", "id": "floor_map"}]},
+            {"success": True},
+            {"result": {"views": []}},
+        ]
+
+        result = await set_tool(url_path="floor-map", title="Updated Floor Map")
+
+        assert result["success"] is True
+        assert result["action"] == "update"
+        assert result["dashboard_created"] is False
+        assert mock_client.send_websocket_message.call_args_list[1].args[0]["type"] == (
+            "lovelace/dashboards/update"
+        )
+
+    @pytest.mark.asyncio
+    async def test_new_hyphenless_dashboard_is_rejected(self, set_tool, mock_client):
+        mock_client.send_websocket_message.return_value = {"result": []}
+
+        with pytest.raises(ToolError) as exc_info:
+            await set_tool(url_path="newmap", title="New Map")
+
+        body = json.loads(str(exc_info.value))
+        assert body["error"]["code"] == "VALIDATION_INVALID_PARAMETER"
+        assert "url_path must contain a hyphen" in body["error"]["message"]
+        assert mock_client.send_websocket_message.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_new_hyphenated_dashboard_is_allowed(self, set_tool, mock_client):
+        mock_client.send_websocket_message.side_effect = [
+            {"result": []},
+            {"success": True, "result": {"id": "new_map"}},
+            {"result": {"views": []}},
+        ]
+
+        result = await set_tool(url_path="new-map", title="New Map")
+
+        assert result["success"] is True
+        assert result["action"] == "create"
+        assert result["dashboard_created"] is True
+        assert mock_client.send_websocket_message.call_args_list[1].args[0]["type"] == (
+            "lovelace/dashboards/create"
+        )

--- a/tests/src/unit/test_tools_config_dashboards.py
+++ b/tests/src/unit/test_tools_config_dashboards.py
@@ -324,6 +324,24 @@ class TestDeleteDashboardNotFoundShape:
         assert "identifier" not in body
 
     @pytest.mark.asyncio
+    async def test_unreadable_registry_raises_service_failure(
+        self, delete_tool, mock_client
+    ):
+        """A failed registry read is not reported as a missing dashboard."""
+        mock_client.send_websocket_message.return_value = "unexpected string"
+
+        with pytest.raises(ToolError) as exc_info:
+            await delete_tool(url_path="existing-dash")
+
+        body = json.loads(str(exc_info.value))
+        assert body["error"]["code"] == "SERVICE_CALL_FAILED"
+        assert "dashboard registry" in body["error"]["message"]
+        assert "not found" not in body["error"]["message"].lower()
+        assert body["action"] == "delete"
+        assert body["url_path"] == "existing-dash"
+        assert mock_client.send_websocket_message.call_count == 1
+
+    @pytest.mark.asyncio
     async def test_already_deleted_returns_idempotent_success_shape(
         self, delete_tool, mock_client
     ):


### PR DESCRIPTION
## What changed

- Treat the dashboard `url_path` hyphen rule as a creation constraint: an exact existing URL path such as `map` remains updateable, while a new hyphenless path remains rejected.
- Preserve internal-ID updates to hyphenated paths without allowing an ID-only match to exempt a different hyphenless URL path.
- Preserve the caller's original identifier in validation context and omit no-op replacement suggestions.
- Fail closed when the dashboard registry cannot be read, for both set and delete operations, instead of reporting invalid input or `RESOURCE_NOT_FOUND`.
- Prevent both full-config replacement and `python_transform` from converting a strategy dashboard into a custom dashboard; Home Assistant's explicit **Take Control** flow remains required.
- Reject existing-dashboard calls that apply no changes. When config is saved but metadata cannot be applied, report that partial result through the standard top-level `warnings` list.
- Add focused unit coverage for metadata, config replacement, and Python-transform modes, plus the seeded `map` dashboard E2E case.

## Why

`_resolve_set_dashboard_url_path` successfully resolved an existing hyphenless dashboard, then unconditionally applied the new-dashboard hyphen validation. That made the documented update contract false for existing dashboards whose stored path predates or does not follow the creation convention.

The follow-up hardening keeps that narrow fix while making the surrounding write path fail safely: ambiguous identifiers cannot redirect to another hyphenless path, registry failures retain their real classification, strategy dashboards cannot be silently taken over, and a no-op cannot report a successful update.

## Impact

Existing hyphenless and hyphenated dashboards can be updated by their exact URL paths. New dashboards still require a hyphen, except for the existing built-in `lovelace` exemption. Existing internal-ID canonicalization to a hyphenated path remains supported and is surfaced through `resolved_from`; exact URL matches intentionally omit that marker and report the outcome through `action`.

## Regression coverage

- existing hyphenless dashboard metadata, full-config, and Python-transform updates: allowed
- existing hyphenated dashboard update: allowed
- new hyphenless dashboard: rejected before creation
- new hyphenated dashboard: allowed
- internal-ID-only match to a different hyphenless URL path: rejected with the original identifier and an actionable suggestion
- unreadable dashboard registry: structured service failure for set and delete
- strategy-to-custom conversion: rejected in full-config and Python-transform modes
- true no-op: rejected; partial metadata/config result: top-level warning
- real seeded `map` dashboard: covered in the dashboard lifecycle E2E test

## Validation

- focused dashboard/error regression suite: 77 passed
- full unit suite: 9,641 passed, 295 skipped
- `ruff check` on `src/` and `tests/`: passed
- `ruff format --check` on changed source/tests: passed
- `mypy src/`: passed (202 source files)
- relevant dashboard lifecycle E2E: test added and local execution attempted, but this host denies access to the Docker daemon socket; no local E2E pass is claimed, and exact-head CI is required


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Dashboard updates now correctly recognize existing URL paths, including hyphenless paths.
  - Dashboard creation requires valid hyphenated paths, while internal IDs resolve to existing canonical paths.
  - Unavailable or unreadable dashboard registries now return clear service errors for update and delete actions.
  - Metadata limitations are reported as warnings when configuration changes succeed.
  - Metadata-only updates and other no-op requests are rejected when they cannot make a change.
  - Strategy dashboards can no longer be converted into custom dashboards.
  - Dashboard snapshots now handle dashboards without stored configurations correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->