### PR TITLE
ci: harden Renovate follow-up behavior

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -39,7 +39,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
-          app-id: ${{ secrets.RENOVATE_APP_ID }}
+          client-id: ${{ secrets.RENOVATE_APP_ID }}
           private-key: ${{ secrets.RENOVATE_APP_PRIVATE_KEY }}
           permission-contents: write
           permission-issues: write
@@ -54,8 +54,8 @@ jobs:
         uses: renovatebot/github-action@316d7cd859606d6039a2182b7d69199e9b036835 # v46.2.1
         with:
           configurationFile: renovate.json
+          renovate-version: 44.26.0
           token: ${{ steps.app-token.outputs.token }}
         env:
           LOG_LEVEL: ${{ inputs.logLevel || 'info' }}
-          RENOVATE_ALLOWED_POST_UPGRADE_COMMANDS: '["^cat.*", "^echo.*", "^cut.*", "^sed.*", "^git add.*"]'
           RENOVATE_REPOSITORIES: ${{ github.repository }}

--- a/renovate.json
+++ b/renovate.json
@@ -8,7 +8,7 @@
     "after 3pm on tuesday"
   ],
   "minimumReleaseAge": "7 days",
-  "minimumReleaseAgeBehaviour": "timestamp-required",
+  "minimumReleaseAgeBehaviour": "timestamp-optional",
   "logLevelRemap": [
     {
       "matchMessage": "External host error causing abort - skipping",
@@ -86,18 +86,6 @@
     }
   ],
   "packageRules": [
-    {
-      "description": "Docker update streams verified not to publish usable release timestamps",
-      "matchDatasources": [
-        "docker"
-      ],
-      "matchPackageNames": [
-        "ghcr.io/astral-sh/uv",
-        "ghcr.io/home-assistant/home-assistant",
-        "python"
-      ],
-      "minimumReleaseAgeBehaviour": "timestamp-optional"
-    },
     {
       "description": "Keep Python interpreter changes coordinated while allowing same-tag digest refreshes",
       "matchManagers": [

--- a/renovate.json
+++ b/renovate.json
@@ -8,7 +8,21 @@
     "after 3pm on tuesday"
   ],
   "minimumReleaseAge": "7 days",
-  "minimumReleaseAgeBehaviour": "timestamp-optional",
+  "minimumReleaseAgeBehaviour": "timestamp-required",
+  "logLevelRemap": [
+    {
+      "matchMessage": "External host error causing abort - skipping",
+      "newLogLevel": "error"
+    },
+    {
+      "matchMessage": "Git error - aborting",
+      "newLogLevel": "error"
+    },
+    {
+      "matchMessage": "/^Some release\\(s\\) did not have a releaseTimestamp, but as we're running with minimumReleaseAgeBehaviour=timestamp-optional, proceeding\\. See debug logs for more information$/",
+      "newLogLevel": "info"
+    }
+  ],
   "vulnerabilityAlerts": {
     "minimumReleaseAge": null
   },
@@ -57,60 +71,56 @@
       ],
       "depNameTemplate": "{{{depName}}}",
       "datasourceTemplate": "{{{datasource}}}"
+    },
+    {
+      "description": "Exact Renovate engine version used by renovatebot/github-action",
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/^\\.github/workflows/renovate\\.yml$/"
+      ],
+      "matchStrings": [
+        "renovate-version:\\s*(?<currentValue>\\d+\\.\\d+\\.\\d+)"
+      ],
+      "depNameTemplate": "renovatebot/renovate",
+      "datasourceTemplate": "github-releases"
     }
   ],
   "packageRules": [
     {
-      "description": "Python runtime images - managed by asdf postUpgradeTasks, not independently",
+      "description": "Docker update streams verified not to publish usable release timestamps",
+      "matchDatasources": [
+        "docker"
+      ],
+      "matchPackageNames": [
+        "ghcr.io/astral-sh/uv",
+        "ghcr.io/home-assistant/home-assistant",
+        "python"
+      ],
+      "minimumReleaseAgeBehaviour": "timestamp-optional"
+    },
+    {
+      "description": "Keep Python interpreter changes coordinated while allowing same-tag digest refreshes",
       "matchManagers": [
         "dockerfile"
       ],
       "matchPackageNames": [
         "python"
       ],
-      "enabled": false
+      "allowedVersions": "/^3\\.13-slim$/"
     },
     {
-      "description": "Python version upgrades - wait 6 months after release",
+      "description": "Webhook proxy images change only through the dev-first promotion workflow",
       "matchManagers": [
-        "asdf"
+        "dockerfile"
       ],
       "matchPackageNames": [
         "python"
       ],
-      "minimumReleaseAge": "180 days",
-      "postUpgradeTasks": {
-        "commands": [
-          "PYTHON_VERSION=$(cat .python-version)",
-          "PYTHON_MAJOR=$(echo $PYTHON_VERSION | cut -d. -f1)",
-          "PYTHON_MINOR=$(echo $PYTHON_VERSION | cut -d. -f2)",
-          "PYTHON_NEXT=\"${PYTHON_MAJOR}.$((PYTHON_MINOR + 1))\"",
-          "sed -i \"s/requires-python = \\\">=3\\.[0-9]\\+,<3\\.[0-9]\\+\\\"/requires-python = \\\">=${PYTHON_VERSION},<${PYTHON_NEXT}\\\"/\" pyproject.toml",
-          "sed -i '/Programming Language :: Python :: 3\\.[0-9]\\+/d' pyproject.toml",
-          "sed -i \"/Programming Language :: Python :: 3\\\",/a\\\\    \\\"Programming Language :: Python :: ${PYTHON_VERSION}\\\",\" pyproject.toml",
-          "sed -i \"s/python3\\.[0-9]\\+\\(-[a-z]\\+-slim\\)/python${PYTHON_VERSION}\\1/\" Dockerfile homeassistant-addon/Dockerfile homeassistant-addon-dev/Dockerfile .github/workflows/pr.yml",
-          "sed -i \"s/python:3\\.[0-9]\\+-slim/python:${PYTHON_VERSION}-slim/\" Dockerfile homeassistant-addon/Dockerfile homeassistant-addon-dev/Dockerfile",
-          "sed -i \"s/Python 3\\.[0-9]\\+ - Security/Python ${PYTHON_VERSION} - Security/\" Dockerfile homeassistant-addon/Dockerfile homeassistant-addon-dev/Dockerfile",
-          "sed -i \"s/PYTHON_VERSION: \\\"3\\.[0-9]\\+\\\"/PYTHON_VERSION: \\\"${PYTHON_VERSION}\\\"/\" .github/workflows/pr.yml .github/workflows/test.yml .github/workflows/e2e-tests.yml .github/workflows/semver-release.yml .github/workflows/performance-tests.yml",
-          "sed -i \"s/python-version: '3\\.[0-9]\\+'/python-version: '${PYTHON_VERSION}'/\" .github/workflows/_build-and-release.yml .github/workflows/build-binary.yml",
-          "git add .python-version pyproject.toml Dockerfile homeassistant-addon/Dockerfile homeassistant-addon-dev/Dockerfile .github/workflows/pr.yml .github/workflows/test.yml .github/workflows/e2e-tests.yml .github/workflows/semver-release.yml .github/workflows/performance-tests.yml .github/workflows/_build-and-release.yml .github/workflows/build-binary.yml"
-        ],
-        "fileFilters": [
-          ".python-version",
-          "pyproject.toml",
-          "Dockerfile",
-          "homeassistant-addon/Dockerfile",
-          "homeassistant-addon-dev/Dockerfile",
-          ".github/workflows/pr.yml",
-          ".github/workflows/test.yml",
-          ".github/workflows/e2e-tests.yml",
-          ".github/workflows/semver-release.yml",
-          ".github/workflows/performance-tests.yml",
-          ".github/workflows/_build-and-release.yml",
-          ".github/workflows/build-binary.yml"
-        ],
-        "executionMode": "branch"
-      }
+      "matchFileNames": [
+        "homeassistant-addon-webhook-proxy/Dockerfile",
+        "homeassistant-addon-webhook-proxy-dev/Dockerfile"
+      ],
+      "enabled": false
     }
   ],
   "labels": [

--- a/tests/src/unit/test_supply_chain_workflow_shape.py
+++ b/tests/src/unit/test_supply_chain_workflow_shape.py
@@ -145,29 +145,24 @@ def test_renovate_engine_uses_a_full_version_pin() -> None:
     )
 
 
