### PR TITLE
fix: support opaque access tokens in OIDC mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ These run the server outside Home Assistant — useful for **Container** / **Cor
 - **Docker (HTTP server):** run `ghcr.io/homeassistant-ai/ha-mcp` in HTTP mode, pointed at your Home Assistant URL and a long-lived token, and connect your client to its secret URL. See the [Setup Wizard](https://homeassistant-ai.github.io/ha-mcp/setup/) for the full command and per-client config.
 - **PyPI / uvx (HTTP server):** run the published `ha-mcp` package with `uvx ha-mcp@latest` (or pip) as a streamable-HTTP server the same way. Details in the [Setup Wizard](https://homeassistant-ai.github.io/ha-mcp/setup/).
 - **Local stdio (not recommended):** runs ha-mcp on your own machine over stdio. The one-command installers in the **Demo server** section below use this path; the [Setup Wizard](https://homeassistant-ai.github.io/ha-mcp/setup/) covers connecting it to your own Home Assistant.
-- **OIDC authentication:** gate remote access behind an external identity provider (Authentik, Keycloak, Auth0, Google, etc.) instead of a secret URL — all authenticated users share the server's Home Assistant credentials. See [OIDC Mode](docs/oidc.md).
+- **OIDC authentication:** gate remote access behind an external identity provider (Authentik, Keycloak, Auth0, etc.) instead of a secret URL — all authenticated users share the server's Home Assistant credentials. See [OIDC Mode](docs/oidc.md).
 
   > ⚠️ **stdio has known transport issues.** The stdio transport has connection problems that streamable HTTP does not ([#1713](https://github.com/homeassistant-ai/ha-mcp/issues/1713)). It is recommended only for demo/testing tinkering — for a real setup, use the custom component or an HTTP method above.
 

--- a/docs/oidc.md
+++ b/docs/oidc.md
@@ -77,9 +77,9 @@ as [OAuth mode](OAUTH.md#1-expose-with-https)).
 | `HA_MCP_DISABLE_SETTINGS_UI` | Set truthy (`1`/`true`/`yes`/`on`) to not serve the web settings UI at all. | unset (UI served) |
 | `OIDC_JWT_SIGNING_KEY` | Optional. Secret key for signing FastMCP session JWTs. Sessions **persist across restarts by default** — when unset, FastMCP derives the signing key deterministically from `OIDC_CLIENT_SECRET`, so restarting the server does not log users out. Set this var to decouple the signing key from the client secret. To force a logout of all sessions, rotate whichever secret the key derives from (this var if set, otherwise `OIDC_CLIENT_SECRET`). Generate with: `python -c "import secrets; print(secrets.token_urlsafe(32))"` | Derived from `OIDC_CLIENT_SECRET` |
 | `OIDC_ALLOWED_CLIENT_REDIRECT_URIS` | Optional but **strongly recommended for internet-facing deployments**. Comma-separated list of redirect URI patterns accepted from dynamically-registered clients. Open dynamic client registration (DCR) lets an attacker register their own client with their own redirect URI; setting this constrains what any dynamically-registered client may register in the first place. | no allow-list — each dynamically-registered client's own redirect URIs are accepted |
-| `OIDC_VERIFY_ID_TOKEN` | Optional. Set `true` for OIDC providers that issue opaque access tokens the default JWT verifier can't validate (e.g. Google always; Auth0 without an API audience configured). | `false` |
+| `OIDC_VERIFY_ID_TOKEN` | Optional. Set `true` for OIDC providers that issue opaque access tokens the default JWT verifier cannot validate (e.g. Authelia and Google; Auth0 without an API audience configured). ha-mcp always requests `openid`, so these providers return the ID token FastMCP verifies instead. | `false` |
 | `OIDC_AUDIENCE` | Optional. Expected `aud` claim for IdP-issued access tokens. Without it (and with `OIDC_VERIFY_ID_TOKEN` off), FastMCP's JWT verifier checks issuer, signature, and expiry but not audience — fine on a dedicated IdP, weaker on a shared one where other clients' tokens would also pass. With `OIDC_VERIFY_ID_TOKEN=true`, verification instead pins `aud` to `OIDC_CLIENT_ID` and this value is not used for verification — it is still forwarded to the IdP's authorize/token endpoints, which is exactly what makes Auth0 issue JWT rather than opaque access tokens (see the `OIDC_VERIFY_ID_TOKEN` row). | Unset (no audience check) |
-| `LOG_LEVEL` | Logging level | `INFO` |
+| `LOG_LEVEL` | Logging level for ha-mcp and FastMCP, including OIDC token-validation diagnostics | `INFO` |
 
 ## IdP Client Registration
 
@@ -87,6 +87,8 @@ When registering ha-mcp as an OAuth/OIDC application with your provider:
 
 - **Redirect URI:** `<MCP_BASE_URL>/auth/callback`
 - **Grant type:** Authorization Code
+- **Allowed scope:** `openid`. ha-mcp always requests this protocol-level OIDC
+  scope, so the provider must allow it for the registered client.
 - **Token endpoint auth method:** **Client Secret Basic.** ha-mcp's OIDC
   client (via authlib) does not pass `token_endpoint_auth_method`, so it uses
   authlib's default, which is Client Secret Basic — not Client Secret Post.
@@ -106,9 +108,15 @@ OIDC mode works out of the box with providers that issue **JWT access
 tokens** — Authentik and Keycloak are known to work without extra
 configuration.
 
-Providers that issue **opaque access tokens** (not JWTs) need
-`OIDC_VERIFY_ID_TOKEN=true` so FastMCP verifies the ID token instead of the
-access token:
+ha-mcp always requests the required `openid` scope. Providers that issue
+**opaque access tokens** (not JWTs) also need `OIDC_VERIFY_ID_TOKEN=true` so
+FastMCP verifies the returned ID token instead of trying to parse the access
+token as a JWT:
+
+- **Authelia** issues opaque access tokens by default. Allow `openid` in the
+  client's `scopes` and set `OIDC_VERIFY_ID_TOKEN=true` for ha-mcp. You do not
+  need to change Authelia's `access_token_signed_response_alg` to enable JWT
+  access tokens.
 - **Google** always issues opaque access tokens.
 - **Auth0** issues opaque access tokens unless the client requests a
   configured API audience.

--- a/docs/oidc.md
+++ b/docs/oidc.md
@@ -79,7 +79,8 @@ as [OAuth mode](OAUTH.md#1-expose-with-https)).
 | `OIDC_ALLOWED_CLIENT_REDIRECT_URIS` | Optional but **strongly recommended for internet-facing deployments**. Comma-separated list of redirect URI patterns accepted from dynamically-registered clients. Open dynamic client registration (DCR) lets an attacker register their own client with their own redirect URI; setting this constrains what any dynamically-registered client may register in the first place. | no allow-list — each dynamically-registered client's own redirect URIs are accepted |
 | `OIDC_VERIFY_ID_TOKEN` | Optional. Set `true` for OIDC providers that issue opaque access tokens the default JWT verifier cannot validate (e.g. Authelia, or Auth0 without an API audience configured). ha-mcp always requests `openid`, so these providers return the ID token FastMCP verifies instead. | `false` |
 | `OIDC_AUDIENCE` | Optional. Expected `aud` claim for IdP-issued access tokens. Without it (and with `OIDC_VERIFY_ID_TOKEN` off), FastMCP's JWT verifier checks issuer, signature, and expiry but not audience — fine on a dedicated IdP, weaker on a shared one where other clients' tokens would also pass. With `OIDC_VERIFY_ID_TOKEN=true`, verification instead pins `aud` to `OIDC_CLIENT_ID` and this value is not used for verification — it is still forwarded to the IdP's authorize/token endpoints, which is exactly what makes Auth0 issue JWT rather than opaque access tokens (see the `OIDC_VERIFY_ID_TOKEN` row). | Unset (no audience check) |
-| `LOG_LEVEL` | Logging level for ha-mcp and FastMCP, including OIDC token-validation diagnostics | `INFO` |
+| `LOG_LEVEL` | Logging level for ha-mcp and, when FastMCP logging is enabled, FastMCP's OIDC token-validation diagnostics | `INFO` |
+| `FASTMCP_LOG_ENABLED` | Set `false` to disable FastMCP framework logging entirely. ha-mcp preserves this opt-out instead of routing FastMCP records through its root logger. | `true` |
 
 ## IdP Client Registration
 
@@ -100,6 +101,27 @@ Example discovery URLs:
 - Authentik: `https://auth.example.com/application/o/<app-slug>/.well-known/openid-configuration`
 - Keycloak: `https://keycloak.example.com/realms/<realm>/.well-known/openid-configuration`
 - Auth0: `https://<tenant>.auth0.com/.well-known/openid-configuration`
+
+## Client Scopes and Upgrades
+
+ha-mcp keeps `openid` as the required, default, and advertised scope. A client
+that omits `scope` during dynamic client registration (DCR) therefore receives
+`openid`, and MCP clients discover only `openid` in protected-resource
+metadata. If a client explicitly requests optional provider scopes such as
+`profile`, `email`, or `offline_access`, ha-mcp retains them and adds `openid`
+when the client omitted it. The compatibility layer also adds `openid` to every
+upstream authorization request, including requests from clients that supplied
+only optional scopes. ha-mcp does not advertise or request optional scopes on
+the client's behalf; the upstream identity provider's client and user policy
+decides whether to grant the optional scopes the client requested.
+
+After upgrading from a version that did not require `openid`, ha-mcp retains
+persisted DCR registrations and adds `openid` to a registration the first time
+it is loaded. A refresh token issued before the fix without `openid` is rejected
+so the client starts authorization once and obtains a compliant token. The DCR
+registration remains intact during this reauthorization. Most clients restart
+authorization automatically; manually clearing the client's connector or
+authorization cache is only a fallback for a client that does not.
 
 ## Provider Compatibility
 

--- a/docs/oidc.md
+++ b/docs/oidc.md
@@ -117,8 +117,9 @@ decides whether to grant the optional scopes the client requested.
 
 After upgrading from a version that did not require `openid`, ha-mcp retains
 persisted DCR registrations and adds `openid` to a registration the first time
-it is loaded. A refresh token issued before the fix without `openid` is rejected
-so the client starts authorization once and obtains a compliant token. The DCR
+it is loaded. A live access token issued before the fix without `openid` is
+rejected on its next MCP request, and its legacy refresh token is rejected too,
+so the client starts authorization once and obtains compliant tokens. The DCR
 registration remains intact during this reauthorization. Most clients restart
 authorization automatically; manually clearing the client's connector or
 authorization cache is only a fallback for a client that does not.

--- a/docs/oidc.md
+++ b/docs/oidc.md
@@ -1,7 +1,7 @@
 # OIDC Authentication for ha-mcp
 
 OIDC mode gates access to the MCP server behind an external identity provider
-(Authentik, Keycloak, Auth0, Google, etc.). Unlike [OAuth mode](OAUTH.md),
+(Authentik, Keycloak, Auth0, etc.). Unlike [OAuth mode](OAUTH.md),
 which collects a per-user Home Assistant Long-Lived Access Token via a consent
 form, OIDC is purely an **access gate**: once a user authenticates through
 your OIDC provider, all requests share the same Home Assistant credentials
@@ -77,7 +77,7 @@ as [OAuth mode](OAUTH.md#1-expose-with-https)).
 | `HA_MCP_DISABLE_SETTINGS_UI` | Set truthy (`1`/`true`/`yes`/`on`) to not serve the web settings UI at all. | unset (UI served) |
 | `OIDC_JWT_SIGNING_KEY` | Optional. Secret key for signing FastMCP session JWTs. Sessions **persist across restarts by default** — when unset, FastMCP derives the signing key deterministically from `OIDC_CLIENT_SECRET`, so restarting the server does not log users out. Set this var to decouple the signing key from the client secret. To force a logout of all sessions, rotate whichever secret the key derives from (this var if set, otherwise `OIDC_CLIENT_SECRET`). Generate with: `python -c "import secrets; print(secrets.token_urlsafe(32))"` | Derived from `OIDC_CLIENT_SECRET` |
 | `OIDC_ALLOWED_CLIENT_REDIRECT_URIS` | Optional but **strongly recommended for internet-facing deployments**. Comma-separated list of redirect URI patterns accepted from dynamically-registered clients. Open dynamic client registration (DCR) lets an attacker register their own client with their own redirect URI; setting this constrains what any dynamically-registered client may register in the first place. | no allow-list — each dynamically-registered client's own redirect URIs are accepted |
-| `OIDC_VERIFY_ID_TOKEN` | Optional. Set `true` for OIDC providers that issue opaque access tokens the default JWT verifier cannot validate (e.g. Authelia and Google; Auth0 without an API audience configured). ha-mcp always requests `openid`, so these providers return the ID token FastMCP verifies instead. | `false` |
+| `OIDC_VERIFY_ID_TOKEN` | Optional. Set `true` for OIDC providers that issue opaque access tokens the default JWT verifier cannot validate (e.g. Authelia, or Auth0 without an API audience configured). ha-mcp always requests `openid`, so these providers return the ID token FastMCP verifies instead. | `false` |
 | `OIDC_AUDIENCE` | Optional. Expected `aud` claim for IdP-issued access tokens. Without it (and with `OIDC_VERIFY_ID_TOKEN` off), FastMCP's JWT verifier checks issuer, signature, and expiry but not audience — fine on a dedicated IdP, weaker on a shared one where other clients' tokens would also pass. With `OIDC_VERIFY_ID_TOKEN=true`, verification instead pins `aud` to `OIDC_CLIENT_ID` and this value is not used for verification — it is still forwarded to the IdP's authorize/token endpoints, which is exactly what makes Auth0 issue JWT rather than opaque access tokens (see the `OIDC_VERIFY_ID_TOKEN` row). | Unset (no audience check) |
 | `LOG_LEVEL` | Logging level for ha-mcp and FastMCP, including OIDC token-validation diagnostics | `INFO` |
 
@@ -100,7 +100,6 @@ Example discovery URLs:
 - Authentik: `https://auth.example.com/application/o/<app-slug>/.well-known/openid-configuration`
 - Keycloak: `https://keycloak.example.com/realms/<realm>/.well-known/openid-configuration`
 - Auth0: `https://<tenant>.auth0.com/.well-known/openid-configuration`
-- Google: `https://accounts.google.com/.well-known/openid-configuration`
 
 ## Provider Compatibility
 
@@ -117,7 +116,6 @@ token as a JWT:
   client's `scopes` and set `OIDC_VERIFY_ID_TOKEN=true` for ha-mcp. You do not
   need to change Authelia's `access_token_signed_response_alg` to enable JWT
   access tokens.
-- **Google** always issues opaque access tokens.
 - **Auth0** issues opaque access tokens unless the client requests a
   configured API audience.
 

--- a/docs/superpowers/plans/2026-08-10-oidc-authelia-scope-fix.md
+++ b/docs/superpowers/plans/2026-08-10-oidc-authelia-scope-fix.md
@@ -1,0 +1,637 @@
+# OIDC Authelia Scope and Diagnostics Fix Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the standalone/container `ha-mcp-oidc` entrypoint work with Authelia's default opaque access tokens by always requesting `openid`, while making `LOG_LEVEL` control FastMCP's OIDC diagnostics and documenting the required configuration.
+
+**Architecture:** Keep FastMCP's existing OIDC proxy and token-verification design. Supply the protocol-level `openid` scope through `OIDCProxy.required_scopes`, retain opt-in ID-token verification for opaque access-token providers, and bridge ha-mcp's common logging level into FastMCP's non-propagating logger without replacing FastMCP's handlers.
+
+**Tech Stack:** Python 3.13, FastMCP 3.4.6 `OIDCProxy`, MCP Python SDK 1.28.1, pytest/pytest-asyncio, Ruff, mypy, Markdown, GitHub CLI.
+
+## Global Constraints
+
+- Work only in `/data/data/com.termux/files/home/ha-mcp/worktree/fix-oidc-authelia` on branch `agent/fix-oidc-authelia`; never modify or commit from `master` or the user's dirty main checkout.
+- The behavior change applies only to the standalone/container `ha-mcp-oidc` entrypoint; do not alter the Home Assistant add-on, custom component, OAuth mode, audience/resource forwarding, redirect URI policy, or token endpoint authentication.
+- Always pass exactly `required_scopes=["openid"]`; do not make OIDC scopes configurable because `openid` is mandatory for this OIDC entrypoint.
+- Keep `OIDC_VERIFY_ID_TOKEN` opt-in: JWT access-token providers retain default verification, while Authelia and other opaque-access-token providers set it to `true`.
+- Preserve FastMCP's handlers and formatting; only set the `fastmcp` logger's level to the validated ha-mcp `LOG_LEVEL` value.
+- Do not require Authelia JWT access tokens or add introspection support.
+- Follow red-green TDD for both behavior changes, use `apply_patch` for source edits, and verify the branch and worktree before every commit.
+- Run Python setup and verification in the existing Ubuntu `proot-distro` environment with `UV_LINK_MODE=copy`; run pytest from the repository's `tests/` directory.
+- Create the GitHub pull request as a draft and do not mark it ready for review without explicit user approval.
+
+## File Map
+
+- `tests/src/unit/test_oidc_entrypoint.py`: pinned `OIDCProxy` constructor contract plus regression coverage for the required OIDC scope and FastMCP logger level.
+- `src/ha_mcp/__main__.py`: common logging setup and standalone/container OIDC proxy construction.
+- `docs/oidc.md`: operator guidance for `openid`, Authelia's opaque tokens, ID-token verification, and debug logging.
+- `docs/superpowers/specs/2026-08-10-oidc-authelia-scope-design.md`: already-approved behavior and non-goals; no further edit is planned.
+
+---
+
+### Task 1: Require the `openid` scope in OIDC mode
+
+**Files:**
+- Modify: `tests/src/unit/test_oidc_entrypoint.py:18-58,270-325,1177-1209`
+- Modify: `src/ha_mcp/__main__.py:1738-1754`
+
+**Interfaces:**
+- Consumes: FastMCP 3.4.6 `OIDCProxy.__init__(..., required_scopes: list[str] | None = None, ...)`.
+- Produces: `_run_oidc_server(...) -> None` constructs every OIDC proxy with `required_scopes=["openid"]`; the pinned mock records that exact list.
+
+- [ ] **Step 1: Verify the isolated branch and install the development environment**
+
+Run from the worktree:
+
+```bash
+pwd
+git rev-parse --abbrev-ref HEAD
+git status --short --branch
+proot-distro login ubuntu --bind /data/data/com.termux/files/home:/mnt/termux -- sh -lc 'cd /mnt/termux/ha-mcp/worktree/fix-oidc-authelia && UV_LINK_MODE=copy uv sync --group dev'
+```
+
+Expected: the path ends in `worktree/fix-oidc-authelia`, the branch is `agent/fix-oidc-authelia`, status contains only the committed design plus this plan when appropriate, and `uv sync` completes successfully.
+
+- [ ] **Step 2: Run the untouched OIDC unit file as a baseline**
+
+Run:
+
+```bash
+proot-distro login ubuntu --bind /data/data/com.termux/files/home:/mnt/termux -- sh -lc 'cd /mnt/termux/ha-mcp/worktree/fix-oidc-authelia/tests && HA_MCP_CONFIG_DIR=/tmp/ha-mcp-2189-baseline uv run pytest src/unit/test_oidc_entrypoint.py -q'
+```
+
+Expected: PASS. If it does not pass before test edits, stop and distinguish an environment/baseline failure from issue #2189 before changing production code.
+
+- [ ] **Step 3: Extend the pinned proxy mock and real-signature contract**
+
+In `_make_mock_oidc_proxy`, document `required_scopes` as a mandatory production argument, insert it after `require_authorization_consent`, and record it unconditionally:
+
+```python
+    ``required_scopes`` is mandatory in production. The remaining optional
+    constructor arguments default to the ``_UNSET`` sentinel and are only
+    recorded in ``capture`` when actually passed.
+
+    class MockOIDCProxy:
+        def __init__(
+            self,
+            *,
+            config_url,
+            client_id,
+            client_secret,
+            base_url,
+            require_authorization_consent,
+            required_scopes,
+            jwt_signing_key,
+            allowed_client_redirect_uris=_UNSET,
+            verify_id_token=_UNSET,
+            audience=_UNSET,
+        ):
+            capture["config_url"] = config_url
+            capture["client_id"] = client_id
+            capture["client_secret"] = client_secret
+            capture["base_url"] = base_url
+            capture["require_authorization_consent"] = require_authorization_consent
+            capture["required_scopes"] = required_scopes
+            capture["jwt_signing_key"] = jwt_signing_key
+```
+
+Add `"required_scopes"` to `run_oidc_server_kwargs` in `TestOIDCProxySignatureSubset`:
+
+```python
+        run_oidc_server_kwargs = {
+            "config_url",
+            "client_id",
+            "client_secret",
+            "base_url",
+            "require_authorization_consent",
+            "required_scopes",
+            "jwt_signing_key",
+            "allowed_client_redirect_uris",
+            "verify_id_token",
+            "audience",
+        }
+```
+
+- [ ] **Step 4: Write the failing OIDC-scope regression assertion**
+
+Rename the existing broad construction test and extend its contract:
+
+```python
+    @pytest.mark.asyncio
+    async def test_creates_oidc_proxy_with_required_openid_scope(self):
+        """OIDC mode should always require the protocol-level openid scope."""
+```
+
+Keep the existing setup and assertions, then add:
+
+```python
+        assert proxy_init_args["required_scopes"] == ["openid"]
+```
+
+- [ ] **Step 5: Run the regression test and verify the red state**
+
+Run:
+
+```bash
+proot-distro login ubuntu --bind /data/data/com.termux/files/home:/mnt/termux -- sh -lc 'cd /mnt/termux/ha-mcp/worktree/fix-oidc-authelia/tests && HA_MCP_CONFIG_DIR=/tmp/ha-mcp-2189-red-scope uv run pytest src/unit/test_oidc_entrypoint.py::TestRunOidcServer::test_creates_oidc_proxy_with_required_openid_scope -q'
+```
+
+Expected: FAIL with `TypeError` reporting that `MockOIDCProxy.__init__()` is missing the required keyword-only argument `required_scopes`. This proves current production never supplies the scope.
+
+- [ ] **Step 6: Implement the minimum production fix**
+
+Add the required scope to the always-present `proxy_kwargs` mapping immediately after the consent setting:
+
+```python
+        # This entrypoint provides OIDC, so request the protocol-level scope
+        # that makes upstream providers return an ID token. FastMCP also
+        # advertises this scope through protected resource metadata so MCP
+        # clients include it in the authorization flow.
+        "required_scopes": ["openid"],
+```
+
+The complete surrounding contract must remain:
+
+```python
+    proxy_kwargs: dict[str, Any] = {
+        "config_url": config_url,
+        "client_id": client_id,
+        "client_secret": client_secret,
+        "base_url": base_url,
+        # "external" tells FastMCP that consent is handled by the upstream
+        # IdP (Authentik, Keycloak, etc.) -- unlike `False`, this does not
+        # log a security warning at startup that consent is disabled.
+        "require_authorization_consent": "external",
+        # This entrypoint provides OIDC, so request the protocol-level scope
+        # that makes upstream providers return an ID token. FastMCP also
+        # advertises this scope through protected resource metadata so MCP
+        # clients include it in the authorization flow.
+        "required_scopes": ["openid"],
+        # Preserve `or None`: an empty-but-set env var must not bypass
+        # FastMCP's derive-from-client-secret default for jwt_signing_key.
+        "jwt_signing_key": os.getenv("OIDC_JWT_SIGNING_KEY") or None,
+    }
+```
+
+- [ ] **Step 7: Run the scope and signature tests and verify green**
+
+Run:
+
+```bash
+proot-distro login ubuntu --bind /data/data/com.termux/files/home:/mnt/termux -- sh -lc 'cd /mnt/termux/ha-mcp/worktree/fix-oidc-authelia/tests && HA_MCP_CONFIG_DIR=/tmp/ha-mcp-2189-green-scope uv run pytest src/unit/test_oidc_entrypoint.py::TestRunOidcServer::test_creates_oidc_proxy_with_required_openid_scope src/unit/test_oidc_entrypoint.py::TestOIDCProxySignatureSubset::test_run_oidc_server_kwargs_are_subset_of_oidc_proxy_params -q'
+```
+
+Expected: `2 passed`.
+
+- [ ] **Step 8: Verify location and branch, then commit the scope regression and fix**
+
+Run:
+
+```bash
+pwd
+git rev-parse --abbrev-ref HEAD
+git diff --check
+git add src/ha_mcp/__main__.py tests/src/unit/test_oidc_entrypoint.py
+git commit -m "fix: require openid scope in OIDC mode"
+```
+
+Expected: a commit on `agent/fix-oidc-authelia`, never on `master` or `main`.
+
+---
+
+### Task 2: Make `LOG_LEVEL` control FastMCP diagnostics
+
+**Files:**
+- Modify: `tests/src/unit/test_oidc_entrypoint.py:7-10,187-269`
+- Modify: `src/ha_mcp/__main__.py:485-518`
+
+**Interfaces:**
+- Consumes: `_setup_logging(log_level_str: str, force: bool = True) -> None` and Python's `logging.getLogger("fastmcp")`.
+- Produces: `_setup_logging` sets both the root configuration and the `fastmcp` logger to the same numeric level while leaving FastMCP's handler and `propagate` configuration untouched.
+
+- [ ] **Step 1: Write the failing FastMCP logging regression test**
+
+Add `import logging` with the standard-library imports at the top of `tests/src/unit/test_oidc_entrypoint.py`:
+
+```python
+import logging
+import os
+```
+
+Add this test to `TestMainOidcLogging`:
+
+```python
+    def test_setup_logging_configures_fastmcp_logger(self):
+        """LOG_LEVEL should apply to FastMCP's non-propagating logger."""
+        import ha_mcp.__main__ as main_module
+
+        fastmcp_logger = logging.getLogger("fastmcp")
+        original_level = fastmcp_logger.level
+        try:
+            fastmcp_logger.setLevel(logging.INFO)
+            main_module._setup_logging("DEBUG", force=False)
+            assert fastmcp_logger.getEffectiveLevel() == logging.DEBUG
+        finally:
+            fastmcp_logger.setLevel(original_level)
+```
+
+Use `force=False` so the test does not replace pytest's root handlers; the behavior under test is the explicit FastMCP logger-level bridge.
+
+- [ ] **Step 2: Run the logging regression test and verify the red state**
+
+Run:
+
+```bash
+proot-distro login ubuntu --bind /data/data/com.termux/files/home:/mnt/termux -- sh -lc 'cd /mnt/termux/ha-mcp/worktree/fix-oidc-authelia/tests && HA_MCP_CONFIG_DIR=/tmp/ha-mcp-2189-red-logging uv run pytest src/unit/test_oidc_entrypoint.py::TestMainOidcLogging::test_setup_logging_configures_fastmcp_logger -q'
+```
+
+Expected: FAIL because the FastMCP logger remains at `logging.INFO` (`20`) rather than `logging.DEBUG` (`10`).
+
+- [ ] **Step 3: Implement the minimum common logging bridge**
+
+Resolve the numeric level once and reuse it in `_setup_logging`:
+
+```python
+    log_level = getattr(logging, log_level_str)
+
+    from ha_mcp.utils.usage_logger import preserve_startup_collector
+
+    with preserve_startup_collector():
+        logging.basicConfig(
+            level=log_level,
+            format="%(asctime)s %(name)s %(levelname)s: %(message)s",
+            datefmt=_LOG_DATE_FORMAT,
+            force=force,
+        )
+
+    # FastMCP configures its own handler and disables propagation, so the root
+    # level above does not control its OIDC diagnostics. Preserve that handler
+    # and formatting while honoring ha-mcp's LOG_LEVEL setting.
+    logging.getLogger("fastmcp").setLevel(log_level)
+```
+
+Leave the existing `mcp.server.streamable_http` and `fastmcp.server.server` filters immediately after this block.
+
+- [ ] **Step 4: Run the logging regression test and verify green**
+
+Run:
+
+```bash
+proot-distro login ubuntu --bind /data/data/com.termux/files/home:/mnt/termux -- sh -lc 'cd /mnt/termux/ha-mcp/worktree/fix-oidc-authelia/tests && HA_MCP_CONFIG_DIR=/tmp/ha-mcp-2189-green-logging uv run pytest src/unit/test_oidc_entrypoint.py::TestMainOidcLogging::test_setup_logging_configures_fastmcp_logger -q'
+```
+
+Expected: `1 passed`.
+
+- [ ] **Step 5: Run all logging and OIDC proxy construction tests**
+
+Run:
+
+```bash
+proot-distro login ubuntu --bind /data/data/com.termux/files/home:/mnt/termux -- sh -lc 'cd /mnt/termux/ha-mcp/worktree/fix-oidc-authelia/tests && HA_MCP_CONFIG_DIR=/tmp/ha-mcp-2189-green-focused uv run pytest src/unit/test_oidc_entrypoint.py::TestMainOidcLogging src/unit/test_oidc_entrypoint.py::TestRunOidcServer src/unit/test_oidc_entrypoint.py::TestOIDCProxySignatureSubset -q'
+```
+
+Expected: all selected tests pass.
+
+- [ ] **Step 6: Verify location and branch, then commit the logging regression and fix**
+
+Run:
+
+```bash
+pwd
+git rev-parse --abbrev-ref HEAD
+git diff --check
+git add src/ha_mcp/__main__.py tests/src/unit/test_oidc_entrypoint.py
+git commit -m "fix: apply log level to FastMCP"
+```
+
+Expected: a second atomic implementation commit on `agent/fix-oidc-authelia`.
+
+---
+
+### Task 3: Document Authelia's working OIDC configuration
+
+**Files:**
+- Modify: `docs/oidc.md:1-117`
+- Modify: `src/ha_mcp/__main__.py:1618-1625`
+
+**Interfaces:**
+- Consumes: the Task 1 guarantee that `openid` is always requested and the existing `OIDC_VERIFY_ID_TOKEN` environment variable.
+- Produces: standalone/container operator guidance that distinguishes opaque access-token providers from JWT access-token providers and gives exact Authelia settings.
+
+- [ ] **Step 1: Update the entrypoint help text for opaque-token providers**
+
+Replace the `OIDC_VERIFY_ID_TOKEN` description in `main_oidc`'s docstring with:
+
+```python
+    - OIDC_VERIFY_ID_TOKEN (optional, default: false): Set true for providers that issue
+      opaque access tokens (e.g. Authelia and Google, or Auth0 without an API audience).
+```
+
+- [ ] **Step 2: Update the environment-variable table**
+
+Replace the two relevant rows with:
+
+```markdown
+| `OIDC_VERIFY_ID_TOKEN` | Optional. Set `true` for OIDC providers that issue opaque access tokens the default JWT verifier cannot validate (e.g. Authelia and Google; Auth0 without an API audience configured). ha-mcp always requests `openid`, so these providers return the ID token FastMCP verifies instead. | `false` |
+| `LOG_LEVEL` | Logging level for ha-mcp and FastMCP, including OIDC token-validation diagnostics | `INFO` |
+```
+
+Keep the existing `OIDC_AUDIENCE` row between these rows.
+
+- [ ] **Step 3: State the required client scope in IdP registration**
+
+Add this bullet after the authorization-code grant type:
+
+```markdown
+- **Allowed scope:** `openid`. ha-mcp always requests this protocol-level OIDC
+  scope, so the provider must allow it for the registered client.
+```
+
+- [ ] **Step 4: Replace provider compatibility guidance with exact opaque-token behavior**
+
+Replace the current `Provider Compatibility` body with:
+
+```markdown
+OIDC mode works out of the box with providers that issue **JWT access
+tokens** — Authentik and Keycloak are known to work without extra
+configuration.
+
+ha-mcp always requests the required `openid` scope. Providers that issue
+**opaque access tokens** (not JWTs) also need `OIDC_VERIFY_ID_TOKEN=true` so
+FastMCP verifies the returned ID token instead of trying to parse the access
+token as a JWT:
+
+- **Authelia** issues opaque access tokens by default. Allow `openid` in the
+  client's `scopes` and set `OIDC_VERIFY_ID_TOKEN=true` for ha-mcp. You do not
+  need to change Authelia's `access_token_signed_response_alg` to enable JWT
+  access tokens.
+- **Google** always issues opaque access tokens.
+- **Auth0** issues opaque access tokens unless the client requests a
+  configured API audience.
+```
+
+- [ ] **Step 5: Review the rendered prose against the standalone/container boundary**
+
+Run:
+
+```bash
+rg -n "openid|Authelia|OIDC_VERIFY_ID_TOKEN|access_token_signed_response_alg|LOG_LEVEL" docs/oidc.md src/ha_mcp/__main__.py
+git diff -- docs/oidc.md src/ha_mcp/__main__.py
+git diff --check
+```
+
+Expected: every instruction refers to OIDC mode, no add-on/custom-component guidance changes, and the diff has no whitespace errors.
+
+- [ ] **Step 6: Verify location and branch, then commit the documentation**
+
+Run:
+
+```bash
+pwd
+git rev-parse --abbrev-ref HEAD
+git add docs/oidc.md src/ha_mcp/__main__.py
+git commit -m "docs: explain Authelia OIDC configuration"
+```
+
+Expected: an atomic documentation commit on `agent/fix-oidc-authelia`.
+
+---
+
+### Task 4: Verify the complete change and prove the regressions
+
+**Files:**
+- Verify: `src/ha_mcp/__main__.py`
+- Verify: `tests/src/unit/test_oidc_entrypoint.py`
+- Verify: `docs/oidc.md`
+
+**Interfaces:**
+- Consumes: the completed Task 1-3 commits.
+- Produces: fresh local evidence for unit behavior, formatting, lint, typing, and red-green causality before publication.
+
+- [ ] **Step 1: Run the complete OIDC unit file**
+
+Run:
+
+```bash
+proot-distro login ubuntu --bind /data/data/com.termux/files/home:/mnt/termux -- sh -lc 'cd /mnt/termux/ha-mcp/worktree/fix-oidc-authelia/tests && HA_MCP_CONFIG_DIR=/tmp/ha-mcp-2189-final-unit uv run pytest src/unit/test_oidc_entrypoint.py -q'
+```
+
+Expected: all tests in `test_oidc_entrypoint.py` pass.
+
+- [ ] **Step 2: Run formatting, lint, and type verification**
+
+Run each command separately from the worktree:
+
+```bash
+proot-distro login ubuntu --bind /data/data/com.termux/files/home:/mnt/termux -- sh -lc 'cd /mnt/termux/ha-mcp/worktree/fix-oidc-authelia && UV_LINK_MODE=copy uv run ruff format --check src/ha_mcp/__main__.py tests/src/unit/test_oidc_entrypoint.py'
+proot-distro login ubuntu --bind /data/data/com.termux/files/home:/mnt/termux -- sh -lc 'cd /mnt/termux/ha-mcp/worktree/fix-oidc-authelia && UV_LINK_MODE=copy uv run ruff check src/ha_mcp/__main__.py tests/src/unit/test_oidc_entrypoint.py'
+proot-distro login ubuntu --bind /data/data/com.termux/files/home:/mnt/termux -- sh -lc 'cd /mnt/termux/ha-mcp/worktree/fix-oidc-authelia && UV_LINK_MODE=copy uv run mypy src/'
+git diff --check origin/master...HEAD
+```
+
+Expected: every command exits zero. Do not describe repository-wide tests as locally passing because no relevant live-IdP/E2E fixture exists; GitHub's ordinary E2E workflow supplies the repository-wide lane.
+
+- [ ] **Step 3: Run the repository's full E2E command**
+
+The repository's issue-to-PR workflow requires the full E2E command even
+though this entrypoint has no live-IdP E2E fixture. Run it and let pytest
+report the actual Docker availability rather than assuming prerequisites are
+missing:
+
+```bash
+proot-distro login ubuntu --bind /data/data/com.termux/files/home:/mnt/termux -- sh -lc 'cd /mnt/termux/ha-mcp/worktree/fix-oidc-authelia/tests && UV_LINK_MODE=copy uv run pytest src/e2e/ -n2 --dist loadscope -v --tb=short'
+```
+
+Expected: the suite passes when Docker is available. If the Android/proot
+environment cannot reach a Docker daemon, retain the exact collection or
+connection failure as local-environment evidence and require the GitHub E2E
+workflow to pass before the PR is reported merge-ready.
+
+- [ ] **Step 4: Temporarily remove both production fixes with `apply_patch`**
+
+Use `apply_patch` to remove only:
+
+```python
+        "required_scopes": ["openid"],
+```
+
+and:
+
+```python
+    logging.getLogger("fastmcp").setLevel(log_level)
+```
+
+Retain the regression tests. Do not stage or commit this temporary mutation.
+
+- [ ] **Step 5: Run both regression tests and require failure**
+
+Run:
+
+```bash
+proot-distro login ubuntu --bind /data/data/com.termux/files/home:/mnt/termux -- sh -lc 'cd /mnt/termux/ha-mcp/worktree/fix-oidc-authelia/tests && HA_MCP_CONFIG_DIR=/tmp/ha-mcp-2189-mutation uv run pytest src/unit/test_oidc_entrypoint.py::TestRunOidcServer::test_creates_oidc_proxy_with_required_openid_scope src/unit/test_oidc_entrypoint.py::TestMainOidcLogging::test_setup_logging_configures_fastmcp_logger -q'
+```
+
+Expected: both tests fail for their intended reasons: missing `required_scopes` and FastMCP remaining at INFO.
+
+- [ ] **Step 6: Restore both fixes with `apply_patch` and rerun the regressions**
+
+Restore the exact Task 1 scope line/comment and Task 2 logger-level line/comment. Then run:
+
+```bash
+proot-distro login ubuntu --bind /data/data/com.termux/files/home:/mnt/termux -- sh -lc 'cd /mnt/termux/ha-mcp/worktree/fix-oidc-authelia/tests && HA_MCP_CONFIG_DIR=/tmp/ha-mcp-2189-restored uv run pytest src/unit/test_oidc_entrypoint.py::TestRunOidcServer::test_creates_oidc_proxy_with_required_openid_scope src/unit/test_oidc_entrypoint.py::TestMainOidcLogging::test_setup_logging_configures_fastmcp_logger -q'
+git diff --check
+git status --short --branch
+```
+
+Expected: `2 passed` and a clean tracked working tree. If restoration changes a committed line, compare it with `git diff HEAD -- src/ha_mcp/__main__.py` and correct it before proceeding.
+
+- [ ] **Step 7: Request the required read-only code review**
+
+Resolve the literal base and head SHAs with:
+
+```bash
+git merge-base origin/master HEAD
+git rev-parse HEAD
+```
+
+Use the `superpowers:requesting-code-review` reviewer template. Give the reviewer the approved spec at `docs/superpowers/specs/2026-08-10-oidc-authelia-scope-design.md`, this plan, the literal SHAs returned above, and a read-only instruction. Require review of plan alignment, OIDC security/compatibility, logger behavior, tests, and operator documentation.
+
+Expected: no Critical or Important finding remains. Validate every finding against current source and policy; fix valid findings with a new TDD cycle and atomic commit, rerun Task 4 verification, then request a fresh review.
+
+---
+
+### Task 5: Publish a draft PR and run the repository resolution loop
+
+**Files:**
+- Publish: commits on `agent/fix-oidc-authelia`
+- Create: one draft pull request against `homeassistant-ai/ha-mcp:master`
+
+**Interfaces:**
+- Consumes: clean reviewed commits and verified GitHub identity.
+- Produces: a draft PR containing `Fixes #2189`, green CI, and no unresolved review threads; it remains draft.
+
+- [ ] **Step 1: Verify final scope, identity, remotes, and branch**
+
+Run:
+
+```bash
+pwd
+git rev-parse --abbrev-ref HEAD
+git status --short --branch
+git diff --stat origin/master...HEAD
+git log --oneline origin/master..HEAD
+git remote -v
+gh auth status
+```
+
+Expected: the worktree is clean, branch is `agent/fix-oidc-authelia`, only the design/plan/scope/logging/docs commits are present, and the authenticated GitHub identity owns the selected writable fork remote.
+
+- [ ] **Step 2: Push the feature branch**
+
+Push to the verified writable fork remote. In the current checkout that remote is expected to be `fork`:
+
+```bash
+git push -u fork agent/fix-oidc-authelia
+```
+
+Expected: the branch is published without modifying `origin/master`.
+
+- [ ] **Step 3: Create the required draft PR with the exact scope**
+
+Create a temporary PR body with `apply_patch` at `/tmp/ha-mcp-2189-pr-body.md` containing:
+
+```markdown
+## Summary
+
+- require the `openid` scope in the standalone/container OIDC authorization flow
+- make `LOG_LEVEL` control FastMCP's OIDC token-validation diagnostics
+- document Authelia's default opaque access-token configuration
+
+## Testing
+
+- `cd tests && uv run pytest src/unit/test_oidc_entrypoint.py -q`
+- `uv run ruff format --check src/ha_mcp/__main__.py tests/src/unit/test_oidc_entrypoint.py`
+- `uv run ruff check src/ha_mcp/__main__.py tests/src/unit/test_oidc_entrypoint.py`
+- `uv run mypy src/`
+
+Fixes #2189
+```
+
+Then run:
+
+```bash
+gh pr create --draft --repo homeassistant-ai/ha-mcp --base master --head kingpanther13:agent/fix-oidc-authelia --title "fix: support opaque access tokens in OIDC mode" --body-file /tmp/ha-mcp-2189-pr-body.md
+```
+
+Expected: one draft PR URL. Read it back with `gh pr view --repo homeassistant-ai/ha-mcp --json number,url,isDraft,author,title,body,headRefName,baseRefName` and verify `isDraft: true`, the expected authenticated author, exact head/base, title, body, and `Fixes #2189`.
+
+- [ ] **Step 4: Wait for and inspect all CI checks**
+
+Use the branch name so the command resolves the newly created PR directly:
+
+```bash
+gh pr checks agent/fix-oidc-authelia --repo homeassistant-ai/ha-mcp --watch
+```
+
+Expected: every required check reaches a terminal success state. If a deterministic workflow fails, resolve its run ID and inspect it once:
+
+```bash
+TASK_FAILED_RUN_ID=$(gh run list --repo homeassistant-ai/ha-mcp --branch agent/fix-oidc-authelia --status failure --limit 1 --json databaseId --jq '.[0].databaseId')
+gh run view "$TASK_FAILED_RUN_ID" --repo homeassistant-ai/ha-mcp --log-failed
+```
+
+Diagnose and fix the root cause rather than repeatedly rerunning it.
+
+- [ ] **Step 5: Inspect comments and thread state after CI**
+
+Resolve the PR number from the unique head branch, then run all reads in the
+same shell session:
+
+```bash
+TASK_PR_NUMBER=$(gh pr view agent/fix-oidc-authelia --repo homeassistant-ai/ha-mcp --json number --jq '.number')
+gh api "repos/homeassistant-ai/ha-mcp/issues/$TASK_PR_NUMBER/comments"
+gh api "repos/homeassistant-ai/ha-mcp/pulls/$TASK_PR_NUMBER/comments"
+gh api graphql -F pr="$TASK_PR_NUMBER" -f query='query($pr: Int!) { repository(owner:"homeassistant-ai", name:"ha-mcp") { pullRequest(number:$pr) { reviews(first:100) { nodes { author { login } state body } } reviewThreads(first:100) { nodes { id isResolved comments(first:100) { nodes { databaseId author { login } body path line } } } } } } }'
+```
+
+Expected: all human and automated feedback is accounted for and no actionable unresolved thread remains.
+
+- [ ] **Step 6: Resolve failures or feedback for at most five iterations**
+
+For each valid finding, reproduce it where practical, add or update a regression test before production code, make an atomic commit after verifying branch/worktree location, push, and return to Steps 4-5. Reply to inline comments with the fixing commit and resolve their GraphQL thread only after the fix is pushed and verified. Do not dismiss technically questionable feedback without checking current source, docs, and tests.
+
+Expected terminal state: all CI green, all comments addressed, no unresolved actionable review threads, and the PR remains draft. If the same external blocker survives five resolution iterations, report the exact blocker rather than marking the PR ready or merging it.
+
+- [ ] **Step 7: Post the repository-required implementation summary**
+
+After checks and threads are clean, resolve the PR number and post this exact
+summary, adjusting only the local-E2E sentence if Docker was available:
+
+```bash
+TASK_PR_NUMBER=$(gh pr view agent/fix-oidc-authelia --repo homeassistant-ai/ha-mcp --json number --jq '.number')
+gh pr comment "$TASK_PR_NUMBER" --repo homeassistant-ai/ha-mcp --body '## Implementation Summary
+
+**Choices Made:**
+- Always request the protocol-level `openid` scope from the standalone/container OIDC proxy.
+- Keep ID-token verification opt-in for opaque access-token providers such as Authelia.
+- Apply ha-mcp `LOG_LEVEL` to FastMCP without replacing FastMCP handlers.
+
+**Problems Encountered:**
+- The original flow requested no `openid` scope, so Authelia returned no ID token while its default access token remained opaque.
+- The local Android/proot environment could not provide a Docker daemon; the pull request E2E workflow supplied full-suite verification.'
+```
+
+Read the comment back and verify the author and body. If Docker was available
+and the full suite passed locally, replace only the second Problems
+Encountered bullet with `- No implementation blockers; the full E2E suite passed locally and in GitHub Actions.`
+
+- [ ] **Step 8: Verify the final draft PR state and report**
+
+Run:
+
+```bash
+gh pr view agent/fix-oidc-authelia --repo homeassistant-ai/ha-mcp --json number,url,isDraft,mergeStateStatus,reviewDecision,statusCheckRollup,comments,reviews
+git status --short --branch
+```
+
+Expected: the final report can cite the PR URL, exact local verification, terminal CI status, and review-thread status. Do not run `gh pr ready`, merge, close the issue manually, delete the branch, or remove the worktree.

--- a/docs/superpowers/plans/2026-08-10-oidc-authelia-scope-fix.md
+++ b/docs/superpowers/plans/2026-08-10-oidc-authelia-scope-fix.md
@@ -11,7 +11,8 @@
 ## Global Constraints
 
 - Work only in `/data/data/com.termux/files/home/ha-mcp/worktree/fix-oidc-authelia` on branch `agent/fix-oidc-authelia`; never modify or commit from `master` or the user's dirty main checkout.
-- The behavior change applies only to the standalone/container `ha-mcp-oidc` entrypoint; do not alter the Home Assistant add-on, custom component, OAuth mode, audience/resource forwarding, redirect URI policy, or token endpoint authentication.
+- The OIDC scope and persisted-state compatibility behavior applies only to the standalone/container `ha-mcp-oidc` entrypoint; do not alter the Home Assistant add-on, custom component, OAuth mode, audience/resource forwarding, redirect URI policy, or token endpoint authentication.
+- The FastMCP logger-level bridge and `FASTMCP_LOG_ENABLED=false` protection are intentionally common behavior for every ha-mcp entrypoint that calls `_setup_logging`; they do not change those entrypoints' authentication models.
 - Always pass exactly `required_scopes=["openid"]`; do not make OIDC scopes configurable because `openid` is mandatory for this OIDC entrypoint.
 - Keep `openid` as the only required, default, and protected-resource-advertised scope. Do not copy every provider discovery scope into DCR metadata.
 - Permit DCR clients to explicitly request optional OIDC scopes, retain those scopes while adding missing `openid`, union `openid` into every authorization request, and leave final optional-scope authorization to the upstream IdP.
@@ -457,9 +458,30 @@ git diff --check origin/master...HEAD
 ```
 
 Expected: every command exits zero. These focused local checks cover the OIDC
-change; the pull request's ordinary CI supplies broad unit and E2E validation.
+change but are not complete E2E evidence.
 
-- [ ] **Step 3: Temporarily remove the entrypoint and logging fixes with `apply_patch`**
+- [ ] **Step 3: Require terminal E2E evidence from the pull request workflows**
+
+There is no live OIDC/IdP fixture in `tests/src/e2e/`, so do not invent or run a
+local OIDC E2E command. The required broad evidence comes from the pull request's
+full `E2E Tests` workflow and every applicable `HAOS E2E Tests` lane, including
+`HAOS E2E Tests (embedded)` and `HAOS E2E Tests (inaddon)` when scheduled.
+
+Use only read-only GitHub inspection commands:
+
+```bash
+gh pr checks 2194 --repo homeassistant-ai/ha-mcp --watch
+gh pr checks 2194 --repo homeassistant-ai/ha-mcp --json name,state,bucket,link,workflow
+gh run list --repo homeassistant-ai/ha-mcp --branch agent/fix-oidc-authelia --limit 100 --json databaseId,workflowName,status,conclusion,headSha,url
+gh run view <run-id> --repo homeassistant-ai/ha-mcp --log-failed
+```
+
+Expected: the full `E2E Tests` workflow and all applicable `HAOS E2E Tests`
+lanes reach terminal success on the current head. If a lane fails, use its run
+ID with the final command to inspect the failed log. Do not claim verification
+complete while any required E2E lane is queued, in progress, failed, or missing.
+
+- [ ] **Step 4: Temporarily remove the entrypoint and logging fixes with `apply_patch`**
 
 Use `apply_patch` to remove only:
 
@@ -483,7 +505,7 @@ captured in Task 1; do not replace `valid_scopes=None` with all provider scopes
 for a mutation test because that would recreate the over-broad advertised-scope
 behavior the design rejects.
 
-- [ ] **Step 4: Run three regression tests and require failure**
+- [ ] **Step 5: Run three regression tests and require failure**
 
 Run:
 
@@ -495,7 +517,7 @@ Expected: all three tests fail for their intended reasons: missing
 `required_scopes`, enabled FastMCP remaining at INFO, and disabled FastMCP
 records inheriting the root handler.
 
-- [ ] **Step 5: Restore both fixes with `apply_patch` and rerun the regressions**
+- [ ] **Step 6: Restore both fixes with `apply_patch` and rerun the regressions**
 
 Restore the exact Task 1 scope line/comment and Task 2 logger-level line/comment. Then run:
 
@@ -507,7 +529,7 @@ git status --short --branch
 
 Expected: `3 passed` and a clean tracked working tree. If restoration changes a committed line, compare it with `git diff HEAD -- src/ha_mcp/__main__.py` and correct it before proceeding.
 
-- [ ] **Step 6: Obtain approval, then request the read-only code review**
+- [ ] **Step 7: Obtain approval, then request the read-only code review**
 
 Resolve the literal base and head SHAs with:
 

--- a/docs/superpowers/plans/2026-08-10-oidc-authelia-scope-fix.md
+++ b/docs/superpowers/plans/2026-08-10-oidc-authelia-scope-fix.md
@@ -57,7 +57,7 @@ Expected: the path ends in `worktree/fix-oidc-authelia`, the branch is `agent/fi
 Run:
 
 ```bash
-proot-distro login ubuntu --bind /data/data/com.termux/files/home:/mnt/termux -- sh -lc 'cd /mnt/termux/ha-mcp/worktree/fix-oidc-authelia/tests && HA_MCP_CONFIG_DIR=/tmp/ha-mcp-2189-baseline uv run pytest src/unit/test_oidc_entrypoint.py -q'
+proot-distro login ubuntu --bind /data/data/com.termux/files/home:/mnt/termux -- sh -lc 'cd /mnt/termux/ha-mcp/worktree/fix-oidc-authelia/tests && HA_MCP_CONFIG_DIR=/tmp/ha-mcp-2189-baseline UV_LINK_MODE=copy uv run pytest src/unit/test_oidc_entrypoint.py -q'
 ```
 
 Expected: PASS. If it does not pass before test edits, stop and distinguish an environment/baseline failure from issue #2189 before changing production code.
@@ -133,7 +133,7 @@ Keep the existing setup and assertions, then add:
 Run:
 
 ```bash
-proot-distro login ubuntu --bind /data/data/com.termux/files/home:/mnt/termux -- sh -lc 'cd /mnt/termux/ha-mcp/worktree/fix-oidc-authelia/tests && HA_MCP_CONFIG_DIR=/tmp/ha-mcp-2189-red-scope uv run pytest src/unit/test_oidc_entrypoint.py::TestRunOidcServer::test_creates_oidc_proxy_with_required_openid_scope -q'
+proot-distro login ubuntu --bind /data/data/com.termux/files/home:/mnt/termux -- sh -lc 'cd /mnt/termux/ha-mcp/worktree/fix-oidc-authelia/tests && HA_MCP_CONFIG_DIR=/tmp/ha-mcp-2189-red-scope UV_LINK_MODE=copy uv run pytest src/unit/test_oidc_entrypoint.py::TestRunOidcServer::test_creates_oidc_proxy_with_required_openid_scope -q'
 ```
 
 Expected: FAIL with `TypeError` reporting that `MockOIDCProxy.__init__()` is missing the required keyword-only argument `required_scopes`. This proves current production never supplies the scope.
@@ -178,7 +178,7 @@ The complete surrounding contract must remain:
 Run:
 
 ```bash
-proot-distro login ubuntu --bind /data/data/com.termux/files/home:/mnt/termux -- sh -lc 'cd /mnt/termux/ha-mcp/worktree/fix-oidc-authelia/tests && HA_MCP_CONFIG_DIR=/tmp/ha-mcp-2189-green-scope uv run pytest src/unit/test_oidc_entrypoint.py::TestRunOidcServer::test_creates_oidc_proxy_with_required_openid_scope src/unit/test_oidc_entrypoint.py::TestOIDCProxySignatureSubset::test_run_oidc_server_kwargs_are_subset_of_oidc_proxy_params -q'
+proot-distro login ubuntu --bind /data/data/com.termux/files/home:/mnt/termux -- sh -lc 'cd /mnt/termux/ha-mcp/worktree/fix-oidc-authelia/tests && HA_MCP_CONFIG_DIR=/tmp/ha-mcp-2189-green-scope UV_LINK_MODE=copy uv run pytest src/unit/test_oidc_entrypoint.py::TestRunOidcServer::test_creates_oidc_proxy_with_required_openid_scope src/unit/test_oidc_entrypoint.py::TestOIDCProxySignatureSubset::test_run_oidc_server_kwargs_are_subset_of_oidc_proxy_params -q'
 ```
 
 Expected: `2 passed`.
@@ -226,13 +226,36 @@ Add this test to `TestMainOidcLogging`:
         import ha_mcp.__main__ as main_module
 
         fastmcp_logger = logging.getLogger("fastmcp")
+        streamable_http_logger = logging.getLogger("mcp.server.streamable_http")
+        fastmcp_server_logger = logging.getLogger("fastmcp.server.server")
         original_level = fastmcp_logger.level
+        original_handlers = fastmcp_logger.handlers[:]
+        original_propagate = fastmcp_logger.propagate
+        original_formatters = [handler.formatter for handler in original_handlers]
+        original_streamable_http_filters = streamable_http_logger.filters[:]
+        original_fastmcp_server_filters = fastmcp_server_logger.filters[:]
         try:
             fastmcp_logger.setLevel(logging.INFO)
             main_module._setup_logging("DEBUG", force=False)
             assert fastmcp_logger.getEffectiveLevel() == logging.DEBUG
+            assert fastmcp_logger.handlers == original_handlers
+            assert fastmcp_logger.propagate is original_propagate
+            assert all(
+                handler.formatter is formatter
+                for handler, formatter in zip(
+                    fastmcp_logger.handlers, original_formatters, strict=True
+                )
+            )
         finally:
             fastmcp_logger.setLevel(original_level)
+            fastmcp_logger.handlers[:] = original_handlers
+            fastmcp_logger.propagate = original_propagate
+            for handler, formatter in zip(
+                original_handlers, original_formatters, strict=True
+            ):
+                handler.setFormatter(formatter)
+            streamable_http_logger.filters[:] = original_streamable_http_filters
+            fastmcp_server_logger.filters[:] = original_fastmcp_server_filters
 ```
 
 Use `force=False` so the test does not replace pytest's root handlers; the behavior under test is the explicit FastMCP logger-level bridge.
@@ -242,7 +265,7 @@ Use `force=False` so the test does not replace pytest's root handlers; the behav
 Run:
 
 ```bash
-proot-distro login ubuntu --bind /data/data/com.termux/files/home:/mnt/termux -- sh -lc 'cd /mnt/termux/ha-mcp/worktree/fix-oidc-authelia/tests && HA_MCP_CONFIG_DIR=/tmp/ha-mcp-2189-red-logging uv run pytest src/unit/test_oidc_entrypoint.py::TestMainOidcLogging::test_setup_logging_configures_fastmcp_logger -q'
+proot-distro login ubuntu --bind /data/data/com.termux/files/home:/mnt/termux -- sh -lc 'cd /mnt/termux/ha-mcp/worktree/fix-oidc-authelia/tests && HA_MCP_CONFIG_DIR=/tmp/ha-mcp-2189-red-logging UV_LINK_MODE=copy uv run pytest src/unit/test_oidc_entrypoint.py::TestMainOidcLogging::test_setup_logging_configures_fastmcp_logger -q'
 ```
 
 Expected: FAIL because the FastMCP logger remains at `logging.INFO` (`20`) rather than `logging.DEBUG` (`10`).
@@ -277,7 +300,7 @@ Leave the existing `mcp.server.streamable_http` and `fastmcp.server.server` filt
 Run:
 
 ```bash
-proot-distro login ubuntu --bind /data/data/com.termux/files/home:/mnt/termux -- sh -lc 'cd /mnt/termux/ha-mcp/worktree/fix-oidc-authelia/tests && HA_MCP_CONFIG_DIR=/tmp/ha-mcp-2189-green-logging uv run pytest src/unit/test_oidc_entrypoint.py::TestMainOidcLogging::test_setup_logging_configures_fastmcp_logger -q'
+proot-distro login ubuntu --bind /data/data/com.termux/files/home:/mnt/termux -- sh -lc 'cd /mnt/termux/ha-mcp/worktree/fix-oidc-authelia/tests && HA_MCP_CONFIG_DIR=/tmp/ha-mcp-2189-green-logging UV_LINK_MODE=copy uv run pytest src/unit/test_oidc_entrypoint.py::TestMainOidcLogging::test_setup_logging_configures_fastmcp_logger -q'
 ```
 
 Expected: `1 passed`.
@@ -287,7 +310,7 @@ Expected: `1 passed`.
 Run:
 
 ```bash
-proot-distro login ubuntu --bind /data/data/com.termux/files/home:/mnt/termux -- sh -lc 'cd /mnt/termux/ha-mcp/worktree/fix-oidc-authelia/tests && HA_MCP_CONFIG_DIR=/tmp/ha-mcp-2189-green-focused uv run pytest src/unit/test_oidc_entrypoint.py::TestMainOidcLogging src/unit/test_oidc_entrypoint.py::TestRunOidcServer src/unit/test_oidc_entrypoint.py::TestOIDCProxySignatureSubset -q'
+proot-distro login ubuntu --bind /data/data/com.termux/files/home:/mnt/termux -- sh -lc 'cd /mnt/termux/ha-mcp/worktree/fix-oidc-authelia/tests && HA_MCP_CONFIG_DIR=/tmp/ha-mcp-2189-green-focused UV_LINK_MODE=copy uv run pytest src/unit/test_oidc_entrypoint.py::TestMainOidcLogging src/unit/test_oidc_entrypoint.py::TestRunOidcServer src/unit/test_oidc_entrypoint.py::TestOIDCProxySignatureSubset -q'
 ```
 
 Expected: all selected tests pass.
@@ -324,7 +347,7 @@ Replace the `OIDC_VERIFY_ID_TOKEN` description in `main_oidc`'s docstring with:
 
 ```python
     - OIDC_VERIFY_ID_TOKEN (optional, default: false): Set true for providers that issue
-      opaque access tokens (e.g. Authelia and Google, or Auth0 without an API audience).
+      opaque access tokens (e.g. Authelia, or Auth0 without an API audience).
 ```
 
 - [ ] **Step 2: Update the environment-variable table**
@@ -332,7 +355,7 @@ Replace the `OIDC_VERIFY_ID_TOKEN` description in `main_oidc`'s docstring with:
 Replace the two relevant rows with:
 
 ```markdown
-| `OIDC_VERIFY_ID_TOKEN` | Optional. Set `true` for OIDC providers that issue opaque access tokens the default JWT verifier cannot validate (e.g. Authelia and Google; Auth0 without an API audience configured). ha-mcp always requests `openid`, so these providers return the ID token FastMCP verifies instead. | `false` |
+| `OIDC_VERIFY_ID_TOKEN` | Optional. Set `true` for OIDC providers that issue opaque access tokens the default JWT verifier cannot validate (e.g. Authelia, or Auth0 without an API audience configured). ha-mcp always requests `openid`, so these providers return the ID token FastMCP verifies instead. | `false` |
 | `LOG_LEVEL` | Logging level for ha-mcp and FastMCP, including OIDC token-validation diagnostics | `INFO` |
 ```
 
@@ -365,7 +388,6 @@ token as a JWT:
   client's `scopes` and set `OIDC_VERIFY_ID_TOKEN=true` for ha-mcp. You do not
   need to change Authelia's `access_token_signed_response_alg` to enable JWT
   access tokens.
-- **Google** always issues opaque access tokens.
 - **Auth0** issues opaque access tokens unless the client requests a
   configured API audience.
 ```
@@ -413,7 +435,7 @@ Expected: an atomic documentation commit on `agent/fix-oidc-authelia`.
 Run:
 
 ```bash
-proot-distro login ubuntu --bind /data/data/com.termux/files/home:/mnt/termux -- sh -lc 'cd /mnt/termux/ha-mcp/worktree/fix-oidc-authelia/tests && HA_MCP_CONFIG_DIR=/tmp/ha-mcp-2189-final-unit uv run pytest src/unit/test_oidc_entrypoint.py -q'
+proot-distro login ubuntu --bind /data/data/com.termux/files/home:/mnt/termux -- sh -lc 'cd /mnt/termux/ha-mcp/worktree/fix-oidc-authelia/tests && HA_MCP_CONFIG_DIR=/tmp/ha-mcp-2189-final-unit UV_LINK_MODE=copy uv run pytest src/unit/test_oidc_entrypoint.py -q'
 ```
 
 Expected: all tests in `test_oidc_entrypoint.py` pass.
@@ -468,7 +490,7 @@ Retain the regression tests. Do not stage or commit this temporary mutation.
 Run:
 
 ```bash
-proot-distro login ubuntu --bind /data/data/com.termux/files/home:/mnt/termux -- sh -lc 'cd /mnt/termux/ha-mcp/worktree/fix-oidc-authelia/tests && HA_MCP_CONFIG_DIR=/tmp/ha-mcp-2189-mutation uv run pytest src/unit/test_oidc_entrypoint.py::TestRunOidcServer::test_creates_oidc_proxy_with_required_openid_scope src/unit/test_oidc_entrypoint.py::TestMainOidcLogging::test_setup_logging_configures_fastmcp_logger -q'
+proot-distro login ubuntu --bind /data/data/com.termux/files/home:/mnt/termux -- sh -lc 'cd /mnt/termux/ha-mcp/worktree/fix-oidc-authelia/tests && HA_MCP_CONFIG_DIR=/tmp/ha-mcp-2189-mutation UV_LINK_MODE=copy uv run pytest src/unit/test_oidc_entrypoint.py::TestRunOidcServer::test_creates_oidc_proxy_with_required_openid_scope src/unit/test_oidc_entrypoint.py::TestMainOidcLogging::test_setup_logging_configures_fastmcp_logger -q'
 ```
 
 Expected: both tests fail for their intended reasons: missing `required_scopes` and FastMCP remaining at INFO.
@@ -478,7 +500,7 @@ Expected: both tests fail for their intended reasons: missing `required_scopes` 
 Restore the exact Task 1 scope line/comment and Task 2 logger-level line/comment. Then run:
 
 ```bash
-proot-distro login ubuntu --bind /data/data/com.termux/files/home:/mnt/termux -- sh -lc 'cd /mnt/termux/ha-mcp/worktree/fix-oidc-authelia/tests && HA_MCP_CONFIG_DIR=/tmp/ha-mcp-2189-restored uv run pytest src/unit/test_oidc_entrypoint.py::TestRunOidcServer::test_creates_oidc_proxy_with_required_openid_scope src/unit/test_oidc_entrypoint.py::TestMainOidcLogging::test_setup_logging_configures_fastmcp_logger -q'
+proot-distro login ubuntu --bind /data/data/com.termux/files/home:/mnt/termux -- sh -lc 'cd /mnt/termux/ha-mcp/worktree/fix-oidc-authelia/tests && HA_MCP_CONFIG_DIR=/tmp/ha-mcp-2189-restored UV_LINK_MODE=copy uv run pytest src/unit/test_oidc_entrypoint.py::TestRunOidcServer::test_creates_oidc_proxy_with_required_openid_scope src/unit/test_oidc_entrypoint.py::TestMainOidcLogging::test_setup_logging_configures_fastmcp_logger -q'
 git diff --check
 git status --short --branch
 ```
@@ -549,10 +571,10 @@ Create a temporary PR body with `apply_patch` at `/tmp/ha-mcp-2189-pr-body.md` c
 
 ## Testing
 
-- `cd tests && uv run pytest src/unit/test_oidc_entrypoint.py -q`
-- `uv run ruff format --check src/ha_mcp/__main__.py tests/src/unit/test_oidc_entrypoint.py`
-- `uv run ruff check src/ha_mcp/__main__.py tests/src/unit/test_oidc_entrypoint.py`
-- `uv run mypy src/`
+- `cd tests && UV_LINK_MODE=copy uv run pytest src/unit/test_oidc_entrypoint.py -q`
+- `UV_LINK_MODE=copy uv run ruff format --check src/ha_mcp/__main__.py tests/src/unit/test_oidc_entrypoint.py`
+- `UV_LINK_MODE=copy uv run ruff check src/ha_mcp/__main__.py tests/src/unit/test_oidc_entrypoint.py`
+- `UV_LINK_MODE=copy uv run mypy src/`
 
 Fixes #2189
 ```

--- a/docs/superpowers/plans/2026-08-10-oidc-authelia-scope-fix.md
+++ b/docs/superpowers/plans/2026-08-10-oidc-authelia-scope-fix.md
@@ -2,9 +2,9 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Make the standalone/container `ha-mcp-oidc` entrypoint work with Authelia's default opaque access tokens by always requesting `openid`, while making `LOG_LEVEL` control FastMCP's OIDC diagnostics and documenting the required configuration.
+**Goal:** Make the standalone/container `ha-mcp-oidc` entrypoint work with Authelia's default opaque access tokens by always requesting `openid`, preserve explicitly requested optional OIDC scopes and pre-fix DCR registrations across the upgrade, make `LOG_LEVEL` control FastMCP's OIDC diagnostics, and document the required configuration.
 
-**Architecture:** Keep FastMCP's existing OIDC proxy and token-verification design. Supply the protocol-level `openid` scope through `OIDCProxy.required_scopes`, retain opt-in ID-token verification for opaque access-token providers, and bridge ha-mcp's common logging level into FastMCP's non-propagating logger without replacing FastMCP's handlers.
+**Architecture:** Wrap FastMCP 3.4.6 `OIDCProxy` in a narrow compatibility subclass with the inherited constructor signature. Supply protocol-level `openid` through `required_scopes`, then explicitly remove only FastMCP's DCR valid-scope allow-list while retaining its `openid` required/default/advertised state. Retain explicitly requested optional scopes, add `openid` to optional-only registrations, and independently union it into every authorization request before proxying upstream. Let the upstream IdP validate requested optional scopes, lazily migrate persisted registrations that lack `openid`, and reject legacy refresh tokens that lack it so clients reauthorize once without losing DCR state. Retain opt-in ID-token verification for opaque access-token providers, and bridge ha-mcp's common logging level into FastMCP's non-propagating logger without replacing FastMCP's handlers while preserving `FASTMCP_LOG_ENABLED=false`.
 
 **Tech Stack:** Python 3.13, FastMCP 3.4.6 `OIDCProxy`, MCP Python SDK 1.28.1, pytest/pytest-asyncio, Ruff, mypy, Markdown, GitHub CLI.
 
@@ -13,8 +13,11 @@
 - Work only in `/data/data/com.termux/files/home/ha-mcp/worktree/fix-oidc-authelia` on branch `agent/fix-oidc-authelia`; never modify or commit from `master` or the user's dirty main checkout.
 - The behavior change applies only to the standalone/container `ha-mcp-oidc` entrypoint; do not alter the Home Assistant add-on, custom component, OAuth mode, audience/resource forwarding, redirect URI policy, or token endpoint authentication.
 - Always pass exactly `required_scopes=["openid"]`; do not make OIDC scopes configurable because `openid` is mandatory for this OIDC entrypoint.
+- Keep `openid` as the only required, default, and protected-resource-advertised scope. Do not copy every provider discovery scope into DCR metadata.
+- Permit DCR clients to explicitly request optional OIDC scopes, retain those scopes while adding missing `openid`, union `openid` into every authorization request, and leave final optional-scope authorization to the upstream IdP.
+- Preserve existing DCR registrations: lazily add missing required scopes and persist only changed records. Reject legacy refresh tokens without `openid` so the client reauthorizes once; manual client cache clearing is only a fallback when automatic reauthorization does not start.
 - Keep `OIDC_VERIFY_ID_TOKEN` opt-in: JWT access-token providers retain default verification, while Authelia and other opaque-access-token providers set it to `true`.
-- Preserve FastMCP's handlers and formatting; only set the `fastmcp` logger's level to the validated ha-mcp `LOG_LEVEL` value.
+- Preserve FastMCP's handlers and formatting; when FastMCP logging is enabled, only set the `fastmcp` logger's level to the validated ha-mcp `LOG_LEVEL` value. When `FASTMCP_LOG_ENABLED=false`, keep its otherwise propagating namespace above `CRITICAL` so it cannot inherit ha-mcp's root handler.
 - Do not require Authelia JWT access tokens or add introspection support.
 - Follow red-green TDD for both behavior changes, use `apply_patch` for source edits, and verify the branch and worktree before every commit.
 - Run Python setup and verification in the existing Ubuntu `proot-distro` environment with `UV_LINK_MODE=copy`; run pytest from the repository's `tests/` directory.
@@ -22,24 +25,29 @@
 
 ## File Map
 
-- `tests/src/unit/test_oidc_entrypoint.py`: pinned `OIDCProxy` constructor contract plus regression coverage for the required OIDC scope and FastMCP logger level.
+- `src/ha_mcp/auth/oidc_compat.py`: FastMCP 3.4.6 compatibility subclass for scope setup, DCR and authorization normalization, persisted-client migration, and refresh-token scope enforcement.
+- `tests/src/unit/test_oidc_compat.py`: focused real-provider tests for inherited constructor compatibility, DCR defaults and optional scopes, protected-resource metadata, upstream authorization scopes, persisted-client migration, and refresh-token rejection.
+- `tests/src/unit/test_oidc_entrypoint.py`: pinned proxy-construction contract plus regression coverage for the required OIDC scope, explicit compatibility setup call, enabled FastMCP logger level, and disabled FastMCP logging behavior.
 - `src/ha_mcp/__main__.py`: common logging setup and standalone/container OIDC proxy construction.
-- `docs/oidc.md`: operator guidance for `openid`, Authelia's opaque tokens, ID-token verification, and debug logging.
-- `docs/superpowers/specs/2026-08-10-oidc-authelia-scope-design.md`: already-approved behavior and non-goals; no further edit is planned.
+- `docs/oidc.md`: operator guidance for scope behavior, state migration and reauthorization, Authelia's opaque tokens, ID-token verification, debug logging, and the FastMCP logging opt-out.
+- `docs/superpowers/specs/2026-08-10-oidc-authelia-scope-design.md`: approved scope/state compatibility behavior, logging opt-out, and non-goals.
 
 ---
 
-### Task 1: Require the `openid` scope in OIDC mode
+### Task 1: Require `openid` without blocking optional scopes or legacy clients
 
 **Files:**
-- Modify: `tests/src/unit/test_oidc_entrypoint.py:18-58,270-325,1177-1209`
-- Modify: `src/ha_mcp/__main__.py:1738-1754`
+- Create: `tests/src/unit/test_oidc_compat.py`
+- Create: `src/ha_mcp/auth/oidc_compat.py`
+- Modify: `tests/src/unit/test_oidc_entrypoint.py`
+- Modify: `src/ha_mcp/__main__.py`
 
 **Interfaces:**
-- Consumes: FastMCP 3.4.6 `OIDCProxy.__init__(..., required_scopes: list[str] | None = None, ...)`.
-- Produces: `_run_oidc_server(...) -> None` constructs every OIDC proxy with `required_scopes=["openid"]`; the pinned mock records that exact list.
+- Consumes: FastMCP 3.4.6 `OIDCProxy`, its DCR stores and token loaders, and MCP Python SDK registration and protected-resource-metadata handlers.
+- Produces: `HaMcpOIDCProxy`, which preserves the inherited constructor signature; an explicit `setup_scope_compatibility() -> None`; DCR and authorization-request scope normalization; lazy persisted-client migration; and required-scope refresh-token validation.
+- Produces: `_run_oidc_server(...) -> None` constructs the compatibility proxy with `required_scopes=["openid"]` and calls setup exactly once before attaching it to the MCP server.
 
-- [ ] **Step 1: Verify the isolated branch and install the development environment**
+- [ ] **Step 1: Verify the isolated branch and baseline**
 
 Run from the worktree:
 
@@ -48,142 +56,116 @@ pwd
 git rev-parse --abbrev-ref HEAD
 git status --short --branch
 proot-distro login ubuntu --bind /data/data/com.termux/files/home:/mnt/termux -- sh -lc 'cd /mnt/termux/ha-mcp/worktree/fix-oidc-authelia && UV_LINK_MODE=copy uv sync --group dev'
-```
-
-Expected: the path ends in `worktree/fix-oidc-authelia`, the branch is `agent/fix-oidc-authelia`, status contains only the committed design plus this plan when appropriate, and `uv sync` completes successfully.
-
-- [ ] **Step 2: Run the untouched OIDC unit file as a baseline**
-
-Run:
-
-```bash
 proot-distro login ubuntu --bind /data/data/com.termux/files/home:/mnt/termux -- sh -lc 'cd /mnt/termux/ha-mcp/worktree/fix-oidc-authelia/tests && HA_MCP_CONFIG_DIR=/tmp/ha-mcp-2189-baseline UV_LINK_MODE=copy uv run pytest src/unit/test_oidc_entrypoint.py -q'
 ```
 
-Expected: PASS. If it does not pass before test edits, stop and distinguish an environment/baseline failure from issue #2189 before changing production code.
+Expected: the branch and worktree are correct, dependency sync succeeds, and the untouched entrypoint unit file passes. Distinguish any environment failure from issue #2189 before changing production code.
 
-- [ ] **Step 3: Extend the pinned proxy mock and real-signature contract**
+- [ ] **Step 2: Create the focused compatibility tests first and capture import red**
 
-In `_make_mock_oidc_proxy`, document `required_scopes` as a mandatory production argument, insert it after `require_authorization_consent`, and record it unconditionally:
+Create `tests/src/unit/test_oidc_compat.py` with a real `OIDCConfiguration`,
+`MemoryStore`, and `RegistrationHandler`; replace only external discovery. Import
+`HaMcpOIDCProxy`, then run:
 
-```python
-    ``required_scopes`` is mandatory in production. The remaining optional
-    constructor arguments default to the ``_UNSET`` sentinel and are only
-    recorded in ``capture`` when actually passed.
-
-    class MockOIDCProxy:
-        def __init__(
-            self,
-            *,
-            config_url,
-            client_id,
-            client_secret,
-            base_url,
-            require_authorization_consent,
-            required_scopes,
-            jwt_signing_key,
-            allowed_client_redirect_uris=_UNSET,
-            verify_id_token=_UNSET,
-            audience=_UNSET,
-        ):
-            capture["config_url"] = config_url
-            capture["client_id"] = client_id
-            capture["client_secret"] = client_secret
-            capture["base_url"] = base_url
-            capture["require_authorization_consent"] = require_authorization_consent
-            capture["required_scopes"] = required_scopes
-            capture["jwt_signing_key"] = jwt_signing_key
+```bash
+proot-distro login ubuntu --bind /data/data/com.termux/files/home:/mnt/termux -- sh -lc 'cd /mnt/termux/ha-mcp/worktree/fix-oidc-authelia/tests && HA_MCP_CONFIG_DIR=/tmp/ha-mcp-2189-red-import UV_LINK_MODE=copy uv run pytest src/unit/test_oidc_compat.py --collect-only -q'
 ```
 
-Add `"required_scopes"` to `run_oidc_server_kwargs` in `TestOIDCProxySignatureSubset`:
+Expected: collection fails with `ModuleNotFoundError` for
+`ha_mcp.auth.oidc_compat`. This proves the compatibility layer does not already
+exist.
+
+- [ ] **Step 3: Add the subclass shell and capture the scope-setup red state**
+
+Create `src/ha_mcp/auth/oidc_compat.py` with `HaMcpOIDCProxy(OIDCProxy)` and a
+no-op explicit setup method, without overriding `__init__`. Add a signature
+assertion and a setup test that starts from FastMCP's
+`valid_scopes == ["openid"]`, invokes setup, and requires all of:
 
 ```python
-        run_oidc_server_kwargs = {
-            "config_url",
-            "client_id",
-            "client_secret",
-            "base_url",
-            "require_authorization_consent",
-            "required_scopes",
-            "jwt_signing_key",
-            "allowed_client_redirect_uris",
-            "verify_id_token",
-            "audience",
-        }
+assert proxy.required_scopes == ["openid"]
+assert proxy.client_registration_options.default_scopes == ["openid"]
+assert proxy._default_scope_str == "openid"
+assert proxy.client_registration_options.valid_scopes is None
 ```
 
-- [ ] **Step 4: Write the failing OIDC-scope regression assertion**
+Run the setup test and require it to fail because `valid_scopes` remains
+`["openid"]`.
 
-Rename the existing broad construction test and extend its contract:
+- [ ] **Step 4: Add focused DCR, metadata, persisted-state, and refresh tests**
 
-```python
-    @pytest.mark.asyncio
-    async def test_creates_oidc_proxy_with_required_openid_scope(self):
-        """OIDC mode should always require the protocol-level openid scope."""
-```
+Before implementing the methods, add behavioral tests proving:
 
-Keep the existing setup and assertions, then add:
+- explicit `openid profile email offline_access` DCR succeeds;
+- omitted DCR scope defaults to `openid`;
+- optional-only DCR retains its requested scopes and adds `openid`;
+- `/.well-known/oauth-protected-resource/mcp` advertises only `openid`;
+- an optional-only authorization request produces an upstream IdP URL whose
+  `scope` contains both `openid` and the requested optional scopes;
+- a persisted `profile email` client is migrated to `openid profile email` and
+  written exactly once across repeated loads;
+- a compliant persisted client keeps its scope order and is not rewritten;
+- a stored refresh token without `openid` is rejected; and
+- a stored refresh token with `openid` remains usable.
 
-```python
-        assert proxy_init_args["required_scopes"] == ["openid"]
-```
+Run the focused file and retain the expected failures from the unimplemented
+scope setup, registration normalization, authorization normalization,
+migration, and refresh checks.
 
-- [ ] **Step 5: Run the regression test and verify the red state**
+- [ ] **Step 5: Implement the narrow FastMCP 3.4.6 compatibility layer**
+
+Implement `setup_scope_compatibility()` so it first verifies exactly
+`required_scopes == ["openid"]`, DCR `default_scopes == ["openid"]`, and
+`_default_scope_str == "openid"`, then sets only
+`client_registration_options.valid_scopes = None`. `None` removes the MCP SDK's
+local complete allow-list while protected-resource metadata continues to fall
+back to required `openid`; the upstream IdP still validates every explicitly
+requested optional scope.
+
+Normalize `register_client()` so explicitly requested optional scopes are
+retained and any missing required scope is added before FastMCP persists the
+registration. Normalize `authorize()` independently so every authorization
+transaction and upstream IdP request unions required `openid` into the client's
+requested scopes; do not rely on registration normalization alone.
+
+Override `get_client()` to detect an already-persisted client, add missing
+required scopes while preserving the existing optional-scope order, and write
+the migrated record only when it changed. Override `load_refresh_token()` to
+return `None` when FastMCP loads a token that lacks any required scope. Retain
+the DCR registration so the rejected refresh triggers authorization, not a new
+client registration.
+
+- [ ] **Step 6: Run the focused compatibility file and verify green**
 
 Run:
 
 ```bash
-proot-distro login ubuntu --bind /data/data/com.termux/files/home:/mnt/termux -- sh -lc 'cd /mnt/termux/ha-mcp/worktree/fix-oidc-authelia/tests && HA_MCP_CONFIG_DIR=/tmp/ha-mcp-2189-red-scope UV_LINK_MODE=copy uv run pytest src/unit/test_oidc_entrypoint.py::TestRunOidcServer::test_creates_oidc_proxy_with_required_openid_scope -q'
+proot-distro login ubuntu --bind /data/data/com.termux/files/home:/mnt/termux -- sh -lc 'cd /mnt/termux/ha-mcp/worktree/fix-oidc-authelia/tests && HA_MCP_CONFIG_DIR=/tmp/ha-mcp-2189-green-compat UV_LINK_MODE=copy uv run pytest src/unit/test_oidc_compat.py -q'
 ```
 
-Expected: FAIL with `TypeError` reporting that `MockOIDCProxy.__init__()` is missing the required keyword-only argument `required_scopes`. This proves current production never supplies the scope.
+Expected: every constructor, DCR/default/optional-only, metadata, upstream
+authorization, persistence, and refresh-token test passes.
 
-- [ ] **Step 6: Implement the minimum production fix**
+- [ ] **Step 7: Integrate the compatibility proxy into the OIDC entrypoint**
 
-Add the required scope to the always-present `proxy_kwargs` mapping immediately after the consent setting:
+Update the pinned proxy mock to require and record `required_scopes`, expose a
+`setup_scope_compatibility` spy, and patch
+`ha_mcp.auth.oidc_compat.HaMcpOIDCProxy`. Assert construction receives exactly
+`["openid"]` and setup is called once. In `_run_oidc_server`, import and
+construct `HaMcpOIDCProxy`, keep the existing optional constructor kwargs, pass
+`required_scopes=["openid"]`, and call setup immediately after construction.
 
-```python
-        # This entrypoint provides OIDC, so request the protocol-level scope
-        # that makes upstream providers return an ID token. FastMCP also
-        # advertises this scope through protected resource metadata so MCP
-        # clients include it in the authorization flow.
-        "required_scopes": ["openid"],
-```
-
-The complete surrounding contract must remain:
-
-```python
-    proxy_kwargs: dict[str, Any] = {
-        "config_url": config_url,
-        "client_id": client_id,
-        "client_secret": client_secret,
-        "base_url": base_url,
-        # "external" tells FastMCP that consent is handled by the upstream
-        # IdP (Authentik, Keycloak, etc.) -- unlike `False`, this does not
-        # log a security warning at startup that consent is disabled.
-        "require_authorization_consent": "external",
-        # This entrypoint provides OIDC, so request the protocol-level scope
-        # that makes upstream providers return an ID token. FastMCP also
-        # advertises this scope through protected resource metadata so MCP
-        # clients include it in the authorization flow.
-        "required_scopes": ["openid"],
-        # Preserve `or None`: an empty-but-set env var must not bypass
-        # FastMCP's derive-from-client-secret default for jwt_signing_key.
-        "jwt_signing_key": os.getenv("OIDC_JWT_SIGNING_KEY") or None,
-    }
-```
-
-- [ ] **Step 7: Run the scope and signature tests and verify green**
+- [ ] **Step 8: Run the entrypoint and compatibility regressions together**
 
 Run:
 
 ```bash
-proot-distro login ubuntu --bind /data/data/com.termux/files/home:/mnt/termux -- sh -lc 'cd /mnt/termux/ha-mcp/worktree/fix-oidc-authelia/tests && HA_MCP_CONFIG_DIR=/tmp/ha-mcp-2189-green-scope UV_LINK_MODE=copy uv run pytest src/unit/test_oidc_entrypoint.py::TestRunOidcServer::test_creates_oidc_proxy_with_required_openid_scope src/unit/test_oidc_entrypoint.py::TestOIDCProxySignatureSubset::test_run_oidc_server_kwargs_are_subset_of_oidc_proxy_params -q'
+proot-distro login ubuntu --bind /data/data/com.termux/files/home:/mnt/termux -- sh -lc 'cd /mnt/termux/ha-mcp/worktree/fix-oidc-authelia/tests && HA_MCP_CONFIG_DIR=/tmp/ha-mcp-2189-green-scope UV_LINK_MODE=copy uv run pytest src/unit/test_oidc_compat.py src/unit/test_oidc_entrypoint.py::TestRunOidcServer src/unit/test_oidc_entrypoint.py::TestOIDCProxySignatureSubset -q'
 ```
 
-Expected: `2 passed`.
+Expected: both the real compatibility behavior and the entrypoint integration pass.
 
-- [ ] **Step 8: Verify location and branch, then commit the scope regression and fix**
+- [ ] **Step 9: Verify location and branch, then commit the scope compatibility change**
 
 Run:
 
@@ -191,15 +173,15 @@ Run:
 pwd
 git rev-parse --abbrev-ref HEAD
 git diff --check
-git add src/ha_mcp/__main__.py tests/src/unit/test_oidc_entrypoint.py
-git commit -m "fix: require openid scope in OIDC mode"
+git add src/ha_mcp/auth/oidc_compat.py src/ha_mcp/__main__.py tests/src/unit/test_oidc_compat.py tests/src/unit/test_oidc_entrypoint.py
+git commit -m "fix: preserve OIDC scope compatibility"
 ```
 
 Expected: a commit on `agent/fix-oidc-authelia`, never on `master` or `main`.
 
 ---
 
-### Task 2: Make `LOG_LEVEL` control FastMCP diagnostics
+### Task 2: Make `LOG_LEVEL` control enabled FastMCP diagnostics
 
 **Files:**
 - Modify: `tests/src/unit/test_oidc_entrypoint.py:7-10,187-269`
@@ -207,7 +189,7 @@ Expected: a commit on `agent/fix-oidc-authelia`, never on `master` or `main`.
 
 **Interfaces:**
 - Consumes: `_setup_logging(log_level_str: str, force: bool = True) -> None` and Python's `logging.getLogger("fastmcp")`.
-- Produces: `_setup_logging` sets both the root configuration and the `fastmcp` logger to the same numeric level while leaving FastMCP's handler and `propagate` configuration untouched.
+- Produces: `_setup_logging` sets both the root configuration and an enabled `fastmcp` logger to the same numeric level while leaving FastMCP's handler and `propagate` configuration untouched; when FastMCP logging is disabled, its namespace remains silent instead of inheriting the root handler.
 
 - [ ] **Step 1: Write the failing FastMCP logging regression test**
 
@@ -221,8 +203,9 @@ import os
 Add this test to `TestMainOidcLogging`:
 
 ```python
-    def test_setup_logging_configures_fastmcp_logger(self):
+    def test_setup_logging_configures_fastmcp_logger(self, monkeypatch):
         """LOG_LEVEL should apply to FastMCP's non-propagating logger."""
+        import fastmcp
         import ha_mcp.__main__ as main_module
 
         fastmcp_logger = logging.getLogger("fastmcp")
@@ -235,6 +218,7 @@ Add this test to `TestMainOidcLogging`:
         original_streamable_http_filters = streamable_http_logger.filters[:]
         original_fastmcp_server_filters = fastmcp_server_logger.filters[:]
         try:
+            monkeypatch.setattr(fastmcp.settings, "log_enabled", True)
             fastmcp_logger.setLevel(logging.INFO)
             main_module._setup_logging("DEBUG", force=False)
             assert fastmcp_logger.getEffectiveLevel() == logging.DEBUG
@@ -270,12 +254,22 @@ proot-distro login ubuntu --bind /data/data/com.termux/files/home:/mnt/termux --
 
 Expected: FAIL because the FastMCP logger remains at `logging.INFO` (`20`) rather than `logging.DEBUG` (`10`).
 
-- [ ] **Step 3: Implement the minimum common logging bridge**
+- [ ] **Step 3: Write and run the disabled-logging regression test**
+
+Add a behavioral regression test that reproduces FastMCP's fresh
+`FASTMCP_LOG_ENABLED=false` state (no handlers, `propagate=True`, namespace
+level `NOTSET`), calls `_setup_logging`, emits a `CRITICAL` record from
+`fastmcp.server.server`, and proves the record does not reach the root capture
+handler. Run it before the production change and require the sentinel to appear.
+
+- [ ] **Step 4: Implement the minimum common logging bridge**
 
 Resolve the numeric level once and reuse it in `_setup_logging`:
 
 ```python
     log_level = getattr(logging, log_level_str)
+
+    import fastmcp
 
     from ha_mcp.utils.usage_logger import preserve_startup_collector
 
@@ -287,25 +281,31 @@ Resolve the numeric level once and reuse it in `_setup_logging`:
             force=force,
         )
 
-    # FastMCP configures its own handler and disables propagation, so the root
-    # level above does not control its OIDC diagnostics. Preserve that handler
-    # and formatting while honoring ha-mcp's LOG_LEVEL setting.
-    logging.getLogger("fastmcp").setLevel(log_level)
+    fastmcp_logger = logging.getLogger("fastmcp")
+    if fastmcp.settings.log_enabled:
+        # FastMCP configures its own handler and disables propagation, so the root
+        # level above does not control its OIDC diagnostics. Preserve that handler
+        # and formatting while honoring ha-mcp's LOG_LEVEL setting.
+        fastmcp_logger.setLevel(log_level)
+    else:
+        # FastMCP deliberately leaves its logger unconfigured when logging is
+        # disabled. Prevent that NOTSET namespace from inheriting our root handler.
+        fastmcp_logger.setLevel(logging.CRITICAL + 1)
 ```
 
 Leave the existing `mcp.server.streamable_http` and `fastmcp.server.server` filters immediately after this block.
 
-- [ ] **Step 4: Run the logging regression test and verify green**
+- [ ] **Step 5: Run both logging regression tests and verify green**
 
 Run:
 
 ```bash
-proot-distro login ubuntu --bind /data/data/com.termux/files/home:/mnt/termux -- sh -lc 'cd /mnt/termux/ha-mcp/worktree/fix-oidc-authelia/tests && HA_MCP_CONFIG_DIR=/tmp/ha-mcp-2189-green-logging UV_LINK_MODE=copy uv run pytest src/unit/test_oidc_entrypoint.py::TestMainOidcLogging::test_setup_logging_configures_fastmcp_logger -q'
+proot-distro login ubuntu --bind /data/data/com.termux/files/home:/mnt/termux -- sh -lc 'cd /mnt/termux/ha-mcp/worktree/fix-oidc-authelia/tests && HA_MCP_CONFIG_DIR=/tmp/ha-mcp-2189-green-logging UV_LINK_MODE=copy uv run pytest src/unit/test_oidc_entrypoint.py::TestMainOidcLogging::test_setup_logging_configures_fastmcp_logger src/unit/test_oidc_entrypoint.py::TestMainOidcLogging::test_setup_logging_preserves_fastmcp_logging_opt_out -q'
 ```
 
-Expected: `1 passed`.
+Expected: `2 passed`.
 
-- [ ] **Step 5: Run all logging and OIDC proxy construction tests**
+- [ ] **Step 6: Run all logging and OIDC proxy construction tests**
 
 Run:
 
@@ -315,7 +315,7 @@ proot-distro login ubuntu --bind /data/data/com.termux/files/home:/mnt/termux --
 
 Expected: all selected tests pass.
 
-- [ ] **Step 6: Verify location and branch, then commit the logging regression and fix**
+- [ ] **Step 7: Verify location and branch, then commit the logging regression and fix**
 
 Run:
 
@@ -338,8 +338,8 @@ Expected: a second atomic implementation commit on `agent/fix-oidc-authelia`.
 - Modify: `src/ha_mcp/__main__.py:1618-1625`
 
 **Interfaces:**
-- Consumes: the Task 1 guarantee that `openid` is always requested and the existing `OIDC_VERIFY_ID_TOKEN` environment variable.
-- Produces: standalone/container operator guidance that distinguishes opaque access-token providers from JWT access-token providers and gives exact Authelia settings.
+- Consumes: the Task 1 guarantee that `openid` is required/default/advertised, added to optional-only registration and authorization scopes, and the existing `OIDC_VERIFY_ID_TOKEN` environment variable.
+- Produces: standalone/container operator guidance for client scopes and upgrades that distinguishes opaque access-token providers from JWT access-token providers and gives exact Authelia settings.
 
 - [ ] **Step 1: Update the entrypoint help text for opaque-token providers**
 
@@ -352,11 +352,12 @@ Replace the `OIDC_VERIFY_ID_TOKEN` description in `main_oidc`'s docstring with:
 
 - [ ] **Step 2: Update the environment-variable table**
 
-Replace the two relevant rows with:
+Replace the relevant rows with:
 
 ```markdown
 | `OIDC_VERIFY_ID_TOKEN` | Optional. Set `true` for OIDC providers that issue opaque access tokens the default JWT verifier cannot validate (e.g. Authelia, or Auth0 without an API audience configured). ha-mcp always requests `openid`, so these providers return the ID token FastMCP verifies instead. | `false` |
-| `LOG_LEVEL` | Logging level for ha-mcp and FastMCP, including OIDC token-validation diagnostics | `INFO` |
+| `LOG_LEVEL` | Logging level for ha-mcp and, when FastMCP logging is enabled, FastMCP's OIDC token-validation diagnostics | `INFO` |
+| `FASTMCP_LOG_ENABLED` | Set `false` to disable FastMCP framework logging entirely. ha-mcp preserves this opt-out instead of routing FastMCP records through its root logger. | `true` |
 ```
 
 Keep the existing `OIDC_AUDIENCE` row between these rows.
@@ -372,39 +373,40 @@ Add this bullet after the authorization-code grant type:
 
 - [ ] **Step 4: Replace provider compatibility guidance with exact opaque-token behavior**
 
-Replace the current `Provider Compatibility` body with:
+Retain the existing JWT-provider examples, then state that opaque-token
+providers need `OIDC_VERIFY_ID_TOKEN=true`. Tell Authelia operators to allow
+`openid`, keep its default opaque access tokens, and avoid changing
+`access_token_signed_response_alg`; retain the existing Auth0 audience note.
 
-```markdown
-OIDC mode works out of the box with providers that issue **JWT access
-tokens** — Authentik and Keycloak are known to work without extra
-configuration.
+- [ ] **Step 5: Document client scope behavior and upgrade state**
 
-ha-mcp always requests the required `openid` scope. Providers that issue
-**opaque access tokens** (not JWTs) also need `OIDC_VERIFY_ID_TOKEN=true` so
-FastMCP verifies the returned ID token instead of trying to parse the access
-token as a JWT:
+Add a client-scopes-and-upgrades section that states all of the following:
 
-- **Authelia** issues opaque access tokens by default. Allow `openid` in the
-  client's `scopes` and set `OIDC_VERIFY_ID_TOKEN=true` for ha-mcp. You do not
-  need to change Authelia's `access_token_signed_response_alg` to enable JWT
-  access tokens.
-- **Auth0** issues opaque access tokens unless the client requests a
-  configured API audience.
-```
+- `openid` is required, defaulted, and the only scope advertised in
+  protected-resource metadata;
+- explicitly requested optional scopes are retained and `openid` is added if
+  the client omitted it;
+- every authorization request independently unions in `openid`, while the
+  upstream IdP decides whether requested optional scopes are granted;
+- persisted pre-fix DCR registrations are retained and lazily migrated;
+- refresh tokens without `openid` are rejected, causing one reauthorization
+  while retaining the DCR registration; and
+- manual client-side connector or authorization-cache clearing is only a
+  fallback when a client does not restart authorization automatically.
 
-- [ ] **Step 5: Review the rendered prose against the standalone/container boundary**
+- [ ] **Step 6: Review the rendered prose against the standalone/container boundary**
 
 Run:
 
 ```bash
-rg -n "openid|Authelia|OIDC_VERIFY_ID_TOKEN|access_token_signed_response_alg|LOG_LEVEL" docs/oidc.md src/ha_mcp/__main__.py
+rg -n "openid|optional|authorization|DCR|refresh|cache|Authelia|OIDC_VERIFY_ID_TOKEN|access_token_signed_response_alg|LOG_LEVEL|FASTMCP_LOG_ENABLED" docs/oidc.md src/ha_mcp/__main__.py
 git diff -- docs/oidc.md src/ha_mcp/__main__.py
 git diff --check
 ```
 
 Expected: every instruction refers to OIDC mode, no add-on/custom-component guidance changes, and the diff has no whitespace errors.
 
-- [ ] **Step 6: Verify location and branch, then commit the documentation**
+- [ ] **Step 7: Verify location and branch, then commit the documentation**
 
 Run:
 
@@ -422,7 +424,9 @@ Expected: an atomic documentation commit on `agent/fix-oidc-authelia`.
 ### Task 4: Verify the complete change and prove the regressions
 
 **Files:**
+- Verify: `src/ha_mcp/auth/oidc_compat.py`
 - Verify: `src/ha_mcp/__main__.py`
+- Verify: `tests/src/unit/test_oidc_compat.py`
 - Verify: `tests/src/unit/test_oidc_entrypoint.py`
 - Verify: `docs/oidc.md`
 
@@ -430,46 +434,32 @@ Expected: an atomic documentation commit on `agent/fix-oidc-authelia`.
 - Consumes: the completed Task 1-3 commits.
 - Produces: fresh local evidence for unit behavior, formatting, lint, typing, and red-green causality before publication.
 
-- [ ] **Step 1: Run the complete OIDC unit file**
+- [ ] **Step 1: Run both complete OIDC unit files**
 
 Run:
 
 ```bash
-proot-distro login ubuntu --bind /data/data/com.termux/files/home:/mnt/termux -- sh -lc 'cd /mnt/termux/ha-mcp/worktree/fix-oidc-authelia/tests && HA_MCP_CONFIG_DIR=/tmp/ha-mcp-2189-final-unit UV_LINK_MODE=copy uv run pytest src/unit/test_oidc_entrypoint.py -q'
+proot-distro login ubuntu --bind /data/data/com.termux/files/home:/mnt/termux -- sh -lc 'cd /mnt/termux/ha-mcp/worktree/fix-oidc-authelia/tests && HA_MCP_CONFIG_DIR=/tmp/ha-mcp-2189-final-unit UV_LINK_MODE=copy uv run pytest src/unit/test_oidc_compat.py src/unit/test_oidc_entrypoint.py -q'
 ```
 
-Expected: all tests in `test_oidc_entrypoint.py` pass.
+Expected: all tests in both focused OIDC unit files pass, including optional-only
+DCR and upstream-authorization scope normalization.
 
 - [ ] **Step 2: Run formatting, lint, and type verification**
 
 Run each command separately from the worktree:
 
 ```bash
-proot-distro login ubuntu --bind /data/data/com.termux/files/home:/mnt/termux -- sh -lc 'cd /mnt/termux/ha-mcp/worktree/fix-oidc-authelia && UV_LINK_MODE=copy uv run ruff format --check src/ha_mcp/__main__.py tests/src/unit/test_oidc_entrypoint.py'
-proot-distro login ubuntu --bind /data/data/com.termux/files/home:/mnt/termux -- sh -lc 'cd /mnt/termux/ha-mcp/worktree/fix-oidc-authelia && UV_LINK_MODE=copy uv run ruff check src/ha_mcp/__main__.py tests/src/unit/test_oidc_entrypoint.py'
+proot-distro login ubuntu --bind /data/data/com.termux/files/home:/mnt/termux -- sh -lc 'cd /mnt/termux/ha-mcp/worktree/fix-oidc-authelia && UV_LINK_MODE=copy uv run ruff format --check src/ha_mcp/auth/oidc_compat.py src/ha_mcp/__main__.py tests/src/unit/test_oidc_compat.py tests/src/unit/test_oidc_entrypoint.py'
+proot-distro login ubuntu --bind /data/data/com.termux/files/home:/mnt/termux -- sh -lc 'cd /mnt/termux/ha-mcp/worktree/fix-oidc-authelia && UV_LINK_MODE=copy uv run ruff check src/ha_mcp/auth/oidc_compat.py src/ha_mcp/__main__.py tests/src/unit/test_oidc_compat.py tests/src/unit/test_oidc_entrypoint.py'
 proot-distro login ubuntu --bind /data/data/com.termux/files/home:/mnt/termux -- sh -lc 'cd /mnt/termux/ha-mcp/worktree/fix-oidc-authelia && UV_LINK_MODE=copy uv run mypy src/'
 git diff --check origin/master...HEAD
 ```
 
-Expected: every command exits zero. Do not describe repository-wide tests as locally passing because no relevant live-IdP/E2E fixture exists; GitHub's ordinary E2E workflow supplies the repository-wide lane.
+Expected: every command exits zero. These focused local checks cover the OIDC
+change; the pull request's ordinary CI supplies broad unit and E2E validation.
 
-- [ ] **Step 3: Run the repository's full E2E command**
-
-The repository's issue-to-PR workflow requires the full E2E command even
-though this entrypoint has no live-IdP E2E fixture. Run it and let pytest
-report the actual Docker availability rather than assuming prerequisites are
-missing:
-
-```bash
-proot-distro login ubuntu --bind /data/data/com.termux/files/home:/mnt/termux -- sh -lc 'cd /mnt/termux/ha-mcp/worktree/fix-oidc-authelia/tests && UV_LINK_MODE=copy uv run pytest src/e2e/ -n2 --dist loadscope -v --tb=short'
-```
-
-Expected: the suite passes when Docker is available. If the Android/proot
-environment cannot reach a Docker daemon, retain the exact collection or
-connection failure as local-environment evidence and require the GitHub E2E
-workflow to pass before the PR is reported merge-ready.
-
-- [ ] **Step 4: Temporarily remove both production fixes with `apply_patch`**
+- [ ] **Step 3: Temporarily remove the entrypoint and logging fixes with `apply_patch`**
 
 Use `apply_patch` to remove only:
 
@@ -477,37 +467,47 @@ Use `apply_patch` to remove only:
         "required_scopes": ["openid"],
 ```
 
-and:
+and the complete FastMCP settings branch:
 
 ```python
-    logging.getLogger("fastmcp").setLevel(log_level)
+    fastmcp_logger = logging.getLogger("fastmcp")
+    if fastmcp.settings.log_enabled:
+        fastmcp_logger.setLevel(log_level)
+    else:
+        fastmcp_logger.setLevel(logging.CRITICAL + 1)
 ```
 
 Retain the regression tests. Do not stage or commit this temporary mutation.
+The compatibility module's import and behavior red states were already
+captured in Task 1; do not replace `valid_scopes=None` with all provider scopes
+for a mutation test because that would recreate the over-broad advertised-scope
+behavior the design rejects.
 
-- [ ] **Step 5: Run both regression tests and require failure**
+- [ ] **Step 4: Run three regression tests and require failure**
 
 Run:
 
 ```bash
-proot-distro login ubuntu --bind /data/data/com.termux/files/home:/mnt/termux -- sh -lc 'cd /mnt/termux/ha-mcp/worktree/fix-oidc-authelia/tests && HA_MCP_CONFIG_DIR=/tmp/ha-mcp-2189-mutation UV_LINK_MODE=copy uv run pytest src/unit/test_oidc_entrypoint.py::TestRunOidcServer::test_creates_oidc_proxy_with_required_openid_scope src/unit/test_oidc_entrypoint.py::TestMainOidcLogging::test_setup_logging_configures_fastmcp_logger -q'
+proot-distro login ubuntu --bind /data/data/com.termux/files/home:/mnt/termux -- sh -lc 'cd /mnt/termux/ha-mcp/worktree/fix-oidc-authelia/tests && HA_MCP_CONFIG_DIR=/tmp/ha-mcp-2189-mutation UV_LINK_MODE=copy uv run pytest src/unit/test_oidc_entrypoint.py::TestRunOidcServer::test_creates_oidc_proxy_with_required_openid_scope src/unit/test_oidc_entrypoint.py::TestMainOidcLogging::test_setup_logging_configures_fastmcp_logger src/unit/test_oidc_entrypoint.py::TestMainOidcLogging::test_setup_logging_preserves_fastmcp_logging_opt_out -q'
 ```
 
-Expected: both tests fail for their intended reasons: missing `required_scopes` and FastMCP remaining at INFO.
+Expected: all three tests fail for their intended reasons: missing
+`required_scopes`, enabled FastMCP remaining at INFO, and disabled FastMCP
+records inheriting the root handler.
 
-- [ ] **Step 6: Restore both fixes with `apply_patch` and rerun the regressions**
+- [ ] **Step 5: Restore both fixes with `apply_patch` and rerun the regressions**
 
 Restore the exact Task 1 scope line/comment and Task 2 logger-level line/comment. Then run:
 
 ```bash
-proot-distro login ubuntu --bind /data/data/com.termux/files/home:/mnt/termux -- sh -lc 'cd /mnt/termux/ha-mcp/worktree/fix-oidc-authelia/tests && HA_MCP_CONFIG_DIR=/tmp/ha-mcp-2189-restored UV_LINK_MODE=copy uv run pytest src/unit/test_oidc_entrypoint.py::TestRunOidcServer::test_creates_oidc_proxy_with_required_openid_scope src/unit/test_oidc_entrypoint.py::TestMainOidcLogging::test_setup_logging_configures_fastmcp_logger -q'
+proot-distro login ubuntu --bind /data/data/com.termux/files/home:/mnt/termux -- sh -lc 'cd /mnt/termux/ha-mcp/worktree/fix-oidc-authelia/tests && HA_MCP_CONFIG_DIR=/tmp/ha-mcp-2189-restored UV_LINK_MODE=copy uv run pytest src/unit/test_oidc_entrypoint.py::TestRunOidcServer::test_creates_oidc_proxy_with_required_openid_scope src/unit/test_oidc_entrypoint.py::TestMainOidcLogging::test_setup_logging_configures_fastmcp_logger src/unit/test_oidc_entrypoint.py::TestMainOidcLogging::test_setup_logging_preserves_fastmcp_logging_opt_out -q'
 git diff --check
 git status --short --branch
 ```
 
-Expected: `2 passed` and a clean tracked working tree. If restoration changes a committed line, compare it with `git diff HEAD -- src/ha_mcp/__main__.py` and correct it before proceeding.
+Expected: `3 passed` and a clean tracked working tree. If restoration changes a committed line, compare it with `git diff HEAD -- src/ha_mcp/__main__.py` and correct it before proceeding.
 
-- [ ] **Step 7: Request the required read-only code review**
+- [ ] **Step 6: Obtain approval, then request the read-only code review**
 
 Resolve the literal base and head SHAs with:
 
@@ -516,21 +516,31 @@ git merge-base origin/master HEAD
 git rev-parse HEAD
 ```
 
-Use the `superpowers:requesting-code-review` reviewer template. Give the reviewer the approved spec at `docs/superpowers/specs/2026-08-10-oidc-authelia-scope-design.md`, this plan, the literal SHAs returned above, and a read-only instruction. Require review of plan alignment, OIDC security/compatibility, logger behavior, tests, and operator documentation.
+Show the user the exact review scope and wait for explicit approval before
+summoning a Codex reviewer. After approval, use the
+`superpowers:requesting-code-review` reviewer template. Give the reviewer the
+approved spec at
+`docs/superpowers/specs/2026-08-10-oidc-authelia-scope-design.md`, this plan,
+the literal SHAs returned above, and a read-only instruction. Require review
+of plan alignment, OIDC security/compatibility, logger behavior, tests, and
+operator documentation.
 
 Expected: no Critical or Important finding remains. Validate every finding against current source and policy; fix valid findings with a new TDD cycle and atomic commit, rerun Task 4 verification, then request a fresh review.
 
 ---
 
-### Task 5: Publish a draft PR and run the repository resolution loop
+### Task 5: Publish a draft PR and run the resolution and approval loop
 
 **Files:**
 - Publish: commits on `agent/fix-oidc-authelia`
-- Create: one draft pull request against `homeassistant-ai/ha-mcp:master`
+- Create: one pull request against `homeassistant-ai/ha-mcp:master` that begins
+  as a draft.
 
 **Interfaces:**
 - Consumes: clean reviewed commits and verified GitHub identity.
-- Produces: a draft PR containing `Fixes #2189`, green CI, and no unresolved review threads; it remains draft.
+- Produces: a PR containing `Fixes #2189`, green CI, and no unresolved review
+  threads. It begins as a draft and is marked ready only after explicit user
+  approval.
 
 - [ ] **Step 1: Verify final scope, identity, remotes, and branch**
 
@@ -565,15 +575,16 @@ Create a temporary PR body with `apply_patch` at `/tmp/ha-mcp-2189-pr-body.md` c
 ```markdown
 ## Summary
 
-- require the `openid` scope in the standalone/container OIDC authorization flow
+- require `openid` while retaining explicitly requested optional OIDC scopes
+- preserve DCR registrations across upgrade and require one reauthorization for legacy refresh tokens
 - make `LOG_LEVEL` control FastMCP's OIDC token-validation diagnostics
 - document Authelia's default opaque access-token configuration
 
 ## Testing
 
-- `cd tests && UV_LINK_MODE=copy uv run pytest src/unit/test_oidc_entrypoint.py -q`
-- `UV_LINK_MODE=copy uv run ruff format --check src/ha_mcp/__main__.py tests/src/unit/test_oidc_entrypoint.py`
-- `UV_LINK_MODE=copy uv run ruff check src/ha_mcp/__main__.py tests/src/unit/test_oidc_entrypoint.py`
+- `cd tests && UV_LINK_MODE=copy uv run pytest src/unit/test_oidc_compat.py src/unit/test_oidc_entrypoint.py -q`
+- `UV_LINK_MODE=copy uv run ruff format --check src/ha_mcp/auth/oidc_compat.py src/ha_mcp/__main__.py tests/src/unit/test_oidc_compat.py tests/src/unit/test_oidc_entrypoint.py`
+- `UV_LINK_MODE=copy uv run ruff check src/ha_mcp/auth/oidc_compat.py src/ha_mcp/__main__.py tests/src/unit/test_oidc_compat.py tests/src/unit/test_oidc_entrypoint.py`
 - `UV_LINK_MODE=copy uv run mypy src/`
 
 Fixes #2189
@@ -622,32 +633,25 @@ Expected: all human and automated feedback is accounted for and no actionable un
 
 For each valid finding, reproduce it where practical, add or update a regression test before production code, make an atomic commit after verifying branch/worktree location, push, and return to Steps 4-5. Reply to inline comments with the fixing commit and resolve their GraphQL thread only after the fix is pushed and verified. Do not dismiss technically questionable feedback without checking current source, docs, and tests.
 
-Expected terminal state: all CI green, all comments addressed, no unresolved actionable review threads, and the PR remains draft. If the same external blocker survives five resolution iterations, report the exact blocker rather than marking the PR ready or merging it.
+Expected terminal state before readiness approval: all CI green, all inline
+review threads addressed, no unresolved actionable feedback, and the PR still
+draft. If the same external blocker survives five resolution iterations,
+report the exact blocker rather than marking the PR ready or merging it.
 
-- [ ] **Step 7: Post the repository-required implementation summary**
+- [ ] **Step 7: Obtain explicit approval, then mark the PR ready**
 
-After checks and threads are clean, resolve the PR number and post this exact
-summary, adjusting only the local-E2E sentence if Docker was available:
+Present the final CI and inline-thread state and wait for explicit user
+approval. Only after that approval, run:
 
 ```bash
-TASK_PR_NUMBER=$(gh pr view agent/fix-oidc-authelia --repo homeassistant-ai/ha-mcp --json number --jq '.number')
-gh pr comment "$TASK_PR_NUMBER" --repo homeassistant-ai/ha-mcp --body '## Implementation Summary
-
-**Choices Made:**
-- Always request the protocol-level `openid` scope from the standalone/container OIDC proxy.
-- Keep ID-token verification opt-in for opaque access-token providers such as Authelia.
-- Apply ha-mcp `LOG_LEVEL` to FastMCP without replacing FastMCP handlers.
-
-**Problems Encountered:**
-- The original flow requested no `openid` scope, so Authelia returned no ID token while its default access token remained opaque.
-- The local Android/proot environment could not provide a Docker daemon; the pull request E2E workflow supplied full-suite verification.'
+gh pr ready agent/fix-oidc-authelia --repo homeassistant-ai/ha-mcp
 ```
 
-Read the comment back and verify the author and body. If Docker was available
-and the full suite passed locally, replace only the second Problems
-Encountered bullet with `- No implementation blockers; the full E2E suite passed locally and in GitHub Actions.`
+Expected: the PR transitions from draft to ready. Do not post a top-level PR
+comment; only reply within existing inline review threads when addressing
+their feedback.
 
-- [ ] **Step 8: Verify the final draft PR state and report**
+- [ ] **Step 8: Verify the final PR state and report**
 
 Run:
 
@@ -656,4 +660,7 @@ gh pr view agent/fix-oidc-authelia --repo homeassistant-ai/ha-mcp --json number,
 git status --short --branch
 ```
 
-Expected: the final report can cite the PR URL, exact local verification, terminal CI status, and review-thread status. Do not run `gh pr ready`, merge, close the issue manually, delete the branch, or remove the worktree.
+Expected: after approval, `isDraft` is false and the final report can cite the
+PR URL, exact focused local verification, terminal CI status, and review-thread
+status. Do not merge, close the issue manually, delete the branch, or remove
+the worktree.

--- a/docs/superpowers/specs/2026-08-10-oidc-authelia-scope-design.md
+++ b/docs/superpowers/specs/2026-08-10-oidc-authelia-scope-design.md
@@ -18,6 +18,14 @@ client selects them from the protected-resource metadata FastMCP derives from
 `required_scopes`. The resulting authorization request therefore has no
 `openid` scope.
 
+FastMCP 3.4.6 also copies `required_scopes` into DCR's `default_scopes` and
+`valid_scopes`. Passing `required_scopes=["openid"]` alone would fix the missing
+ID token but make the MCP SDK reject an explicit request such as
+`openid profile email offline_access` before the identity provider sees it.
+Copying every discovery-advertised provider scope into `valid_scopes` is not a
+safe alternative: FastMCP also publishes that list in protected-resource
+metadata, and ordinary MCP clients may then request every advertised scope.
+
 Authelia issues opaque access tokens by default and only returns an ID token
 when `openid` is requested. Consequently:
 
@@ -29,44 +37,92 @@ when `openid` is requested. Consequently:
   local reference JWT before it revalidates the stored upstream token on the
   first `/mcp` request.
 
-The sparse diagnostics are a separate logging integration defect. FastMCP's
-`fastmcp` logger has its own handler and does not propagate to the root logger,
-so ha-mcp's root `LOG_LEVEL` configuration does not change FastMCP's effective
-level.
+The sparse diagnostics are a separate logging integration defect. When FastMCP
+logging is enabled, its `fastmcp` logger has its own handler and does not
+propagate to the root logger, so ha-mcp's root `LOG_LEVEL` configuration does
+not change FastMCP's effective level. When `FASTMCP_LOG_ENABLED=false`, FastMCP
+instead leaves that namespace unconfigured; ha-mcp must not let it inherit the
+root handler and accidentally restore the framework logs.
 
 ## Design
 
-### OIDC scope
+### OIDC scope and DCR compatibility
 
-Pass `required_scopes=["openid"]` whenever `ha-mcp-oidc` constructs
-`OIDCProxy`. This entrypoint promises OIDC rather than generic OAuth, so
-`openid` is a protocol requirement, not an optional provider-specific
-permission. FastMCP will advertise the scope to MCP clients, include it in the
-upstream authorization request, and retain it for FastMCP-token enforcement.
+Add `ha_mcp.auth.oidc_compat.HaMcpOIDCProxy`, a narrowly scoped FastMCP 3.4.6
+compatibility subclass that inherits `OIDCProxy.__init__` unchanged. Pass
+`required_scopes=["openid"]` whenever `ha-mcp-oidc` constructs this proxy, then
+call its explicit compatibility setup method. This entrypoint promises OIDC
+rather than generic OAuth, so `openid` is a protocol requirement, not an
+optional provider-specific permission.
+
+The setup method verifies that `required_scopes`, DCR `default_scopes`, and
+FastMCP's upstream default scope string still contain only `openid`, then sets
+DCR `valid_scopes` to `None`. This keeps `openid` required, defaulted, advertised
+in protected-resource metadata, included in upstream authorization, and
+enforced on FastMCP tokens. At the same time, the MCP SDK no longer treats
+`openid` as a complete allow-list: a client can explicitly request optional
+scopes such as `profile`, `email`, or `offline_access`, and the upstream IdP's
+client and user policy remains responsible for accepting or rejecting them.
+Optional provider scopes are not advertised automatically, so ordinary MCP
+clients do not request every scope from discovery metadata.
+
+Normalize both boundaries that can otherwise omit the required scope. During
+DCR, retain every explicitly requested optional scope and add `openid` when the
+client supplied only optional scopes. Independently union `openid` into every
+authorization request before FastMCP stores the transaction or builds the
+upstream IdP URL. Registration normalization alone is insufficient because a
+legacy or unusual client can still send authorization parameters that omit a
+scope present in its registration. Together these guards ensure the upstream
+request always contains `openid` without discarding client-requested optional
+scopes.
 
 Keep `OIDC_VERIFY_ID_TOKEN` opt-in. JWT-access-token providers continue using
 the default verification path. Opaque-access-token providers use ID-token
 verification after the now-guaranteed `openid` request causes them to return
 an ID token.
 
+### Persisted state compatibility
+
+Override persisted-client loading narrowly in the compatibility subclass.
+When a pre-fix DCR registration lacks a required scope, add `openid` while
+preserving its existing optional scopes and persist the migrated registration.
+Do not write when the registration is already compliant. This lazy migration
+retains the client ID, secret, redirect URIs, and other DCR state.
+
+After FastMCP loads a refresh token, reject it if it lacks `openid`. A token
+created before the fix must not perpetuate a session without the required
+scope, so the client performs authorization once and receives a compliant
+token while keeping its migrated DCR registration. Most clients restart that
+flow automatically. Manual client-side connector or authorization-cache
+clearing is only a fallback for clients that do not restart authorization after
+the rejected refresh token.
+
 ### Logging
 
 Extend the common `_setup_logging` helper to set the `fastmcp` logger to the
-same level as ha-mcp's root logger. This preserves FastMCP's existing handler
-and formatting while making `LOG_LEVEL` behave consistently for every ha-mcp
-entrypoint. It also avoids requiring operators to discover and duplicate the
-setting as `FASTMCP_LOG_LEVEL`.
+same level as ha-mcp's root logger when FastMCP logging is enabled. This
+preserves FastMCP's existing handler and formatting while making `LOG_LEVEL`
+behave consistently for every ha-mcp entrypoint. When
+`FASTMCP_LOG_ENABLED=false`, set the FastMCP namespace above `CRITICAL` so its
+otherwise unconfigured, propagating child loggers cannot inherit ha-mcp's root
+handler. This preserves the upstream opt-out and avoids requiring operators to
+duplicate `LOG_LEVEL` as `FASTMCP_LOG_LEVEL`.
 
 ### Documentation
 
 Update `docs/oidc.md` to:
 
-- state that ha-mcp always requests the required `openid` scope;
+- state that `openid` remains required, default, and advertised, is added to
+  optional-only registrations and every authorization request, while retained
+  client-requested optional scopes remain subject to upstream IdP policy;
 - add Authelia to opaque-access-token provider compatibility guidance;
 - tell Authelia users to allow `openid` and set
   `OIDC_VERIFY_ID_TOKEN=true`;
-- clarify that they do not need to enable JWT access tokens in Authelia; and
-- state that `LOG_LEVEL` covers FastMCP/OIDC diagnostics.
+- clarify that they do not need to enable JWT access tokens in Authelia;
+- explain lazy DCR migration, one-time reauthorization for legacy refresh
+  tokens, retained registrations, and manual cache clearing as a fallback; and
+- state that `LOG_LEVEL` covers enabled FastMCP/OIDC diagnostics while
+  `FASTMCP_LOG_ENABLED=false` still disables FastMCP logging entirely.
 
 The guidance applies to the Docker/standalone `ha-mcp-oidc` entrypoint only.
 It does not alter the Home Assistant add-on, custom component, or OAuth mode's
@@ -74,25 +130,41 @@ authentication design.
 
 ## Testing
 
-Follow red-green TDD with unit-level regression coverage in
-`tests/src/unit/test_oidc_entrypoint.py`:
+Follow red-green TDD with entrypoint coverage in
+`tests/src/unit/test_oidc_entrypoint.py` and focused compatibility coverage in
+`tests/src/unit/test_oidc_compat.py`:
 
 1. Extend the pinned `OIDCProxy` mock and real-signature subset assertion for
-   `required_scopes`.
-2. Add a failing test proving every OIDC proxy construction receives exactly
-   `["openid"]`.
-3. Add a failing test proving `_setup_logging("DEBUG")` lowers the effective
+   `required_scopes` and the explicit compatibility setup call.
+2. Before adding `src/ha_mcp/auth/oidc_compat.py`, collect the new focused test
+   file and require the import failure; after adding a no-op setup method,
+   require the scope-setup assertion to fail with DCR `valid_scopes` still set
+   to `["openid"]`.
+3. Exercise real FastMCP/MCP behavior to prove optional multi-scope DCR is
+   accepted, omitted scopes default to `openid`, optional-only DCR retains its
+   scopes while adding `openid`, protected-resource metadata advertises only
+   `openid`, and an optional-only authorization request reaches the upstream
+   IdP with both `openid` and the requested optional scopes.
+4. Prove a persisted legacy registration is migrated and written exactly once,
+   a compliant registration is not rewritten, a legacy refresh token without
+   `openid` is rejected, and a compliant refresh token remains usable.
+5. Add a failing test proving every OIDC proxy construction receives exactly
+   `["openid"]` and invokes compatibility setup once.
+6. Add a failing test proving `_setup_logging("DEBUG")` lowers the effective
    FastMCP logger level to DEBUG despite its non-propagating handler.
-4. Implement the minimum production changes and rerun the focused tests.
-5. Run `uv run ruff format --check` and `uv run ruff check` on the touched
-   Python files, `uv run mypy src/`, and the full OIDC unit file. There is no
-   OIDC E2E test or live-IdP fixture in `tests/src/e2e/`; the pull request's
-   ordinary CI still runs the repository-wide E2E lanes. Before publishing,
-   prove each regression test fails with its production fix temporarily
-   reverted, then restore the fixes and rerun the tests successfully.
+7. Add a behavioral regression test proving `FASTMCP_LOG_ENABLED=false` keeps
+   a FastMCP child record out of ha-mcp's root handler.
+8. Implement the compatibility subclass, entrypoint integration, and logging
+   changes, then rerun both focused OIDC unit modules.
+9. Run `uv run ruff format --check` and `uv run ruff check` on all touched
+   Python files, `uv run mypy src/`, and both OIDC unit files. There is no OIDC
+   E2E test or live-IdP fixture in `tests/src/e2e/`; the pull request's ordinary
+   CI still runs the repository-wide E2E lanes. Before publishing, retain the
+   recorded red evidence, restore any safe temporary regression mutations, and
+   rerun the tests successfully.
 
 No live Authelia instance or Home Assistant state is required: the defect is
-the deterministic constructor and logging configuration passed to FastMCP.
+the deterministic proxy, persisted-state, and logging behavior around FastMCP.
 
 ## Non-goals
 
@@ -101,5 +173,7 @@ the deterministic constructor and logging configuration passed to FastMCP.
 - Adding token introspection support to FastMCP.
 - Changing `OIDC_AUDIENCE`, resource forwarding, redirect URI policy, or token
   endpoint authentication.
+- Advertising every discovery-provided scope or bypassing the upstream IdP's
+  optional-scope policy.
 - Modifying add-on or custom-component authentication.
 - Changing FastMCP itself.

--- a/docs/superpowers/specs/2026-08-10-oidc-authelia-scope-design.md
+++ b/docs/superpowers/specs/2026-08-10-oidc-authelia-scope-design.md
@@ -108,6 +108,11 @@ otherwise unconfigured, propagating child loggers cannot inherit ha-mcp's root
 handler. This preserves the upstream opt-out and avoids requiring operators to
 duplicate `LOG_LEVEL` as `FASTMCP_LOG_LEVEL`.
 
+This logging bridge is intentionally common behavior: every ha-mcp entrypoint
+that calls `_setup_logging` receives the FastMCP level synchronization and
+disabled-logging protection. It is not part of the OIDC-only authentication
+boundary and does not change any entrypoint's authentication model.
+
 ### Documentation
 
 Update `docs/oidc.md` to:
@@ -124,9 +129,11 @@ Update `docs/oidc.md` to:
 - state that `LOG_LEVEL` covers enabled FastMCP/OIDC diagnostics while
   `FASTMCP_LOG_ENABLED=false` still disables FastMCP logging entirely.
 
-The guidance applies to the Docker/standalone `ha-mcp-oidc` entrypoint only.
-It does not alter the Home Assistant add-on, custom component, or OAuth mode's
-authentication design.
+The OIDC scope, persisted-state, and operator-configuration guidance applies
+to the Docker/standalone `ha-mcp-oidc` entrypoint only. It does not alter the
+Home Assistant add-on, custom component, or OAuth mode's authentication design.
+The common logging bridge described above separately applies to every
+entrypoint that uses `_setup_logging`.
 
 ## Testing
 
@@ -157,11 +164,14 @@ Follow red-green TDD with entrypoint coverage in
 8. Implement the compatibility subclass, entrypoint integration, and logging
    changes, then rerun both focused OIDC unit modules.
 9. Run `uv run ruff format --check` and `uv run ruff check` on all touched
-   Python files, `uv run mypy src/`, and both OIDC unit files. There is no OIDC
-   E2E test or live-IdP fixture in `tests/src/e2e/`; the pull request's ordinary
-   CI still runs the repository-wide E2E lanes. Before publishing, retain the
-   recorded red evidence, restore any safe temporary regression mutations, and
-   rerun the tests successfully.
+   Python files, `uv run mypy src/`, and both OIDC unit files. There is no live
+   OIDC/IdP fixture in `tests/src/e2e/`, so do not invent a local OIDC E2E
+   command. Require terminal success from the pull request's full `E2E Tests`
+   workflow and every applicable `HAOS E2E Tests` lane, including the embedded
+   and in-addon lanes when scheduled. Do not report verification complete until
+   those CI lanes pass. Before publishing, retain the recorded red evidence,
+   restore any safe temporary regression mutations, and rerun the focused tests
+   successfully.
 
 No live Authelia instance or Home Assistant state is required: the defect is
 the deterministic proxy, persisted-state, and logging behavior around FastMCP.

--- a/docs/superpowers/specs/2026-08-10-oidc-authelia-scope-design.md
+++ b/docs/superpowers/specs/2026-08-10-oidc-authelia-scope-design.md
@@ -173,6 +173,12 @@ Follow red-green TDD with entrypoint coverage in
    restore any safe temporary regression mutations, and rerun the focused tests
    successfully.
 
+Run both focused OIDC unit files with the repository test runner:
+
+```bash
+cd tests && UV_LINK_MODE=copy uv run pytest src/unit/test_oidc_compat.py src/unit/test_oidc_entrypoint.py -q
+```
+
 No live Authelia instance or Home Assistant state is required: the defect is
 the deterministic proxy, persisted-state, and logging behavior around FastMCP.
 

--- a/docs/superpowers/specs/2026-08-10-oidc-authelia-scope-design.md
+++ b/docs/superpowers/specs/2026-08-10-oidc-authelia-scope-design.md
@@ -1,0 +1,105 @@
+# OIDC Authelia scope and diagnostics fix (closes #2189)
+
+**Status:** approved 2026-08-10
+**Issue:** [#2189](https://github.com/homeassistant-ai/ha-mcp/issues/2189)
+**Branch:** `agent/fix-oidc-authelia` (worktree `worktree/fix-oidc-authelia/`)
+
+## Goal
+
+Make the standalone/container `ha-mcp-oidc` entrypoint interoperate with
+OIDC providers such as Authelia that issue opaque access tokens, and make
+`LOG_LEVEL=DEBUG` expose FastMCP's token-validation diagnostics.
+
+## Root cause
+
+The OIDC entrypoint constructs FastMCP's `OIDCProxy` without
+`required_scopes`. `fastmcp-remote` does not supply scopes itself; the MCP
+client selects them from the protected-resource metadata FastMCP derives from
+`required_scopes`. The resulting authorization request therefore has no
+`openid` scope.
+
+Authelia issues opaque access tokens by default and only returns an ID token
+when `openid` is requested. Consequently:
+
+- Default FastMCP verification attempts to parse the opaque access token as a
+  JWT and rejects the first MCP request with `invalid_token`.
+- `OIDC_VERIFY_ID_TOKEN=true` cannot help because the token response contains
+  no ID token to verify.
+- The preceding `/token` request still succeeds because FastMCP issues its
+  local reference JWT before it revalidates the stored upstream token on the
+  first `/mcp` request.
+
+The sparse diagnostics are a separate logging integration defect. FastMCP's
+`fastmcp` logger has its own handler and does not propagate to the root logger,
+so ha-mcp's root `LOG_LEVEL` configuration does not change FastMCP's effective
+level.
+
+## Design
+
+### OIDC scope
+
+Pass `required_scopes=["openid"]` whenever `ha-mcp-oidc` constructs
+`OIDCProxy`. This entrypoint promises OIDC rather than generic OAuth, so
+`openid` is a protocol requirement, not an optional provider-specific
+permission. FastMCP will advertise the scope to MCP clients, include it in the
+upstream authorization request, and retain it for FastMCP-token enforcement.
+
+Keep `OIDC_VERIFY_ID_TOKEN` opt-in. JWT-access-token providers continue using
+the default verification path. Opaque-access-token providers use ID-token
+verification after the now-guaranteed `openid` request causes them to return
+an ID token.
+
+### Logging
+
+Extend the common `_setup_logging` helper to set the `fastmcp` logger to the
+same level as ha-mcp's root logger. This preserves FastMCP's existing handler
+and formatting while making `LOG_LEVEL` behave consistently for every ha-mcp
+entrypoint. It also avoids requiring operators to discover and duplicate the
+setting as `FASTMCP_LOG_LEVEL`.
+
+### Documentation
+
+Update `docs/oidc.md` to:
+
+- state that ha-mcp always requests the required `openid` scope;
+- add Authelia to opaque-access-token provider compatibility guidance;
+- tell Authelia users to allow `openid` and set
+  `OIDC_VERIFY_ID_TOKEN=true`;
+- clarify that they do not need to enable JWT access tokens in Authelia; and
+- state that `LOG_LEVEL` covers FastMCP/OIDC diagnostics.
+
+The guidance applies to the Docker/standalone `ha-mcp-oidc` entrypoint only.
+It does not alter the Home Assistant add-on, custom component, or OAuth mode's
+authentication design.
+
+## Testing
+
+Follow red-green TDD with unit-level regression coverage in
+`tests/src/unit/test_oidc_entrypoint.py`:
+
+1. Extend the pinned `OIDCProxy` mock and real-signature subset assertion for
+   `required_scopes`.
+2. Add a failing test proving every OIDC proxy construction receives exactly
+   `["openid"]`.
+3. Add a failing test proving `_setup_logging("DEBUG")` lowers the effective
+   FastMCP logger level to DEBUG despite its non-propagating handler.
+4. Implement the minimum production changes and rerun the focused tests.
+5. Run `uv run ruff format --check` and `uv run ruff check` on the touched
+   Python files, `uv run mypy src/`, and the full OIDC unit file. There is no
+   OIDC E2E test or live-IdP fixture in `tests/src/e2e/`; the pull request's
+   ordinary CI still runs the repository-wide E2E lanes. Before publishing,
+   prove each regression test fails with its production fix temporarily
+   reverted, then restore the fixes and rerun the tests successfully.
+
+No live Authelia instance or Home Assistant state is required: the defect is
+the deterministic constructor and logging configuration passed to FastMCP.
+
+## Non-goals
+
+- Changing Authelia's access-token format or requiring RFC 9068 JWT access
+  tokens.
+- Adding token introspection support to FastMCP.
+- Changing `OIDC_AUDIENCE`, resource forwarding, redirect URI policy, or token
+  endpoint authentication.
+- Modifying add-on or custom-component authentication.
+- Changing FastMCP itself.

--- a/src/ha_mcp/__main__.py
+++ b/src/ha_mcp/__main__.py
@@ -1167,7 +1167,7 @@ def _oidc_verify_id_token_enabled() -> bool:
 
     Off by default: FastMCP's OIDCProxy verifies the access token as a JWT,
     which works for providers like Authentik and Keycloak. Providers that
-    issue opaque access tokens (Google always; Auth0 without an API
+    issue opaque access tokens (such as Authelia, or Auth0 without an API
     audience) need ``verify_id_token=True`` so FastMCP verifies the ID token
     instead.
     """
@@ -1607,7 +1607,7 @@ def main_oidc() -> None:
     """Run server with OIDC authentication over HTTP.
 
     This mode enables authentication via an external OIDC provider
-    (Authentik, Keycloak, Auth0, Google, etc.). All authenticated users
+    (Authentik, Keycloak, Auth0, etc.). All authenticated users
     share the same Home Assistant instance via the configured credentials.
 
     Unlike OAuth mode which collects per-user HA credentials via a consent form,
@@ -1629,7 +1629,7 @@ def main_oidc() -> None:
       patterns accepted from dynamically-registered clients. Strongly recommended for
       internet-facing deployments.
     - OIDC_VERIFY_ID_TOKEN (optional, default: false): Set true for providers that issue
-      opaque access tokens (e.g. Authelia and Google, or Auth0 without an API audience).
+      opaque access tokens (e.g. Authelia, or Auth0 without an API audience).
     - OIDC_AUDIENCE (optional): Expected `aud` claim for IdP-issued access tokens.
       Without it (and with OIDC_VERIFY_ID_TOKEN off), FastMCP's JWT verifier checks
       issuer, signature, and expiry but not audience. With OIDC_VERIFY_ID_TOKEN=true,

--- a/src/ha_mcp/__main__.py
+++ b/src/ha_mcp/__main__.py
@@ -1742,6 +1742,11 @@ async def _run_oidc_server(
         # IdP (Authentik, Keycloak, etc.) -- unlike `False`, this does not
         # log a security warning at startup that consent is disabled.
         "require_authorization_consent": "external",
+        # This entrypoint provides OIDC, so request the protocol-level scope
+        # that makes upstream providers return an ID token. FastMCP also
+        # advertises this scope through protected resource metadata so MCP
+        # clients include it in the authorization flow.
+        "required_scopes": ["openid"],
         # Preserve `or None`: an empty-but-set env var must not bypass
         # FastMCP's derive-from-client-secret default for jwt_signing_key.
         "jwt_signing_key": os.getenv("OIDC_JWT_SIGNING_KEY") or None,

--- a/src/ha_mcp/__main__.py
+++ b/src/ha_mcp/__main__.py
@@ -505,6 +505,8 @@ def _setup_logging(log_level_str: str, force: bool = True) -> None:
     """
     log_level = getattr(logging, log_level_str)
 
+    import fastmcp
+
     from ha_mcp.utils.usage_logger import preserve_startup_collector
 
     with preserve_startup_collector():
@@ -515,10 +517,16 @@ def _setup_logging(log_level_str: str, force: bool = True) -> None:
             force=force,
         )
 
-    # FastMCP configures its own handler and disables propagation, so the root
-    # level above does not control its OIDC diagnostics. Preserve that handler
-    # and formatting while honoring ha-mcp's LOG_LEVEL setting.
-    logging.getLogger("fastmcp").setLevel(log_level)
+    fastmcp_logger = logging.getLogger("fastmcp")
+    if fastmcp.settings.log_enabled:
+        # FastMCP configures its own handler and disables propagation, so the root
+        # level above does not control its OIDC diagnostics. Preserve that handler
+        # and formatting while honoring ha-mcp's LOG_LEVEL setting.
+        fastmcp_logger.setLevel(log_level)
+    else:
+        # FastMCP deliberately leaves its logger unconfigured when logging is
+        # disabled. Prevent that NOTSET namespace from inheriting our root handler.
+        fastmcp_logger.setLevel(logging.CRITICAL + 1)
 
     logging.getLogger("mcp.server.streamable_http").addFilter(
         StatelessSessionLogFilter()
@@ -1646,6 +1654,8 @@ def main_oidc() -> None:
     - HA_MCP_DISABLE_SETTINGS_UI (optional): set truthy to not serve the
       settings UI at all
     - LOG_LEVEL (optional, default: INFO)
+    - FASTMCP_LOG_ENABLED (optional, default: true): Set false to suppress
+      FastMCP framework logs while leaving ha-mcp logs at LOG_LEVEL.
     """
     # Configure logging for OIDC mode (force=True needed since logging may already be configured)
     log_level = os.getenv("LOG_LEVEL", "INFO").upper()
@@ -1731,8 +1741,7 @@ async def _run_oidc_server(
         port: Port to listen on
         path: MCP endpoint path
     """
-    from fastmcp.server.auth.oidc_proxy import OIDCProxy
-
+    from ha_mcp.auth.oidc_compat import HaMcpOIDCProxy
     from ha_mcp.server import HomeAssistantSmartMCPServer
     from ha_mcp.transport_security import ensure_host_origin_guard_default_off
 
@@ -1778,7 +1787,8 @@ async def _run_oidc_server(
         proxy_kwargs["audience"] = audience
 
     # Create OIDC auth provider — auto-discovers endpoints from config_url
-    auth = OIDCProxy(**proxy_kwargs)
+    auth = HaMcpOIDCProxy(**proxy_kwargs)
+    auth.setup_scope_compatibility()
 
     # Standard server with shared credentials (no proxy client needed)
     global _server

--- a/src/ha_mcp/__main__.py
+++ b/src/ha_mcp/__main__.py
@@ -1629,7 +1629,7 @@ def main_oidc() -> None:
       patterns accepted from dynamically-registered clients. Strongly recommended for
       internet-facing deployments.
     - OIDC_VERIFY_ID_TOKEN (optional, default: false): Set true for providers that issue
-      opaque access tokens (e.g. Google, or Auth0 without an API audience).
+      opaque access tokens (e.g. Authelia and Google, or Auth0 without an API audience).
     - OIDC_AUDIENCE (optional): Expected `aud` claim for IdP-issued access tokens.
       Without it (and with OIDC_VERIFY_ID_TOKEN off), FastMCP's JWT verifier checks
       issuer, signature, and expiry but not audience. With OIDC_VERIFY_ID_TOKEN=true,

--- a/src/ha_mcp/__main__.py
+++ b/src/ha_mcp/__main__.py
@@ -503,15 +503,23 @@ def _setup_logging(log_level_str: str, force: bool = True) -> None:
     of the sweep ``force`` performs (which removes *and closes* every root
     handler) so ``ha_report_issue`` keeps its startup diagnostics.
     """
+    log_level = getattr(logging, log_level_str)
+
     from ha_mcp.utils.usage_logger import preserve_startup_collector
 
     with preserve_startup_collector():
         logging.basicConfig(
-            level=getattr(logging, log_level_str),
+            level=log_level,
             format="%(asctime)s %(name)s %(levelname)s: %(message)s",
             datefmt=_LOG_DATE_FORMAT,
             force=force,
         )
+
+    # FastMCP configures its own handler and disables propagation, so the root
+    # level above does not control its OIDC diagnostics. Preserve that handler
+    # and formatting while honoring ha-mcp's LOG_LEVEL setting.
+    logging.getLogger("fastmcp").setLevel(log_level)
+
     logging.getLogger("mcp.server.streamable_http").addFilter(
         StatelessSessionLogFilter()
     )

--- a/src/ha_mcp/auth/oidc_compat.py
+++ b/src/ha_mcp/auth/oidc_compat.py
@@ -2,12 +2,15 @@
 
 from __future__ import annotations
 
+import logging
 from typing import override
 
 from fastmcp.server.auth.oauth_proxy.models import ProxyDCRClient
 from fastmcp.server.auth.oidc_proxy import OIDCProxy
 from mcp.server.auth.provider import AuthorizationParams, RefreshToken
 from mcp.shared.auth import OAuthClientInformationFull
+
+logger = logging.getLogger(__name__)
 
 
 class HaMcpOIDCProxy(OIDCProxy):
@@ -91,6 +94,13 @@ class HaMcpOIDCProxy(OIDCProxy):
         loaded = await super().load_refresh_token(client, refresh_token)
         if loaded is None:
             return None
-        if not set(self.required_scopes).issubset(loaded.scopes):
+        missing_scopes = set(self.required_scopes) - set(loaded.scopes)
+        if missing_scopes:
+            logger.debug(
+                "Rejecting legacy refresh token for client_id=%s: "
+                "missing required scopes %s",
+                client.client_id,
+                sorted(missing_scopes),
+            )
             return None
         return loaded

--- a/src/ha_mcp/auth/oidc_compat.py
+++ b/src/ha_mcp/auth/oidc_compat.py
@@ -1,0 +1,96 @@
+"""FastMCP OIDC compatibility behavior scoped to ha-mcp's OIDC entrypoint."""
+
+from __future__ import annotations
+
+from typing import override
+
+from fastmcp.server.auth.oauth_proxy.models import ProxyDCRClient
+from fastmcp.server.auth.oidc_proxy import OIDCProxy
+from mcp.server.auth.provider import AuthorizationParams, RefreshToken
+from mcp.shared.auth import OAuthClientInformationFull
+
+
+class HaMcpOIDCProxy(OIDCProxy):
+    """OIDC proxy with ha-mcp's FastMCP 3.4.6 compatibility behavior."""
+
+    def _add_required_scopes(self, scopes: list[str]) -> list[str]:
+        """Prepend any configured required scopes missing from ``scopes``."""
+        missing_scopes = [
+            scope for scope in self.required_scopes if scope not in scopes
+        ]
+        return [*missing_scopes, *scopes]
+
+    def setup_scope_compatibility(self) -> None:
+        """Allow optional DCR scopes without advertising them as requirements.
+
+        FastMCP 3.4.6 copies ``required_scopes`` into both the DCR default and
+        valid-scope allow-list.  The MCP SDK then rejects clients that add
+        ordinary optional OIDC scopes.  ``None`` restores upstream IdP scope
+        validation while FastMCP continues to default, advertise, and enforce
+        ha-mcp's required ``openid`` scope.
+        """
+        if self.required_scopes != ["openid"]:
+            raise RuntimeError(
+                "HaMcpOIDCProxy requires exactly the openid scope before setup"
+            )
+        options = self.client_registration_options
+        if options is None:
+            raise RuntimeError("FastMCP OIDCProxy did not enable client registration")
+        if options.default_scopes != ["openid"] or self._default_scope_str != "openid":
+            raise RuntimeError("FastMCP OIDCProxy did not preserve the openid default")
+        options.valid_scopes = None
+
+    @override
+    async def register_client(self, client_info: OAuthClientInformationFull) -> None:
+        """Persist DCR clients with every required scope included."""
+        current_scopes = client_info.scope.split() if client_info.scope else []
+        normalized_scopes = self._add_required_scopes(current_scopes)
+        if normalized_scopes != current_scopes:
+            client_info.scope = " ".join(normalized_scopes)
+        await super().register_client(client_info)
+
+    @override
+    async def authorize(
+        self,
+        client: OAuthClientInformationFull,
+        params: AuthorizationParams,
+    ) -> str:
+        """Forward every authorization with required scopes included."""
+        current_scopes = params.scopes or []
+        normalized_scopes = self._add_required_scopes(current_scopes)
+        if normalized_scopes != current_scopes:
+            params = params.model_copy(update={"scopes": normalized_scopes})
+        return await super().authorize(client, params)
+
+    @override
+    async def get_client(self, client_id: str) -> OAuthClientInformationFull | None:
+        """Load a client, adding required scopes to persisted legacy records once."""
+        was_persisted = await self._client_store.get(key=client_id) is not None
+        client = await super().get_client(client_id)
+        if client is None or not was_persisted:
+            return client
+        if not isinstance(client, ProxyDCRClient):
+            raise RuntimeError("FastMCP returned an unexpected persisted client type")
+
+        current_scopes = client.scope.split() if client.scope else []
+        normalized_scopes = self._add_required_scopes(current_scopes)
+        if normalized_scopes == current_scopes:
+            return client
+
+        migrated = client.model_copy(update={"scope": " ".join(normalized_scopes)})
+        await self._client_store.put(key=client_id, value=migrated)
+        return migrated
+
+    @override
+    async def load_refresh_token(
+        self,
+        client: OAuthClientInformationFull,
+        refresh_token: str,
+    ) -> RefreshToken | None:
+        """Reject legacy refresh tokens that predate required OIDC scopes."""
+        loaded = await super().load_refresh_token(client, refresh_token)
+        if loaded is None:
+            return None
+        if not set(self.required_scopes).issubset(loaded.scopes):
+            return None
+        return loaded

--- a/tests/src/unit/test_oidc_compat.py
+++ b/tests/src/unit/test_oidc_compat.py
@@ -1,0 +1,320 @@
+"""Regression tests for ha-mcp's FastMCP 3.4.6 OIDC compatibility layer."""
+
+from __future__ import annotations
+
+import hashlib
+import inspect
+import json
+import time
+from unittest.mock import AsyncMock, patch
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+from fastmcp.server.auth.oauth_proxy.models import (
+    ProxyDCRClient,
+    RefreshTokenMetadata,
+)
+from fastmcp.server.auth.oidc_proxy import OIDCConfiguration, OIDCProxy
+from key_value.aio.stores.memory import MemoryStore
+from mcp.server.auth.handlers.register import RegistrationHandler
+from mcp.server.auth.provider import AuthorizationParams
+from mcp.shared.auth import OAuthClientInformationFull
+from pydantic import AnyUrl
+from starlette.applications import Starlette
+from starlette.requests import Request
+from starlette.testclient import TestClient
+
+from ha_mcp.auth.oidc_compat import HaMcpOIDCProxy
+
+
+@pytest.fixture
+def oidc_proxy(monkeypatch: pytest.MonkeyPatch) -> HaMcpOIDCProxy:
+    """Create a real proxy while replacing only external OIDC discovery."""
+    configuration = OIDCConfiguration(
+        issuer="https://idp.example.com",
+        authorization_endpoint="https://idp.example.com/authorize",
+        token_endpoint="https://idp.example.com/token",
+        jwks_uri="https://idp.example.com/jwks",
+        response_types_supported=["code"],
+        subject_types_supported=["public"],
+        id_token_signing_alg_values_supported=["RS256"],
+        scopes_supported=["openid", "profile", "email", "offline_access"],
+    )
+    monkeypatch.setattr(
+        HaMcpOIDCProxy,
+        "get_oidc_configuration",
+        lambda self, config_url, strict, timeout_seconds: configuration,
+    )
+    return HaMcpOIDCProxy(
+        config_url="https://idp.example.com/.well-known/openid-configuration",
+        client_id="ha-mcp",
+        client_secret="test-client-secret",
+        base_url="https://mcp.example.com",
+        required_scopes=["openid"],
+        client_storage=MemoryStore(),
+        jwt_signing_key="test-jwt-signing-key",
+        require_authorization_consent="external",
+        enable_cimd=False,
+    )
+
+
+def _registration_request(scope: str | None) -> Request:
+    body = {
+        "redirect_uris": ["http://127.0.0.1:8765/callback"],
+        "grant_types": ["authorization_code", "refresh_token"],
+        "response_types": ["code"],
+    }
+    if scope is not None:
+        body["scope"] = scope
+    encoded = json.dumps(body).encode()
+
+    sent = False
+
+    async def receive() -> dict[str, object]:
+        nonlocal sent
+        if sent:
+            return {"type": "http.disconnect"}
+        sent = True
+        return {"type": "http.request", "body": encoded, "more_body": False}
+
+    return Request(
+        {
+            "type": "http",
+            "method": "POST",
+            "path": "/register",
+            "headers": [(b"content-type", b"application/json")],
+            "query_string": b"",
+        },
+        receive,
+    )
+
+
+async def _registered_payload(
+    proxy: HaMcpOIDCProxy, scope: str | None
+) -> dict[str, object]:
+    assert proxy.client_registration_options is not None
+    response = await RegistrationHandler(
+        provider=proxy,
+        options=proxy.client_registration_options,
+    ).handle(_registration_request(scope))
+    assert response.status_code == 201, response.body.decode()
+    return json.loads(response.body)
+
+
+def test_subclass_preserves_oidc_proxy_constructor_signature() -> None:
+    """Adding compatibility behavior must not narrow FastMCP's constructor API."""
+    assert inspect.signature(HaMcpOIDCProxy.__init__) == inspect.signature(
+        OIDCProxy.__init__
+    )
+
+
+def test_setup_keeps_openid_required_and_default_without_dcr_allow_list(
+    oidc_proxy: HaMcpOIDCProxy,
+) -> None:
+    """Setup must decouple DCR validation without broadening advertised defaults."""
+    assert oidc_proxy.client_registration_options is not None
+    assert oidc_proxy.client_registration_options.valid_scopes == ["openid"]
+
+    oidc_proxy.setup_scope_compatibility()
+
+    assert oidc_proxy.required_scopes == ["openid"]
+    assert oidc_proxy.client_registration_options.default_scopes == ["openid"]
+    assert oidc_proxy._default_scope_str == "openid"
+    assert oidc_proxy.client_registration_options.valid_scopes is None
+
+
+def test_protected_resource_metadata_advertises_only_openid(
+    oidc_proxy: HaMcpOIDCProxy,
+) -> None:
+    """Optional provider scopes must not make MCP clients request every scope."""
+    oidc_proxy.setup_scope_compatibility()
+    app = Starlette(routes=oidc_proxy.get_routes(mcp_path="/mcp"))
+
+    with TestClient(app) as client:
+        response = client.get("/.well-known/oauth-protected-resource/mcp")
+
+    assert response.status_code == 200
+    assert response.json()["scopes_supported"] == ["openid"]
+
+
+@pytest.mark.asyncio
+async def test_dcr_accepts_explicit_optional_oidc_scopes(
+    oidc_proxy: HaMcpOIDCProxy,
+) -> None:
+    """An MCP client may request optional scopes in addition to required openid."""
+    oidc_proxy.setup_scope_compatibility()
+
+    payload = await _registered_payload(
+        oidc_proxy, "openid profile email offline_access"
+    )
+
+    assert payload["scope"] == "openid profile email offline_access"
+
+
+@pytest.mark.asyncio
+async def test_dcr_and_authorize_add_openid_to_optional_only_scope(
+    oidc_proxy: HaMcpOIDCProxy,
+) -> None:
+    """Required scopes survive DCR and a later subset authorization request."""
+    oidc_proxy.setup_scope_compatibility()
+
+    payload = await _registered_payload(oidc_proxy, "profile")
+
+    assert payload["scope"] == "openid profile"
+    client_id = payload["client_id"]
+    assert isinstance(client_id, str)
+    persisted = await oidc_proxy._client_store.get(key=client_id)
+    assert persisted is not None
+    assert persisted.scope == "openid profile"
+
+    redirect_url = await oidc_proxy.authorize(
+        persisted,
+        AuthorizationParams(
+            state="client-state",
+            scopes=["profile"],
+            code_challenge="client-code-challenge",
+            redirect_uri=AnyUrl("http://127.0.0.1:8765/callback"),
+            redirect_uri_provided_explicitly=True,
+        ),
+    )
+
+    assert parse_qs(urlparse(redirect_url).query)["scope"] == ["openid profile"]
+
+
+@pytest.mark.asyncio
+async def test_dcr_without_scope_still_defaults_to_openid(
+    oidc_proxy: HaMcpOIDCProxy,
+) -> None:
+    """Decoupling valid scopes must not remove FastMCP's openid default."""
+    oidc_proxy.setup_scope_compatibility()
+
+    payload = await _registered_payload(oidc_proxy, None)
+
+    assert payload["scope"] == "openid"
+
+
+@pytest.mark.asyncio
+async def test_get_client_migrates_and_persists_legacy_scope_once(
+    oidc_proxy: HaMcpOIDCProxy,
+) -> None:
+    """A persisted pre-fix client missing openid is repaired on its first load."""
+    oidc_proxy.setup_scope_compatibility()
+    await oidc_proxy._client_store.put(
+        key="legacy-client",
+        value=ProxyDCRClient(
+            client_id="legacy-client",
+            redirect_uris=[AnyUrl("http://127.0.0.1:8765/callback")],
+            scope="profile email",
+            token_endpoint_auth_method="none",
+        ),
+    )
+
+    original_put = oidc_proxy._client_store.put
+    with patch.object(
+        oidc_proxy._client_store,
+        "put",
+        new=AsyncMock(wraps=original_put),
+    ) as put_spy:
+        migrated = await oidc_proxy.get_client("legacy-client")
+        unchanged = await oidc_proxy.get_client("legacy-client")
+
+    assert migrated is not None
+    assert migrated.scope == "openid profile email"
+    assert unchanged is not None
+    assert unchanged.scope == "openid profile email"
+    put_spy.assert_awaited_once()
+    persisted = await oidc_proxy._client_store.get(key="legacy-client")
+    assert persisted is not None
+    assert persisted.scope == "openid profile email"
+
+
+@pytest.mark.asyncio
+async def test_get_client_does_not_rewrite_compliant_persisted_client(
+    oidc_proxy: HaMcpOIDCProxy,
+) -> None:
+    """A persisted client that already has openid must remain byte-for-byte scoped."""
+    oidc_proxy.setup_scope_compatibility()
+    await oidc_proxy.register_client(
+        OAuthClientInformationFull(
+            client_id="current-client",
+            redirect_uris=["http://127.0.0.1:8765/callback"],
+            scope="profile openid email",
+        )
+    )
+
+    original_put = oidc_proxy._client_store.put
+    with patch.object(
+        oidc_proxy._client_store,
+        "put",
+        new=AsyncMock(wraps=original_put),
+    ) as put_spy:
+        client = await oidc_proxy.get_client("current-client")
+
+    assert client is not None
+    assert client.scope == "profile openid email"
+    put_spy.assert_not_awaited()
+
+
+async def _store_refresh_token(
+    proxy: HaMcpOIDCProxy,
+    *,
+    token: str,
+    client_id: str,
+    scopes: list[str],
+) -> None:
+    await proxy._refresh_token_store.put(
+        key=hashlib.sha256(token.encode()).hexdigest(),
+        value=RefreshTokenMetadata(
+            client_id=client_id,
+            scopes=scopes,
+            expires_at=int(time.time()) + 3600,
+            created_at=time.time(),
+        ),
+    )
+
+
+@pytest.mark.asyncio
+async def test_load_refresh_token_rejects_legacy_token_missing_openid(
+    oidc_proxy: HaMcpOIDCProxy,
+) -> None:
+    """A legacy refresh token cannot perpetuate a session without required scopes."""
+    oidc_proxy.setup_scope_compatibility()
+    client = OAuthClientInformationFull(
+        client_id="legacy-client",
+        redirect_uris=["http://127.0.0.1:8765/callback"],
+        scope="openid profile",
+    )
+    await _store_refresh_token(
+        oidc_proxy,
+        token="legacy-refresh-token",
+        client_id="legacy-client",
+        scopes=["profile"],
+    )
+
+    loaded = await oidc_proxy.load_refresh_token(client, "legacy-refresh-token")
+
+    assert loaded is None
+
+
+@pytest.mark.asyncio
+async def test_load_refresh_token_keeps_compliant_token_working(
+    oidc_proxy: HaMcpOIDCProxy,
+) -> None:
+    """The compatibility guard must not reject refresh tokens that contain openid."""
+    oidc_proxy.setup_scope_compatibility()
+    client = OAuthClientInformationFull(
+        client_id="current-client",
+        redirect_uris=["http://127.0.0.1:8765/callback"],
+        scope="openid profile",
+    )
+    await _store_refresh_token(
+        oidc_proxy,
+        token="current-refresh-token",
+        client_id="current-client",
+        scopes=["openid", "profile"],
+    )
+
+    loaded = await oidc_proxy.load_refresh_token(client, "current-refresh-token")
+
+    assert loaded is not None
+    assert loaded.scopes == ["openid", "profile"]

--- a/tests/src/unit/test_oidc_compat.py
+++ b/tests/src/unit/test_oidc_compat.py
@@ -59,6 +59,7 @@ def oidc_proxy(monkeypatch: pytest.MonkeyPatch) -> HaMcpOIDCProxy:
 
 
 def _registration_request(scope: str | None) -> Request:
+    """Build an MCP dynamic-client-registration request with an optional scope."""
     body = {
         "redirect_uris": ["http://127.0.0.1:8765/callback"],
         "grant_types": ["authorization_code", "refresh_token"],
@@ -71,6 +72,7 @@ def _registration_request(scope: str | None) -> Request:
     sent = False
 
     async def receive() -> dict[str, object]:
+        """Yield the encoded registration body once to Starlette."""
         nonlocal sent
         if sent:
             return {"type": "http.disconnect"}
@@ -92,6 +94,7 @@ def _registration_request(scope: str | None) -> Request:
 async def _registered_payload(
     proxy: HaMcpOIDCProxy, scope: str | None
 ) -> dict[str, object]:
+    """Register a client through the MCP handler and return its response payload."""
     assert proxy.client_registration_options is not None
     response = await RegistrationHandler(
         provider=proxy,
@@ -262,6 +265,7 @@ async def _store_refresh_token(
     client_id: str,
     scopes: list[str],
 ) -> None:
+    """Store refresh-token metadata for compatibility-guard tests."""
     await proxy._refresh_token_store.put(
         key=hashlib.sha256(token.encode()).hexdigest(),
         value=RefreshTokenMetadata(

--- a/tests/src/unit/test_oidc_compat.py
+++ b/tests/src/unit/test_oidc_compat.py
@@ -5,16 +5,20 @@ from __future__ import annotations
 import hashlib
 import inspect
 import json
+import logging
 import time
 from unittest.mock import AsyncMock, patch
 from urllib.parse import parse_qs, urlparse
 
 import pytest
 from fastmcp.server.auth.oauth_proxy.models import (
+    JTIMapping,
     ProxyDCRClient,
     RefreshTokenMetadata,
+    UpstreamTokenSet,
 )
 from fastmcp.server.auth.oidc_proxy import OIDCConfiguration, OIDCProxy
+from fastmcp.server.auth.providers.jwt import StaticTokenVerifier
 from key_value.aio.stores.memory import MemoryStore
 from mcp.server.auth.handlers.register import RegistrationHandler
 from mcp.server.auth.provider import AuthorizationParams
@@ -124,6 +128,59 @@ def test_setup_keeps_openid_required_and_default_without_dcr_allow_list(
     assert oidc_proxy.client_registration_options.default_scopes == ["openid"]
     assert oidc_proxy._default_scope_str == "openid"
     assert oidc_proxy.client_registration_options.valid_scopes is None
+
+
+def test_setup_rejects_wrong_required_scopes(
+    oidc_proxy: HaMcpOIDCProxy,
+) -> None:
+    """Compatibility setup must fail if the entrypoint scope contract drifts."""
+    oidc_proxy.required_scopes = ["profile"]
+
+    with pytest.raises(
+        RuntimeError,
+        match="HaMcpOIDCProxy requires exactly the openid scope before setup",
+    ):
+        oidc_proxy.setup_scope_compatibility()
+
+
+def test_setup_rejects_missing_registration_options(
+    oidc_proxy: HaMcpOIDCProxy,
+) -> None:
+    """Compatibility setup must fail if FastMCP disables DCR."""
+    oidc_proxy.client_registration_options = None
+
+    with pytest.raises(
+        RuntimeError,
+        match="FastMCP OIDCProxy did not enable client registration",
+    ):
+        oidc_proxy.setup_scope_compatibility()
+
+
+def test_setup_rejects_wrong_default_scopes(
+    oidc_proxy: HaMcpOIDCProxy,
+) -> None:
+    """Compatibility setup must fail if FastMCP changes the DCR scope default."""
+    assert oidc_proxy.client_registration_options is not None
+    oidc_proxy.client_registration_options.default_scopes = ["profile"]
+
+    with pytest.raises(
+        RuntimeError,
+        match="FastMCP OIDCProxy did not preserve the openid default",
+    ):
+        oidc_proxy.setup_scope_compatibility()
+
+
+def test_setup_rejects_wrong_upstream_default_scope_string(
+    oidc_proxy: HaMcpOIDCProxy,
+) -> None:
+    """Compatibility setup must fail if FastMCP changes its upstream default."""
+    oidc_proxy._default_scope_str = "profile"
+
+    with pytest.raises(
+        RuntimeError,
+        match="FastMCP OIDCProxy did not preserve the openid default",
+    ):
+        oidc_proxy.setup_scope_compatibility()
 
 
 def test_protected_resource_metadata_advertises_only_openid(
@@ -258,6 +315,124 @@ async def test_get_client_does_not_rewrite_compliant_persisted_client(
     put_spy.assert_not_awaited()
 
 
+@pytest.mark.asyncio
+async def test_get_client_rejects_unexpected_persisted_client_type(
+    oidc_proxy: HaMcpOIDCProxy,
+) -> None:
+    """Persisted migration must fail if FastMCP stops returning its DCR model."""
+    await oidc_proxy._client_store.put(
+        key="unexpected-client",
+        value=ProxyDCRClient(
+            client_id="unexpected-client",
+            redirect_uris=[AnyUrl("http://127.0.0.1:8765/callback")],
+            scope="profile",
+            token_endpoint_auth_method="none",
+        ),
+    )
+    unexpected = OAuthClientInformationFull(
+        client_id="unexpected-client",
+        redirect_uris=["http://127.0.0.1:8765/callback"],
+        scope="profile",
+    )
+
+    with (
+        patch.object(
+            OIDCProxy,
+            "get_client",
+            new=AsyncMock(return_value=unexpected),
+        ),
+        pytest.raises(
+            RuntimeError,
+            match="FastMCP returned an unexpected persisted client type",
+        ),
+    ):
+        await oidc_proxy.get_client("unexpected-client")
+
+
+async def _store_access_token(
+    proxy: HaMcpOIDCProxy,
+    *,
+    scopes: list[str],
+) -> str:
+    """Create a real FastMCP JWT backed by a stored upstream token set."""
+    now = time.time()
+    upstream_token = "upstream-access-token"
+    upstream_token_id = "upstream-token-id"
+    access_jti = "fastmcp-access-jti"
+    proxy._token_validator = StaticTokenVerifier(
+        tokens={
+            upstream_token: {
+                "client_id": "access-client",
+                "scopes": scopes,
+                "expires_at": int(now) + 3600,
+            }
+        },
+        required_scopes=proxy.required_scopes,
+    )
+    await proxy._upstream_token_store.put(
+        key=upstream_token_id,
+        value=UpstreamTokenSet(
+            upstream_token_id=upstream_token_id,
+            access_token=upstream_token,
+            refresh_token=None,
+            refresh_token_expires_at=None,
+            expires_at=now + 3600,
+            token_type="Bearer",
+            scope=" ".join(scopes),
+            client_id="access-client",
+            created_at=now,
+            raw_token_data={
+                "access_token": upstream_token,
+                "scope": " ".join(scopes),
+                "token_type": "Bearer",
+                "expires_in": 3600,
+            },
+        ),
+    )
+    await proxy._jti_mapping_store.put(
+        key=access_jti,
+        value=JTIMapping(
+            jti=access_jti,
+            upstream_token_id=upstream_token_id,
+            created_at=now,
+        ),
+    )
+    proxy.get_routes(mcp_path="/mcp")
+    return proxy.jwt_issuer.issue_access_token(
+        client_id="access-client",
+        scopes=scopes,
+        jti=access_jti,
+        expires_in=3600,
+    )
+
+
+@pytest.mark.asyncio
+async def test_load_access_token_rejects_legacy_token_missing_openid(
+    oidc_proxy: HaMcpOIDCProxy,
+) -> None:
+    """A live pre-fix access token must fail on its next MCP request."""
+    oidc_proxy.setup_scope_compatibility()
+    token = await _store_access_token(oidc_proxy, scopes=["profile"])
+
+    loaded = await oidc_proxy.load_access_token(token)
+
+    assert loaded is None
+
+
+@pytest.mark.asyncio
+async def test_load_access_token_keeps_compliant_token_working(
+    oidc_proxy: HaMcpOIDCProxy,
+) -> None:
+    """A FastMCP access token with required scopes must remain usable."""
+    oidc_proxy.setup_scope_compatibility()
+    token = await _store_access_token(oidc_proxy, scopes=["openid", "profile"])
+
+    loaded = await oidc_proxy.load_access_token(token)
+
+    assert loaded is not None
+    assert loaded.scopes == ["openid", "profile"]
+
+
 async def _store_refresh_token(
     proxy: HaMcpOIDCProxy,
     *,
@@ -280,6 +455,7 @@ async def _store_refresh_token(
 @pytest.mark.asyncio
 async def test_load_refresh_token_rejects_legacy_token_missing_openid(
     oidc_proxy: HaMcpOIDCProxy,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """A legacy refresh token cannot perpetuate a session without required scopes."""
     oidc_proxy.setup_scope_compatibility()
@@ -295,9 +471,13 @@ async def test_load_refresh_token_rejects_legacy_token_missing_openid(
         scopes=["profile"],
     )
 
-    loaded = await oidc_proxy.load_refresh_token(client, "legacy-refresh-token")
+    with caplog.at_level(logging.DEBUG, logger="ha_mcp.auth.oidc_compat"):
+        loaded = await oidc_proxy.load_refresh_token(client, "legacy-refresh-token")
 
     assert loaded is None
+    assert "client_id=legacy-client" in caplog.text
+    assert "missing required scopes" in caplog.text
+    assert "legacy-refresh-token" not in caplog.text
 
 
 @pytest.mark.asyncio

--- a/tests/src/unit/test_oidc_entrypoint.py
+++ b/tests/src/unit/test_oidc_entrypoint.py
@@ -23,9 +23,9 @@ def _make_mock_oidc_proxy(capture: dict) -> type:
     a kwarg not listed here, this raises TypeError instead of silently
     swallowing it — catching drift in *our own* call, not in FastMCP's
     constructor (see ``TestOIDCProxySignatureSubset`` for that check).
-    ``allowed_client_redirect_uris``, ``verify_id_token``, and ``audience``
-    are optional in production, so they default to the ``_UNSET`` sentinel
-    here and are only recorded in ``capture`` when actually passed.
+    ``required_scopes`` is mandatory in production. The remaining optional
+    constructor arguments default to the ``_UNSET`` sentinel and are only
+    recorded in ``capture`` when actually passed.
     """
 
     class MockOIDCProxy:
@@ -37,6 +37,7 @@ def _make_mock_oidc_proxy(capture: dict) -> type:
             client_secret,
             base_url,
             require_authorization_consent,
+            required_scopes,
             jwt_signing_key,
             allowed_client_redirect_uris=_UNSET,
             verify_id_token=_UNSET,
@@ -47,6 +48,7 @@ def _make_mock_oidc_proxy(capture: dict) -> type:
             capture["client_secret"] = client_secret
             capture["base_url"] = base_url
             capture["require_authorization_consent"] = require_authorization_consent
+            capture["required_scopes"] = required_scopes
             capture["jwt_signing_key"] = jwt_signing_key
             if allowed_client_redirect_uris is not _UNSET:
                 capture["allowed_client_redirect_uris"] = allowed_client_redirect_uris
@@ -271,8 +273,8 @@ class TestRunOidcServer:
     """Tests for _run_oidc_server async function."""
 
     @pytest.mark.asyncio
-    async def test_creates_oidc_proxy(self):
-        """_run_oidc_server should create an OIDCProxy with correct args."""
+    async def test_creates_oidc_proxy_with_required_openid_scope(self):
+        """OIDC mode should always require the protocol-level openid scope."""
         import ha_mcp.__main__ as main_module
 
         proxy_init_args: dict = {}
@@ -321,6 +323,7 @@ class TestRunOidcServer:
         assert proxy_init_args["client_secret"] == "test-secret"
         assert proxy_init_args["base_url"] == "https://mcp.example.com"
         assert proxy_init_args["require_authorization_consent"] == "external"
+        assert proxy_init_args["required_scopes"] == ["openid"]
 
     @pytest.mark.asyncio
     async def test_jwt_signing_key_passed_from_env(self):
@@ -1197,6 +1200,7 @@ class TestOIDCProxySignatureSubset:
             "client_secret",
             "base_url",
             "require_authorization_consent",
+            "required_scopes",
             "jwt_signing_key",
             "allowed_client_redirect_uris",
             "verify_id_token",

--- a/tests/src/unit/test_oidc_entrypoint.py
+++ b/tests/src/unit/test_oidc_entrypoint.py
@@ -274,13 +274,19 @@ class TestMainOidcLogging:
         import ha_mcp.__main__ as main_module
 
         fastmcp_logger = logging.getLogger("fastmcp")
+        streamable_http_logger = logging.getLogger("mcp.server.streamable_http")
+        fastmcp_server_logger = logging.getLogger("fastmcp.server.server")
         original_level = fastmcp_logger.level
+        original_streamable_http_filters = streamable_http_logger.filters[:]
+        original_fastmcp_server_filters = fastmcp_server_logger.filters[:]
         try:
             fastmcp_logger.setLevel(logging.INFO)
             main_module._setup_logging("DEBUG", force=False)
             assert fastmcp_logger.getEffectiveLevel() == logging.DEBUG
         finally:
             fastmcp_logger.setLevel(original_level)
+            streamable_http_logger.filters[:] = original_streamable_http_filters
+            fastmcp_server_logger.filters[:] = original_fastmcp_server_filters
 
 
 class TestRunOidcServer:

--- a/tests/src/unit/test_oidc_entrypoint.py
+++ b/tests/src/unit/test_oidc_entrypoint.py
@@ -60,6 +60,7 @@ def _make_mock_oidc_proxy(capture: dict) -> type:
                 capture["audience"] = audience
 
         def setup_scope_compatibility(self):
+            """Record that the entrypoint activated OIDC scope compatibility."""
             capture["setup_scope_compatibility_calls"] = (
                 capture.get("setup_scope_compatibility_calls", 0) + 1
             )

--- a/tests/src/unit/test_oidc_entrypoint.py
+++ b/tests/src/unit/test_oidc_entrypoint.py
@@ -277,14 +277,31 @@ class TestMainOidcLogging:
         streamable_http_logger = logging.getLogger("mcp.server.streamable_http")
         fastmcp_server_logger = logging.getLogger("fastmcp.server.server")
         original_level = fastmcp_logger.level
+        original_handlers = fastmcp_logger.handlers[:]
+        original_propagate = fastmcp_logger.propagate
+        original_formatters = [handler.formatter for handler in original_handlers]
         original_streamable_http_filters = streamable_http_logger.filters[:]
         original_fastmcp_server_filters = fastmcp_server_logger.filters[:]
         try:
             fastmcp_logger.setLevel(logging.INFO)
             main_module._setup_logging("DEBUG", force=False)
             assert fastmcp_logger.getEffectiveLevel() == logging.DEBUG
+            assert fastmcp_logger.handlers == original_handlers
+            assert fastmcp_logger.propagate is original_propagate
+            assert all(
+                handler.formatter is formatter
+                for handler, formatter in zip(
+                    fastmcp_logger.handlers, original_formatters, strict=True
+                )
+            )
         finally:
             fastmcp_logger.setLevel(original_level)
+            fastmcp_logger.handlers[:] = original_handlers
+            fastmcp_logger.propagate = original_propagate
+            for handler, formatter in zip(
+                original_handlers, original_formatters, strict=True
+            ):
+                handler.setFormatter(formatter)
             streamable_http_logger.filters[:] = original_streamable_http_filters
             fastmcp_server_logger.filters[:] = original_fastmcp_server_filters
 

--- a/tests/src/unit/test_oidc_entrypoint.py
+++ b/tests/src/unit/test_oidc_entrypoint.py
@@ -4,6 +4,7 @@ These tests verify environment variable validation, logging setup,
 and the OIDC server startup path without requiring a real OIDC provider.
 """
 
+import logging
 import os
 from typing import ClassVar
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -267,6 +268,19 @@ class TestMainOidcLogging:
             main_module.main_oidc()
 
         assert setup_logging_calls[0]["level"] == "INFO"
+
+    def test_setup_logging_configures_fastmcp_logger(self):
+        """LOG_LEVEL should apply to FastMCP's non-propagating logger."""
+        import ha_mcp.__main__ as main_module
+
+        fastmcp_logger = logging.getLogger("fastmcp")
+        original_level = fastmcp_logger.level
+        try:
+            fastmcp_logger.setLevel(logging.INFO)
+            main_module._setup_logging("DEBUG", force=False)
+            assert fastmcp_logger.getEffectiveLevel() == logging.DEBUG
+        finally:
+            fastmcp_logger.setLevel(original_level)
 
 
 class TestRunOidcServer:

--- a/tests/src/unit/test_oidc_entrypoint.py
+++ b/tests/src/unit/test_oidc_entrypoint.py
@@ -14,6 +14,7 @@ import pytest
 # Sentinel used by MockOIDCProxy below to distinguish "kwarg not passed" from
 # "kwarg passed with a falsy/None value" for the optional constructor args.
 _UNSET = object()
+_OIDC_PROXY_PATCH_TARGET = "ha_mcp.auth.oidc_compat.HaMcpOIDCProxy"
 
 
 def _make_mock_oidc_proxy(capture: dict) -> type:
@@ -57,6 +58,11 @@ def _make_mock_oidc_proxy(capture: dict) -> type:
                 capture["verify_id_token"] = verify_id_token
             if audience is not _UNSET:
                 capture["audience"] = audience
+
+        def setup_scope_compatibility(self):
+            capture["setup_scope_compatibility_calls"] = (
+                capture.get("setup_scope_compatibility_calls", 0) + 1
+            )
 
     return MockOIDCProxy
 
@@ -269,8 +275,10 @@ class TestMainOidcLogging:
 
         assert setup_logging_calls[0]["level"] == "INFO"
 
-    def test_setup_logging_configures_fastmcp_logger(self):
+    def test_setup_logging_configures_fastmcp_logger(self, monkeypatch):
         """LOG_LEVEL should apply to FastMCP's non-propagating logger."""
+        import fastmcp
+
         import ha_mcp.__main__ as main_module
 
         fastmcp_logger = logging.getLogger("fastmcp")
@@ -283,6 +291,7 @@ class TestMainOidcLogging:
         original_streamable_http_filters = streamable_http_logger.filters[:]
         original_fastmcp_server_filters = fastmcp_server_logger.filters[:]
         try:
+            monkeypatch.setattr(fastmcp.settings, "log_enabled", True)
             fastmcp_logger.setLevel(logging.INFO)
             main_module._setup_logging("DEBUG", force=False)
             assert fastmcp_logger.getEffectiveLevel() == logging.DEBUG
@@ -305,13 +314,70 @@ class TestMainOidcLogging:
             streamable_http_logger.filters[:] = original_streamable_http_filters
             fastmcp_server_logger.filters[:] = original_fastmcp_server_filters
 
+    def test_setup_logging_preserves_fastmcp_logging_opt_out(self, monkeypatch, caplog):
+        """FASTMCP_LOG_ENABLED=false should suppress FastMCP records."""
+        import fastmcp
+
+        import ha_mcp.__main__ as main_module
+
+        fastmcp_logger = logging.getLogger("fastmcp")
+        fastmcp_server_logger = logging.getLogger("fastmcp.server.server")
+        streamable_http_logger = logging.getLogger("mcp.server.streamable_http")
+        original_fastmcp_state = (
+            fastmcp_logger.level,
+            fastmcp_logger.handlers[:],
+            fastmcp_logger.propagate,
+            fastmcp_logger.disabled,
+        )
+        original_server_state = (
+            fastmcp_server_logger.level,
+            fastmcp_server_logger.handlers[:],
+            fastmcp_server_logger.propagate,
+            fastmcp_server_logger.disabled,
+            fastmcp_server_logger.filters[:],
+        )
+        original_streamable_http_filters = streamable_http_logger.filters[:]
+        try:
+            monkeypatch.setattr(fastmcp.settings, "log_enabled", False)
+            # Reproduce FastMCP's fresh disabled-startup state: configure_logging
+            # returns before installing handlers or disabling propagation.
+            fastmcp_logger.setLevel(logging.NOTSET)
+            fastmcp_logger.handlers.clear()
+            fastmcp_logger.propagate = True
+            fastmcp_logger.disabled = False
+            fastmcp_server_logger.setLevel(logging.NOTSET)
+            fastmcp_server_logger.handlers.clear()
+            fastmcp_server_logger.propagate = True
+            fastmcp_server_logger.disabled = False
+
+            with caplog.at_level(logging.DEBUG):
+                main_module._setup_logging("DEBUG", force=False)
+                fastmcp_server_logger.critical("disabled-fastmcp-sentinel")
+
+            assert "disabled-fastmcp-sentinel" not in caplog.messages
+        finally:
+            (
+                fastmcp_logger.level,
+                fastmcp_logger.handlers[:],
+                fastmcp_logger.propagate,
+                fastmcp_logger.disabled,
+            ) = original_fastmcp_state
+            (
+                fastmcp_server_logger.level,
+                fastmcp_server_logger.handlers[:],
+                fastmcp_server_logger.propagate,
+                fastmcp_server_logger.disabled,
+                fastmcp_server_logger.filters[:],
+            ) = original_server_state
+            streamable_http_logger.filters[:] = original_streamable_http_filters
+
 
 class TestRunOidcServer:
     """Tests for _run_oidc_server async function."""
 
     @pytest.mark.asyncio
     async def test_creates_oidc_proxy_with_required_openid_scope(self):
-        """OIDC mode should always require the protocol-level openid scope."""
+        """OIDC mode should require openid and enable scope compatibility."""
         import ha_mcp.__main__ as main_module
 
         proxy_init_args: dict = {}
@@ -332,9 +398,7 @@ class TestRunOidcServer:
 
         with (
             patch(
-                "ha_mcp.__main__.OIDCProxy"
-                if hasattr(main_module, "OIDCProxy")
-                else "fastmcp.server.auth.oidc_proxy.OIDCProxy",
+                _OIDC_PROXY_PATCH_TARGET,
                 MockOIDCProxy,
             ),
             patch(
@@ -361,6 +425,7 @@ class TestRunOidcServer:
         assert proxy_init_args["base_url"] == "https://mcp.example.com"
         assert proxy_init_args["require_authorization_consent"] == "external"
         assert proxy_init_args["required_scopes"] == ["openid"]
+        assert proxy_init_args.get("setup_scope_compatibility_calls", 0) == 1
 
     @pytest.mark.asyncio
     async def test_jwt_signing_key_passed_from_env(self):
@@ -388,9 +453,7 @@ class TestRunOidcServer:
                 os.environ, {"OIDC_JWT_SIGNING_KEY": "test-jwt-key"}, clear=False
             ),
             patch(
-                "ha_mcp.__main__.OIDCProxy"
-                if hasattr(main_module, "OIDCProxy")
-                else "fastmcp.server.auth.oidc_proxy.OIDCProxy",
+                _OIDC_PROXY_PATCH_TARGET,
                 MockOIDCProxy,
             ),
             patch(
@@ -437,9 +500,7 @@ class TestRunOidcServer:
         with (
             patch.dict(os.environ, env_without_key, clear=True),
             patch(
-                "ha_mcp.__main__.OIDCProxy"
-                if hasattr(main_module, "OIDCProxy")
-                else "fastmcp.server.auth.oidc_proxy.OIDCProxy",
+                _OIDC_PROXY_PATCH_TARGET,
                 MockOIDCProxy,
             ),
             patch(
@@ -482,7 +543,7 @@ class TestRunOidcServer:
             coro.close()
 
         with (
-            patch("fastmcp.server.auth.oidc_proxy.OIDCProxy", return_value=mock_auth),
+            patch(_OIDC_PROXY_PATCH_TARGET, return_value=mock_auth),
             patch(
                 "ha_mcp.server.HomeAssistantSmartMCPServer", return_value=mock_server
             ),
@@ -527,7 +588,7 @@ class TestRunOidcServer:
         mock_server.mcp = mock_mcp
 
         with (
-            patch("fastmcp.server.auth.oidc_proxy.OIDCProxy", return_value=MagicMock()),
+            patch(_OIDC_PROXY_PATCH_TARGET, return_value=MagicMock()),
             patch(
                 "ha_mcp.server.HomeAssistantSmartMCPServer", return_value=mock_server
             ),
@@ -581,9 +642,7 @@ class TestRunOidcServer:
                 "ha_mcp.transport_security.ensure_host_origin_guard_default_off"
             ) as mock_guard,
             patch(
-                "ha_mcp.__main__.OIDCProxy"
-                if hasattr(main_module, "OIDCProxy")
-                else "fastmcp.server.auth.oidc_proxy.OIDCProxy",
+                _OIDC_PROXY_PATCH_TARGET,
                 MockOIDCProxy,
             ),
             patch(
@@ -633,9 +692,7 @@ class TestRunOidcServer:
                 clear=False,
             ),
             patch(
-                "ha_mcp.__main__.OIDCProxy"
-                if hasattr(main_module, "OIDCProxy")
-                else "fastmcp.server.auth.oidc_proxy.OIDCProxy",
+                _OIDC_PROXY_PATCH_TARGET,
                 MockOIDCProxy,
             ),
             patch(
@@ -687,9 +744,7 @@ class TestRunOidcServer:
         with (
             patch.dict(os.environ, env_without_var, clear=True),
             patch(
-                "ha_mcp.__main__.OIDCProxy"
-                if hasattr(main_module, "OIDCProxy")
-                else "fastmcp.server.auth.oidc_proxy.OIDCProxy",
+                _OIDC_PROXY_PATCH_TARGET,
                 MockOIDCProxy,
             ),
             patch(
@@ -733,9 +788,7 @@ class TestRunOidcServer:
         with (
             patch.dict(os.environ, {"OIDC_VERIFY_ID_TOKEN": "true"}, clear=False),
             patch(
-                "ha_mcp.__main__.OIDCProxy"
-                if hasattr(main_module, "OIDCProxy")
-                else "fastmcp.server.auth.oidc_proxy.OIDCProxy",
+                _OIDC_PROXY_PATCH_TARGET,
                 MockOIDCProxy,
             ),
             patch(
@@ -782,9 +835,7 @@ class TestRunOidcServer:
         with (
             patch.dict(os.environ, env_without_var, clear=True),
             patch(
-                "ha_mcp.__main__.OIDCProxy"
-                if hasattr(main_module, "OIDCProxy")
-                else "fastmcp.server.auth.oidc_proxy.OIDCProxy",
+                _OIDC_PROXY_PATCH_TARGET,
                 MockOIDCProxy,
             ),
             patch(
@@ -832,9 +883,7 @@ class TestRunOidcServer:
         with (
             patch.dict(os.environ, {"OIDC_JWT_SIGNING_KEY": ""}, clear=False),
             patch(
-                "ha_mcp.__main__.OIDCProxy"
-                if hasattr(main_module, "OIDCProxy")
-                else "fastmcp.server.auth.oidc_proxy.OIDCProxy",
+                _OIDC_PROXY_PATCH_TARGET,
                 MockOIDCProxy,
             ),
             patch(
@@ -878,9 +927,7 @@ class TestRunOidcServer:
         with (
             patch.dict(os.environ, {"OIDC_VERIFY_ID_TOKEN": "false"}, clear=False),
             patch(
-                "ha_mcp.__main__.OIDCProxy"
-                if hasattr(main_module, "OIDCProxy")
-                else "fastmcp.server.auth.oidc_proxy.OIDCProxy",
+                _OIDC_PROXY_PATCH_TARGET,
                 MockOIDCProxy,
             ),
             patch(
@@ -928,9 +975,7 @@ class TestRunOidcServer:
                 clear=False,
             ),
             patch(
-                "ha_mcp.__main__.OIDCProxy"
-                if hasattr(main_module, "OIDCProxy")
-                else "fastmcp.server.auth.oidc_proxy.OIDCProxy",
+                _OIDC_PROXY_PATCH_TARGET,
                 MockOIDCProxy,
             ),
             patch(
@@ -980,9 +1025,7 @@ class TestRunOidcServer:
         with (
             patch.dict(os.environ, env_without_var, clear=True),
             patch(
-                "ha_mcp.__main__.OIDCProxy"
-                if hasattr(main_module, "OIDCProxy")
-                else "fastmcp.server.auth.oidc_proxy.OIDCProxy",
+                _OIDC_PROXY_PATCH_TARGET,
                 MockOIDCProxy,
             ),
             patch(
@@ -1036,9 +1079,7 @@ class TestRunOidcServer:
                 clear=False,
             ),
             patch(
-                "ha_mcp.__main__.OIDCProxy"
-                if hasattr(main_module, "OIDCProxy")
-                else "fastmcp.server.auth.oidc_proxy.OIDCProxy",
+                _OIDC_PROXY_PATCH_TARGET,
                 MockOIDCProxy,
             ),
             patch(
@@ -1090,9 +1131,7 @@ class TestRunOidcServer:
                 clear=False,
             ),
             patch(
-                "ha_mcp.__main__.OIDCProxy"
-                if hasattr(main_module, "OIDCProxy")
-                else "fastmcp.server.auth.oidc_proxy.OIDCProxy",
+                _OIDC_PROXY_PATCH_TARGET,
                 MockOIDCProxy,
             ),
             patch(
@@ -1144,9 +1183,7 @@ class TestRunOidcServer:
                 clear=False,
             ),
             patch(
-                "ha_mcp.__main__.OIDCProxy"
-                if hasattr(main_module, "OIDCProxy")
-                else "fastmcp.server.auth.oidc_proxy.OIDCProxy",
+                _OIDC_PROXY_PATCH_TARGET,
                 MockOIDCProxy,
             ),
             patch(
@@ -1191,9 +1228,7 @@ class TestRunOidcServer:
         with (
             patch.dict(os.environ, env_without_var, clear=True),
             patch(
-                "ha_mcp.__main__.OIDCProxy"
-                if hasattr(main_module, "OIDCProxy")
-                else "fastmcp.server.auth.oidc_proxy.OIDCProxy",
+                _OIDC_PROXY_PATCH_TARGET,
                 MockOIDCProxy,
             ),
             patch(
@@ -1285,9 +1320,7 @@ class TestRunOidcServerSettingsUI:
 
         with (
             patch(
-                "ha_mcp.__main__.OIDCProxy"
-                if hasattr(main_module, "OIDCProxy")
-                else "fastmcp.server.auth.oidc_proxy.OIDCProxy",
+                _OIDC_PROXY_PATCH_TARGET,
                 MockOIDCProxy,
             ),
             patch(


### PR DESCRIPTION
## What does this PR do?

Fixes #2189.

The standalone/container `ha-mcp-oidc` entrypoint now always requires the
protocol-level `openid` scope. A FastMCP 3.4.6 compatibility layer keeps
`openid` required, defaulted, and advertised while still allowing clients to
request optional provider scopes such as `profile`, `email`, or
`offline_access`. It also adds `openid` to optional-only registrations and
authorization requests so the upstream provider always returns an ID token.

Existing dynamic client registrations are retained and lazily migrated to add
`openid`. Legacy refresh tokens without the required scope are rejected once,
triggering reauthorization without normally requiring client re-registration.

This also makes ha-mcp's `LOG_LEVEL` apply to FastMCP's non-propagating logger,
while preserving `FASTMCP_LOG_ENABLED=false` as a complete FastMCP logging
opt-out.

The OIDC guide documents Authelia's default opaque-token configuration, the
scope behavior and upgrade path, ID-token verification, and logging controls.

## Type of change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [x] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing

- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

## Checklist

- [x] I have updated documentation if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved OIDC compatibility with Authelia and opaque-token providers.
  - OIDC configurations now require the `openid` scope while preserving optional scopes.
  - Added compatibility handling for existing registrations and refresh tokens.
  - Added configurable FastMCP diagnostics through `LOG_LEVEL`, including logging opt-out support.

- **Documentation**
  - Expanded guidance for Auth0, Authelia, and other OIDC providers.
  - Documented token verification, scope retention, upgrades, and registration behavior.

- **Tests**
  - Added coverage for scope compatibility, token handling, and logging configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->