### PR TITLE
fix: route the embedded self-reload through the shielded services endpoint

### DIFF
--- a/src/ha_mcp/tools/tools_dev.py
+++ b/src/ha_mcp/tools/tools_dev.py
@@ -481,19 +481,12 @@ def schedule_deferred_entry_reload(client: Any, entry_id: str) -> None:
     response has flushed. Failures can only be logged — there is no caller
     left to answer.
 
-    Routed through the ``homeassistant.reload_config_entry`` SERVICE rather
-    than ``POST /config/config_entries/entry/{id}/reload`` because only the
-    services endpoint is cancellation-safe. Home Assistant runs aiohttp with
-    ``handler_cancellation=True``, so a dropped connection cancels the
-    request handler — and this request is issued by the embedded server's
-    own HTTP client, which the reload destroys when it stops the worker
-    thread. On the config-entries route that cancels ``async_reload``
-    mid-flight, after the entry state is set to ``UNLOAD_IN_PROGRESS`` but
-    before the unload completes, stranding the entry in a state Home
-    Assistant treats as non-recoverable (reload, unload and disable all
-    raise ``OperationNotAllowed``) until Home Assistant itself is restarted.
-    The services handler wraps the call in ``asyncio.shield`` for exactly
-    this reason, so the reload survives losing its caller.
+    Uses the ``homeassistant.reload_config_entry`` service, NOT
+    ``POST /config/config_entries/entry/{id}/reload``: only the services
+    handler shields the call. HA runs aiohttp with
+    ``handler_cancellation=True``, and the reload kills the client sending
+    this request, so on the unshielded route it cancelled itself mid-unload
+    and stranded the entry in ``UNLOAD_IN_PROGRESS`` until HA restarted.
     """
 
     async def _reload() -> None:
@@ -504,16 +497,13 @@ def schedule_deferred_entry_reload(client: Any, entry_id: str) -> None:
             )
             logger.info("Deferred reload of entry %s requested", entry_id)
         except Exception as exc:
-            # Losing the reply mid-flight is the EXPECTED outcome of a
-            # successful embedded self-restart: the reload stops the worker
-            # thread that owns this HTTP client, and the shielded service call
-            # runs to completion without us. Reporting that as a failure sends
-            # users hunting a reload that actually worked. Only a read/protocol
-            # error qualifies — the request reached Home Assistant and just the
-            # reply was lost. A connect error or timeout means the reload may
-            # never have been dispatched, so those still surface as errors.
+            # A lost reply means the request reached HA and the shielded reload
+            # then killed this client — the expected end of a self-restart, not
+            # a failure. A connect error or timeout may never have dispatched,
+            # so those stay loud. WARNING, not INFO: HA surfaces this package
+            # at WARNING and above, so INFO here would log nothing at all.
             if isinstance(exc.__cause__, httpx.ReadError | httpx.RemoteProtocolError):
-                logger.info(
+                logger.warning(
                     "Deferred reload of entry %s dispatched; it tore down this "
                     "connection before the reply arrived (expected)",
                     entry_id,

--- a/src/ha_mcp/tools/tools_dev.py
+++ b/src/ha_mcp/tools/tools_dev.py
@@ -479,13 +479,27 @@ def schedule_deferred_entry_reload(client: Any, entry_id: str) -> None:
     very worker answering the current request, so it must not run until the
     response has flushed. Failures can only be logged — there is no caller
     left to answer.
+
+    Routed through the ``homeassistant.reload_config_entry`` SERVICE rather
+    than ``POST /config/config_entries/entry/{id}/reload`` because only the
+    services endpoint is cancellation-safe. Home Assistant runs aiohttp with
+    ``handler_cancellation=True``, so a dropped connection cancels the
+    request handler — and this request is issued by the embedded server's
+    own HTTP client, which the reload destroys when it stops the worker
+    thread. On the config-entries route that cancels ``async_reload``
+    mid-flight, after the entry state is set to ``UNLOAD_IN_PROGRESS`` but
+    before the unload completes, stranding the entry in a state Home
+    Assistant treats as non-recoverable (reload, unload and disable all
+    raise ``OperationNotAllowed``) until Home Assistant itself is restarted.
+    The services handler wraps the call in ``asyncio.shield`` for exactly
+    this reason, so the reload survives losing its caller.
     """
 
     async def _reload() -> None:
         await asyncio.sleep(_SELF_ACTION_FLUSH_DELAY_S)
         try:
-            await client._request(
-                "POST", f"/config/config_entries/entry/{entry_id}/reload"
+            await client.call_service(
+                "homeassistant", "reload_config_entry", {"entry_id": entry_id}
             )
             logger.info("Deferred reload of entry %s requested", entry_id)
         except Exception:

--- a/src/ha_mcp/tools/tools_dev.py
+++ b/src/ha_mcp/tools/tools_dev.py
@@ -16,6 +16,7 @@ import logging
 import sys
 from typing import Annotated, Any, Literal
 
+import httpx
 from fastmcp.exceptions import ToolError
 from fastmcp.tools import tool
 from pydantic import Field
@@ -502,8 +503,23 @@ def schedule_deferred_entry_reload(client: Any, entry_id: str) -> None:
                 "homeassistant", "reload_config_entry", {"entry_id": entry_id}
             )
             logger.info("Deferred reload of entry %s requested", entry_id)