-def test_renovate_age_gate_is_exact_and_scoped() -> None:
+def test_renovate_age_gate_does_not_freeze_timestamp_less_updates() -> None:
     config = json.loads((_REPO_ROOT / "renovate.json").read_text(encoding="utf-8"))
 
     assert config.get("minimumReleaseAge") == "7 days", (
         "the release-age gate from #2196 is part of the supply-chain contract"
     )
-    assert config.get("minimumReleaseAgeBehaviour") == "timestamp-required"
-
-    optional_rules = [
+    assert config.get("minimumReleaseAgeBehaviour") == "timestamp-optional", (
+        "timestamp-required permanently freezes updates from registries that do "
+        "not publish release timestamps"
+    )
+    required_rules = [
         rule
         for rule in config["packageRules"]
-        if rule.get("minimumReleaseAgeBehaviour") == "timestamp-optional"
+        if rule.get("minimumReleaseAgeBehaviour") == "timestamp-required"
     ]
-    assert len(optional_rules) == 1
-    optional_rule = optional_rules[0]
-    assert optional_rule.get("matchDatasources") == ["docker"]
-    assert set(optional_rule.get("matchPackageNames", [])) == {
-        "ghcr.io/astral-sh/uv",
-        "ghcr.io/home-assistant/home-assistant",
-        "python",
-    }, (
-        "only the verified GHCR streams and version-locked Python digest updates "
-        "may bypass the age gate"
+    assert not required_rules, (
+        "package-level timestamp requirements can recreate the permanent freeze "
+        "fixed by #2200"
     )
 
 
@@ -201,8 +196,8 @@ def test_renovate_log_levels_make_failures_actionable_without_warning_noise() ->
         in str(remap.get("matchMessage", ""))
     ]
     assert timestamp_warning_levels == ["info"], (
-        "the expected warning for the two scoped GHCR exceptions should not pollute "
-        "the dependency dashboard"
+        "the expected warning for timestamp-less sources should not pollute the "
+        "dependency dashboard"
     )
 
 

--- a/tests/src/unit/test_supply_chain_workflow_shape.py
+++ b/tests/src/unit/test_supply_chain_workflow_shape.py
@@ -1,6 +1,7 @@
 """Guard supply-chain hardening that cannot be exercised by PR workflows."""
 
 import json
+import re
 from pathlib import Path
 from typing import Any
 
@@ -108,23 +109,149 @@ def test_renovate_token_can_read_vulnerability_alerts() -> None:
         if "actions/create-github-app-token" in str(step.get("uses", ""))
     )
 
