### PR TITLE
test: generalize PR checkout credential guard

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -278,6 +278,7 @@ jobs:
     - name: Setup Node
       uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
       with:
+        # Corepack is bundled only through Node 24; `corepack npm ci` enforces packageManager.
         node-version: "22"
         cache: npm
         cache-dependency-path: site/package-lock.json

--- a/tests/src/unit/test_supply_chain_workflow_shape.py
+++ b/tests/src/unit/test_supply_chain_workflow_shape.py
@@ -3,14 +3,15 @@
 from pathlib import Path
 from typing import Any
 
+import pytest
 import yaml
 
 _REPO_ROOT = Path(__file__).resolve().parents[3]
 _WORKFLOW_DIR = _REPO_ROOT / ".github" / "workflows"
 
 
-def _workflow(name: str) -> dict[str, Any]:
-    return yaml.safe_load((_WORKFLOW_DIR / name).read_text(encoding="utf-8"))
+def _workflow(path: Path) -> dict[str, Any]:
+    return yaml.safe_load(path.read_text(encoding="utf-8"))
 
 
 def _triggers(data: dict[str, Any]) -> set[str]:
@@ -22,37 +23,77 @@ def _triggers(data: dict[str, Any]) -> set[str]:
     return set(on_node)
 
 
-def test_pr_workflows_do_not_persist_checkout_credentials() -> None:
+def _assert_checkout_credentials_are_not_persisted(
+    path: Path, repo_root: Path, visited: set[Path] | None = None
+) -> int:
+    path = path.resolve()
+    visited = visited or set()
+    if path in visited:
+        return 0
+    visited.add(path)
+
+    data = _workflow(path)
     checked = 0
+    for job in data["jobs"].values():
+        for step in job.get("steps", []):
+            if "actions/checkout" not in str(step.get("uses", "")):
+                continue
+            checked += 1
+            assert (step.get("with") or {}).get("persist-credentials") is False, (
+                f"{path.relative_to(repo_root)} persists checkout credentials in a "
+                "pull_request workflow"
+            )
+
+        uses = job.get("uses")
+        if isinstance(uses, str) and uses.startswith("./.github/workflows/"):
+            called_path = repo_root / uses.removeprefix("./")
+            checked += _assert_checkout_credentials_are_not_persisted(
+                called_path, repo_root, visited
+            )
+
+    return checked
+
+
+def test_pr_workflows_do_not_persist_checkout_credentials() -> None:
+    checked_workflows = 0
+    checked_checkouts = 0
     workflow_paths = sorted(
         path for path in _WORKFLOW_DIR.iterdir() if path.suffix in {".yml", ".yaml"}
     )
     for path in workflow_paths:
-        data = _workflow(path.name)
+        data = _workflow(path)
         if "pull_request" not in _triggers(data):
             continue
 
-        jobs = data["jobs"].values()
-        checkouts = [
-            step
-            for job in jobs
-            for step in job.get("steps", [])
-            if "actions/checkout" in str(step.get("uses", ""))
-        ]
-        if not checkouts:
-            continue
+        checked_workflows += 1
+        checked_checkouts += _assert_checkout_credentials_are_not_persisted(
+            path, _REPO_ROOT
+        )
 
-        checked += 1
-        assert all(
-            (step.get("with") or {}).get("persist-credentials") is False
-            for step in checkouts
-        ), f"{path.name} persists checkout credentials in a pull_request workflow"
+    assert checked_workflows, "trigger derivation matched no pull_request workflow"
+    assert checked_checkouts, "pull_request workflows contained no checkout steps"
 