-        except Exception:
-            logger.exception("Deferred config-entry reload failed")
+        except Exception as exc:
+            # Losing the reply mid-flight is the EXPECTED outcome of a
+            # successful embedded self-restart: the reload stops the worker
+            # thread that owns this HTTP client, and the shielded service call
+            # runs to completion without us. Reporting that as a failure sends
+            # users hunting a reload that actually worked. Only a read/protocol
+            # error qualifies — the request reached Home Assistant and just the
+            # reply was lost. A connect error or timeout means the reload may
+            # never have been dispatched, so those still surface as errors.
+            if isinstance(exc.__cause__, httpx.ReadError | httpx.RemoteProtocolError):
+                logger.info(
+                    "Deferred reload of entry %s dispatched; it tore down this "
+                    "connection before the reply arrived (expected)",
+                    entry_id,
+                )
+            else:
+                logger.exception("Deferred config-entry reload failed")
 
     _spawn_background(_reload())
 

--- a/tests/src/e2e/basic/test_backend_dispatch_smoke.py
+++ b/tests/src/e2e/basic/test_backend_dispatch_smoke.py
@@ -97,9 +97,9 @@ _SKIP_CEILING_PER_LANE = {
     # Static def-level derivation (Docker-less, so parametrize item-inflation isn't
     # visible locally): haos_only 52 + inaddon_only-outside-haos 11 + external_only
     # 36 (auto_backup 19, supervisor_mock 15, self_update_notice 1, file_operations
-    # 1) + not_on_embedded 2 = 101. Initially set to 115 as a buffer for
-    # parametrize item-inflation; round 6 (run 28709196071) observed the exact
-    # item count and the entry below is pinned to it.
+    # 1) + not_on_embedded 2 = 101. Parametrize inflates that to the CI-observed
+    # count the entry below is pinned to — 133 on this PR's run, 132 before the
+    # self-restart e2e. Read the count off a run rather than deriving it.
     "embedded": 133,  # was 132; +1 embedded self-restart e2e (haos_only)
     # HAOS embedded backend (#1527, HAOS_TEST_MODE=embedded). A HAOS lane, so it
     # skips the SAME set as the external HAOS lane (container_only + inaddon_only)
@@ -114,10 +114,9 @@ _SKIP_CEILING_PER_LANE = {
     # item-inflation isn't visible): container_only 16 + inaddon_only 20 +
     # external_only 40 + smoke 4 = 80 (no overlaps: no external_only test is also
     # container_only/inaddon_only, and the 2 not_on_embedded tests are already
-    # container_only). Applying the ~1.16x parametrize inflation the other HAOS
-    # lanes show (haos def 30 → ~35 observed; haos_inaddon def 50 → ~58) gives
-    # ~84; initially set to 90 with a small buffer, and round 8 observed
-    # exactly 90 — the entry below is pinned to the observed count.
+    # container_only). Parametrize inflates that to the CI-observed count the
+    # entry below is pinned to — 107 on this PR's run, 106 before the
+    # self-restart e2e. Read the count off a run rather than deriving it.
     "haos_embedded": 107,  # was 106; +1 embedded self-restart e2e (not_on_haos_embedded)
 }
 

--- a/tests/src/e2e/basic/test_backend_dispatch_smoke.py
+++ b/tests/src/e2e/basic/test_backend_dispatch_smoke.py
@@ -100,7 +100,7 @@ _SKIP_CEILING_PER_LANE = {
     # 1) + not_on_embedded 2 = 101. Initially set to 115 as a buffer for
     # parametrize item-inflation; round 6 (run 28709196071) observed the exact
     # item count and the entry below is pinned to it.
-    "embedded": 132,  # was 130; +1 embedded HACS-nudge skip e2e (not_on_embedded), +1 inaddon startup-nudge e2e (haos_only + inaddon_only)
+    "embedded": 133,  # was 132; +1 embedded self-restart e2e (haos_only)
     # HAOS embedded backend (#1527, HAOS_TEST_MODE=embedded). A HAOS lane, so it
     # skips the SAME set as the external HAOS lane (container_only + inaddon_only)
     # PLUS two haos_embedded-specific additions:
@@ -108,17 +108,17 @@ _SKIP_CEILING_PER_LANE = {
     #     HAOS core container, unreachable by test-process env/monkeypatch — same
     #     reason as inaddon/container-embedded; alternative coverage on the external
     #     HAOS lane, where the in-process FastMCP server IS in the test process), and
-    #   - the 3 haos_only embedded smoke tests skip (not_on_haos_embedded) because
+    #   - the haos_only embedded smoke tests skip (not_on_haos_embedded) because
     #     the session backend already enables the entry + drives the server.
     # Static def-level derivation (Docker/HAOS-less locally, so parametrize
     # item-inflation isn't visible): container_only 16 + inaddon_only 20 +
-    # external_only 40 + smoke 3 = 79 (no overlaps: no external_only test is also
+    # external_only 40 + smoke 4 = 80 (no overlaps: no external_only test is also
     # container_only/inaddon_only, and the 2 not_on_embedded tests are already
     # container_only). Applying the ~1.16x parametrize inflation the other HAOS
     # lanes show (haos def 30 → ~35 observed; haos_inaddon def 50 → ~58) gives
     # ~84; initially set to 90 with a small buffer, and round 8 observed
     # exactly 90 — the entry below is pinned to the observed count.
-    "haos_embedded": 106,  # was 104; +1 embedded HACS-nudge skip e2e (container_only), +1 inaddon startup-nudge e2e (inaddon_only)
+    "haos_embedded": 107,  # was 106; +1 embedded self-restart e2e (not_on_haos_embedded)
 }
 
 

--- a/tests/src/e2e/haos_only/test_embedded_server_haos.py
+++ b/tests/src/e2e/haos_only/test_embedded_server_haos.py
@@ -313,27 +313,19 @@ class TestEmbeddedSelfRestartOnHaos:
     ) -> None:
         """The settings-UI Restart button must not strand its own entry.
 
-        Regression: the restart dispatched the reload over the in-process
-        server's own HTTP client, and the reload destroys that client when it
-        stops the worker thread. Home Assistant does not shield the
-        ``/config/config_entries/entry/{id}/reload`` handler and runs aiohttp
-        with ``handler_cancellation=True``, so the disconnect cancelled
-        ``async_reload`` after the state became ``UNLOAD_IN_PROGRESS`` but
-        before the unload finished. HA treats that state as non-recoverable —
-        reload, unload and disable all raise ``OperationNotAllowed`` — so the
-        server stayed dead until Home Assistant itself restarted.
-
-        Needs no developer mode: ``/api/settings/restart`` is the ordinary
-        Restart button any user can press.
+        Regression: the restart dispatched the reload over the client the
+        reload then destroys, and HA cancels that unshielded handler on the
+        disconnect — stranding the entry in ``UNLOAD_IN_PROGRESS``, which
+        nothing but a Home Assistant restart clears. Needs no developer mode;
+        ``/api/settings/restart`` is the ordinary Restart button.
         """
         base_url, _session_id, info = embedded_server
         token = info["token"]
 
         assert _entry_state(base_url, token, HA_MCP_SERVER_ENTRY_ID) == "loaded"
 
-        # Press Restart from inside the VM: the settings routes are mounted
-        # under the secret path on the server's own port, not behind the
-        # webhook (which only carries MCP traffic).
+        # From inside the VM: settings routes live under the secret path on the
+        # server's own port, not behind the webhook (MCP traffic only).
         restart_url = (
             f"http://127.0.0.1:{HA_MCP_SERVER_PORT}"
             f"{HA_MCP_SERVER_SECRET_PATH}/api/settings/restart"
@@ -374,6 +366,19 @@ class TestEmbeddedSelfRestartOnHaos:
             f"and only a Home Assistant restart can recover the server"
         )
 
-        # ...and the server is actually serving again, not merely re-registered.
-        ready, _ = _initialize(base_url)
-        assert ready, "in-process server did not answer MCP after its self-restart"
+        # `loaded` precedes the listener binding, so poll. Own budget: the
+        # deadline above can be spent by the time the entry flips.
+        ready_deadline = time.monotonic() + _RESTART_RECOVER_TIMEOUT_S
+        ready = False
+        while time.monotonic() < ready_deadline:
+            try:
+                ready, _ = _initialize(base_url)
+            except requests.exceptions.RequestException:
+                ready = False
+            if ready:
+                break
+            time.sleep(_RESTART_POLL_S)
+        assert ready, (
+            "the entry is loaded but the in-process server never answered MCP "
+            f"within {_RESTART_RECOVER_TIMEOUT_S}s of the self-restart"
+        )

--- a/tests/src/e2e/haos_only/test_embedded_server_haos.py
+++ b/tests/src/e2e/haos_only/test_embedded_server_haos.py
@@ -291,6 +291,7 @@ class TestEmbeddedServerOnHaos:
 # multi-minute first bring-up.
 _RESTART_RECOVER_TIMEOUT_S = 180
 _RESTART_POLL_S = 3
+_WS_RECV_TIMEOUT_S = 30
 
 
 def _entry_states_while(
@@ -331,24 +332,36 @@ def _subscribe_to_config_entries(base_url: str, token: str) -> Any:
         + "/api/websocket"
     )
     ws = websockets.sync.client.connect(ws_url, max_size=None, open_timeout=30)
-    first = json.loads(ws.recv())
-    if first.get("type") != "auth_required":
-        raise RuntimeError(f"WS handshake: expected auth_required, got {first!r}")
-    ws.send(json.dumps({"type": "auth", "access_token": token}))
-    auth = json.loads(ws.recv())
-    if auth.get("type") != "auth_ok":
-        raise RuntimeError(f"WS auth rejected: {auth}")
+    # Every recv is bounded: the sync client blocks forever by default, so a HA
+    # that accepts the socket and then goes quiet would hang the run until the
+    # module timeout killed it with nothing useful to show.
+    try:
+        first = json.loads(ws.recv(timeout=_WS_RECV_TIMEOUT_S))
+        if first.get("type") != "auth_required":
+            raise RuntimeError(f"WS handshake: expected auth_required, got {first!r}")
+        ws.send(json.dumps({"type": "auth", "access_token": token}))
+        auth = json.loads(ws.recv(timeout=_WS_RECV_TIMEOUT_S))
+        if auth.get("type") != "auth_ok":
+            raise RuntimeError(f"WS auth rejected: {auth}")
 
-    ws.send(json.dumps({"id": 1, "type": "config_entries/subscribe"}))
-    # The command result, then a snapshot of every current entry (each carrying
-    # type=null), both land before any change event — drain them so the caller
-    # only sees transitions its trigger caused.
-    while True:
-        msg = json.loads(ws.recv(timeout=30))
-        if msg.get("type") == "event" and any(
-            item.get("type") is None for item in msg.get("event", [])
-        ):
-            return ws
+        ws.send(json.dumps({"id": 1, "type": "config_entries/subscribe"}))
+        # The command result, then a snapshot of every current entry (each
+        # carrying type=null), both land before any change event — drain them so
+        # the caller only sees transitions its trigger caused.
+        deadline = time.monotonic() + _WS_RECV_TIMEOUT_S
+        while time.monotonic() < deadline:
+            msg = json.loads(ws.recv(timeout=deadline - time.monotonic()))
+            if msg.get("type") == "event" and any(
+                item.get("type") is None for item in msg.get("event", [])
+            ):
+                return ws
+        raise AssertionError(
+            "config_entries/subscribe never sent its entry snapshot within "
+            f"{_WS_RECV_TIMEOUT_S}s"
+        )
+    except BaseException:
+        ws.close()
+        raise
 
 
 def _collect_entry_states(ws: Any, entry_id: str, deadline: float) -> list[str]:

--- a/tests/src/e2e/haos_only/test_embedded_server_haos.py
+++ b/tests/src/e2e/haos_only/test_embedded_server_haos.py
@@ -47,9 +47,12 @@ import pytest
 import requests
 from haos_runtime import (
     HA_MCP_SERVER_ENTRY_ID,
+    HA_MCP_SERVER_PORT,
+    HA_MCP_SERVER_SECRET_PATH,
     HA_MCP_SERVER_WEBHOOK_ID,
     enable_config_entry,
     read_embedded_staging_status,
+    ssh_exec,
 )
 
 from ..utilities.streamable_http import parse_mcp_response
@@ -71,7 +74,7 @@ _READY_POLL_S = 5
 pytestmark = [
     pytest.mark.slow,
     pytest.mark.haos_only,
-    # These 3 tests enable the baked entry and drive the webhook per-test. On the
+    # These tests enable the baked entry and drive the webhook per-test. On the
     # haos_embedded lane the session backend already enables the entry ONCE and
     # runs the whole suite through the in-process server, so running them there
     # would double-enable the entry and race that backend — skip. They stay the
@@ -281,3 +284,96 @@ class TestEmbeddedServerOnHaos:
                 f"external haos lane should have no add-on running, but "
                 f"addon_mcp_url={info.get('addon_mcp_url')!r}"
             )
+
+
+# A self-restart reinstalls nothing (warm start) but does tear the worker down
+# and set the entry back up; on a loaded QEMU guest that is seconds, not the
+# multi-minute first bring-up.
+_RESTART_RECOVER_TIMEOUT_S = 180
+_RESTART_POLL_S = 3
+
+
+def _entry_state(base_url: str, token: str, entry_id: str) -> str | None:
+    """Current config-entry state, or None if the entry is absent."""
+    resp = requests.get(
+        f"{base_url}/api/config/config_entries/entry",
+        headers={"Authorization": f"Bearer {token}"},
+        timeout=30,
+    )
+    resp.raise_for_status()
+    for entry in resp.json():
+        if entry.get("entry_id") == entry_id:
+            return entry.get("state")
+    return None
+
+
+class TestEmbeddedSelfRestartOnHaos:
+    def test_self_restart_leaves_the_entry_loaded(
+        self, embedded_server: tuple[str, str | None, dict[str, Any]]
+    ) -> None:
+        """The settings-UI Restart button must not strand its own entry.
+
+        Regression: the restart dispatched the reload over the in-process
+        server's own HTTP client, and the reload destroys that client when it
+        stops the worker thread. Home Assistant does not shield the
+        ``/config/config_entries/entry/{id}/reload`` handler and runs aiohttp
+        with ``handler_cancellation=True``, so the disconnect cancelled
+        ``async_reload`` after the state became ``UNLOAD_IN_PROGRESS`` but
+        before the unload finished. HA treats that state as non-recoverable —
+        reload, unload and disable all raise ``OperationNotAllowed`` — so the
+        server stayed dead until Home Assistant itself restarted.
+
+        Needs no developer mode: ``/api/settings/restart`` is the ordinary
+        Restart button any user can press.
+        """
+        base_url, _session_id, info = embedded_server
+        token = info["token"]
+
+        assert _entry_state(base_url, token, HA_MCP_SERVER_ENTRY_ID) == "loaded"
+
+        # Press Restart from inside the VM: the settings routes are mounted
+        # under the secret path on the server's own port, not behind the
+        # webhook (which only carries MCP traffic).
+        restart_url = (
+            f"http://127.0.0.1:{HA_MCP_SERVER_PORT}"
+            f"{HA_MCP_SERVER_SECRET_PATH}/api/settings/restart"
+        )
+        result = ssh_exec(
+            [
+                "curl",
+                "-s",
+                "-o",
+                "/dev/null",
+                "-w",
+                "%{http_code}",
+                "-X",
+                "POST",
+                restart_url,
+            ],
+            timeout=60,
+        )
+        assert result.stdout.strip().endswith("200"), (
+            f"settings restart endpoint returned {result.stdout!r} "
+            f"(stderr={result.stderr!r})"
+        )
+
+        # The regression parks the entry in unload_in_progress forever, so the
+        # poll simply never reaches loaded. Report the last state seen — that
+        # distinguishes the wedge from a slow-but-healthy recovery.
+        deadline = time.monotonic() + _RESTART_RECOVER_TIMEOUT_S
+        state: str | None = None
+        while time.monotonic() < deadline:
+            state = _entry_state(base_url, token, HA_MCP_SERVER_ENTRY_ID)
+            if state == "loaded":
+                break
+            time.sleep(_RESTART_POLL_S)
+        assert state == "loaded", (
+            f"{HA_MCP_SERVER_ENTRY_ID} is {state!r} "
+            f"{_RESTART_RECOVER_TIMEOUT_S}s after a self-restart; "
+            f"'unload_in_progress' means the reload cancelled itself mid-unload "
+            f"and only a Home Assistant restart can recover the server"
+        )
+
+        # ...and the server is actually serving again, not merely re-registered.
+        ready, _ = _initialize(base_url)
+        assert ready, "in-process server did not answer MCP after its self-restart"

--- a/tests/src/e2e/haos_only/test_embedded_server_haos.py
+++ b/tests/src/e2e/haos_only/test_embedded_server_haos.py
@@ -40,7 +40,7 @@ from __future__ import annotations
 import json
 import logging
 import time
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from typing import Any
 
 import pytest
@@ -293,18 +293,82 @@ _RESTART_RECOVER_TIMEOUT_S = 180
 _RESTART_POLL_S = 3
 
 
-def _entry_state(base_url: str, token: str, entry_id: str) -> str | None:
-    """Current config-entry state, or None if the entry is absent."""
-    resp = requests.get(
-        f"{base_url}/api/config/config_entries/entry",
-        headers={"Authorization": f"Bearer {token}"},
-        timeout=30,
+def _entry_states_while(
+    base_url: str,
+    token: str,
+    entry_id: str,
+    trigger: Callable[[], None],
+    timeout: float,
+) -> list[str]:
+    """Record ``entry_id``'s state transitions while ``trigger`` runs.
+
+    Subscribes BEFORE triggering and reads the event stream rather than
+    polling: the restart endpoint answers ~1s before the reload is even
+    dispatched, so a poll started on that response reads the stale
+    pre-restart ``loaded`` and cannot tell a real reload from no reload at
+    all. HA dispatches ``SIGNAL_CONFIG_ENTRY_CHANGED`` on every state
+    assignment, so the stream catches transitions no sampling interval can
+    guarantee to see.
+
+    Returns the states observed, in order, stopping once the entry is back to
+    ``loaded`` or the timeout expires (the wedge never returns, so the caller
+    sees where it stopped).
+    """
+    ws = _subscribe_to_config_entries(base_url, token)
+    try:
+        trigger()
+        return _collect_entry_states(ws, entry_id, time.monotonic() + timeout)
+    finally:
+        ws.close()
+
+
+def _subscribe_to_config_entries(base_url: str, token: str) -> Any:
+    """Authenticated WS with ``config_entries/subscribe`` live and drained."""
+    import websockets.sync.client
+
+    ws_url = (
+        base_url.replace("http://", "ws://").replace("https://", "wss://")
+        + "/api/websocket"
     )
-    resp.raise_for_status()
-    for entry in resp.json():
-        if entry.get("entry_id") == entry_id:
-            return entry.get("state")
-    return None
+    ws = websockets.sync.client.connect(ws_url, max_size=None, open_timeout=30)
+    first = json.loads(ws.recv())
+    if first.get("type") != "auth_required":
+        raise RuntimeError(f"WS handshake: expected auth_required, got {first!r}")
+    ws.send(json.dumps({"type": "auth", "access_token": token}))
+    auth = json.loads(ws.recv())
+    if auth.get("type") != "auth_ok":
+        raise RuntimeError(f"WS auth rejected: {auth}")
+
+    ws.send(json.dumps({"id": 1, "type": "config_entries/subscribe"}))
+    # The command result, then a snapshot of every current entry (each carrying
+    # type=null), both land before any change event — drain them so the caller
+    # only sees transitions its trigger caused.
+    while True:
+        msg = json.loads(ws.recv(timeout=30))
+        if msg.get("type") == "event" and any(
+            item.get("type") is None for item in msg.get("event", [])
+        ):
+            return ws
+
+
+def _collect_entry_states(ws: Any, entry_id: str, deadline: float) -> list[str]:
+    """``entry_id``'s successive states until it is loaded or time runs out."""
+    observed: list[str] = []
+    while time.monotonic() < deadline:
+        try:
+            msg = json.loads(ws.recv(timeout=deadline - time.monotonic()))
+        except TimeoutError:
+            break
+        for item in msg.get("event", []) if msg.get("type") == "event" else []:
+            entry = item.get("entry") or {}
+            state = entry.get("state")
+            if entry.get("entry_id") != entry_id or not state:
+                continue
+            if not observed or observed[-1] != state:
+                observed.append(state)
+        if observed and observed[-1] == "loaded":
+            break
+    return observed
 
 
 class TestEmbeddedSelfRestartOnHaos:
@@ -322,52 +386,55 @@ class TestEmbeddedSelfRestartOnHaos:
         base_url, _session_id, info = embedded_server
         token = info["token"]
 
-        assert _entry_state(base_url, token, HA_MCP_SERVER_ENTRY_ID) == "loaded"
-
         # From inside the VM: settings routes live under the secret path on the
         # server's own port, not behind the webhook (MCP traffic only).
         restart_url = (
             f"http://127.0.0.1:{HA_MCP_SERVER_PORT}"
             f"{HA_MCP_SERVER_SECRET_PATH}/api/settings/restart"
         )
-        result = ssh_exec(
-            [
-                "curl",
-                "-s",
-                "-o",
-                "/dev/null",
-                "-w",
-                "%{http_code}",
-                "-X",
-                "POST",
-                restart_url,
-            ],
-            timeout=60,
-        )
-        assert result.stdout.strip().endswith("200"), (
-            f"settings restart endpoint returned {result.stdout!r} "
-            f"(stderr={result.stderr!r})"
+
+        def _press_restart() -> None:
+            result = ssh_exec(
+                [
+                    "curl",
+                    "-s",
+                    "-o",
+                    "/dev/null",
+                    "-w",
+                    "%{http_code}",
+                    "-X",
+                    "POST",
+                    restart_url,
+                ],
+                timeout=60,
+            )
+            assert result.stdout.strip().endswith("200"), (
+                f"settings restart endpoint returned {result.stdout!r} "
+                f"(stderr={result.stderr!r})"
+            )
+
+        states = _entry_states_while(
+            base_url,
+            token,
+            HA_MCP_SERVER_ENTRY_ID,
+            _press_restart,
+            _RESTART_RECOVER_TIMEOUT_S,
         )
 
-        # The regression parks the entry in unload_in_progress forever, so the
-        # poll simply never reaches loaded. Report the last state seen — that
-        # distinguishes the wedge from a slow-but-healthy recovery.
-        deadline = time.monotonic() + _RESTART_RECOVER_TIMEOUT_S
-        state: str | None = None
-        while time.monotonic() < deadline:
-            state = _entry_state(base_url, token, HA_MCP_SERVER_ENTRY_ID)
-            if state == "loaded":
-                break
-            time.sleep(_RESTART_POLL_S)
-        assert state == "loaded", (
-            f"{HA_MCP_SERVER_ENTRY_ID} is {state!r} "
-            f"{_RESTART_RECOVER_TIMEOUT_S}s after a self-restart; "
+        # Both halves matter: without the first, a test that never triggered a
+        # reload passes; without the second, the wedge passes.
+        assert states, (
+            "the Restart button produced no config-entry state change at all — "
+            "the reload was never dispatched, so this asserted nothing"
+        )
+        assert states[-1] == "loaded", (
+            f"{HA_MCP_SERVER_ENTRY_ID} went {states} and did not return to "
+            f"loaded within {_RESTART_RECOVER_TIMEOUT_S}s; ending in "
             f"'unload_in_progress' means the reload cancelled itself mid-unload "
             f"and only a Home Assistant restart can recover the server"
         )
 
-        # `loaded` precedes the listener binding, so poll. Own budget: the
-        # deadline above can be spent by the time the entry flips.
+        # `loaded` precedes the listener binding, so poll for MCP separately.
         ready_deadline = time.monotonic() + _RESTART_RECOVER_TIMEOUT_S
         ready = False
         while time.monotonic() < ready_deadline:

--- a/tests/src/unit/test_tools_dev.py
+++ b/tests/src/unit/test_tools_dev.py
@@ -244,6 +244,7 @@ def _mock_client(entries=None, flows=None):
     client.abort_options_flow = AsyncMock(return_value={})
     client.submit_options_flow_step = AsyncMock(return_value={"type": "create_entry"})
     client._request = AsyncMock(return_value={})
+    client.call_service = AsyncMock(return_value=[])
     return client
 
 
@@ -574,9 +575,47 @@ class TestManageServer:
             "note": result["data"]["note"],
         }
         await _drain_background_tasks()
-        client._request.assert_awaited_once_with(
-            "POST", "/config/config_entries/entry/server-e/reload"
+        client.call_service.assert_awaited_once_with(
+            "homeassistant", "reload_config_entry", {"entry_id": "server-e"}
         )
+
+    async def test_restart_embedded_reload_is_cancellation_safe(self, monkeypatch):
+        """The self-reload must go through the SHIELDED services endpoint.
+
+        Regression (embedded deployment wedges the entry permanently):
+        the reload used to be POSTed to
+        ``/config/config_entries/entry/{id}/reload``. Home Assistant does
+        NOT shield that handler, and the request is issued by the embedded
+        server's own HTTP client — the very client the reload tears down.
+
+        Sequence: the unload stops the server thread, the client socket
+        dies mid-request, and aiohttp (started with
+        ``handler_cancellation=True``) cancels the request handler. That
+        kills ``async_reload`` AFTER the entry state is set to
+        ``UNLOAD_IN_PROGRESS`` but BEFORE the unload finishes, orphaning
+        the entry in a state HA treats as non-recoverable — reload,
+        unload and disable all refuse, so only a full Home Assistant
+        restart brings the server back.
+
+        ``homeassistant.reload_config_entry`` goes through the services
+        endpoint, which wraps the call in ``asyncio.shield`` precisely so
+        a dropped connection cannot cancel it.
+        """
+        monkeypatch.setenv("HA_MCP_EMBEDDED", "1")
+        monkeypatch.setattr(tools_dev, "_SELF_ACTION_FLUSH_DELAY_S", 0)
+        client = _mock_client(
+            entries=[{"entry_id": "server-e"}], flows=[dict(_SERVER_FLOW)]
+        )
+        await DevTools(client).ha_dev_manage_server(action="restart")
+        await _drain_background_tasks()
+
+        client.call_service.assert_awaited_once_with(
+            "homeassistant", "reload_config_entry", {"entry_id": "server-e"}
+        )
+        # The unshielded config-entries endpoint must never be used for a
+        # self-reload, whatever else the tool touched.
+        for call in client._request.await_args_list:
+            assert "/config/config_entries/entry/" not in str(call)
 
     async def test_restart_addon_schedules_supervisor_restart(self, monkeypatch):
         monkeypatch.setenv("SUPERVISOR_TOKEN", "t")

--- a/tests/src/unit/test_tools_dev.py
+++ b/tests/src/unit/test_tools_dev.py
@@ -584,24 +584,12 @@ class TestManageServer:
     async def test_restart_embedded_reload_is_cancellation_safe(self, monkeypatch):
         """The self-reload must go through the SHIELDED services endpoint.
 
-        Regression (embedded deployment wedges the entry permanently):
-        the reload used to be POSTed to
-        ``/config/config_entries/entry/{id}/reload``. Home Assistant does
-        NOT shield that handler, and the request is issued by the embedded
-        server's own HTTP client — the very client the reload tears down.
-
-        Sequence: the unload stops the server thread, the client socket
-        dies mid-request, and aiohttp (started with
-        ``handler_cancellation=True``) cancels the request handler. That
-        kills ``async_reload`` AFTER the entry state is set to
-        ``UNLOAD_IN_PROGRESS`` but BEFORE the unload finishes, orphaning
-        the entry in a state HA treats as non-recoverable — reload,
-        unload and disable all refuse, so only a full Home Assistant
-        restart brings the server back.
-
-        ``homeassistant.reload_config_entry`` goes through the services
-        endpoint, which wraps the call in ``asyncio.shield`` precisely so
-        a dropped connection cannot cancel it.
+        Regression: POSTing to ``/config/config_entries/entry/{id}/reload``
+        wedged the entry permanently. That handler is unshielded and aiohttp
+        runs with ``handler_cancellation=True``, so when the unload killed
+        the client sending the request, ``async_reload`` was cancelled after
+        the state became ``UNLOAD_IN_PROGRESS`` but before the unload
+        finished — non-recoverable short of restarting Home Assistant.
         """
         monkeypatch.setenv("HA_MCP_EMBEDDED", "1")
         monkeypatch.setattr(tools_dev, "_SELF_ACTION_FLUSH_DELAY_S", 0)
@@ -643,7 +631,10 @@ class TestManageServer:
             await _drain_background_tasks()
 
         assert not [r for r in caplog.records if r.levelno >= logging.ERROR]
-        assert "expected" in caplog.text
+        # WARNING specifically: HA surfaces this package at WARNING and above,
+        # so an INFO line would make a successful restart look like silence.
+        dispatched = [r for r in caplog.records if "tore down this" in r.message]
+        assert [r.levelno for r in dispatched] == [logging.WARNING]
 
     async def test_self_reload_connect_failure_still_logs_an_error(
         self, monkeypatch, caplog

--- a/tests/src/unit/test_tools_dev.py
+++ b/tests/src/unit/test_tools_dev.py
@@ -2,8 +2,10 @@
 
 import asyncio
 import json
+import logging
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import httpx
 import pytest
 from fastmcp.exceptions import ToolError
 
@@ -616,6 +618,56 @@ class TestManageServer:
         # self-reload, whatever else the tool touched.
         for call in client._request.await_args_list:
             assert "/config/config_entries/entry/" not in str(call)
+
+    async def test_self_reload_disconnect_is_not_logged_as_a_failure(
+        self, monkeypatch, caplog
+    ):
+        """Losing the reply is how a SUCCESSFUL self-restart ends.
+
+        The reload stops the worker thread owning this HTTP client, so the
+        shielded service call finishes without us and the response never
+        arrives. Logging that at ERROR ("Deferred config-entry reload
+        failed") describes a reload that actually worked as broken.
+        """
+        monkeypatch.setenv("HA_MCP_EMBEDDED", "1")
+        monkeypatch.setattr(tools_dev, "_SELF_ACTION_FLUSH_DELAY_S", 0)
+        client = _mock_client(
+            entries=[{"entry_id": "server-e"}], flows=[dict(_SERVER_FLOW)]
+        )
+        lost_reply = RuntimeError("HTTP error")
+        lost_reply.__cause__ = httpx.ReadError("peer went away")
+        client.call_service = AsyncMock(side_effect=lost_reply)
+
+        await DevTools(client).ha_dev_manage_server(action="restart")
+        with caplog.at_level(logging.INFO, logger="ha_mcp.tools.tools_dev"):
+            await _drain_background_tasks()
+
+        assert not [r for r in caplog.records if r.levelno >= logging.ERROR]
+        assert "expected" in caplog.text
+
+    async def test_self_reload_connect_failure_still_logs_an_error(
+        self, monkeypatch, caplog
+    ):
+        """A reload that never reached HA must stay loud.
+
+        Guards the fix above from swallowing real failures: on a connect
+        error the service call may never have been dispatched, so the
+        server can be left un-reloaded with nobody informed.
+        """
+        monkeypatch.setenv("HA_MCP_EMBEDDED", "1")
+        monkeypatch.setattr(tools_dev, "_SELF_ACTION_FLUSH_DELAY_S", 0)
+        client = _mock_client(
+            entries=[{"entry_id": "server-e"}], flows=[dict(_SERVER_FLOW)]
+        )
+        never_sent = RuntimeError("Failed to connect to Home Assistant")
+        never_sent.__cause__ = httpx.ConnectError("refused")
+        client.call_service = AsyncMock(side_effect=never_sent)
+
+        await DevTools(client).ha_dev_manage_server(action="restart")
+        with caplog.at_level(logging.INFO, logger="ha_mcp.tools.tools_dev"):
+            await _drain_background_tasks()
+
+        assert [r for r in caplog.records if r.levelno >= logging.ERROR]
 
     async def test_restart_addon_schedules_supervisor_restart(self, monkeypatch):
         monkeypatch.setenv("SUPERVISOR_TOKEN", "t")


### PR DESCRIPTION
## What does this PR do?

The embedded server's self-restart wedged its own config entry in
`UNLOAD_IN_PROGRESS` — a state HA treats as non-recoverable, where reload,
unload and disable all raise `OperationNotAllowed`. The server stays dead
until Home Assistant itself is restarted. Triggered by the ordinary
settings-UI Restart button — **no developer mode required**,
`/api/settings/restart` is ungated — and by
`ha_dev_manage_server(action="restart")`. Present in v8.1.1 and master.

The reload was POSTed to `/config/config_entries/entry/{id}/reload`. HA does
not shield that handler and runs aiohttp with `handler_cancellation=True`.
The request is issued by the embedded server's own HTTP client — the client
the reload destroys when it stops the worker thread — so the reload cancelled
itself mid-unload, after the entry state was set but before the unload
finished. `homeassistant.reload_config_entry` goes through the services
endpoint, which wraps the call in `asyncio.shield` for exactly this reason.

Second commit: losing the reply is how a *successful* self-restart ends, so it
no longer logs `Deferred config-entry reload failed`. That phantom error is
what made the real wedge hard to diagnose. Connect errors and timeouts still
log loudly.

## Type of change
- [x] 🐛 Bug fix

## Testing
- [x] I have tested these changes with a LLM agent
- [x] Code follows style guidelines (`uv run ruff check`)

Verified live on HA 2026.8.0 in an embedded deployment, running the identical
`ha_dev_manage_server(action="restart")` against each build: the unfixed build
left the entry in `unload_in_progress` with the server dead until Home
Assistant was restarted, the first commit left it `loaded`, and both commits
together left it `loaded` with no phantom error logged.

Also adds HAOS e2e coverage for the gap that let this through: nothing
exercised the embedded self-reload. The only e2e touching `action: "restart"`
asserts it is *rejected* in standalone, and the HAOS add-on lifecycle tests
restart the add-on via Supervisor, which never reaches
`schedule_deferred_entry_reload`. The new test presses the ordinary Restart
button and asserts the entry returns to `loaded` and the server answers MCP
again.

Locally: 150 tests in `tests/src/unit/test_tools_dev.py` pass, ruff clean,
mypy clean on the changed file. Full suite left to CI.

## Checklist
- [ ] I have updated documentation if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved embedded configuration reloads by using Home Assistant’s reload service.
  * Embedded self-restarts now recover reliably and leave the configuration entry loaded.
  * Expected connection interruptions during self-reloads are handled gracefully without misleading errors.
  * Unexpected connection failures continue to be reported with full error details.
  * Improved cancellation safety during embedded restarts while preserving MCP responsiveness afterward.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->