-    assert (token_step["with"]).get("permission-vulnerability-alerts") == "read", (
+    token_inputs = token_step["with"]
+    assert token_inputs.get("client-id") == "${{ secrets.RENOVATE_APP_ID }}"
+    assert "app-id" not in token_inputs
+    assert token_inputs.get("permission-vulnerability-alerts") == "read", (
         "the Renovate token lists permission-* inputs and so drops every "
         "permission it does not name; without vulnerability_alerts read the "
         "vulnerabilityAlerts carve-out in renovate.json cannot fire"
     )
 
 
-def test_renovate_age_gate_tolerates_datasources_without_timestamps() -> None:
+def test_renovate_engine_uses_a_full_version_pin() -> None:
+    steps = _workflow(_WORKFLOW_DIR / "renovate.yml")["jobs"]["renovate"]["steps"]
+    renovate_step = next(
+        step
+        for step in steps
+        if "renovatebot/github-action" in str(step.get("uses", ""))
+    )
+
+    version = str((renovate_step.get("with") or {}).get("renovate-version", ""))
+    assert re.fullmatch(r"\d+\.\d+\.\d+", version), (
+        "the action version and Renovate engine version are separate pins; a "
+        "major-only engine tag changes behavior without a workflow diff"
+    )
+
+    config = json.loads((_REPO_ROOT / "renovate.json").read_text(encoding="utf-8"))
+    engine_manager = next(
+        manager
+        for manager in config["customManagers"]
+        if manager.get("depNameTemplate") == "renovatebot/renovate"
+    )
+    assert engine_manager.get("datasourceTemplate") == "github-releases", (
+        "the engine self-update must use a datasource with release timestamps so "
+        "the global age gate can eventually release it"
+    )
+
+
+def test_renovate_age_gate_is_exact_and_scoped() -> None:
     config = json.loads((_REPO_ROOT / "renovate.json").read_text(encoding="utf-8"))
 
-    assert config.get("minimumReleaseAge") is not None, (
+    assert config.get("minimumReleaseAge") == "7 days", (
         "the release-age gate from #2196 is part of the supply-chain contract"
     )
-    assert config.get("minimumReleaseAgeBehaviour") == "timestamp-optional", (
-        "ghcr.io tags carry no releaseTimestamp - the docker datasource reads it "
-        "from Docker Hub only - so minimumReleaseAge under the default "
-        "timestamp-required behaviour holds every ghcr update pending forever"
+    assert config.get("minimumReleaseAgeBehaviour") == "timestamp-required"
+
+    optional_rules = [
+        rule
+        for rule in config["packageRules"]
+        if rule.get("minimumReleaseAgeBehaviour") == "timestamp-optional"
+    ]
+    assert len(optional_rules) == 1
+    optional_rule = optional_rules[0]
+    assert optional_rule.get("matchDatasources") == ["docker"]
+    assert set(optional_rule.get("matchPackageNames", [])) == {
+        "ghcr.io/astral-sh/uv",
+        "ghcr.io/home-assistant/home-assistant",
+        "python",
+    }, (
+        "only the verified GHCR streams and version-locked Python digest updates "
+        "may bypass the age gate"
+    )
+
+
+def test_renovate_log_levels_make_failures_actionable_without_warning_noise() -> None:
+    config = json.loads((_REPO_ROOT / "renovate.json").read_text(encoding="utf-8"))
+    remaps = config.get("logLevelRemap", [])
+
+    host_error_levels = [
+        remap.get("newLogLevel")
+        for remap in remaps
+        if "External host error causing abort - skipping"
+        in str(remap.get("matchMessage", ""))
+    ]
+    assert host_error_levels == ["error"], (
+        "an aborted repository scan must fail the workflow instead of finishing green"
+    )
+
+    git_error_levels = [
+        remap.get("newLogLevel")
+        for remap in remaps
+        if remap.get("matchMessage") == "Git error - aborting"
+    ]
+    assert git_error_levels == ["error"], (
+        "a Git 5xx abort also returns external-host-error and must fail the workflow"
+    )
+
+    timestamp_warning_levels = [
+        remap.get("newLogLevel")
+        for remap in remaps
+        if "minimumReleaseAgeBehaviour=timestamp-optional"
+        in str(remap.get("matchMessage", ""))
+    ]
+    assert timestamp_warning_levels == ["info"], (
+        "the expected warning for the two scoped GHCR exceptions should not pollute "
+        "the dependency dashboard"
+    )
+
+
+def test_python_runtime_automation_is_digest_only() -> None:
+    config = json.loads((_REPO_ROOT / "renovate.json").read_text(encoding="utf-8"))
+    package_rules = config["packageRules"]
+    python_rules = [
+        rule
+        for rule in package_rules
+        if "dockerfile" in rule.get("matchManagers", [])
+        and "python" in rule.get("matchPackageNames", [])
+    ]
+
+    version_rule = next(
+        rule
+        for rule in python_rules
+        if rule.get("allowedVersions") == "/^3\\.13-slim$/"
+    )
+    assert "matchFileNames" not in version_rule, (
+        "every Python Dockerfile must inherit the coordinated 3.13-slim baseline"
+    )
+
+    proxy_rule = next(rule for rule in python_rules if rule.get("enabled") is False)
+    assert set(proxy_rule.get("matchFileNames", [])) == {
+        "homeassistant-addon-webhook-proxy/Dockerfile",
+        "homeassistant-addon-webhook-proxy-dev/Dockerfile",
+    }, "webhook-proxy images change only through the dev-first promotion workflow"
+
+    python_dockerfiles = {
+        path.relative_to(_REPO_ROOT).as_posix()
+        for path in _REPO_ROOT.rglob("Dockerfile")
+        if "FROM python:" in path.read_text(encoding="utf-8")
+    }
+    assert python_dockerfiles - set(proxy_rule["matchFileNames"]) == {
+        "Dockerfile",
+        "homeassistant-addon/Dockerfile",
+        "homeassistant-addon-dev/Dockerfile",
+        "tests/haos_image_build/screenshot_engine_mock/Dockerfile",
+    }
+    assert not any("matchUpdateTypes" in rule for rule in python_rules), (
+        "a pre-lookup enabled=false rule cannot be overridden later for digest updates"
+    )
+    assert "asdf" not in config.get("enabledManagers", [])
+    assert not any(
+        "asdf" in rule.get("matchManagers", []) or "postUpgradeTasks" in rule
+        for rule in package_rules
+    ), (
+        "Python minor-version changes span independent runtime contracts and must "
+        "not be rewritten by the old dead asdf task"
     )
 
 


### PR DESCRIPTION
## What does this PR do?

Follow-up to #2200 and the Renovate findings discussed in #1237.

- Fails the workflow when Renovate aborts on external-host or Git 5xx errors.
- Pins the Renovate engine exactly and tracks updates through timestamped GitHub releases.
- Preserves the global seven-day age gate wherever timestamps exist while ensuring timestamp-less update streams cannot freeze permanently.
- Removes the dead asdf Python updater, keeps interpreter changes coordinated manually, and restores same-tag digest updates without touching the webhook-proxy promotion flow.
- Migrates the Renovate App token step to the supported client-id input.

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [x] Maintenance/refactor
- [ ] Tests only
- [ ] Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [ ] All automated tests pass (uv run pytest)
- [x] Code follows style guidelines (uv run ruff check)

Targeted verification:
- Renovate 44.26.0 validated renovate.json.
- A full-repository Renovate 44.26.0 lookup confirmed timestamp-less GHCR and Python digest updates remain eligible while the timestamped engine update remains subject to the seven-day wait.

## Checklist
- [x] No documentation changes are required


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated automated dependency management with current authentication settings and a fully pinned version.
  * Refined release-age checks and improved actionable error reporting.
  * Limited Python container updates to approved slim images and digest-only changes.
  * Disabled webhook proxy image updates and removed legacy automation settings.

* **Tests**
  * Expanded validation for dependency-management configuration, version pinning, release-age rules, logging, and container update policies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->