### PR TITLE
fix: Survive a rich older than fastmcp's logging setup expects

### DIFF
--- a/src/ha_mcp/__init__.py
+++ b/src/ha_mcp/__init__.py
@@ -5,6 +5,10 @@ A Model Context Protocol server that provides complete control over Home Assista
 through REST API and WebSocket integration.
 """
 
+# Must be imported before anything that reaches fastmcp (``.auth`` below does),
+# because fastmcp configures rich logging at import time and dies on a rich
+# older than 13.9.4. Importing this module applies the shim. See #2186.
+from . import _rich_compat as _rich_compat
 from ._version import get_version
 
 __version__ = get_version()

--- a/src/ha_mcp/_rich_compat.py
+++ b/src/ha_mcp/_rich_compat.py
@@ -106,4 +106,4 @@ def ensure_rich_handler_compat() -> bool:
 # Applied as an import side effect: ``ha_mcp/__init__.py`` imports this module
 # ahead of anything that reaches fastmcp, and that is the only window in which
 # the shim can do any good.
-_SHIM_APPLIED = ensure_rich_handler_compat()
+ensure_rich_handler_compat()

--- a/src/ha_mcp/_rich_compat.py
+++ b/src/ha_mcp/_rich_compat.py
@@ -1,0 +1,103 @@
+"""Tolerate a ``rich`` older than fastmcp's logging setup expects (#2186).
+
+``fastmcp/__init__.py`` calls ``configure_logging()`` at import time, which
+builds a ``rich.logging.RichHandler`` with ``tracebacks_max_frames`` and
+``tracebacks_suppress`` unconditionally — no version guard, no ``try``. Both
+keywords require ``rich>=13.9.4`` (``fastmcp-slim``'s declared floor), so an
+environment holding an older ``rich`` cannot ``import fastmcp`` at all::
+
+    TypeError: RichHandler.__init__() got an unexpected keyword argument
+    'tracebacks_max_frames'
+
+Since ``ha_mcp/__init__.py`` imports ``.auth`` -> ``fastmcp``, that takes the
+whole package down before any of our code runs. It is not hypothetical: the
+official Home Assistant container ships ``rich 10.16.2`` (held below 11 by
+``surepy``'s ``rich>=10.1.0,<11.0.0``) and ``rich`` is absent from HA's
+``package_constraints.txt``, so whether installing ``ha-mcp`` pulls ``rich``
+forward is left entirely to the resolver — it usually does, and when it does
+not the integration cannot start.
+
+The declared dependency floor is correct upstream and this module does not
+second-guess it: it only intervenes when the *installed* ``RichHandler``
+genuinely cannot accept a keyword, dropping the unsupported ones so logging
+setup degrades instead of aborting the import. On ``rich>=13.9.4`` it is a
+no-op. Handlers still attach and still render; such installs lose only
+traceback frame-limiting and framework-frame suppression, which beats not
+importing.
+
+Remove this once the upstream fix is released and ha-mcp's floor excludes the
+affected fastmcp versions.
+"""
+
+from __future__ import annotations
+
+import functools
+import inspect
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Marker set on our wrapper so repeated calls do not stack wrappers.
+_PATCH_MARKER = "_ha_mcp_filters_unsupported_kwargs"
+
+# Present only on rich>=13.9.4; its absence is what makes fastmcp's call fatal.
+_PROBE_KWARG = "tracebacks_max_frames"
+
+
+def ensure_rich_handler_compat() -> bool:
+    """Make ``RichHandler`` ignore keywords the installed ``rich`` lacks.
+
+    Returns ``True`` when a shim is in place (freshly applied or already
+    applied), ``False`` when none is needed or none could be applied — an
+    unimportable ``rich``, an uninspectable ``__init__``, or a signature that
+    already absorbs ``**kwargs``.
+    """
+    try:
+        from rich.logging import RichHandler
+    except Exception:  # pragma: no cover - rich absent or broken
+        # fastmcp depends on rich, so this means the import would fail anyway
+        # for reasons this shim cannot address.
+        logger.debug("rich.logging unavailable; skipping RichHandler shim")
+        return False
+
+    original_init = RichHandler.__init__
+    if getattr(original_init, _PATCH_MARKER, False):
+        return True
+
+    try:
+        parameters = inspect.signature(original_init).parameters
+    except (TypeError, ValueError):  # pragma: no cover - exotic rich build
+        logger.debug("RichHandler.__init__ is not introspectable; skipping shim")
+        return False
+
+    if any(p.kind is inspect.Parameter.VAR_KEYWORD for p in parameters.values()):
+        # Already tolerant of anything fastmcp passes.
+        return False
+
+    if _PROBE_KWARG in parameters:
+        return False
+
+    supported = frozenset(parameters)
+
+    @functools.wraps(original_init)
+    def _init(self: Any, *args: Any, **kwargs: Any) -> Any:
+        return original_init(
+            self, *args, **{k: v for k, v in kwargs.items() if k in supported}
+        )
+
+    setattr(_init, _PATCH_MARKER, True)
+    RichHandler.__init__ = _init  # type: ignore[method-assign]
+
+    logger.debug(
+        "Installed RichHandler compatibility shim: rich is older than "
+        "fastmcp expects, so tracebacks lose frame-limiting and "
+        "framework-frame suppression. Upgrade to rich>=13.9.4 to restore them."
+    )
+    return True
+
+
+# Applied as an import side effect: ``ha_mcp/__init__.py`` imports this module
+# ahead of anything that reaches fastmcp, and that is the only window in which
+# the shim can do any good.
+_SHIM_APPLIED = ensure_rich_handler_compat()

--- a/src/ha_mcp/_rich_compat.py
+++ b/src/ha_mcp/_rich_compat.py
@@ -82,6 +82,12 @@ def ensure_rich_handler_compat() -> bool:
 
     @functools.wraps(original_init)
     def _init(self: Any, *args: Any, **kwargs: Any) -> Any:
+        dropped = kwargs.keys() - supported
+        if dropped:
+            logger.debug(
+                "Dropping RichHandler kwargs this rich does not accept: %s",
+                ", ".join(sorted(dropped)),
+            )
         return original_init(
             self, *args, **{k: v for k, v in kwargs.items() if k in supported}
         )

--- a/tests/src/unit/test_rich_compat.py
+++ b/tests/src/unit/test_rich_compat.py
@@ -1,0 +1,204 @@
+"""Unit tests for the ``rich``-version compatibility shim (#2186).
+
+``fastmcp.utilities.logging.configure_logging`` constructs a
+``rich.logging.RichHandler`` with ``tracebacks_max_frames`` and
+``tracebacks_suppress`` unconditionally, and ``fastmcp/__init__.py`` calls it
+at *import* time. Those two keyword arguments only exist on ``rich>=13.9.4``
+(``fastmcp-slim``'s declared floor), so on an environment that resolves an
+older ``rich`` the very first ``import fastmcp`` dies with::
+
+    TypeError: RichHandler.__init__() got an unexpected keyword argument
+    'tracebacks_max_frames'
+
+That is fatal for ha-mcp: ``ha_mcp/__init__.py`` imports ``.auth``, which
+imports ``fastmcp``, so *nothing* in the package can be imported. It is
+reachable in practice — the official Home Assistant container ships
+``rich 10.16.2`` (held below 11 by ``surepy``'s ``rich>=10.1.0,<11.0.0``),
+and ``rich`` is absent from HA's ``package_constraints.txt``, so whether the
+runtime install of ``ha-mcp`` drags ``rich`` up is left to the resolver.
+
+``ha_mcp._rich_compat`` filters keyword arguments the installed
+``RichHandler`` cannot accept, and only when it cannot accept them. The
+tracebacks lose frame-limiting and framework-frame suppression on such
+installs; they render.
+"""
+
+from __future__ import annotations
+
+import inspect
+import logging
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
+from ha_mcp._rich_compat import ensure_rich_handler_compat
+
+# The keyword arguments fastmcp passes that predate rich 13.9.4.
+_MODERN_ONLY_KWARGS = ("tracebacks_max_frames", "tracebacks_suppress")
+
+
+class _OldRichHandler(logging.Handler):
+    """Stand-in for ``rich<13.9.4``'s ``RichHandler``.
+
+    Accepts the keyword arguments that old rich understood and nothing else,
+    so passing a modern-only kwarg raises ``TypeError`` exactly as the real
+    old class does.
+    """
+
+    def __init__(
+        self,
+        level: int = logging.NOTSET,
+        console: object = None,
+        *,
+        show_path: bool = True,
+        show_level: bool = True,
+        rich_tracebacks: bool = False,
+    ) -> None:
+        super().__init__(level=level)
+        self.console = console
+        self.show_path = show_path
+        self.show_level = show_level
+        self.rich_tracebacks = rich_tracebacks
+
+
+class _ModernRichHandler(_OldRichHandler):
+    """Stand-in for ``rich>=13.9.4`` — understands the newer kwargs."""
+
+    def __init__(
+        self,
+        level: int = logging.NOTSET,
+        console: object = None,
+        *,
+        show_path: bool = True,
+        show_level: bool = True,
+        rich_tracebacks: bool = False,
+        tracebacks_max_frames: int = 100,
+        tracebacks_suppress: object = (),
+    ) -> None:
+        super().__init__(
+            level=level,
+            console=console,
+            show_path=show_path,
+            show_level=show_level,
+            rich_tracebacks=rich_tracebacks,
+        )
+        self.tracebacks_max_frames = tracebacks_max_frames
+        self.tracebacks_suppress = tracebacks_suppress
+
+
+@pytest.fixture
+def patched_rich(monkeypatch):
+    """Swap ``rich.logging.RichHandler`` for a stub, restored on teardown."""
+
+    def _install(handler_cls: type) -> type:
+        import rich.logging
+
+        # Subclass per test so the shim's mutation never leaks between tests.
+        stub = type(handler_cls.__name__, (handler_cls,), {})
+        monkeypatch.setattr(rich.logging, "RichHandler", stub)
+        return stub
+
+    return _install
+
+
+def test_old_rich_drops_unsupported_kwargs(patched_rich):
+    """The shim makes fastmcp's exact call survive on pre-13.9.4 rich."""
+    stub = patched_rich(_OldRichHandler)
+
+    # Without the shim this is the reported crash.
+    with pytest.raises(TypeError, match="tracebacks_max_frames"):
+        stub(rich_tracebacks=True, tracebacks_max_frames=3, tracebacks_suppress=[])
+
+    assert ensure_rich_handler_compat() is True
+
+    handler = stub(
+        show_path=False,
+        show_level=False,
+        rich_tracebacks=True,
+        tracebacks_max_frames=3,
+        tracebacks_suppress=[object()],
+    )
+
+    # Unsupported kwargs dropped, supported ones still applied.
+    assert handler.rich_tracebacks is True
+    assert handler.show_path is False
+    assert handler.show_level is False
+    for kwarg in _MODERN_ONLY_KWARGS:
+        assert not hasattr(handler, kwarg)
+
+
+def test_modern_rich_is_left_alone(patched_rich):
+    """On rich>=13.9.4 the shim must not touch ``RichHandler``."""
+    stub = patched_rich(_ModernRichHandler)
+    original_init = stub.__init__
+
+    assert ensure_rich_handler_compat() is False
+    assert stub.__init__ is original_init
+
+    handler = stub(rich_tracebacks=True, tracebacks_max_frames=3)
+    assert handler.tracebacks_max_frames == 3
+
+
+def test_shim_is_idempotent(patched_rich):
+    """Repeated calls must not stack wrappers around ``__init__``."""
+    stub = patched_rich(_OldRichHandler)
+
+    assert ensure_rich_handler_compat() is True
+    after_first = stub.__init__
+
+    assert ensure_rich_handler_compat() is True
+    assert stub.__init__ is after_first
+
+
+def test_missing_rich_is_not_fatal(monkeypatch):
+    """A ``rich`` that cannot be imported must not break ``import ha_mcp``."""
+    monkeypatch.setitem(sys.modules, "rich.logging", None)
+    assert ensure_rich_handler_compat() is False
+
+
+def test_importing_ha_mcp_survives_old_rich():
+    """End-to-end: ``import ha_mcp`` works when rich predates the kwargs.
+
+    This is the regression the issue actually reports, and it also pins the
+    ordering requirement — the shim has to run before anything imports
+    ``fastmcp``, which happens via ``ha_mcp/__init__.py`` -> ``.auth``.
+    """
+    program = textwrap.dedent(
+        """
+        import logging
+        import rich.logging
+
+        class OldRichHandler(logging.Handler):
+            def __init__(self, level=logging.NOTSET, console=None, *,
+                         show_path=True, show_level=True, rich_tracebacks=False):
+                super().__init__(level=level)
+
+        # Simulate rich<13.9.4 before anything imports fastmcp.
+        rich.logging.RichHandler = OldRichHandler
+
+        import ha_mcp
+        print("IMPORT_OK", ha_mcp.__version__)
+        """
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", program],
+        capture_output=True,
+        text=True,
+        timeout=120,
+        check=False,
+    )
+    assert "IMPORT_OK" in result.stdout, (
+        f"import ha_mcp failed under an old rich\n"
+        f"stdout: {result.stdout}\nstderr: {result.stderr}"
+    )
+
+
+def test_shim_signature_is_preserved(patched_rich):
+    """The wrapper keeps ``__init__`` introspectable for other callers."""
+    stub = patched_rich(_OldRichHandler)
+    ensure_rich_handler_compat()
+
+    params = inspect.signature(stub.__init__).parameters
+    assert "rich_tracebacks" in params

--- a/tests/src/unit/test_rich_compat.py
+++ b/tests/src/unit/test_rich_compat.py
@@ -129,6 +129,18 @@ def test_old_rich_drops_unsupported_kwargs(patched_rich):
         assert not hasattr(handler, kwarg)
 
 
+def test_dropped_kwargs_are_logged(patched_rich, caplog):
+    """Dropping is visible at debug level rather than silent."""
+    stub = patched_rich(_OldRichHandler)
+    ensure_rich_handler_compat()
+
+    with caplog.at_level(logging.DEBUG, logger="ha_mcp._rich_compat"):
+        stub(rich_tracebacks=True, tracebacks_max_frames=3, tracebacks_suppress=[])
+
+    for kwarg in _MODERN_ONLY_KWARGS:
+        assert kwarg in caplog.text
+
+
 def test_modern_rich_is_left_alone(patched_rich):
     """On rich>=13.9.4 the shim must not touch ``RichHandler``."""
     stub = patched_rich(_ModernRichHandler)
@@ -188,6 +200,10 @@ def test_importing_ha_mcp_survives_old_rich():
         text=True,
         timeout=120,
         check=False,
+    )
+    assert result.returncode == 0, (
+        f"import ha_mcp exited with {result.returncode}\n"
+        f"stdout: {result.stdout}\nstderr: {result.stderr}"
     )
     assert "IMPORT_OK" in result.stdout, (
         f"import ha_mcp failed under an old rich\n"


### PR DESCRIPTION
## What does this PR do?

Makes `import ha_mcp` survive an environment holding `rich < 13.9.4`, which
currently kills the package outright:

    TypeError: RichHandler.__init__() got an unexpected keyword argument 'tracebacks_max_frames'

`fastmcp/__init__.py:22` calls `configure_logging()` at *import* time, and it
passes `tracebacks_max_frames` and `tracebacks_suppress` to `RichHandler`
unconditionally — no version guard, no `try`. Both need `rich>=13.9.4`. Since
`ha_mcp/__init__.py` imports `.auth` -> `fastmcp`, the whole package becomes
unimportable and the integration is dead on arrival.

The official HA container ships **rich 10.16.2**, held below 11 by `surepy`'s
`rich>=10.1.0,<11.0.0`, and `rich` is absent from HA's
`package_constraints.txt` — so whether installing `ha-mcp` pulls rich forward is
left to the resolver. It usually does; when it doesn't, you get the above.

`ha_mcp._rich_compat` filters keyword arguments the installed `RichHandler`
cannot accept, and only when it cannot accept them. Imported first from
`ha_mcp/__init__.py` — the only window before `fastmcp` loads. Generic rather
than name-based: rich 10.16.2 also lacks `tracebacks_suppress`, so dropping only
`tracebacks_max_frames` moves the `TypeError` one keyword down. No-op on
`rich>=13.9.4`; affected installs keep working handlers and lose only traceback
frame-limiting and framework-frame suppression. Anything it drops is logged at
debug level, so the shim is discoverable rather than silent.

Not an upstream fix — `fastmcp-slim` 3.4.6 still passes the kwarg unguarded, and
its `rich>=13.9.4` floor was already declared and simply not honoured in the
failing environment. Remove the shim once upstream ships the fix and our floor
excludes the affected versions.

Server-package only — no `custom_components/` change, so no component version bump.

Fixes #2186

## Type of change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

## Checklist
- [x] I have updated documentation if needed