-    assert checked, "trigger derivation matched no pull_request workflow with checkout"
+
+def test_pr_checkout_guard_follows_reusable_workflows(tmp_path: Path) -> None:
+    workflow_dir = tmp_path / ".github" / "workflows"
+    workflow_dir.mkdir(parents=True)
+    caller = workflow_dir / "caller.yml"
+    caller.write_text(
+        "jobs:\n  delegated:\n    uses: ./.github/workflows/reusable.yaml\n",
+        encoding="utf-8",
+    )
+    reusable = workflow_dir / "reusable.yaml"
+    reusable.write_text(
+        "jobs:\n  build:\n    steps:\n      - uses: actions/checkout@v4\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(AssertionError, match=r"reusable\.yaml persists"):
+        _assert_checkout_credentials_are_not_persisted(caller, tmp_path)
 
 
 def test_dev_release_tag_cleanup_uses_authenticated_github_api() -> None:
-    jobs = _workflow("publish-dev.yml")["jobs"]
+    jobs = _workflow(_WORKFLOW_DIR / "publish-dev.yml")["jobs"]
     create_run = next(
         step["run"]
         for step in jobs["create-prerelease"]["steps"]

--- a/tests/src/unit/test_supply_chain_workflow_shape.py
+++ b/tests/src/unit/test_supply_chain_workflow_shape.py
@@ -24,7 +24,10 @@ def _triggers(data: dict[str, Any]) -> set[str]:
 
 def test_pr_workflows_do_not_persist_checkout_credentials() -> None:
     checked = 0
-    for path in sorted(_WORKFLOW_DIR.glob("*.yml")):
+    workflow_paths = sorted(
+        path for path in _WORKFLOW_DIR.iterdir() if path.suffix in {".yml", ".yaml"}
+    )
+    for path in workflow_paths:
         data = _workflow(path.name)
         if "pull_request" not in _triggers(data):
             continue

--- a/tests/src/unit/test_supply_chain_workflow_shape.py
+++ b/tests/src/unit/test_supply_chain_workflow_shape.py
@@ -39,7 +39,8 @@ def _assert_checkout_credentials_are_not_persisted(
             if "actions/checkout" not in str(step.get("uses", "")):
                 continue
             checked += 1
-            assert (step.get("with") or {}).get("persist-credentials") is False, (
+            persist_credentials = (step.get("with") or {}).get("persist-credentials")
+            assert persist_credentials is False or persist_credentials == "false", (
                 f"{path.relative_to(repo_root)} persists checkout credentials in a "
                 "pull_request workflow"
             )
@@ -84,10 +85,16 @@ def test_pr_checkout_guard_follows_reusable_workflows(tmp_path: Path) -> None:
     )
     reusable = workflow_dir / "reusable.yaml"
     reusable.write_text(
+        "jobs:\n  build:\n    steps:\n      - uses: actions/checkout@v4\n"
+        '        with:\n          persist-credentials: "false"\n',
+        encoding="utf-8",
+    )
+    assert _assert_checkout_credentials_are_not_persisted(caller, tmp_path) == 1
+
+    reusable.write_text(
         "jobs:\n  build:\n    steps:\n      - uses: actions/checkout@v4\n",
         encoding="utf-8",
     )
-
     with pytest.raises(AssertionError, match=r"reusable\.yaml persists"):
         _assert_checkout_credentials_are_not_persisted(caller, tmp_path)
 

--- a/tests/src/unit/test_supply_chain_workflow_shape.py
+++ b/tests/src/unit/test_supply_chain_workflow_shape.py
@@ -13,24 +13,39 @@ def _workflow(name: str) -> dict[str, Any]:
     return yaml.safe_load((_WORKFLOW_DIR / name).read_text(encoding="utf-8"))
 
 
+def _triggers(data: dict[str, Any]) -> set[str]:
+    on_node = data.get(True) or data.get("on") or {}
+    if isinstance(on_node, str):
+        return {on_node}
+    if isinstance(on_node, list):
+        return set(on_node)
+    return set(on_node)
+
+
 def test_pr_workflows_do_not_persist_checkout_credentials() -> None:
-    for name in (
-        "haos-e2e-tests.yml",
-        "build-binary.yml",
-        "performance-tests.yml",
-    ):
-        jobs = _workflow(name)["jobs"].values()
+    checked = 0
+    for path in sorted(_WORKFLOW_DIR.glob("*.yml")):
+        data = _workflow(path.name)
+        if "pull_request" not in _triggers(data):
+            continue
+
+        jobs = data["jobs"].values()
         checkouts = [
             step
             for job in jobs
             for step in job.get("steps", [])
             if "actions/checkout" in str(step.get("uses", ""))
         ]
-        assert checkouts, f"{name} must contain a checkout step"
+        if not checkouts:
+            continue
+
+        checked += 1
         assert all(
             (step.get("with") or {}).get("persist-credentials") is False
             for step in checkouts
-        ), f"{name} persists checkout credentials in a pull_request workflow"
+        ), f"{path.name} persists checkout credentials in a pull_request workflow"
+
+    assert checked, "trigger derivation matched no pull_request workflow with checkout"
 
 
 def test_dev_release_tag_cleanup_uses_authenticated_github_api() -> None:


### PR DESCRIPTION
## Summary

- derive the checkout credential guard from every workflow's parsed `pull_request` trigger instead of hardcoding three filenames
- discover both supported GitHub Actions extensions (`.yml` and `.yaml`)
- recursively inspect local reusable workflows reached by PR workflows, with cycle protection
- normalize YAML scalar, list, and mapping trigger forms and retain non-vacuous workflow and checkout assertions
- document the Corepack compatibility constraint at the remaining Node setup that runs `corepack npm ci`

## Rationale

PR #2196 established that every checkout in a `pull_request` workflow disables persisted credentials. This change makes the structural test enforce that repository-wide invariant for current and future workflows, including checkout steps delegated to local reusable workflows.

## Validation

- `uv run ruff format --check tests/src/unit/test_supply_chain_workflow_shape.py`
- `uv run ruff check tests/src/unit/test_supply_chain_workflow_shape.py`
- `uv run pytest tests/src/unit/test_supply_chain_workflow_shape.py -q`
- synthetic regression test verifies a credential-persisting checkout in a reusable workflow is rejected
- trigger audit: 11 workflows and 33 checkout steps covered
- full PR CI, E2E, HAOS, CodeQL, and CodeRabbit checks passed before the latest review fix; rerun pending
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified that Corepack is bundled through Node.js 24 and that package installation enforces the declared package manager.
- **Chores**
  - Strengthened automated checks for site workflows, including reusable workflow coverage and checkout credential persistence.
  - Expanded workflow validation across supported trigger configuration formats and all applicable pull request workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->