### PR TITLE
ci: restore Renovate updates and vulnerability-alert access

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -44,6 +44,10 @@ jobs:
           permission-contents: write
           permission-issues: write
           permission-pull-requests: write
+          # Without this the vulnerabilityAlerts carve-out in renovate.json is
+          # dead: an installation token that lists any permission-* input drops
+          # every permission it does not name, including vulnerability_alerts.
+          permission-vulnerability-alerts: read
           permission-workflows: write
 
       - name: Self-hosted Renovate

--- a/renovate.json
+++ b/renovate.json
@@ -8,6 +8,7 @@
     "after 3pm on tuesday"
   ],
   "minimumReleaseAge": "7 days",
+  "minimumReleaseAgeBehaviour": "timestamp-optional",
   "vulnerabilityAlerts": {
     "minimumReleaseAge": null
   },

--- a/tests/src/unit/test_supply_chain_workflow_shape.py
+++ b/tests/src/unit/test_supply_chain_workflow_shape.py
@@ -118,10 +118,10 @@ def test_renovate_token_can_read_vulnerability_alerts() -> None:
 def test_renovate_age_gate_tolerates_datasources_without_timestamps() -> None:
     config = json.loads((_REPO_ROOT / "renovate.json").read_text(encoding="utf-8"))
 
-    assert (
-        config.get("minimumReleaseAge") is None
-        or config.get("minimumReleaseAgeBehaviour") == "timestamp-optional"
-    ), (
+    assert config.get("minimumReleaseAge") is not None, (
+        "the release-age gate from #2196 is part of the supply-chain contract"
+    )
+    assert config.get("minimumReleaseAgeBehaviour") == "timestamp-optional", (
         "ghcr.io tags carry no releaseTimestamp - the docker datasource reads it "
         "from Docker Hub only - so minimumReleaseAge under the default "
         "timestamp-required behaviour holds every ghcr update pending forever"

--- a/tests/src/unit/test_supply_chain_workflow_shape.py
+++ b/tests/src/unit/test_supply_chain_workflow_shape.py
@@ -1,5 +1,6 @@
 """Guard supply-chain hardening that cannot be exercised by PR workflows."""
 
+import json
 from pathlib import Path
 from typing import Any
 
@@ -97,6 +98,34 @@ def test_pr_checkout_guard_follows_reusable_workflows(tmp_path: Path) -> None:
     )
     with pytest.raises(AssertionError, match=r"reusable\.yaml persists"):
         _assert_checkout_credentials_are_not_persisted(caller, tmp_path)
+
+
+def test_renovate_token_can_read_vulnerability_alerts() -> None:
+    steps = _workflow(_WORKFLOW_DIR / "renovate.yml")["jobs"]["renovate"]["steps"]
+    token_step = next(
+        step
+        for step in steps
+        if "actions/create-github-app-token" in str(step.get("uses", ""))
+    )
+
+    assert (token_step["with"]).get("permission-vulnerability-alerts") == "read", (
+        "the Renovate token lists permission-* inputs and so drops every "
+        "permission it does not name; without vulnerability_alerts read the "
+        "vulnerabilityAlerts carve-out in renovate.json cannot fire"
+    )
+
+
+def test_renovate_age_gate_tolerates_datasources_without_timestamps() -> None:
+    config = json.loads((_REPO_ROOT / "renovate.json").read_text(encoding="utf-8"))
+
+    assert (
+        config.get("minimumReleaseAge") is None
+        or config.get("minimumReleaseAgeBehaviour") == "timestamp-optional"
+    ), (
+        "ghcr.io tags carry no releaseTimestamp - the docker datasource reads it "
+        "from Docker Hub only - so minimumReleaseAge under the default "
+        "timestamp-required behaviour holds every ghcr update pending forever"
+    )
 
 
 def test_dev_release_tag_cleanup_uses_authenticated_github_api() -> None:


### PR DESCRIPTION
## What does this PR do?

Fixes two regressions that the first Renovate run under the config from #2196 surfaced, and pins both with structural tests. Full evidence trail in #1237.

**1. `minimumReleaseAge` freezes every ghcr.io update, not just recent ones**

`minimumReleaseAge: "7 days"` runs under the default `minimumReleaseAgeBehaviour: timestamp-required`, and the docker datasource derives a release timestamp for Docker Hub images only ("Only supported on Docker Hub: The release timestamp is determined from the `tag_last_pushed` field"). Both CI images live on ghcr.io, so Renovate has no timestamp for them and `lib/util/minimum-release-age.ts` returns `isPending: true` by definition.

Manual run [31591982463](https://github.com/homeassistant-ai/ha-mcp/actions/runs/31591982463):

```
DEBUG: Marking 4 release(s) as pending, as they do not have a releaseTimestamp
       and we're running with minimumReleaseAgeBehaviour=timestamp-required
  "depName": "ghcr.io/astral-sh/uv",
  "versions": ["0.12.3", "0.12.2", "0.12.1", "0.12.0"],
  "check": "minimumReleaseAge"
```

Same for the HA container with `["2026.8.1"]`. uv 0.12.0 was built 2026-07-28 and is blocked for the same reason as 0.12.3, so this is not a seven-day wait — no scheduled run resolves it. `timestamp-optional` keeps the age gate wherever a timestamp exists (github-releases for HAOS, pypi for the vendored pin) and stops blocking where none does. Scoping the rule with a `matchDatasources` exemption for docker was the alternative; it also exempts Docker Hub images, where the timestamp is available and the wait works as intended.

**2. The Renovate token can no longer read vulnerability alerts**

#2196 narrowed the installation token to four `permission-*` inputs. A token that names any permission drops the ones it does not name, so `vulnerability_alerts` went away. The run now logs `WARN: Cannot access vulnerability alerts. Please ensure permissions have been granted.` with `x-accepted-github-permissions: vulnerability_alerts=read`, and the dashboard carries a Repository Problems section for it; the 2026-08-04 run logged nothing of the kind. Alerts are enabled on the repository (`GET /repos/.../vulnerability-alerts` → 204).

That leaves the `vulnerabilityAlerts: {minimumReleaseAge: null}` carve-out added in the same PR unable to fire, which is the one path that should bypass the wait. Granting the permission on the token is the first step — the same warning also appeared in the dashboard's first revision on 2026-05-11, long before #2196, so if it survives this change the App installation itself lacks the Dependabot alerts permission and it has to be granted there.

**Tests**

Two guards in `tests/src/unit/test_supply_chain_workflow_shape.py`, next to the existing #2196 shape tests. Both were fault-injected: removing the permission input and flipping the behaviour back to `timestamp-required` each turn their test red.

## Type of change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [ ] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

The unit suite was run on this branch and on a clean checkout of master, both with `--maxfail=0`, and the failure sets are identical: 9 failed / 5 errors on each, all from the local sandbox (submodule not checked out, `aiohttp` absent), with this branch at +2 passed for the two new guards. So the second box is unticked deliberately - nothing here regressed, but the local run is not a clean pass and CI is the authority. The agent-facing box does not apply to a CI-configuration change.

The real verification for the Renovate side is the next run: the two pending entries should become PRs, and the Repository Problems section should disappear.

## Checklist
- [x] I have updated documentation if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automated update configuration to preserve vulnerability-alert read access.
  * Updated release-age validation to handle releases where timestamp information is unavailable.
  * Automated dependency updates now continue to be evaluated consistently across supported release metadata.

* **Tests**
  * Added regression coverage for vulnerability-alert permissions and timestamp-optional release validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->