### PR TITLE
feat: add bounded Aurora deployment adapter

### DIFF
--- a/aurora_deploy_trusted_keys.json
+++ b/aurora_deploy_trusted_keys.json
@@ -1,0 +1,1 @@
+{"release-aurora-dashboard":"ObGvRsdwo7xs8lqsfTPJDeVAxkn0STusL247PQUFyt0=","validation-aurora-dashboard":"GhHeu7I9ueEowyzNgOP+SHYiTQj/ovHx/zK3TtE3qP4="}

--- a/custom_components/aurora_deploy/__init__.py
+++ b/custom_components/aurora_deploy/__init__.py
@@ -1,0 +1,24 @@
+"""Authenticated, fixed-scope Aurora dashboard deployment adapter."""
+from __future__ import annotations
+
+try:
+    from homeassistant.core import HomeAssistant
+except ModuleNotFoundError:  # pragma: no cover - standalone validation tests
+    HomeAssistant = object  # type: ignore[misc,assignment]
+
+from .adapter import DOMAIN, AuroraState, RootView, TransactionView
+
+
+async def async_setup(hass: HomeAssistant, config: dict) -> bool:
+    """Register the dedicated API without exposing a generic file surface."""
+    state = await AuroraState.create(hass)
+    hass.data[DOMAIN] = state
+    hass.http.register_view(RootView(hass, state))
+    hass.http.register_view(TransactionView(hass, state))
+    return True
+
+
+async def async_unload(hass: HomeAssistant) -> bool:
+    """Home Assistant cannot unregister HTTP views during a running session."""
+    hass.data.pop(DOMAIN, None)
+    return True

--- a/custom_components/aurora_deploy/adapter.py
+++ b/custom_components/aurora_deploy/adapter.py
@@ -1094,11 +1094,25 @@ async def _admin(request: web.Request) -> bool:
 
 
 async def _body(request: web.Request) -> dict[str, Any] | None:
-    if request.content_length and request.content_length > MAX_BODY:
+    content_length = request.content_length
+    if content_length is not None and (
+        isinstance(content_length, bool)
+        or not isinstance(content_length, int)
+        or content_length < 0
+        or content_length > MAX_BODY
+    ):
         return None
-    raw = await request.content.read(MAX_BODY + 1)
-    if len(raw) > MAX_BODY:
-        return None
+    raw = bytearray()
+    while True:
+        remaining = MAX_BODY - len(raw)
+        chunk = await request.content.read(min(64 * 1024, remaining + 1))
+        if not isinstance(chunk, (bytes, bytearray, memoryview)):
+            return None
+        if not chunk:
+            break
+        if len(chunk) > remaining:
+            return None
+        raw.extend(chunk)
     try:
         value = json.loads(raw.decode("utf-8")) if raw else {}
     except (UnicodeError, json.JSONDecodeError):

--- a/custom_components/aurora_deploy/adapter.py
+++ b/custom_components/aurora_deploy/adapter.py
@@ -1,0 +1,1517 @@
+"""Narrow Aurora deployment API.
+
+Only the fixed preview and production pointers are addressable. This module has
+no path, shell, upload, Supervisor, File Editor, SSH, or arbitrary Lovelace API.
+"""
+from __future__ import annotations
+
+import asyncio
+import base64
+import binascii
+import hashlib
+import json
+import os
+import re
+import secrets
+import stat
+import tarfile
+import time
+from collections import deque
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta
+from io import BytesIO
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+try:
+    from aiohttp import web
+except ModuleNotFoundError:  # pragma: no cover - standalone validation tests
+    class _WebStub:
+        class Request:
+            pass
+
+        class Response:
+            pass
+
+    web = _WebStub()  # type: ignore[assignment]
+
+try:  # Keep pure validation helpers testable in the ha-mcp-only environment.
+    from homeassistant.components.http import HomeAssistantView
+    from homeassistant.components.lovelace.const import (
+        CONF_ICON,
+        CONF_REQUIRE_ADMIN,
+        CONF_SHOW_IN_SIDEBAR,
+        CONF_TITLE,
+        CONF_URL_PATH,
+    )
+    from homeassistant.core import HomeAssistant
+except ModuleNotFoundError:  # pragma: no cover - only used by standalone unit tests
+    class HomeAssistantView:  # type: ignore[no-redef]
+        requires_auth = True
+
+    HomeAssistant = Any  # type: ignore[misc,assignment]
+    CONF_ICON = "icon"
+    CONF_REQUIRE_ADMIN = "require_admin"
+    CONF_SHOW_IN_SIDEBAR = "show_in_sidebar"
+    CONF_TITLE = "title"
+    CONF_URL_PATH = "url_path"
+
+DOMAIN = "aurora_deploy"
+BASE = "/api/aurora/deploy-preview/v1"
+PREVIEW = "home-command-preview"
+PRODUCTION = "home-command"
+# A prior Aurora release used this target. It is a fixed migration collision, not a caller-
+# selectable dashboard id; refusing it prevents bootstrap from creating a third Aurora environment.
+LEGACY_PREVIEW = "aurora-preview"
+TARGET = "aurora-v9-preview"
+APPROVED_RELEASE = "0.1.16"
+MAX_BODY = 80 * 1024 * 1024
+MAX_MANIFEST = 512 * 1024
+MAX_PACKAGE = 64 * 1024 * 1024
+MAX_DASHBOARD = 8 * 1024 * 1024
+MAX_MEMBERS = 256
+MAX_EXPANDED = 32 * 1024 * 1024
+CLOCK_SKEW = timedelta(minutes=5)
+MAX_LIFETIME = timedelta(hours=24)
+MAX_REQUESTS_PER_MINUTE = 60
+REQUEST_WINDOW_SECONDS = 60.0
+REQUEST_TIMEOUT_SECONDS = 30.0
+_SAFE_NONCE = re.compile(r"^[A-Za-z0-9._-]{8,128}$")
+_SAFE_REVISION = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_-]{0,127}$")
+PACKAGE_ROOT = "custom_components/aurora_camera_ai/"
+PACKAGE_ROOT_FILES = frozenset(
+    {
+        "manifest.json",
+        "activation-manifest.json",
+        "custom-component-manifest.json",
+        "install-aurora-camera-ai-component.py",
+    }
+)
+COMPONENT_DOMAIN = "aurora_camera_ai"
+COMPONENT_VERSION = "0.3.0"
+APPROVED_COMPONENT_FILES = frozenset(
+    {
+        "__init__.py",
+        "analysis_models.py",
+        "api.py",
+        "attention_policy.py",
+        "coordinator.py",
+        "event_store.py",
+        "manifest.json",
+        "models.py",
+        "review_store.py",
+        "services.yaml",
+        "timeline_contract.py",
+        "vehicle_catalog_v1.json",
+    }
+)
+APPROVED_PACKAGE_FILES = PACKAGE_ROOT_FILES | frozenset(
+    PACKAGE_ROOT + filename for filename in APPROVED_COMPONENT_FILES
+)
+APPROVED_PACKAGE_DIRECTORIES = frozenset(
+    {"custom_components", "custom_components/aurora_camera_ai"}
+)
+VALIDATION_RECEIPT_KEYS = frozenset(
+    {
+        "schema_version",
+        "preview_revision",
+        "expected_production_revision",
+        "preview_config_sha256",
+        "expected_production_config_sha256",
+        "dashboard_target",
+        "physical_validation",
+        "device_results",
+        "manifest_sha256",
+        "package_sha256",
+        "dashboard_sha256",
+        "issued_at",
+        "nonce",
+        "signer",
+        "signature",
+        "expires_at",
+    }
+)
+DASHBOARD_URL = "/local/aurora/aurora-preview-dashboard.js"
+DASHBOARD_URL_PREFIX = "/local/aurora/revisions/"
+PRIVACY_POLICY = "no-sensitive-inference-v1"
+FORBIDDEN_PRIVACY = frozenset(
+    {
+        "biometric",
+        "face recognition",
+        "facial recognition",
+        "identity inference",
+        "appearance inference",
+        "appearance profiling",
+        "license plate",
+        "licence plate",
+        "plate recognition",
+        "intent inference",
+        "emotion inference",
+        "criminality",
+        "suspicion score",
+    }
+)
+_PROHIBITION = re.compile(
+    r"\b(?:never|no|not|without|do\s+not|don't|must\s+not|prohibit(?:s|ed)?|"
+    r"forbid(?:s|den)?|deny[- ]?list|reject(?:s|ed|ing)?|refus(?:e|es|ed|ing)|"
+    r"removed|disallow(?:s|ed)?|forbidden)\b",
+    re.IGNORECASE,
+)
+_CAPABILITY = re.compile(
+    r"\b(?:"
+    r"biometric[_\s-]?(?:template|templates|embedding|embeddings|match|matches|id)?|"
+    r"(?:face|facial)[_\s-]?(?:match|matching|recognition|recognise|recognize|embedding|template|id)|"
+    r"identity[_\s-]?(?:match|matching|result|results|inference|id|embedding)|"
+    r"(?:appearance)[_\s-]?(?:profile|profiling|inference|result)|"
+    r"(?:license|licence|number)[_\s-]?plate[_\s-]?(?:ocr|text|number|read|reading|extract|extraction|result)?|"
+    r"plate[_\s-]?(?:ocr|text|number|read|reading|extract|extraction|recognition|result)|"
+    r"ocr[_\s-]?(?:text|plate|number|read|reading|extract|extraction|result)|"
+    r"(?:emotion|gender|ethnicity|racial?|age|criminality|intent|suspicion)[_\s-]?"
+    r"(?:score|scores|label|labels|inference|inferred|result|results|classification|class)"
+    r")\b",
+    re.IGNORECASE | re.VERBOSE,
+)
+_SENSITIVE_ASSIGNMENT = re.compile(
+    r"(?m)(?:^|[,\[{(]\s*)['\"]?"
+    r"(?:biometric|face|facial|identity|appearance|license|licence|plate|ocr|"
+    r"emotion|gender|ethnicity|race|age|criminality|intent|suspicion)"
+    r"[A-Za-z0-9_-]*['\"]?\s*[:=]",
+    re.IGNORECASE,
+)
+
+
+def _now() -> datetime:
+    return datetime.now(UTC)
+
+
+def _json_bytes(value: Any) -> bytes:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True).encode()
+
+
+def _config_sha256(config: dict[str, Any]) -> str:
+    return hashlib.sha256(_json_bytes(config)).hexdigest()
+
+
+def _is_sha256(value: Any) -> bool:
+    return (
+        isinstance(value, str)
+        and len(value) == 64
+        and all(character in "0123456789abcdef" for character in value)
+    )
+
+
+def _json_response(payload: dict[str, Any], status: int = 200) -> web.Response:
+    return web.json_response(payload, status=status)
+
+
+def _error(status: int, code: str) -> web.Response:
+    return _json_response({"error_code": code}, status)
+
+
+def _parse_time(value: Any) -> datetime:
+    if not isinstance(value, str):
+        raise ValueError("timestamp")
+    result = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if result.tzinfo is None:
+        raise ValueError("timestamp")
+    return result.astimezone(UTC)
+
+
+def _canonical_manifest(manifest: dict[str, Any]) -> bytes:
+    unsigned = {key: value for key, value in manifest.items() if key != "signature"}
+    return _json_bytes(unsigned)
+
+
+def _decode_b64(value: Any, maximum: int) -> bytes:
+    if not isinstance(value, str) or len(value) > maximum * 2:
+        raise ValueError("encoding")
+    try:
+        raw = base64.b64decode(value, validate=True)
+    except (ValueError, binascii.Error) as exc:
+        raise ValueError("encoding") from exc
+    if len(raw) > maximum:
+        raise ValueError("size")
+    return raw
+
+
+def _trusted_keys(hass: HomeAssistant) -> dict[str, bytes]:
+    """Load pinned public keys from a fixed, operator-managed file."""
+    path = Path(hass.config.path("aurora_deploy_trusted_keys.json"))
+    try:
+        if not path.is_file() or path.is_symlink():
+            return {}
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError):
+        return {}
+    if not isinstance(data, dict):
+        return {}
+    result: dict[str, bytes] = {}
+    for key_id, encoded in data.items():
+        if not isinstance(key_id, str) or not isinstance(encoded, str):
+            continue
+        try:
+            key = base64.b64decode(encoded, validate=True)
+        except (ValueError, binascii.Error):
+            continue
+        if len(key) == 32 and key_id and len(key_id) <= 64:
+            result[key_id] = key
+    return result
+
+
+def _verify_signature(hass: HomeAssistant, document: dict[str, Any], *, prefix: str) -> None:
+    key_id = document.get("key_id") or document.get("signer")
+    signature_text = document.get("signature")
+    if not isinstance(key_id, str) or not isinstance(signature_text, str):
+        raise ValueError("signature")
+    if prefix and not key_id.startswith(prefix):
+        raise ValueError("signer")
+    try:
+        signature = base64.b64decode(signature_text, validate=True)
+        public = _trusted_keys(hass)[key_id]
+        if len(signature) != 64:
+            raise ValueError("signature")
+        from cryptography.exceptions import InvalidSignature
+        from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+
+        try:
+            Ed25519PublicKey.from_public_bytes(public).verify(signature, _canonical_manifest(document))
+        except InvalidSignature as exc:
+            raise ValueError("signature") from exc
+    except (KeyError, ValueError, TypeError, binascii.Error) as exc:
+        raise ValueError("signature") from exc
+
+
+def _privacy_guard_context(text: str, line_number: int) -> bool:
+    lines = text.splitlines()
+    start = max(0, line_number - 4)
+    end = min(len(lines), line_number + 5)
+    context = "\n".join(lines[start:end])
+    return bool(_PROHIBITION.search(context)) or "denylist" in context.casefold()
+
+
+def _scan_privacy(raw: bytes) -> None:
+    text = raw.decode("utf-8", errors="ignore")
+    lowered = text.casefold()
+    for term in FORBIDDEN_PRIVACY:
+        start = 0
+        needle = term.casefold()
+        while (offset := lowered.find(needle, start)) != -1:
+            if not _privacy_guard_context(text, text.count("\n", 0, offset)):
+                raise ValueError("privacy")
+            start = offset + len(needle)
+    for match in _CAPABILITY.finditer(text):
+        line = text.count("\n", 0, match.start())
+        line_text = text.splitlines()[line]
+        executable_shape = bool(
+            re.search(r"\b[A-Za-z_][A-Za-z0-9_-]*['\"]?\s*[:=]", line_text)
+        )
+        if not _privacy_guard_context(text, line) or executable_shape:
+            raise ValueError("privacy")
+    for match in _SENSITIVE_ASSIGNMENT.finditer(text):
+        line = text.count("\n", 0, match.start())
+        if not _privacy_guard_context(text, line):
+            raise ValueError("privacy")
+
+
+def _json_object(raw: bytes, error_code: str) -> dict[str, Any]:
+    try:
+        value = json.loads(raw)
+    except (UnicodeError, json.JSONDecodeError) as exc:
+        raise ValueError(error_code) from exc
+    if not isinstance(value, dict):
+        raise ValueError(error_code)
+    return value
+
+
+def _package_members(raw: bytes) -> dict[str, bytes]:  # noqa: C901 - archive policy is intentionally explicit
+    if not raw.startswith(b"\x1f\x8b"):
+        raise ValueError("package_format")
+    count = 0
+    expanded = 0
+    files: dict[str, bytes] = {}
+    try:
+        with tarfile.open(fileobj=BytesIO(raw), mode="r:gz") as archive:
+            for member in archive.getmembers():
+                count += 1
+                if count > MAX_MEMBERS:
+                    raise ValueError("package_members")
+                name = member.name.replace("\\", "/")
+                path = PurePosixPath(name)
+                if path.is_absolute() or ".." in path.parts or name == "":
+                    raise ValueError("package_path")
+                if member.issym() or member.islnk() or member.isdev() or member.isfifo():
+                    raise ValueError("package_link")
+                normalized = name.rstrip("/")
+                if member.isdir():
+                    if normalized not in APPROVED_PACKAGE_DIRECTORIES:
+                        raise ValueError("package_member")
+                    continue
+                if not member.isfile():
+                    raise ValueError("package_member_type")
+                if name not in APPROVED_PACKAGE_FILES:
+                    raise ValueError("package_member")
+                if name.endswith((".tar", ".tar.gz", ".tgz", ".zip")):
+                    raise ValueError("nested_archive")
+                if name in files:
+                    raise ValueError("package_duplicate")
+                expanded += max(0, member.size)
+                if expanded > MAX_EXPANDED:
+                    raise ValueError("package_expanded")
+                stream = archive.extractfile(member)
+                if stream is None:
+                    raise ValueError("package_member")
+                data = stream.read(member.size + 1)
+                if len(data) != member.size:
+                    raise ValueError("package_size")
+                _scan_privacy(data)
+                files[name] = data
+    except (tarfile.TarError, OSError) as exc:
+        raise ValueError("package_format") from exc
+
+    if set(files) != APPROVED_PACKAGE_FILES:
+        raise ValueError("package_source_missing")
+
+    component_manifest_raw = files["custom-component-manifest.json"]
+    component_manifest = _json_object(
+        component_manifest_raw, "package_component_manifest"
+    )
+    if any(
+        (
+            component_manifest.get("schemaVersion") != "1.0",
+            component_manifest.get("domain") != COMPONENT_DOMAIN,
+            component_manifest.get("version") != COMPONENT_VERSION,
+            component_manifest.get("configurationKey") != COMPONENT_DOMAIN,
+            component_manifest.get("restartRequired") is not True,
+        )
+    ):
+        raise ValueError("package_component_manifest")
+    installation = component_manifest.get("installation")
+    rollback = component_manifest.get("rollback")
+    if not isinstance(installation, dict) or any(
+        (
+            installation.get("mode") != "transactional-atomic-rename",
+            installation.get("installer")
+            != "install-aurora-camera-ai-component.py",
+            installation.get("configurationHashGuardRequired") is not True,
+            installation.get("prestateCapture") != "exact-bytes",
+        )
+    ):
+        raise ValueError("package_component_manifest")
+    if not isinstance(rollback, dict) or any(
+        (
+            rollback.get("mode") != "restore-exact-prestate",
+            rollback.get("configurationHashGuardRequired") is not True,
+            rollback.get("restartRequired") is not True,
+        )
+    ):
+        raise ValueError("package_component_manifest")
+
+    entries = component_manifest.get("files")
+    if not isinstance(entries, list):
+        raise ValueError("package_component_manifest")
+    described: set[str] = set()
+    for entry in entries:
+        if not isinstance(entry, dict):
+            raise ValueError("package_component_manifest")
+        path = entry.get("path")
+        if not isinstance(path, str) or path not in APPROVED_PACKAGE_FILES:
+            raise ValueError("package_component_manifest")
+        if not path.startswith(PACKAGE_ROOT) or path in described:
+            raise ValueError("package_component_manifest")
+        data = files[path]
+        if entry.get("size") != len(data) or entry.get("sha256") != hashlib.sha256(
+            data
+        ).hexdigest():
+            raise ValueError("package_component_hash")
+        described.add(path)
+    expected_component_paths = {
+        PACKAGE_ROOT + filename for filename in APPROVED_COMPONENT_FILES
+    }
+    if described != expected_component_paths:
+        raise ValueError("package_source_missing")
+
+    package_manifest = _json_object(files["manifest.json"], "package_manifest")
+    installer = package_manifest.get("installer")
+    if any(
+        (
+            package_manifest.get("entry") != "activation-manifest.json",
+            package_manifest.get("sha256")
+            != hashlib.sha256(files["activation-manifest.json"]).hexdigest(),
+            package_manifest.get("componentManifestEntry")
+            != "custom-component-manifest.json",
+            package_manifest.get("componentManifestSha256")
+            != hashlib.sha256(component_manifest_raw).hexdigest(),
+            not isinstance(installer, dict),
+        )
+    ):
+        raise ValueError("package_manifest")
+    installer_bytes = files["install-aurora-camera-ai-component.py"]
+    if not isinstance(installer, dict) or any(
+        (
+            installer.get("entry") != "install-aurora-camera-ai-component.py",
+            installer.get("size") != len(installer_bytes),
+            installer.get("sha256")
+            != hashlib.sha256(installer_bytes).hexdigest(),
+        )
+    ):
+        raise ValueError("package_manifest")
+
+    integration_manifest = _json_object(
+        files[PACKAGE_ROOT + "manifest.json"], "package_integration_manifest"
+    )
+    if (
+        integration_manifest.get("domain") != COMPONENT_DOMAIN
+        or integration_manifest.get("version") != COMPONENT_VERSION
+    ):
+        raise ValueError("package_integration_manifest")
+    return {
+        filename: files[PACKAGE_ROOT + filename]
+        for filename in APPROVED_COMPONENT_FILES
+    }
+
+
+def _validate_package(raw: bytes) -> dict[str, bytes]:
+    """Return the exact reviewed component payload after fail-closed validation."""
+    return _package_members(raw)
+
+
+def _component_binding(members: dict[str, bytes]) -> str:
+    if set(members) != APPROVED_COMPONENT_FILES:
+        raise ValueError("package_source_missing")
+    digest = hashlib.sha256()
+    for filename in sorted(APPROVED_COMPONENT_FILES):
+        data = members[filename]
+        if not isinstance(data, bytes):
+            raise ValueError("package_member")
+        digest.update(filename.encode("utf-8"))
+        digest.update(b"\0")
+        digest.update(hashlib.sha256(data).digest())
+    return digest.hexdigest()
+
+
+def _live_component_members(hass: HomeAssistant) -> dict[str, bytes]:
+    root = Path(hass.config.path(f"custom_components/{COMPONENT_DOMAIN}"))
+    if root.is_symlink() or not root.is_dir():
+        raise ValueError("active_component_missing")
+    members: dict[str, bytes] = {}
+    for filename in APPROVED_COMPONENT_FILES:
+        path = root / filename
+        if path.is_symlink() or not path.is_file():
+            raise ValueError("active_component_missing")
+        members[filename] = path.read_bytes()
+    return members
+
+
+def _transaction_token(transaction: dict[str, Any]) -> str:
+    transaction_id = transaction.get("transaction_id")
+    if not isinstance(transaction_id, str):
+        raise ValueError("transaction_id")
+    return hashlib.sha256(transaction_id.encode("utf-8")).hexdigest()
+
+
+def _activate_component_package(
+    hass: HomeAssistant,
+    state: "AuroraState",
+    transaction: dict[str, Any],
+    members: dict[str, bytes],
+) -> str:
+    """Atomically replace only the fixed Aurora component directory."""
+    binding = _component_binding(members)
+    token = _transaction_token(transaction)
+    attempt = transaction.get("component_activation_attempt", 0)
+    if not isinstance(attempt, int) or isinstance(attempt, bool) or attempt < 0:
+        raise ValueError("component_activation_attempt")
+    attempt += 1
+    transaction["component_activation_attempt"] = attempt
+    attempt_name = str(attempt)
+    candidate_root = state.root / "component-candidates" / token / attempt_name
+    candidate = candidate_root / COMPONENT_DOMAIN
+    prestate = state.root / "component-prestate" / token / attempt_name
+    if candidate_root.exists() or prestate.exists():
+        raise ValueError("component_transaction_collision")
+    candidate.mkdir(parents=True)
+    for filename, data in members.items():
+        _atomic_write(candidate / filename, data)
+
+    parent = Path(hass.config.path("custom_components"))
+    if parent.is_symlink():
+        raise ValueError("component_parent")
+    parent.mkdir(parents=True, exist_ok=True)
+    destination = parent / COMPONENT_DOMAIN
+    if destination.is_symlink():
+        raise ValueError("component_destination")
+    previous_exists = destination.exists()
+    if previous_exists and not destination.is_dir():
+        raise ValueError("component_destination")
+    moved_previous = False
+    try:
+        if previous_exists:
+            prestate.parent.mkdir(parents=True, exist_ok=True)
+            os.replace(destination, prestate)
+            moved_previous = True
+        os.replace(candidate, destination)
+        candidate_root.rmdir()
+    except OSError:
+        if moved_previous and not destination.exists() and prestate.exists():
+            os.replace(prestate, destination)
+        raise
+    transaction["component_prestate_exists"] = previous_exists
+    transaction["component_binding_sha256"] = binding
+    return binding
+
+
+def _restore_component_prestate(
+    hass: HomeAssistant, state: "AuroraState", transaction: dict[str, Any]
+) -> None:
+    """Restore the exact component directory captured by this transaction."""
+    if "component_prestate_exists" not in transaction:
+        return
+    expected = transaction.get("component_binding_sha256")
+    if not isinstance(expected, str):
+        raise ValueError("component_rollback_snapshot_missing")
+    live = _component_binding(_live_component_members(hass))
+    if live != expected:
+        raise ValueError("component_cas_mismatch")
+    token = _transaction_token(transaction)
+    attempt = transaction.get("component_activation_attempt")
+    if not isinstance(attempt, int) or isinstance(attempt, bool) or attempt < 1:
+        raise ValueError("component_rollback_snapshot_missing")
+    attempt_name = str(attempt)
+    destination = Path(hass.config.path(f"custom_components/{COMPONENT_DOMAIN}"))
+    prestate = state.root / "component-prestate" / token / attempt_name
+    retired = state.root / "component-retired" / token / attempt_name
+    if retired.exists():
+        raise ValueError("component_transaction_collision")
+    retired.parent.mkdir(parents=True, exist_ok=True)
+    os.replace(destination, retired)
+    if transaction["component_prestate_exists"]:
+        if prestate.is_symlink() or not prestate.is_dir():
+            os.replace(retired, destination)
+            raise ValueError("component_rollback_snapshot_missing")
+        try:
+            os.replace(prestate, destination)
+        except OSError:
+            os.replace(retired, destination)
+            raise
+
+
+async def _verify_active_bindings(
+    hass: HomeAssistant,
+    transaction: dict[str, Any],
+    members: dict[str, bytes],
+    dashboard_bytes: bytes,
+) -> str:
+    expected_component = _component_binding(members)
+    if transaction.get("component_binding_sha256") != expected_component:
+        raise ValueError("active_component_binding")
+    live_members = await asyncio.to_thread(_live_component_members, hass)
+    if _component_binding(live_members) != expected_component:
+        raise ValueError("active_component_binding")
+
+    dashboard_sha = hashlib.sha256(dashboard_bytes).hexdigest()
+    asset_name = f"aurora-preview-dashboard-{dashboard_sha}.js"
+    if transaction.get("active_dashboard_asset") != asset_name:
+        raise ValueError("active_dashboard_binding")
+    asset_path = Path(hass.config.path(f"www/aurora/revisions/{asset_name}"))
+    if asset_path.is_symlink() or not asset_path.is_file():
+        raise ValueError("active_dashboard_binding")
+    if hashlib.sha256(asset_path.read_bytes()).hexdigest() != dashboard_sha:
+        raise ValueError("active_dashboard_binding")
+    _dashboard, config = await _load_dashboard(hass, PREVIEW)
+    resources = config.get("resources")
+    expected_url = f"{DASHBOARD_URL_PREFIX}{asset_name}"
+    if not isinstance(resources, list) or not any(
+        isinstance(item, dict)
+        and item.get("url") == expected_url
+        and item.get("res_type") == "module"
+        for item in resources
+    ):
+        raise ValueError("active_dashboard_binding")
+    return expected_component
+
+
+async def _verify_active_transaction(
+    hass: HomeAssistant, transaction: dict[str, Any], root: Path | None = None
+) -> str:
+    package, dashboard, _manifest = _verify_staged_artifacts(transaction, root)
+    if package is None or dashboard is None:
+        raise ValueError("staged_artifact_missing")
+    members = _validate_package(package)
+    return await _verify_active_bindings(hass, transaction, members, dashboard)
+
+
+def _validate_manifest(hass: HomeAssistant, manifest: Any, package: bytes, dashboard: bytes) -> tuple[str, str, str]:  # noqa: C901 - fail-closed policy checks are kept together
+    if not isinstance(manifest, dict) or len(_json_bytes(manifest)) > MAX_MANIFEST:
+        raise ValueError("manifest")
+    if manifest.get("schema_version") != 1 or manifest.get("target") != TARGET:
+        raise ValueError("target")
+    if manifest.get("dashboard_target", PREVIEW) != PREVIEW or manifest.get("preview_only") is not True:
+        raise ValueError("dashboard")
+    if manifest.get("target_release") != APPROVED_RELEASE:
+        raise ValueError("release")
+    if manifest.get("privacy_policy") != "no-sensitive-inference-v1":
+        raise ValueError("privacy_policy")
+    issued = _parse_time(manifest.get("issued_at", manifest.get("created_at")))
+    expires = _parse_time(manifest.get("expires_at"))
+    now = _now()
+    if issued - CLOCK_SKEW > now or expires + CLOCK_SKEW < now or expires <= issued or expires - issued > MAX_LIFETIME:
+        raise ValueError("expiry")
+    nonce = manifest.get("nonce")
+    if not isinstance(nonce, str) or not (8 <= len(nonce) <= 128) or any(ch not in "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789._-" for ch in nonce):
+        raise ValueError("nonce")
+    _verify_signature(hass, manifest, prefix="release-")
+    package_hash = hashlib.sha256(package).hexdigest()
+    dashboard_hash = hashlib.sha256(dashboard).hexdigest()
+    if manifest.get("artifact_sha256", manifest.get("package_sha256")) != package_hash or manifest.get("dashboard_sha256") != dashboard_hash:
+        raise ValueError("hash")
+    assets = manifest.get("assets")
+    expected = {"aurora-preview-package": package_hash, "aurora-preview-dashboard": dashboard_hash}
+    if not isinstance(assets, list) or len(assets) != 2:
+        raise ValueError("assets")
+    seen: set[str] = set()
+    for item in assets:
+        if not isinstance(item, dict) or item.get("name") not in expected or item["name"] in seen or item.get("sha256") != expected[item["name"]]:
+            raise ValueError("assets")
+        seen.add(item["name"])
+    if seen != set(expected):
+        raise ValueError("assets")
+    _scan_privacy(_json_bytes(manifest))
+    _scan_privacy(dashboard)
+    _validate_package(package)
+    return hashlib.sha256(_canonical_manifest(manifest)).hexdigest(), package_hash, dashboard_hash
+
+
+def _atomic_write(path: Path, data: bytes) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(f".{path.name}.{secrets.token_hex(8)}.tmp")
+    fd = os.open(temporary, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    try:
+        with os.fdopen(fd, "wb") as stream:
+            stream.write(data)
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.replace(temporary, path)
+        directory = os.open(path.parent, os.O_RDONLY)
+        try:
+            os.fsync(directory)
+        finally:
+            os.close(directory)
+    finally:
+        if temporary.exists():
+            temporary.unlink(missing_ok=True)
+
+
+def _staged_revision_dir(transaction: dict[str, Any], root: Path) -> Path:
+    revision = transaction.get("revision")
+    if not isinstance(revision, str) or not _SAFE_REVISION.fullmatch(revision):
+        raise ValueError("staged_path_confined")
+    if revision in {".", ".."} or root.is_symlink():
+        raise ValueError("staged_path_confined")
+    staged_root = root / "staged"
+    if staged_root.is_symlink() or not staged_root.is_dir():
+        raise ValueError("staged_path_confined")
+    try:
+        if staged_root.resolve(strict=True).parent != root.resolve(strict=True):
+            raise ValueError("staged_path_confined")
+    except OSError as exc:
+        raise ValueError("staged_path_confined") from exc
+    candidate = staged_root / revision
+    if candidate.is_symlink() or (candidate.exists() and not candidate.is_dir()):
+        raise ValueError("staged_path_confined")
+    return candidate
+
+
+def _read_staged_file(path: Path, limit: int) -> bytes:
+    try:
+        fd = os.open(path, os.O_RDONLY | os.O_NOFOLLOW)
+    except OSError as exc:
+        raise ValueError("staged_artifact_invalid") from exc
+    try:
+        metadata = os.fstat(fd)
+        if not stat.S_ISREG(metadata.st_mode) or metadata.st_nlink != 1:
+            raise ValueError("staged_artifact_invalid")
+        with os.fdopen(fd, "rb", closefd=True) as stream:
+            fd = -1
+            data = stream.read(limit + 1)
+        if len(data) > limit:
+            raise ValueError("staged_artifact_oversized")
+        return data
+    except OSError as exc:
+        raise ValueError("staged_artifact_invalid") from exc
+    finally:
+        if fd != -1:
+            os.close(fd)
+
+
+def _verify_staged_artifacts(
+    transaction: dict[str, Any],
+    root: Path,
+) -> tuple[bytes | None, bytes | None, dict[str, Any] | None]:
+    """Read and rehash all staged artifacts beneath the fixed state root."""
+    revision_dir = _staged_revision_dir(transaction, root)
+    manifest_path = revision_dir / "manifest.json"
+    package_path = revision_dir / "aurora-preview-package.tar.gz"
+    dashboard_path = revision_dir / "aurora-preview-dashboard.js"
+    expected = {
+        "manifest_sha256": transaction.get("manifest_sha256"),
+        "package_sha256": transaction.get("package_sha256"),
+        "dashboard_sha256": transaction.get("dashboard_sha256"),
+    }
+    paths = (manifest_path, package_path, dashboard_path)
+    for path in paths:
+        if path.is_symlink():
+            raise ValueError("staged_artifact_symlink")
+        if not path.exists():
+            # Transactions created before staged readback verification did not retain
+            # a complete artifact set. New transactions always have all three hashes.
+            if all(isinstance(value, str) for value in expected.values()):
+                raise ValueError("staged_artifact_missing")
+            return None, None, None
+        if not path.is_file():
+            raise ValueError("staged_artifact_invalid")
+    try:
+        manifest = json.loads(
+            _read_staged_file(manifest_path, MAX_MANIFEST).decode("utf-8")
+        )
+    except (UnicodeError, json.JSONDecodeError, ValueError) as exc:
+        raise ValueError("staged_manifest_invalid") from exc
+    if not isinstance(manifest, dict):
+        raise ValueError("staged_manifest_invalid")
+    package = _read_staged_file(package_path, MAX_PACKAGE)
+    dashboard = _read_staged_file(dashboard_path, MAX_DASHBOARD)
+    actual = {
+        "manifest_sha256": hashlib.sha256(_canonical_manifest(manifest)).hexdigest(),
+        "package_sha256": hashlib.sha256(package).hexdigest(),
+        "dashboard_sha256": hashlib.sha256(dashboard).hexdigest(),
+    }
+    if any(
+        isinstance(expected_hash, str) and actual[name] != expected_hash
+        for name, expected_hash in expected.items()
+    ):
+        raise ValueError("staged_artifact_hash_mismatch")
+    if all(isinstance(value, str) for value in expected.values()):
+        calculated_revision = hashlib.sha256(
+            (
+                actual["manifest_sha256"]
+                + actual["package_sha256"]
+                + actual["dashboard_sha256"]
+            ).encode()
+        ).hexdigest()[:32]
+        if calculated_revision != transaction.get("revision"):
+            raise ValueError("staged_revision_mismatch")
+    return package, dashboard, manifest
+
+
+def _save_immutable_asset(path: Path, data: bytes) -> None:
+    """Create an immutable content-addressed asset or verify its existing bytes."""
+    if path.exists():
+        if not path.is_file() or path.read_bytes() != data:
+            raise ValueError("dashboard_asset_collision")
+        return
+    _atomic_write(path, data)
+
+
+@dataclass
+class AuroraState:
+    hass: HomeAssistant
+    root: Path
+    journal: dict[str, Any] = field(default_factory=dict)
+    lock: Any = field(default_factory=__import__("asyncio").Lock)
+    request_times: deque[float] = field(default_factory=deque)
+
+    @classmethod
+    async def create(cls, hass: HomeAssistant) -> AuroraState:
+        return await hass.async_add_executor_job(cls._create_sync, hass)
+
+    @classmethod
+    def _create_sync(cls, hass: HomeAssistant) -> AuroraState:
+        root = Path(hass.config.path(".storage/aurora_deploy_preview"))
+        root.mkdir(parents=True, exist_ok=True)
+        os.chmod(root, 0o700)
+        journal_path = root / "journal.json"
+        try:
+            journal = json.loads(journal_path.read_text(encoding="utf-8")) if journal_path.exists() else {}
+        except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+            raise RuntimeError("aurora_deploy_journal_corrupt") from exc
+        if not isinstance(journal, dict):
+            raise RuntimeError("aurora_deploy_journal_invalid")
+        transition = journal.get("production_transition")
+        if isinstance(transition, dict) and transition.get("status") == "prepared":
+            journal["production_recovery_required"] = True
+        return cls(hass, root, journal)
+
+    def save(self) -> None:
+        _atomic_write(self.root / "journal.json", _json_bytes(self.journal))
+
+    def tx(self, transaction_id: str) -> dict[str, Any] | None:
+        value = self.journal.get("transactions", {}).get(transaction_id)
+        return value if isinstance(value, dict) else None
+
+    def admit_request(self) -> bool:
+        now = time.monotonic()
+        while self.request_times and now - self.request_times[0] >= REQUEST_WINDOW_SECONDS:
+            self.request_times.popleft()
+        if len(self.request_times) >= MAX_REQUESTS_PER_MINUTE:
+            return False
+        self.request_times.append(now)
+        return True
+
+
+def _ensure_production_baseline(state: AuroraState, config_sha256: str) -> str:
+    """Persist a deterministic CAS revision for a fresh installation."""
+    current = state.journal.get("production_revision")
+    recorded_hash = state.journal.get("production_config_sha256")
+    if isinstance(current, str) and current:
+        if _is_sha256(recorded_hash) and recorded_hash != config_sha256:
+            raise ValueError("production_config_conflict")
+        if recorded_hash != config_sha256:
+            state.journal["production_config_sha256"] = config_sha256
+        return current
+    baseline = "baseline-" + config_sha256
+    state.journal["production_revision"] = baseline
+    state.journal["production_config_sha256"] = config_sha256
+    state.save()
+    return baseline
+
+
+async def _admin(request: web.Request) -> bool:
+    user = request.get("hass_user")
+    return bool(user is not None and getattr(user, "is_admin", False))
+
+
+async def _body(request: web.Request) -> dict[str, Any] | None:
+    if request.content_length and request.content_length > MAX_BODY:
+        return None
+    raw = await request.content.read(MAX_BODY + 1)
+    if len(raw) > MAX_BODY:
+        return None
+    try:
+        value = json.loads(raw.decode("utf-8")) if raw else {}
+    except (UnicodeError, json.JSONDecodeError):
+        return None
+    return value if isinstance(value, dict) else None
+
+
+async def _dashboards(hass: HomeAssistant) -> tuple[Any, dict[Any, Any]]:
+    from homeassistant.components.lovelace import LOVELACE_DATA
+    data = hass.data[LOVELACE_DATA]
+    return data, data.dashboards
+
+
+async def _ensure_preview(hass: HomeAssistant) -> tuple[bool, str]:
+    data, dashboards = await _dashboards(hass)
+    if LEGACY_PREVIEW in dashboards:
+        raise ValueError("legacy_preview_collision")
+    existing = dashboards.get(PREVIEW)
+    metadata = {
+        CONF_URL_PATH: PREVIEW,
+        CONF_TITLE: "Aurora Preview",
+        CONF_ICON: "mdi:aurora",
+        CONF_SHOW_IN_SIDEBAR: False,
+        CONF_REQUIRE_ADMIN: True,
+    }
+    if existing is not None:
+        config = getattr(existing, "config", {}) or {}
+        if any(config.get(key) != value for key, value in metadata.items()):
+            raise ValueError("preview_collision")
+        return False, PREVIEW
+    from homeassistant.components.lovelace import _register_panel, dashboard
+
+    collection = dashboard.DashboardsCollection(hass)
+    await collection.async_load()
+    item = await collection.async_create_item(dict(metadata))
+    dashboards[PREVIEW] = dashboard.LovelaceStorage(hass, item)
+    _register_panel(hass, PREVIEW, dashboard.MODE_STORAGE, item, False)
+    return True, PREVIEW
+
+
+async def _load_dashboard(hass: HomeAssistant, url_path: str) -> tuple[Any, dict[str, Any]]:
+    _data, dashboards = await _dashboards(hass)
+    dashboard = dashboards.get(url_path)
+    if dashboard is None:
+        raise ValueError("dashboard_missing")
+    config = await dashboard.async_load(False)
+    return dashboard, config if isinstance(config, dict) else {"views": []}
+
+
+async def _save_preview_asset(hass: HomeAssistant, dashboard_bytes: bytes) -> str:
+    asset_revision = hashlib.sha256(dashboard_bytes).hexdigest()
+    asset_name = f"aurora-preview-dashboard-{asset_revision}.js"
+    path = Path(hass.config.path(f"www/aurora/revisions/{asset_name}"))
+    await asyncio.to_thread(_save_immutable_asset, path, dashboard_bytes)
+    dashboard_url = f"{DASHBOARD_URL_PREFIX}{asset_name}"
+    dashboard, config = await _load_dashboard(hass, PREVIEW)
+    resources = config.get("resources")
+    if not isinstance(resources, list):
+        resources = []
+    resources = [
+        item
+        for item in resources
+        if not (
+            isinstance(item, dict)
+            and (
+                item.get("url") == DASHBOARD_URL
+                or (
+                    isinstance(item.get("url"), str)
+                    and item["url"].startswith(DASHBOARD_URL_PREFIX)
+                )
+            )
+        )
+    ]
+    resources.append({"url": dashboard_url, "res_type": "module"})
+    config["resources"] = resources
+    await dashboard.async_save(config)
+    return asset_name
+
+
+async def _reload_backend(hass: HomeAssistant) -> None:
+    """Reload only the fixed Lovelace resources and core configuration hooks."""
+    services = getattr(hass, "services", None)
+    has_service = getattr(services, "has_service", None)
+    async_call = getattr(services, "async_call", None)
+    if not callable(has_service) or not callable(async_call):
+        raise RuntimeError("reload_backend_unavailable")
+    called = False
+    for domain, service in (("lovelace", "reload_resources"), ("homeassistant", "reload_core_config")):
+        if has_service(domain, service):
+            await async_call(domain, service, {}, blocking=True)
+            called = True
+    if not called:
+        raise RuntimeError("reload_backend_unavailable")
+
+
+async def _reconcile_production_transition(
+    hass: HomeAssistant, state: AuroraState
+) -> None:
+    """Resolve one durable prepared promotion from live production bytes."""
+    transition = state.journal.get("production_transition")
+    if not isinstance(transition, dict) or transition.get("status") != "prepared":
+        state.journal.pop("production_recovery_required", None)
+        return
+    previous = transition.get("previous")
+    next_config = transition.get("next_config")
+    transaction_id = transition.get("transaction_id")
+    receipt_nonce = transition.get("receipt_nonce")
+    if (
+        not isinstance(previous, dict)
+        or not isinstance(previous.get("config"), dict)
+        or not _is_sha256(previous.get("config_sha256"))
+        or not isinstance(next_config, dict)
+        or not _is_sha256(transition.get("next_config_sha256"))
+        or not isinstance(transaction_id, str)
+        or not isinstance(receipt_nonce, str)
+    ):
+        raise ValueError("production_transition_recovery_invalid")
+    transaction = state.tx(transaction_id)
+    if transaction is None or transaction.get("revision") != transition.get(
+        "to_revision"
+    ):
+        raise ValueError("production_transition_recovery_invalid")
+    _production, current_config = await _load_dashboard(hass, PRODUCTION)
+    current_sha = _config_sha256(current_config)
+    previous_sha = previous["config_sha256"]
+    next_sha = transition["next_config_sha256"]
+    if current_sha == next_sha:
+        committed_at = _now().isoformat()
+        state.journal["previous_production"] = previous
+        state.journal["production_revision"] = transition["to_revision"]
+        state.journal["production_config_sha256"] = next_sha
+        state.journal.setdefault("receipt_nonces", {})[receipt_nonce] = transaction_id
+        transaction["status"] = "promoted"
+        transaction["promoted_at"] = committed_at
+        transition["status"] = "committed"
+        transition["committed_at"] = committed_at
+        transition["recovered"] = True
+    elif current_sha == previous_sha:
+        transition["status"] = "aborted"
+        transition["aborted_at"] = _now().isoformat()
+        transition["recovered"] = True
+    else:
+        raise ValueError("production_transition_recovery_conflict")
+    state.journal.pop("production_recovery_required", None)
+    state.save()
+
+
+class RootView(HomeAssistantView):
+    """Bootstrap, stage, promote, and rollback routes."""
+
+    requires_auth = True
+    url = BASE + "/{operation}"
+    name = DOMAIN + ":root"
+
+    def __init__(self, hass: HomeAssistant, state: AuroraState) -> None:
+        self._hass = hass
+        self._state = state
+
+    async def post(self, request: web.Request, operation: str) -> web.Response:
+        if not await _admin(request):
+            return _error(403, "admin_required")
+        if not self._state.admit_request():
+            return _error(429, "rate_limited")
+        async with self._state.lock:
+            try:
+                body = await asyncio.wait_for(_body(request), REQUEST_TIMEOUT_SECONDS)
+                if body is None:
+                    return _error(400, "invalid_body")
+                if operation in {"promote-home-command", "rollback-home-command"}:
+                    try:
+                        await _reconcile_production_transition(
+                            self._hass, self._state
+                        )
+                    except ValueError:
+                        return _error(409, "production_recovery_required")
+                if operation == "bootstrap":
+                    created, target = await _ensure_preview(self._hass)
+                    return _json_response({"dashboard_target": target, "created": created, "production_unchanged": True})
+                if operation == "stage":
+                    return await self._stage(body)
+                if operation == "promote-home-command":
+                    return await self._promote(body)
+                if operation == "rollback-home-command":
+                    return await self._rollback()
+            except ValueError as exc:
+                return _error(422, str(exc))
+            except (OSError, RuntimeError):
+                return _error(500, "adapter_failure")
+        return _error(404, "not_found")
+
+    async def _stage(self, body: dict[str, Any]) -> web.Response:
+        if body.get("dashboard_target") != PREVIEW or body.get("preview_only") is not True:
+            return _error(422, "fixed_target_required")
+        package = _decode_b64((body.get("artifacts") or {}).get("package"), MAX_PACKAGE)
+        dashboard = _decode_b64((body.get("artifacts") or {}).get("dashboard"), MAX_DASHBOARD)
+        manifest_sha, package_sha, dashboard_sha = _validate_manifest(self._hass, body.get("manifest"), package, dashboard)
+        manifest = body["manifest"]
+        nonce = manifest["nonce"]
+        used = self._state.journal.setdefault("nonces", {})
+        if nonce in used:
+            return _error(409, "manifest_replay")
+        revision = hashlib.sha256((manifest_sha + package_sha + dashboard_sha).encode()).hexdigest()[:32]
+        transaction_id = "tx-" + secrets.token_hex(16)
+        revision_dir = self._state.root / "staged" / revision
+        revision_dir.mkdir(parents=True, exist_ok=False)
+        _atomic_write(revision_dir / "manifest.json", _json_bytes(manifest))
+        _atomic_write(revision_dir / "aurora-preview-package.tar.gz", package)
+        _atomic_write(revision_dir / "aurora-preview-dashboard.js", dashboard)
+        transaction = {
+            "transaction_id": transaction_id,
+            "revision": revision,
+            "status": "verified",
+            "manifest_sha256": manifest_sha,
+            "package_sha256": package_sha,
+            "dashboard_sha256": dashboard_sha,
+            "target": PREVIEW,
+            "created_at": _now().isoformat(),
+            "expires_at": manifest["expires_at"],
+        }
+        self._state.journal.setdefault("transactions", {})[transaction_id] = transaction
+        used[nonce] = transaction_id
+        self._state.save()
+        public_keys = (
+            "transaction_id",
+            "revision",
+            "status",
+            "manifest_sha256",
+            "package_sha256",
+            "dashboard_sha256",
+            "target",
+            "created_at",
+            "expires_at",
+        )
+        return _json_response(
+            {key: transaction[key] for key in public_keys} | {"staged_revision": revision}
+        )
+
+    async def _promote(  # noqa: C901 - explicit fail-closed promotion state machine
+        self, body: dict[str, Any]
+    ) -> web.Response:
+        """Durably prepare, CAS-check, apply, and commit one promotion."""
+        revision = body.get("preview_revision")
+        if not isinstance(revision, str):
+            return _error(422, "preview_revision_required")
+        transaction = next(
+            (
+                item
+                for item in self._state.journal.get("transactions", {}).values()
+                if isinstance(item, dict)
+                and item.get("revision") == revision
+                and item.get("status") in {"activated", "reloaded", "promoted"}
+            ),
+            None,
+        )
+        if transaction is None or self._state.journal.get("active_preview") != revision:
+            return _error(409, "preview_revision_not_active")
+        try:
+                await _verify_active_transaction(
+                    self._hass, transaction, self._state.root
+                )
+        except (OSError, ValueError, RuntimeError):
+            return _error(409, "preview_integrity_failed")
+        _preview, preview_config = await _load_dashboard(self._hass, PREVIEW)
+        production, production_config = await _load_dashboard(self._hass, PRODUCTION)
+        preview_config_sha = _config_sha256(preview_config)
+        production_config_sha = _config_sha256(production_config)
+        expected_production_revision = _ensure_production_baseline(
+            self._state, production_config_sha
+        )
+        if body.get("inspect") is True:
+            return _json_response(
+                {
+                    "preview_revision": revision,
+                    "status": transaction.get("status"),
+                    "active_revision": self._state.journal.get("active_preview"),
+                    "target_dashboard": PRODUCTION,
+                    "preview_config_sha256": preview_config_sha,
+                    "production_revision": expected_production_revision,
+                    "expected_production_config_sha256": production_config_sha,
+                    "verified": True,
+                }
+            )
+        if (
+            transaction.get("status") == "promoted"
+            and self._state.journal.get("production_revision") == revision
+            and production_config_sha == preview_config_sha
+        ):
+            previous = self._state.journal.get("previous_production")
+            return _json_response(
+                {
+                    "promoted": True,
+                    "active_revision": revision,
+                    "previous_revision": (
+                        previous.get("revision")
+                        if isinstance(previous, dict)
+                        else None
+                    ),
+                    "preview_config_sha256": preview_config_sha,
+                    "expected_production_config_sha256": production_config_sha,
+                }
+            )
+        receipt = body.get("receipt")
+        if not isinstance(receipt, dict):
+            return _error(422, "validation_receipt_required")
+        if set(receipt) != VALIDATION_RECEIPT_KEYS or receipt.get(
+            "schema_version"
+        ) != 1:
+            return _error(422, "validation_receipt_schema_invalid")
+        if receipt.get("preview_revision") != revision or receipt.get("dashboard_target") != PREVIEW or receipt.get("physical_validation") is not True:
+            return _error(422, "validation_receipt_invalid")
+        expected_production_revision = body.get("expected_production_revision")
+        if not isinstance(expected_production_revision, str) or not expected_production_revision:
+            return _error(422, "expected_production_revision_required")
+        if receipt.get("expected_production_revision") != expected_production_revision:
+            return _error(422, "validation_receipt_revision_mismatch")
+        device_results = receipt.get("device_results")
+        required_devices = {"mobile", "kiosk", "tablet", "laptop", "desktop"}
+        if (
+            not isinstance(device_results, list)
+            or len(device_results) != len(required_devices)
+            or {
+                item.get("device_id")
+                for item in device_results
+                if isinstance(item, dict)
+            }
+                != required_devices
+            or any(
+                not isinstance(item, dict)
+                or set(item) != {"device_id", "passed"}
+                or item.get("passed") is not True
+                for item in device_results
+            )
+        ):
+            return _error(422, "validation_receipt_devices_invalid")
+        issued_at = _parse_time(receipt.get("issued_at"))
+        expires_at = _parse_time(receipt.get("expires_at"))
+        now = _now()
+        if (
+            issued_at - CLOCK_SKEW > now
+            or expires_at <= issued_at
+            or expires_at <= now
+            or expires_at - issued_at > MAX_LIFETIME
+        ):
+            return _error(422, "validation_receipt_time_invalid")
+        receipt_nonce = receipt.get("nonce")
+        if not isinstance(receipt_nonce, str) or _SAFE_NONCE.fullmatch(receipt_nonce) is None:
+            return _error(422, "validation_receipt_nonce_invalid")
+        used_receipts = self._state.journal.setdefault("receipt_nonces", {})
+        if receipt_nonce in used_receipts:
+            return _error(409, "validation_receipt_replay")
+        _verify_signature(self._hass, receipt, prefix="validation-")
+        if any(receipt.get(key) != transaction.get(key) for key in ("manifest_sha256", "package_sha256", "dashboard_sha256")):
+            return _error(422, "validation_receipt_hash_mismatch")
+        expected_revision = self._state.journal.get("production_revision")
+        if expected_production_revision != expected_revision:
+            return _error(409, "production_revision_conflict")
+        if (
+            not _is_sha256(receipt.get("preview_config_sha256"))
+            or receipt.get("preview_config_sha256") != preview_config_sha
+        ):
+            return _error(422, "validation_receipt_preview_config_mismatch")
+        if (
+            not _is_sha256(receipt.get("expected_production_config_sha256"))
+            or receipt.get("expected_production_config_sha256")
+            != production_config_sha
+        ):
+            return _error(409, "production_config_conflict")
+        transition = self._state.journal.get("production_transition")
+        if isinstance(transition, dict) and transition.get("status") == "prepared":
+            if (
+                transition.get("to_revision") != revision
+                or transition.get("expected_revision") != expected_revision
+                or transition.get("expected_config_sha256")
+                != production_config_sha
+                or transition.get("next_config_sha256") != preview_config_sha
+            ):
+                return _error(409, "production_transition_in_progress")
+            previous = transition.get("previous")
+            next_config = transition.get("next_config")
+            if not isinstance(previous, dict) or not isinstance(next_config, dict):
+                return _error(409, "production_transition_invalid")
+        else:
+            previous = {
+                "revision": expected_revision,
+                "config": json.loads(_json_bytes(production_config)),
+                "config_sha256": production_config_sha,
+            }
+            next_config = json.loads(_json_bytes(preview_config))
+            transition = {
+                "transition_id": "promotion-" + secrets.token_hex(16),
+                "status": "prepared",
+                "expected_revision": expected_revision,
+                "expected_config_sha256": production_config_sha,
+                "to_revision": revision,
+                "transaction_id": transaction["transaction_id"],
+                "receipt_nonce": receipt_nonce,
+                "previous": previous,
+                "next_config": next_config,
+                "next_config_sha256": preview_config_sha,
+                "prepared_at": _now().isoformat(),
+            }
+            self._state.journal["production_transition"] = transition
+            self._state.save()
+        if (
+            self._state.journal.get("production_revision") != expected_revision
+            or self._state.journal.get("production_transition") is not transition
+        ):
+            return _error(409, "production_revision_conflict")
+        _preview_check, preview_check = await _load_dashboard(self._hass, PREVIEW)
+        _production_check, production_check = await _load_dashboard(
+            self._hass, PRODUCTION
+        )
+        if _config_sha256(preview_check) != preview_config_sha:
+            return _error(409, "preview_config_conflict")
+        if _config_sha256(production_check) != production_config_sha:
+            return _error(409, "production_config_conflict")
+        await production.async_save(next_config)
+        if (
+            self._state.journal.get("production_revision") != expected_revision
+            or self._state.journal.get("production_transition") is not transition
+        ):
+            return _error(409, "production_revision_conflict")
+        self._state.journal["previous_production"] = previous
+        self._state.journal["production_revision"] = revision
+        self._state.journal["production_config_sha256"] = preview_config_sha
+        transaction["status"] = "promoted"
+        transaction["promoted_at"] = _now().isoformat()
+        used_receipts[receipt_nonce] = transaction["transaction_id"]
+        transition["status"] = "committed"
+        transition["committed_at"] = transaction["promoted_at"]
+        self._state.save()
+        return _json_response(
+            {
+                "promoted": True,
+                "active_revision": revision,
+                "previous_revision": previous.get("revision"),
+                "preview_config_sha256": preview_config_sha,
+                "expected_production_config_sha256": production_config_sha,
+            }
+        )
+
+    async def _rollback(self) -> web.Response:
+        previous = self._state.journal.get("previous_production")
+        if (
+            not isinstance(previous, dict)
+            or not isinstance(previous.get("config"), dict)
+            or not _is_sha256(previous.get("config_sha256"))
+            or not _is_sha256(
+                self._state.journal.get("production_config_sha256")
+            )
+        ):
+            return _error(409, "no_prior_production_revision")
+        production, current = await _load_dashboard(self._hass, PRODUCTION)
+        if _config_sha256(current) != self._state.journal.get(
+            "production_config_sha256"
+        ):
+            return _error(409, "production_config_conflict")
+        if _config_sha256(previous["config"]) != previous["config_sha256"]:
+            return _error(409, "production_rollback_evidence_invalid")
+        await production.async_save(previous["config"])
+        active = self._state.journal.get("production_revision")
+        self._state.journal["production_revision"] = previous.get("revision")
+        self._state.journal["production_config_sha256"] = previous[
+            "config_sha256"
+        ]
+        self._state.journal["previous_production"] = None
+        for transaction in self._state.journal.get("transactions", {}).values():
+            if isinstance(transaction, dict) and transaction.get("revision") == active:
+                transaction["status"] = "rolled_back"
+                transaction["rolled_back_at"] = _now().isoformat()
+        self._state.save()
+        return _json_response({"rolled_back": True, "active_revision": previous.get("revision")})
+
+
+class TransactionView(HomeAssistantView):
+    """Readback, activation, and reload routes for one transaction."""
+
+    requires_auth = True
+    url = BASE + "/{transaction_id}/{operation}"
+    name = DOMAIN + ":transaction"
+
+    def __init__(self, hass: HomeAssistant, state: AuroraState) -> None:
+        self._hass = hass
+        self._state = state
+
+    async def get(self, request: web.Request, transaction_id: str, operation: str) -> web.Response:
+        if not await _admin(request):
+            return _error(403, "admin_required")
+        if not self._state.admit_request():
+            return _error(429, "rate_limited")
+        if operation != "readback":
+            return _error(404, "not_found")
+        transaction = self._state.tx(transaction_id)
+        if transaction is None:
+            return _error(404, "transaction_not_found")
+        try:
+            package, dashboard, _manifest = _verify_staged_artifacts(
+                transaction, self._state.root
+            )
+        except (OSError, ValueError):
+            return _error(409, "staged_integrity_failed")
+        active_component_sha: str | None = None
+        if transaction.get("status") in {"activated", "reloaded", "promoted"}:
+            try:
+                if package is None or dashboard is None:
+                    raise ValueError("staged_artifact_missing")
+                members = _validate_package(package)
+                active_component_sha = await _verify_active_bindings(
+                    self._hass, transaction, members, dashboard
+                )
+            except (OSError, ValueError, RuntimeError):
+                return _error(409, "active_integrity_failed")
+        payload = {
+            key: transaction.get(key)
+            for key in (
+                "transaction_id",
+                "revision",
+                "status",
+                "manifest_sha256",
+                "package_sha256",
+                "dashboard_sha256",
+                "target",
+            )
+        }
+        payload["verified"] = transaction.get("status") in {
+            "verified",
+            "activated",
+            "reloaded",
+            "promoted",
+        }
+        if active_component_sha is not None:
+            payload["active_package_sha256"] = active_component_sha
+            payload["active_package_verified"] = True
+            payload["active_dashboard_verified"] = True
+        return _json_response(payload)
+
+    async def post(self, request: web.Request, transaction_id: str, operation: str) -> web.Response:
+        if not await _admin(request):
+            return _error(403, "admin_required")
+        if not self._state.admit_request():
+            return _error(429, "rate_limited")
+        async with self._state.lock:
+            transaction = self._state.tx(transaction_id)
+            if transaction is None:
+                return _error(404, "transaction_not_found")
+            try:
+                if operation == "activate":
+                    if transaction.get("status") != "verified":
+                        return _error(409, "transaction_not_verified")
+                    package, dashboard, _manifest = _verify_staged_artifacts(
+                        transaction, self._state.root
+                    )
+                    if package is None or dashboard is None:
+                        raise ValueError("staged_artifact_missing")
+                    component_members = _validate_package(package)
+                    await _ensure_preview(self._hass)
+                    preview, preview_config = await _load_dashboard(self._hass, PREVIEW)
+                    transaction["preview_before"] = json.loads(_json_bytes(preview_config))
+                    transaction["preview_revision_before"] = self._state.journal.get(
+                        "active_preview"
+                    )
+                    component_activated = False
+                    try:
+                        await asyncio.to_thread(
+                            _activate_component_package,
+                            self._hass,
+                            self._state,
+                            transaction,
+                            component_members,
+                        )
+                        component_activated = True
+                        asset_name = await _save_preview_asset(self._hass, dashboard)
+                    except (OSError, ValueError, RuntimeError):
+                        if component_activated:
+                            await asyncio.to_thread(
+                                _restore_component_prestate,
+                                self._hass,
+                                self._state,
+                                transaction,
+                            )
+                        try:
+                            await preview.async_save(transaction["preview_before"])
+                        except (OSError, ValueError, RuntimeError):
+                            pass
+                        raise
+                    transaction["active_dashboard_asset"] = asset_name
+                    self._state.journal["active_preview"] = transaction["revision"]
+                    transaction["status"] = "activated"
+                    transaction["activated_at"] = _now().isoformat()
+                    self._state.save()
+                    return _json_response({"activated": True, "active_revision": transaction["revision"], "status": "activated"})
+                if operation == "rollback":
+                    if transaction.get("status") not in {"activated", "reloaded"}:
+                        return _error(409, "transaction_not_rollbackable")
+                    previous_preview = transaction.get("preview_before")
+                    if not isinstance(previous_preview, dict):
+                        return _error(409, "preview_rollback_snapshot_missing")
+                    preview, _current = await _load_dashboard(self._hass, PREVIEW)
+                    await preview.async_save(previous_preview)
+                    await asyncio.to_thread(
+                        _restore_component_prestate,
+                        self._hass,
+                        self._state,
+                        transaction,
+                    )
+                    if self._state.journal.get("active_preview") == transaction.get("revision"):
+                        previous_revision = transaction.get("preview_revision_before")
+                        if isinstance(previous_revision, str):
+                            self._state.journal["active_preview"] = previous_revision
+                        else:
+                            self._state.journal.pop("active_preview", None)
+                    transaction["status"] = "rolled_back"
+                    transaction["rolled_back_at"] = _now().isoformat()
+                    self._state.save()
+                    active_revision = self._state.journal.get("active_preview")
+                    return _json_response(
+                        {
+                            "rolled_back": True,
+                            "active_revision": active_revision,
+                            "preview_active": isinstance(active_revision, str),
+                            "status": "rolled_back",
+                        }
+                    )
+                if operation == "reload":
+                    if transaction.get("status") != "activated":
+                        return _error(409, "transaction_not_activated")
+                    return _error(409, "restart_required")
+            except (OSError, ValueError, RuntimeError):
+                return _error(500, "activation_failed")
+        return _error(404, "not_found")

--- a/custom_components/aurora_deploy/adapter.py
+++ b/custom_components/aurora_deploy/adapter.py
@@ -1898,6 +1898,9 @@ class RootView(HomeAssistantView):
         )
         if transaction is None or self._state.journal.get("active_preview") != revision:
             return _error(409, "preview_revision_not_active")
+        transaction_id = transaction.get("transaction_id")
+        if not isinstance(transaction_id, str) or not transaction_id:
+            return _error(409, "preview_integrity_failed")
         try:
             await _verify_active_transaction(self._hass, transaction, self._state.root)
             resource_context = await asyncio.to_thread(
@@ -1919,7 +1922,8 @@ class RootView(HomeAssistantView):
             return _json_response(
                 {
                     "preview_revision": revision,
-                    "transaction_id": transaction.get("transaction_id"),
+                    "transaction_id": transaction_id,
+                    "active_preview_transaction_id": transaction_id,
                     "status": transaction.get("status"),
                     "active_revision": self._state.journal.get("active_preview"),
                     "dashboard_target": PREVIEW,

--- a/custom_components/aurora_deploy/adapter.py
+++ b/custom_components/aurora_deploy/adapter.py
@@ -3,6 +3,7 @@
 Only the fixed preview and production pointers are addressable. This module has
 no path, shell, upload, Supervisor, File Editor, SSH, or arbitrary Lovelace API.
 """
+
 from __future__ import annotations
 
 import asyncio
@@ -16,6 +17,7 @@ import secrets
 import stat
 import tarfile
 import time
+import uuid
 from collections import deque
 from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta
@@ -26,6 +28,7 @@ from typing import Any
 try:
     from aiohttp import web
 except ModuleNotFoundError:  # pragma: no cover - standalone validation tests
+
     class _WebStub:
         class Request:
             pass
@@ -46,6 +49,7 @@ try:  # Keep pure validation helpers testable in the ha-mcp-only environment.
     )
     from homeassistant.core import HomeAssistant
 except ModuleNotFoundError:  # pragma: no cover - only used by standalone unit tests
+
     class HomeAssistantView:  # type: ignore[no-redef]
         requires_auth = True
 
@@ -58,11 +62,11 @@ except ModuleNotFoundError:  # pragma: no cover - only used by standalone unit t
 
 DOMAIN = "aurora_deploy"
 BASE = "/api/aurora/deploy-preview/v1"
-PREVIEW = "home-command-preview"
+PREVIEW = "aurora-preview"
 PRODUCTION = "home-command"
-# A prior Aurora release used this target. It is a fixed migration collision, not a caller-
-# selectable dashboard id; refusing it prevents bootstrap from creating a third Aurora environment.
-LEGACY_PREVIEW = "aurora-preview"
+# This obsolete candidate target is a fixed collision, not a caller-selectable
+# dashboard id; refusing it prevents bootstrap from creating a third environment.
+LEGACY_PREVIEW = "home-command-preview"
 TARGET = "aurora-v9-preview"
 APPROVED_RELEASE = "0.1.16"
 MAX_BODY = 80 * 1024 * 1024
@@ -73,6 +77,7 @@ MAX_MEMBERS = 256
 MAX_EXPANDED = 32 * 1024 * 1024
 CLOCK_SKEW = timedelta(minutes=5)
 MAX_LIFETIME = timedelta(hours=24)
+MAX_AUTOMATED_E2E_LIFETIME = timedelta(minutes=10)
 MAX_REQUESTS_PER_MINUTE = 60
 REQUEST_WINDOW_SECONDS = 60.0
 REQUEST_TIMEOUT_SECONDS = 30.0
@@ -111,7 +116,7 @@ APPROVED_PACKAGE_FILES = PACKAGE_ROOT_FILES | frozenset(
 APPROVED_PACKAGE_DIRECTORIES = frozenset(
     {"custom_components", "custom_components/aurora_camera_ai"}
 )
-VALIDATION_RECEIPT_KEYS = frozenset(
+VALIDATION_RECEIPT_V1_KEYS = frozenset(
     {
         "schema_version",
         "preview_revision",
@@ -131,8 +136,45 @@ VALIDATION_RECEIPT_KEYS = frozenset(
         "expires_at",
     }
 )
+VALIDATION_RECEIPT_V2_KEYS = frozenset(
+    {
+        "schema_version",
+        "preview_revision",
+        "transaction_id",
+        "operation_id",
+        "expected_production_revision",
+        "preview_config_sha256",
+        "expected_production_config_sha256",
+        "dashboard_target",
+        "validation_kind",
+        "e2e_evidence_sha256",
+        "profile_results",
+        "manifest_sha256",
+        "package_sha256",
+        "dashboard_sha256",
+        "audience",
+        "action",
+        "issued_at",
+        "expires_at",
+        "nonce",
+        "signer",
+        "signature",
+    }
+)
+AUTOMATED_E2E_PROFILES = (
+    ("mobile-390x844", 390, 844),
+    ("tablet-portrait-800x1280", 800, 1280),
+    ("tablet-landscape-1280x800", 1280, 800),
+    ("kiosk-1280x800", 1280, 800),
+    ("laptop-1100x800", 1100, 800),
+    ("desktop-1440x1000", 1440, 1000),
+)
 DASHBOARD_URL = "/local/aurora/aurora-preview-dashboard.js"
 DASHBOARD_URL_PREFIX = "/local/aurora/revisions/"
+_CONTENT_ADDRESSED_DASHBOARD_URL = re.compile(
+    re.escape(DASHBOARD_URL_PREFIX)
+    + r"aurora-preview-dashboard-([0-9a-f]{64})\.js"
+)
 PRIVACY_POLICY = "no-sensitive-inference-v1"
 FORBIDDEN_PRIVACY = frozenset(
     {
@@ -184,8 +226,21 @@ def _now() -> datetime:
     return datetime.now(UTC)
 
 
+def _is_uuid_operation_id(value: Any) -> bool:
+    """Return whether value is a canonical RFC 4122 UUID identifier."""
+    if not isinstance(value, str):
+        return False
+    try:
+        parsed = uuid.UUID(value)
+    except (ValueError, AttributeError):
+        return False
+    return parsed.variant == uuid.RFC_4122 and str(parsed) == value
+
+
 def _json_bytes(value: Any) -> bytes:
-    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True).encode()
+    return json.dumps(
+        value, sort_keys=True, separators=(",", ":"), ensure_ascii=True
+    ).encode()
 
 
 def _config_sha256(config: dict[str, Any]) -> str:
@@ -258,7 +313,9 @@ def _trusted_keys(hass: HomeAssistant) -> dict[str, bytes]:
     return result
 
 
-def _verify_signature(hass: HomeAssistant, document: dict[str, Any], *, prefix: str) -> None:
+def _verify_signature(
+    hass: HomeAssistant, document: dict[str, Any], *, prefix: str
+) -> None:
     key_id = document.get("key_id") or document.get("signer")
     signature_text = document.get("signature")
     if not isinstance(key_id, str) or not isinstance(signature_text, str):
@@ -274,7 +331,9 @@ def _verify_signature(hass: HomeAssistant, document: dict[str, Any], *, prefix: 
         from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
 
         try:
-            Ed25519PublicKey.from_public_bytes(public).verify(signature, _canonical_manifest(document))
+            Ed25519PublicKey.from_public_bytes(public).verify(
+                signature, _canonical_manifest(document)
+            )
         except InvalidSignature as exc:
             raise ValueError("signature") from exc
     except (KeyError, ValueError, TypeError, binascii.Error) as exc:
@@ -339,7 +398,12 @@ def _package_members(raw: bytes) -> dict[str, bytes]:  # noqa: C901 - archive po
                 path = PurePosixPath(name)
                 if path.is_absolute() or ".." in path.parts or name == "":
                     raise ValueError("package_path")
-                if member.issym() or member.islnk() or member.isdev() or member.isfifo():
+                if (
+                    member.issym()
+                    or member.islnk()
+                    or member.isdev()
+                    or member.isfifo()
+                ):
                     raise ValueError("package_link")
                 normalized = name.rstrip("/")
                 if member.isdir():
@@ -390,8 +454,7 @@ def _package_members(raw: bytes) -> dict[str, bytes]:  # noqa: C901 - archive po
     if not isinstance(installation, dict) or any(
         (
             installation.get("mode") != "transactional-atomic-rename",
-            installation.get("installer")
-            != "install-aurora-camera-ai-component.py",
+            installation.get("installer") != "install-aurora-camera-ai-component.py",
             installation.get("configurationHashGuardRequired") is not True,
             installation.get("prestateCapture") != "exact-bytes",
         )
@@ -419,9 +482,10 @@ def _package_members(raw: bytes) -> dict[str, bytes]:  # noqa: C901 - archive po
         if not path.startswith(PACKAGE_ROOT) or path in described:
             raise ValueError("package_component_manifest")
         data = files[path]
-        if entry.get("size") != len(data) or entry.get("sha256") != hashlib.sha256(
-            data
-        ).hexdigest():
+        if (
+            entry.get("size") != len(data)
+            or entry.get("sha256") != hashlib.sha256(data).hexdigest()
+        ):
             raise ValueError("package_component_hash")
         described.add(path)
     expected_component_paths = {
@@ -450,8 +514,7 @@ def _package_members(raw: bytes) -> dict[str, bytes]:  # noqa: C901 - archive po
         (
             installer.get("entry") != "install-aurora-camera-ai-component.py",
             installer.get("size") != len(installer_bytes),
-            installer.get("sha256")
-            != hashlib.sha256(installer_bytes).hexdigest(),
+            installer.get("sha256") != hashlib.sha256(installer_bytes).hexdigest(),
         )
     ):
         raise ValueError("package_manifest")
@@ -475,148 +538,19 @@ def _validate_package(raw: bytes) -> dict[str, bytes]:
     return _package_members(raw)
 
 
-def _component_binding(members: dict[str, bytes]) -> str:
-    if set(members) != APPROVED_COMPONENT_FILES:
-        raise ValueError("package_source_missing")
-    digest = hashlib.sha256()
-    for filename in sorted(APPROVED_COMPONENT_FILES):
-        data = members[filename]
-        if not isinstance(data, bytes):
-            raise ValueError("package_member")
-        digest.update(filename.encode("utf-8"))
-        digest.update(b"\0")
-        digest.update(hashlib.sha256(data).digest())
-    return digest.hexdigest()
-
-
-def _live_component_members(hass: HomeAssistant) -> dict[str, bytes]:
-    root = Path(hass.config.path(f"custom_components/{COMPONENT_DOMAIN}"))
-    if root.is_symlink() or not root.is_dir():
-        raise ValueError("active_component_missing")
-    members: dict[str, bytes] = {}
-    for filename in APPROVED_COMPONENT_FILES:
-        path = root / filename
-        if path.is_symlink() or not path.is_file():
-            raise ValueError("active_component_missing")
-        members[filename] = path.read_bytes()
-    return members
-
-
-def _transaction_token(transaction: dict[str, Any]) -> str:
-    transaction_id = transaction.get("transaction_id")
-    if not isinstance(transaction_id, str):
-        raise ValueError("transaction_id")
-    return hashlib.sha256(transaction_id.encode("utf-8")).hexdigest()
-
-
-def _activate_component_package(
-    hass: HomeAssistant,
-    state: "AuroraState",
-    transaction: dict[str, Any],
-    members: dict[str, bytes],
-) -> str:
-    """Atomically replace only the fixed Aurora component directory."""
-    binding = _component_binding(members)
-    token = _transaction_token(transaction)
-    attempt = transaction.get("component_activation_attempt", 0)
-    if not isinstance(attempt, int) or isinstance(attempt, bool) or attempt < 0:
-        raise ValueError("component_activation_attempt")
-    attempt += 1
-    transaction["component_activation_attempt"] = attempt
-    attempt_name = str(attempt)
-    candidate_root = state.root / "component-candidates" / token / attempt_name
-    candidate = candidate_root / COMPONENT_DOMAIN
-    prestate = state.root / "component-prestate" / token / attempt_name
-    if candidate_root.exists() or prestate.exists():
-        raise ValueError("component_transaction_collision")
-    candidate.mkdir(parents=True)
-    for filename, data in members.items():
-        _atomic_write(candidate / filename, data)
-
-    parent = Path(hass.config.path("custom_components"))
-    if parent.is_symlink():
-        raise ValueError("component_parent")
-    parent.mkdir(parents=True, exist_ok=True)
-    destination = parent / COMPONENT_DOMAIN
-    if destination.is_symlink():
-        raise ValueError("component_destination")
-    previous_exists = destination.exists()
-    if previous_exists and not destination.is_dir():
-        raise ValueError("component_destination")
-    moved_previous = False
-    try:
-        if previous_exists:
-            prestate.parent.mkdir(parents=True, exist_ok=True)
-            os.replace(destination, prestate)
-            moved_previous = True
-        os.replace(candidate, destination)
-        candidate_root.rmdir()
-    except OSError:
-        if moved_previous and not destination.exists() and prestate.exists():
-            os.replace(prestate, destination)
-        raise
-    transaction["component_prestate_exists"] = previous_exists
-    transaction["component_binding_sha256"] = binding
-    return binding
-
-
-def _restore_component_prestate(
-    hass: HomeAssistant, state: "AuroraState", transaction: dict[str, Any]
-) -> None:
-    """Restore the exact component directory captured by this transaction."""
-    if "component_prestate_exists" not in transaction:
-        return
-    expected = transaction.get("component_binding_sha256")
-    if not isinstance(expected, str):
-        raise ValueError("component_rollback_snapshot_missing")
-    live = _component_binding(_live_component_members(hass))
-    if live != expected:
-        raise ValueError("component_cas_mismatch")
-    token = _transaction_token(transaction)
-    attempt = transaction.get("component_activation_attempt")
-    if not isinstance(attempt, int) or isinstance(attempt, bool) or attempt < 1:
-        raise ValueError("component_rollback_snapshot_missing")
-    attempt_name = str(attempt)
-    destination = Path(hass.config.path(f"custom_components/{COMPONENT_DOMAIN}"))
-    prestate = state.root / "component-prestate" / token / attempt_name
-    retired = state.root / "component-retired" / token / attempt_name
-    if retired.exists():
-        raise ValueError("component_transaction_collision")
-    retired.parent.mkdir(parents=True, exist_ok=True)
-    os.replace(destination, retired)
-    if transaction["component_prestate_exists"]:
-        if prestate.is_symlink() or not prestate.is_dir():
-            os.replace(retired, destination)
-            raise ValueError("component_rollback_snapshot_missing")
-        try:
-            os.replace(prestate, destination)
-        except OSError:
-            os.replace(retired, destination)
-            raise
-
-
 async def _verify_active_bindings(
     hass: HomeAssistant,
     transaction: dict[str, Any],
-    members: dict[str, bytes],
     dashboard_bytes: bytes,
 ) -> str:
-    expected_component = _component_binding(members)
-    if transaction.get("component_binding_sha256") != expected_component:
-        raise ValueError("active_component_binding")
-    live_members = await asyncio.to_thread(_live_component_members, hass)
-    if _component_binding(live_members) != expected_component:
-        raise ValueError("active_component_binding")
-
+    """Verify only the content-addressed preview dashboard deployment."""
     dashboard_sha = hashlib.sha256(dashboard_bytes).hexdigest()
-    asset_name = f"aurora-preview-dashboard-{dashboard_sha}.js"
-    if transaction.get("active_dashboard_asset") != asset_name:
+    resource_context = await asyncio.to_thread(
+        _active_resource_context, hass, transaction
+    )
+    if resource_context["preview_resource_sha256"] != dashboard_sha:
         raise ValueError("active_dashboard_binding")
-    asset_path = Path(hass.config.path(f"www/aurora/revisions/{asset_name}"))
-    if asset_path.is_symlink() or not asset_path.is_file():
-        raise ValueError("active_dashboard_binding")
-    if hashlib.sha256(asset_path.read_bytes()).hexdigest() != dashboard_sha:
-        raise ValueError("active_dashboard_binding")
+    asset_name = transaction["active_dashboard_asset"]
     _dashboard, config = await _load_dashboard(hass, PREVIEW)
     resources = config.get("resources")
     expected_url = f"{DASHBOARD_URL_PREFIX}{asset_name}"
@@ -627,7 +561,7 @@ async def _verify_active_bindings(
         for item in resources
     ):
         raise ValueError("active_dashboard_binding")
-    return expected_component
+    return dashboard_sha
 
 
 async def _verify_active_transaction(
@@ -636,16 +570,21 @@ async def _verify_active_transaction(
     package, dashboard, _manifest = _verify_staged_artifacts(transaction, root)
     if package is None or dashboard is None:
         raise ValueError("staged_artifact_missing")
-    members = _validate_package(package)
-    return await _verify_active_bindings(hass, transaction, members, dashboard)
+    _validate_package(package)
+    return await _verify_active_bindings(hass, transaction, dashboard)
 
 
-def _validate_manifest(hass: HomeAssistant, manifest: Any, package: bytes, dashboard: bytes) -> tuple[str, str, str]:  # noqa: C901 - fail-closed policy checks are kept together
+def _validate_manifest(  # noqa: C901 - fail-closed policy checks are kept together
+    hass: HomeAssistant, manifest: Any, package: bytes, dashboard: bytes
+) -> tuple[str, str, str]:
     if not isinstance(manifest, dict) or len(_json_bytes(manifest)) > MAX_MANIFEST:
         raise ValueError("manifest")
     if manifest.get("schema_version") != 1 or manifest.get("target") != TARGET:
         raise ValueError("target")
-    if manifest.get("dashboard_target", PREVIEW) != PREVIEW or manifest.get("preview_only") is not True:
+    if (
+        manifest.get("dashboard_target", PREVIEW) != PREVIEW
+        or manifest.get("preview_only") is not True
+    ):
         raise ValueError("dashboard")
     if manifest.get("target_release") != APPROVED_RELEASE:
         raise ValueError("release")
@@ -654,23 +593,47 @@ def _validate_manifest(hass: HomeAssistant, manifest: Any, package: bytes, dashb
     issued = _parse_time(manifest.get("issued_at", manifest.get("created_at")))
     expires = _parse_time(manifest.get("expires_at"))
     now = _now()
-    if issued - CLOCK_SKEW > now or expires + CLOCK_SKEW < now or expires <= issued or expires - issued > MAX_LIFETIME:
+    if (
+        issued - CLOCK_SKEW > now
+        or expires + CLOCK_SKEW < now
+        or expires <= issued
+        or expires - issued > MAX_LIFETIME
+    ):
         raise ValueError("expiry")
     nonce = manifest.get("nonce")
-    if not isinstance(nonce, str) or not (8 <= len(nonce) <= 128) or any(ch not in "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789._-" for ch in nonce):
+    if (
+        not isinstance(nonce, str)
+        or not (8 <= len(nonce) <= 128)
+        or any(
+            ch
+            not in "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789._-"
+            for ch in nonce
+        )
+    ):
         raise ValueError("nonce")
     _verify_signature(hass, manifest, prefix="release-")
     package_hash = hashlib.sha256(package).hexdigest()
     dashboard_hash = hashlib.sha256(dashboard).hexdigest()
-    if manifest.get("artifact_sha256", manifest.get("package_sha256")) != package_hash or manifest.get("dashboard_sha256") != dashboard_hash:
+    if (
+        manifest.get("artifact_sha256", manifest.get("package_sha256")) != package_hash
+        or manifest.get("dashboard_sha256") != dashboard_hash
+    ):
         raise ValueError("hash")
     assets = manifest.get("assets")
-    expected = {"aurora-preview-package": package_hash, "aurora-preview-dashboard": dashboard_hash}
+    expected = {
+        "aurora-preview-package": package_hash,
+        "aurora-preview-dashboard": dashboard_hash,
+    }
     if not isinstance(assets, list) or len(assets) != 2:
         raise ValueError("assets")
     seen: set[str] = set()
     for item in assets:
-        if not isinstance(item, dict) or item.get("name") not in expected or item["name"] in seen or item.get("sha256") != expected[item["name"]]:
+        if (
+            not isinstance(item, dict)
+            or item.get("name") not in expected
+            or item["name"] in seen
+            or item.get("sha256") != expected[item["name"]]
+        ):
             raise ValueError("assets")
         seen.add(item["name"])
     if seen != set(expected):
@@ -678,7 +641,11 @@ def _validate_manifest(hass: HomeAssistant, manifest: Any, package: bytes, dashb
     _scan_privacy(_json_bytes(manifest))
     _scan_privacy(dashboard)
     _validate_package(package)
-    return hashlib.sha256(_canonical_manifest(manifest)).hexdigest(), package_hash, dashboard_hash
+    return (
+        hashlib.sha256(_canonical_manifest(manifest)).hexdigest(),
+        package_hash,
+        dashboard_hash,
+    )
 
 
 def _atomic_write(path: Path, data: bytes) -> None:
@@ -743,7 +710,7 @@ def _read_staged_file(path: Path, limit: int) -> bytes:
             os.close(fd)
 
 
-def _verify_staged_artifacts(
+def _verify_staged_artifacts(  # noqa: C901 - staged evidence checks are fail-closed
     transaction: dict[str, Any],
     root: Path,
 ) -> tuple[bytes | None, bytes | None, dict[str, Any] | None]:
@@ -804,8 +771,16 @@ def _verify_staged_artifacts(
 
 def _save_immutable_asset(path: Path, data: bytes) -> None:
     """Create an immutable content-addressed asset or verify its existing bytes."""
+    if path.is_symlink():
+        raise ValueError("dashboard_asset_collision")
     if path.exists():
-        if not path.is_file() or path.read_bytes() != data:
+        metadata = path.stat(follow_symlinks=False)
+        if (
+            not stat.S_ISREG(metadata.st_mode)
+            or metadata.st_nlink != 1
+            or metadata.st_size != len(data)
+            or path.read_bytes() != data
+        ):
             raise ValueError("dashboard_asset_collision")
         return
     _atomic_write(path, data)
@@ -830,7 +805,11 @@ class AuroraState:
         os.chmod(root, 0o700)
         journal_path = root / "journal.json"
         try:
-            journal = json.loads(journal_path.read_text(encoding="utf-8")) if journal_path.exists() else {}
+            journal = (
+                json.loads(journal_path.read_text(encoding="utf-8"))
+                if journal_path.exists()
+                else {}
+            )
         except (OSError, UnicodeError, json.JSONDecodeError) as exc:
             raise RuntimeError("aurora_deploy_journal_corrupt") from exc
         if not isinstance(journal, dict):
@@ -849,7 +828,9 @@ class AuroraState:
 
     def admit_request(self) -> bool:
         now = time.monotonic()
-        while self.request_times and now - self.request_times[0] >= REQUEST_WINDOW_SECONDS:
+        while (
+            self.request_times and now - self.request_times[0] >= REQUEST_WINDOW_SECONDS
+        ):
             self.request_times.popleft()
         if len(self.request_times) >= MAX_REQUESTS_PER_MINUTE:
             return False
@@ -866,12 +847,238 @@ def _ensure_production_baseline(state: AuroraState, config_sha256: str) -> str:
             raise ValueError("production_config_conflict")
         if recorded_hash != config_sha256:
             state.journal["production_config_sha256"] = config_sha256
+            state.save()
         return current
     baseline = "baseline-" + config_sha256
     state.journal["production_revision"] = baseline
     state.journal["production_config_sha256"] = config_sha256
     state.save()
     return baseline
+
+
+def _deployment_audience(state: AuroraState) -> str:
+    """Return a stable public identifier for receipts issued to this HA instance."""
+    audience = state.journal.get("audience")
+    if audience is None:
+        audience = "urn:home-assistant:aurora-deploy:" + secrets.token_hex(16)
+        state.journal["audience"] = audience
+        state.save()
+    if (
+        not isinstance(audience, str)
+        or re.fullmatch(r"urn:home-assistant:aurora-deploy:[0-9a-f]{32}", audience)
+        is None
+    ):
+        raise ValueError("deployment_audience_invalid")
+    return audience
+
+
+def _active_resource_context(
+    hass: HomeAssistant, transaction: dict[str, Any]
+) -> dict[str, Any]:
+    """Return bounded public resource evidence after exact path/hash validation."""
+    dashboard_sha = transaction.get("dashboard_sha256")
+    if not _is_sha256(dashboard_sha):
+        raise ValueError("active_dashboard_binding")
+    asset_name = f"aurora-preview-dashboard-{dashboard_sha}.js"
+    if transaction.get("active_dashboard_asset") != asset_name:
+        raise ValueError("active_dashboard_binding")
+    path = Path(hass.config.path(f"www/aurora/revisions/{asset_name}"))
+    if path.is_symlink() or not path.is_file():
+        raise ValueError("active_dashboard_binding")
+    raw = _read_staged_file(path, MAX_DASHBOARD)
+    if hashlib.sha256(raw).hexdigest() != dashboard_sha:
+        raise ValueError("active_dashboard_binding")
+    return {
+        "preview_resource_url": DASHBOARD_URL_PREFIX + asset_name,
+        "preview_resource_sha256": dashboard_sha,
+        "preview_resource_size": len(raw),
+    }
+
+
+def _dashboard_resource_binding_from_config(
+    hass: HomeAssistant, config: dict[str, Any]
+) -> dict[str, Any]:
+    """Rehash the sole content-addressed Aurora resource, if one is configured."""
+    resources = config.get("resources")
+    if not isinstance(resources, list):
+        return {}
+    candidates = [
+        item
+        for item in resources
+        if isinstance(item, dict)
+        and isinstance(item.get("url"), str)
+        and (
+            item["url"] == DASHBOARD_URL
+            or item["url"].startswith(DASHBOARD_URL_PREFIX)
+        )
+    ]
+    if not candidates:
+        return {}
+    if len(candidates) != 1:
+        raise ValueError("dashboard_resource_binding")
+    item = candidates[0]
+    url = item.get("url")
+    match = (
+        _CONTENT_ADDRESSED_DASHBOARD_URL.fullmatch(url)
+        if isinstance(url, str)
+        else None
+    )
+    if match is None or item.get("res_type") != "module":
+        raise ValueError("dashboard_resource_binding")
+    dashboard_sha = match.group(1)
+    asset_name = url.removeprefix(DASHBOARD_URL_PREFIX)
+    path = Path(hass.config.path(f"www/aurora/revisions/{asset_name}"))
+    if path.is_symlink() or not path.is_file():
+        raise ValueError("dashboard_resource_binding")
+    raw = _read_staged_file(path, MAX_DASHBOARD)
+    if hashlib.sha256(raw).hexdigest() != dashboard_sha:
+        raise ValueError("dashboard_resource_binding")
+    return {
+        "dashboard_resource_url": url,
+        "dashboard_sha256": dashboard_sha,
+        "dashboard_size": len(raw),
+    }
+
+
+def _verify_recorded_resource_binding(
+    hass: HomeAssistant,
+    config: dict[str, Any],
+    record: dict[str, Any],
+    *,
+    prefix: str = "",
+) -> dict[str, Any]:
+    """Verify a live config's optional asset binding against one durable record."""
+    actual = _dashboard_resource_binding_from_config(hass, config)
+    recorded = {
+        key: record.get(prefix + key)
+        for key in (
+            "dashboard_resource_url",
+            "dashboard_sha256",
+            "dashboard_size",
+        )
+        if record.get(prefix + key) is not None
+    }
+    if actual != recorded:
+        raise ValueError("dashboard_resource_binding")
+    return actual
+
+
+def _verify_preview_revision_resource_binding(
+    hass: HomeAssistant,
+    state: AuroraState,
+    revision: Any,
+    config: dict[str, Any],
+) -> dict[str, Any]:
+    """Bind restored preview config and asset bytes to its journaled revision."""
+    binding = _dashboard_resource_binding_from_config(hass, config)
+    if revision is None:
+        if binding:
+            raise ValueError("preview_revision_binding")
+        return {}
+    if not isinstance(revision, str):
+        raise ValueError("preview_revision_binding")
+    previous = next(
+        (
+            item
+            for item in state.journal.get("transactions", {}).values()
+            if isinstance(item, dict) and item.get("revision") == revision
+        ),
+        None,
+    )
+    if (
+        previous is None
+        or not binding
+        or previous.get("dashboard_sha256") != binding.get("dashboard_sha256")
+        or previous.get("active_dashboard_asset")
+        != binding["dashboard_resource_url"].removeprefix(DASHBOARD_URL_PREFIX)
+        or previous.get("active_preview_config_sha256") != _config_sha256(config)
+    ):
+        raise ValueError("preview_revision_binding")
+    return binding
+
+
+def _dashboard_config_with_asset(
+    config: dict[str, Any], asset_name: str
+) -> dict[str, Any]:
+    """Return a canonical copy with exactly one Aurora revision resource."""
+    updated = json.loads(_json_bytes(config))
+    resources = updated.get("resources")
+    if not isinstance(resources, list):
+        resources = []
+    resources = [
+        item
+        for item in resources
+        if not (
+            isinstance(item, dict)
+            and (
+                item.get("url") == DASHBOARD_URL
+                or (
+                    isinstance(item.get("url"), str)
+                    and item["url"].startswith(DASHBOARD_URL_PREFIX)
+                )
+            )
+        )
+    ]
+    resources.append(
+        {
+            "url": DASHBOARD_URL_PREFIX + asset_name,
+            "res_type": "module",
+        }
+    )
+    updated["resources"] = resources
+    return updated
+
+
+def _config_has_exact_dashboard_resource(
+    config: dict[str, Any], expected_url: str
+) -> bool:
+    resources = config.get("resources")
+    return isinstance(resources, list) and any(
+        isinstance(item, dict)
+        and set(item) >= {"url", "res_type"}
+        and item.get("url") == expected_url
+        and item.get("res_type") == "module"
+        for item in resources
+    )
+
+
+def _verify_operation_resource_binding(
+    hass: HomeAssistant,
+    state: AuroraState,
+    operation: dict[str, Any],
+    production_config: dict[str, Any],
+) -> dict[str, Any]:
+    """Rehash the exact promoted asset and bind it to production config."""
+    transaction_id = operation.get("transaction_id")
+    transaction = state.tx(transaction_id) if isinstance(transaction_id, str) else None
+    expected_url = operation.get("dashboard_resource_url")
+    expected_sha = operation.get("dashboard_sha256")
+    expected_size = operation.get("dashboard_size")
+    if (
+        transaction is None
+        or transaction.get("dashboard_sha256") != expected_sha
+        or not isinstance(expected_url, str)
+        or not _is_sha256(expected_sha)
+        or not isinstance(expected_size, int)
+        or isinstance(expected_size, bool)
+        or expected_size < 0
+        or not _config_has_exact_dashboard_resource(production_config, expected_url)
+    ):
+        raise ValueError("operation_dashboard_binding")
+    context = _active_resource_context(hass, transaction)
+    if any(
+        (
+            context["preview_resource_url"] != expected_url,
+            context["preview_resource_sha256"] != expected_sha,
+            context["preview_resource_size"] != expected_size,
+        )
+    ):
+        raise ValueError("operation_dashboard_binding")
+    return {
+        "dashboard_resource_url": expected_url,
+        "dashboard_sha256": expected_sha,
+        "dashboard_size": expected_size,
+    }
 
 
 async def _admin(request: web.Request) -> bool:
@@ -894,6 +1101,7 @@ async def _body(request: web.Request) -> dict[str, Any] | None:
 
 async def _dashboards(hass: HomeAssistant) -> tuple[Any, dict[Any, Any]]:
     from homeassistant.components.lovelace import LOVELACE_DATA
+
     data = hass.data[LOVELACE_DATA]
     return data, data.dashboards
 
@@ -925,7 +1133,9 @@ async def _ensure_preview(hass: HomeAssistant) -> tuple[bool, str]:
     return True, PREVIEW
 
 
-async def _load_dashboard(hass: HomeAssistant, url_path: str) -> tuple[Any, dict[str, Any]]:
+async def _load_dashboard(
+    hass: HomeAssistant, url_path: str
+) -> tuple[Any, dict[str, Any]]:
     _data, dashboards = await _dashboards(hass)
     dashboard = dashboards.get(url_path)
     if dashboard is None:
@@ -939,45 +1149,9 @@ async def _save_preview_asset(hass: HomeAssistant, dashboard_bytes: bytes) -> st
     asset_name = f"aurora-preview-dashboard-{asset_revision}.js"
     path = Path(hass.config.path(f"www/aurora/revisions/{asset_name}"))
     await asyncio.to_thread(_save_immutable_asset, path, dashboard_bytes)
-    dashboard_url = f"{DASHBOARD_URL_PREFIX}{asset_name}"
     dashboard, config = await _load_dashboard(hass, PREVIEW)
-    resources = config.get("resources")
-    if not isinstance(resources, list):
-        resources = []
-    resources = [
-        item
-        for item in resources
-        if not (
-            isinstance(item, dict)
-            and (
-                item.get("url") == DASHBOARD_URL
-                or (
-                    isinstance(item.get("url"), str)
-                    and item["url"].startswith(DASHBOARD_URL_PREFIX)
-                )
-            )
-        )
-    ]
-    resources.append({"url": dashboard_url, "res_type": "module"})
-    config["resources"] = resources
-    await dashboard.async_save(config)
+    await dashboard.async_save(_dashboard_config_with_asset(config, asset_name))
     return asset_name
-
-
-async def _reload_backend(hass: HomeAssistant) -> None:
-    """Reload only the fixed Lovelace resources and core configuration hooks."""
-    services = getattr(hass, "services", None)
-    has_service = getattr(services, "has_service", None)
-    async_call = getattr(services, "async_call", None)
-    if not callable(has_service) or not callable(async_call):
-        raise RuntimeError("reload_backend_unavailable")
-    called = False
-    for domain, service in (("lovelace", "reload_resources"), ("homeassistant", "reload_core_config")):
-        if has_service(domain, service):
-            await async_call(domain, service, {}, blocking=True)
-            called = True
-    if not called:
-        raise RuntimeError("reload_backend_unavailable")
 
 
 async def _reconcile_production_transition(
@@ -991,27 +1165,74 @@ async def _reconcile_production_transition(
     previous = transition.get("previous")
     next_config = transition.get("next_config")
     transaction_id = transition.get("transaction_id")
+    operation_id = transition.get("operation_id")
     receipt_nonce = transition.get("receipt_nonce")
+    expected_revision = transition.get("expected_revision")
+    expected_config_sha = transition.get("expected_config_sha256")
+    next_sha = transition.get("next_config_sha256")
     if (
         not isinstance(previous, dict)
+        or not isinstance(previous.get("revision"), str)
         or not isinstance(previous.get("config"), dict)
         or not _is_sha256(previous.get("config_sha256"))
         or not isinstance(next_config, dict)
-        or not _is_sha256(transition.get("next_config_sha256"))
+        or not isinstance(expected_revision, str)
+        or not _is_sha256(expected_config_sha)
+        or not isinstance(transition.get("to_revision"), str)
+        or not _is_sha256(next_sha)
         or not isinstance(transaction_id, str)
+        or not isinstance(operation_id, str)
         or not isinstance(receipt_nonce, str)
+        or previous.get("revision") != expected_revision
+        or previous.get("config_sha256") != expected_config_sha
+        or _config_sha256(previous["config"]) != expected_config_sha
+        or _config_sha256(next_config) != next_sha
     ):
         raise ValueError("production_transition_recovery_invalid")
     transaction = state.tx(transaction_id)
-    if transaction is None or transaction.get("revision") != transition.get(
-        "to_revision"
+    operation = state.journal.get("operations", {}).get(operation_id)
+    if (
+        transaction is None
+        or transaction.get("revision") != transition.get("to_revision")
+        or not isinstance(operation, dict)
+        or state.journal.get("active_preview") != transition.get("to_revision")
+        or state.journal.get("production_revision") != expected_revision
+        or state.journal.get("production_config_sha256") != expected_config_sha
+        or operation.get("operation_id") != operation_id
+        or operation.get("action") != "promote_home_command"
+        or operation.get("status") != "prepared"
+        or operation.get("transaction_id") != transaction_id
+        or operation.get("preview_revision") != transition.get("to_revision")
+        or operation.get("target_revision") != transition.get("to_revision")
+        or operation.get("expected_production_revision") != expected_revision
+        or operation.get("expected_production_config_sha256")
+        != expected_config_sha
+        or operation.get("preview_config_sha256") != next_sha
+        or operation.get("receipt_sha256") != transition.get("receipt_sha256")
+        or not _is_sha256(operation.get("receipt_sha256"))
+        or operation.get("request_sha256") != transition.get("request_sha256")
+        or not _is_sha256(operation.get("request_sha256"))
+        or transaction.get("status") not in {"activated", "reloaded"}
+        or state.journal.get("receipt_nonces", {}).get(receipt_nonce)
+        != transaction_id
+        or any(
+            operation.get(key) != transition.get(key)
+            for key in (
+                "dashboard_resource_url",
+                "dashboard_sha256",
+                "dashboard_size",
+                "expected_dashboard_resource_url",
+                "expected_dashboard_sha256",
+                "expected_dashboard_size",
+            )
+        )
     ):
         raise ValueError("production_transition_recovery_invalid")
     _production, current_config = await _load_dashboard(hass, PRODUCTION)
     current_sha = _config_sha256(current_config)
     previous_sha = previous["config_sha256"]
-    next_sha = transition["next_config_sha256"]
     if current_sha == next_sha:
+        _verify_operation_resource_binding(hass, state, operation, current_config)
         committed_at = _now().isoformat()
         state.journal["previous_production"] = previous
         state.journal["production_revision"] = transition["to_revision"]
@@ -1019,17 +1240,376 @@ async def _reconcile_production_transition(
         state.journal.setdefault("receipt_nonces", {})[receipt_nonce] = transaction_id
         transaction["status"] = "promoted"
         transaction["promoted_at"] = committed_at
+        transaction["promotion_operation_id"] = operation_id
         transition["status"] = "committed"
         transition["committed_at"] = committed_at
         transition["recovered"] = True
+        operation["status"] = "committed"
+        operation["production_config_sha256"] = next_sha
+        operation["completed_at"] = committed_at
+        operation["recovered"] = True
     elif current_sha == previous_sha:
+        _verify_recorded_resource_binding(
+            hass, current_config, transition, prefix="expected_"
+        )
         transition["status"] = "aborted"
         transition["aborted_at"] = _now().isoformat()
         transition["recovered"] = True
+        operation["status"] = "aborted"
+        operation["completed_at"] = transition["aborted_at"]
+        operation["recovered"] = True
     else:
         raise ValueError("production_transition_recovery_conflict")
     state.journal.pop("production_recovery_required", None)
     state.save()
+
+
+def _commit_rollback_transition(
+    state: AuroraState,
+    transition: dict[str, Any],
+    operation: dict[str, Any],
+    *,
+    recovered: bool = False,
+) -> None:
+    """Commit journal state only after production readback matches rollback bytes."""
+    completed_at = _now().isoformat()
+    from_revision = transition["from_revision"]
+    to_revision = transition["to_revision"]
+    next_sha = transition["next_config_sha256"]
+    state.journal["production_revision"] = to_revision
+    state.journal["production_config_sha256"] = next_sha
+    state.journal["previous_production"] = None
+    for transaction in state.journal.get("transactions", {}).values():
+        if (
+            isinstance(transaction, dict)
+            and transaction.get("revision") == from_revision
+        ):
+            transaction["status"] = "rolled_back"
+            transaction["rolled_back_at"] = completed_at
+    transition["status"] = "committed"
+    transition["committed_at"] = completed_at
+    operation["status"] = "committed"
+    operation["production_config_sha256"] = next_sha
+    operation["completed_at"] = completed_at
+    if recovered:
+        transition["recovered"] = True
+        operation["recovered"] = True
+    state.save()
+
+
+async def _reconcile_rollback_transition(
+    hass: HomeAssistant, state: AuroraState
+) -> None:
+    """Resolve one durable prepared rollback from live production bytes."""
+    transition = state.journal.get("rollback_transition")
+    if not isinstance(transition, dict) or transition.get("status") != "prepared":
+        return
+    operation_id = transition.get("operation_id")
+    operation = state.journal.get("operations", {}).get(operation_id)
+    previous = state.journal.get("previous_production")
+    if any(
+        (
+            not isinstance(operation_id, str),
+            not isinstance(operation, dict),
+            not isinstance(previous, dict),
+            not isinstance(previous.get("config"), dict),
+            not _is_sha256(previous.get("config_sha256")),
+            not isinstance(transition.get("from_revision"), str),
+            not isinstance(transition.get("to_revision"), str),
+            not _is_sha256(transition.get("expected_config_sha256")),
+            not _is_sha256(transition.get("next_config_sha256")),
+            not isinstance(transition.get("next_config"), dict),
+        )
+    ):
+        raise ValueError("rollback_transition_recovery_invalid")
+    if any(
+        (
+            _config_sha256(transition["next_config"])
+            != transition["next_config_sha256"],
+            previous.get("revision") != transition.get("to_revision"),
+            previous.get("config_sha256") != transition.get("next_config_sha256"),
+            _config_sha256(previous["config"])
+            != transition.get("next_config_sha256"),
+            state.journal.get("production_revision")
+            != transition.get("from_revision"),
+            state.journal.get("production_config_sha256")
+            != transition.get("expected_config_sha256"),
+            operation.get("operation_id") != operation_id,
+            operation.get("action") != "rollback_home_command",
+            operation.get("status") != "prepared",
+            operation.get("expected_production_revision")
+            != transition.get("from_revision"),
+            operation.get("expected_production_config_sha256")
+            != transition.get("expected_config_sha256"),
+            operation.get("target_revision") != transition.get("to_revision"),
+            operation.get("request_sha256") != transition.get("request_sha256"),
+            not _is_sha256(operation.get("request_sha256")),
+            any(
+                operation.get(key) != transition.get(key)
+                for key in (
+                    "dashboard_resource_url",
+                    "dashboard_sha256",
+                    "dashboard_size",
+                    "expected_dashboard_resource_url",
+                    "expected_dashboard_sha256",
+                    "expected_dashboard_size",
+                )
+            ),
+        )
+    ):
+        raise ValueError("rollback_transition_recovery_invalid")
+    _production, current_config = await _load_dashboard(hass, PRODUCTION)
+    current_sha = _config_sha256(current_config)
+    if current_sha == transition["next_config_sha256"]:
+        _verify_recorded_resource_binding(hass, current_config, transition)
+        _commit_rollback_transition(state, transition, operation, recovered=True)
+    elif current_sha == transition["expected_config_sha256"]:
+        _verify_recorded_resource_binding(
+            hass, current_config, transition, prefix="expected_"
+        )
+        completed_at = _now().isoformat()
+        transition["status"] = "aborted"
+        transition["aborted_at"] = completed_at
+        transition["recovered"] = True
+        operation["status"] = "aborted"
+        operation["completed_at"] = completed_at
+        operation["recovered"] = True
+        state.save()
+    else:
+        raise ValueError("rollback_transition_recovery_conflict")
+
+
+def _commit_preview_activation(
+    state: AuroraState,
+    transaction: dict[str, Any],
+    transition: dict[str, Any],
+    *,
+    recovered: bool = False,
+) -> None:
+    completed_at = _now().isoformat()
+    state.journal["active_preview"] = transaction["revision"]
+    transaction["status"] = "activated"
+    transaction["activated_at"] = completed_at
+    transaction["active_preview_config_sha256"] = transition["next_config_sha256"]
+    transition["status"] = "committed"
+    transition["committed_at"] = completed_at
+    if recovered:
+        transition["recovered"] = True
+    state.save()
+
+
+def _commit_preview_rollback(
+    state: AuroraState,
+    transaction: dict[str, Any],
+    transition: dict[str, Any],
+    *,
+    recovered: bool = False,
+) -> None:
+    completed_at = _now().isoformat()
+    previous_revision = transition.get("to_revision")
+    if isinstance(previous_revision, str):
+        state.journal["active_preview"] = previous_revision
+    else:
+        state.journal.pop("active_preview", None)
+    transaction["status"] = "rolled_back"
+    transaction["rolled_back_at"] = completed_at
+    transition["status"] = "committed"
+    transition["committed_at"] = completed_at
+    if recovered:
+        transition["recovered"] = True
+    state.save()
+
+
+def _reconcile_stage_transition(
+    state: AuroraState, transaction: dict[str, Any]
+) -> None:
+    """Settle a caller-addressable prepared stage from exact staged bytes."""
+    transition = transaction.get("stage_transition")
+    if not isinstance(transition, dict) or transition.get("status") != "prepared":
+        return
+    if any(
+        (
+            transition.get("transaction_id") != transaction.get("transaction_id"),
+            transition.get("revision") != transaction.get("revision"),
+            transition.get("request_sha256")
+            != transaction.get("stage_request_sha256"),
+            not _is_sha256(transition.get("request_sha256")),
+            transition.get("manifest_sha256")
+            != transaction.get("manifest_sha256"),
+            transition.get("package_sha256") != transaction.get("package_sha256"),
+            transition.get("dashboard_sha256")
+            != transaction.get("dashboard_sha256"),
+            transaction.get("status") != "staging",
+        )
+    ):
+        raise ValueError("stage_transition_invalid")
+    staged_root = state.root / "staged"
+    revision_dir = staged_root / transaction["revision"]
+    if not staged_root.exists() or not revision_dir.exists():
+        if staged_root.is_symlink() or revision_dir.is_symlink():
+            raise ValueError("stage_transition_invalid")
+        completed_at = _now().isoformat()
+        transition["status"] = "aborted"
+        transition["aborted_at"] = completed_at
+        transition["recovered"] = True
+        transaction["status"] = "aborted"
+        transaction["completed_at"] = completed_at
+        state.save()
+        return
+    try:
+        package, dashboard, manifest = _verify_staged_artifacts(
+            transaction, state.root
+        )
+    except ValueError as exc:
+        if str(exc) != "staged_artifact_missing":
+            raise
+        completed_at = _now().isoformat()
+        transition["status"] = "aborted"
+        transition["aborted_at"] = completed_at
+        transition["recovered"] = True
+        transaction["status"] = "aborted"
+        transaction["completed_at"] = completed_at
+        state.save()
+        return
+    if package is None or dashboard is None or manifest is None:
+        raise ValueError("stage_transition_invalid")
+    completed_at = _now().isoformat()
+    transition["status"] = "committed"
+    transition["committed_at"] = completed_at
+    transition["recovered"] = True
+    transaction["status"] = "verified"
+    transaction["verified_at"] = completed_at
+    state.save()
+
+
+async def _reconcile_transaction_transition(  # noqa: C901 - fail-closed recovery
+    hass: HomeAssistant,
+    state: AuroraState,
+    transaction: dict[str, Any],
+) -> None:
+    """Settle a prepared preview activation or rollback from live config."""
+    _reconcile_stage_transition(state, transaction)
+    activation = transaction.get("activation_transition")
+    rollback = transaction.get("preview_rollback_transition")
+    prepared = [
+        ("activate", activation),
+        ("rollback", rollback),
+    ]
+    prepared = [
+        (kind, item)
+        for kind, item in prepared
+        if isinstance(item, dict) and item.get("status") == "prepared"
+    ]
+    if not prepared:
+        return
+    if len(prepared) != 1:
+        raise ValueError("preview_transition_invalid")
+    kind, transition = prepared[0]
+    preview_before = transaction.get("preview_before")
+    dashboard_sha = transaction.get("dashboard_sha256")
+    expected_asset = (
+        f"aurora-preview-dashboard-{dashboard_sha}.js"
+        if _is_sha256(dashboard_sha)
+        else None
+    )
+    if (
+        not isinstance(preview_before, dict)
+        or not _is_sha256(transition.get("previous_config_sha256"))
+        or not _is_sha256(transition.get("next_config_sha256"))
+        or transition.get("transaction_id") != transaction.get("transaction_id")
+            or transition.get("action") != kind
+            or expected_asset is None
+            or transition.get("asset_name") != expected_asset
+        or transaction.get("active_dashboard_asset") != expected_asset
+        or _config_sha256(preview_before)
+        != transaction.get("preview_config_sha256_before")
+    ):
+        raise ValueError("preview_transition_invalid")
+    if kind == "activate":
+        expected_next = _dashboard_config_with_asset(preview_before, expected_asset)
+        if any(
+            (
+                transition.get("previous_revision")
+                != transaction.get("preview_revision_before"),
+                transition.get("next_revision") != transaction.get("revision"),
+                transition.get("previous_config_sha256")
+                != transaction.get("preview_config_sha256_before"),
+                transition.get("next_config_sha256")
+                != _config_sha256(expected_next),
+                transaction.get("status") != "verified",
+                state.journal.get("active_preview")
+                != transition.get("previous_revision"),
+            )
+        ):
+            raise ValueError("preview_transition_invalid")
+    elif any(
+        (
+            transition.get("from_status") not in {"activated", "reloaded"},
+            transaction.get("status") != transition.get("from_status"),
+            transition.get("from_revision") != transaction.get("revision"),
+            transition.get("to_revision")
+            != transaction.get("preview_revision_before"),
+            transition.get("previous_config_sha256")
+            != transaction.get("active_preview_config_sha256"),
+            transition.get("next_config_sha256")
+            != transaction.get("preview_config_sha256_before"),
+            state.journal.get("active_preview") != transition.get("from_revision"),
+        )
+    ):
+        raise ValueError("preview_transition_invalid")
+    _preview, current_config = await _load_dashboard(hass, PREVIEW)
+    current_sha = _config_sha256(current_config)
+    if current_sha == transition["next_config_sha256"]:
+        if kind == "activate":
+            await _verify_active_transaction(hass, transaction, state.root)
+            _commit_preview_activation(state, transaction, transition, recovered=True)
+        else:
+            _verify_preview_revision_resource_binding(
+                hass, state, transition.get("to_revision"), current_config
+            )
+            _commit_preview_rollback(state, transaction, transition, recovered=True)
+    elif current_sha == transition["previous_config_sha256"]:
+        if kind == "rollback":
+            await _verify_active_transaction(hass, transaction, state.root)
+        completed_at = _now().isoformat()
+        transition["status"] = "aborted"
+        transition["aborted_at"] = completed_at
+        transition["recovered"] = True
+        if kind == "activate":
+            transaction["status"] = "verified"
+            transaction.pop("active_dashboard_asset", None)
+        else:
+            transaction["status"] = transition["from_status"]
+        state.save()
+    else:
+        raise ValueError("preview_transition_recovery_conflict")
+
+
+async def _reconcile_operation_transition(
+    hass: HomeAssistant,
+    state: AuroraState,
+    operation_id: str,
+    operation: dict[str, Any],
+) -> None:
+    """Settle only the durable transition bound to one queried operation."""
+    if operation.get("status") != "prepared":
+        return
+    action = operation.get("action")
+    if action == "promote_home_command":
+        transition = state.journal.get("production_transition")
+        reconciler = _reconcile_production_transition
+    elif action == "rollback_home_command":
+        transition = state.journal.get("rollback_transition")
+        reconciler = _reconcile_rollback_transition
+    else:
+        raise ValueError("operation_transition_invalid")
+    if (
+        not isinstance(transition, dict)
+        or transition.get("status") != "prepared"
+        or transition.get("operation_id") != operation_id
+    ):
+        raise ValueError("operation_transition_invalid")
+    await reconciler(hass, state)
 
 
 class RootView(HomeAssistantView):
@@ -1043,7 +1623,9 @@ class RootView(HomeAssistantView):
         self._hass = hass
         self._state = state
 
-    async def post(self, request: web.Request, operation: str) -> web.Response:
+    async def post(  # noqa: C901 - explicit fixed-route dispatcher
+        self, request: web.Request, operation: str
+    ) -> web.Response:
         if not await _admin(request):
             return _error(403, "admin_required")
         if not self._state.admit_request():
@@ -1055,57 +1637,199 @@ class RootView(HomeAssistantView):
                     return _error(400, "invalid_body")
                 if operation in {"promote-home-command", "rollback-home-command"}:
                     try:
-                        await _reconcile_production_transition(
-                            self._hass, self._state
-                        )
+                        await _reconcile_production_transition(self._hass, self._state)
+                        if operation == "rollback-home-command":
+                            await _reconcile_rollback_transition(
+                                self._hass, self._state
+                            )
                     except ValueError:
                         return _error(409, "production_recovery_required")
                 if operation == "bootstrap":
                     created, target = await _ensure_preview(self._hass)
-                    return _json_response({"dashboard_target": target, "created": created, "production_unchanged": True})
+                    return _json_response(
+                        {
+                            "dashboard_target": target,
+                            "created": created,
+                            "production_unchanged": True,
+                        }
+                    )
                 if operation == "stage":
                     return await self._stage(body)
                 if operation == "promote-home-command":
                     return await self._promote(body)
                 if operation == "rollback-home-command":
-                    return await self._rollback()
+                    return await self._rollback(body)
             except ValueError as exc:
                 return _error(422, str(exc))
             except (OSError, RuntimeError):
                 return _error(500, "adapter_failure")
         return _error(404, "not_found")
 
-    async def _stage(self, body: dict[str, Any]) -> web.Response:
-        if body.get("dashboard_target") != PREVIEW or body.get("preview_only") is not True:
+    async def _stage(  # noqa: C901 - durable staged-artifact transaction
+        self, body: dict[str, Any]
+    ) -> web.Response:
+        if set(body) != {
+            "transaction_id",
+            "dashboard_target",
+            "preview_only",
+            "manifest",
+            "artifacts",
+        }:
+            transaction_id = body.get("transaction_id")
+            if (
+                isinstance(transaction_id, str)
+                and self._state.tx(transaction_id) is not None
+            ):
+                return _error(409, "transaction_id_conflict")
+            return _error(422, "stage_request_schema_invalid")
+        if (
+            body.get("dashboard_target") != PREVIEW
+            or body.get("preview_only") is not True
+        ):
             return _error(422, "fixed_target_required")
-        package = _decode_b64((body.get("artifacts") or {}).get("package"), MAX_PACKAGE)
-        dashboard = _decode_b64((body.get("artifacts") or {}).get("dashboard"), MAX_DASHBOARD)
-        manifest_sha, package_sha, dashboard_sha = _validate_manifest(self._hass, body.get("manifest"), package, dashboard)
-        manifest = body["manifest"]
+        transaction_id = body.get("transaction_id")
+        if (
+            not isinstance(transaction_id, str)
+            or _SAFE_NONCE.fullmatch(transaction_id) is None
+        ):
+            return _error(422, "transaction_id_required")
+        if transaction_id in self._state.journal.get("operations", {}):
+            return _error(409, "transaction_id_conflict")
+        artifacts = body.get("artifacts")
+        if not isinstance(artifacts, dict) or set(artifacts) != {
+            "package",
+            "dashboard",
+        }:
+            return _error(422, "stage_request_schema_invalid")
+        package = _decode_b64(artifacts.get("package"), MAX_PACKAGE)
+        dashboard = _decode_b64(artifacts.get("dashboard"), MAX_DASHBOARD)
+        manifest = body.get("manifest")
+        if not isinstance(manifest, dict):
+            return _error(422, "manifest")
+        manifest_sha = hashlib.sha256(_canonical_manifest(manifest)).hexdigest()
+        package_sha = hashlib.sha256(package).hexdigest()
+        dashboard_sha = hashlib.sha256(dashboard).hexdigest()
+        nonce = manifest.get("nonce")
+        request_sha = hashlib.sha256(
+            _json_bytes(
+                {
+                    "transaction_id": transaction_id,
+                    "dashboard_target": PREVIEW,
+                    "preview_only": True,
+                    "manifest_sha256": manifest_sha,
+                    "package_sha256": package_sha,
+                    "dashboard_sha256": dashboard_sha,
+                    "nonce": nonce,
+                }
+            )
+        ).hexdigest()
+        transactions = self._state.journal.setdefault("transactions", {})
+        existing = transactions.get(transaction_id)
+        if transaction_id in transactions:
+            if (
+                not isinstance(existing, dict)
+                or existing.get("stage_request_sha256") != request_sha
+            ):
+                return _error(409, "transaction_id_conflict")
+            try:
+                _reconcile_stage_transition(self._state, existing)
+                if existing.get("status") != "aborted":
+                    package_readback, dashboard_readback, manifest_readback = (
+                        _verify_staged_artifacts(existing, self._state.root)
+                    )
+                    if any(
+                        item is None
+                        for item in (
+                            package_readback,
+                            dashboard_readback,
+                            manifest_readback,
+                        )
+                    ):
+                        raise ValueError("staged_artifact_missing")
+            except (OSError, ValueError):
+                return _error(409, "staged_integrity_failed")
+            public_keys = (
+                "transaction_id",
+                "revision",
+                "status",
+                "manifest_sha256",
+                "package_sha256",
+                "dashboard_sha256",
+                "target",
+                "created_at",
+                "expires_at",
+            )
+            return _json_response(
+                {key: existing[key] for key in public_keys}
+                | {
+                    "staged_revision": existing["revision"],
+                    "previous_revision": existing.get(
+                        "preview_revision_before",
+                        existing.get("stage_previous_revision"),
+                    ),
+                    "idempotent": True,
+                }
+            )
+        manifest_sha, package_sha, dashboard_sha = _validate_manifest(
+            self._hass, manifest, package, dashboard
+        )
         nonce = manifest["nonce"]
         used = self._state.journal.setdefault("nonces", {})
         if nonce in used:
             return _error(409, "manifest_replay")
-        revision = hashlib.sha256((manifest_sha + package_sha + dashboard_sha).encode()).hexdigest()[:32]
-        transaction_id = "tx-" + secrets.token_hex(16)
-        revision_dir = self._state.root / "staged" / revision
-        revision_dir.mkdir(parents=True, exist_ok=False)
-        _atomic_write(revision_dir / "manifest.json", _json_bytes(manifest))
-        _atomic_write(revision_dir / "aurora-preview-package.tar.gz", package)
-        _atomic_write(revision_dir / "aurora-preview-dashboard.js", dashboard)
+        revision = hashlib.sha256(
+            (manifest_sha + package_sha + dashboard_sha).encode()
+        ).hexdigest()[:32]
+        prepared_at = _now().isoformat()
         transaction = {
             "transaction_id": transaction_id,
             "revision": revision,
-            "status": "verified",
+            "status": "staging",
             "manifest_sha256": manifest_sha,
             "package_sha256": package_sha,
             "dashboard_sha256": dashboard_sha,
             "target": PREVIEW,
-            "created_at": _now().isoformat(),
+            "stage_request_sha256": request_sha,
+            "stage_previous_revision": self._state.journal.get("active_preview"),
+            "created_at": prepared_at,
             "expires_at": manifest["expires_at"],
+            "stage_transition": {
+                "status": "prepared",
+                "transaction_id": transaction_id,
+                "revision": revision,
+                "request_sha256": request_sha,
+                "manifest_sha256": manifest_sha,
+                "package_sha256": package_sha,
+                "dashboard_sha256": dashboard_sha,
+                "prepared_at": prepared_at,
+            },
         }
-        self._state.journal.setdefault("transactions", {})[transaction_id] = transaction
+        transactions[transaction_id] = transaction
         used[nonce] = transaction_id
+        self._state.save()
+        revision_dir = self._state.root / "staged" / revision
+        revision_dir.mkdir(parents=True, exist_ok=True)
+        if revision_dir.is_symlink() or not revision_dir.is_dir():
+            raise ValueError("staged_revision_invalid")
+        _save_immutable_asset(revision_dir / "manifest.json", _json_bytes(manifest))
+        _save_immutable_asset(
+            revision_dir / "aurora-preview-package.tar.gz", package
+        )
+        _save_immutable_asset(
+            revision_dir / "aurora-preview-dashboard.js", dashboard
+        )
+        package_readback, dashboard_readback, manifest_readback = (
+            _verify_staged_artifacts(transaction, self._state.root)
+        )
+        if any(
+            item is None
+            for item in (package_readback, dashboard_readback, manifest_readback)
+        ):
+            raise ValueError("staged_artifact_missing")
+        transaction["status"] = "verified"
+        transaction["verified_at"] = _now().isoformat()
+        transaction["stage_transition"]["status"] = "committed"
+        transaction["stage_transition"]["committed_at"] = transaction["verified_at"]
         self._state.save()
         public_keys = (
             "transaction_id",
@@ -1119,7 +1843,11 @@ class RootView(HomeAssistantView):
             "expires_at",
         )
         return _json_response(
-            {key: transaction[key] for key in public_keys} | {"staged_revision": revision}
+            {key: transaction[key] for key in public_keys}
+            | {
+                "staged_revision": revision,
+                "previous_revision": transaction.get("stage_previous_revision"),
+            }
         )
 
     async def _promote(  # noqa: C901 - explicit fail-closed promotion state machine
@@ -1142,9 +1870,10 @@ class RootView(HomeAssistantView):
         if transaction is None or self._state.journal.get("active_preview") != revision:
             return _error(409, "preview_revision_not_active")
         try:
-                await _verify_active_transaction(
-                    self._hass, transaction, self._state.root
-                )
+            await _verify_active_transaction(self._hass, transaction, self._state.root)
+            resource_context = await asyncio.to_thread(
+                _active_resource_context, self._hass, transaction
+            )
         except (OSError, ValueError, RuntimeError):
             return _error(409, "preview_integrity_failed")
         _preview, preview_config = await _load_dashboard(self._hass, PREVIEW)
@@ -1154,33 +1883,44 @@ class RootView(HomeAssistantView):
         expected_production_revision = _ensure_production_baseline(
             self._state, production_config_sha
         )
+        audience = _deployment_audience(self._state)
         if body.get("inspect") is True:
+            if set(body) != {"preview_revision", "inspect"}:
+                return _error(422, "promotion_inspection_schema_invalid")
             return _json_response(
                 {
                     "preview_revision": revision,
+                    "transaction_id": transaction.get("transaction_id"),
                     "status": transaction.get("status"),
                     "active_revision": self._state.journal.get("active_preview"),
+                    "dashboard_target": PREVIEW,
                     "target_dashboard": PRODUCTION,
                     "preview_config_sha256": preview_config_sha,
                     "production_revision": expected_production_revision,
                     "expected_production_config_sha256": production_config_sha,
+                    "manifest_sha256": transaction.get("manifest_sha256"),
+                    "package_sha256": transaction.get("package_sha256"),
+                    "dashboard_sha256": transaction.get("dashboard_sha256"),
+                    "audience": audience,
                     "verified": True,
+                    **resource_context,
                 }
             )
         if (
             transaction.get("status") == "promoted"
             and self._state.journal.get("production_revision") == revision
             and production_config_sha == preview_config_sha
+            and not isinstance(body.get("receipt"), dict)
         ):
             previous = self._state.journal.get("previous_production")
             return _json_response(
                 {
                     "promoted": True,
+                    "operation_id": transaction.get("promotion_operation_id"),
+                    "status": "committed",
                     "active_revision": revision,
                     "previous_revision": (
-                        previous.get("revision")
-                        if isinstance(previous, dict)
-                        else None
+                        previous.get("revision") if isinstance(previous, dict) else None
                     ),
                     "preview_config_sha256": preview_config_sha,
                     "expected_production_config_sha256": production_config_sha,
@@ -1189,36 +1929,108 @@ class RootView(HomeAssistantView):
         receipt = body.get("receipt")
         if not isinstance(receipt, dict):
             return _error(422, "validation_receipt_required")
-        if set(receipt) != VALIDATION_RECEIPT_KEYS or receipt.get(
-            "schema_version"
-        ) != 1:
+        if set(body) != {
+            "preview_revision",
+            "expected_production_revision",
+            "operation_id",
+            "receipt",
+        }:
+            claimed_operation_id = body.get("operation_id")
+            if isinstance(claimed_operation_id, str) and claimed_operation_id in (
+                self._state.journal.get("operations", {})
+            ):
+                return _error(409, "operation_id_conflict")
+            return _error(422, "promotion_request_schema_invalid")
+        schema_version = receipt.get("schema_version")
+        if schema_version == 1:
+            expected_receipt_keys = VALIDATION_RECEIPT_V1_KEYS
+        elif schema_version == 2:
+            expected_receipt_keys = VALIDATION_RECEIPT_V2_KEYS
+        else:
             return _error(422, "validation_receipt_schema_invalid")
-        if receipt.get("preview_revision") != revision or receipt.get("dashboard_target") != PREVIEW or receipt.get("physical_validation") is not True:
-            return _error(422, "validation_receipt_invalid")
-        expected_production_revision = body.get("expected_production_revision")
-        if not isinstance(expected_production_revision, str) or not expected_production_revision:
-            return _error(422, "expected_production_revision_required")
-        if receipt.get("expected_production_revision") != expected_production_revision:
-            return _error(422, "validation_receipt_revision_mismatch")
-        device_results = receipt.get("device_results")
-        required_devices = {"mobile", "kiosk", "tablet", "laptop", "desktop"}
+        if set(receipt) != expected_receipt_keys:
+            return _error(422, "validation_receipt_schema_invalid")
         if (
-            not isinstance(device_results, list)
-            or len(device_results) != len(required_devices)
-            or {
-                item.get("device_id")
-                for item in device_results
-                if isinstance(item, dict)
-            }
-                != required_devices
-            or any(
-                not isinstance(item, dict)
-                or set(item) != {"device_id", "passed"}
-                or item.get("passed") is not True
-                for item in device_results
+            receipt.get("preview_revision") != revision
+            or receipt.get("dashboard_target") != PREVIEW
+        ):
+            return _error(422, "validation_receipt_invalid")
+        if schema_version == 1 and receipt.get("physical_validation") is not True:
+            return _error(422, "validation_receipt_invalid")
+        if schema_version == 2 and any(
+            (
+                receipt.get("transaction_id") != transaction.get("transaction_id"),
+                not isinstance(receipt.get("operation_id"), str),
+                _SAFE_NONCE.fullmatch(receipt.get("operation_id", "")) is None,
+                body.get("operation_id") != receipt.get("operation_id"),
+                receipt.get("validation_kind") != "automated_e2e",
+                receipt.get("audience") != audience,
+                receipt.get("action") != "promote_home_command",
+                not _is_sha256(receipt.get("e2e_evidence_sha256")),
             )
         ):
-            return _error(422, "validation_receipt_devices_invalid")
+            return _error(422, "validation_receipt_invalid")
+        expected_production_revision = body.get("expected_production_revision")
+        if (
+            not isinstance(expected_production_revision, str)
+            or not expected_production_revision
+        ):
+            return _error(422, "expected_production_revision_required")
+        if receipt.get("expected_production_revision") != expected_production_revision:
+            claimed_operation_id = body.get("operation_id")
+            if isinstance(
+                claimed_operation_id, str
+            ) and claimed_operation_id in self._state.journal.get("operations", {}):
+                return _error(409, "operation_id_conflict")
+            return _error(422, "validation_receipt_revision_mismatch")
+        if schema_version == 1:
+            device_results = receipt.get("device_results")
+            required_devices = {"mobile", "kiosk", "tablet", "laptop", "desktop"}
+            if (
+                not isinstance(device_results, list)
+                or len(device_results) != len(required_devices)
+                or {
+                    item.get("device_id")
+                    for item in device_results
+                    if isinstance(item, dict)
+                }
+                != required_devices
+                or any(
+                    not isinstance(item, dict)
+                    or set(item) != {"device_id", "passed"}
+                    or item.get("passed") is not True
+                    for item in device_results
+                )
+            ):
+                return _error(422, "validation_receipt_devices_invalid")
+        else:
+            profile_results = receipt.get("profile_results")
+            if (
+                not isinstance(profile_results, list)
+                or len(profile_results) != len(AUTOMATED_E2E_PROFILES)
+                or any(
+                    not isinstance(item, dict)
+                    or set(item)
+                    != {
+                        "profile_id",
+                        "width",
+                        "height",
+                        "passed",
+                        "screenshot_sha256",
+                    }
+                    or item.get("profile_id") != profile_id
+                    or item.get("width") != width
+                    or isinstance(item.get("width"), bool)
+                    or item.get("height") != height
+                    or isinstance(item.get("height"), bool)
+                    or item.get("passed") is not True
+                    or not _is_sha256(item.get("screenshot_sha256"))
+                    for item, (profile_id, width, height) in zip(
+                        profile_results, AUTOMATED_E2E_PROFILES, strict=True
+                    )
+                )
+            ):
+                return _error(422, "validation_receipt_profiles_invalid")
         issued_at = _parse_time(receipt.get("issued_at"))
         expires_at = _parse_time(receipt.get("expires_at"))
         now = _now()
@@ -1226,17 +2038,130 @@ class RootView(HomeAssistantView):
             issued_at - CLOCK_SKEW > now
             or expires_at <= issued_at
             or expires_at <= now
-            or expires_at - issued_at > MAX_LIFETIME
+            or expires_at - issued_at
+            > (MAX_AUTOMATED_E2E_LIFETIME if schema_version == 2 else MAX_LIFETIME)
         ):
             return _error(422, "validation_receipt_time_invalid")
         receipt_nonce = receipt.get("nonce")
-        if not isinstance(receipt_nonce, str) or _SAFE_NONCE.fullmatch(receipt_nonce) is None:
+        if (
+            not isinstance(receipt_nonce, str)
+            or _SAFE_NONCE.fullmatch(receipt_nonce) is None
+        ):
             return _error(422, "validation_receipt_nonce_invalid")
+        receipt_sha = hashlib.sha256(_canonical_manifest(receipt)).hexdigest()
+        _verify_signature(self._hass, receipt, prefix="validation-")
+        if schema_version == 2:
+            operation_id = receipt["operation_id"]
+        else:
+            requested_operation_id = body.get("operation_id")
+            if not _is_uuid_operation_id(requested_operation_id):
+                return _error(422, "operation_id_uuid_required")
+            operation_id = requested_operation_id
+        request_sha = hashlib.sha256(
+            _json_bytes(
+                {
+                    "action": "promote_home_command",
+                    "request": body,
+                }
+            )
+        ).hexdigest()
+        operations = self._state.journal.setdefault("operations", {})
+        existing_operation = operations.get(operation_id)
+        if operation_id in operations or self._state.tx(operation_id) is not None:
+            if (
+                not isinstance(existing_operation, dict)
+                or existing_operation.get("operation_id") != operation_id
+                or existing_operation.get("action") != "promote_home_command"
+                or existing_operation.get("request_sha256") != request_sha
+                or existing_operation.get("receipt_sha256") != receipt_sha
+                or existing_operation.get("transaction_id")
+                != transaction.get("transaction_id")
+                or existing_operation.get("preview_revision") != revision
+                or existing_operation.get("expected_production_revision")
+                != expected_production_revision
+                or existing_operation.get("expected_production_config_sha256")
+                != receipt.get("expected_production_config_sha256")
+            ):
+                return _error(409, "operation_id_conflict")
+            status = existing_operation.get("status")
+            if status == "committed":
+                if (
+                    self._state.journal.get("production_revision") != revision
+                    or production_config_sha
+                    != existing_operation.get("production_config_sha256")
+                    or production_config_sha != preview_config_sha
+                ):
+                    return _error(409, "operation_readback_mismatch")
+                try:
+                    resource_binding = await asyncio.to_thread(
+                        _verify_operation_resource_binding,
+                        self._hass,
+                        self._state,
+                        existing_operation,
+                        production_config,
+                    )
+                except (OSError, ValueError, RuntimeError):
+                    return _error(409, "operation_readback_mismatch")
+                return _json_response(
+                    {
+                        "promoted": True,
+                        "operation_id": operation_id,
+                        "status": "committed",
+                        "active_revision": revision,
+                        "previous_revision": existing_operation.get(
+                            "previous_production_revision"
+                        ),
+                        "preview_config_sha256": preview_config_sha,
+                        "expected_production_config_sha256": receipt.get(
+                            "expected_production_config_sha256"
+                        ),
+                        "applied": True,
+                        "verified": True,
+                        "dashboard_resource_present": True,
+                        "idempotent": True,
+                        **resource_binding,
+                    }
+                )
+            if status == "aborted":
+                if (
+                    self._state.journal.get("production_revision")
+                    != expected_production_revision
+                    or production_config_sha
+                    != receipt.get("expected_production_config_sha256")
+                ):
+                    return _error(409, "operation_readback_mismatch")
+                try:
+                    resource_binding = await asyncio.to_thread(
+                        _verify_recorded_resource_binding,
+                        self._hass,
+                        production_config,
+                        existing_operation,
+                        prefix="expected_",
+                    )
+                except (OSError, ValueError, RuntimeError):
+                    return _error(409, "operation_readback_mismatch")
+                return _json_response(
+                    {
+                        "promoted": False,
+                        "operation_id": operation_id,
+                        "status": "aborted",
+                        "active_revision": expected_production_revision,
+                        "expected_production_config_sha256": production_config_sha,
+                        "applied": False,
+                        "verified": True,
+                        "dashboard_resource_present": bool(resource_binding),
+                        "idempotent": True,
+                        **resource_binding,
+                    }
+                )
+            return _error(409, "operation_transition_in_progress")
         used_receipts = self._state.journal.setdefault("receipt_nonces", {})
         if receipt_nonce in used_receipts:
             return _error(409, "validation_receipt_replay")
-        _verify_signature(self._hass, receipt, prefix="validation-")
-        if any(receipt.get(key) != transaction.get(key) for key in ("manifest_sha256", "package_sha256", "dashboard_sha256")):
+        if any(
+            receipt.get(key) != transaction.get(key)
+            for key in ("manifest_sha256", "package_sha256", "dashboard_sha256")
+        ):
             return _error(422, "validation_receipt_hash_mismatch")
         expected_revision = self._state.journal.get("production_revision")
         if expected_production_revision != expected_revision:
@@ -1248,46 +2173,76 @@ class RootView(HomeAssistantView):
             return _error(422, "validation_receipt_preview_config_mismatch")
         if (
             not _is_sha256(receipt.get("expected_production_config_sha256"))
-            or receipt.get("expected_production_config_sha256")
-            != production_config_sha
+            or receipt.get("expected_production_config_sha256") != production_config_sha
         ):
             return _error(409, "production_config_conflict")
+        try:
+            expected_resource_binding = await asyncio.to_thread(
+                _dashboard_resource_binding_from_config,
+                self._hass,
+                production_config,
+            )
+        except (OSError, ValueError, RuntimeError):
+            return _error(409, "production_config_integrity_failed")
+        expected_resource_record = {
+            "expected_" + key: value
+            for key, value in expected_resource_binding.items()
+        }
         transition = self._state.journal.get("production_transition")
         if isinstance(transition, dict) and transition.get("status") == "prepared":
-            if (
-                transition.get("to_revision") != revision
-                or transition.get("expected_revision") != expected_revision
-                or transition.get("expected_config_sha256")
-                != production_config_sha
-                or transition.get("next_config_sha256") != preview_config_sha
-            ):
-                return _error(409, "production_transition_in_progress")
-            previous = transition.get("previous")
-            next_config = transition.get("next_config")
-            if not isinstance(previous, dict) or not isinstance(next_config, dict):
-                return _error(409, "production_transition_invalid")
-        else:
-            previous = {
-                "revision": expected_revision,
-                "config": json.loads(_json_bytes(production_config)),
-                "config_sha256": production_config_sha,
-            }
-            next_config = json.loads(_json_bytes(preview_config))
-            transition = {
-                "transition_id": "promotion-" + secrets.token_hex(16),
-                "status": "prepared",
-                "expected_revision": expected_revision,
-                "expected_config_sha256": production_config_sha,
-                "to_revision": revision,
-                "transaction_id": transaction["transaction_id"],
-                "receipt_nonce": receipt_nonce,
-                "previous": previous,
-                "next_config": next_config,
-                "next_config_sha256": preview_config_sha,
-                "prepared_at": _now().isoformat(),
-            }
-            self._state.journal["production_transition"] = transition
-            self._state.save()
+            return _error(409, "production_transition_in_progress")
+        previous = {
+            "revision": expected_revision,
+            "config": json.loads(_json_bytes(production_config)),
+            "config_sha256": production_config_sha,
+        }
+        next_config = json.loads(_json_bytes(preview_config))
+        prepared_at = _now().isoformat()
+        operation_record = {
+            "operation_id": operation_id,
+            "action": "promote_home_command",
+            "status": "prepared",
+            "transaction_id": transaction["transaction_id"],
+            "preview_revision": revision,
+            "target_revision": revision,
+            "expected_production_revision": expected_revision,
+            "expected_production_config_sha256": production_config_sha,
+            "preview_config_sha256": preview_config_sha,
+            "previous_production_revision": expected_revision,
+            "receipt_sha256": receipt_sha,
+            "request_sha256": request_sha,
+            "dashboard_resource_url": resource_context["preview_resource_url"],
+            "dashboard_sha256": resource_context["preview_resource_sha256"],
+            "dashboard_size": resource_context["preview_resource_size"],
+            **expected_resource_record,
+            "created_at": prepared_at,
+        }
+        transition = {
+            "transition_id": "promotion-" + secrets.token_hex(16),
+            "operation_id": operation_id,
+            "status": "prepared",
+            "expected_revision": expected_revision,
+            "expected_config_sha256": production_config_sha,
+            "to_revision": revision,
+            "transaction_id": transaction["transaction_id"],
+            "receipt_nonce": receipt_nonce,
+            "receipt_sha256": receipt_sha,
+            "request_sha256": request_sha,
+            "previous": previous,
+            "next_config": next_config,
+            "next_config_sha256": preview_config_sha,
+            "dashboard_resource_url": resource_context["preview_resource_url"],
+            "dashboard_sha256": resource_context["preview_resource_sha256"],
+            "dashboard_size": resource_context["preview_resource_size"],
+            **expected_resource_record,
+            "prepared_at": prepared_at,
+        }
+        if operation_id in operations or self._state.tx(operation_id) is not None:
+            return _error(409, "operation_id_conflict")
+        operations[operation_id] = operation_record
+        used_receipts[receipt_nonce] = transaction["transaction_id"]
+        self._state.journal["production_transition"] = transition
+        self._state.save()
         if (
             self._state.journal.get("production_revision") != expected_revision
             or self._state.journal.get("production_transition") is not transition
@@ -1302,6 +2257,21 @@ class RootView(HomeAssistantView):
         if _config_sha256(production_check) != production_config_sha:
             return _error(409, "production_config_conflict")
         await production.async_save(next_config)
+        _production_readback, production_readback = await _load_dashboard(
+            self._hass, PRODUCTION
+        )
+        if _config_sha256(production_readback) != preview_config_sha:
+            return _error(409, "production_readback_failed")
+        try:
+            await asyncio.to_thread(
+                _verify_operation_resource_binding,
+                self._hass,
+                self._state,
+                operation_record,
+                production_readback,
+            )
+        except (OSError, ValueError, RuntimeError):
+            return _error(409, "production_readback_failed")
         if (
             self._state.journal.get("production_revision") != expected_revision
             or self._state.journal.get("production_transition") is not transition
@@ -1312,51 +2282,246 @@ class RootView(HomeAssistantView):
         self._state.journal["production_config_sha256"] = preview_config_sha
         transaction["status"] = "promoted"
         transaction["promoted_at"] = _now().isoformat()
-        used_receipts[receipt_nonce] = transaction["transaction_id"]
+        transaction["promotion_operation_id"] = operation_id
         transition["status"] = "committed"
         transition["committed_at"] = transaction["promoted_at"]
+        operation_record["status"] = "committed"
+        operation_record["production_config_sha256"] = preview_config_sha
+        operation_record["completed_at"] = transaction["promoted_at"]
         self._state.save()
         return _json_response(
             {
                 "promoted": True,
+                "operation_id": operation_id,
+                "status": "committed",
                 "active_revision": revision,
                 "previous_revision": previous.get("revision"),
                 "preview_config_sha256": preview_config_sha,
                 "expected_production_config_sha256": production_config_sha,
+                "dashboard_resource_url": operation_record[
+                    "dashboard_resource_url"
+                ],
+                "dashboard_sha256": operation_record["dashboard_sha256"],
+                "dashboard_size": operation_record["dashboard_size"],
+                "applied": True,
+                "verified": True,
+                "dashboard_resource_present": True,
             }
         )
 
-    async def _rollback(self) -> web.Response:
+    async def _rollback(  # noqa: C901 - explicit rollback CAS state machine
+        self, body: dict[str, Any]
+    ) -> web.Response:
+        operation_id = body.get("operation_id")
+        if set(body) != {
+            "operation_id",
+            "expected_current_revision",
+            "expected_current_config_sha256",
+        }:
+            if isinstance(operation_id, str) and operation_id in (
+                self._state.journal.get("operations", {})
+            ):
+                return _error(409, "operation_id_conflict")
+            return _error(422, "rollback_request_schema_invalid")
+        expected_current_revision = body.get("expected_current_revision")
+        expected_current_config_sha = body.get("expected_current_config_sha256")
+        if (
+            not isinstance(operation_id, str)
+            or _SAFE_NONCE.fullmatch(operation_id) is None
+            or not isinstance(expected_current_revision, str)
+            or not _is_sha256(expected_current_config_sha)
+        ):
+            return _error(422, "rollback_cas_required")
+        request_sha = hashlib.sha256(
+            _json_bytes({"action": "rollback_home_command", "request": body})
+        ).hexdigest()
+        operations = self._state.journal.setdefault("operations", {})
+        if operation_id in operations or self._state.tx(operation_id) is not None:
+            if operation_id not in operations:
+                return _error(409, "operation_id_conflict")
+            existing = operations[operation_id]
+            if (
+                isinstance(existing, dict)
+                and existing.get("action") == "rollback_home_command"
+                and existing.get("request_sha256") == request_sha
+                and existing.get("status") == "committed"
+            ):
+                _production, current = await _load_dashboard(self._hass, PRODUCTION)
+                current_sha = _config_sha256(current)
+                if self._state.journal.get("production_revision") != existing.get(
+                    "target_revision"
+                ) or current_sha != existing.get("production_config_sha256"):
+                    return _error(409, "operation_readback_mismatch")
+                try:
+                    resource_binding = await asyncio.to_thread(
+                        _verify_recorded_resource_binding,
+                        self._hass,
+                        current,
+                        existing,
+                    )
+                except (OSError, ValueError, RuntimeError):
+                    return _error(409, "operation_readback_mismatch")
+                return _json_response(
+                    {
+                        "rolled_back": True,
+                        "operation_id": operation_id,
+                        "status": "committed",
+                        "active_revision": existing.get("target_revision"),
+                        "production_config_sha256": current_sha,
+                        "applied": True,
+                        "verified": True,
+                        "dashboard_resource_present": bool(resource_binding),
+                        "idempotent": True,
+                        **resource_binding,
+                    }
+                )
+            if (
+                isinstance(existing, dict)
+                and existing.get("action") == "rollback_home_command"
+                and existing.get("request_sha256") == request_sha
+                and existing.get("status") == "aborted"
+            ):
+                _production, current = await _load_dashboard(self._hass, PRODUCTION)
+                current_sha = _config_sha256(current)
+                if (
+                    self._state.journal.get("production_revision")
+                    != existing.get("expected_production_revision")
+                    or current_sha
+                    != existing.get("expected_production_config_sha256")
+                ):
+                    return _error(409, "operation_readback_mismatch")
+                try:
+                    resource_binding = await asyncio.to_thread(
+                        _verify_recorded_resource_binding,
+                        self._hass,
+                        current,
+                        existing,
+                        prefix="expected_",
+                    )
+                except (OSError, ValueError, RuntimeError):
+                    return _error(409, "operation_readback_mismatch")
+                return _json_response(
+                    {
+                        "rolled_back": False,
+                        "operation_id": operation_id,
+                        "status": "aborted",
+                        "active_revision": existing.get(
+                            "expected_production_revision"
+                        ),
+                        "production_config_sha256": current_sha,
+                        "applied": False,
+                        "verified": True,
+                        "dashboard_resource_present": bool(resource_binding),
+                        "idempotent": True,
+                        **resource_binding,
+                    }
+                )
+            return _error(409, "operation_id_conflict")
         previous = self._state.journal.get("previous_production")
         if (
             not isinstance(previous, dict)
+            or not isinstance(previous.get("revision"), str)
             or not isinstance(previous.get("config"), dict)
             or not _is_sha256(previous.get("config_sha256"))
-            or not _is_sha256(
-                self._state.journal.get("production_config_sha256")
-            )
+            or not _is_sha256(self._state.journal.get("production_config_sha256"))
         ):
             return _error(409, "no_prior_production_revision")
-        production, current = await _load_dashboard(self._hass, PRODUCTION)
-        if _config_sha256(current) != self._state.journal.get(
+        active = self._state.journal.get("production_revision")
+        if expected_current_revision != active:
+            return _error(409, "production_revision_conflict")
+        if expected_current_config_sha != self._state.journal.get(
             "production_config_sha256"
         ):
             return _error(409, "production_config_conflict")
+        production, current = await _load_dashboard(self._hass, PRODUCTION)
+        if _config_sha256(current) != expected_current_config_sha:
+            return _error(409, "production_config_conflict")
         if _config_sha256(previous["config"]) != previous["config_sha256"]:
             return _error(409, "production_rollback_evidence_invalid")
-        await production.async_save(previous["config"])
-        active = self._state.journal.get("production_revision")
-        self._state.journal["production_revision"] = previous.get("revision")
-        self._state.journal["production_config_sha256"] = previous[
-            "config_sha256"
-        ]
-        self._state.journal["previous_production"] = None
-        for transaction in self._state.journal.get("transactions", {}).values():
-            if isinstance(transaction, dict) and transaction.get("revision") == active:
-                transaction["status"] = "rolled_back"
-                transaction["rolled_back_at"] = _now().isoformat()
+        try:
+            expected_resource_binding = await asyncio.to_thread(
+                _dashboard_resource_binding_from_config, self._hass, current
+            )
+            target_resource_binding = await asyncio.to_thread(
+                _dashboard_resource_binding_from_config,
+                self._hass,
+                previous["config"],
+            )
+        except (OSError, ValueError, RuntimeError):
+            return _error(409, "production_rollback_evidence_invalid")
+        expected_resource_record = {
+            "expected_" + key: value
+            for key, value in expected_resource_binding.items()
+        }
+        prepared_at = _now().isoformat()
+        operation_record = {
+            "operation_id": operation_id,
+            "action": "rollback_home_command",
+            "status": "prepared",
+            "expected_production_revision": active,
+            "expected_production_config_sha256": expected_current_config_sha,
+            "target_revision": previous["revision"],
+            "request_sha256": request_sha,
+            **target_resource_binding,
+            **expected_resource_record,
+            "created_at": prepared_at,
+        }
+        transition = {
+            "operation_id": operation_id,
+            "status": "prepared",
+            "from_revision": active,
+            "to_revision": previous["revision"],
+            "expected_config_sha256": expected_current_config_sha,
+            "next_config": json.loads(_json_bytes(previous["config"])),
+            "next_config_sha256": previous["config_sha256"],
+            "request_sha256": request_sha,
+            **target_resource_binding,
+            **expected_resource_record,
+            "prepared_at": prepared_at,
+        }
+        operations[operation_id] = operation_record
+        self._state.journal["rollback_transition"] = transition
         self._state.save()
-        return _json_response({"rolled_back": True, "active_revision": previous.get("revision")})
+        if (
+            self._state.journal.get("production_revision") != active
+            or self._state.journal.get("production_config_sha256")
+            != expected_current_config_sha
+            or self._state.journal.get("rollback_transition") is not transition
+        ):
+            return _error(409, "production_revision_conflict")
+        await production.async_save(previous["config"])
+        _production_readback, readback = await _load_dashboard(self._hass, PRODUCTION)
+        if _config_sha256(readback) != previous["config_sha256"]:
+            return _error(409, "production_rollback_readback_failed")
+        try:
+            await asyncio.to_thread(
+                _verify_recorded_resource_binding,
+                self._hass,
+                readback,
+                operation_record,
+            )
+        except (OSError, ValueError, RuntimeError):
+            return _error(409, "production_rollback_readback_failed")
+        if (
+            self._state.journal.get("production_revision") != active
+            or self._state.journal.get("production_config_sha256")
+            != expected_current_config_sha
+        ):
+            return _error(409, "production_revision_conflict")
+        _commit_rollback_transition(self._state, transition, operation_record)
+        return _json_response(
+            {
+                "rolled_back": True,
+                "operation_id": operation_id,
+                "status": "committed",
+                "active_revision": previous["revision"],
+                "production_config_sha256": previous["config_sha256"],
+                "applied": True,
+                "verified": True,
+                "dashboard_resource_present": bool(target_resource_binding),
+                **target_resource_binding,
+            }
+        )
 
 
 class TransactionView(HomeAssistantView):
@@ -1370,33 +2535,171 @@ class TransactionView(HomeAssistantView):
         self._hass = hass
         self._state = state
 
-    async def get(self, request: web.Request, transaction_id: str, operation: str) -> web.Response:
+    async def get(  # noqa: C901 - transaction and operation readback dispatcher
+        self, request: web.Request, transaction_id: str, operation: str
+    ) -> web.Response:
         if not await _admin(request):
             return _error(403, "admin_required")
         if not self._state.admit_request():
             return _error(429, "rate_limited")
+        if operation in {"status", "readback"}:
+            async with self._state.lock:
+                operation_record = self._state.journal.get("operations", {}).get(
+                    transaction_id
+                )
+                if isinstance(operation_record, dict):
+                    try:
+                        await _reconcile_operation_transition(
+                            self._hass,
+                            self._state,
+                            transaction_id,
+                            operation_record,
+                        )
+                    except (OSError, ValueError, RuntimeError):
+                        return _error(409, "production_recovery_required")
+                    operation_record = self._state.journal.get("operations", {}).get(
+                        transaction_id
+                    )
+                    if not isinstance(operation_record, dict):
+                        return _error(409, "operation_recovery_invalid")
+                    public_keys = (
+                        "operation_id",
+                        "action",
+                        "status",
+                        "transaction_id",
+                        "preview_revision",
+                        "target_revision",
+                        "expected_production_revision",
+                        "expected_production_config_sha256",
+                        "preview_config_sha256",
+                        "production_config_sha256",
+                        "created_at",
+                        "completed_at",
+                    )
+                    payload = {
+                        key: operation_record.get(key)
+                        for key in public_keys
+                        if operation_record.get(key) is not None
+                    }
+                    if operation_record.get("action") == "rollback_home_command":
+                        payload.update(
+                            {
+                                "expected_current_revision": operation_record.get(
+                                    "expected_production_revision"
+                                ),
+                                "expected_current_config_sha256": operation_record.get(
+                                    "expected_production_config_sha256"
+                                ),
+                            }
+                        )
+                    if operation == "readback":
+                        try:
+                            _production, production_config = await _load_dashboard(
+                                self._hass, PRODUCTION
+                            )
+                        except (OSError, ValueError, RuntimeError):
+                            return _error(409, "operation_readback_failed")
+                        live_sha = _config_sha256(production_config)
+                        status = operation_record.get("status")
+                        if status == "committed":
+                            expected_revision = operation_record.get(
+                                "target_revision",
+                                operation_record.get("preview_revision"),
+                            )
+                            expected_sha = operation_record.get(
+                                "production_config_sha256"
+                            )
+                            applied = True
+                        elif status == "aborted":
+                            expected_revision = operation_record.get(
+                                "expected_production_revision"
+                            )
+                            expected_sha = operation_record.get(
+                                "expected_production_config_sha256"
+                            )
+                            applied = False
+                        else:
+                            return _error(409, "operation_readback_mismatch")
+                        if (
+                            self._state.journal.get("production_revision")
+                            != expected_revision
+                            or live_sha != expected_sha
+                        ):
+                            return _error(409, "operation_readback_mismatch")
+                        resource_binding: dict[str, Any] = {}
+                        if (
+                            applied
+                            and operation_record.get("action") == "promote_home_command"
+                        ):
+                            try:
+                                resource_binding = await asyncio.to_thread(
+                                    _verify_operation_resource_binding,
+                                    self._hass,
+                                    self._state,
+                                    operation_record,
+                                    production_config,
+                                )
+                            except (OSError, ValueError, RuntimeError):
+                                return _error(409, "operation_readback_mismatch")
+                        elif operation_record.get("action") == "promote_home_command":
+                            try:
+                                resource_binding = await asyncio.to_thread(
+                                    _verify_recorded_resource_binding,
+                                    self._hass,
+                                    production_config,
+                                    operation_record,
+                                    prefix="expected_",
+                                )
+                            except (OSError, ValueError, RuntimeError):
+                                return _error(409, "operation_readback_mismatch")
+                        elif operation_record.get("action") == "rollback_home_command":
+                            try:
+                                resource_binding = await asyncio.to_thread(
+                                    _verify_recorded_resource_binding,
+                                    self._hass,
+                                    production_config,
+                                    operation_record,
+                                    prefix="" if applied else "expected_",
+                                )
+                            except (OSError, ValueError, RuntimeError):
+                                return _error(409, "operation_readback_mismatch")
+                        payload.update(
+                            {
+                                "target_dashboard": PRODUCTION,
+                                "active_revision": self._state.journal.get(
+                                    "production_revision"
+                                ),
+                                "live_production_config_sha256": live_sha,
+                                "applied": applied,
+                                "verified": True,
+                                "dashboard_resource_present": bool(resource_binding),
+                                **resource_binding,
+                            }
+                        )
+                    return _json_response(payload)
         if operation != "readback":
             return _error(404, "not_found")
-        transaction = self._state.tx(transaction_id)
-        if transaction is None:
-            return _error(404, "transaction_not_found")
-        try:
-            package, dashboard, _manifest = _verify_staged_artifacts(
-                transaction, self._state.root
-            )
-        except (OSError, ValueError):
-            return _error(409, "staged_integrity_failed")
-        active_component_sha: str | None = None
-        if transaction.get("status") in {"activated", "reloaded", "promoted"}:
+        async with self._state.lock:
+            transaction = self._state.tx(transaction_id)
+            if transaction is None:
+                return _error(404, "transaction_not_found")
             try:
-                if package is None or dashboard is None:
-                    raise ValueError("staged_artifact_missing")
-                members = _validate_package(package)
-                active_component_sha = await _verify_active_bindings(
-                    self._hass, transaction, members, dashboard
+                await _reconcile_transaction_transition(
+                    self._hass, self._state, transaction
                 )
             except (OSError, ValueError, RuntimeError):
-                return _error(409, "active_integrity_failed")
+                return _error(409, "transaction_recovery_required")
+            return await self._transaction_readback(transaction)
+
+    async def _transaction_readback(  # noqa: C901 - fail-closed outcome projection
+        self, transaction: dict[str, Any]
+    ) -> web.Response:
+        stage = transaction.get("stage_transition")
+        previous_revision = (
+            transaction.get("preview_revision_before")
+            if "preview_revision_before" in transaction
+            else transaction.get("stage_previous_revision")
+        )
         payload = {
             key: transaction.get(key)
             for key in (
@@ -1409,19 +2712,172 @@ class TransactionView(HomeAssistantView):
                 "target",
             )
         }
+        payload["previous_revision"] = previous_revision
+        payload["dashboard_resource_present"] = False
+        if isinstance(stage, dict) and stage.get("status") in {
+            "committed",
+            "aborted",
+        }:
+            payload["stage_status"] = stage["status"]
+        if transaction.get("status") == "aborted":
+            if (
+                not isinstance(stage, dict)
+                or stage.get("status") != "aborted"
+                or stage.get("transaction_id") != transaction.get("transaction_id")
+                or stage.get("request_sha256")
+                != transaction.get("stage_request_sha256")
+            ):
+                return _error(409, "stage_readback_failed")
+            payload.update({"verified": False, "staged_package_verified": False})
+            return _json_response(payload)
+        if any(
+            (
+                transaction.get("target") != PREVIEW,
+                not _is_sha256(transaction.get("manifest_sha256")),
+                not _is_sha256(transaction.get("package_sha256")),
+                not _is_sha256(transaction.get("dashboard_sha256")),
+                transaction.get("status") == "staging",
+            )
+        ):
+            return _error(409, "staged_integrity_failed")
+        try:
+            package, dashboard, manifest = _verify_staged_artifacts(
+                transaction, self._state.root
+            )
+        except (OSError, ValueError):
+            return _error(409, "staged_integrity_failed")
+        if package is None or dashboard is None or manifest is None:
+            return _error(409, "staged_integrity_failed")
+        active_dashboard_sha: str | None = None
+        active_resource_binding: dict[str, Any] = {}
+        if transaction.get("status") in {"activated", "reloaded", "promoted"}:
+            try:
+                _validate_package(package)
+                active_dashboard_sha = await _verify_active_bindings(
+                    self._hass, transaction, dashboard
+                )
+                active_context = await asyncio.to_thread(
+                    _active_resource_context, self._hass, transaction
+                )
+                active_resource_binding = {
+                    "active_dashboard_resource_url": active_context[
+                        "preview_resource_url"
+                    ],
+                    "active_dashboard_sha256": active_context[
+                        "preview_resource_sha256"
+                    ],
+                    "active_dashboard_size": active_context[
+                        "preview_resource_size"
+                    ],
+                }
+                _preview, preview_config = await _load_dashboard(self._hass, PREVIEW)
+                if any(
+                    (
+                        self._state.journal.get("active_preview")
+                        != transaction.get("revision"),
+                        not _is_sha256(
+                            transaction.get("active_preview_config_sha256")
+                        ),
+                        _config_sha256(preview_config)
+                        != transaction.get("active_preview_config_sha256"),
+                    )
+                ):
+                    raise ValueError("active_preview_binding")
+            except (OSError, ValueError, RuntimeError):
+                return _error(409, "active_integrity_failed")
+        payload["staged_package_verified"] = True
+        activation = transaction.get("activation_transition")
+        if isinstance(activation, dict) and activation.get("status") in {
+            "committed",
+            "aborted",
+        }:
+            payload["activation_status"] = activation["status"]
+        rollback = transaction.get("preview_rollback_transition")
+        if isinstance(rollback, dict) and rollback.get("status") in {
+            "committed",
+            "aborted",
+        }:
+            payload["rollback_status"] = rollback["status"]
+        if active_dashboard_sha is not None:
+            payload.update(
+                {
+                    "active_revision": self._state.journal.get("active_preview"),
+                    "active_dashboard_verified": True,
+                    "dashboard_resource_present": True,
+                    **active_resource_binding,
+                }
+            )
+        if transaction.get("status") == "rolled_back":
+            if (
+                not isinstance(rollback, dict)
+                or rollback.get("status") != "committed"
+                or rollback.get("action") != "rollback"
+                or rollback.get("transaction_id")
+                != transaction.get("transaction_id")
+                or rollback.get("from_revision") != transaction.get("revision")
+                or rollback.get("to_revision")
+                != transaction.get("preview_revision_before")
+                or rollback.get("next_config_sha256")
+                != transaction.get("preview_config_sha256_before")
+                or not _is_sha256(rollback.get("next_config_sha256"))
+            ):
+                return _error(409, "preview_rollback_readback_failed")
+            try:
+                _preview, preview_config = await _load_dashboard(self._hass, PREVIEW)
+            except (OSError, ValueError, RuntimeError):
+                return _error(409, "preview_rollback_readback_failed")
+            active_revision = self._state.journal.get("active_preview")
+            if (
+                _config_sha256(preview_config) != rollback["next_config_sha256"]
+                or active_revision != rollback.get("to_revision")
+            ):
+                return _error(409, "preview_rollback_readback_failed")
+            try:
+                restored_resource_binding = await asyncio.to_thread(
+                    _verify_preview_revision_resource_binding,
+                    self._hass,
+                    self._state,
+                    active_revision,
+                    preview_config,
+                )
+            except (OSError, ValueError, RuntimeError):
+                return _error(409, "preview_rollback_readback_failed")
+            payload.update(
+                {
+                    "rolled_back": True,
+                    "active_revision": active_revision,
+                    "previous_revision": active_revision,
+                    "preview_active": isinstance(active_revision, str),
+                    "dashboard_resource_present": bool(restored_resource_binding),
+                    **(
+                        {
+                            "active_dashboard_resource_url": restored_resource_binding[
+                                "dashboard_resource_url"
+                            ],
+                            "active_dashboard_sha256": restored_resource_binding[
+                                "dashboard_sha256"
+                            ],
+                            "active_dashboard_size": restored_resource_binding[
+                                "dashboard_size"
+                            ],
+                        }
+                        if restored_resource_binding
+                        else {}
+                    ),
+                }
+            )
         payload["verified"] = transaction.get("status") in {
             "verified",
             "activated",
             "reloaded",
             "promoted",
+            "rolled_back",
         }
-        if active_component_sha is not None:
-            payload["active_package_sha256"] = active_component_sha
-            payload["active_package_verified"] = True
-            payload["active_dashboard_verified"] = True
         return _json_response(payload)
 
-    async def post(self, request: web.Request, transaction_id: str, operation: str) -> web.Response:
+    async def post(  # noqa: C901 - explicit transaction lifecycle dispatcher
+        self, request: web.Request, transaction_id: str, operation: str
+    ) -> web.Response:
         if not await _admin(request):
             return _error(403, "admin_required")
         if not self._state.admit_request():
@@ -1431,7 +2887,44 @@ class TransactionView(HomeAssistantView):
             if transaction is None:
                 return _error(404, "transaction_not_found")
             try:
+                await _reconcile_transaction_transition(
+                    self._hass, self._state, transaction
+                )
                 if operation == "activate":
+                    if transaction.get("status") in {
+                        "activated",
+                        "reloaded",
+                        "promoted",
+                    } and self._state.journal.get("active_preview") == transaction.get(
+                        "revision"
+                    ):
+                        await _verify_active_transaction(
+                            self._hass, transaction, self._state.root
+                        )
+                        _preview, active_config = await _load_dashboard(
+                            self._hass, PREVIEW
+                        )
+                        if (
+                            not _is_sha256(
+                                transaction.get("active_preview_config_sha256")
+                            )
+                            or _config_sha256(active_config)
+                            != transaction.get("active_preview_config_sha256")
+                        ):
+                            return _error(409, "active_integrity_failed")
+                        return _json_response(
+                            {
+                                "activated": True,
+                                "active_revision": transaction["revision"],
+                                "previous_revision": transaction.get(
+                                    "preview_revision_before"
+                                ),
+                                "status": transaction["status"],
+                                "restart_required": False,
+                                "backend_unchanged": True,
+                                "idempotent": True,
+                            }
+                        )
                     if transaction.get("status") != "verified":
                         return _error(409, "transaction_not_verified")
                     package, dashboard, _manifest = _verify_staged_artifacts(
@@ -1439,79 +2932,289 @@ class TransactionView(HomeAssistantView):
                     )
                     if package is None or dashboard is None:
                         raise ValueError("staged_artifact_missing")
-                    component_members = _validate_package(package)
+                    _validate_package(package)
                     await _ensure_preview(self._hass)
                     preview, preview_config = await _load_dashboard(self._hass, PREVIEW)
-                    transaction["preview_before"] = json.loads(_json_bytes(preview_config))
+                    try:
+                        await asyncio.to_thread(
+                            _verify_preview_revision_resource_binding,
+                            self._hass,
+                            self._state,
+                            self._state.journal.get("active_preview"),
+                            preview_config,
+                        )
+                    except (OSError, ValueError, RuntimeError):
+                        return _error(409, "preview_prestate_invalid")
+                    transaction["preview_before"] = json.loads(
+                        _json_bytes(preview_config)
+                    )
+                    transaction["preview_config_sha256_before"] = _config_sha256(
+                        preview_config
+                    )
                     transaction["preview_revision_before"] = self._state.journal.get(
                         "active_preview"
                     )
-                    component_activated = False
+                    asset_name = (
+                        f"aurora-preview-dashboard-{transaction['dashboard_sha256']}.js"
+                    )
+                    next_config = _dashboard_config_with_asset(
+                        preview_config, asset_name
+                    )
+                    transition = {
+                        "status": "prepared",
+                        "action": "activate",
+                        "transaction_id": transaction["transaction_id"],
+                        "previous_revision": transaction.get(
+                            "preview_revision_before"
+                        ),
+                        "next_revision": transaction["revision"],
+                        "previous_config_sha256": _config_sha256(preview_config),
+                        "next_config_sha256": _config_sha256(next_config),
+                        "asset_name": asset_name,
+                        "prepared_at": _now().isoformat(),
+                    }
+                    transaction["active_dashboard_asset"] = asset_name
+                    transaction["activation_transition"] = transition
+                    self._state.save()
                     try:
-                        await asyncio.to_thread(
-                            _activate_component_package,
-                            self._hass,
-                            self._state,
-                            transaction,
-                            component_members,
+                        saved_asset_name = await _save_preview_asset(
+                            self._hass, dashboard
                         )
-                        component_activated = True
-                        asset_name = await _save_preview_asset(self._hass, dashboard)
+                        if saved_asset_name != asset_name:
+                            raise ValueError("active_dashboard_binding")
                     except (OSError, ValueError, RuntimeError):
-                        if component_activated:
-                            await asyncio.to_thread(
-                                _restore_component_prestate,
-                                self._hass,
-                                self._state,
-                                transaction,
-                            )
                         try:
                             await preview.async_save(transaction["preview_before"])
                         except (OSError, ValueError, RuntimeError):
                             pass
                         raise
-                    transaction["active_dashboard_asset"] = asset_name
-                    self._state.journal["active_preview"] = transaction["revision"]
-                    transaction["status"] = "activated"
-                    transaction["activated_at"] = _now().isoformat()
-                    self._state.save()
-                    return _json_response({"activated": True, "active_revision": transaction["revision"], "status": "activated"})
+                    try:
+                        _preview_readback, preview_readback = await _load_dashboard(
+                            self._hass, PREVIEW
+                        )
+                        await _verify_active_bindings(
+                            self._hass, transaction, dashboard
+                        )
+                    except (OSError, ValueError, RuntimeError):
+                        try:
+                            await preview.async_save(transaction["preview_before"])
+                        except (OSError, ValueError, RuntimeError):
+                            pass
+                        raise
+                    if (
+                        _config_sha256(preview_readback)
+                        != transition["next_config_sha256"]
+                    ):
+                        raise ValueError("preview_activation_readback_failed")
+                    _commit_preview_activation(self._state, transaction, transition)
+                    return _json_response(
+                        {
+                            "activated": True,
+                            "active_revision": transaction["revision"],
+                            "previous_revision": transaction.get(
+                                "preview_revision_before"
+                            ),
+                            "status": "activated",
+                            "restart_required": False,
+                            "backend_unchanged": True,
+                        }
+                    )
                 if operation == "rollback":
+                    if transaction.get("status") == "rolled_back":
+                        rollback = transaction.get("preview_rollback_transition")
+                        active_revision = self._state.journal.get("active_preview")
+                        try:
+                            _preview, rolled_back_config = await _load_dashboard(
+                                self._hass, PREVIEW
+                            )
+                        except (OSError, ValueError, RuntimeError):
+                            return _error(409, "preview_rollback_readback_failed")
+                        if (
+                            not isinstance(rollback, dict)
+                            or rollback.get("status") != "committed"
+                            or rollback.get("action") != "rollback"
+                            or rollback.get("transaction_id")
+                            != transaction.get("transaction_id")
+                            or rollback.get("from_revision")
+                            != transaction.get("revision")
+                            or rollback.get("to_revision") != active_revision
+                            or rollback.get("to_revision")
+                            != transaction.get("preview_revision_before")
+                            or not _is_sha256(rollback.get("next_config_sha256"))
+                            or rollback.get("next_config_sha256")
+                            != transaction.get("preview_config_sha256_before")
+                            or not isinstance(transaction.get("preview_before"), dict)
+                            or _config_sha256(transaction["preview_before"])
+                            != rollback.get("next_config_sha256")
+                            or _config_sha256(rolled_back_config)
+                            != rollback.get("next_config_sha256")
+                        ):
+                            return _error(409, "preview_rollback_readback_failed")
+                        try:
+                            await asyncio.to_thread(
+                                _verify_preview_revision_resource_binding,
+                                self._hass,
+                                self._state,
+                                active_revision,
+                                rolled_back_config,
+                            )
+                        except (OSError, ValueError, RuntimeError):
+                            return _error(409, "preview_rollback_readback_failed")
+                        return _json_response(
+                            {
+                                "rolled_back": True,
+                                "active_revision": active_revision,
+                                "previous_revision": active_revision,
+                                "preview_active": isinstance(active_revision, str),
+                                "status": "rolled_back",
+                                "idempotent": True,
+                            }
+                        )
                     if transaction.get("status") not in {"activated", "reloaded"}:
                         return _error(409, "transaction_not_rollbackable")
                     previous_preview = transaction.get("preview_before")
-                    if not isinstance(previous_preview, dict):
+                    if (
+                        not isinstance(previous_preview, dict)
+                        or not _is_sha256(
+                            transaction.get("preview_config_sha256_before")
+                        )
+                        or _config_sha256(previous_preview)
+                        != transaction.get("preview_config_sha256_before")
+                        or not _is_sha256(
+                            transaction.get("active_preview_config_sha256")
+                        )
+                    ):
                         return _error(409, "preview_rollback_snapshot_missing")
-                    preview, _current = await _load_dashboard(self._hass, PREVIEW)
-                    await preview.async_save(previous_preview)
-                    await asyncio.to_thread(
-                        _restore_component_prestate,
-                        self._hass,
-                        self._state,
-                        transaction,
-                    )
-                    if self._state.journal.get("active_preview") == transaction.get("revision"):
-                        previous_revision = transaction.get("preview_revision_before")
-                        if isinstance(previous_revision, str):
-                            self._state.journal["active_preview"] = previous_revision
-                        else:
-                            self._state.journal.pop("active_preview", None)
-                    transaction["status"] = "rolled_back"
-                    transaction["rolled_back_at"] = _now().isoformat()
+                    try:
+                        await asyncio.to_thread(
+                            _verify_preview_revision_resource_binding,
+                            self._hass,
+                            self._state,
+                            transaction.get("preview_revision_before"),
+                            previous_preview,
+                        )
+                    except (OSError, ValueError, RuntimeError):
+                        return _error(409, "preview_rollback_snapshot_missing")
+                    if self._state.journal.get("active_preview") != transaction.get(
+                        "revision"
+                    ):
+                        return _error(409, "preview_revision_conflict")
+                    preview, current = await _load_dashboard(self._hass, PREVIEW)
+                    if _config_sha256(current) != transaction.get(
+                        "active_preview_config_sha256"
+                    ):
+                        return _error(409, "preview_config_conflict")
+                    try:
+                        await _verify_active_transaction(
+                            self._hass, transaction, self._state.root
+                        )
+                    except (OSError, ValueError, RuntimeError):
+                        return _error(409, "active_integrity_failed")
+                    transition = {
+                        "status": "prepared",
+                        "action": "rollback",
+                        "transaction_id": transaction["transaction_id"],
+                        "from_status": transaction["status"],
+                        "from_revision": transaction["revision"],
+                        "to_revision": transaction.get("preview_revision_before"),
+                        "previous_config_sha256": _config_sha256(current),
+                        "next_config_sha256": transaction[
+                            "preview_config_sha256_before"
+                        ],
+                        "asset_name": transaction.get("active_dashboard_asset"),
+                        "prepared_at": _now().isoformat(),
+                    }
+                    transaction["preview_rollback_transition"] = transition
                     self._state.save()
+                    await preview.async_save(previous_preview)
+                    _preview_readback, preview_readback = await _load_dashboard(
+                        self._hass, PREVIEW
+                    )
+                    if _config_sha256(preview_readback) != transaction.get(
+                        "preview_config_sha256_before"
+                    ):
+                        return _error(409, "preview_rollback_readback_failed")
+                    try:
+                        await asyncio.to_thread(
+                            _verify_preview_revision_resource_binding,
+                            self._hass,
+                            self._state,
+                            transaction.get("preview_revision_before"),
+                            preview_readback,
+                        )
+                    except (OSError, ValueError, RuntimeError):
+                        return _error(409, "preview_rollback_readback_failed")
+                    _commit_preview_rollback(self._state, transaction, transition)
                     active_revision = self._state.journal.get("active_preview")
                     return _json_response(
                         {
                             "rolled_back": True,
                             "active_revision": active_revision,
+                            "previous_revision": active_revision,
                             "preview_active": isinstance(active_revision, str),
                             "status": "rolled_back",
                         }
                     )
                 if operation == "reload":
+                    if transaction.get("status") == "reloaded":
+                        await _verify_active_transaction(
+                            self._hass, transaction, self._state.root
+                        )
+                        _preview, active_config = await _load_dashboard(
+                            self._hass, PREVIEW
+                        )
+                        if (
+                            not _is_sha256(
+                                transaction.get("active_preview_config_sha256")
+                            )
+                            or _config_sha256(active_config)
+                            != transaction.get("active_preview_config_sha256")
+                        ):
+                            return _error(409, "active_integrity_failed")
+                        return _json_response(
+                            {
+                                "reloaded": True,
+                                "verified": True,
+                                "active_revision": transaction["revision"],
+                                "previous_revision": transaction.get(
+                                    "preview_revision_before"
+                                ),
+                                "status": "reloaded",
+                                "restart_required": False,
+                                "backend_unchanged": True,
+                                "idempotent": True,
+                            }
+                        )
                     if transaction.get("status") != "activated":
                         return _error(409, "transaction_not_activated")
-                    return _error(409, "restart_required")
+                    await _verify_active_transaction(
+                        self._hass, transaction, self._state.root
+                    )
+                    _preview, active_config = await _load_dashboard(self._hass, PREVIEW)
+                    if (
+                        not _is_sha256(
+                            transaction.get("active_preview_config_sha256")
+                        )
+                        or _config_sha256(active_config)
+                        != transaction.get("active_preview_config_sha256")
+                    ):
+                        return _error(409, "active_integrity_failed")
+                    transaction["status"] = "reloaded"
+                    transaction["reloaded_at"] = _now().isoformat()
+                    self._state.save()
+                    return _json_response(
+                        {
+                            "reloaded": True,
+                            "verified": True,
+                            "active_revision": transaction["revision"],
+                            "previous_revision": transaction.get(
+                                "preview_revision_before"
+                            ),
+                            "status": "reloaded",
+                            "restart_required": False,
+                            "backend_unchanged": True,
+                        }
+                    )
             except (OSError, ValueError, RuntimeError):
                 return _error(500, "activation_failed")
         return _error(404, "not_found")

--- a/custom_components/aurora_deploy/adapter.py
+++ b/custom_components/aurora_deploy/adapter.py
@@ -81,6 +81,8 @@ MAX_PACKAGE = 64 * 1024 * 1024
 MAX_DASHBOARD = 8 * 1024 * 1024
 MAX_MEMBERS = 256
 MAX_EXPANDED = 32 * 1024 * 1024
+MAX_STAGED_REVISIONS = 8
+MAX_STAGED_TOTAL_BYTES = 256 * 1024 * 1024
 CLOCK_SKEW = timedelta(minutes=5)
 MAX_LIFETIME = timedelta(hours=24)
 MAX_AUTOMATED_E2E_LIFETIME = timedelta(minutes=10)
@@ -389,7 +391,43 @@ def _json_object(raw: bytes, error_code: str) -> dict[str, Any]:
     return value
 
 
-def _package_members(raw: bytes) -> dict[str, bytes]:  # noqa: C901 - archive policy is intentionally explicit
+def _package_file_name(member: tarfile.TarInfo) -> str | None:
+    """Validate one archive member and return its approved file name."""
+    name = member.name.replace("\\", "/")
+    path = PurePosixPath(name)
+    if path.is_absolute() or ".." in path.parts or name == "":
+        raise ValueError("package_path")
+    if member.issym() or member.islnk() or member.isdev() or member.isfifo():
+        raise ValueError("package_link")
+    if member.isdir():
+        if name.rstrip("/") not in APPROVED_PACKAGE_DIRECTORIES:
+            raise ValueError("package_member")
+        return None
+    if not member.isfile():
+        raise ValueError("package_member_type")
+    if name not in APPROVED_PACKAGE_FILES:
+        raise ValueError("package_member")
+    if name.endswith((".tar", ".tar.gz", ".tgz", ".zip")):
+        raise ValueError("nested_archive")
+    return name
+
+
+def _read_archive_member(
+    archive: tarfile.TarFile, member: tarfile.TarInfo
+) -> bytes:
+    """Read one member exactly and apply the privacy denylist."""
+    stream = archive.extractfile(member)
+    if stream is None:
+        raise ValueError("package_member")
+    data = stream.read(member.size + 1)
+    if len(data) != member.size:
+        raise ValueError("package_size")
+    _scan_privacy(data)
+    return data
+
+
+def _extract_package_files(raw: bytes) -> dict[str, bytes]:
+    """Extract only the fixed, regular-file package allowlist."""
     if not raw.startswith(b"\x1f\x8b"):
         raise ValueError("package_format")
     count = 0
@@ -401,61 +439,64 @@ def _package_members(raw: bytes) -> dict[str, bytes]:  # noqa: C901 - archive po
                 count += 1
                 if count > MAX_MEMBERS:
                     raise ValueError("package_members")
-                name = member.name.replace("\\", "/")
-                path = PurePosixPath(name)
-                if path.is_absolute() or ".." in path.parts or name == "":
-                    raise ValueError("package_path")
-                if (
-                    member.issym()
-                    or member.islnk()
-                    or member.isdev()
-                    or member.isfifo()
-                ):
-                    raise ValueError("package_link")
-                normalized = name.rstrip("/")
-                if member.isdir():
-                    if normalized not in APPROVED_PACKAGE_DIRECTORIES:
-                        raise ValueError("package_member")
+                name = _package_file_name(member)
+                if name is None:
                     continue
-                if not member.isfile():
-                    raise ValueError("package_member_type")
-                if name not in APPROVED_PACKAGE_FILES:
-                    raise ValueError("package_member")
-                if name.endswith((".tar", ".tar.gz", ".tgz", ".zip")):
-                    raise ValueError("nested_archive")
                 if name in files:
                     raise ValueError("package_duplicate")
                 expanded += max(0, member.size)
                 if expanded > MAX_EXPANDED:
                     raise ValueError("package_expanded")
-                stream = archive.extractfile(member)
-                if stream is None:
-                    raise ValueError("package_member")
-                data = stream.read(member.size + 1)
-                if len(data) != member.size:
-                    raise ValueError("package_size")
-                _scan_privacy(data)
-                files[name] = data
+                files[name] = _read_archive_member(archive, member)
     except (tarfile.TarError, OSError) as exc:
         raise ValueError("package_format") from exc
-
     if set(files) != APPROVED_PACKAGE_FILES:
         raise ValueError("package_source_missing")
+    return files
 
+
+def _validate_component_entries(
+    files: dict[str, bytes], entries: Any
+) -> None:
+    """Validate the component manifest's exact file list and digests."""
+    if not isinstance(entries, list):
+        raise ValueError("package_component_manifest")
+    described: set[str] = set()
+    for entry in entries:
+        if not isinstance(entry, dict):
+            raise ValueError("package_component_manifest")
+        path = entry.get("path")
+        if not isinstance(path, str) or path not in APPROVED_PACKAGE_FILES:
+            raise ValueError("package_component_manifest")
+        if not path.startswith(PACKAGE_ROOT) or path in described:
+            raise ValueError("package_component_manifest")
+        data = files[path]
+        if entry.get("size") != len(data):
+            raise ValueError("package_component_hash")
+        if entry.get("sha256") != hashlib.sha256(data).hexdigest():
+            raise ValueError("package_component_hash")
+        described.add(path)
+    expected = {PACKAGE_ROOT + name for name in APPROVED_COMPONENT_FILES}
+    if described != expected:
+        raise ValueError("package_source_missing")
+
+
+def _validate_component_manifest(files: dict[str, bytes]) -> None:
+    """Validate the component installation manifest and every file digest."""
     component_manifest_raw = files["custom-component-manifest.json"]
     component_manifest = _json_object(
         component_manifest_raw, "package_component_manifest"
     )
-    if any(
-        (
-            component_manifest.get("schemaVersion") != "1.0",
-            component_manifest.get("domain") != COMPONENT_DOMAIN,
-            component_manifest.get("version") != COMPONENT_VERSION,
-            component_manifest.get("configurationKey") != COMPONENT_DOMAIN,
-            component_manifest.get("restartRequired") is not True,
-        )
-    ):
+    required = {
+        "schemaVersion": "1.0",
+        "domain": COMPONENT_DOMAIN,
+        "version": COMPONENT_VERSION,
+        "configurationKey": COMPONENT_DOMAIN,
+        "restartRequired": True,
+    }
+    if any(component_manifest.get(key) != value for key, value in required.items()):
         raise ValueError("package_component_manifest")
+
     installation = component_manifest.get("installation")
     rollback = component_manifest.get("rollback")
     if not isinstance(installation, dict) or any(
@@ -476,30 +517,12 @@ def _package_members(raw: bytes) -> dict[str, bytes]:  # noqa: C901 - archive po
     ):
         raise ValueError("package_component_manifest")
 
-    entries = component_manifest.get("files")
-    if not isinstance(entries, list):
-        raise ValueError("package_component_manifest")
-    described: set[str] = set()
-    for entry in entries:
-        if not isinstance(entry, dict):
-            raise ValueError("package_component_manifest")
-        path = entry.get("path")
-        if not isinstance(path, str) or path not in APPROVED_PACKAGE_FILES:
-            raise ValueError("package_component_manifest")
-        if not path.startswith(PACKAGE_ROOT) or path in described:
-            raise ValueError("package_component_manifest")
-        data = files[path]
-        if (
-            entry.get("size") != len(data)
-            or entry.get("sha256") != hashlib.sha256(data).hexdigest()
-        ):
-            raise ValueError("package_component_hash")
-        described.add(path)
-    expected_component_paths = {
-        PACKAGE_ROOT + filename for filename in APPROVED_COMPONENT_FILES
-    }
-    if described != expected_component_paths:
-        raise ValueError("package_source_missing")
+    _validate_component_entries(files, component_manifest.get("files"))
+
+
+def _validate_package_metadata(files: dict[str, bytes]) -> None:
+    """Bind the package entrypoints to the exact component manifest bytes."""
+    component_manifest_raw = files["custom-component-manifest.json"]
 
     package_manifest = _json_object(files["manifest.json"], "package_manifest")
     installer = package_manifest.get("installer")
@@ -525,6 +548,13 @@ def _package_members(raw: bytes) -> dict[str, bytes]:  # noqa: C901 - archive po
         )
     ):
         raise ValueError("package_manifest")
+
+
+def _package_members(raw: bytes) -> dict[str, bytes]:
+    """Return the validated component members from one release package."""
+    files = _extract_package_files(raw)
+    _validate_component_manifest(files)
+    _validate_package_metadata(files)
 
     integration_manifest = _json_object(
         files[PACKAGE_ROOT + "manifest.json"], "package_integration_manifest"
@@ -574,29 +604,17 @@ async def _verify_active_bindings(
 async def _verify_active_transaction(
     hass: HomeAssistant, transaction: dict[str, Any], root: Path | None = None
 ) -> str:
-    package, dashboard, _manifest = _verify_staged_artifacts(transaction, root)
+    package, dashboard, _manifest = _verify_staged_artifacts(
+        transaction, root, hass
+    )
     if package is None or dashboard is None:
         raise ValueError("staged_artifact_missing")
     _validate_package(package)
     return await _verify_active_bindings(hass, transaction, dashboard)
 
 
-def _validate_manifest(  # noqa: C901 - fail-closed policy checks are kept together
-    hass: HomeAssistant, manifest: Any, package: bytes, dashboard: bytes
-) -> tuple[str, str, str]:
-    if not isinstance(manifest, dict) or len(_json_bytes(manifest)) > MAX_MANIFEST:
-        raise ValueError("manifest")
-    if manifest.get("schema_version") != 1 or manifest.get("target") != TARGET:
-        raise ValueError("target")
-    if (
-        manifest.get("dashboard_target", PREVIEW) != PREVIEW
-        or manifest.get("preview_only") is not True
-    ):
-        raise ValueError("dashboard")
-    if manifest.get("target_release") != APPROVED_RELEASE:
-        raise ValueError("release")
-    if manifest.get("privacy_policy") != "no-sensitive-inference-v1":
-        raise ValueError("privacy_policy")
+def _validate_manifest_window(manifest: dict[str, Any]) -> None:
+    """Validate the signed release lifetime and nonce."""
     issued = _parse_time(manifest.get("issued_at", manifest.get("created_at")))
     expires = _parse_time(manifest.get("expires_at"))
     now = _now()
@@ -618,6 +636,43 @@ def _validate_manifest(  # noqa: C901 - fail-closed policy checks are kept toget
         )
     ):
         raise ValueError("nonce")
+
+
+def _validate_manifest_assets(
+    manifest: dict[str, Any], expected: dict[str, str]
+) -> None:
+    """Validate the exact two-artifact allowlist and digests."""
+    assets = manifest.get("assets")
+    if not isinstance(assets, list) or len(assets) != len(expected):
+        raise ValueError("assets")
+    seen: set[str] = set()
+    for item in assets:
+        if not isinstance(item, dict):
+            raise ValueError("assets")
+        name = item.get("name")
+        if name not in expected or name in seen or item.get("sha256") != expected[name]:
+            raise ValueError("assets")
+        seen.add(name)
+    if seen != set(expected):
+        raise ValueError("assets")
+
+
+def _validate_manifest(
+    hass: HomeAssistant, manifest: Any, package: bytes, dashboard: bytes
+) -> tuple[str, str, str]:
+    if not isinstance(manifest, dict) or len(_json_bytes(manifest)) > MAX_MANIFEST:
+        raise ValueError("manifest")
+    if manifest.get("schema_version") != 1 or manifest.get("target") != TARGET:
+        raise ValueError("target")
+    if manifest.get("dashboard_target", PREVIEW) != PREVIEW:
+        raise ValueError("dashboard")
+    if manifest.get("preview_only") is not True:
+        raise ValueError("dashboard")
+    if manifest.get("target_release") != APPROVED_RELEASE:
+        raise ValueError("release")
+    if manifest.get("privacy_policy") != PRIVACY_POLICY:
+        raise ValueError("privacy_policy")
+    _validate_manifest_window(manifest)
     _verify_signature(hass, manifest, prefix="release-")
     package_hash = hashlib.sha256(package).hexdigest()
     dashboard_hash = hashlib.sha256(dashboard).hexdigest()
@@ -626,25 +681,11 @@ def _validate_manifest(  # noqa: C901 - fail-closed policy checks are kept toget
         or manifest.get("dashboard_sha256") != dashboard_hash
     ):
         raise ValueError("hash")
-    assets = manifest.get("assets")
     expected = {
         "aurora-preview-package": package_hash,
         "aurora-preview-dashboard": dashboard_hash,
     }
-    if not isinstance(assets, list) or len(assets) != 2:
-        raise ValueError("assets")
-    seen: set[str] = set()
-    for item in assets:
-        if (
-            not isinstance(item, dict)
-            or item.get("name") not in expected
-            or item["name"] in seen
-            or item.get("sha256") != expected[item["name"]]
-        ):
-            raise ValueError("assets")
-        seen.add(item["name"])
-    if seen != set(expected):
-        raise ValueError("assets")
+    _validate_manifest_assets(manifest, expected)
     _scan_privacy(_json_bytes(manifest))
     _scan_privacy(dashboard)
     _validate_package(package)
@@ -673,6 +714,43 @@ def _atomic_write(path: Path, data: bytes) -> None:
     finally:
         if temporary.exists():
             temporary.unlink(missing_ok=True)
+
+
+def _staged_revision_size(path: Path) -> int:
+    """Return one staged revision's bounded regular-file size."""
+    if path.is_symlink() or not path.is_dir():
+        raise ValueError("staged_retention_invalid")
+    total = 0
+    for artifact in path.iterdir():
+        metadata = artifact.stat(follow_symlinks=False)
+        if artifact.is_symlink() or not stat.S_ISREG(metadata.st_mode):
+            raise ValueError("staged_retention_invalid")
+        total += metadata.st_size
+        if total > MAX_STAGED_TOTAL_BYTES:
+            raise ValueError("staged_capacity_exceeded")
+    return total
+
+
+def _reserve_staged_capacity(
+    root: Path, revision: str, incoming_size: int
+) -> None:
+    """Reject a new staged revision before it can exceed fixed disk quotas."""
+    if _SAFE_REVISION.fullmatch(revision) is None or incoming_size < 0:
+        raise ValueError("staged_retention_invalid")
+    staged_root = root / "staged"
+    staged_root.mkdir(parents=True, exist_ok=True)
+    if staged_root.is_symlink() or not staged_root.is_dir():
+        raise ValueError("staged_retention_invalid")
+    revisions = list(staged_root.iterdir())
+    total = sum(_staged_revision_size(path) for path in revisions)
+    already_retained = any(path.name == revision for path in revisions)
+    revision_count = len(revisions) + (0 if already_retained else 1)
+    projected = total + (0 if already_retained else incoming_size)
+    if (
+        revision_count > MAX_STAGED_REVISIONS
+        or projected > MAX_STAGED_TOTAL_BYTES
+    ):
+        raise ValueError("staged_capacity_exceeded")
 
 
 def _staged_revision_dir(transaction: dict[str, Any], root: Path) -> Path:
@@ -717,32 +795,43 @@ def _read_staged_file(path: Path, limit: int) -> bytes:
             os.close(fd)
 
 
-def _verify_staged_artifacts(  # noqa: C901 - staged evidence checks are fail-closed
+def _existing_staged_paths(
+    transaction: dict[str, Any], root: Path, expected: dict[str, Any]
+) -> tuple[Path, Path, Path] | None:
+    """Return the complete staged artifact set or a legacy missing marker."""
+    revision_dir = _staged_revision_dir(transaction, root)
+    paths = (
+        revision_dir / "manifest.json",
+        revision_dir / "aurora-preview-package.tar.gz",
+        revision_dir / "aurora-preview-dashboard.js",
+    )
+    for path in paths:
+        if path.is_symlink():
+            raise ValueError("staged_artifact_symlink")
+        if not path.exists():
+            if all(isinstance(value, str) for value in expected.values()):
+                raise ValueError("staged_artifact_missing")
+            return None
+        if not path.is_file():
+            raise ValueError("staged_artifact_invalid")
+    return paths
+
+
+def _verify_staged_artifacts(
     transaction: dict[str, Any],
     root: Path,
+    hass: HomeAssistant,
 ) -> tuple[bytes | None, bytes | None, dict[str, Any] | None]:
     """Read and rehash all staged artifacts beneath the fixed state root."""
-    revision_dir = _staged_revision_dir(transaction, root)
-    manifest_path = revision_dir / "manifest.json"
-    package_path = revision_dir / "aurora-preview-package.tar.gz"
-    dashboard_path = revision_dir / "aurora-preview-dashboard.js"
     expected = {
         "manifest_sha256": transaction.get("manifest_sha256"),
         "package_sha256": transaction.get("package_sha256"),
         "dashboard_sha256": transaction.get("dashboard_sha256"),
     }
-    paths = (manifest_path, package_path, dashboard_path)
-    for path in paths:
-        if path.is_symlink():
-            raise ValueError("staged_artifact_symlink")
-        if not path.exists():
-            # Transactions created before staged readback verification did not retain
-            # a complete artifact set. New transactions always have all three hashes.
-            if all(isinstance(value, str) for value in expected.values()):
-                raise ValueError("staged_artifact_missing")
-            return None, None, None
-        if not path.is_file():
-            raise ValueError("staged_artifact_invalid")
+    paths = _existing_staged_paths(transaction, root, expected)
+    if paths is None:
+        return None, None, None
+    manifest_path, package_path, dashboard_path = paths
     try:
         manifest = json.loads(
             _read_staged_file(manifest_path, MAX_MANIFEST).decode("utf-8")
@@ -751,6 +840,7 @@ def _verify_staged_artifacts(  # noqa: C901 - staged evidence checks are fail-cl
         raise ValueError("staged_manifest_invalid") from exc
     if not isinstance(manifest, dict):
         raise ValueError("staged_manifest_invalid")
+    _verify_signature(hass, manifest, prefix="release-")
     package = _read_staged_file(package_path, MAX_PACKAGE)
     dashboard = _read_staged_file(dashboard_path, MAX_DASHBOARD)
     actual = {
@@ -845,13 +935,59 @@ class AuroraState:
         return True
 
 
-def _ensure_production_baseline(state: AuroraState, config_sha256: str) -> str:
+class _RequestFailure(ValueError):
+    """Carry one stable HTTP status and public adapter error code."""
+
+    def __init__(self, status: int, code: str) -> None:
+        super().__init__(code)
+        self.status = status
+        self.code = code
+
+
+@dataclass
+class _PromotionContext:
+    revision: str
+    transaction: dict[str, Any]
+    transaction_id: str
+    resource: dict[str, Any]
+    preview_config: dict[str, Any]
+    production: Any
+    production_config: dict[str, Any]
+    preview_sha: str
+    production_sha: str
+    expected_revision: str
+    audience: str
+
+
+def _has_prepared_production_transition(state: AuroraState) -> bool:
+    """Return whether production state has an unsettled durable transition."""
+    return any(
+        isinstance(state.journal.get(key), dict)
+        and state.journal[key].get("status") == "prepared"
+        for key in ("production_transition", "rollback_transition")
+    )
+
+
+def _ensure_production_baseline(
+    state: AuroraState,
+    config_sha256: str,
+    *,
+    allow_refresh: bool = False,
+) -> str:
     """Persist a deterministic CAS revision for a fresh installation."""
     current = state.journal.get("production_revision")
     recorded_hash = state.journal.get("production_config_sha256")
     if isinstance(current, str) and current:
         if _is_sha256(recorded_hash) and recorded_hash != config_sha256:
-            raise ValueError("production_config_conflict")
+            if not allow_refresh or _has_prepared_production_transition(state):
+                raise ValueError("production_config_conflict")
+            refreshed = "baseline-" + config_sha256
+            state.journal["production_revision"] = refreshed
+            state.journal["production_config_sha256"] = config_sha256
+            state.journal["previous_production"] = None
+            state.journal["production_baseline_refreshed_at"] = _now().isoformat()
+            state.save()
+            return refreshed
         if recorded_hash != config_sha256:
             state.journal["production_config_sha256"] = config_sha256
             state.save()
@@ -1047,6 +1183,173 @@ def _config_has_exact_dashboard_resource(
         and item.get("res_type") == "module"
         for item in resources
     )
+
+
+def _decode_stage_request(
+    body: dict[str, Any],
+) -> tuple[str, dict[str, Any], bytes, bytes]:
+    """Validate and decode the fixed stage request schema."""
+    required = {
+        "transaction_id",
+        "dashboard_target",
+        "preview_only",
+        "manifest",
+        "artifacts",
+    }
+    if set(body) != required:
+        raise ValueError("stage_request_schema_invalid")
+    if body.get("dashboard_target") != PREVIEW or body.get("preview_only") is not True:
+        raise ValueError("fixed_target_required")
+    transaction_id = body.get("transaction_id")
+    if not isinstance(transaction_id, str) or _SAFE_NONCE.fullmatch(transaction_id) is None:
+        raise ValueError("transaction_id_required")
+    artifacts = body.get("artifacts")
+    if not isinstance(artifacts, dict) or set(artifacts) != {"package", "dashboard"}:
+        raise ValueError("stage_request_schema_invalid")
+    manifest = body.get("manifest")
+    if not isinstance(manifest, dict):
+        raise ValueError("manifest")
+    return (
+        transaction_id,
+        manifest,
+        _decode_b64(artifacts.get("package"), MAX_PACKAGE),
+        _decode_b64(artifacts.get("dashboard"), MAX_DASHBOARD),
+    )
+
+
+def _stage_request_sha256(
+    transaction_id: str,
+    manifest: dict[str, Any],
+    package: bytes,
+    dashboard: bytes,
+) -> str:
+    """Bind stage idempotency to decoded artifact bytes and manifest nonce."""
+    return hashlib.sha256(
+        _json_bytes(
+            {
+                "transaction_id": transaction_id,
+                "dashboard_target": PREVIEW,
+                "preview_only": True,
+                "manifest_sha256": hashlib.sha256(
+                    _canonical_manifest(manifest)
+                ).hexdigest(),
+                "package_sha256": hashlib.sha256(package).hexdigest(),
+                "dashboard_sha256": hashlib.sha256(dashboard).hexdigest(),
+                "nonce": manifest.get("nonce"),
+            }
+        )
+    ).hexdigest()
+
+
+def _stage_response(
+    transaction: dict[str, Any], *, idempotent: bool = False
+) -> web.Response:
+    """Project a staged transaction without exposing paths or signed bytes."""
+    public_keys = (
+        "transaction_id",
+        "revision",
+        "status",
+        "manifest_sha256",
+        "package_sha256",
+        "dashboard_sha256",
+        "target",
+        "created_at",
+        "expires_at",
+    )
+    payload = {key: transaction[key] for key in public_keys}
+    payload.update(
+        {
+            "staged_revision": transaction["revision"],
+            "previous_revision": transaction.get(
+                "preview_revision_before",
+                transaction.get("stage_previous_revision"),
+            ),
+        }
+    )
+    if idempotent:
+        payload["idempotent"] = True
+    return _json_response(payload)
+
+
+def _receipt_schema(receipt: dict[str, Any]) -> int:
+    """Validate the closed receipt keyset and return its schema version."""
+    schema_version = receipt.get("schema_version")
+    expected = {
+        1: VALIDATION_RECEIPT_V1_KEYS,
+        2: VALIDATION_RECEIPT_V2_KEYS,
+    }.get(schema_version)
+    if expected is None or set(receipt) != expected:
+        raise _RequestFailure(422, "validation_receipt_schema_invalid")
+    return schema_version
+
+
+def _validate_receipt_results(receipt: dict[str, Any], schema_version: int) -> None:
+    """Validate physical-device or automated-profile success evidence."""
+    if schema_version == 1:
+        results = receipt.get("device_results")
+        required = {"mobile", "kiosk", "tablet", "laptop", "desktop"}
+        valid = (
+            isinstance(results, list)
+            and len(results) == len(required)
+            and {
+                item.get("device_id") for item in results if isinstance(item, dict)
+            }
+            == required
+            and all(
+                isinstance(item, dict)
+                and set(item) == {"device_id", "passed"}
+                and item.get("passed") is True
+                for item in results
+            )
+        )
+        if not valid:
+            raise _RequestFailure(422, "validation_receipt_devices_invalid")
+        return
+    results = receipt.get("profile_results")
+    valid = isinstance(results, list) and len(results) == len(AUTOMATED_E2E_PROFILES)
+    if valid:
+        valid = all(
+            isinstance(item, dict)
+            and set(item)
+            == {
+                "profile_id",
+                "width",
+                "height",
+                "passed",
+                "screenshot_sha256",
+            }
+            and item.get("profile_id") == profile_id
+            and item.get("width") == width
+            and not isinstance(item.get("width"), bool)
+            and item.get("height") == height
+            and not isinstance(item.get("height"), bool)
+            and item.get("passed") is True
+            and _is_sha256(item.get("screenshot_sha256"))
+            for item, (profile_id, width, height) in zip(
+                results, AUTOMATED_E2E_PROFILES, strict=True
+            )
+        )
+    if not valid:
+        raise _RequestFailure(422, "validation_receipt_profiles_invalid")
+
+
+def _validate_receipt_window(receipt: dict[str, Any], schema_version: int) -> str:
+    """Validate receipt time bounds and return its replay nonce."""
+    issued_at = _parse_time(receipt.get("issued_at"))
+    expires_at = _parse_time(receipt.get("expires_at"))
+    lifetime = MAX_AUTOMATED_E2E_LIFETIME if schema_version == 2 else MAX_LIFETIME
+    now = _now()
+    if (
+        issued_at - CLOCK_SKEW > now
+        or expires_at <= issued_at
+        or expires_at <= now
+        or expires_at - issued_at > lifetime
+    ):
+        raise _RequestFailure(422, "validation_receipt_time_invalid")
+    nonce = receipt.get("nonce")
+    if not isinstance(nonce, str) or _SAFE_NONCE.fullmatch(nonce) is None:
+        raise _RequestFailure(422, "validation_receipt_nonce_invalid")
+    return nonce
 
 
 def _verify_operation_resource_binding(
@@ -1487,7 +1790,7 @@ def _reconcile_stage_transition(
         return
     try:
         package, dashboard, manifest = _verify_staged_artifacts(
-            transaction, state.root
+            transaction, state.root, state.hass
         )
     except ValueError as exc:
         if str(exc) != "staged_artifact_missing":
@@ -1511,29 +1814,31 @@ def _reconcile_stage_transition(
     state.save()
 
 
-async def _reconcile_transaction_transition(  # noqa: C901 - fail-closed recovery
-    hass: HomeAssistant,
-    state: AuroraState,
+def _prepared_preview_transition(
     transaction: dict[str, Any],
-) -> None:
-    """Settle a prepared preview activation or rollback from live config."""
-    _reconcile_stage_transition(state, transaction)
+) -> tuple[str, dict[str, Any]] | None:
+    """Return the sole prepared preview transition, if present."""
     activation = transaction.get("activation_transition")
     rollback = transaction.get("preview_rollback_transition")
     prepared = [
-        ("activate", activation),
-        ("rollback", rollback),
-    ]
-    prepared = [
         (kind, item)
-        for kind, item in prepared
+        for kind, item in (("activate", activation), ("rollback", rollback))
         if isinstance(item, dict) and item.get("status") == "prepared"
     ]
     if not prepared:
-        return
+        return None
     if len(prepared) != 1:
         raise ValueError("preview_transition_invalid")
-    kind, transition = prepared[0]
+    return prepared[0]
+
+
+def _validate_preview_transition(
+    state: AuroraState,
+    transaction: dict[str, Any],
+    kind: str,
+    transition: dict[str, Any],
+) -> None:
+    """Validate common and action-specific durable preview evidence."""
     preview_before = transaction.get("preview_before")
     dashboard_sha = transaction.get("dashboard_sha256")
     expected_asset = (
@@ -1586,6 +1891,20 @@ async def _reconcile_transaction_transition(  # noqa: C901 - fail-closed recover
         )
     ):
         raise ValueError("preview_transition_invalid")
+
+
+async def _reconcile_transaction_transition(
+    hass: HomeAssistant,
+    state: AuroraState,
+    transaction: dict[str, Any],
+) -> None:
+    """Settle a prepared preview activation or rollback from live config."""
+    _reconcile_stage_transition(state, transaction)
+    prepared = _prepared_preview_transition(transaction)
+    if prepared is None:
+        return
+    kind, transition = prepared
+    _validate_preview_transition(state, transaction, kind, transition)
     _preview, current_config = await _load_dashboard(hass, PREVIEW)
     current_sha = _config_sha256(current_config)
     if current_sha == transition["next_config_sha256"]:
@@ -1652,7 +1971,32 @@ class RootView(HomeAssistantView):
         self._hass = hass
         self._state = state
 
-    async def post(  # noqa: C901 - explicit fixed-route dispatcher
+    async def _dispatch(self, operation: str, body: dict[str, Any]) -> web.Response:
+        """Dispatch one fixed root operation after authentication and recovery."""
+        if operation in {"promote-home-command", "rollback-home-command"}:
+            try:
+                await _reconcile_production_transition(self._hass, self._state)
+                await _reconcile_rollback_transition(self._hass, self._state)
+            except ValueError:
+                return _error(409, "production_recovery_required")
+        if operation == "bootstrap":
+            created, target = await _ensure_preview(self._hass)
+            return _json_response(
+                {
+                    "dashboard_target": target,
+                    "created": created,
+                    "production_unchanged": True,
+                }
+            )
+        handlers = {
+            "stage": self._stage,
+            "promote-home-command": self._promote,
+            "rollback-home-command": self._rollback,
+        }
+        handler = handlers.get(operation)
+        return await handler(body) if handler is not None else _error(404, "not_found")
+
+    async def post(
         self, request: web.Request, operation: str
     ) -> web.Response:
         if not await _admin(request):
@@ -1664,140 +2008,80 @@ class RootView(HomeAssistantView):
                 body = await asyncio.wait_for(_body(request), REQUEST_TIMEOUT_SECONDS)
                 if body is None:
                     return _error(400, "invalid_body")
-                if operation in {"promote-home-command", "rollback-home-command"}:
-                    try:
-                        await _reconcile_production_transition(self._hass, self._state)
-                        if operation == "rollback-home-command":
-                            await _reconcile_rollback_transition(
-                                self._hass, self._state
-                            )
-                    except ValueError:
-                        return _error(409, "production_recovery_required")
-                if operation == "bootstrap":
-                    created, target = await _ensure_preview(self._hass)
-                    return _json_response(
-                        {
-                            "dashboard_target": target,
-                            "created": created,
-                            "production_unchanged": True,
-                        }
-                    )
-                if operation == "stage":
-                    return await self._stage(body)
-                if operation == "promote-home-command":
-                    return await self._promote(body)
-                if operation == "rollback-home-command":
-                    return await self._rollback(body)
+                return await self._dispatch(operation, body)
             except ValueError as exc:
                 return _error(422, str(exc))
             except (OSError, RuntimeError):
                 return _error(500, "adapter_failure")
-        return _error(404, "not_found")
 
-    async def _stage(  # noqa: C901 - durable staged-artifact transaction
-        self, body: dict[str, Any]
+    async def _existing_stage(
+        self,
+        existing: Any,
+        request_sha: str,
     ) -> web.Response:
-        if set(body) != {
-            "transaction_id",
-            "dashboard_target",
-            "preview_only",
-            "manifest",
-            "artifacts",
-        }:
+        """Verify and return one exact idempotent stage retry."""
+        if (
+            not isinstance(existing, dict)
+            or existing.get("stage_request_sha256") != request_sha
+        ):
+            return _error(409, "transaction_id_conflict")
+        try:
+            _reconcile_stage_transition(self._state, existing)
+            if existing.get("status") != "aborted":
+                artifacts = _verify_staged_artifacts(
+                    existing, self._state.root, self._hass
+                )
+                if any(item is None for item in artifacts):
+                    raise ValueError("staged_artifact_missing")
+        except (OSError, ValueError):
+            return _error(409, "staged_integrity_failed")
+        return _stage_response(existing, idempotent=True)
+
+    def _write_staged_artifacts(
+        self,
+        transaction: dict[str, Any],
+        manifest: dict[str, Any],
+        package: bytes,
+        dashboard: bytes,
+    ) -> None:
+        """Persist and reverify the immutable bytes for one prepared stage."""
+        revision_dir = self._state.root / "staged" / transaction["revision"]
+        revision_dir.mkdir(parents=True, exist_ok=True)
+        if revision_dir.is_symlink() or not revision_dir.is_dir():
+            raise ValueError("staged_revision_invalid")
+        _save_immutable_asset(revision_dir / "manifest.json", _json_bytes(manifest))
+        _save_immutable_asset(
+            revision_dir / "aurora-preview-package.tar.gz", package
+        )
+        _save_immutable_asset(
+            revision_dir / "aurora-preview-dashboard.js", dashboard
+        )
+        readback = _verify_staged_artifacts(
+            transaction, self._state.root, self._hass
+        )
+        if any(item is None for item in readback):
+            raise ValueError("staged_artifact_missing")
+
+    async def _stage(self, body: dict[str, Any]) -> web.Response:
+        try:
+            transaction_id, manifest, package, dashboard = _decode_stage_request(body)
+        except ValueError as exc:
             transaction_id = body.get("transaction_id")
             if (
                 isinstance(transaction_id, str)
                 and self._state.tx(transaction_id) is not None
             ):
                 return _error(409, "transaction_id_conflict")
-            return _error(422, "stage_request_schema_invalid")
-        if (
-            body.get("dashboard_target") != PREVIEW
-            or body.get("preview_only") is not True
-        ):
-            return _error(422, "fixed_target_required")
-        transaction_id = body.get("transaction_id")
-        if (
-            not isinstance(transaction_id, str)
-            or _SAFE_NONCE.fullmatch(transaction_id) is None
-        ):
-            return _error(422, "transaction_id_required")
+            return _error(422, str(exc))
         if transaction_id in self._state.journal.get("operations", {}):
             return _error(409, "transaction_id_conflict")
-        artifacts = body.get("artifacts")
-        if not isinstance(artifacts, dict) or set(artifacts) != {
-            "package",
-            "dashboard",
-        }:
-            return _error(422, "stage_request_schema_invalid")
-        package = _decode_b64(artifacts.get("package"), MAX_PACKAGE)
-        dashboard = _decode_b64(artifacts.get("dashboard"), MAX_DASHBOARD)
-        manifest = body.get("manifest")
-        if not isinstance(manifest, dict):
-            return _error(422, "manifest")
-        manifest_sha = hashlib.sha256(_canonical_manifest(manifest)).hexdigest()
-        package_sha = hashlib.sha256(package).hexdigest()
-        dashboard_sha = hashlib.sha256(dashboard).hexdigest()
-        nonce = manifest.get("nonce")
-        request_sha = hashlib.sha256(
-            _json_bytes(
-                {
-                    "transaction_id": transaction_id,
-                    "dashboard_target": PREVIEW,
-                    "preview_only": True,
-                    "manifest_sha256": manifest_sha,
-                    "package_sha256": package_sha,
-                    "dashboard_sha256": dashboard_sha,
-                    "nonce": nonce,
-                }
-            )
-        ).hexdigest()
+        request_sha = _stage_request_sha256(
+            transaction_id, manifest, package, dashboard
+        )
         transactions = self._state.journal.setdefault("transactions", {})
-        existing = transactions.get(transaction_id)
         if transaction_id in transactions:
-            if (
-                not isinstance(existing, dict)
-                or existing.get("stage_request_sha256") != request_sha
-            ):
-                return _error(409, "transaction_id_conflict")
-            try:
-                _reconcile_stage_transition(self._state, existing)
-                if existing.get("status") != "aborted":
-                    package_readback, dashboard_readback, manifest_readback = (
-                        _verify_staged_artifacts(existing, self._state.root)
-                    )
-                    if any(
-                        item is None
-                        for item in (
-                            package_readback,
-                            dashboard_readback,
-                            manifest_readback,
-                        )
-                    ):
-                        raise ValueError("staged_artifact_missing")
-            except (OSError, ValueError):
-                return _error(409, "staged_integrity_failed")
-            public_keys = (
-                "transaction_id",
-                "revision",
-                "status",
-                "manifest_sha256",
-                "package_sha256",
-                "dashboard_sha256",
-                "target",
-                "created_at",
-                "expires_at",
-            )
-            return _json_response(
-                {key: existing[key] for key in public_keys}
-                | {
-                    "staged_revision": existing["revision"],
-                    "previous_revision": existing.get(
-                        "preview_revision_before",
-                        existing.get("stage_previous_revision"),
-                    ),
-                    "idempotent": True,
-                }
+            return await self._existing_stage(
+                transactions.get(transaction_id), request_sha
             )
         manifest_sha, package_sha, dashboard_sha = _validate_manifest(
             self._hass, manifest, package, dashboard
@@ -1809,6 +2093,16 @@ class RootView(HomeAssistantView):
         revision = hashlib.sha256(
             (manifest_sha + package_sha + dashboard_sha).encode()
         ).hexdigest()[:32]
+        try:
+            _reserve_staged_capacity(
+                self._state.root,
+                revision,
+                len(_json_bytes(manifest)) + len(package) + len(dashboard),
+            )
+        except ValueError as exc:
+            if str(exc) == "staged_capacity_exceeded":
+                return _error(409, "staged_capacity_exceeded")
+            raise
         prepared_at = _now().isoformat()
         transaction = {
             "transaction_id": transaction_id,
@@ -1836,56 +2130,21 @@ class RootView(HomeAssistantView):
         transactions[transaction_id] = transaction
         used[nonce] = transaction_id
         self._state.save()
-        revision_dir = self._state.root / "staged" / revision
-        revision_dir.mkdir(parents=True, exist_ok=True)
-        if revision_dir.is_symlink() or not revision_dir.is_dir():
-            raise ValueError("staged_revision_invalid")
-        _save_immutable_asset(revision_dir / "manifest.json", _json_bytes(manifest))
-        _save_immutable_asset(
-            revision_dir / "aurora-preview-package.tar.gz", package
-        )
-        _save_immutable_asset(
-            revision_dir / "aurora-preview-dashboard.js", dashboard
-        )
-        package_readback, dashboard_readback, manifest_readback = (
-            _verify_staged_artifacts(transaction, self._state.root)
-        )
-        if any(
-            item is None
-            for item in (package_readback, dashboard_readback, manifest_readback)
-        ):
-            raise ValueError("staged_artifact_missing")
+        self._write_staged_artifacts(transaction, manifest, package, dashboard)
         transaction["status"] = "verified"
         transaction["verified_at"] = _now().isoformat()
         transaction["stage_transition"]["status"] = "committed"
         transaction["stage_transition"]["committed_at"] = transaction["verified_at"]
         self._state.save()
-        public_keys = (
-            "transaction_id",
-            "revision",
-            "status",
-            "manifest_sha256",
-            "package_sha256",
-            "dashboard_sha256",
-            "target",
-            "created_at",
-            "expires_at",
-        )
-        return _json_response(
-            {key: transaction[key] for key in public_keys}
-            | {
-                "staged_revision": revision,
-                "previous_revision": transaction.get("stage_previous_revision"),
-            }
-        )
+        return _stage_response(transaction)
 
-    async def _promote(  # noqa: C901 - explicit fail-closed promotion state machine
+    async def _promotion_context(
         self, body: dict[str, Any]
-    ) -> web.Response:
-        """Durably prepare, CAS-check, apply, and commit one promotion."""
+    ) -> _PromotionContext:
+        """Load and verify the active preview and production CAS context."""
         revision = body.get("preview_revision")
         if not isinstance(revision, str):
-            return _error(422, "preview_revision_required")
+            raise _RequestFailure(422, "preview_revision_required")
         transaction = next(
             (
                 item
@@ -1897,465 +2156,513 @@ class RootView(HomeAssistantView):
             None,
         )
         if transaction is None or self._state.journal.get("active_preview") != revision:
-            return _error(409, "preview_revision_not_active")
+            raise _RequestFailure(409, "preview_revision_not_active")
         transaction_id = transaction.get("transaction_id")
         if not isinstance(transaction_id, str) or not transaction_id:
-            return _error(409, "preview_integrity_failed")
+            raise _RequestFailure(409, "preview_integrity_failed")
         try:
             await _verify_active_transaction(self._hass, transaction, self._state.root)
             resource_context = await asyncio.to_thread(
                 _active_resource_context, self._hass, transaction
             )
         except (OSError, ValueError, RuntimeError):
-            return _error(409, "preview_integrity_failed")
+            raise _RequestFailure(409, "preview_integrity_failed") from None
         _preview, preview_config = await _load_dashboard(self._hass, PREVIEW)
         production, production_config = await _load_dashboard(self._hass, PRODUCTION)
         preview_config_sha = _config_sha256(preview_config)
         production_config_sha = _config_sha256(production_config)
+        inspection_requested = body.get("inspect") is True
+        if inspection_requested and set(body) != {"preview_revision", "inspect"}:
+            raise _RequestFailure(422, "promotion_inspection_schema_invalid")
         expected_production_revision = _ensure_production_baseline(
-            self._state, production_config_sha
+            self._state,
+            production_config_sha,
+            allow_refresh=inspection_requested,
         )
         audience = _deployment_audience(self._state)
-        if body.get("inspect") is True:
-            if set(body) != {"preview_revision", "inspect"}:
-                return _error(422, "promotion_inspection_schema_invalid")
-            return _json_response(
-                {
-                    "preview_revision": revision,
-                    "transaction_id": transaction_id,
-                    "active_preview_transaction_id": transaction_id,
-                    "status": transaction.get("status"),
-                    "active_revision": self._state.journal.get("active_preview"),
-                    "dashboard_target": PREVIEW,
-                    "target_dashboard": PRODUCTION,
-                    "preview_config_sha256": preview_config_sha,
-                    "production_revision": expected_production_revision,
-                    "expected_production_config_sha256": production_config_sha,
-                    "manifest_sha256": transaction.get("manifest_sha256"),
-                    "package_sha256": transaction.get("package_sha256"),
-                    "dashboard_sha256": transaction.get("dashboard_sha256"),
-                    "audience": audience,
-                    "verified": True,
-                    **resource_context,
-                }
-            )
-        if (
-            transaction.get("status") == "promoted"
-            and self._state.journal.get("production_revision") == revision
-            and production_config_sha == preview_config_sha
-            and not isinstance(body.get("receipt"), dict)
-        ):
-            previous = self._state.journal.get("previous_production")
-            return _json_response(
-                {
-                    "promoted": True,
-                    "operation_id": transaction.get("promotion_operation_id"),
-                    "status": "committed",
-                    "active_revision": revision,
-                    "previous_revision": (
-                        previous.get("revision") if isinstance(previous, dict) else None
-                    ),
-                    "preview_config_sha256": preview_config_sha,
-                    "expected_production_config_sha256": production_config_sha,
-                }
-            )
+        return _PromotionContext(
+            revision=revision,
+            transaction=transaction,
+            transaction_id=transaction_id,
+            resource=resource_context,
+            preview_config=preview_config,
+            production=production,
+            production_config=production_config,
+            preview_sha=preview_config_sha,
+            production_sha=production_config_sha,
+            expected_revision=expected_production_revision,
+            audience=audience,
+        )
+
+    def _promotion_inspection(self, context: _PromotionContext) -> web.Response:
+        """Return signed-input evidence for an exact promotion request."""
+        transaction = context.transaction
+        return _json_response(
+            {
+                "preview_revision": context.revision,
+                "transaction_id": context.transaction_id,
+                "active_preview_transaction_id": context.transaction_id,
+                "status": transaction.get("status"),
+                "active_revision": self._state.journal.get("active_preview"),
+                "dashboard_target": PREVIEW,
+                "target_dashboard": PRODUCTION,
+                "preview_config_sha256": context.preview_sha,
+                "production_revision": context.expected_revision,
+                "expected_production_config_sha256": context.production_sha,
+                "manifest_sha256": transaction.get("manifest_sha256"),
+                "package_sha256": transaction.get("package_sha256"),
+                "dashboard_sha256": transaction.get("dashboard_sha256"),
+                "audience": context.audience,
+                "verified": True,
+                **context.resource,
+            }
+        )
+
+    def _validate_promotion_receipt(
+        self, body: dict[str, Any], context: _PromotionContext
+    ) -> tuple[dict[str, Any], str, str, str, str]:
+        """Validate a complete signed receipt and return durable request ids."""
         receipt = body.get("receipt")
         if not isinstance(receipt, dict):
-            return _error(422, "validation_receipt_required")
-        if set(body) != {
+            raise _RequestFailure(422, "validation_receipt_required")
+        required_body = {
             "preview_revision",
             "expected_production_revision",
             "operation_id",
             "receipt",
-        }:
-            claimed_operation_id = body.get("operation_id")
-            if isinstance(claimed_operation_id, str) and claimed_operation_id in (
-                self._state.journal.get("operations", {})
+        }
+        if set(body) != required_body:
+            claimed = body.get("operation_id")
+            if isinstance(claimed, str) and claimed in self._state.journal.get(
+                "operations", {}
             ):
-                return _error(409, "operation_id_conflict")
-            return _error(422, "promotion_request_schema_invalid")
-        schema_version = receipt.get("schema_version")
-        if schema_version == 1:
-            expected_receipt_keys = VALIDATION_RECEIPT_V1_KEYS
-        elif schema_version == 2:
-            expected_receipt_keys = VALIDATION_RECEIPT_V2_KEYS
-        else:
-            return _error(422, "validation_receipt_schema_invalid")
-        if set(receipt) != expected_receipt_keys:
-            return _error(422, "validation_receipt_schema_invalid")
-        if (
-            receipt.get("preview_revision") != revision
-            or receipt.get("dashboard_target") != PREVIEW
-        ):
-            return _error(422, "validation_receipt_invalid")
+                raise _RequestFailure(409, "operation_id_conflict")
+            raise _RequestFailure(422, "promotion_request_schema_invalid")
+        schema_version = _receipt_schema(receipt)
+        if receipt.get("preview_revision") != context.revision:
+            raise _RequestFailure(422, "validation_receipt_invalid")
+        if receipt.get("dashboard_target") != PREVIEW:
+            raise _RequestFailure(422, "validation_receipt_invalid")
+        self._validate_receipt_identity(body, receipt, schema_version, context)
+        _validate_receipt_results(receipt, schema_version)
+        receipt_nonce = _validate_receipt_window(receipt, schema_version)
+        _verify_signature(self._hass, receipt, prefix="validation-")
+        receipt_sha = hashlib.sha256(_canonical_manifest(receipt)).hexdigest()
+        operation_id = self._receipt_operation_id(body, receipt, schema_version)
+        request_sha = hashlib.sha256(
+            _json_bytes({"action": "promote_home_command", "request": body})
+        ).hexdigest()
+        return receipt, operation_id, receipt_nonce, receipt_sha, request_sha
+
+    def _validate_receipt_identity(
+        self,
+        body: dict[str, Any],
+        receipt: dict[str, Any],
+        schema_version: int,
+        context: _PromotionContext,
+    ) -> None:
+        """Bind receipt identity, action, audience, and production revision."""
         if schema_version == 1 and receipt.get("physical_validation") is not True:
-            return _error(422, "validation_receipt_invalid")
+            raise _RequestFailure(422, "validation_receipt_invalid")
         if schema_version == 2 and any(
             (
-                receipt.get("transaction_id") != transaction.get("transaction_id"),
+                receipt.get("transaction_id") != context.transaction_id,
                 not isinstance(receipt.get("operation_id"), str),
                 _SAFE_NONCE.fullmatch(receipt.get("operation_id", "")) is None,
                 body.get("operation_id") != receipt.get("operation_id"),
                 receipt.get("validation_kind") != "automated_e2e",
-                receipt.get("audience") != audience,
+                receipt.get("audience") != context.audience,
                 receipt.get("action") != "promote_home_command",
                 not _is_sha256(receipt.get("e2e_evidence_sha256")),
             )
         ):
-            return _error(422, "validation_receipt_invalid")
-        expected_production_revision = body.get("expected_production_revision")
-        if (
-            not isinstance(expected_production_revision, str)
-            or not expected_production_revision
-        ):
-            return _error(422, "expected_production_revision_required")
-        if receipt.get("expected_production_revision") != expected_production_revision:
-            claimed_operation_id = body.get("operation_id")
-            if isinstance(
-                claimed_operation_id, str
-            ) and claimed_operation_id in self._state.journal.get("operations", {}):
-                return _error(409, "operation_id_conflict")
-            return _error(422, "validation_receipt_revision_mismatch")
-        if schema_version == 1:
-            device_results = receipt.get("device_results")
-            required_devices = {"mobile", "kiosk", "tablet", "laptop", "desktop"}
-            if (
-                not isinstance(device_results, list)
-                or len(device_results) != len(required_devices)
-                or {
-                    item.get("device_id")
-                    for item in device_results
-                    if isinstance(item, dict)
-                }
-                != required_devices
-                or any(
-                    not isinstance(item, dict)
-                    or set(item) != {"device_id", "passed"}
-                    or item.get("passed") is not True
-                    for item in device_results
-                )
+            raise _RequestFailure(422, "validation_receipt_invalid")
+        expected = body.get("expected_production_revision")
+        if not isinstance(expected, str) or not expected:
+            raise _RequestFailure(422, "expected_production_revision_required")
+        if receipt.get("expected_production_revision") != expected:
+            claimed = body.get("operation_id")
+            if isinstance(claimed, str) and claimed in self._state.journal.get(
+                "operations", {}
             ):
-                return _error(422, "validation_receipt_devices_invalid")
-        else:
-            profile_results = receipt.get("profile_results")
-            if (
-                not isinstance(profile_results, list)
-                or len(profile_results) != len(AUTOMATED_E2E_PROFILES)
-                or any(
-                    not isinstance(item, dict)
-                    or set(item)
-                    != {
-                        "profile_id",
-                        "width",
-                        "height",
-                        "passed",
-                        "screenshot_sha256",
-                    }
-                    or item.get("profile_id") != profile_id
-                    or item.get("width") != width
-                    or isinstance(item.get("width"), bool)
-                    or item.get("height") != height
-                    or isinstance(item.get("height"), bool)
-                    or item.get("passed") is not True
-                    or not _is_sha256(item.get("screenshot_sha256"))
-                    for item, (profile_id, width, height) in zip(
-                        profile_results, AUTOMATED_E2E_PROFILES, strict=True
-                    )
-                )
-            ):
-                return _error(422, "validation_receipt_profiles_invalid")
-        issued_at = _parse_time(receipt.get("issued_at"))
-        expires_at = _parse_time(receipt.get("expires_at"))
-        now = _now()
-        if (
-            issued_at - CLOCK_SKEW > now
-            or expires_at <= issued_at
-            or expires_at <= now
-            or expires_at - issued_at
-            > (MAX_AUTOMATED_E2E_LIFETIME if schema_version == 2 else MAX_LIFETIME)
-        ):
-            return _error(422, "validation_receipt_time_invalid")
-        receipt_nonce = receipt.get("nonce")
-        if (
-            not isinstance(receipt_nonce, str)
-            or _SAFE_NONCE.fullmatch(receipt_nonce) is None
-        ):
-            return _error(422, "validation_receipt_nonce_invalid")
-        receipt_sha = hashlib.sha256(_canonical_manifest(receipt)).hexdigest()
-        _verify_signature(self._hass, receipt, prefix="validation-")
+                raise _RequestFailure(409, "operation_id_conflict")
+            raise _RequestFailure(422, "validation_receipt_revision_mismatch")
+
+    @staticmethod
+    def _receipt_operation_id(
+        body: dict[str, Any], receipt: dict[str, Any], schema_version: int
+    ) -> str:
+        """Return the schema-bound operation id after UUID validation."""
         if schema_version == 2:
-            operation_id = receipt["operation_id"]
-        else:
-            requested_operation_id = body.get("operation_id")
-            if not _is_uuid_operation_id(requested_operation_id):
-                return _error(422, "operation_id_uuid_required")
-            operation_id = requested_operation_id
-        request_sha = hashlib.sha256(
-            _json_bytes(
-                {
-                    "action": "promote_home_command",
-                    "request": body,
-                }
-            )
-        ).hexdigest()
+            return receipt["operation_id"]
+        operation_id = body.get("operation_id")
+        if not _is_uuid_operation_id(operation_id):
+            raise _RequestFailure(422, "operation_id_uuid_required")
+        return operation_id
+
+    async def _existing_promotion_response(
+        self,
+        context: _PromotionContext,
+        receipt: dict[str, Any],
+        operation_id: str,
+        receipt_sha: str,
+        request_sha: str,
+    ) -> web.Response | None:
+        """Return one exact committed or aborted promotion retry."""
         operations = self._state.journal.setdefault("operations", {})
-        existing_operation = operations.get(operation_id)
-        if operation_id in operations or self._state.tx(operation_id) is not None:
-            if (
-                not isinstance(existing_operation, dict)
-                or existing_operation.get("operation_id") != operation_id
-                or existing_operation.get("action") != "promote_home_command"
-                or existing_operation.get("request_sha256") != request_sha
-                or existing_operation.get("receipt_sha256") != receipt_sha
-                or existing_operation.get("transaction_id")
-                != transaction.get("transaction_id")
-                or existing_operation.get("preview_revision") != revision
-                or existing_operation.get("expected_production_revision")
-                != expected_production_revision
-                or existing_operation.get("expected_production_config_sha256")
-                != receipt.get("expected_production_config_sha256")
-            ):
-                return _error(409, "operation_id_conflict")
-            status = existing_operation.get("status")
-            if status == "committed":
-                if (
-                    self._state.journal.get("production_revision") != revision
-                    or production_config_sha
-                    != existing_operation.get("production_config_sha256")
-                    or production_config_sha != preview_config_sha
-                ):
-                    return _error(409, "operation_readback_mismatch")
-                try:
-                    resource_binding = await asyncio.to_thread(
-                        _verify_operation_resource_binding,
-                        self._hass,
-                        self._state,
-                        existing_operation,
-                        production_config,
-                    )
-                except (OSError, ValueError, RuntimeError):
-                    return _error(409, "operation_readback_mismatch")
-                return _json_response(
-                    {
-                        "promoted": True,
-                        "operation_id": operation_id,
-                        "status": "committed",
-                        "active_revision": revision,
-                        "previous_revision": existing_operation.get(
-                            "previous_production_revision"
-                        ),
-                        "preview_config_sha256": preview_config_sha,
-                        "expected_production_config_sha256": receipt.get(
-                            "expected_production_config_sha256"
-                        ),
-                        "applied": True,
-                        "verified": True,
-                        "dashboard_resource_present": True,
-                        "idempotent": True,
-                        **resource_binding,
-                    }
-                )
-            if status == "aborted":
-                if (
-                    self._state.journal.get("production_revision")
-                    != expected_production_revision
-                    or production_config_sha
-                    != receipt.get("expected_production_config_sha256")
-                ):
-                    return _error(409, "operation_readback_mismatch")
-                try:
-                    resource_binding = await asyncio.to_thread(
-                        _verify_recorded_resource_binding,
-                        self._hass,
-                        production_config,
-                        existing_operation,
-                        prefix="expected_",
-                    )
-                except (OSError, ValueError, RuntimeError):
-                    return _error(409, "operation_readback_mismatch")
-                return _json_response(
-                    {
-                        "promoted": False,
-                        "operation_id": operation_id,
-                        "status": "aborted",
-                        "active_revision": expected_production_revision,
-                        "expected_production_config_sha256": production_config_sha,
-                        "applied": False,
-                        "verified": True,
-                        "dashboard_resource_present": bool(resource_binding),
-                        "idempotent": True,
-                        **resource_binding,
-                    }
-                )
-            return _error(409, "operation_transition_in_progress")
-        used_receipts = self._state.journal.setdefault("receipt_nonces", {})
-        if receipt_nonce in used_receipts:
-            return _error(409, "validation_receipt_replay")
-        if any(
-            receipt.get(key) != transaction.get(key)
-            for key in ("manifest_sha256", "package_sha256", "dashboard_sha256")
-        ):
-            return _error(422, "validation_receipt_hash_mismatch")
-        expected_revision = self._state.journal.get("production_revision")
-        if expected_production_revision != expected_revision:
-            return _error(409, "production_revision_conflict")
+        existing = operations.get(operation_id)
+        if operation_id not in operations and self._state.tx(operation_id) is None:
+            return None
+        valid = (
+            isinstance(existing, dict)
+            and existing.get("operation_id") == operation_id
+            and existing.get("action") == "promote_home_command"
+            and existing.get("request_sha256") == request_sha
+            and existing.get("receipt_sha256") == receipt_sha
+            and existing.get("transaction_id") == context.transaction_id
+            and existing.get("preview_revision") == context.revision
+            and existing.get("expected_production_revision")
+            == receipt.get("expected_production_revision")
+            and existing.get("expected_production_config_sha256")
+            == receipt.get("expected_production_config_sha256")
+        )
+        if not valid:
+            return _error(409, "operation_id_conflict")
+        if existing.get("status") == "committed":
+            return await self._committed_promotion_retry(context, receipt, existing)
+        if existing.get("status") == "aborted":
+            return await self._aborted_promotion_retry(context, existing)
+        return _error(409, "operation_transition_in_progress")
+
+    async def _committed_promotion_retry(
+        self,
+        context: _PromotionContext,
+        receipt: dict[str, Any],
+        operation: dict[str, Any],
+    ) -> web.Response:
+        """Verify and project an already committed promotion."""
         if (
-            not _is_sha256(receipt.get("preview_config_sha256"))
-            or receipt.get("preview_config_sha256") != preview_config_sha
+            self._state.journal.get("production_revision") != context.revision
+            or context.production_sha != operation.get("production_config_sha256")
+            or context.production_sha != context.preview_sha
         ):
-            return _error(422, "validation_receipt_preview_config_mismatch")
-        if (
-            not _is_sha256(receipt.get("expected_production_config_sha256"))
-            or receipt.get("expected_production_config_sha256") != production_config_sha
-        ):
-            return _error(409, "production_config_conflict")
+            return _error(409, "operation_readback_mismatch")
         try:
-            expected_resource_binding = await asyncio.to_thread(
-                _dashboard_resource_binding_from_config,
+            binding = await asyncio.to_thread(
+                _verify_operation_resource_binding,
                 self._hass,
-                production_config,
+                self._state,
+                operation,
+                context.production_config,
             )
         except (OSError, ValueError, RuntimeError):
-            return _error(409, "production_config_integrity_failed")
-        expected_resource_record = {
-            "expected_" + key: value
-            for key, value in expected_resource_binding.items()
-        }
-        transition = self._state.journal.get("production_transition")
-        if isinstance(transition, dict) and transition.get("status") == "prepared":
-            return _error(409, "production_transition_in_progress")
+            return _error(409, "operation_readback_mismatch")
+        return _json_response(
+            {
+                "promoted": True,
+                "operation_id": operation["operation_id"],
+                "status": "committed",
+                "active_revision": context.revision,
+                "previous_revision": operation.get("previous_production_revision"),
+                "preview_config_sha256": context.preview_sha,
+                "expected_production_config_sha256": receipt.get(
+                    "expected_production_config_sha256"
+                ),
+                "applied": True,
+                "verified": True,
+                "dashboard_resource_present": True,
+                "idempotent": True,
+                **binding,
+            }
+        )
+
+    async def _aborted_promotion_retry(
+        self, context: _PromotionContext, operation: dict[str, Any]
+    ) -> web.Response:
+        """Verify and project an already aborted promotion."""
+        if (
+            self._state.journal.get("production_revision")
+            != context.expected_revision
+            or context.production_sha
+            != operation.get("expected_production_config_sha256")
+        ):
+            return _error(409, "operation_readback_mismatch")
+        try:
+            binding = await asyncio.to_thread(
+                _verify_recorded_resource_binding,
+                self._hass,
+                context.production_config,
+                operation,
+                prefix="expected_",
+            )
+        except (OSError, ValueError, RuntimeError):
+            return _error(409, "operation_readback_mismatch")
+        return _json_response(
+            {
+                "promoted": False,
+                "operation_id": operation["operation_id"],
+                "status": "aborted",
+                "active_revision": context.expected_revision,
+                "expected_production_config_sha256": context.production_sha,
+                "applied": False,
+                "verified": True,
+                "dashboard_resource_present": bool(binding),
+                "idempotent": True,
+                **binding,
+            }
+        )
+
+    async def _validate_new_promotion(
+        self,
+        context: _PromotionContext,
+        receipt: dict[str, Any],
+        receipt_nonce: str,
+    ) -> dict[str, Any]:
+        """Validate replay, artifact, CAS, and live resource preconditions."""
+        if receipt_nonce in self._state.journal.setdefault("receipt_nonces", {}):
+            raise _RequestFailure(409, "validation_receipt_replay")
+        self._validate_promotion_hashes(context, receipt)
+        try:
+            binding = await asyncio.to_thread(
+                _dashboard_resource_binding_from_config,
+                self._hass,
+                context.production_config,
+            )
+        except (OSError, ValueError, RuntimeError):
+            raise _RequestFailure(409, "production_config_integrity_failed") from None
+        if _has_prepared_production_transition(self._state):
+            raise _RequestFailure(409, "production_transition_in_progress")
+        return {"expected_" + key: value for key, value in binding.items()}
+
+    def _validate_promotion_hashes(
+        self, context: _PromotionContext, receipt: dict[str, Any]
+    ) -> None:
+        """Bind signed artifact and config hashes to current CAS state."""
+        if any(
+            receipt.get(key) != context.transaction.get(key)
+            for key in ("manifest_sha256", "package_sha256", "dashboard_sha256")
+        ):
+            raise _RequestFailure(422, "validation_receipt_hash_mismatch")
+        if receipt.get("expected_production_revision") != context.expected_revision:
+            raise _RequestFailure(409, "production_revision_conflict")
+        if context.expected_revision != self._state.journal.get("production_revision"):
+            raise _RequestFailure(409, "production_revision_conflict")
+        if receipt.get("preview_config_sha256") != context.preview_sha:
+            raise _RequestFailure(422, "validation_receipt_preview_config_mismatch")
+        if not _is_sha256(receipt.get("preview_config_sha256")):
+            raise _RequestFailure(422, "validation_receipt_preview_config_mismatch")
+        if receipt.get("expected_production_config_sha256") != context.production_sha:
+            raise _RequestFailure(409, "production_config_conflict")
+        if not _is_sha256(receipt.get("expected_production_config_sha256")):
+            raise _RequestFailure(409, "production_config_conflict")
+
+    def _prepare_promotion(
+        self,
+        context: _PromotionContext,
+        operation_id: str,
+        receipt_nonce: str,
+        receipt_sha: str,
+        request_sha: str,
+        expected_resource: dict[str, Any],
+    ) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any]]:
+        """Durably prepare one promotion before touching production config."""
         previous = {
-            "revision": expected_revision,
-            "config": json.loads(_json_bytes(production_config)),
-            "config_sha256": production_config_sha,
+            "revision": context.expected_revision,
+            "config": json.loads(_json_bytes(context.production_config)),
+            "config_sha256": context.production_sha,
         }
-        next_config = json.loads(_json_bytes(preview_config))
         prepared_at = _now().isoformat()
-        operation_record = {
+        common = {
+            "dashboard_resource_url": context.resource["preview_resource_url"],
+            "dashboard_sha256": context.resource["preview_resource_sha256"],
+            "dashboard_size": context.resource["preview_resource_size"],
+            **expected_resource,
+        }
+        operation = {
             "operation_id": operation_id,
             "action": "promote_home_command",
             "status": "prepared",
-            "transaction_id": transaction["transaction_id"],
-            "preview_revision": revision,
-            "target_revision": revision,
-            "expected_production_revision": expected_revision,
-            "expected_production_config_sha256": production_config_sha,
-            "preview_config_sha256": preview_config_sha,
-            "previous_production_revision": expected_revision,
+            "transaction_id": context.transaction_id,
+            "preview_revision": context.revision,
+            "target_revision": context.revision,
+            "expected_production_revision": context.expected_revision,
+            "expected_production_config_sha256": context.production_sha,
+            "preview_config_sha256": context.preview_sha,
+            "previous_production_revision": context.expected_revision,
             "receipt_sha256": receipt_sha,
             "request_sha256": request_sha,
-            "dashboard_resource_url": resource_context["preview_resource_url"],
-            "dashboard_sha256": resource_context["preview_resource_sha256"],
-            "dashboard_size": resource_context["preview_resource_size"],
-            **expected_resource_record,
+            **common,
             "created_at": prepared_at,
         }
         transition = {
             "transition_id": "promotion-" + secrets.token_hex(16),
             "operation_id": operation_id,
             "status": "prepared",
-            "expected_revision": expected_revision,
-            "expected_config_sha256": production_config_sha,
-            "to_revision": revision,
-            "transaction_id": transaction["transaction_id"],
+            "expected_revision": context.expected_revision,
+            "expected_config_sha256": context.production_sha,
+            "to_revision": context.revision,
+            "transaction_id": context.transaction_id,
             "receipt_nonce": receipt_nonce,
             "receipt_sha256": receipt_sha,
             "request_sha256": request_sha,
             "previous": previous,
-            "next_config": next_config,
-            "next_config_sha256": preview_config_sha,
-            "dashboard_resource_url": resource_context["preview_resource_url"],
-            "dashboard_sha256": resource_context["preview_resource_sha256"],
-            "dashboard_size": resource_context["preview_resource_size"],
-            **expected_resource_record,
+            "next_config": json.loads(_json_bytes(context.preview_config)),
+            "next_config_sha256": context.preview_sha,
+            **common,
             "prepared_at": prepared_at,
         }
+        operations = self._state.journal.setdefault("operations", {})
         if operation_id in operations or self._state.tx(operation_id) is not None:
-            return _error(409, "operation_id_conflict")
-        operations[operation_id] = operation_record
-        used_receipts[receipt_nonce] = transaction["transaction_id"]
+            raise _RequestFailure(409, "operation_id_conflict")
+        operations[operation_id] = operation
+        self._state.journal.setdefault("receipt_nonces", {})[receipt_nonce] = (
+            context.transaction_id
+        )
         self._state.journal["production_transition"] = transition
         self._state.save()
+        return previous, operation, transition
+
+    async def _apply_promotion(
+        self,
+        context: _PromotionContext,
+        previous: dict[str, Any],
+        operation: dict[str, Any],
+        transition: dict[str, Any],
+    ) -> web.Response:
+        """CAS-check, write, read back, and commit one prepared promotion."""
         if (
-            self._state.journal.get("production_revision") != expected_revision
+            self._state.journal.get("production_revision") != context.expected_revision
             or self._state.journal.get("production_transition") is not transition
         ):
             return _error(409, "production_revision_conflict")
-        _preview_check, preview_check = await _load_dashboard(self._hass, PREVIEW)
-        _production_check, production_check = await _load_dashboard(
-            self._hass, PRODUCTION
-        )
-        if _config_sha256(preview_check) != preview_config_sha:
+        _preview, preview = await _load_dashboard(self._hass, PREVIEW)
+        _production, production = await _load_dashboard(self._hass, PRODUCTION)
+        if _config_sha256(preview) != context.preview_sha:
             return _error(409, "preview_config_conflict")
-        if _config_sha256(production_check) != production_config_sha:
+        if _config_sha256(production) != context.production_sha:
             return _error(409, "production_config_conflict")
-        await production.async_save(next_config)
-        _production_readback, production_readback = await _load_dashboard(
-            self._hass, PRODUCTION
-        )
-        if _config_sha256(production_readback) != preview_config_sha:
+        await context.production.async_save(transition["next_config"])
+        _dashboard, readback = await _load_dashboard(self._hass, PRODUCTION)
+        if _config_sha256(readback) != context.preview_sha:
             return _error(409, "production_readback_failed")
         try:
             await asyncio.to_thread(
                 _verify_operation_resource_binding,
                 self._hass,
                 self._state,
-                operation_record,
-                production_readback,
+                operation,
+                readback,
             )
         except (OSError, ValueError, RuntimeError):
             return _error(409, "production_readback_failed")
+        return self._commit_promotion(context, previous, operation, transition)
+
+    def _commit_promotion(
+        self,
+        context: _PromotionContext,
+        previous: dict[str, Any],
+        operation: dict[str, Any],
+        transition: dict[str, Any],
+    ) -> web.Response:
+        """Commit journal pointers after exact production readback."""
         if (
-            self._state.journal.get("production_revision") != expected_revision
+            self._state.journal.get("production_revision") != context.expected_revision
             or self._state.journal.get("production_transition") is not transition
         ):
             return _error(409, "production_revision_conflict")
         self._state.journal["previous_production"] = previous
-        self._state.journal["production_revision"] = revision
-        self._state.journal["production_config_sha256"] = preview_config_sha
-        transaction["status"] = "promoted"
-        transaction["promoted_at"] = _now().isoformat()
-        transaction["promotion_operation_id"] = operation_id
-        transition["status"] = "committed"
-        transition["committed_at"] = transaction["promoted_at"]
-        operation_record["status"] = "committed"
-        operation_record["production_config_sha256"] = preview_config_sha
-        operation_record["completed_at"] = transaction["promoted_at"]
+        self._state.journal["production_revision"] = context.revision
+        self._state.journal["production_config_sha256"] = context.preview_sha
+        promoted_at = _now().isoformat()
+        context.transaction.update(
+            {
+                "status": "promoted",
+                "promoted_at": promoted_at,
+                "promotion_operation_id": operation["operation_id"],
+            }
+        )
+        transition.update({"status": "committed", "committed_at": promoted_at})
+        operation.update(
+            {
+                "status": "committed",
+                "production_config_sha256": context.preview_sha,
+                "completed_at": promoted_at,
+            }
+        )
         self._state.save()
         return _json_response(
             {
                 "promoted": True,
-                "operation_id": operation_id,
+                "operation_id": operation["operation_id"],
                 "status": "committed",
-                "active_revision": revision,
+                "active_revision": context.revision,
                 "previous_revision": previous.get("revision"),
-                "preview_config_sha256": preview_config_sha,
-                "expected_production_config_sha256": production_config_sha,
-                "dashboard_resource_url": operation_record[
-                    "dashboard_resource_url"
-                ],
-                "dashboard_sha256": operation_record["dashboard_sha256"],
-                "dashboard_size": operation_record["dashboard_size"],
+                "preview_config_sha256": context.preview_sha,
+                "expected_production_config_sha256": context.production_sha,
+                "dashboard_resource_url": operation["dashboard_resource_url"],
+                "dashboard_sha256": operation["dashboard_sha256"],
+                "dashboard_size": operation["dashboard_size"],
                 "applied": True,
                 "verified": True,
                 "dashboard_resource_present": True,
             }
         )
 
-    async def _rollback(  # noqa: C901 - explicit rollback CAS state machine
+    async def _promote(
         self, body: dict[str, Any]
     ) -> web.Response:
+        """Durably prepare, CAS-check, apply, and commit one promotion."""
+        try:
+            context = await self._promotion_context(body)
+        except _RequestFailure as exc:
+            return _error(exc.status, exc.code)
+        if body.get("inspect") is True:
+            return self._promotion_inspection(context)
+        try:
+            receipt, operation_id, receipt_nonce, receipt_sha, request_sha = (
+                self._validate_promotion_receipt(body, context)
+            )
+        except _RequestFailure as exc:
+            return _error(exc.status, exc.code)
+        existing_response = await self._existing_promotion_response(
+            context, receipt, operation_id, receipt_sha, request_sha
+        )
+        if existing_response is not None:
+            return existing_response
+        try:
+            expected_resource = await self._validate_new_promotion(
+                context, receipt, receipt_nonce
+            )
+            previous, operation, transition = self._prepare_promotion(
+                context,
+                operation_id,
+                receipt_nonce,
+                receipt_sha,
+                request_sha,
+                expected_resource,
+            )
+        except _RequestFailure as exc:
+            return _error(exc.status, exc.code)
+        return await self._apply_promotion(
+            context, previous, operation, transition
+        )
+
+    def _decode_rollback_request(
+        self, body: dict[str, Any]
+    ) -> tuple[str, str, str, str]:
+        """Validate rollback CAS inputs and return their request digest."""
         operation_id = body.get("operation_id")
-        if set(body) != {
+        required = {
             "operation_id",
             "expected_current_revision",
             "expected_current_config_sha256",
-        }:
+        }
+        if set(body) != required:
             if isinstance(operation_id, str) and operation_id in (
                 self._state.journal.get("operations", {})
             ):
-                return _error(409, "operation_id_conflict")
-            return _error(422, "rollback_request_schema_invalid")
+                raise _RequestFailure(409, "operation_id_conflict")
+            raise _RequestFailure(422, "rollback_request_schema_invalid")
         expected_current_revision = body.get("expected_current_revision")
         expected_current_config_sha = body.get("expected_current_config_sha256")
         if (
@@ -2364,92 +2671,83 @@ class RootView(HomeAssistantView):
             or not isinstance(expected_current_revision, str)
             or not _is_sha256(expected_current_config_sha)
         ):
-            return _error(422, "rollback_cas_required")
+            raise _RequestFailure(422, "rollback_cas_required")
         request_sha = hashlib.sha256(
             _json_bytes({"action": "rollback_home_command", "request": body})
         ).hexdigest()
+        return (
+            operation_id,
+            expected_current_revision,
+            expected_current_config_sha,
+            request_sha,
+        )
+
+    async def _existing_rollback_response(
+        self, operation_id: str, request_sha: str
+    ) -> web.Response | None:
+        """Verify and project one exact completed rollback retry."""
         operations = self._state.journal.setdefault("operations", {})
-        if operation_id in operations or self._state.tx(operation_id) is not None:
-            if operation_id not in operations:
-                return _error(409, "operation_id_conflict")
-            existing = operations[operation_id]
-            if (
-                isinstance(existing, dict)
-                and existing.get("action") == "rollback_home_command"
-                and existing.get("request_sha256") == request_sha
-                and existing.get("status") == "committed"
-            ):
-                _production, current = await _load_dashboard(self._hass, PRODUCTION)
-                current_sha = _config_sha256(current)
-                if self._state.journal.get("production_revision") != existing.get(
-                    "target_revision"
-                ) or current_sha != existing.get("production_config_sha256"):
-                    return _error(409, "operation_readback_mismatch")
-                try:
-                    resource_binding = await asyncio.to_thread(
-                        _verify_recorded_resource_binding,
-                        self._hass,
-                        current,
-                        existing,
-                    )
-                except (OSError, ValueError, RuntimeError):
-                    return _error(409, "operation_readback_mismatch")
-                return _json_response(
-                    {
-                        "rolled_back": True,
-                        "operation_id": operation_id,
-                        "status": "committed",
-                        "active_revision": existing.get("target_revision"),
-                        "production_config_sha256": current_sha,
-                        "applied": True,
-                        "verified": True,
-                        "dashboard_resource_present": bool(resource_binding),
-                        "idempotent": True,
-                        **resource_binding,
-                    }
-                )
-            if (
-                isinstance(existing, dict)
-                and existing.get("action") == "rollback_home_command"
-                and existing.get("request_sha256") == request_sha
-                and existing.get("status") == "aborted"
-            ):
-                _production, current = await _load_dashboard(self._hass, PRODUCTION)
-                current_sha = _config_sha256(current)
-                if (
-                    self._state.journal.get("production_revision")
-                    != existing.get("expected_production_revision")
-                    or current_sha
-                    != existing.get("expected_production_config_sha256")
-                ):
-                    return _error(409, "operation_readback_mismatch")
-                try:
-                    resource_binding = await asyncio.to_thread(
-                        _verify_recorded_resource_binding,
-                        self._hass,
-                        current,
-                        existing,
-                        prefix="expected_",
-                    )
-                except (OSError, ValueError, RuntimeError):
-                    return _error(409, "operation_readback_mismatch")
-                return _json_response(
-                    {
-                        "rolled_back": False,
-                        "operation_id": operation_id,
-                        "status": "aborted",
-                        "active_revision": existing.get(
-                            "expected_production_revision"
-                        ),
-                        "production_config_sha256": current_sha,
-                        "applied": False,
-                        "verified": True,
-                        "dashboard_resource_present": bool(resource_binding),
-                        "idempotent": True,
-                        **resource_binding,
-                    }
-                )
+        if operation_id not in operations and self._state.tx(operation_id) is None:
+            return None
+        existing = operations.get(operation_id)
+        if (
+            not isinstance(existing, dict)
+            or existing.get("action") != "rollback_home_command"
+            or existing.get("request_sha256") != request_sha
+        ):
             return _error(409, "operation_id_conflict")
+        if existing.get("status") not in {"committed", "aborted"}:
+            return _error(409, "operation_id_conflict")
+        return await self._rollback_retry_response(existing)
+
+    async def _rollback_retry_response(
+        self, operation: dict[str, Any]
+    ) -> web.Response:
+        """Rehash live production for one committed or aborted rollback."""
+        _production, current = await _load_dashboard(self._hass, PRODUCTION)
+        current_sha = _config_sha256(current)
+        committed = operation.get("status") == "committed"
+        revision_key = "target_revision" if committed else "expected_production_revision"
+        sha_key = "production_config_sha256" if committed else "expected_production_config_sha256"
+        prefix = "" if committed else "expected_"
+        if (
+            self._state.journal.get("production_revision") != operation.get(revision_key)
+            or current_sha != operation.get(sha_key)
+        ):
+            return _error(409, "operation_readback_mismatch")
+        try:
+            binding = await asyncio.to_thread(
+                _verify_recorded_resource_binding,
+                self._hass,
+                current,
+                operation,
+                prefix=prefix,
+            )
+        except (OSError, ValueError, RuntimeError):
+            return _error(409, "operation_readback_mismatch")
+        return _json_response(
+            {
+                "rolled_back": committed,
+                "operation_id": operation["operation_id"],
+                "status": operation["status"],
+                "active_revision": operation.get(revision_key),
+                "production_config_sha256": current_sha,
+                "applied": committed,
+                "verified": True,
+                "dashboard_resource_present": bool(binding),
+                "idempotent": True,
+                **binding,
+            }
+        )
+
+    async def _prepare_rollback(
+        self,
+        operation_id: str,
+        expected_revision: str,
+        expected_sha: str,
+        request_sha: str,
+    ) -> tuple[Any, dict[str, Any], dict[str, Any], dict[str, Any], dict[str, Any]]:
+        """Validate evidence and durably prepare one rollback transition."""
         previous = self._state.journal.get("previous_production")
         if (
             not isinstance(previous, dict)
@@ -2458,19 +2756,17 @@ class RootView(HomeAssistantView):
             or not _is_sha256(previous.get("config_sha256"))
             or not _is_sha256(self._state.journal.get("production_config_sha256"))
         ):
-            return _error(409, "no_prior_production_revision")
+            raise _RequestFailure(409, "no_prior_production_revision")
         active = self._state.journal.get("production_revision")
-        if expected_current_revision != active:
-            return _error(409, "production_revision_conflict")
-        if expected_current_config_sha != self._state.journal.get(
-            "production_config_sha256"
-        ):
-            return _error(409, "production_config_conflict")
+        if expected_revision != active:
+            raise _RequestFailure(409, "production_revision_conflict")
+        if expected_sha != self._state.journal.get("production_config_sha256"):
+            raise _RequestFailure(409, "production_config_conflict")
         production, current = await _load_dashboard(self._hass, PRODUCTION)
-        if _config_sha256(current) != expected_current_config_sha:
-            return _error(409, "production_config_conflict")
+        if _config_sha256(current) != expected_sha:
+            raise _RequestFailure(409, "production_config_conflict")
         if _config_sha256(previous["config"]) != previous["config_sha256"]:
-            return _error(409, "production_rollback_evidence_invalid")
+            raise _RequestFailure(409, "production_rollback_evidence_invalid")
         try:
             expected_resource_binding = await asyncio.to_thread(
                 _dashboard_resource_binding_from_config, self._hass, current
@@ -2481,7 +2777,7 @@ class RootView(HomeAssistantView):
                 previous["config"],
             )
         except (OSError, ValueError, RuntimeError):
-            return _error(409, "production_rollback_evidence_invalid")
+            raise _RequestFailure(409, "production_rollback_evidence_invalid") from None
         expected_resource_record = {
             "expected_" + key: value
             for key, value in expected_resource_binding.items()
@@ -2492,7 +2788,7 @@ class RootView(HomeAssistantView):
             "action": "rollback_home_command",
             "status": "prepared",
             "expected_production_revision": active,
-            "expected_production_config_sha256": expected_current_config_sha,
+            "expected_production_config_sha256": expected_sha,
             "target_revision": previous["revision"],
             "request_sha256": request_sha,
             **target_resource_binding,
@@ -2504,7 +2800,7 @@ class RootView(HomeAssistantView):
             "status": "prepared",
             "from_revision": active,
             "to_revision": previous["revision"],
-            "expected_config_sha256": expected_current_config_sha,
+            "expected_config_sha256": expected_sha,
             "next_config": json.loads(_json_bytes(previous["config"])),
             "next_config_sha256": previous["config_sha256"],
             "request_sha256": request_sha,
@@ -2512,13 +2808,27 @@ class RootView(HomeAssistantView):
             **expected_resource_record,
             "prepared_at": prepared_at,
         }
+        operations = self._state.journal.setdefault("operations", {})
         operations[operation_id] = operation_record
         self._state.journal["rollback_transition"] = transition
         self._state.save()
+        return production, previous, operation_record, transition, target_resource_binding
+
+    async def _apply_rollback(
+        self,
+        production: Any,
+        previous: dict[str, Any],
+        operation: dict[str, Any],
+        transition: dict[str, Any],
+        target_binding: dict[str, Any],
+    ) -> web.Response:
+        """CAS-check, apply, read back, and commit one prepared rollback."""
+        active = transition["from_revision"]
+        expected_sha = transition["expected_config_sha256"]
         if (
             self._state.journal.get("production_revision") != active
             or self._state.journal.get("production_config_sha256")
-            != expected_current_config_sha
+            != expected_sha
             or self._state.journal.get("rollback_transition") is not transition
         ):
             return _error(409, "production_revision_conflict")
@@ -2531,30 +2841,47 @@ class RootView(HomeAssistantView):
                 _verify_recorded_resource_binding,
                 self._hass,
                 readback,
-                operation_record,
+                operation,
             )
         except (OSError, ValueError, RuntimeError):
             return _error(409, "production_rollback_readback_failed")
         if (
             self._state.journal.get("production_revision") != active
             or self._state.journal.get("production_config_sha256")
-            != expected_current_config_sha
+            != expected_sha
         ):
             return _error(409, "production_revision_conflict")
-        _commit_rollback_transition(self._state, transition, operation_record)
+        _commit_rollback_transition(self._state, transition, operation)
         return _json_response(
             {
                 "rolled_back": True,
-                "operation_id": operation_id,
+                "operation_id": operation["operation_id"],
                 "status": "committed",
                 "active_revision": previous["revision"],
                 "production_config_sha256": previous["config_sha256"],
                 "applied": True,
                 "verified": True,
-                "dashboard_resource_present": bool(target_resource_binding),
-                **target_resource_binding,
+                "dashboard_resource_present": bool(target_binding),
+                **target_binding,
             }
         )
+
+    async def _rollback(self, body: dict[str, Any]) -> web.Response:
+        try:
+            operation_id, expected_revision, expected_sha, request_sha = (
+                self._decode_rollback_request(body)
+            )
+            existing = await self._existing_rollback_response(
+                operation_id, request_sha
+            )
+            if existing is not None:
+                return existing
+            prepared = await self._prepare_rollback(
+                operation_id, expected_revision, expected_sha, request_sha
+            )
+        except _RequestFailure as exc:
+            return _error(exc.status, exc.code)
+        return await self._apply_rollback(*prepared)
 
 
 class TransactionView(HomeAssistantView):
@@ -2568,7 +2895,121 @@ class TransactionView(HomeAssistantView):
         self._hass = hass
         self._state = state
 
-    async def get(  # noqa: C901 - transaction and operation readback dispatcher
+    @staticmethod
+    def _operation_payload(operation: dict[str, Any]) -> dict[str, Any]:
+        """Project public operation fields."""
+        keys = (
+            "operation_id", "action", "status", "transaction_id",
+            "preview_revision", "target_revision", "expected_production_revision",
+            "expected_production_config_sha256", "preview_config_sha256",
+            "production_config_sha256", "created_at", "completed_at",
+        )
+        payload = {key: operation[key] for key in keys if operation.get(key) is not None}
+        if operation.get("action") == "rollback_home_command":
+            payload.update(
+                {
+                    "expected_current_revision": operation.get(
+                        "expected_production_revision"
+                    ),
+                    "expected_current_config_sha256": operation.get(
+                        "expected_production_config_sha256"
+                    ),
+                }
+            )
+        return payload
+
+    async def _operation_binding(
+        self,
+        operation: dict[str, Any],
+        config: dict[str, Any],
+        applied: bool,
+    ) -> dict[str, Any]:
+        """Verify the action-specific production dashboard resource binding."""
+        action = operation.get("action")
+        if applied and action == "promote_home_command":
+            return await asyncio.to_thread(
+                _verify_operation_resource_binding,
+                self._hass,
+                self._state,
+                operation,
+                config,
+            )
+        if action == "promote_home_command":
+            prefix = "expected_"
+        elif action == "rollback_home_command":
+            prefix = "" if applied else "expected_"
+        else:
+            return {}
+        return await asyncio.to_thread(
+            _verify_recorded_resource_binding,
+            self._hass,
+            config,
+            operation,
+            prefix=prefix,
+        )
+
+    async def _operation_readback(
+        self, operation: dict[str, Any], payload: dict[str, Any]
+    ) -> web.Response:
+        """Verify live production against one terminal operation."""
+        try:
+            _production, config = await _load_dashboard(self._hass, PRODUCTION)
+        except (OSError, ValueError, RuntimeError):
+            return _error(409, "operation_readback_failed")
+        live_sha = _config_sha256(config)
+        committed = operation.get("status") == "committed"
+        aborted = operation.get("status") == "aborted"
+        if not committed and not aborted:
+            return _error(409, "operation_readback_mismatch")
+        revision = operation.get(
+            "target_revision" if committed else "expected_production_revision",
+            operation.get("preview_revision"),
+        )
+        expected_sha = operation.get(
+            "production_config_sha256"
+            if committed
+            else "expected_production_config_sha256"
+        )
+        if self._state.journal.get("production_revision") != revision or live_sha != expected_sha:
+            return _error(409, "operation_readback_mismatch")
+        try:
+            binding = await self._operation_binding(operation, config, committed)
+        except (OSError, ValueError, RuntimeError):
+            return _error(409, "operation_readback_mismatch")
+        payload.update(
+            {
+                "target_dashboard": PRODUCTION,
+                "active_revision": self._state.journal.get("production_revision"),
+                "live_production_config_sha256": live_sha,
+                "applied": committed,
+                "verified": True,
+                "dashboard_resource_present": bool(binding),
+                **binding,
+            }
+        )
+        return _json_response(payload)
+
+    async def _operation_get(
+        self, transaction_id: str, operation: str, record: dict[str, Any]
+    ) -> web.Response:
+        """Reconcile and return one operation status or readback."""
+        try:
+            await _reconcile_operation_transition(
+                self._hass, self._state, transaction_id, record
+            )
+        except (OSError, ValueError, RuntimeError):
+            return _error(409, "production_recovery_required")
+        record = self._state.journal.get("operations", {}).get(transaction_id)
+        if not isinstance(record, dict):
+            return _error(409, "operation_recovery_invalid")
+        payload = self._operation_payload(record)
+        return (
+            await self._operation_readback(record, payload)
+            if operation == "readback"
+            else _json_response(payload)
+        )
+
+    async def get(
         self, request: web.Request, transaction_id: str, operation: str
     ) -> web.Response:
         if not await _admin(request):
@@ -2577,139 +3018,9 @@ class TransactionView(HomeAssistantView):
             return _error(429, "rate_limited")
         if operation in {"status", "readback"}:
             async with self._state.lock:
-                operation_record = self._state.journal.get("operations", {}).get(
-                    transaction_id
-                )
-                if isinstance(operation_record, dict):
-                    try:
-                        await _reconcile_operation_transition(
-                            self._hass,
-                            self._state,
-                            transaction_id,
-                            operation_record,
-                        )
-                    except (OSError, ValueError, RuntimeError):
-                        return _error(409, "production_recovery_required")
-                    operation_record = self._state.journal.get("operations", {}).get(
-                        transaction_id
-                    )
-                    if not isinstance(operation_record, dict):
-                        return _error(409, "operation_recovery_invalid")
-                    public_keys = (
-                        "operation_id",
-                        "action",
-                        "status",
-                        "transaction_id",
-                        "preview_revision",
-                        "target_revision",
-                        "expected_production_revision",
-                        "expected_production_config_sha256",
-                        "preview_config_sha256",
-                        "production_config_sha256",
-                        "created_at",
-                        "completed_at",
-                    )
-                    payload = {
-                        key: operation_record.get(key)
-                        for key in public_keys
-                        if operation_record.get(key) is not None
-                    }
-                    if operation_record.get("action") == "rollback_home_command":
-                        payload.update(
-                            {
-                                "expected_current_revision": operation_record.get(
-                                    "expected_production_revision"
-                                ),
-                                "expected_current_config_sha256": operation_record.get(
-                                    "expected_production_config_sha256"
-                                ),
-                            }
-                        )
-                    if operation == "readback":
-                        try:
-                            _production, production_config = await _load_dashboard(
-                                self._hass, PRODUCTION
-                            )
-                        except (OSError, ValueError, RuntimeError):
-                            return _error(409, "operation_readback_failed")
-                        live_sha = _config_sha256(production_config)
-                        status = operation_record.get("status")
-                        if status == "committed":
-                            expected_revision = operation_record.get(
-                                "target_revision",
-                                operation_record.get("preview_revision"),
-                            )
-                            expected_sha = operation_record.get(
-                                "production_config_sha256"
-                            )
-                            applied = True
-                        elif status == "aborted":
-                            expected_revision = operation_record.get(
-                                "expected_production_revision"
-                            )
-                            expected_sha = operation_record.get(
-                                "expected_production_config_sha256"
-                            )
-                            applied = False
-                        else:
-                            return _error(409, "operation_readback_mismatch")
-                        if (
-                            self._state.journal.get("production_revision")
-                            != expected_revision
-                            or live_sha != expected_sha
-                        ):
-                            return _error(409, "operation_readback_mismatch")
-                        resource_binding: dict[str, Any] = {}
-                        if (
-                            applied
-                            and operation_record.get("action") == "promote_home_command"
-                        ):
-                            try:
-                                resource_binding = await asyncio.to_thread(
-                                    _verify_operation_resource_binding,
-                                    self._hass,
-                                    self._state,
-                                    operation_record,
-                                    production_config,
-                                )
-                            except (OSError, ValueError, RuntimeError):
-                                return _error(409, "operation_readback_mismatch")
-                        elif operation_record.get("action") == "promote_home_command":
-                            try:
-                                resource_binding = await asyncio.to_thread(
-                                    _verify_recorded_resource_binding,
-                                    self._hass,
-                                    production_config,
-                                    operation_record,
-                                    prefix="expected_",
-                                )
-                            except (OSError, ValueError, RuntimeError):
-                                return _error(409, "operation_readback_mismatch")
-                        elif operation_record.get("action") == "rollback_home_command":
-                            try:
-                                resource_binding = await asyncio.to_thread(
-                                    _verify_recorded_resource_binding,
-                                    self._hass,
-                                    production_config,
-                                    operation_record,
-                                    prefix="" if applied else "expected_",
-                                )
-                            except (OSError, ValueError, RuntimeError):
-                                return _error(409, "operation_readback_mismatch")
-                        payload.update(
-                            {
-                                "target_dashboard": PRODUCTION,
-                                "active_revision": self._state.journal.get(
-                                    "production_revision"
-                                ),
-                                "live_production_config_sha256": live_sha,
-                                "applied": applied,
-                                "verified": True,
-                                "dashboard_resource_present": bool(resource_binding),
-                                **resource_binding,
-                            }
-                        )
-                    return _json_response(payload)
+                record = self._state.journal.get("operations", {}).get(transaction_id)
+                if isinstance(record, dict):
+                    return await self._operation_get(transaction_id, operation, record)
         if operation != "readback":
             return _error(404, "not_found")
         async with self._state.lock:
@@ -2724,9 +3035,9 @@ class TransactionView(HomeAssistantView):
                 return _error(409, "transaction_recovery_required")
             return await self._transaction_readback(transaction)
 
-    async def _transaction_readback(  # noqa: C901 - fail-closed outcome projection
-        self, transaction: dict[str, Any]
-    ) -> web.Response:
+    @staticmethod
+    def _transaction_payload(transaction: dict[str, Any]) -> dict[str, Any]:
+        """Project public transaction fields and durable transition statuses."""
         stage = transaction.get("stage_transition")
         previous_revision = (
             transaction.get("preview_revision_before")
@@ -2747,12 +3058,26 @@ class TransactionView(HomeAssistantView):
         }
         payload["previous_revision"] = previous_revision
         payload["dashboard_resource_present"] = False
-        if isinstance(stage, dict) and stage.get("status") in {
-            "committed",
-            "aborted",
-        }:
+        if isinstance(stage, dict) and stage.get("status") in {"committed", "aborted"}:
             payload["stage_status"] = stage["status"]
+        for key, name in (
+            ("activation_transition", "activation_status"),
+            ("preview_rollback_transition", "rollback_status"),
+        ):
+            transition = transaction.get(key)
+            if isinstance(transition, dict) and transition.get("status") in {
+                "committed", "aborted"
+            }:
+                payload[name] = transition["status"]
+        return payload
+
+    @staticmethod
+    def _aborted_stage_readback(
+        transaction: dict[str, Any], payload: dict[str, Any]
+    ) -> web.Response | None:
+        """Return a verified aborted stage result when applicable."""
         if transaction.get("status") == "aborted":
+            stage = transaction.get("stage_transition")
             if (
                 not isinstance(stage, dict)
                 or stage.get("status") != "aborted"
@@ -2763,6 +3088,12 @@ class TransactionView(HomeAssistantView):
                 return _error(409, "stage_readback_failed")
             payload.update({"verified": False, "staged_package_verified": False})
             return _json_response(payload)
+        return None
+
+    def _staged_readback_artifacts(
+        self, transaction: dict[str, Any]
+    ) -> tuple[bytes, bytes, dict[str, Any]]:
+        """Validate staged transaction metadata, bytes, hashes, and signature."""
         if any(
             (
                 transaction.get("target") != PREVIEW,
@@ -2772,76 +3103,55 @@ class TransactionView(HomeAssistantView):
                 transaction.get("status") == "staging",
             )
         ):
-            return _error(409, "staged_integrity_failed")
+            raise _RequestFailure(409, "staged_integrity_failed")
         try:
             package, dashboard, manifest = _verify_staged_artifacts(
-                transaction, self._state.root
+                transaction, self._state.root, self._hass
             )
         except (OSError, ValueError):
-            return _error(409, "staged_integrity_failed")
+            raise _RequestFailure(409, "staged_integrity_failed") from None
         if package is None or dashboard is None or manifest is None:
-            return _error(409, "staged_integrity_failed")
-        active_dashboard_sha: str | None = None
-        active_resource_binding: dict[str, Any] = {}
-        if transaction.get("status") in {"activated", "reloaded", "promoted"}:
-            try:
-                _validate_package(package)
-                active_dashboard_sha = await _verify_active_bindings(
-                    self._hass, transaction, dashboard
-                )
-                active_context = await asyncio.to_thread(
-                    _active_resource_context, self._hass, transaction
-                )
-                active_resource_binding = {
-                    "active_dashboard_resource_url": active_context[
-                        "preview_resource_url"
-                    ],
-                    "active_dashboard_sha256": active_context[
-                        "preview_resource_sha256"
-                    ],
-                    "active_dashboard_size": active_context[
-                        "preview_resource_size"
-                    ],
-                }
-                _preview, preview_config = await _load_dashboard(self._hass, PREVIEW)
-                if any(
-                    (
-                        self._state.journal.get("active_preview")
-                        != transaction.get("revision"),
-                        not _is_sha256(
-                            transaction.get("active_preview_config_sha256")
-                        ),
-                        _config_sha256(preview_config)
-                        != transaction.get("active_preview_config_sha256"),
-                    )
-                ):
-                    raise ValueError("active_preview_binding")
-            except (OSError, ValueError, RuntimeError):
-                return _error(409, "active_integrity_failed")
-        payload["staged_package_verified"] = True
-        activation = transaction.get("activation_transition")
-        if isinstance(activation, dict) and activation.get("status") in {
-            "committed",
-            "aborted",
-        }:
-            payload["activation_status"] = activation["status"]
-        rollback = transaction.get("preview_rollback_transition")
-        if isinstance(rollback, dict) and rollback.get("status") in {
-            "committed",
-            "aborted",
-        }:
-            payload["rollback_status"] = rollback["status"]
-        if active_dashboard_sha is not None:
-            payload.update(
-                {
-                    "active_revision": self._state.journal.get("active_preview"),
-                    "active_dashboard_verified": True,
-                    "dashboard_resource_present": True,
-                    **active_resource_binding,
-                }
+            raise _RequestFailure(409, "staged_integrity_failed")
+        return package, dashboard, manifest
+
+    async def _active_transaction_readback(
+        self, transaction: dict[str, Any], package: bytes, dashboard: bytes
+    ) -> dict[str, Any]:
+        """Verify an active preview and return its public resource evidence."""
+        if transaction.get("status") not in {"activated", "reloaded", "promoted"}:
+            return {}
+        try:
+            _validate_package(package)
+            await _verify_active_bindings(self._hass, transaction, dashboard)
+            context = await asyncio.to_thread(
+                _active_resource_context, self._hass, transaction
             )
-        if transaction.get("status") == "rolled_back":
-            if (
+            _preview, config = await _load_dashboard(self._hass, PREVIEW)
+            if self._state.journal.get("active_preview") != transaction.get("revision"):
+                raise ValueError("active_preview_binding")
+            if not _is_sha256(transaction.get("active_preview_config_sha256")):
+                raise ValueError("active_preview_binding")
+            if _config_sha256(config) != transaction.get("active_preview_config_sha256"):
+                raise ValueError("active_preview_binding")
+        except (OSError, ValueError, RuntimeError):
+            raise _RequestFailure(409, "active_integrity_failed") from None
+        return {
+            "active_revision": self._state.journal.get("active_preview"),
+            "active_dashboard_verified": True,
+            "dashboard_resource_present": True,
+            "active_dashboard_resource_url": context["preview_resource_url"],
+            "active_dashboard_sha256": context["preview_resource_sha256"],
+            "active_dashboard_size": context["preview_resource_size"],
+        }
+
+    async def _rolled_back_transaction_readback(
+        self, transaction: dict[str, Any]
+    ) -> dict[str, Any]:
+        """Verify a restored preview snapshot and return its resource evidence."""
+        if transaction.get("status") != "rolled_back":
+            return {}
+        rollback = transaction.get("preview_rollback_transition")
+        if (
                 not isinstance(rollback, dict)
                 or rollback.get("status") != "committed"
                 or rollback.get("action") != "rollback"
@@ -2854,52 +3164,59 @@ class TransactionView(HomeAssistantView):
                 != transaction.get("preview_config_sha256_before")
                 or not _is_sha256(rollback.get("next_config_sha256"))
             ):
-                return _error(409, "preview_rollback_readback_failed")
-            try:
-                _preview, preview_config = await _load_dashboard(self._hass, PREVIEW)
-            except (OSError, ValueError, RuntimeError):
-                return _error(409, "preview_rollback_readback_failed")
+            raise _RequestFailure(409, "preview_rollback_readback_failed")
+        try:
+            _preview, config = await _load_dashboard(self._hass, PREVIEW)
             active_revision = self._state.journal.get("active_preview")
-            if (
-                _config_sha256(preview_config) != rollback["next_config_sha256"]
-                or active_revision != rollback.get("to_revision")
-            ):
-                return _error(409, "preview_rollback_readback_failed")
-            try:
-                restored_resource_binding = await asyncio.to_thread(
-                    _verify_preview_revision_resource_binding,
-                    self._hass,
-                    self._state,
-                    active_revision,
-                    preview_config,
-                )
-            except (OSError, ValueError, RuntimeError):
-                return _error(409, "preview_rollback_readback_failed")
-            payload.update(
+            if _config_sha256(config) != rollback["next_config_sha256"]:
+                raise ValueError("preview_rollback_readback_failed")
+            if active_revision != rollback.get("to_revision"):
+                raise ValueError("preview_rollback_readback_failed")
+            binding = await asyncio.to_thread(
+                _verify_preview_revision_resource_binding,
+                self._hass,
+                self._state,
+                active_revision,
+                config,
+            )
+        except (OSError, ValueError, RuntimeError):
+            raise _RequestFailure(409, "preview_rollback_readback_failed") from None
+        result = {
+            "rolled_back": True,
+            "active_revision": active_revision,
+            "previous_revision": active_revision,
+            "preview_active": isinstance(active_revision, str),
+            "dashboard_resource_present": bool(binding),
+            "active_dashboard_verified": bool(binding),
+        }
+        if binding:
+            result.update(
                 {
-                    "rolled_back": True,
-                    "active_revision": active_revision,
-                    "previous_revision": active_revision,
-                    "preview_active": isinstance(active_revision, str),
-                    "dashboard_resource_present": bool(restored_resource_binding),
-                    "active_dashboard_verified": bool(restored_resource_binding),
-                    **(
-                        {
-                            "active_dashboard_resource_url": restored_resource_binding[
-                                "dashboard_resource_url"
-                            ],
-                            "active_dashboard_sha256": restored_resource_binding[
-                                "dashboard_sha256"
-                            ],
-                            "active_dashboard_size": restored_resource_binding[
-                                "dashboard_size"
-                            ],
-                        }
-                        if restored_resource_binding
-                        else {}
-                    ),
+                    "active_dashboard_resource_url": binding["dashboard_resource_url"],
+                    "active_dashboard_sha256": binding["dashboard_sha256"],
+                    "active_dashboard_size": binding["dashboard_size"],
                 }
             )
+        return result
+
+    async def _transaction_readback(
+        self, transaction: dict[str, Any]
+    ) -> web.Response:
+        payload = self._transaction_payload(transaction)
+        aborted = self._aborted_stage_readback(transaction, payload)
+        if aborted is not None:
+            return aborted
+        try:
+            package, dashboard, _manifest = self._staged_readback_artifacts(transaction)
+            payload.update(
+                await self._active_transaction_readback(
+                    transaction, package, dashboard
+                )
+            )
+            payload.update(await self._rolled_back_transaction_readback(transaction))
+        except _RequestFailure as exc:
+            return _error(exc.status, exc.code)
+        payload["staged_package_verified"] = True
         payload["verified"] = transaction.get("status") in {
             "verified",
             "activated",
@@ -2909,7 +3226,262 @@ class TransactionView(HomeAssistantView):
         }
         return _json_response(payload)
 
-    async def post(  # noqa: C901 - explicit transaction lifecycle dispatcher
+    async def _verify_active_config(self, transaction: dict[str, Any]) -> None:
+        """Verify staged bytes, active resource, and current preview config hash."""
+        await _verify_active_transaction(self._hass, transaction, self._state.root)
+        _preview, config = await _load_dashboard(self._hass, PREVIEW)
+        expected = transaction.get("active_preview_config_sha256")
+        if not _is_sha256(expected) or _config_sha256(config) != expected:
+            raise _RequestFailure(409, "active_integrity_failed")
+
+    @staticmethod
+    def _lifecycle_response(
+        transaction: dict[str, Any], action: str, *, idempotent: bool = False
+    ) -> web.Response:
+        """Project a successful activate or reload lifecycle result."""
+        payload = {
+            {"activate": "activated", "reload": "reloaded"}[action]: True,
+            "active_revision": transaction["revision"],
+            "previous_revision": transaction.get("preview_revision_before"),
+            "status": transaction["status"],
+            "restart_required": False,
+            "backend_unchanged": True,
+        }
+        if action == "reload":
+            payload["verified"] = True
+        if idempotent:
+            payload["idempotent"] = True
+        return _json_response(payload)
+
+    async def _apply_activation(
+        self,
+        transaction: dict[str, Any],
+        preview: Any,
+        dashboard: bytes,
+        transition: dict[str, Any],
+    ) -> web.Response:
+        """Save the immutable asset, verify preview readback, and commit activation."""
+        try:
+            saved = await _save_preview_asset(self._hass, dashboard)
+            if saved != transition["asset_name"]:
+                raise ValueError("active_dashboard_binding")
+            _preview, readback = await _load_dashboard(self._hass, PREVIEW)
+            await _verify_active_bindings(self._hass, transaction, dashboard)
+        except (OSError, ValueError, RuntimeError):
+            try:
+                await preview.async_save(transaction["preview_before"])
+            except (OSError, ValueError, RuntimeError):
+                pass
+            raise
+        if _config_sha256(readback) != transition["next_config_sha256"]:
+            raise ValueError("preview_activation_readback_failed")
+        _commit_preview_activation(self._state, transaction, transition)
+        return self._lifecycle_response(transaction, "activate")
+
+    async def _activate(self, transaction: dict[str, Any]) -> web.Response:
+        """Activate one verified staged dashboard transaction."""
+        already_active = transaction.get("status") in {
+            "activated", "reloaded", "promoted"
+        } and self._state.journal.get("active_preview") == transaction.get("revision")
+        if already_active:
+            await self._verify_active_config(transaction)
+            return self._lifecycle_response(transaction, "activate", idempotent=True)
+        if transaction.get("status") != "verified":
+            return _error(409, "transaction_not_verified")
+        package, dashboard, _manifest = _verify_staged_artifacts(
+            transaction, self._state.root, self._hass
+        )
+        if package is None or dashboard is None:
+            raise ValueError("staged_artifact_missing")
+        _validate_package(package)
+        await _ensure_preview(self._hass)
+        preview, config = await _load_dashboard(self._hass, PREVIEW)
+        try:
+            await asyncio.to_thread(
+                _verify_preview_revision_resource_binding,
+                self._hass,
+                self._state,
+                self._state.journal.get("active_preview"),
+                config,
+            )
+        except (OSError, ValueError, RuntimeError):
+            return _error(409, "preview_prestate_invalid")
+        transaction["preview_before"] = json.loads(_json_bytes(config))
+        transaction["preview_config_sha256_before"] = _config_sha256(config)
+        transaction["preview_revision_before"] = self._state.journal.get("active_preview")
+        asset_name = f"aurora-preview-dashboard-{transaction['dashboard_sha256']}.js"
+        next_config = _dashboard_config_with_asset(config, asset_name)
+        transition = {
+            "status": "prepared",
+            "action": "activate",
+            "transaction_id": transaction["transaction_id"],
+            "previous_revision": transaction.get("preview_revision_before"),
+            "next_revision": transaction["revision"],
+            "previous_config_sha256": _config_sha256(config),
+            "next_config_sha256": _config_sha256(next_config),
+            "asset_name": asset_name,
+            "prepared_at": _now().isoformat(),
+        }
+        transaction["active_dashboard_asset"] = asset_name
+        transaction["activation_transition"] = transition
+        self._state.save()
+        return await self._apply_activation(transaction, preview, dashboard, transition)
+
+    async def _rolled_back_response(
+        self, transaction: dict[str, Any]
+    ) -> web.Response:
+        """Verify and project an idempotent preview rollback."""
+        rollback = transaction.get("preview_rollback_transition")
+        active_revision = self._state.journal.get("active_preview")
+        try:
+            _preview, config = await _load_dashboard(self._hass, PREVIEW)
+            valid = (
+                isinstance(rollback, dict)
+                and rollback.get("status") == "committed"
+                and rollback.get("action") == "rollback"
+                and rollback.get("transaction_id") == transaction.get("transaction_id")
+                and rollback.get("from_revision") == transaction.get("revision")
+                and rollback.get("to_revision") == active_revision
+                and rollback.get("to_revision") == transaction.get("preview_revision_before")
+                and _is_sha256(rollback.get("next_config_sha256"))
+                and rollback.get("next_config_sha256") == transaction.get("preview_config_sha256_before")
+                and isinstance(transaction.get("preview_before"), dict)
+                and _config_sha256(transaction["preview_before"]) == rollback.get("next_config_sha256")
+                and _config_sha256(config) == rollback.get("next_config_sha256")
+            )
+            if not valid:
+                raise ValueError("preview_rollback_readback_failed")
+            await asyncio.to_thread(
+                _verify_preview_revision_resource_binding,
+                self._hass,
+                self._state,
+                active_revision,
+                config,
+            )
+        except (OSError, ValueError, RuntimeError):
+            return _error(409, "preview_rollback_readback_failed")
+        return _json_response(
+            {
+                "rolled_back": True,
+                "active_revision": active_revision,
+                "previous_revision": active_revision,
+                "preview_active": isinstance(active_revision, str),
+                "status": "rolled_back",
+                "idempotent": True,
+            }
+        )
+
+    async def _prepare_preview_rollback(
+        self, transaction: dict[str, Any]
+    ) -> tuple[Any, dict[str, Any], dict[str, Any]]:
+        """Validate and durably prepare restoration of the prior preview."""
+        previous = transaction.get("preview_before")
+        if (
+            not isinstance(previous, dict)
+            or not _is_sha256(transaction.get("preview_config_sha256_before"))
+            or _config_sha256(previous) != transaction.get("preview_config_sha256_before")
+            or not _is_sha256(transaction.get("active_preview_config_sha256"))
+        ):
+            raise _RequestFailure(409, "preview_rollback_snapshot_missing")
+        try:
+            await asyncio.to_thread(
+                _verify_preview_revision_resource_binding,
+                self._hass,
+                self._state,
+                transaction.get("preview_revision_before"),
+                previous,
+            )
+        except (OSError, ValueError, RuntimeError):
+            raise _RequestFailure(409, "preview_rollback_snapshot_missing") from None
+        if self._state.journal.get("active_preview") != transaction.get("revision"):
+            raise _RequestFailure(409, "preview_revision_conflict")
+        preview, current = await _load_dashboard(self._hass, PREVIEW)
+        if _config_sha256(current) != transaction.get("active_preview_config_sha256"):
+            raise _RequestFailure(409, "preview_config_conflict")
+        try:
+            await _verify_active_transaction(self._hass, transaction, self._state.root)
+        except (OSError, ValueError, RuntimeError):
+            raise _RequestFailure(409, "active_integrity_failed") from None
+        transition = {
+            "status": "prepared",
+            "action": "rollback",
+            "transaction_id": transaction["transaction_id"],
+            "from_status": transaction["status"],
+            "from_revision": transaction["revision"],
+            "to_revision": transaction.get("preview_revision_before"),
+            "previous_config_sha256": _config_sha256(current),
+            "next_config_sha256": transaction["preview_config_sha256_before"],
+            "asset_name": transaction.get("active_dashboard_asset"),
+            "prepared_at": _now().isoformat(),
+        }
+        transaction["preview_rollback_transition"] = transition
+        self._state.save()
+        return preview, previous, transition
+
+    async def _apply_preview_rollback(
+        self,
+        transaction: dict[str, Any],
+        preview: Any,
+        previous: dict[str, Any],
+        transition: dict[str, Any],
+    ) -> web.Response:
+        """Restore, verify, and commit a prepared preview rollback."""
+        await preview.async_save(previous)
+        _preview, readback = await _load_dashboard(self._hass, PREVIEW)
+        if _config_sha256(readback) != transition["next_config_sha256"]:
+            return _error(409, "preview_rollback_readback_failed")
+        try:
+            await asyncio.to_thread(
+                _verify_preview_revision_resource_binding,
+                self._hass,
+                self._state,
+                transition.get("to_revision"),
+                readback,
+            )
+        except (OSError, ValueError, RuntimeError):
+            return _error(409, "preview_rollback_readback_failed")
+        _commit_preview_rollback(self._state, transaction, transition)
+        active_revision = self._state.journal.get("active_preview")
+        return _json_response(
+            {
+                "rolled_back": True,
+                "active_revision": active_revision,
+                "previous_revision": active_revision,
+                "preview_active": isinstance(active_revision, str),
+                "status": "rolled_back",
+            }
+        )
+
+    async def _preview_rollback(self, transaction: dict[str, Any]) -> web.Response:
+        """Rollback an active preview transaction once, with exact idempotency."""
+        if transaction.get("status") == "rolled_back":
+            return await self._rolled_back_response(transaction)
+        if transaction.get("status") not in {"activated", "reloaded"}:
+            return _error(409, "transaction_not_rollbackable")
+        try:
+            preview, previous, transition = await self._prepare_preview_rollback(
+                transaction
+            )
+        except _RequestFailure as exc:
+            return _error(exc.status, exc.code)
+        return await self._apply_preview_rollback(
+            transaction, preview, previous, transition
+        )
+
+    async def _reload(self, transaction: dict[str, Any]) -> web.Response:
+        """Verify and mark one active dashboard transaction reloaded."""
+        if transaction.get("status") == "reloaded":
+            await self._verify_active_config(transaction)
+            return self._lifecycle_response(transaction, "reload", idempotent=True)
+        if transaction.get("status") != "activated":
+            return _error(409, "transaction_not_activated")
+        await self._verify_active_config(transaction)
+        transaction["status"] = "reloaded"
+        transaction["reloaded_at"] = _now().isoformat()
+        self._state.save()
+        return self._lifecycle_response(transaction, "reload")
+
+    async def post(
         self, request: web.Request, transaction_id: str, operation: str
     ) -> web.Response:
         if not await _admin(request):
@@ -2924,331 +3496,16 @@ class TransactionView(HomeAssistantView):
                 await _reconcile_transaction_transition(
                     self._hass, self._state, transaction
                 )
-                if operation == "activate":
-                    if transaction.get("status") in {
-                        "activated",
-                        "reloaded",
-                        "promoted",
-                    } and self._state.journal.get("active_preview") == transaction.get(
-                        "revision"
-                    ):
-                        await _verify_active_transaction(
-                            self._hass, transaction, self._state.root
-                        )
-                        _preview, active_config = await _load_dashboard(
-                            self._hass, PREVIEW
-                        )
-                        if (
-                            not _is_sha256(
-                                transaction.get("active_preview_config_sha256")
-                            )
-                            or _config_sha256(active_config)
-                            != transaction.get("active_preview_config_sha256")
-                        ):
-                            return _error(409, "active_integrity_failed")
-                        return _json_response(
-                            {
-                                "activated": True,
-                                "active_revision": transaction["revision"],
-                                "previous_revision": transaction.get(
-                                    "preview_revision_before"
-                                ),
-                                "status": transaction["status"],
-                                "restart_required": False,
-                                "backend_unchanged": True,
-                                "idempotent": True,
-                            }
-                        )
-                    if transaction.get("status") != "verified":
-                        return _error(409, "transaction_not_verified")
-                    package, dashboard, _manifest = _verify_staged_artifacts(
-                        transaction, self._state.root
-                    )
-                    if package is None or dashboard is None:
-                        raise ValueError("staged_artifact_missing")
-                    _validate_package(package)
-                    await _ensure_preview(self._hass)
-                    preview, preview_config = await _load_dashboard(self._hass, PREVIEW)
-                    try:
-                        await asyncio.to_thread(
-                            _verify_preview_revision_resource_binding,
-                            self._hass,
-                            self._state,
-                            self._state.journal.get("active_preview"),
-                            preview_config,
-                        )
-                    except (OSError, ValueError, RuntimeError):
-                        return _error(409, "preview_prestate_invalid")
-                    transaction["preview_before"] = json.loads(
-                        _json_bytes(preview_config)
-                    )
-                    transaction["preview_config_sha256_before"] = _config_sha256(
-                        preview_config
-                    )
-                    transaction["preview_revision_before"] = self._state.journal.get(
-                        "active_preview"
-                    )
-                    asset_name = (
-                        f"aurora-preview-dashboard-{transaction['dashboard_sha256']}.js"
-                    )
-                    next_config = _dashboard_config_with_asset(
-                        preview_config, asset_name
-                    )
-                    transition = {
-                        "status": "prepared",
-                        "action": "activate",
-                        "transaction_id": transaction["transaction_id"],
-                        "previous_revision": transaction.get(
-                            "preview_revision_before"
-                        ),
-                        "next_revision": transaction["revision"],
-                        "previous_config_sha256": _config_sha256(preview_config),
-                        "next_config_sha256": _config_sha256(next_config),
-                        "asset_name": asset_name,
-                        "prepared_at": _now().isoformat(),
-                    }
-                    transaction["active_dashboard_asset"] = asset_name
-                    transaction["activation_transition"] = transition
-                    self._state.save()
-                    try:
-                        saved_asset_name = await _save_preview_asset(
-                            self._hass, dashboard
-                        )
-                        if saved_asset_name != asset_name:
-                            raise ValueError("active_dashboard_binding")
-                    except (OSError, ValueError, RuntimeError):
-                        try:
-                            await preview.async_save(transaction["preview_before"])
-                        except (OSError, ValueError, RuntimeError):
-                            pass
-                        raise
-                    try:
-                        _preview_readback, preview_readback = await _load_dashboard(
-                            self._hass, PREVIEW
-                        )
-                        await _verify_active_bindings(
-                            self._hass, transaction, dashboard
-                        )
-                    except (OSError, ValueError, RuntimeError):
-                        try:
-                            await preview.async_save(transaction["preview_before"])
-                        except (OSError, ValueError, RuntimeError):
-                            pass
-                        raise
-                    if (
-                        _config_sha256(preview_readback)
-                        != transition["next_config_sha256"]
-                    ):
-                        raise ValueError("preview_activation_readback_failed")
-                    _commit_preview_activation(self._state, transaction, transition)
-                    return _json_response(
-                        {
-                            "activated": True,
-                            "active_revision": transaction["revision"],
-                            "previous_revision": transaction.get(
-                                "preview_revision_before"
-                            ),
-                            "status": "activated",
-                            "restart_required": False,
-                            "backend_unchanged": True,
-                        }
-                    )
-                if operation == "rollback":
-                    if transaction.get("status") == "rolled_back":
-                        rollback = transaction.get("preview_rollback_transition")
-                        active_revision = self._state.journal.get("active_preview")
-                        try:
-                            _preview, rolled_back_config = await _load_dashboard(
-                                self._hass, PREVIEW
-                            )
-                        except (OSError, ValueError, RuntimeError):
-                            return _error(409, "preview_rollback_readback_failed")
-                        if (
-                            not isinstance(rollback, dict)
-                            or rollback.get("status") != "committed"
-                            or rollback.get("action") != "rollback"
-                            or rollback.get("transaction_id")
-                            != transaction.get("transaction_id")
-                            or rollback.get("from_revision")
-                            != transaction.get("revision")
-                            or rollback.get("to_revision") != active_revision
-                            or rollback.get("to_revision")
-                            != transaction.get("preview_revision_before")
-                            or not _is_sha256(rollback.get("next_config_sha256"))
-                            or rollback.get("next_config_sha256")
-                            != transaction.get("preview_config_sha256_before")
-                            or not isinstance(transaction.get("preview_before"), dict)
-                            or _config_sha256(transaction["preview_before"])
-                            != rollback.get("next_config_sha256")
-                            or _config_sha256(rolled_back_config)
-                            != rollback.get("next_config_sha256")
-                        ):
-                            return _error(409, "preview_rollback_readback_failed")
-                        try:
-                            await asyncio.to_thread(
-                                _verify_preview_revision_resource_binding,
-                                self._hass,
-                                self._state,
-                                active_revision,
-                                rolled_back_config,
-                            )
-                        except (OSError, ValueError, RuntimeError):
-                            return _error(409, "preview_rollback_readback_failed")
-                        return _json_response(
-                            {
-                                "rolled_back": True,
-                                "active_revision": active_revision,
-                                "previous_revision": active_revision,
-                                "preview_active": isinstance(active_revision, str),
-                                "status": "rolled_back",
-                                "idempotent": True,
-                            }
-                        )
-                    if transaction.get("status") not in {"activated", "reloaded"}:
-                        return _error(409, "transaction_not_rollbackable")
-                    previous_preview = transaction.get("preview_before")
-                    if (
-                        not isinstance(previous_preview, dict)
-                        or not _is_sha256(
-                            transaction.get("preview_config_sha256_before")
-                        )
-                        or _config_sha256(previous_preview)
-                        != transaction.get("preview_config_sha256_before")
-                        or not _is_sha256(
-                            transaction.get("active_preview_config_sha256")
-                        )
-                    ):
-                        return _error(409, "preview_rollback_snapshot_missing")
-                    try:
-                        await asyncio.to_thread(
-                            _verify_preview_revision_resource_binding,
-                            self._hass,
-                            self._state,
-                            transaction.get("preview_revision_before"),
-                            previous_preview,
-                        )
-                    except (OSError, ValueError, RuntimeError):
-                        return _error(409, "preview_rollback_snapshot_missing")
-                    if self._state.journal.get("active_preview") != transaction.get(
-                        "revision"
-                    ):
-                        return _error(409, "preview_revision_conflict")
-                    preview, current = await _load_dashboard(self._hass, PREVIEW)
-                    if _config_sha256(current) != transaction.get(
-                        "active_preview_config_sha256"
-                    ):
-                        return _error(409, "preview_config_conflict")
-                    try:
-                        await _verify_active_transaction(
-                            self._hass, transaction, self._state.root
-                        )
-                    except (OSError, ValueError, RuntimeError):
-                        return _error(409, "active_integrity_failed")
-                    transition = {
-                        "status": "prepared",
-                        "action": "rollback",
-                        "transaction_id": transaction["transaction_id"],
-                        "from_status": transaction["status"],
-                        "from_revision": transaction["revision"],
-                        "to_revision": transaction.get("preview_revision_before"),
-                        "previous_config_sha256": _config_sha256(current),
-                        "next_config_sha256": transaction[
-                            "preview_config_sha256_before"
-                        ],
-                        "asset_name": transaction.get("active_dashboard_asset"),
-                        "prepared_at": _now().isoformat(),
-                    }
-                    transaction["preview_rollback_transition"] = transition
-                    self._state.save()
-                    await preview.async_save(previous_preview)
-                    _preview_readback, preview_readback = await _load_dashboard(
-                        self._hass, PREVIEW
-                    )
-                    if _config_sha256(preview_readback) != transaction.get(
-                        "preview_config_sha256_before"
-                    ):
-                        return _error(409, "preview_rollback_readback_failed")
-                    try:
-                        await asyncio.to_thread(
-                            _verify_preview_revision_resource_binding,
-                            self._hass,
-                            self._state,
-                            transaction.get("preview_revision_before"),
-                            preview_readback,
-                        )
-                    except (OSError, ValueError, RuntimeError):
-                        return _error(409, "preview_rollback_readback_failed")
-                    _commit_preview_rollback(self._state, transaction, transition)
-                    active_revision = self._state.journal.get("active_preview")
-                    return _json_response(
-                        {
-                            "rolled_back": True,
-                            "active_revision": active_revision,
-                            "previous_revision": active_revision,
-                            "preview_active": isinstance(active_revision, str),
-                            "status": "rolled_back",
-                        }
-                    )
-                if operation == "reload":
-                    if transaction.get("status") == "reloaded":
-                        await _verify_active_transaction(
-                            self._hass, transaction, self._state.root
-                        )
-                        _preview, active_config = await _load_dashboard(
-                            self._hass, PREVIEW
-                        )
-                        if (
-                            not _is_sha256(
-                                transaction.get("active_preview_config_sha256")
-                            )
-                            or _config_sha256(active_config)
-                            != transaction.get("active_preview_config_sha256")
-                        ):
-                            return _error(409, "active_integrity_failed")
-                        return _json_response(
-                            {
-                                "reloaded": True,
-                                "verified": True,
-                                "active_revision": transaction["revision"],
-                                "previous_revision": transaction.get(
-                                    "preview_revision_before"
-                                ),
-                                "status": "reloaded",
-                                "restart_required": False,
-                                "backend_unchanged": True,
-                                "idempotent": True,
-                            }
-                        )
-                    if transaction.get("status") != "activated":
-                        return _error(409, "transaction_not_activated")
-                    await _verify_active_transaction(
-                        self._hass, transaction, self._state.root
-                    )
-                    _preview, active_config = await _load_dashboard(self._hass, PREVIEW)
-                    if (
-                        not _is_sha256(
-                            transaction.get("active_preview_config_sha256")
-                        )
-                        or _config_sha256(active_config)
-                        != transaction.get("active_preview_config_sha256")
-                    ):
-                        return _error(409, "active_integrity_failed")
-                    transaction["status"] = "reloaded"
-                    transaction["reloaded_at"] = _now().isoformat()
-                    self._state.save()
-                    return _json_response(
-                        {
-                            "reloaded": True,
-                            "verified": True,
-                            "active_revision": transaction["revision"],
-                            "previous_revision": transaction.get(
-                                "preview_revision_before"
-                            ),
-                            "status": "reloaded",
-                            "restart_required": False,
-                            "backend_unchanged": True,
-                        }
-                    )
+                handlers = {
+                    "activate": self._activate,
+                    "rollback": self._preview_rollback,
+                    "reload": self._reload,
+                }
+                handler = handlers.get(operation)
+                if handler is not None:
+                    return await handler(transaction)
+            except _RequestFailure as exc:
+                return _error(exc.status, exc.code)
             except (OSError, ValueError, RuntimeError):
                 return _error(500, "activation_failed")
         return _error(404, "not_found")

--- a/custom_components/aurora_deploy/adapter.py
+++ b/custom_components/aurora_deploy/adapter.py
@@ -69,6 +69,12 @@ PRODUCTION = "home-command"
 LEGACY_PREVIEW = "home-command-preview"
 TARGET = "aurora-v9-preview"
 APPROVED_RELEASE = "0.1.16"
+APPROVED_PREVIEW_DISPLAY_PAIRS = frozenset(
+    {
+        ("Aurora Preview", "mdi:aurora"),
+        ("Aurora V9 Preview", "mdi:home-analytics"),
+    }
+)
 MAX_BODY = 80 * 1024 * 1024
 MAX_MANIFEST = 512 * 1024
 MAX_PACKAGE = 64 * 1024 * 1024
@@ -1121,7 +1127,15 @@ async def _ensure_preview(hass: HomeAssistant) -> tuple[bool, str]:
     }
     if existing is not None:
         config = getattr(existing, "config", {}) or {}
-        if any(config.get(key) != value for key, value in metadata.items()):
+        fixed_metadata = {
+            CONF_URL_PATH: PREVIEW,
+            CONF_SHOW_IN_SIDEBAR: False,
+            CONF_REQUIRE_ADMIN: True,
+        }
+        display_pair = (config.get(CONF_TITLE), config.get(CONF_ICON))
+        if any(
+            config.get(key) != value for key, value in fixed_metadata.items()
+        ) or display_pair not in APPROVED_PREVIEW_DISPLAY_PAIRS:
             raise ValueError("preview_collision")
         return False, PREVIEW
     from homeassistant.components.lovelace import _register_panel, dashboard

--- a/custom_components/aurora_deploy/adapter.py
+++ b/custom_components/aurora_deploy/adapter.py
@@ -106,6 +106,7 @@ APPROVED_COMPONENT_FILES = frozenset(
         "models.py",
         "review_store.py",
         "services.yaml",
+        "synthetic_fixture.py",
         "timeline_contract.py",
         "vehicle_catalog_v1.json",
     }
@@ -2849,6 +2850,7 @@ class TransactionView(HomeAssistantView):
                     "previous_revision": active_revision,
                     "preview_active": isinstance(active_revision, str),
                     "dashboard_resource_present": bool(restored_resource_binding),
+                    "active_dashboard_verified": bool(restored_resource_binding),
                     **(
                         {
                             "active_dashboard_resource_url": restored_resource_binding[

--- a/custom_components/aurora_deploy/manifest.json
+++ b/custom_components/aurora_deploy/manifest.json
@@ -1,0 +1,10 @@
+{
+  "domain": "aurora_deploy",
+  "name": "Aurora Deployment Adapter",
+  "version": "0.1.16",
+  "documentation": "https://github.com/homeassistant-ai/ha-mcp",
+  "codeowners": ["@homeassistant-ai"],
+  "config_flow": false,
+  "dependencies": ["http", "lovelace"],
+  "iot_class": "local_push"
+}

--- a/docs/AURORA-SERVER-INTEGRATION.md
+++ b/docs/AURORA-SERVER-INTEGRATION.md
@@ -1,0 +1,74 @@
+# Aurora deployment adapter server contract
+
+This document defines the Home Assistant-side half of `ha-cli aurora`. It is a
+separate `custom_components/aurora_deploy` integration and is not implemented
+through `ha-mcp`, File Editor, Supervisor filesystem APIs, SSH, or generic
+uploads.
+
+## Installation boundary
+
+1. Install the reviewed `aurora_deploy` component and its manifest through the
+   approved Aurora add-on/custom-component release.
+2. Place the server-managed trust file at the fixed Home Assistant config path
+   `aurora_deploy_trusted_keys.json`. It maps `release-*` and `validation-*`
+   key IDs to base64 Ed25519 public keys. The file is operator-managed; the
+   deployment API cannot modify it.
+3. Restart Home Assistant and verify that the component registers exactly two
+   authenticated view families:
+   `/api/aurora/deploy-preview/v1/{operation}` and
+   `/api/aurora/deploy-preview/v1/{transaction_id}/{operation}`.
+4. The route is accessed with the existing Home Assistant authentication
+   boundary and requires an administrator user. It is not exposed through
+   Supervisor ingress.
+
+## Fixed contract
+
+Only these operations exist:
+
+- `POST /bootstrap`
+- `POST /stage`
+- `GET /{transaction}/readback`
+- `POST /{transaction}/activate`
+- `POST /{transaction}/reload`
+- `POST /promote-home-command`
+- `POST /rollback-home-command`
+
+The only dashboard targets are `home-command-preview` and `home-command`.
+Bootstrap creates the preview dashboard only when absent, hidden and admin-only;
+a mismatched existing preview fails closed. Bootstrap and staging never mutate
+production.
+
+## Verification and journal
+
+Stage accepts only the signed canonical manifest, the deterministic Aurora
+component archive, and the dashboard JavaScript bytes. The adapter verifies the
+Ed25519 signature, key prefix, issue/expiry window, nonce replay state, fixed
+release, fixed target, SHA-256 values, archive member policy, symlink/hardlink
+absence, expanded-size/file-count bounds, and privacy denylist before writing a
+fresh revision directory.
+
+The durable journal is stored under the adapter-owned `.storage` directory and
+is updated with atomic replace plus fsync. Transaction states are
+`verified`, `activated`, and `promoted`; failed operations leave production
+unchanged. Readback rehashes the immutable staged files rather than trusting
+journal claims. Only the immediately prior verified production revision is
+retained for rollback.
+
+## Promotion
+
+Promotion accepts only the currently activated preview revision and a separately
+signed validation receipt. The receipt binds the exact revision and all asset
+hashes, fixed dashboard target, responsive results for mobile/kiosk/tablet/
+laptop/desktop, physical validation, issue/expiry, an isolated validation
+signer, `preview_config_sha256`, and `expected_production_config_sha256`.
+Promotion CAS-checks both the production revision label and canonical dashboard
+configuration bytes immediately before saving. The restart-required
+`aurora_camera_ai` component is never reported as reloaded; `/reload` returns
+`409 restart_required` until an approved Home Assistant restart is completed.
+The server rejects missing, expired, malformed, replayed, or mismatched receipts.
+Rollback has no caller-selected revision and restores only the stored immediate
+prior production revision after config-byte CAS verification.
+
+No endpoint returns tokens, credentials, URLs, paths, private artifact content,
+or raw dashboard/package bytes. Responses contain bounded transaction IDs,
+revision IDs, states, booleans, and SHA-256 evidence only.

--- a/docs/AURORA-SERVER-INTEGRATION.md
+++ b/docs/AURORA-SERVER-INTEGRATION.md
@@ -28,12 +28,15 @@ Only these operations exist:
 - `POST /bootstrap`
 - `POST /stage`
 - `GET /{transaction}/readback`
+- `GET /{operation_id}/status`
+- `GET /{operation_id}/readback`
 - `POST /{transaction}/activate`
 - `POST /{transaction}/reload`
 - `POST /promote-home-command`
 - `POST /rollback-home-command`
 
-The only dashboard targets are `home-command-preview` and `home-command`.
+The only dashboard targets are `aurora-preview` and `home-command`.
+`home-command-preview` is a refused legacy collision, not a third environment.
 Bootstrap creates the preview dashboard only when absent, hidden and admin-only;
 a mismatched existing preview fails closed. Bootstrap and staging never mutate
 production.
@@ -41,34 +44,117 @@ production.
 ## Verification and journal
 
 Stage accepts only the signed canonical manifest, the deterministic Aurora
-component archive, and the dashboard JavaScript bytes. The adapter verifies the
+compatibility archive, and the dashboard JavaScript bytes. The adapter verifies the
 Ed25519 signature, key prefix, issue/expiry window, nonce replay state, fixed
 release, fixed target, SHA-256 values, archive member policy, symlink/hardlink
 absence, expanded-size/file-count bounds, and privacy denylist before writing a
-fresh revision directory.
+fresh revision directory. The archive remains staged evidence only: this adapter
+never installs, replaces, reloads, or rolls back `custom_components/aurora_camera_ai`.
+The Camera AI backend has its own release and restart lifecycle.
+
+Stage requires a caller-known safe `transaction_id`. Before writing artifact
+bytes, the journal records a prepared stage transition bound to the exact
+manifest/package/dashboard request and reserves the manifest nonce. An exact
+retry is idempotent, reuse with different bytes is rejected, and transaction
+readback settles a response lost before, during, or after the artifact writes as
+final `verified` or `aborted`. Manifest nonces remain globally replay-protected.
 
 The durable journal is stored under the adapter-owned `.storage` directory and
-is updated with atomic replace plus fsync. Transaction states are
-`verified`, `activated`, and `promoted`; failed operations leave production
-unchanged. Readback rehashes the immutable staged files rather than trusting
-journal claims. Only the immediately prior verified production revision is
-retained for rollback.
+is updated with atomic replace plus fsync. Transaction states include `staging`,
+`verified`, `activated`, `reloaded`, `promoted`, `rolled_back`, and final
+`aborted` recovery outcomes. Readback rehashes the immutable staged files rather
+than trusting journal claims. Activation first verifies that any prior preview
+revision and resource are journal-bound and content-addressed. Activation and
+reload operate only on the fixed preview dashboard resource; both truthfully
+return `restart_required: false` and `backend_unchanged: true`. Reload is a
+verified no-op for already active dashboard assets. Only the immediately prior
+verified production revision is retained for rollback.
+
+Transaction readback runs under the transaction lock and reconciles a prepared
+preview activation or preview rollback from the independently loaded live config.
+It reports `activation_status` or `rollback_status` as `committed`/`aborted`, plus
+the nullable `previous_revision`. `dashboard_resource_present` is always explicit;
+when true, transaction readback returns `active_dashboard_resource_url`,
+`active_dashboard_sha256`, and `active_dashboard_size` after rehashing the file.
+A committed preview rollback independently
+reloads the prior config and rehashes its content-addressed asset when a prior
+revision exists. Activation, reload, and preview rollback are idempotent after a
+committed response, so clients can keep mutation retries disabled and resolve an
+ambiguous response through readback without repeating a save.
 
 ## Promotion
 
-Promotion accepts only the currently activated preview revision and a separately
-signed validation receipt. The receipt binds the exact revision and all asset
-hashes, fixed dashboard target, responsive results for mobile/kiosk/tablet/
-laptop/desktop, physical validation, issue/expiry, an isolated validation
-signer, `preview_config_sha256`, and `expected_production_config_sha256`.
-Promotion CAS-checks both the production revision label and canonical dashboard
-configuration bytes immediately before saving. The restart-required
-`aurora_camera_ai` component is never reported as reloaded; `/reload` returns
-`409 restart_required` until an approved Home Assistant restart is completed.
-The server rejects missing, expired, malformed, replayed, or mismatched receipts.
-Rollback has no caller-selected revision and restores only the stored immediate
-prior production revision after config-byte CAS verification.
+Promotion inspection returns the active preview revision and transaction ID,
+manifest/package/dashboard hashes, preview and expected-production config hashes,
+production revision, strict same-origin resource URL/hash/size, and a stable
+non-secret Home Assistant audience persisted in the journal. It names both sides
+explicitly as `dashboard_target: aurora-preview` and
+`target_dashboard: home-command`.
 
-No endpoint returns tokens, credentials, URLs, paths, private artifact content,
-or raw dashboard/package bytes. Responses contain bounded transaction IDs,
-revision IDs, states, booleans, and SHA-256 evidence only.
+Inspection is the non-mutating `POST /promote-home-command` request
+`{"preview_revision":"<revision>","inspect":true}`. Its fixed resource fields
+are `preview_resource_url`, `preview_resource_sha256`, and
+`preview_resource_size`; the URL is exactly
+`/local/aurora/revisions/aurora-preview-dashboard-<dashboard_sha256>.js`.
+
+Promotion accepts only the currently activated preview revision and a separately
+signed validation receipt. Schema v1 remains the physical-device receipt format.
+Schema v2 is the automated E2E format and contains no `physical_validation` claim.
+It binds `validation_kind: automated_e2e`, `action: promote_home_command`, the
+inspection audience and transaction, a caller-generated `operation_id`, an E2E
+evidence SHA-256, and exactly these
+six passing screenshot profiles: `mobile-390x844`,
+`tablet-portrait-800x1280`, `tablet-landscape-1280x800`, `kiosk-1280x800`,
+`laptop-1100x800`, and `desktop-1440x1000`. Each profile record contains only
+`profile_id`, `width`, `height`, `passed`, and `screenshot_sha256`. V2 receipts
+expire no more than ten minutes after issue. Both schemas use canonical compact,
+key-sorted JSON with `signature` omitted for Ed25519 verification and require a
+`validation-*` signer. There is no additional signature-domain prefix.
+
+Schema v1 keeps its physical receipt unchanged, but the promotion request now
+requires a caller-known canonical RFC 4122 UUID in body `operation_id`. The exact
+v1 request is `preview_revision`, `expected_production_revision`, `operation_id`,
+and `receipt`. Exact committed/aborted replay of that operation is idempotent;
+reusing the UUID with a different candidate, CAS value, or canonical receipt is
+rejected. Schema v2 retains its signed safe 8–128 character `operation_id`, which
+must also equal the body value.
+
+Promotion CAS-checks both the production revision label and canonical dashboard
+configuration bytes immediately before saving. It persists an operation ID before
+the write, independently reloads and hashes production before committing success,
+and exposes read-only status/readback by operation ID. An exact retry of the same
+committed v2 operation is idempotent; reusing its ID with different signed
+receipt/evidence is rejected. The server rejects missing, expired, malformed,
+replayed, or mismatched receipts.
+
+Operation status and readback acquire the same journal lock and settle their own
+prepared promotion/rollback transition before returning. Readback verifies the
+final committed or aborted revision/config state. A committed promotion additionally
+requires production to reference the exact content-addressed
+`/local/aurora/revisions/aurora-preview-dashboard-<sha256>.js` module and
+independently rehashes that file against the transaction-bound SHA-256 and size.
+Aborted promotion readback likewise verifies any content-addressed resource in
+the expected production prestate. Missing, tampered, or substituted resources
+fail closed. Committed readback fields use `dashboard_resource_url`,
+`dashboard_sha256`, and `dashboard_size`, plus `applied: true` and
+`verified: true`. Operation readback always reports
+`dashboard_resource_present`; an aborted operation returns `applied: false` only
+after the original CAS state and optional resource are independently verified.
+
+Production rollback has no caller-selected destination. Its request must bind a
+caller-known `operation_id`, `expected_current_revision`, and
+`expected_current_config_sha256`; the server checks both CAS values against the
+journal and live production, durably prepares the operation, restores only the
+stored immediate prior revision, and independently reloads and hashes the result
+before committing the rollback journal update. Exact committed retries are
+idempotent and status/readback use the same operation ID. Rollback status and
+readback expose `expected_current_revision` and
+`expected_current_config_sha256` aliases so the caller can bind reconciliation
+to its request. Both the expected-current and restored configs rehash their
+content-addressed assets when present.
+
+No endpoint returns tokens, credentials, filesystem paths, private artifact
+content, raw dashboard/package bytes, or caller-controlled/external URLs. The
+only returned URL is the strictly validated fixed same-origin dashboard resource.
+Other responses contain bounded transaction IDs, revision IDs, states, booleans,
+and SHA-256 evidence only.

--- a/docs/AURORA-SERVER-INTEGRATION.md
+++ b/docs/AURORA-SERVER-INTEGRATION.md
@@ -31,6 +31,7 @@ Only these operations exist:
 - `GET /{operation_id}/status`
 - `GET /{operation_id}/readback`
 - `POST /{transaction}/activate`
+- `POST /{transaction}/rollback`
 - `POST /{transaction}/reload`
 - `POST /promote-home-command`
 - `POST /rollback-home-command`

--- a/docs/AURORA-SERVER-INTEGRATION.md
+++ b/docs/AURORA-SERVER-INTEGRATION.md
@@ -51,6 +51,9 @@ absence, expanded-size/file-count bounds, and privacy denylist before writing a
 fresh revision directory. The archive remains staged evidence only: this adapter
 never installs, replaces, reloads, or rolls back `custom_components/aurora_camera_ai`.
 The Camera AI backend has its own release and restart lifecycle.
+The closed reviewed source allowlist includes the runtime-imported
+`custom_components/aurora_camera_ai/synthetic_fixture.py`; any undeclared archive
+member remains rejected.
 
 Stage requires a caller-known safe `transaction_id`. Before writing artifact
 bytes, the journal records a prepared stage transition bound to the exact

--- a/docs/AURORA-SERVER-INTEGRATION.md
+++ b/docs/AURORA-SERVER-INTEGRATION.md
@@ -38,8 +38,11 @@ Only these operations exist:
 The only dashboard targets are `aurora-preview` and `home-command`.
 `home-command-preview` is a refused legacy collision, not a third environment.
 Bootstrap creates the preview dashboard only when absent, hidden and admin-only;
-a mismatched existing preview fails closed. Bootstrap and staging never mutate
-production.
+an existing preview is accepted without registry mutation only for the canonical
+`Aurora Preview`/`mdi:aurora` display pair or the exact historical
+`Aurora V9 Preview`/`mdi:home-analytics` pair. Its URL path must remain
+`aurora-preview`, hidden, and admin-only; all other values for these guarded
+fields fail closed. Bootstrap and staging never mutate production.
 
 ## Verification and journal
 

--- a/scripts/bootstrap_aurora_deploy_via_file_editor.py
+++ b/scripts/bootstrap_aurora_deploy_via_file_editor.py
@@ -88,6 +88,15 @@ class PayloadFile(NamedTuple):
     size: int
 
 
+class BootstrapInputs(NamedTuple):
+    txid: str | None
+    payload: Payload | None
+    configuration_sha256: str | None
+    component_sha256: str | None
+    trust_sha256: str | None
+    recovery_arguments: dict[str, str | bool]
+
+
 class Payload(NamedTuple):
     files: tuple[PayloadFile, ...]
     manifest: bytes
@@ -168,9 +177,8 @@ def _validate_url(value: str) -> str:
     return value.rstrip("/")
 
 
-def _load_credentials() -> tuple[str, str]:  # noqa: C901
-    """Load credentials only from the fixed main-repository ``.env``."""
-    env_path = APPROVED_CREDENTIAL_ENV
+def _credential_env_lines(env_path: Path) -> list[str]:
+    """Read the fixed credential file after exact type and mode checks."""
     try:
         info = env_path.lstat()
     except OSError:
@@ -179,30 +187,42 @@ def _load_credentials() -> tuple[str, str]:  # noqa: C901
         raise BootstrapError("root_env_invalid")
     if stat.S_IMODE(info.st_mode) != 0o600:
         raise BootstrapError("root_env_permissions_unsafe")
-    values: dict[str, str] = {}
     try:
-        lines = env_path.read_text(encoding="utf-8").splitlines()
+        return env_path.read_text(encoding="utf-8").splitlines()
     except (OSError, UnicodeDecodeError):
         raise BootstrapError("root_env_invalid") from None
+
+
+def _credential_assignment(raw: str) -> tuple[str, str] | None:
+    """Return one allowed credential assignment or ignore an unrelated line."""
+    line = raw.strip()
+    if not line or line.startswith("#"):
+        return None
+    if line.startswith("export "):
+        line = line[7:].strip()
+    if "=" not in line:
+        return None
+    key, value = (part.strip() for part in line.split("=", 1))
+    if key not in {"HOMEASSISTANT_URL", "HOMEASSISTANT_TOKEN"}:
+        return None
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in {'"', "'"}:
+        value = value[1:-1]
+    if not value or "\r" in value or "\n" in value or "${" in value:
+        raise BootstrapError("root_env_invalid")
+    return key, value
+
+
+def _load_credentials() -> tuple[str, str]:
+    """Load credentials only from the fixed main-repository ``.env``."""
+    values: dict[str, str] = {}
+    lines = _credential_env_lines(APPROVED_CREDENTIAL_ENV)
     for raw in lines:
-        line = raw.strip()
-        if not line or line.startswith("#"):
+        assignment = _credential_assignment(raw)
+        if assignment is None:
             continue
-        if line.startswith("export "):
-            line = line[7:].strip()
-        if "=" not in line:
-            continue
-        key, value = line.split("=", 1)
-        key = key.strip()
-        if key not in {"HOMEASSISTANT_URL", "HOMEASSISTANT_TOKEN"}:
-            continue
+        key, value = assignment
         if key in values:
             raise BootstrapError("root_env_duplicate_credential")
-        value = value.strip()
-        if len(value) >= 2 and value[0] == value[-1] and value[0] in {'"', "'"}:
-            value = value[1:-1]
-        if not value or "\r" in value or "\n" in value or "${" in value:
-            raise BootstrapError("root_env_invalid")
         values[key] = value
     if set(values) != {"HOMEASSISTANT_URL", "HOMEASSISTANT_TOKEN"}:
         raise BootstrapError("root_env_credentials_required")
@@ -272,7 +292,50 @@ def _git_output(source_root: Path, *args: str) -> str:
     return result.stdout.strip()
 
 
-def validate_local_payload(  # noqa: C901 - exact source and independent pin gate
+def _validated_source_root(source_root: Path) -> Path:
+    """Resolve the source root and reject symlinked or non-directory roots."""
+    try:
+        info = source_root.lstat()
+        root = source_root.resolve(strict=True)
+    except OSError:
+        raise BootstrapError("source_root_unavailable") from None
+    if stat.S_ISLNK(info.st_mode) or not root.is_dir():
+        raise BootstrapError("source_root_invalid")
+    return root
+
+
+def _validate_component_file_set(root: Path) -> None:
+    """Require the exact Aurora component source file set."""
+    directory = root / "custom_components" / "aurora_deploy"
+    try:
+        info = directory.lstat()
+    except OSError:
+        raise BootstrapError("source_component_unavailable") from None
+    if stat.S_ISLNK(info.st_mode) or not stat.S_ISDIR(info.st_mode):
+        raise BootstrapError("source_component_invalid")
+    actual: set[str] = set()
+    for item in directory.iterdir():
+        if item.name == "__pycache__" and item.is_dir() and not item.is_symlink():
+            continue
+        if item.is_symlink() or not item.is_file():
+            raise BootstrapError("source_component_file_set_invalid")
+        actual.add(item.name)
+    if actual != set(COMPONENT_FILES):
+        raise BootstrapError("source_component_file_set_invalid")
+
+
+def _validated_payload_files(root: Path) -> tuple[PayloadFile, ...]:
+    """Require every payload path to be tracked and return exact bytes."""
+    for relative in PAYLOAD_PATHS:
+        _git_output(root, "ls-files", "--error-unmatch", "--", relative)
+    return tuple(
+        PayloadFile(relative, content, _digest(content), len(content))
+        for relative in PAYLOAD_PATHS
+        for content in (_regular_bytes(root, relative),)
+    )
+
+
+def validate_local_payload(
     source_root: Path,
     *,
     expected_manifest_sha256: str,
@@ -292,41 +355,14 @@ def validate_local_payload(  # noqa: C901 - exact source and independent pin gat
     )
     if REVISION.fullmatch(expected_source_revision) is None:
         raise BootstrapError("expected_source_revision_required")
-    try:
-        root_info = source_root.lstat()
-        root = source_root.resolve(strict=True)
-    except OSError:
-        raise BootstrapError("source_root_unavailable") from None
-    if stat.S_ISLNK(root_info.st_mode) or not root.is_dir():
-        raise BootstrapError("source_root_invalid")
-    component_directory = root / "custom_components" / "aurora_deploy"
-    try:
-        component_info = component_directory.lstat()
-    except OSError:
-        raise BootstrapError("source_component_unavailable") from None
-    if stat.S_ISLNK(component_info.st_mode) or not stat.S_ISDIR(component_info.st_mode):
-        raise BootstrapError("source_component_invalid")
-    actual_component_files: set[str] = set()
-    for item in component_directory.iterdir():
-        if item.name == "__pycache__" and item.is_dir() and not item.is_symlink():
-            continue
-        if item.is_symlink() or not item.is_file():
-            raise BootstrapError("source_component_file_set_invalid")
-        actual_component_files.add(item.name)
-    if actual_component_files != set(COMPONENT_FILES):
-        raise BootstrapError("source_component_file_set_invalid")
+    root = _validated_source_root(source_root)
+    _validate_component_file_set(root)
     revision = _git_output(root, "rev-parse", "HEAD")
     if revision != expected_source_revision:
         raise BootstrapError("source_revision_mismatch")
     if _git_output(root, "status", "--porcelain=v1", "--untracked-files=all"):
         raise BootstrapError("source_worktree_not_clean")
-    for relative in PAYLOAD_PATHS:
-        _git_output(root, "ls-files", "--error-unmatch", "--", relative)
-    files = tuple(
-        PayloadFile(relative, content, _digest(content), len(content))
-        for relative in PAYLOAD_PATHS
-        for content in (_regular_bytes(root, relative),)
-    )
+    files = _validated_payload_files(root)
     component_manifest = next(
         item for item in files if item.relative_path.endswith("/manifest.json")
     )
@@ -429,29 +465,8 @@ def _fresh_ha_recovery_backup(
     return item
 
 
-def validate_supervisor_preflight(  # noqa: C901
-    *,
-    user: dict[str, Any],
-    supervisor: dict[str, Any],
-    host: dict[str, Any],
-    backup: dict[str, Any] | None,
-    addon: dict[str, Any],
-    store: dict[str, Any],
-    backup_id: str | None,
-    expected_backup_agent_id: str | None,
-    require_backup: bool,
-    now: datetime | None = None,
-) -> str:
-    if user.get("is_admin") is not True:
-        raise BootstrapError("administrator_required")
-    if (
-        supervisor.get("healthy") is not True
-        or supervisor.get("supported") is not True
-        or ("state" in supervisor and supervisor["state"] != "running")
-    ):
-        raise BootstrapError("supervisor_not_ready")
-    if supervisor.get("arch") != "amd64":
-        raise BootstrapError("unsupported_architecture")
+def _validate_haos_host(host: dict[str, Any]) -> None:
+    """Validate either explicit host architecture or legacy HAOS metadata."""
     host_arch_fields = [key for key in ("arch", "architecture") if key in host]
     if host_arch_fields:
         if any(host[key] != "amd64" for key in host_arch_fields):
@@ -481,9 +496,17 @@ def validate_supervisor_preflight(  # noqa: C901
             raise BootstrapError("host_metadata_invalid")
     if host.get("features") is not None and not isinstance(host["features"], list):
         raise BootstrapError("host_metadata_invalid")
-    if require_backup:
-        if (
-            expected_backup_agent_id != APPROVED_BACKUP_AGENT_ID
+
+
+def _validate_recovery_backup(
+    backup: dict[str, Any] | None,
+    backup_id: str | None,
+    expected_agent_id: str | None,
+    now: datetime | None,
+) -> None:
+    """Validate one fresh protected database-inclusive HA backup."""
+    if (
+            expected_agent_id != APPROVED_BACKUP_AGENT_ID
             or not isinstance(backup_id, str)
             or SAFE_BACKUP_ID.fullmatch(backup_id) is None
             or not isinstance(backup, dict)
@@ -493,12 +516,16 @@ def validate_supervisor_preflight(  # noqa: C901
             or _fresh_ha_recovery_backup(
                 backup.get("backups"),
                 backup_id,
-                expected_backup_agent_id,
+                expected_agent_id,
                 now=now,
             )
             is None
-        ):
-            raise BootstrapError("protected_ha_recovery_backup_required")
+    ):
+        raise BootstrapError("protected_ha_recovery_backup_required")
+
+
+def _validate_file_editor_addon(addon: dict[str, Any]) -> str:
+    """Validate the installed File editor identity and confinement."""
     if addon.get("slug") != FILE_EDITOR_SLUG or addon.get("name") != "File editor":
         raise BootstrapError("file_editor_identity_mismatch")
     if addon.get("version") != FILE_EDITOR_VERSION:
@@ -516,6 +543,11 @@ def validate_supervisor_preflight(  # noqa: C901
         raise BootstrapError("file_editor_network_exposed")
     if addon.get("repository") != "core":
         raise BootstrapError("file_editor_not_official")
+    return ingress
+
+
+def _validate_file_editor_store(store: dict[str, Any]) -> None:
+    """Validate the Supervisor store metadata for the pinned add-on."""
     store_version = store.get("version_latest") or store.get("version")
     if (
         store.get("slug") != FILE_EDITOR_SLUG
@@ -530,6 +562,38 @@ def validate_supervisor_preflight(  # noqa: C901
         raise BootstrapError("file_editor_store_mismatch")
     if "network" in store and store["network"] is not None:
         raise BootstrapError("file_editor_network_exposed")
+
+
+def validate_supervisor_preflight(
+    *,
+    user: dict[str, Any],
+    supervisor: dict[str, Any],
+    host: dict[str, Any],
+    backup: dict[str, Any] | None,
+    addon: dict[str, Any],
+    store: dict[str, Any],
+    backup_id: str | None,
+    expected_backup_agent_id: str | None,
+    require_backup: bool,
+    now: datetime | None = None,
+) -> str:
+    if user.get("is_admin") is not True:
+        raise BootstrapError("administrator_required")
+    if (
+        supervisor.get("healthy") is not True
+        or supervisor.get("supported") is not True
+        or ("state" in supervisor and supervisor["state"] != "running")
+    ):
+        raise BootstrapError("supervisor_not_ready")
+    if supervisor.get("arch") != "amd64":
+        raise BootstrapError("unsupported_architecture")
+    _validate_haos_host(host)
+    if require_backup:
+        _validate_recovery_backup(
+            backup, backup_id, expected_backup_agent_id, now
+        )
+    ingress = _validate_file_editor_addon(addon)
+    _validate_file_editor_store(store)
     return ingress
 
 
@@ -672,22 +736,10 @@ def _validated_file_state(value: Any, *, required: bool) -> dict[str, Any]:
     return value
 
 
-def _component_state_digest(value: Any) -> str:  # noqa: C901
-    if not isinstance(value, dict) or not isinstance(value.get("exists"), bool):
-        raise BootstrapError("transaction_invalid")
-    if value["exists"] is False:
-        if value != {"exists": False, "files": {}, "directories": {}}:
-            raise BootstrapError("transaction_invalid")
-        return _digest(_canonical({"exists": False, "files": {}, "directories": []}))
-    if (
-        set(value) != {"exists", "files", "directories"}
-        or not isinstance(value["files"], dict)
-        or not isinstance(value["directories"], dict)
-        or len(value["files"]) + len(value["directories"]) > 129
-    ):
-        raise BootstrapError("transaction_invalid")
+def _component_file_hashes(entries: dict[Any, Any]) -> dict[str, str]:
+    """Validate component files and omit bounded interpreter artifacts."""
     files: dict[str, str] = {}
-    for name, state in value["files"].items():
+    for name, state in entries.items():
         if not isinstance(name, str):
             raise BootstrapError("transaction_invalid")
         _validated_file_state({"exists": True, **state}, required=True)
@@ -696,8 +748,13 @@ def _component_state_digest(value: Any) -> str:  # noqa: C901
                 raise BootstrapError("component_generated_artifact_invalid")
             continue
         files[name] = state["sha256"]
+    return files
+
+
+def _component_directories(entries: dict[Any, Any]) -> list[str]:
+    """Validate component directory metadata and return semantic paths."""
     directories: list[str] = []
-    for name, state in value["directories"].items():
+    for name, state in entries.items():
         if (
             not isinstance(name, str)
             or not isinstance(state, dict)
@@ -713,10 +770,29 @@ def _component_state_digest(value: Any) -> str:  # noqa: C901
         if name.startswith("__pycache__/"):
             raise BootstrapError("component_generated_artifact_invalid")
         directories.append(name)
-    if "." not in value["directories"]:
+    if "." not in entries:
         raise BootstrapError("transaction_invalid")
+    return sorted(directories)
+
+
+def _component_state_digest(value: Any) -> str:
+    if not isinstance(value, dict) or not isinstance(value.get("exists"), bool):
+        raise BootstrapError("transaction_invalid")
+    if value["exists"] is False:
+        if value != {"exists": False, "files": {}, "directories": {}}:
+            raise BootstrapError("transaction_invalid")
+        return _digest(_canonical({"exists": False, "files": {}, "directories": []}))
+    if (
+        set(value) != {"exists", "files", "directories"}
+        or not isinstance(value["files"], dict)
+        or not isinstance(value["directories"], dict)
+        or len(value["files"]) + len(value["directories"]) > 129
+    ):
+        raise BootstrapError("transaction_invalid")
+    files = _component_file_hashes(value["files"])
+    directories = _component_directories(value["directories"])
     return _digest(
-        _canonical({"exists": True, "files": files, "directories": sorted(directories)})
+        _canonical({"exists": True, "files": files, "directories": directories})
     )
 
 
@@ -1067,7 +1143,43 @@ class FileEditorIngressClient:
             return "absent"
         return _digest(self._download_path(REMOTE_TRUST))
 
-    def component_tree_sha256(self) -> str:  # noqa: C901
+    def _component_tree_item(
+        self,
+        item: Any,
+        directory: str,
+        prefix: str,
+        files: dict[str, str],
+        directories: set[str],
+        pending: list[tuple[str, str]],
+    ) -> int:
+        """Validate and account for one remote component entry."""
+        if not isinstance(item, dict) or not isinstance(item.get("name"), str):
+            raise BootstrapError("remote_component_invalid")
+        name = item["name"]
+        if name in {".", ".."} or "/" in name or "\\" in name:
+            raise BootstrapError("remote_component_invalid")
+        relative = f"{prefix}/{name}".lstrip("/")
+        if len(PurePosixPath(relative).parts) > 8 or len(files) + len(pending) >= 128:
+            raise BootstrapError("remote_component_too_large")
+        expected = f"{directory}/{name}"
+        if item.get("fullpath") != expected or item.get("type") not in {"file", "dir"}:
+            raise BootstrapError("remote_component_invalid")
+        if item["type"] == "dir":
+            if relative != "__pycache__":
+                if relative.startswith("__pycache__/"):
+                    raise BootstrapError("component_generated_artifact_invalid")
+                directories.add(relative)
+            pending.append((expected, relative))
+            return 0
+        content = self._download_path(expected)
+        if SAFE_PYCACHE.fullmatch(relative) is not None:
+            return len(content)
+        if relative.startswith("__pycache__/"):
+            raise BootstrapError("component_generated_artifact_invalid")
+        files[relative] = _digest(content)
+        return len(content)
+
+    def component_tree_sha256(self) -> str:
         if not self._exists(REMOTE_COMPONENT, expected_type="dir"):
             return _digest(
                 _canonical({"exists": False, "files": {}, "directories": []})
@@ -1079,41 +1191,11 @@ class FileEditorIngressClient:
         while pending:
             directory, prefix = pending.pop()
             for item in self._list(directory):
-                if not isinstance(item, dict) or not isinstance(item.get("name"), str):
-                    raise BootstrapError("remote_component_invalid")
-                name = item["name"]
-                if name in {".", ".."} or "/" in name or "\\" in name:
-                    raise BootstrapError("remote_component_invalid")
-                relative = f"{prefix}/{name}".lstrip("/")
-                if (
-                    len(PurePosixPath(relative).parts) > 8
-                    or len(files) + len(pending) >= 128
-                ):
+                total_bytes += self._component_tree_item(
+                    item, directory, prefix, files, directories, pending
+                )
+                if total_bytes > 8 * 1024 * 1024:
                     raise BootstrapError("remote_component_too_large")
-                expected = f"{directory}/{name}"
-                if item.get("fullpath") != expected or item.get("type") not in {
-                    "file",
-                    "dir",
-                }:
-                    raise BootstrapError("remote_component_invalid")
-                if item["type"] == "dir":
-                    if relative == "__pycache__":
-                        pass
-                    elif relative.startswith("__pycache__/"):
-                        raise BootstrapError("component_generated_artifact_invalid")
-                    else:
-                        directories.add(relative)
-                    pending.append((expected, relative))
-                else:
-                    content = self._download_path(expected)
-                    total_bytes += len(content)
-                    if total_bytes > 8 * 1024 * 1024:
-                        raise BootstrapError("remote_component_too_large")
-                    if SAFE_PYCACHE.fullmatch(relative) is not None:
-                        continue
-                    if relative.startswith("__pycache__/"):
-                        raise BootstrapError("component_generated_artifact_invalid")
-                    files[relative] = _digest(content)
         return _digest(
             _canonical(
                 {
@@ -1233,9 +1315,10 @@ class FileEditorIngressClient:
         verified = all(result.get(key) == value for key, value in current.items())
         return {**result, **current, "verified": verified}
 
-    def execute(  # noqa: C901 - fixed command and lost-response state machine
-        self, *, mode: str, transaction_id: str, arguments: dict[str, str | bool]
-    ) -> dict[str, Any]:
+    def _installer_command(
+        self, mode: str, transaction_id: str, arguments: dict[str, str | bool]
+    ) -> str:
+        """Build the fixed installer command after exact argument validation."""
         if mode not in {
             "install",
             "rollback",
@@ -1280,6 +1363,38 @@ class FileEditorIngressClient:
                 raise BootstrapError("installer_argument_invalid")
         if any(char in command for char in ";&|`$<>(){}[]\\\r\n"):
             raise BootstrapError("installer_command_invalid")
+        return command
+
+    def _validated_command_wrapper(
+        self,
+        wrapper: dict[str, Any],
+        command: str,
+        mode: str,
+        transaction_id: str,
+    ) -> dict[str, Any]:
+        """Validate File editor command output and installer receipt."""
+        if (
+            set(wrapper) != {"error", "message", "returncode", "stdout", "stderr"}
+            or wrapper["error"] is not False
+            or wrapper["message"] != f"Command executed: {command}"
+            or not isinstance(wrapper["returncode"], int)
+            or isinstance(wrapper["returncode"], bool)
+            or wrapper["returncode"] != 0
+        ):
+            raise BootstrapError("installer_outcome_unknown")
+        stdout = wrapper.get("stdout")
+        if not isinstance(stdout, str) or wrapper.get("stderr") != "" or len(stdout) > 4096:
+            raise BootstrapError("installer_outcome_unknown")
+        return _validated_installer_receipt(
+            _json_object(stdout.encode(), "installer_output_invalid"),
+            mode,
+            transaction_id,
+        )
+
+    def execute(
+        self, *, mode: str, transaction_id: str, arguments: dict[str, str | bool]
+    ) -> dict[str, Any]:
+        command = self._installer_command(mode, transaction_id, arguments)
         try:
             wrapper = self._request(
                 "/api/exec_command",
@@ -1294,26 +1409,8 @@ class FileEditorIngressClient:
                 raise
             return self._reconcile_lost_response(mode, transaction_id, arguments)
         try:
-            if (
-                set(wrapper) != {"error", "message", "returncode", "stdout", "stderr"}
-                or wrapper["error"] is not False
-                or wrapper["message"] != f"Command executed: {command}"
-                or not isinstance(wrapper["returncode"], int)
-                or isinstance(wrapper["returncode"], bool)
-                or wrapper["returncode"] != 0
-            ):
-                raise BootstrapError("installer_outcome_unknown")
-            stdout = wrapper.get("stdout")
-            if (
-                not isinstance(stdout, str)
-                or wrapper.get("stderr") != ""
-                or len(stdout) > 4096
-            ):
-                raise BootstrapError("installer_outcome_unknown")
-            return _validated_installer_receipt(
-                _json_object(stdout.encode(), "installer_output_invalid"),
-                mode,
-                transaction_id,
+            return self._validated_command_wrapper(
+                wrapper, command, mode, transaction_id
             )
         except Exception:
             return self._reconcile_lost_response(mode, transaction_id, arguments)
@@ -1970,7 +2067,103 @@ async def _addon_action(url: str, token: str, action: str, socket_factory: Any) 
     raise BootstrapError("file_editor_lifecycle_unverified")
 
 
-async def _open_editor(  # noqa: C901
+def _preflight_snapshot(
+    snapshot: dict[str, Any],
+    backup_id: str | None,
+    expected_agent: str | None,
+    require_backup: bool,
+) -> tuple[Any, str]:
+    """Validate one Supervisor snapshot and return state plus ingress id."""
+    return snapshot["addon"].get("state"), validate_supervisor_preflight(
+        **snapshot,
+        backup_id=backup_id,
+        expected_backup_agent_id=expected_agent,
+        require_backup=require_backup,
+    )
+
+
+async def _adopt_lifecycle_lease(
+    url: str,
+    token: str,
+    observed: Any,
+    initial: Any,
+    operation_mode: str,
+    transaction_id: str | None,
+    socket_factory: Any,
+) -> tuple[Any, Any, bool]:
+    """Recover or adopt one stale File editor lifecycle lease."""
+    lease = _read_lifecycle_lease()
+    if lease is None:
+        return observed, initial, False
+    if _lifecycle_process_alive(lease["processId"]):
+        raise BootstrapError("file_editor_lifecycle_lease_active")
+    if lease["initialState"] == "started":
+        if observed == "stopped":
+            await _addon_action(url, token, "start", socket_factory)
+        _clear_lifecycle_lease()
+        return "started", "started", False
+    if observed == "started":
+        _write_lifecycle_lease(operation_mode, transaction_id, create=False)
+        return observed, "stopped", True
+    _clear_lifecycle_lease()
+    return observed, initial, False
+
+
+async def _start_editor_for_operation(
+    url: str,
+    token: str,
+    operation_mode: str,
+    transaction_id: str | None,
+    observed: Any,
+    initial: Any,
+    adopted: bool,
+    socket_factory: Any,
+) -> tuple[bool, bool]:
+    """Start or cycle File editor and return cleanup/recheck flags."""
+    started_by_us = initial == "stopped"
+    recovery_cycled = operation_mode == "recover-lock" and observed == "started"
+    if recovery_cycled:
+        if not adopted:
+            _write_lifecycle_lease(
+                operation_mode, transaction_id, create=True, initial_state="started"
+            )
+        await _addon_action(url, token, "stop", socket_factory)
+        await _addon_action(url, token, "start", socket_factory)
+        if not adopted:
+            _clear_lifecycle_lease()
+    elif started_by_us and not adopted:
+        _write_lifecycle_lease(operation_mode, transaction_id, create=True)
+        await _addon_action(url, token, "start", socket_factory)
+    return started_by_us, recovery_cycled
+
+
+async def _ingress_session(url: str, token: str, socket_factory: Any) -> str:
+    """Create and validate one bounded Supervisor ingress session."""
+    async with socket_factory(url, token) as socket:
+        session = _supervisor_data(
+            await socket.call(
+                "supervisor/api", endpoint="/ingress/session", method="post", data={}
+            )
+        ).get("session")
+    if not isinstance(session, str) or SAFE_SESSION.fullmatch(session) is None:
+        raise BootstrapError("ingress_session_invalid")
+    return session
+
+
+async def _restore_editor_after_failure(
+    url: str, token: str, initial: Any, socket_factory: Any
+) -> None:
+    """Restore the add-on to its recorded initial state after failure."""
+    if initial != "stopped":
+        return
+    try:
+        await _addon_action(url, token, "stop", socket_factory)
+        _clear_lifecycle_lease()
+    except BaseException:
+        raise BootstrapError("operation_failed_and_file_editor_restore_failed") from None
+
+
+async def _open_editor(
     url: str,
     token: str,
     backup_id: str | None,
@@ -1981,100 +2174,34 @@ async def _open_editor(  # noqa: C901
     socket_factory: Any,
 ) -> tuple[str, str, str]:
     snapshot = await _supervisor_snapshot(url, token, socket_factory)
-    observed_initial = snapshot["addon"].get("state")
-    initial = observed_initial
-    ingress = validate_supervisor_preflight(
-        **snapshot,
-        backup_id=backup_id,
-        expected_backup_agent_id=expected_backup_agent_id,
-        require_backup=require_backup,
+    observed_initial, ingress = _preflight_snapshot(
+        snapshot, backup_id, expected_backup_agent_id, require_backup
     )
-    lease = _read_lifecycle_lease()
-    adopted = False
-    if lease is not None:
-        if _lifecycle_process_alive(lease["processId"]):
-            raise BootstrapError("file_editor_lifecycle_lease_active")
-        if lease["initialState"] == "started":
-            if observed_initial == "stopped":
-                await _addon_action(url, token, "start", socket_factory)
-            _clear_lifecycle_lease()
-            snapshot = await _supervisor_snapshot(url, token, socket_factory)
-            observed_initial = snapshot["addon"].get("state")
-            initial = observed_initial
-            ingress = validate_supervisor_preflight(
-                **snapshot,
-                backup_id=backup_id,
-                expected_backup_agent_id=expected_backup_agent_id,
-                require_backup=require_backup,
-            )
-        elif observed_initial == "started":
-            _write_lifecycle_lease(operation_mode, transaction_id, create=False)
-            initial = "stopped"
-            adopted = True
-        else:
-            _clear_lifecycle_lease()
-    started_by_us = initial == "stopped"
-    restore_started_on_failure = False
+    initial = observed_initial
+    observed_initial, initial, adopted = await _adopt_lifecycle_lease(
+        url,
+        token,
+        observed_initial,
+        initial,
+        operation_mode,
+        transaction_id,
+        socket_factory,
+    )
     try:
-        recovery_cycled = False
-        if operation_mode == "recover-lock" and observed_initial == "started":
-            if not adopted:
-                _write_lifecycle_lease(
-                    operation_mode,
-                    transaction_id,
-                    create=True,
-                    initial_state="started",
-                )
-                restore_started_on_failure = True
-            await _addon_action(url, token, "stop", socket_factory)
-            await _addon_action(url, token, "start", socket_factory)
-            recovery_cycled = True
-            if restore_started_on_failure:
-                _clear_lifecycle_lease()
-                restore_started_on_failure = False
-        if started_by_us:
-            if not adopted and not recovery_cycled:
-                _write_lifecycle_lease(operation_mode, transaction_id, create=True)
-                await _addon_action(url, token, "start", socket_factory)
+        started_by_us, recovery_cycled = await _start_editor_for_operation(
+            url, token, operation_mode, transaction_id, observed_initial,
+            initial, adopted, socket_factory
+        )
         if started_by_us or recovery_cycled:
             snapshot = await _supervisor_snapshot(url, token, socket_factory)
-            ingress = validate_supervisor_preflight(
-                **snapshot,
-                backup_id=backup_id,
-                expected_backup_agent_id=expected_backup_agent_id,
-                require_backup=require_backup,
+            state, ingress = _preflight_snapshot(
+                snapshot, backup_id, expected_backup_agent_id, require_backup
             )
-            if snapshot["addon"].get("state") != "started":
+            if state != "started":
                 raise BootstrapError("file_editor_start_unverified")
-        async with socket_factory(url, token) as socket:
-            session = _supervisor_data(
-                await socket.call(
-                    "supervisor/api",
-                    endpoint="/ingress/session",
-                    method="post",
-                    data={},
-                )
-            ).get("session")
-        if not isinstance(session, str) or SAFE_SESSION.fullmatch(session) is None:
-            raise BootstrapError("ingress_session_invalid")
-        return initial, ingress, session
+        return initial, ingress, await _ingress_session(url, token, socket_factory)
     except BaseException as primary:
-        if restore_started_on_failure:
-            try:
-                await _addon_action(url, token, "start", socket_factory)
-                _clear_lifecycle_lease()
-            except BaseException:
-                raise BootstrapError(
-                    "operation_failed_and_file_editor_restore_failed"
-                ) from None
-        elif started_by_us:
-            try:
-                await _addon_action(url, token, "stop", socket_factory)
-                _clear_lifecycle_lease()
-            except BaseException:
-                raise BootstrapError(
-                    "operation_failed_and_file_editor_restore_failed"
-                ) from None
+        await _restore_editor_after_failure(url, token, initial, socket_factory)
         raise primary
 
 
@@ -2126,9 +2253,8 @@ def _ensure_stage_abort_installer(
         raise BootstrapError("remote_installer_hash_mismatch")
 
 
-def _write_local_record(  # noqa: C901
-    txid: str, value: dict[str, Any], *, create: bool
-) -> None:
+def _local_record_path(txid: str, *, create: bool) -> tuple[Path, Path, str]:
+    """Validate local state root and target file semantics."""
     directory = APPROVED_STATE_DIRECTORY
     local_root = directory.parent
     if local_root.exists() and local_root.is_symlink():
@@ -2155,6 +2281,11 @@ def _write_local_record(  # noqa: C901
     elif not create:
         raise BootstrapError("local_transaction_missing")
     prefix = f".{txid}.new-"
+    return directory, path, prefix
+
+
+def _cleanup_local_residue(directory: Path, prefix: str) -> None:
+    """Remove only stale, structurally valid temp files."""
     residue = [item for item in directory.iterdir() if item.name.startswith(prefix)]
     if len(residue) > 128:
         raise BootstrapError("local_state_invalid")
@@ -2176,10 +2307,14 @@ def _write_local_record(  # noqa: C901
             item.unlink()
         except PermissionError:
             pass
+
+
+def _write_temp_record(directory: Path, prefix: str, value: dict[str, Any]) -> tuple[Path, os.stat_result]:
+    """Create, fully write, and fsync one protected temp record."""
     temp = directory / f"{prefix}{os.getpid()}-{secrets.token_hex(8)}"
     flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0)
     fd = os.open(temp, flags, 0o600)
-    temp_info = os.fstat(fd)
+    info = os.fstat(fd)
     try:
         try:
             remaining = memoryview(_canonical(value))
@@ -2191,6 +2326,35 @@ def _write_local_record(  # noqa: C901
             os.fsync(fd)
         finally:
             os.close(fd)
+    except BaseException:
+        _remove_temp_record(temp, info)
+        raise
+    return temp, info
+
+
+def _remove_temp_record(temp: Path, expected: os.stat_result) -> None:
+    """Delete a temp record only if its inode is unchanged."""
+    if not os.path.lexists(temp):
+        return
+    current = temp.lstat()
+    if (
+        stat.S_ISLNK(current.st_mode)
+        or not stat.S_ISREG(current.st_mode)
+        or current.st_dev != expected.st_dev
+        or current.st_ino != expected.st_ino
+    ):
+        raise BootstrapError("local_state_invalid")
+    temp.unlink()
+    _fsync_local_directory(temp.parent)
+
+
+def _write_local_record(
+    txid: str, value: dict[str, Any], *, create: bool
+) -> None:
+    directory, path, prefix = _local_record_path(txid, create=create)
+    _cleanup_local_residue(directory, prefix)
+    temp, temp_info = _write_temp_record(directory, prefix, value)
+    try:
         if create:
             try:
                 os.link(temp, path, follow_symlinks=False)
@@ -2200,17 +2364,7 @@ def _write_local_record(  # noqa: C901
             os.replace(temp, path)
         _fsync_local_directory(directory)
     finally:
-        if os.path.lexists(temp):
-            current = temp.lstat()
-            if (
-                stat.S_ISLNK(current.st_mode)
-                or not stat.S_ISREG(current.st_mode)
-                or current.st_dev != temp_info.st_dev
-                or current.st_ino != temp_info.st_ino
-            ):
-                raise BootstrapError("local_state_invalid") from None
-            temp.unlink()
-            _fsync_local_directory(directory)
+        _remove_temp_record(temp, temp_info)
 
 
 def _fsync_local_directory(directory: Path) -> None:
@@ -2562,7 +2716,441 @@ def _credential_transport_receipt(url: str) -> dict[str, str]:
     }
 
 
-async def bootstrap(  # noqa: C901
+def _verify_client_hashes(
+    client: FileEditorIngressClient,
+    expected_configuration: Any,
+    expected_component: Any,
+    expected_trust: Any,
+    code: str,
+) -> None:
+    """Verify all three remote state hashes or raise one stable code."""
+    if (
+        _digest(client.configuration_bytes()) != expected_configuration
+        or client.component_tree_sha256() != expected_component
+        or client.trust_sha256() != expected_trust
+    ):
+        raise BootstrapError(code)
+
+
+def _preflight_result(client: FileEditorIngressClient, payload: Payload) -> dict[str, Any]:
+    """Return the exact local and remote pins established by preflight."""
+    return {
+        "status": "preflight_ready",
+        "configurationSha256": _digest(client.configuration_bytes()),
+        "componentTreeSha256": client.component_tree_sha256(),
+        "trustSha256": client.trust_sha256(),
+        "payloadManifestSha256": payload.manifest_sha256,
+        "releaseKeySha256": payload.release_key_sha256,
+        "validationKeySha256": payload.validation_key_sha256,
+        "sourceRevision": payload.source_revision,
+        "installerSha256": INSTALLER_SHA256,
+    }
+
+
+def _install_result(
+    client: FileEditorIngressClient,
+    txid: str,
+    payload: Payload,
+    expected_configuration: str,
+    expected_component: str,
+    expected_trust: str,
+    replace_exact: bool,
+    recovery_arguments: dict[str, str | bool],
+    config_check: Any,
+    url: str,
+    token: str,
+) -> dict[str, Any]:
+    """Stage, install, validate, and roll back on failed validation."""
+    config_check(url, token)
+    _verify_client_hashes(
+        client, expected_configuration, expected_component, expected_trust,
+        "prestage_cas_mismatch"
+    )
+    _stage_payload(client, txid, payload)
+    arguments = dict(recovery_arguments)
+    if replace_exact:
+        arguments["replace-exact"] = True
+    result = client.execute(mode="install", transaction_id=txid, arguments=arguments)
+    try:
+        config_check(url, token)
+        _verify_client_hashes(
+            client,
+            result.get("configurationSha256"),
+            result.get("componentTreeSha256"),
+            result.get("trustSha256"),
+            "post_install_readback_mismatch",
+        )
+    except BaseException:
+        try:
+            rollback = client.execute(
+                mode="rollback", transaction_id=txid, arguments=recovery_arguments
+            )
+            config_check(url, token)
+            _verify_client_hashes(
+                client,
+                rollback.get("configurationSha256"),
+                rollback.get("componentTreeSha256"),
+                rollback.get("trustSha256"),
+                "rollback_readback_mismatch",
+            )
+        except BaseException:
+            raise BootstrapError("post_install_validation_failed_rollback_unverified") from None
+        raise BootstrapError("post_install_validation_failed_rolled_back") from None
+    result["restartRequired"] = True
+    return result
+
+
+def _rollback_result(
+    client: FileEditorIngressClient,
+    txid: str,
+    arguments: dict[str, str | bool],
+    config_check: Any,
+    url: str,
+    token: str,
+) -> dict[str, Any]:
+    """Execute and verify one exact bootstrap rollback."""
+    result = client.execute(mode="rollback", transaction_id=txid, arguments=arguments)
+    config_check(url, token)
+    _verify_client_hashes(
+        client,
+        result.get("configurationSha256"),
+        result.get("componentTreeSha256"),
+        result.get("trustSha256"),
+        "rollback_readback_mismatch",
+    )
+    result["restartRequired"] = True
+    return result
+
+
+def _abort_stage_result(
+    client: FileEditorIngressClient,
+    txid: str,
+    arguments: dict[str, str | bool],
+) -> dict[str, Any]:
+    """Ensure the pinned installer exists and abort an uncommitted stage."""
+    if client.transaction_exists(txid):
+        raise BootstrapError("stage_abort_transaction_exists")
+    expected = arguments["expected-installer-sha256"]
+    if not isinstance(expected, str):
+        raise BootstrapError("expected_installer_hash_required")
+    _ensure_stage_abort_installer(
+        client, txid, expected, _local_installer_bytes(_read_local_record(txid))
+    )
+    return client.execute(
+        mode="abort-stage",
+        transaction_id=txid,
+        arguments={"expected-installer-sha256": expected},
+    )
+
+
+def _reconciled_finalize_result(
+    client: FileEditorIngressClient,
+    txid: str,
+    status: dict[str, Any],
+    local: dict[str, Any],
+    config_check: Any,
+    url: str,
+    token: str,
+) -> dict[str, Any] | None:
+    """Finish a local finalize after the remote transaction already vanished."""
+    if status.get("status") != "not_found":
+        return None
+    absent = all(
+        status.get(key) is False
+        for key in (
+            "lockHeld", "lockOwnerMatches", "stagePresent", "lockCandidatePresent",
+            "transactionPresent", "initializationPresent",
+        )
+    )
+    if local.get("status") not in {"finalize_authorized", "finalized"} or not absent:
+        raise BootstrapError("finalize_not_allowed")
+    expected_configuration = _validate_hash(
+        local.get("finalizeConfigurationSha256"), "finalize_authorization_invalid"
+    )
+    expected_component = _validate_hash(
+        local.get("finalizeComponentTreeSha256"), "finalize_authorization_invalid"
+    )
+    expected_trust = _validate_hash(
+        local.get("finalizeTrustSha256"), "finalize_authorization_invalid", absent=True
+    )
+    config_check(url, token)
+    _verify_client_hashes(
+        client, expected_configuration, expected_component, expected_trust,
+        "finalize_readback_mismatch"
+    )
+    return {
+        "status": "finalized",
+        "transactionId": txid,
+        "payloadManifestSha256": _validate_hash(
+            local.get("payloadManifestSha256"), "local_payload_pin_required"
+        ),
+        "reconciled": True,
+    }
+
+
+def _validate_finalize_status(
+    client: FileEditorIngressClient,
+    status: dict[str, Any],
+    config_check: Any,
+    url: str,
+    token: str,
+) -> None:
+    """Verify a remote transaction is in one permitted finalize state."""
+    allowed = {
+        "installed", "restart_verified", "finalize_prepared", "rolled_back",
+        "rolled_back_after_failure", "rolled_back_after_recovery",
+        "rollback_finalize_prepared",
+    }
+    if status.get("status") not in allowed:
+        raise BootstrapError("finalize_not_allowed")
+    if status.get("verified") is not True:
+        raise BootstrapError("restart_readback_mismatch")
+    config_check(url, token)
+    _verify_client_hashes(
+        client,
+        status.get("configurationSha256"),
+        status.get("componentTreeSha256"),
+        status.get("trustSha256"),
+        "restart_readback_mismatch",
+    )
+
+
+def _finalize_result(
+    client: FileEditorIngressClient,
+    txid: str,
+    arguments: dict[str, str | bool],
+    config_check: Any,
+    component_route_check: Any,
+    url: str,
+    token: str,
+) -> dict[str, Any]:
+    """Authorize, execute, or reconcile one exact finalization."""
+    status = _bind_status_to_local(
+        _redacted_status(client, txid, readback=True), txid, required=True
+    )
+    local = _read_local_record(txid)
+    reconciled = _reconciled_finalize_result(
+        client, txid, status, local, config_check, url, token
+    )
+    if reconciled is not None:
+        return reconciled
+    _validate_finalize_status(client, status, config_check, url, token)
+    rolled_back = status.get("status") in {
+        "rolled_back", "rolled_back_after_failure", "rolled_back_after_recovery",
+        "rollback_finalize_prepared",
+    }
+    if not rolled_back:
+        component_route_check(url, token, txid)
+        if status.get("status") == "installed":
+            client.execute(
+                mode="mark-verified", transaction_id=txid, arguments=arguments
+            )
+    local.update(
+        {
+            "status": "finalize_authorized",
+            "finalizeConfigurationSha256": status["configurationSha256"],
+            "finalizeComponentTreeSha256": status["componentTreeSha256"],
+            "finalizeTrustSha256": status["trustSha256"],
+            "finalizeRemoteStatus": status["status"],
+        }
+    )
+    _write_local_record(txid, local, create=False)
+    return client.execute(mode="finalize", transaction_id=txid, arguments=arguments)
+
+
+def _execute_bootstrap_mode(
+    mode: str,
+    client: FileEditorIngressClient,
+    txid: str | None,
+    payload: Payload | None,
+    expected_configuration: str | None,
+    expected_component: str | None,
+    expected_trust: str | None,
+    replace_exact: bool,
+    recovery_arguments: dict[str, str | bool],
+    config_check: Any,
+    component_route_check: Any,
+    url: str,
+    token: str,
+) -> dict[str, Any]:
+    """Execute one fixed bootstrap mode using already validated inputs."""
+    if mode in {"status", "readback"}:
+        return _bind_status_to_local(
+            _redacted_status(client, txid, readback=mode == "readback"),
+            txid,
+            required=False,
+        )
+    if mode == "preflight" and payload is not None:
+        return _preflight_result(client, payload)
+    if txid is None:
+        raise BootstrapError("transaction_id_required")
+    if mode == "install" and payload is not None:
+        if not all(isinstance(value, str) for value in (
+            expected_configuration, expected_component, expected_trust
+        )):
+            raise BootstrapError("install_pins_required")
+        return _install_result(
+            client, txid, payload, expected_configuration, expected_component,
+            expected_trust, replace_exact, recovery_arguments, config_check, url, token
+        )
+    if mode == "rollback":
+        return _rollback_result(client, txid, recovery_arguments, config_check, url, token)
+    if mode == "recover-lock":
+        return client.execute(
+            mode="recover-lock", transaction_id=txid, arguments=recovery_arguments
+        )
+    if mode == "abort-stage":
+        return _abort_stage_result(client, txid, recovery_arguments)
+    return _finalize_result(
+        client, txid, recovery_arguments, config_check,
+        component_route_check, url, token
+    )
+
+
+def _prepare_bootstrap_inputs(
+    *,
+    mode: str,
+    source_root: Path,
+    transaction_id: str | None,
+    expected_configuration: str | None,
+    expected_component: str | None,
+    expected_trust: str | None,
+    expected_manifest: str | None,
+    expected_release_key: str | None,
+    expected_validation_key: str | None,
+    expected_source_revision: str | None,
+    replace_exact: bool,
+    config_check: Any,
+    url: str,
+    token: str,
+) -> BootstrapInputs:
+    """Validate local payload, CAS pins, and durable recovery arguments."""
+    txid = None if mode == "preflight" and transaction_id is None else _validate_uuid(transaction_id)
+    payload = None
+    if mode in {"preflight", "install"}:
+        payload = validate_local_payload(
+            source_root,
+            expected_manifest_sha256=_validate_hash(
+                expected_manifest, "expected_payload_manifest_hash_required"
+            ),
+            expected_release_key_sha256=_validate_hash(
+                expected_release_key, "expected_release_key_fingerprint_required"
+            ),
+            expected_validation_key_sha256=_validate_hash(
+                expected_validation_key, "expected_validation_key_fingerprint_required"
+            ),
+            expected_source_revision=expected_source_revision or "",
+        )
+        config_check(url, token)
+    if mode == "install":
+        configuration = _validate_hash(
+            expected_configuration, "expected_configuration_hash_required"
+        )
+        component = _validate_hash(
+            expected_component, "expected_component_tree_hash_required"
+        )
+        trust = _validate_hash(expected_trust, "expected_trust_hash_required", absent=True)
+        _prepare_install_record(
+            txid,
+            {
+                "schemaVersion": "aurora-deploy-bootstrap-local-v1",
+                "status": "prepared",
+                "transactionId": txid,
+                "payloadManifestSha256": payload.manifest_sha256,
+                "sourceRevision": payload.source_revision,
+                "sourceRoot": str(source_root.resolve(strict=True)),
+                "installerSha256": INSTALLER_SHA256,
+                "installerSourceBase64": base64.b64encode(INSTALLER_SOURCE).decode(),
+                "replaceExact": replace_exact,
+                "expectedConfigurationSha256": configuration,
+                "expectedComponentTreeSha256": component,
+                "expectedTrustSha256": trust,
+            },
+        )
+        recovery = {
+            "expected-installer-sha256": INSTALLER_SHA256,
+            "payload-manifest-sha256": payload.manifest_sha256,
+            "expected-configuration-sha256": configuration,
+            "expected-component-tree-sha256": component,
+            "expected-trust-sha256": trust,
+        }
+        return BootstrapInputs(txid, payload, configuration, component, trust, recovery)
+    recovery = (
+        _persist_local_request(txid, mode)
+        if mode in {"rollback", "recover-lock", "abort-stage", "finalize"}
+        else {}
+    )
+    return BootstrapInputs(
+        txid, payload, expected_configuration, expected_component, expected_trust, recovery
+    )
+
+
+async def _run_with_editor(
+    *,
+    mode: str,
+    inputs: BootstrapInputs,
+    url: str,
+    token: str,
+    backup_id: str | None,
+    expected_backup_agent_id: str | None,
+    replace_exact: bool,
+    socket_factory: Any,
+    ingress_client_factory: Any,
+    config_check: Any,
+    component_route_check: Any,
+) -> dict[str, Any]:
+    """Open File editor, execute one mode, and always restore add-on state."""
+    initial: Any = None
+    primary: BaseException | None = None
+    result: dict[str, Any] | None = None
+    try:
+        initial, ingress, session = await _open_editor(
+            url, token, backup_id, expected_backup_agent_id,
+            mode in {"preflight", "install"}, mode, inputs.txid, socket_factory
+        )
+        client = ingress_client_factory(url, ingress, session)
+        result = _execute_bootstrap_mode(
+            mode, client, inputs.txid, inputs.payload, inputs.configuration_sha256,
+            inputs.component_sha256, inputs.trust_sha256, replace_exact,
+            inputs.recovery_arguments, config_check, component_route_check, url, token
+        )
+    except BaseException as error:
+        primary = error
+    cleanup: BaseException | None = None
+    if initial == "stopped":
+        try:
+            await _addon_action(url, token, "stop", socket_factory)
+            _clear_lifecycle_lease()
+        except BaseException as error:
+            cleanup = error
+    if primary is not None and cleanup is not None:
+        raise BootstrapError("operation_failed_and_file_editor_restore_failed") from None
+    if cleanup is not None:
+        raise BootstrapError("file_editor_restore_failed") from None
+    if primary is not None:
+        if isinstance(primary, (BootstrapError, asyncio.CancelledError)):
+            raise primary
+        raise BootstrapError("operation_failed") from None
+    if result is None:
+        raise BootstrapError("operation_failed")
+    return result
+
+
+def _record_bootstrap_receipt(
+    mode: str, txid: str | None, result: dict[str, Any]
+) -> None:
+    """Bind one mutating operation's local record to its redacted receipt."""
+    if txid is None or mode not in {
+        "install", "rollback", "recover-lock", "abort-stage", "finalize"
+    }:
+        return
+    local = _read_local_record(txid)
+    local["status"] = str(result.get("status"))
+    local["receiptSha256"] = _digest(_canonical(result))
+    _write_local_record(txid, local, create=False)
+
+
+async def bootstrap(
     *,
     mode: str,
     source_root: Path,
@@ -2598,320 +3186,24 @@ async def bootstrap(  # noqa: C901
     url, token = credential_loader()
     if mode == "credential-check":
         return _credential_transport_receipt(url)
-    txid = (
-        None
-        if mode == "preflight" and transaction_id is None
-        else _validate_uuid(transaction_id)
+    inputs = _prepare_bootstrap_inputs(
+        mode=mode, source_root=source_root, transaction_id=transaction_id,
+        expected_configuration=expected_configuration_sha256,
+        expected_component=expected_component_tree_sha256,
+        expected_trust=expected_trust_sha256,
+        expected_manifest=expected_payload_manifest_sha256,
+        expected_release_key=expected_release_key_sha256,
+        expected_validation_key=expected_validation_key_sha256,
+        expected_source_revision=expected_source_revision,
+        replace_exact=replace_exact, config_check=config_check, url=url, token=token,
     )
-    payload = None
-    if mode in {"preflight", "install"}:
-        payload = validate_local_payload(
-            source_root,
-            expected_manifest_sha256=_validate_hash(
-                expected_payload_manifest_sha256,
-                "expected_payload_manifest_hash_required",
-            ),
-            expected_release_key_sha256=_validate_hash(
-                expected_release_key_sha256, "expected_release_key_fingerprint_required"
-            ),
-            expected_validation_key_sha256=_validate_hash(
-                expected_validation_key_sha256,
-                "expected_validation_key_fingerprint_required",
-            ),
-            expected_source_revision=expected_source_revision or "",
-        )
-        config_check(url, token)
-    recovery_arguments: dict[str, str | bool] = {}
-    if mode == "install":
-        expected_configuration_sha256 = _validate_hash(
-            expected_configuration_sha256, "expected_configuration_hash_required"
-        )
-        expected_component_tree_sha256 = _validate_hash(
-            expected_component_tree_sha256, "expected_component_tree_hash_required"
-        )
-        expected_trust_sha256 = _validate_hash(
-            expected_trust_sha256, "expected_trust_hash_required", absent=True
-        )
-        _prepare_install_record(
-            txid,
-            {
-                "schemaVersion": "aurora-deploy-bootstrap-local-v1",
-                "status": "prepared",
-                "transactionId": txid,
-                "payloadManifestSha256": payload.manifest_sha256,
-                "sourceRevision": payload.source_revision,
-                "sourceRoot": str(source_root.resolve(strict=True)),  # noqa: ASYNC240
-                "installerSha256": INSTALLER_SHA256,
-                "installerSourceBase64": base64.b64encode(INSTALLER_SOURCE).decode(),
-                "replaceExact": replace_exact,
-                "expectedConfigurationSha256": expected_configuration_sha256,
-                "expectedComponentTreeSha256": expected_component_tree_sha256,
-                "expectedTrustSha256": expected_trust_sha256,
-            },
-        )
-        recovery_arguments = {
-            "expected-installer-sha256": INSTALLER_SHA256,
-            "payload-manifest-sha256": payload.manifest_sha256,
-            "expected-configuration-sha256": expected_configuration_sha256,
-            "expected-component-tree-sha256": expected_component_tree_sha256,
-            "expected-trust-sha256": expected_trust_sha256,
-        }
-    elif mode in {"rollback", "recover-lock", "abort-stage", "finalize"}:
-        recovery_arguments = _persist_local_request(txid, mode)
-    initial = None
-    primary: BaseException | None = None
-    result: dict[str, Any] | None = None
-    try:
-        initial, ingress, session = await _open_editor(
-            url,
-            token,
-            backup_id,
-            expected_backup_agent_id,
-            mode in {"preflight", "install"},
-            mode,
-            txid,
-            socket_factory,
-        )
-        client = ingress_client_factory(url, ingress, session)
-        if mode in {"status", "readback"}:
-            result = _bind_status_to_local(
-                _redacted_status(client, txid, readback=mode == "readback"),
-                txid,
-                required=False,
-            )
-        elif mode == "preflight":
-            result = {
-                "status": "preflight_ready",
-                "configurationSha256": _digest(client.configuration_bytes()),
-                "componentTreeSha256": client.component_tree_sha256(),
-                "trustSha256": client.trust_sha256(),
-                "payloadManifestSha256": payload.manifest_sha256,
-                "releaseKeySha256": payload.release_key_sha256,
-                "validationKeySha256": payload.validation_key_sha256,
-                "sourceRevision": payload.source_revision,
-                "installerSha256": INSTALLER_SHA256,
-            }
-        elif mode == "install":
-            config_check(url, token)
-            if (
-                _digest(client.configuration_bytes()) != expected_configuration_sha256
-                or client.component_tree_sha256() != expected_component_tree_sha256
-                or client.trust_sha256() != expected_trust_sha256
-            ):
-                raise BootstrapError("prestage_cas_mismatch")
-            _stage_payload(client, txid, payload)
-            result = client.execute(
-                mode="install",
-                transaction_id=txid,
-                arguments={
-                    "expected-configuration-sha256": expected_configuration_sha256,
-                    "expected-component-tree-sha256": expected_component_tree_sha256,
-                    "expected-trust-sha256": expected_trust_sha256,
-                    "payload-manifest-sha256": payload.manifest_sha256,
-                    "expected-installer-sha256": INSTALLER_SHA256,
-                    **({"replace-exact": True} if replace_exact else {}),
-                },
-            )
-            try:
-                config_check(url, token)
-                if (
-                    _digest(client.configuration_bytes())
-                    != result.get("configurationSha256")
-                    or client.component_tree_sha256()
-                    != result.get("componentTreeSha256")
-                    or client.trust_sha256() != result.get("trustSha256")
-                ):
-                    raise BootstrapError("post_install_readback_mismatch")
-            except BaseException:
-                try:
-                    rollback = client.execute(
-                        mode="rollback",
-                        transaction_id=txid,
-                        arguments=recovery_arguments,
-                    )
-                    config_check(url, token)
-                    if (
-                        _digest(client.configuration_bytes())
-                        != rollback.get("configurationSha256")
-                        or client.component_tree_sha256()
-                        != rollback.get("componentTreeSha256")
-                        or client.trust_sha256() != rollback.get("trustSha256")
-                    ):
-                        raise BootstrapError("rollback_readback_mismatch")
-                except BaseException:
-                    raise BootstrapError(
-                        "post_install_validation_failed_rollback_unverified"
-                    ) from None
-                raise BootstrapError(
-                    "post_install_validation_failed_rolled_back"
-                ) from None
-            result["restartRequired"] = True
-        elif mode == "rollback":
-            result = client.execute(
-                mode="rollback",
-                transaction_id=txid,
-                arguments=recovery_arguments,
-            )
-            config_check(url, token)
-            if (
-                _digest(client.configuration_bytes())
-                != result.get("configurationSha256")
-                or client.component_tree_sha256() != result.get("componentTreeSha256")
-                or client.trust_sha256() != result.get("trustSha256")
-            ):
-                raise BootstrapError("rollback_readback_mismatch")
-            result["restartRequired"] = True
-        elif mode == "recover-lock":
-            result = client.execute(
-                mode="recover-lock",
-                transaction_id=txid,
-                arguments=recovery_arguments,
-            )
-        elif mode == "abort-stage":
-            if client.transaction_exists(txid):
-                raise BootstrapError("stage_abort_transaction_exists")
-            _ensure_stage_abort_installer(
-                client,
-                txid,
-                recovery_arguments["expected-installer-sha256"],
-                _local_installer_bytes(_read_local_record(txid)),
-            )
-            result = client.execute(
-                mode="abort-stage",
-                transaction_id=txid,
-                arguments={
-                    "expected-installer-sha256": recovery_arguments[
-                        "expected-installer-sha256"
-                    ]
-                },
-            )
-        else:
-            status = _bind_status_to_local(
-                _redacted_status(client, txid, readback=True), txid, required=True
-            )
-            local = _read_local_record(txid)
-            if status.get("status") == "not_found":
-                if (
-                    local.get("status") not in {"finalize_authorized", "finalized"}
-                    or status.get("lockHeld") is not False
-                    or status.get("lockOwnerMatches") is not False
-                    or status.get("stagePresent") is not False
-                    or status.get("lockCandidatePresent") is not False
-                    or status.get("transactionPresent") is not False
-                    or status.get("initializationPresent") is not False
-                ):
-                    raise BootstrapError("finalize_not_allowed")
-                expected_configuration = _validate_hash(
-                    local.get("finalizeConfigurationSha256"),
-                    "finalize_authorization_invalid",
-                )
-                expected_component = _validate_hash(
-                    local.get("finalizeComponentTreeSha256"),
-                    "finalize_authorization_invalid",
-                )
-                expected_trust = _validate_hash(
-                    local.get("finalizeTrustSha256"),
-                    "finalize_authorization_invalid",
-                    absent=True,
-                )
-                config_check(url, token)
-                if (
-                    _digest(client.configuration_bytes()) != expected_configuration
-                    or client.component_tree_sha256() != expected_component
-                    or client.trust_sha256() != expected_trust
-                ):
-                    raise BootstrapError("finalize_readback_mismatch")
-                result = {
-                    "status": "finalized",
-                    "transactionId": txid,
-                    "payloadManifestSha256": _validate_hash(
-                        local.get("payloadManifestSha256"),
-                        "local_payload_pin_required",
-                    ),
-                    "reconciled": True,
-                }
-                status = None
-            if status is None:
-                pass
-            elif status.get("status") not in {
-                "installed",
-                "restart_verified",
-                "finalize_prepared",
-                "rolled_back",
-                "rolled_back_after_failure",
-                "rolled_back_after_recovery",
-                "rollback_finalize_prepared",
-            }:
-                raise BootstrapError("finalize_not_allowed")
-            elif status.get("verified") is not True:
-                raise BootstrapError("restart_readback_mismatch")
-            else:
-                config_check(url, token)
-                if (
-                    _digest(client.configuration_bytes())
-                    != status.get("configurationSha256")
-                    or client.component_tree_sha256()
-                    != status.get("componentTreeSha256")
-                    or client.trust_sha256() != status.get("trustSha256")
-                ):
-                    raise BootstrapError("restart_readback_mismatch")
-            if status is not None and status.get("status") not in {
-                "rolled_back",
-                "rolled_back_after_failure",
-                "rolled_back_after_recovery",
-                "rollback_finalize_prepared",
-            }:
-                component_route_check(url, token, txid)
-                if status.get("status") == "installed":
-                    client.execute(
-                        mode="mark-verified",
-                        transaction_id=txid,
-                        arguments=recovery_arguments,
-                    )
-            if status is not None:
-                local["status"] = "finalize_authorized"
-                local["finalizeConfigurationSha256"] = status["configurationSha256"]
-                local["finalizeComponentTreeSha256"] = status["componentTreeSha256"]
-                local["finalizeTrustSha256"] = status["trustSha256"]
-                local["finalizeRemoteStatus"] = status["status"]
-                _write_local_record(txid, local, create=False)
-                result = client.execute(
-                    mode="finalize",
-                    transaction_id=txid,
-                    arguments=recovery_arguments,
-                )
-    except BaseException as error:
-        primary = error
-    cleanup: BaseException | None = None
-    if initial == "stopped":
-        try:
-            await _addon_action(url, token, "stop", socket_factory)
-            _clear_lifecycle_lease()
-        except BaseException as error:
-            cleanup = error
-    if primary is not None and cleanup is not None:
-        raise BootstrapError(
-            "operation_failed_and_file_editor_restore_failed"
-        ) from None
-    if cleanup is not None:
-        raise BootstrapError("file_editor_restore_failed") from None
-    if primary is not None:
-        if isinstance(primary, (BootstrapError, asyncio.CancelledError)):
-            raise primary
-        raise BootstrapError("operation_failed") from None
-    if result is None:
-        raise BootstrapError("operation_failed")
-    if txid is not None and mode in {
-        "install",
-        "rollback",
-        "recover-lock",
-        "abort-stage",
-        "finalize",
-    }:
-        local = _read_local_record(txid)
-        local["status"] = str(result.get("status"))
-        local["receiptSha256"] = _digest(_canonical(result))
-        _write_local_record(txid, local, create=False)
+    result = await _run_with_editor(
+        mode=mode, inputs=inputs, url=url, token=token, backup_id=backup_id,
+        expected_backup_agent_id=expected_backup_agent_id, replace_exact=replace_exact,
+        socket_factory=socket_factory, ingress_client_factory=ingress_client_factory,
+        config_check=config_check, component_route_check=component_route_check,
+    )
+    _record_bootstrap_receipt(mode, inputs.txid, result)
     return result
 
 

--- a/scripts/bootstrap_aurora_deploy_via_file_editor.py
+++ b/scripts/bootstrap_aurora_deploy_via_file_editor.py
@@ -1,0 +1,2918 @@
+#!/usr/bin/env python3
+"""Auditable, fixed-scope bootstrap for the Aurora deployment adapter.
+
+Credentials are read only from the fixed approved main-repository ``.env``.
+Recovery pins and lifecycle leases live under that repository's mode-0700 local
+state directory. The remote installer
+has no caller-selectable paths, commands, or URLs and can touch only the fixed
+Aurora component, trust store, configuration key, lock, stage, and transaction.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import base64
+import hashlib
+import ipaddress
+import json
+import math
+import os
+import re
+import secrets
+import stat
+import subprocess
+import time
+import urllib.error
+import urllib.request
+import uuid
+from datetime import UTC, datetime, timedelta
+from pathlib import Path, PurePosixPath
+from typing import Any, NamedTuple
+from urllib.parse import urlencode, urljoin, urlparse
+
+FILE_EDITOR_SLUG = "core_configurator"
+FILE_EDITOR_VERSION = "6.1.0"
+APPROVED_BACKUP_AGENT_ID = "hassio.local"
+REMOTE_ROOT = "/homeassistant"
+REMOTE_CONFIGURATION = f"{REMOTE_ROOT}/configuration.yaml"
+REMOTE_COMPONENT = f"{REMOTE_ROOT}/custom_components/aurora_deploy"
+REMOTE_TRUST = f"{REMOTE_ROOT}/aurora_deploy_trusted_keys.json"
+REMOTE_LOCK = f"{REMOTE_ROOT}/.aurora-deploy-bootstrap-global.lock"
+LOCK_CANDIDATE_PREFIX = ".aurora-deploy-bootstrap-lock-candidate-"
+STAGE_PREFIX = ".aurora-deploy-bootstrap-stage-"
+TRANSACTION_PREFIX = ".aurora-deploy-bootstrap-transaction-"
+TRANSACTION_INIT_PREFIX = ".aurora-deploy-bootstrap-transaction-init-"
+INSTALLER_NAME = "install-aurora-deploy-bootstrap.py"
+PAYLOAD_MANIFEST_NAME = "payload-manifest.json"
+COMPONENT_FILES = ("__init__.py", "adapter.py", "manifest.json")
+SOURCE_PATHS = tuple(
+    f"custom_components/aurora_deploy/{name}" for name in COMPONENT_FILES
+)
+TRUST_PATH = "aurora_deploy_trusted_keys.json"
+PAYLOAD_PATHS = (*SOURCE_PATHS, TRUST_PATH)
+APPROVED_REPOSITORY_ROOT = Path(
+    "/Users/terencevanrooyen/Development/Private/home-assistant"
+)
+APPROVED_CREDENTIAL_ENV = APPROVED_REPOSITORY_ROOT / ".env"
+APPROVED_STATE_DIRECTORY = APPROVED_REPOSITORY_ROOT / "local/aurora-deploy-state"
+ROLLBACK_WINDOW_SECONDS = 24 * 60 * 60
+STALE_LOCK_SECONDS = 60 * 60
+MAX_FILE_BYTES = 2 * 1024 * 1024
+MAX_RESPONSE_BYTES = 2 * 1024 * 1024
+MAX_BACKUP_AGE = timedelta(hours=24)
+MAX_BACKUP_FUTURE_SKEW = timedelta(minutes=5)
+SAFE_INGRESS_ENTRY = re.compile(r"^/api/hassio_ingress/[A-Za-z0-9_-]+$")
+SAFE_SESSION = re.compile(r"^[A-Za-z0-9._~+/=-]{16,1024}$")
+SAFE_BACKUP_ID = re.compile(r"^[A-Za-z0-9._-]{1,160}$")
+SAFE_KEY_ID = re.compile(r"^(?=.{8,64}$)(?:release|validation)-[A-Za-z0-9._-]+$")
+SAFE_PYCACHE = re.compile(
+    r"^__pycache__/(?:__init__|adapter)\.cpython-\d{3}(?:\.opt-[12])?\.pyc$"
+)
+SHA256 = re.compile(r"^[0-9a-f]{64}$")
+REVISION = re.compile(r"^[0-9a-f]{40,64}$")
+
+
+class BootstrapError(RuntimeError):
+    """Stable, non-sensitive bootstrap failure code."""
+
+
+class PayloadFile(NamedTuple):
+    relative_path: str
+    content: bytes
+    sha256: str
+    size: int
+
+
+class Payload(NamedTuple):
+    files: tuple[PayloadFile, ...]
+    manifest: bytes
+    manifest_sha256: str
+    release_key_sha256: str
+    validation_key_sha256: str
+    source_revision: str
+
+
+def _digest(content: bytes) -> str:
+    return hashlib.sha256(content).hexdigest()
+
+
+def _canonical(value: Any) -> bytes:
+    return json.dumps(value, sort_keys=True, separators=(",", ":")).encode()
+
+
+def _reject_duplicate_pairs(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise BootstrapError("json_duplicate_key")
+        result[key] = value
+    return result
+
+
+def _json_object(content: bytes, code: str) -> dict[str, Any]:
+    try:
+        value = json.loads(content.decode(), object_pairs_hook=_reject_duplicate_pairs)
+    except BootstrapError:
+        raise
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        raise BootstrapError(code) from None
+    if not isinstance(value, dict):
+        raise BootstrapError(code)
+    return value
+
+
+def _validate_uuid(value: str | None) -> str:
+    try:
+        parsed = uuid.UUID(value)
+    except (ValueError, AttributeError):
+        raise BootstrapError("transaction_id_required") from None
+    if parsed.version != 4 or str(parsed) != value:
+        raise BootstrapError("transaction_id_invalid")
+    return value
+
+
+def _validate_hash(value: str | None, code: str, *, absent: bool = False) -> str:
+    if absent and value == "absent":
+        return value
+    if not isinstance(value, str) or SHA256.fullmatch(value) is None:
+        raise BootstrapError(code)
+    return value
+
+
+def _validate_url(value: str) -> str:
+    parsed = urlparse(value)
+    if (
+        parsed.scheme not in {"http", "https"}
+        or not parsed.hostname
+        or parsed.username is not None
+        or parsed.password is not None
+        or parsed.query
+        or parsed.fragment
+        or parsed.path not in {"", "/"}
+    ):
+        raise BootstrapError("home_assistant_url_invalid")
+    if parsed.scheme == "http":
+        host = parsed.hostname.rstrip(".").lower()
+        loopback = host == "localhost"
+        try:
+            loopback = loopback or ipaddress.ip_address(host).is_loopback
+        except ValueError:
+            pass
+        if not loopback:
+            raise BootstrapError("https_required")
+    return value.rstrip("/")
+
+
+def _load_credentials() -> tuple[str, str]:  # noqa: C901
+    """Load credentials only from the fixed main-repository ``.env``."""
+    env_path = APPROVED_CREDENTIAL_ENV
+    try:
+        info = env_path.lstat()
+    except OSError:
+        raise BootstrapError("root_env_required") from None
+    if stat.S_ISLNK(info.st_mode) or not stat.S_ISREG(info.st_mode):
+        raise BootstrapError("root_env_invalid")
+    if stat.S_IMODE(info.st_mode) != 0o600:
+        raise BootstrapError("root_env_permissions_unsafe")
+    values: dict[str, str] = {}
+    try:
+        lines = env_path.read_text(encoding="utf-8").splitlines()
+    except (OSError, UnicodeDecodeError):
+        raise BootstrapError("root_env_invalid") from None
+    for raw in lines:
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        if line.startswith("export "):
+            line = line[7:].strip()
+        if "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        key = key.strip()
+        if key not in {"HOMEASSISTANT_URL", "HOMEASSISTANT_TOKEN"}:
+            continue
+        if key in values:
+            raise BootstrapError("root_env_duplicate_credential")
+        value = value.strip()
+        if len(value) >= 2 and value[0] == value[-1] and value[0] in {'"', "'"}:
+            value = value[1:-1]
+        if not value or "\r" in value or "\n" in value or "${" in value:
+            raise BootstrapError("root_env_invalid")
+        values[key] = value
+    if set(values) != {"HOMEASSISTANT_URL", "HOMEASSISTANT_TOKEN"}:
+        raise BootstrapError("root_env_credentials_required")
+    return _validate_url(values["HOMEASSISTANT_URL"]), values["HOMEASSISTANT_TOKEN"]
+
+
+def _decode_public_key(value: Any) -> bytes:
+    if not isinstance(value, str) or len(value) > 128:
+        raise BootstrapError("trust_store_invalid")
+    try:
+        decoded = base64.b64decode(value, validate=True)
+    except (ValueError, TypeError):
+        raise BootstrapError("trust_store_invalid") from None
+    if len(decoded) != 32 or base64.b64encode(decoded).decode() != value:
+        raise BootstrapError("trust_store_invalid")
+    return decoded
+
+
+def validate_trust_store(content: bytes) -> tuple[str, str]:
+    value = _json_object(content, "trust_store_invalid")
+    if any(not isinstance(key, str) for key in value):
+        raise BootstrapError("trust_store_invalid")
+    release = [key for key in value if key.startswith("release-")]
+    validation = [key for key in value if key.startswith("validation-")]
+    if len(release) != 1 or len(validation) != 1:
+        raise BootstrapError("trust_store_roles_invalid")
+    if len(value) != 2 or any(SAFE_KEY_ID.fullmatch(key) is None for key in value):
+        raise BootstrapError("trust_store_invalid")
+    release_raw = _decode_public_key(value[release[0]])
+    validation_raw = _decode_public_key(value[validation[0]])
+    if secrets.compare_digest(release_raw, validation_raw):
+        raise BootstrapError("trust_store_keys_not_distinct")
+    return _digest(release_raw), _digest(validation_raw)
+
+
+def _regular_bytes(root: Path, relative: str) -> bytes:
+    path = root / relative
+    try:
+        info = path.lstat()
+    except OSError:
+        raise BootstrapError("source_file_unavailable") from None
+    if stat.S_ISLNK(info.st_mode) or not stat.S_ISREG(info.st_mode):
+        raise BootstrapError("source_file_invalid")
+    try:
+        resolved_root = root.resolve(strict=True)
+        resolved = path.resolve(strict=True)
+    except OSError:
+        raise BootstrapError("source_file_invalid") from None
+    if resolved != resolved_root / relative or info.st_size > MAX_FILE_BYTES:
+        raise BootstrapError("source_file_invalid")
+    return path.read_bytes()
+
+
+def _git_output(source_root: Path, *args: str) -> str:
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(source_root), *args],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        raise BootstrapError("source_revision_unavailable") from None
+    if result.returncode != 0:
+        raise BootstrapError("source_revision_unavailable")
+    return result.stdout.strip()
+
+
+def validate_local_payload(  # noqa: C901 - exact source and independent pin gate
+    source_root: Path,
+    *,
+    expected_manifest_sha256: str,
+    expected_release_key_sha256: str,
+    expected_validation_key_sha256: str,
+    expected_source_revision: str,
+) -> Payload:
+    """Validate exact committed source and independently supplied pins."""
+    expected_manifest_sha256 = _validate_hash(
+        expected_manifest_sha256, "expected_payload_manifest_hash_required"
+    )
+    expected_release_key_sha256 = _validate_hash(
+        expected_release_key_sha256, "expected_release_key_fingerprint_required"
+    )
+    expected_validation_key_sha256 = _validate_hash(
+        expected_validation_key_sha256, "expected_validation_key_fingerprint_required"
+    )
+    if REVISION.fullmatch(expected_source_revision) is None:
+        raise BootstrapError("expected_source_revision_required")
+    try:
+        root_info = source_root.lstat()
+        root = source_root.resolve(strict=True)
+    except OSError:
+        raise BootstrapError("source_root_unavailable") from None
+    if stat.S_ISLNK(root_info.st_mode) or not root.is_dir():
+        raise BootstrapError("source_root_invalid")
+    component_directory = root / "custom_components" / "aurora_deploy"
+    try:
+        component_info = component_directory.lstat()
+    except OSError:
+        raise BootstrapError("source_component_unavailable") from None
+    if stat.S_ISLNK(component_info.st_mode) or not stat.S_ISDIR(component_info.st_mode):
+        raise BootstrapError("source_component_invalid")
+    actual_component_files: set[str] = set()
+    for item in component_directory.iterdir():
+        if item.name == "__pycache__" and item.is_dir() and not item.is_symlink():
+            continue
+        if item.is_symlink() or not item.is_file():
+            raise BootstrapError("source_component_file_set_invalid")
+        actual_component_files.add(item.name)
+    if actual_component_files != set(COMPONENT_FILES):
+        raise BootstrapError("source_component_file_set_invalid")
+    revision = _git_output(root, "rev-parse", "HEAD")
+    if revision != expected_source_revision:
+        raise BootstrapError("source_revision_mismatch")
+    if _git_output(root, "status", "--porcelain=v1", "--untracked-files=all"):
+        raise BootstrapError("source_worktree_not_clean")
+    for relative in PAYLOAD_PATHS:
+        _git_output(root, "ls-files", "--error-unmatch", "--", relative)
+    files = tuple(
+        PayloadFile(relative, content, _digest(content), len(content))
+        for relative in PAYLOAD_PATHS
+        for content in (_regular_bytes(root, relative),)
+    )
+    component_manifest = next(
+        item for item in files if item.relative_path.endswith("/manifest.json")
+    )
+    _json_object(component_manifest.content, "component_manifest_invalid")
+    trust = next(item for item in files if item.relative_path == TRUST_PATH)
+    release_digest, validation_digest = validate_trust_store(trust.content)
+    if release_digest != expected_release_key_sha256:
+        raise BootstrapError("release_key_fingerprint_mismatch")
+    if validation_digest != expected_validation_key_sha256:
+        raise BootstrapError("validation_key_fingerprint_mismatch")
+    manifest = _canonical(
+        {
+            "schemaVersion": "aurora-deploy-bootstrap-v2",
+            "component": "aurora_deploy",
+            "configurationKey": "aurora_deploy",
+            "sourceRevision": revision,
+            "files": [
+                {"path": item.relative_path, "sha256": item.sha256, "size": item.size}
+                for item in files
+            ],
+            "trust": {
+                "releaseKeySha256": release_digest,
+                "validationKeySha256": validation_digest,
+            },
+        }
+    )
+    manifest_digest = _digest(manifest)
+    if manifest_digest != expected_manifest_sha256:
+        raise BootstrapError("payload_manifest_hash_mismatch")
+    return Payload(
+        files,
+        manifest,
+        manifest_digest,
+        release_digest,
+        validation_digest,
+        revision,
+    )
+
+
+def _parse_backup_date(value: Any) -> datetime:
+    if not isinstance(value, str):
+        raise BootstrapError("protected_ha_recovery_backup_required")
+    value = value[:-1] + "+00:00" if value.endswith("Z") else value
+    try:
+        parsed = datetime.fromisoformat(value)
+    except ValueError:
+        raise BootstrapError("protected_ha_recovery_backup_required") from None
+    if parsed.tzinfo is None:
+        raise BootstrapError("protected_ha_recovery_backup_required")
+    return parsed.astimezone(UTC)
+
+
+def _fresh_ha_recovery_backup(
+    backups: Any,
+    backup_id: str,
+    expected_agent_id: str,
+    *,
+    now: datetime | None = None,
+) -> dict[str, Any] | None:
+    if not isinstance(backups, list):
+        return None
+    matches = [
+        item
+        for item in backups
+        if isinstance(item, dict) and item.get("backup_id") == backup_id
+    ]
+    if len(matches) != 1:
+        return None
+    item = matches[0]
+    agents = item.get("agents")
+    if not isinstance(agents, dict) or len(agents) != 1:
+        return None
+    agent_id, agent = next(iter(agents.items()))
+    if agent_id != expected_agent_id or not isinstance(agent, dict):
+        return None
+    size = agent.get("size")
+    healthy_agent = (
+        agent.get("protected") is True
+        and isinstance(size, (int, float))
+        and not isinstance(size, bool)
+        and math.isfinite(size)
+        and size > 0
+        and agent.get("status") in {None, "available"}
+    )
+    no_agent_failures = item.get("failed_agent_ids") in (None, []) and item.get(
+        "agent_errors"
+    ) in (None, {})
+    if not (
+        healthy_agent
+        and no_agent_failures
+        and isinstance(item.get("name"), str)
+        and bool(item["name"].strip())
+        and item.get("database_included") is True
+        and item.get("homeassistant_included") is True
+    ):
+        return None
+    age = (now or datetime.now(UTC)) - _parse_backup_date(item.get("date"))
+    if age < -MAX_BACKUP_FUTURE_SKEW or age > MAX_BACKUP_AGE:
+        return None
+    return item
+
+
+def _homeassistant_config_rw(value: Any) -> bool:
+    if not isinstance(value, list):
+        return False
+    for item in value:
+        if item == "homeassistant_config:rw":
+            return True
+        if isinstance(item, dict):
+            name = item.get("type", item.get("name"))
+            if name == "homeassistant_config" and item.get("read_only") is False:
+                return True
+    return False
+
+
+def validate_supervisor_preflight(  # noqa: C901
+    *,
+    user: dict[str, Any],
+    supervisor: dict[str, Any],
+    host: dict[str, Any],
+    backup: dict[str, Any] | None,
+    addon: dict[str, Any],
+    store: dict[str, Any],
+    backup_id: str | None,
+    expected_backup_agent_id: str | None,
+    require_backup: bool,
+    now: datetime | None = None,
+) -> str:
+    if user.get("is_admin") is not True:
+        raise BootstrapError("administrator_required")
+    if (
+        supervisor.get("healthy") is not True
+        or supervisor.get("supported") is not True
+        or supervisor.get("state") != "running"
+    ):
+        raise BootstrapError("supervisor_not_ready")
+    if supervisor.get("arch") != "amd64" or host.get("arch") != "amd64":
+        raise BootstrapError("unsupported_architecture")
+    if host.get("features") is not None and not isinstance(host["features"], list):
+        raise BootstrapError("host_metadata_invalid")
+    if require_backup:
+        if (
+            expected_backup_agent_id != APPROVED_BACKUP_AGENT_ID
+            or not isinstance(backup_id, str)
+            or SAFE_BACKUP_ID.fullmatch(backup_id) is None
+            or not isinstance(backup, dict)
+            or backup.get("state") not in {None, "idle"}
+            or backup.get("failed_agent_ids") not in (None, [])
+            or backup.get("agent_errors") not in (None, {})
+            or _fresh_ha_recovery_backup(
+                backup.get("backups"),
+                backup_id,
+                expected_backup_agent_id,
+                now=now,
+            )
+            is None
+        ):
+            raise BootstrapError("protected_ha_recovery_backup_required")
+    if addon.get("slug") != FILE_EDITOR_SLUG or addon.get("name") != "File editor":
+        raise BootstrapError("file_editor_identity_mismatch")
+    if addon.get("version") != FILE_EDITOR_VERSION:
+        raise BootstrapError("file_editor_version_mismatch")
+    if addon.get("state") not in {"started", "stopped"}:
+        raise BootstrapError("file_editor_state_unsafe")
+    if addon.get("protected") is not True or addon.get("ingress") is not True:
+        raise BootstrapError("file_editor_boundary_mismatch")
+    ingress = addon.get("ingress_entry")
+    if not isinstance(ingress, str) or SAFE_INGRESS_ENTRY.fullmatch(ingress) is None:
+        raise BootstrapError("ingress_entry_invalid")
+    if addon.get("host_network") is not False or addon.get("network") != {}:
+        raise BootstrapError("file_editor_network_exposed")
+    if addon.get("repository") != "core":
+        raise BootstrapError("file_editor_not_official")
+    store_version = store.get("version_latest") or store.get("version")
+    if (
+        store.get("slug") != FILE_EDITOR_SLUG
+        or store.get("name") != "File editor"
+        or store_version != FILE_EDITOR_VERSION
+        or store.get("repository") != "core"
+        or store.get("ingress") is not True
+        or store.get("network") != {}
+        or "amd64" not in (store.get("arch") or [])
+        or store.get("available") is not True
+        or not _homeassistant_config_rw(store.get("map"))
+    ):
+        raise BootstrapError("file_editor_store_mismatch")
+    return ingress
+
+
+class HomeAssistantSocket:
+    def __init__(self, url: str, token: str) -> None:
+        self._url, self._token, self._socket, self._id = url, token, None, 0
+
+    async def __aenter__(self) -> HomeAssistantSocket:
+        import websockets
+
+        parsed = urlparse(self._url)
+        scheme = "wss" if parsed.scheme == "https" else "ws"
+        try:
+            self._socket = await websockets.connect(
+                f"{scheme}://{parsed.netloc}/api/websocket",
+                open_timeout=20,
+                max_size=MAX_RESPONSE_BYTES,
+            )
+            if json.loads(await self._socket.recv()).get("type") != "auth_required":
+                raise BootstrapError("websocket_auth_failed")
+            await self._socket.send(
+                json.dumps({"type": "auth", "access_token": self._token})
+            )
+            if json.loads(await self._socket.recv()).get("type") != "auth_ok":
+                raise BootstrapError("websocket_auth_failed")
+        except BootstrapError:
+            raise
+        except Exception:
+            raise BootstrapError("websocket_connection_failed") from None
+        return self
+
+    async def __aexit__(self, *_args: Any) -> None:
+        if self._socket is not None:
+            await self._socket.close()
+
+    async def call(self, command: str, **fields: Any) -> dict[str, Any]:
+        self._id += 1
+        try:
+            await self._socket.send(
+                json.dumps({"id": self._id, "type": command, **fields})
+            )
+            response = json.loads(await asyncio.wait_for(self._socket.recv(), 180))
+        except Exception:
+            raise BootstrapError("websocket_command_failed") from None
+        if (
+            not isinstance(response, dict)
+            or response.get("id") != self._id
+            or response.get("type") != "result"
+            or response.get("success") is not True
+            or not isinstance(response.get("result"), dict)
+        ):
+            raise BootstrapError("websocket_command_failed")
+        return response["result"]
+
+
+def _supervisor_data(value: dict[str, Any]) -> dict[str, Any]:
+    if value.get("result") == "ok" and isinstance(value.get("data"), dict):
+        return value["data"]
+    if "result" not in value:
+        return value
+    raise BootstrapError("supervisor_response_invalid")
+
+
+def _validated_installer_receipt(
+    value: dict[str, Any], mode: str, transaction_id: str
+) -> dict[str, Any]:
+    allowed = {
+        "status",
+        "transactionId",
+        "payloadManifestSha256",
+        "configurationSha256",
+        "componentTreeSha256",
+        "trustSha256",
+        "rollbackDeadline",
+        "installerSha256",
+    }
+    if set(value) - allowed or value.get("transactionId") != transaction_id:
+        raise BootstrapError("installer_output_invalid")
+    expected = {
+        "install": "installed",
+        "rollback": "rolled_back",
+        "recover-lock": "lock_recovered",
+        "abort-stage": "stage_aborted",
+        "mark-verified": "restart_verified",
+        "finalize": "finalized",
+    }[mode]
+    if value.get("status") != expected:
+        raise BootstrapError("installer_output_invalid")
+    for key in (
+        "payloadManifestSha256",
+        "configurationSha256",
+        "componentTreeSha256",
+    ):
+        if key in value and SHA256.fullmatch(str(value[key])) is None:
+            raise BootstrapError("installer_output_invalid")
+    if (
+        "trustSha256" in value
+        and value["trustSha256"] != "absent"
+        and SHA256.fullmatch(str(value["trustSha256"])) is None
+    ):
+        raise BootstrapError("installer_output_invalid")
+    if "rollbackDeadline" in value and (
+        not isinstance(value["rollbackDeadline"], int)
+        or isinstance(value["rollbackDeadline"], bool)
+    ):
+        raise BootstrapError("installer_output_invalid")
+    return value
+
+
+TRANSACTION_STATUSES = {
+    "prepared",
+    "installed",
+    "rollback_prepared",
+    "rolled_back",
+    "rolled_back_after_failure",
+    "rolled_back_after_recovery",
+    "restart_verified",
+    "finalize_prepared",
+    "rollback_finalize_prepared",
+}
+
+
+def _validated_file_state(value: Any, *, required: bool) -> dict[str, Any]:
+    if not isinstance(value, dict) or not isinstance(value.get("exists"), bool):
+        raise BootstrapError("transaction_invalid")
+    if value["exists"] is False:
+        if required or set(value) != {"exists"}:
+            raise BootstrapError("transaction_invalid")
+        return value
+    if (
+        set(value) != {"exists", "sha256", "size", "mode", "uid", "gid"}
+        or SHA256.fullmatch(str(value.get("sha256", ""))) is None
+        or any(
+            not isinstance(value.get(key), int) or isinstance(value.get(key), bool)
+            for key in ("size", "mode", "uid", "gid")
+        )
+        or value["size"] < 0
+    ):
+        raise BootstrapError("transaction_invalid")
+    return value
+
+
+def _component_state_digest(value: Any) -> str:  # noqa: C901
+    if not isinstance(value, dict) or not isinstance(value.get("exists"), bool):
+        raise BootstrapError("transaction_invalid")
+    if value["exists"] is False:
+        if value != {"exists": False, "files": {}, "directories": {}}:
+            raise BootstrapError("transaction_invalid")
+        return _digest(_canonical({"exists": False, "files": {}, "directories": []}))
+    if (
+        set(value) != {"exists", "files", "directories"}
+        or not isinstance(value["files"], dict)
+        or not isinstance(value["directories"], dict)
+        or len(value["files"]) + len(value["directories"]) > 129
+    ):
+        raise BootstrapError("transaction_invalid")
+    files: dict[str, str] = {}
+    for name, state in value["files"].items():
+        if not isinstance(name, str):
+            raise BootstrapError("transaction_invalid")
+        _validated_file_state({"exists": True, **state}, required=True)
+        if name.startswith("__pycache__/"):
+            if SAFE_PYCACHE.fullmatch(name) is None:
+                raise BootstrapError("component_generated_artifact_invalid")
+            continue
+        files[name] = state["sha256"]
+    directories: list[str] = []
+    for name, state in value["directories"].items():
+        if (
+            not isinstance(name, str)
+            or not isinstance(state, dict)
+            or set(state) != {"mode", "uid", "gid"}
+            or any(
+                not isinstance(state.get(key), int) or isinstance(state.get(key), bool)
+                for key in ("mode", "uid", "gid")
+            )
+        ):
+            raise BootstrapError("transaction_invalid")
+        if name in {".", "__pycache__"}:
+            continue
+        if name.startswith("__pycache__/"):
+            raise BootstrapError("component_generated_artifact_invalid")
+        directories.append(name)
+    if "." not in value["directories"]:
+        raise BootstrapError("transaction_invalid")
+    return _digest(
+        _canonical({"exists": True, "files": files, "directories": sorted(directories)})
+    )
+
+
+def _validated_transaction_journal(
+    value: dict[str, Any], transaction_id: str
+) -> dict[str, Any]:
+    allowed = {
+        "schemaVersion",
+        "transactionId",
+        "payloadManifestSha256",
+        "installerSha256",
+        "replaceExact",
+        "status",
+        "createdAt",
+        "rollbackDeadline",
+        "prestate",
+        "installed",
+        "configurationSha256",
+        "componentTreeSha256",
+        "trustSha256",
+    }
+    if (
+        set(value) - allowed
+        or value.get("schemaVersion") != "aurora-deploy-bootstrap-transaction-v2"
+        or value.get("transactionId") != transaction_id
+        or value.get("status") not in TRANSACTION_STATUSES
+        or SHA256.fullmatch(str(value.get("payloadManifestSha256", ""))) is None
+        or SHA256.fullmatch(str(value.get("installerSha256", ""))) is None
+        or not isinstance(value.get("replaceExact"), bool)
+    ):
+        raise BootstrapError("transaction_invalid")
+    created = value.get("createdAt")
+    deadline = value.get("rollbackDeadline")
+    if (
+        not isinstance(created, int)
+        or isinstance(created, bool)
+        or not isinstance(deadline, int)
+        or isinstance(deadline, bool)
+        or deadline != created + ROLLBACK_WINDOW_SECONDS
+    ):
+        raise BootstrapError("transaction_invalid")
+    for state_name in ("prestate", "installed"):
+        state = value.get(state_name)
+        if (
+            not isinstance(state, dict)
+            or set(state) != {"configuration", "component", "trust"}
+            or any(not isinstance(state.get(key), dict) for key in state)
+            or any(
+                not isinstance(state[key].get("exists"), bool)
+                for key in ("configuration", "component", "trust")
+            )
+        ):
+            raise BootstrapError("transaction_invalid")
+        _validated_file_state(state["configuration"], required=True)
+        _validated_file_state(state["trust"], required=state_name == "installed")
+        _component_state_digest(state["component"])
+        if state_name == "installed" and state["component"].get("exists") is not True:
+            raise BootstrapError("transaction_invalid")
+    summary_keys = {
+        "configurationSha256",
+        "componentTreeSha256",
+        "trustSha256",
+    }
+    if value["status"] == "prepared":
+        if summary_keys & set(value):
+            raise BootstrapError("transaction_invalid")
+    else:
+        source = (
+            value["installed"]
+            if value["status"]
+            in {
+                "installed",
+                "restart_verified",
+                "finalize_prepared",
+                "rollback_prepared",
+            }
+            else value["prestate"]
+        )
+        expected_summary = {
+            "configurationSha256": source["configuration"]["sha256"],
+            "componentTreeSha256": _component_state_digest(source["component"]),
+            "trustSha256": source["trust"].get("sha256", "absent"),
+        }
+        if any(
+            value.get(key) != expected for key, expected in expected_summary.items()
+        ):
+            raise BootstrapError("transaction_invalid")
+    return value
+
+
+class _NoRedirect(urllib.request.HTTPRedirectHandler):
+    def redirect_request(self, *_args: Any, **_kwargs: Any) -> None:
+        return None
+
+
+class FileEditorIngressClient:
+    """Fixed File editor surface; no public method accepts a remote path."""
+
+    def __init__(
+        self, url: str, entry: str, session: str, *, opener: Any | None = None
+    ) -> None:
+        self._url = _validate_url(url)
+        if (
+            SAFE_INGRESS_ENTRY.fullmatch(entry) is None
+            or SAFE_SESSION.fullmatch(session) is None
+        ):
+            raise BootstrapError("ingress_session_invalid")
+        self._entry, self._session = entry, session
+        self._opener = opener or urllib.request.build_opener(
+            urllib.request.ProxyHandler({}), _NoRedirect()
+        )
+
+    def _url_for(self, endpoint: str, query: dict[str, str] | None = None) -> str:
+        if endpoint not in {
+            "/api/listdir",
+            "/api/newfolder",
+            "/api/upload",
+            "/api/file",
+            "/api/exec_command",
+        }:
+            raise BootstrapError("file_editor_endpoint_invalid")
+        base = urljoin(f"{self._url}/", f"{self._entry.lstrip('/').rstrip('/')}/")
+        target = urljoin(base, endpoint.lstrip("/"))
+        return f"{target}?{urlencode(query)}" if query else target
+
+    def _open(self, request: urllib.request.Request, timeout: float = 30) -> bytes:
+        request.add_header("Cookie", f"ingress_session={self._session}")
+        try:
+            with self._opener.open(request, timeout=timeout) as response:
+                if response.status != 200:
+                    raise BootstrapError("file_editor_http_failure")
+                content = response.read(MAX_RESPONSE_BYTES + 1)
+        except BootstrapError:
+            raise
+        except Exception:
+            raise BootstrapError("file_editor_transport_failure") from None
+        if len(content) > MAX_RESPONSE_BYTES:
+            raise BootstrapError("file_editor_response_too_large")
+        return content
+
+    def _request(
+        self,
+        endpoint: str,
+        *,
+        query: dict[str, str] | None = None,
+        form: dict[str, str] | None = None,
+        timeout: float = 30,
+    ) -> dict[str, Any]:
+        data = urlencode(form).encode() if form is not None else None
+        request = urllib.request.Request(
+            self._url_for(endpoint, query),
+            data=data,
+            method="POST" if data is not None else "GET",
+        )
+        if data is not None:
+            request.add_header("Content-Type", "application/x-www-form-urlencoded")
+        return _json_object(
+            self._open(request, timeout), "file_editor_response_invalid"
+        )
+
+    @staticmethod
+    def _stage(transaction_id: str, relative: str = "") -> str:
+        transaction_id = _validate_uuid(transaction_id)
+        root = f"{REMOTE_ROOT}/{STAGE_PREFIX}{transaction_id}"
+        return f"{root}/{relative}" if relative else root
+
+    @staticmethod
+    def _transaction(transaction_id: str, relative: str = "") -> str:
+        transaction_id = _validate_uuid(transaction_id)
+        root = f"{REMOTE_ROOT}/{TRANSACTION_PREFIX}{transaction_id}"
+        return f"{root}/{relative}" if relative else root
+
+    @staticmethod
+    def _initialization(transaction_id: str) -> str:
+        transaction_id = _validate_uuid(transaction_id)
+        return f"{REMOTE_ROOT}/{TRANSACTION_INIT_PREFIX}{transaction_id}"
+
+    def _list(self, path: str) -> list[dict[str, Any]]:
+        result = self._request("/api/listdir", query={"path": path})
+        if (
+            result.get("error") not in {None, False}
+            or result.get("abspath") != path
+            or not isinstance(result.get("content"), list)
+        ):
+            raise BootstrapError("remote_path_mismatch")
+        return result["content"]
+
+    def _exists(self, fixed_path: str, *, expected_type: str) -> bool:
+        parent, name = (
+            str(PurePosixPath(fixed_path).parent),
+            PurePosixPath(fixed_path).name,
+        )
+        matches = [
+            item
+            for item in self._list(parent)
+            if isinstance(item, dict) and item.get("name") == name
+        ]
+        if not matches:
+            return False
+        if (
+            len(matches) != 1
+            or matches[0].get("type") != expected_type
+            or matches[0].get("fullpath") != fixed_path
+        ):
+            raise BootstrapError("remote_path_invalid")
+        return True
+
+    def transaction_exists(self, transaction_id: str) -> bool:
+        return self._exists(self._transaction(transaction_id), expected_type="dir")
+
+    def initialization_exists(self, transaction_id: str) -> bool:
+        return self._exists(self._initialization(transaction_id), expected_type="dir")
+
+    def stage_exists(self, transaction_id: str) -> bool:
+        return self._exists(self._stage(transaction_id), expected_type="dir")
+
+    def stage_file_exists(self, transaction_id: str, relative: str) -> bool:
+        if relative not in {*PAYLOAD_PATHS, PAYLOAD_MANIFEST_NAME, INSTALLER_NAME}:
+            raise BootstrapError("stage_target_invalid")
+        return self._exists(self._stage(transaction_id, relative), expected_type="file")
+
+    def _mkdir(self, path: str) -> None:
+        parent, name = str(PurePosixPath(path).parent), PurePosixPath(path).name
+        result = self._request("/api/newfolder", form={"path": parent, "name": name})
+        if result.get("error") is not False or result.get("path") != path:
+            raise BootstrapError("remote_directory_create_failed")
+
+    def create_stage(self, transaction_id: str) -> None:
+        root = self._stage(transaction_id)
+        for directory in (
+            root,
+            f"{root}/custom_components",
+            f"{root}/custom_components/aurora_deploy",
+        ):
+            if not self._exists(directory, expected_type="dir"):
+                self._mkdir(directory)
+
+    def upload(self, transaction_id: str, relative: str, content: bytes) -> None:
+        if relative not in {*PAYLOAD_PATHS, PAYLOAD_MANIFEST_NAME, INSTALLER_NAME}:
+            raise BootstrapError("upload_target_invalid")
+        target = self._stage(transaction_id, relative)
+        destination, filename = (
+            str(PurePosixPath(target).parent),
+            PurePosixPath(target).name,
+        )
+        boundary = f"aurora-{secrets.token_hex(16)}"
+        body = (
+            (
+                f'--{boundary}\r\nContent-Disposition: form-data; name="path"\r\n\r\n{destination}\r\n--{boundary}\r\nContent-Disposition: form-data; name="file"; filename="{filename}"\r\nContent-Type: application/octet-stream\r\n\r\n'
+            ).encode()
+            + content
+            + f"\r\n--{boundary}--\r\n".encode()
+        )
+        result = _json_object(
+            self._open(
+                urllib.request.Request(
+                    self._url_for("/api/upload"),
+                    data=body,
+                    method="POST",
+                    headers={
+                        "Content-Type": f"multipart/form-data; boundary={boundary}"
+                    },
+                )
+            ),
+            "file_editor_response_invalid",
+        )
+        # hass-configurator 0.6.0 does not echo the destination. Treat only
+        # its complete success object as acknowledgement; the fixed-target
+        # list/download/hash readback in _stage_payload remains authoritative.
+        if (
+            set(result) != {"error", "message"}
+            or result["error"] is not False
+            or result["message"] != "Upload successful"
+        ):
+            raise BootstrapError("remote_upload_failed")
+
+    def _download_path(self, path: str) -> bytes:
+        return self._open(
+            urllib.request.Request(self._url_for("/api/file", {"filename": path}))
+        )
+
+    def download_stage(self, transaction_id: str, relative: str) -> bytes:
+        if relative not in {*PAYLOAD_PATHS, PAYLOAD_MANIFEST_NAME, INSTALLER_NAME}:
+            raise BootstrapError("download_target_invalid")
+        return self._download_path(self._stage(transaction_id, relative))
+
+    def configuration_bytes(self) -> bytes:
+        if not self._exists(REMOTE_CONFIGURATION, expected_type="file"):
+            raise BootstrapError("remote_configuration_missing")
+        return self._download_path(REMOTE_CONFIGURATION)
+
+    def trust_sha256(self) -> str:
+        if not self._exists(REMOTE_TRUST, expected_type="file"):
+            return "absent"
+        return _digest(self._download_path(REMOTE_TRUST))
+
+    def component_tree_sha256(self) -> str:  # noqa: C901
+        if not self._exists(REMOTE_COMPONENT, expected_type="dir"):
+            return _digest(
+                _canonical({"exists": False, "files": {}, "directories": []})
+            )
+        files: dict[str, str] = {}
+        directories: set[str] = set()
+        pending = [(REMOTE_COMPONENT, "")]
+        total_bytes = 0
+        while pending:
+            directory, prefix = pending.pop()
+            for item in self._list(directory):
+                if not isinstance(item, dict) or not isinstance(item.get("name"), str):
+                    raise BootstrapError("remote_component_invalid")
+                name = item["name"]
+                if name in {".", ".."} or "/" in name or "\\" in name:
+                    raise BootstrapError("remote_component_invalid")
+                relative = f"{prefix}/{name}".lstrip("/")
+                if (
+                    len(PurePosixPath(relative).parts) > 8
+                    or len(files) + len(pending) >= 128
+                ):
+                    raise BootstrapError("remote_component_too_large")
+                expected = f"{directory}/{name}"
+                if item.get("fullpath") != expected or item.get("type") not in {
+                    "file",
+                    "dir",
+                }:
+                    raise BootstrapError("remote_component_invalid")
+                if item["type"] == "dir":
+                    if relative == "__pycache__":
+                        pass
+                    elif relative.startswith("__pycache__/"):
+                        raise BootstrapError("component_generated_artifact_invalid")
+                    else:
+                        directories.add(relative)
+                    pending.append((expected, relative))
+                else:
+                    content = self._download_path(expected)
+                    total_bytes += len(content)
+                    if total_bytes > 8 * 1024 * 1024:
+                        raise BootstrapError("remote_component_too_large")
+                    if SAFE_PYCACHE.fullmatch(relative) is not None:
+                        continue
+                    if relative.startswith("__pycache__/"):
+                        raise BootstrapError("component_generated_artifact_invalid")
+                    files[relative] = _digest(content)
+        return _digest(
+            _canonical(
+                {
+                    "exists": True,
+                    "files": files,
+                    "directories": sorted(directories),
+                }
+            )
+        )
+
+    def transaction_journal(self, transaction_id: str) -> dict[str, Any] | None:
+        if not self.transaction_exists(transaction_id):
+            return None
+        return _validated_transaction_journal(
+            _json_object(
+                self._download_path(
+                    self._transaction(transaction_id, "transaction.json")
+                ),
+                "transaction_invalid",
+            ),
+            transaction_id,
+        )
+
+    def lock_status(self) -> dict[str, Any] | None:
+        if not self._exists(REMOTE_LOCK, expected_type="file"):
+            return None
+        lock = _json_object(self._download_path(REMOTE_LOCK), "global_lock_invalid")
+        if (
+            lock.get("schemaVersion") != "aurora-deploy-bootstrap-lock-v4"
+            or not isinstance(lock.get("transactionId"), str)
+            or not isinstance(lock.get("acquiredAt"), int)
+            or SHA256.fullmatch(str(lock.get("installerSha256", ""))) is None
+            or not isinstance(lock.get("processId"), int)
+            or isinstance(lock.get("processId"), bool)
+            or lock.get("processId") <= 0
+            or not isinstance(lock.get("processStartTicks"), int)
+            or isinstance(lock.get("processStartTicks"), bool)
+            or lock.get("processStartTicks") < 0
+            or not isinstance(lock.get("bootId"), str)
+            or not isinstance(lock.get("probeNonce"), str)
+            or re.fullmatch(r"[0-9a-f]{32}", lock["probeNonce"]) is None
+        ):
+            raise BootstrapError("global_lock_invalid")
+        return lock
+
+    def lock_candidate_exists(self, transaction_id: str) -> bool:
+        transaction_id = _validate_uuid(transaction_id)
+        return self._exists(
+            f"{REMOTE_ROOT}/{LOCK_CANDIDATE_PREFIX}{transaction_id}",
+            expected_type="file",
+        )
+
+    def status(self, transaction_id: str) -> dict[str, Any]:
+        transaction_present = self.transaction_exists(transaction_id)
+        journal = (
+            self.transaction_journal(transaction_id) if transaction_present else None
+        )
+        lock = self.lock_status()
+        stage_present = self.stage_exists(transaction_id)
+        lock_candidate_present = self.lock_candidate_exists(transaction_id)
+        initialization_present = self.initialization_exists(transaction_id)
+        result: dict[str, Any] = {
+            "status": "not_found",
+            "transactionId": transaction_id,
+            "stagePresent": stage_present,
+            "lockCandidatePresent": lock_candidate_present,
+            "transactionPresent": transaction_present,
+            "initializationPresent": initialization_present,
+        }
+        if journal is not None:
+            for source, target in (
+                ("status", "status"),
+                ("payloadManifestSha256", "payloadManifestSha256"),
+                ("configurationSha256", "configurationSha256"),
+                ("componentTreeSha256", "componentTreeSha256"),
+                ("trustSha256", "trustSha256"),
+                ("rollbackDeadline", "rollbackDeadline"),
+                ("installerSha256", "installerSha256"),
+                ("replaceExact", "replaceExact"),
+            ):
+                value = journal.get(source)
+                if value is not None:
+                    result[target] = value
+            prestate = journal["prestate"]
+            result.update(
+                {
+                    "prestateConfigurationSha256": prestate["configuration"].get(
+                        "sha256"
+                    ),
+                    "prestateComponentTreeSha256": _component_state_digest(
+                        prestate["component"]
+                    ),
+                    "prestateTrustSha256": prestate["trust"].get("sha256", "absent"),
+                }
+            )
+        elif initialization_present:
+            result["status"] = "initializing"
+        elif lock_candidate_present:
+            result["status"] = "lock_candidate"
+        elif stage_present:
+            result["status"] = "staged_partial"
+        result["lockHeld"] = lock is not None
+        result["lockOwnerMatches"] = (
+            lock is not None and lock.get("transactionId") == transaction_id
+        )
+        return result
+
+    def readback(self, transaction_id: str) -> dict[str, Any]:
+        result = self.status(transaction_id)
+        if result.get("status") == "not_found":
+            return {**result, "verified": False}
+        current = {
+            "configurationSha256": _digest(self.configuration_bytes()),
+            "componentTreeSha256": self.component_tree_sha256(),
+            "trustSha256": self.trust_sha256(),
+        }
+        verified = all(result.get(key) == value for key, value in current.items())
+        return {**result, **current, "verified": verified}
+
+    def execute(  # noqa: C901 - fixed command and lost-response state machine
+        self, *, mode: str, transaction_id: str, arguments: dict[str, str | bool]
+    ) -> dict[str, Any]:
+        if mode not in {
+            "install",
+            "rollback",
+            "recover-lock",
+            "abort-stage",
+            "mark-verified",
+            "finalize",
+        }:
+            raise BootstrapError("installer_mode_invalid")
+        if mode in {"install", "abort-stage"}:
+            installer = self._stage(transaction_id, INSTALLER_NAME)
+        else:
+            installer = self._transaction(transaction_id, INSTALLER_NAME)
+            if mode == "recover-lock" and not self.transaction_exists(transaction_id):
+                installer = self._stage(transaction_id, INSTALLER_NAME)
+        expected_installer_sha256 = _validate_hash(
+            arguments.get("expected-installer-sha256"),
+            "expected_installer_hash_required",
+        )
+        if _digest(self._download_path(installer)) != expected_installer_sha256:
+            raise BootstrapError("remote_installer_hash_mismatch")
+        command = f"python3 {installer} {mode} --transaction-id {transaction_id}"
+        allowed = {
+            "expected-configuration-sha256",
+            "expected-component-tree-sha256",
+            "expected-trust-sha256",
+            "payload-manifest-sha256",
+            "expected-installer-sha256",
+            "replace-exact",
+        }
+        if set(arguments) - allowed:
+            raise BootstrapError("installer_argument_invalid")
+        for key in sorted(arguments):
+            value = arguments[key]
+            if value is True:
+                command += f" --{key}"
+            elif isinstance(value, str) and (
+                SHA256.fullmatch(value) or value == "absent"
+            ):
+                command += f" --{key} {value}"
+            else:
+                raise BootstrapError("installer_argument_invalid")
+        if any(char in command for char in ";&|`$<>(){}[]\\\r\n"):
+            raise BootstrapError("installer_command_invalid")
+        try:
+            wrapper = self._request(
+                "/api/exec_command",
+                form={"command": command, "timeout": "25"},
+                timeout=35,
+            )
+        except BootstrapError as error:
+            if str(error) not in {
+                "file_editor_transport_failure",
+                "file_editor_http_failure",
+            }:
+                raise
+            return self._reconcile_lost_response(mode, transaction_id, arguments)
+        try:
+            if (
+                set(wrapper) != {"error", "message", "returncode", "stdout", "stderr"}
+                or wrapper["error"] is not False
+                or wrapper["message"] != f"Command executed: {command}"
+                or not isinstance(wrapper["returncode"], int)
+                or isinstance(wrapper["returncode"], bool)
+                or wrapper["returncode"] != 0
+            ):
+                raise BootstrapError("installer_outcome_unknown")
+            stdout = wrapper.get("stdout")
+            if (
+                not isinstance(stdout, str)
+                or wrapper.get("stderr") != ""
+                or len(stdout) > 4096
+            ):
+                raise BootstrapError("installer_outcome_unknown")
+            return _validated_installer_receipt(
+                _json_object(stdout.encode(), "installer_output_invalid"),
+                mode,
+                transaction_id,
+            )
+        except Exception:
+            return self._reconcile_lost_response(mode, transaction_id, arguments)
+
+    def _reconcile_lost_response(
+        self,
+        mode: str,
+        transaction_id: str,
+        arguments: dict[str, str | bool],
+    ) -> dict[str, Any]:
+        first = self.readback(transaction_id)
+        second = self.readback(transaction_id)
+        stable_keys = {
+            "status",
+            "transactionId",
+            "payloadManifestSha256",
+            "installerSha256",
+            "replaceExact",
+            "configurationSha256",
+            "componentTreeSha256",
+            "trustSha256",
+            "rollbackDeadline",
+            "prestateConfigurationSha256",
+            "prestateComponentTreeSha256",
+            "prestateTrustSha256",
+            "stagePresent",
+            "lockCandidatePresent",
+            "transactionPresent",
+            "initializationPresent",
+            "lockOwnerMatches",
+            "verified",
+        }
+        topology_keys = {
+            "stagePresent",
+            "lockCandidatePresent",
+            "transactionPresent",
+            "initializationPresent",
+            "lockHeld",
+            "lockOwnerMatches",
+            "verified",
+        }
+        if (
+            first.get("transactionId") != transaction_id
+            or second.get("transactionId") != transaction_id
+            or any(
+                not isinstance(snapshot.get(key), bool)
+                for snapshot in (first, second)
+                for key in topology_keys
+            )
+            or first.get("lockHeld") is not False
+            or second.get("lockHeld") is not False
+            or first.get("lockOwnerMatches") is not False
+            or second.get("lockOwnerMatches") is not False
+            or {key: first.get(key) for key in stable_keys}
+            != {key: second.get(key) for key in stable_keys}
+        ):
+            raise BootstrapError("installer_result_ambiguous")
+        status = second
+        transaction_present = status.get("transactionPresent") is True
+        if transaction_present:
+            bindings = {
+                "installerSha256": arguments.get("expected-installer-sha256"),
+                "payloadManifestSha256": arguments.get("payload-manifest-sha256"),
+                "prestateConfigurationSha256": arguments.get(
+                    "expected-configuration-sha256"
+                ),
+                "prestateComponentTreeSha256": arguments.get(
+                    "expected-component-tree-sha256"
+                ),
+                "prestateTrustSha256": arguments.get("expected-trust-sha256"),
+                "replaceExact": bool(arguments.get("replace-exact", False)),
+            }
+            if any(
+                (not isinstance(expected, (str, bool)) or status.get(key) != expected)
+                for key, expected in bindings.items()
+            ):
+                raise BootstrapError("installer_result_ambiguous")
+        expected = {
+            "install": "installed",
+            "rollback": "rolled_back",
+            "recover-lock": "lock_recovered",
+            "abort-stage": "stage_aborted",
+            "mark-verified": "restart_verified",
+            "finalize": "not_found",
+        }[mode]
+        if (
+            mode == "recover-lock"
+            and status.get("lockCandidatePresent") is False
+            and status.get("initializationPresent") is False
+            and status.get("status")
+            in {
+                "not_found",
+                "staged_partial",
+                "installed",
+                "rolled_back",
+                "rolled_back_after_failure",
+                "rolled_back_after_recovery",
+                "restart_verified",
+                "finalize_prepared",
+                "rollback_finalize_prepared",
+            }
+            and (
+                (
+                    status.get("status") == "not_found"
+                    and status.get("stagePresent") is False
+                    and transaction_present is False
+                )
+                or (
+                    status.get("status") == "staged_partial"
+                    and status.get("stagePresent") is True
+                    and transaction_present is False
+                )
+                or (transaction_present and status.get("verified") is True)
+            )
+        ):
+            return {
+                "status": "lock_recovered",
+                "transactionId": transaction_id,
+                "reconciled": True,
+            }
+        if (
+            mode == "abort-stage"
+            and status.get("lockCandidatePresent") is False
+            and status.get("initializationPresent") is False
+            and status.get("transactionPresent") is False
+            and status.get("stagePresent") is False
+        ):
+            return {
+                "status": "stage_aborted",
+                "transactionId": transaction_id,
+                "reconciled": True,
+            }
+        if (
+            mode == "finalize"
+            and status.get("status") == "not_found"
+            and status.get("lockCandidatePresent") is False
+            and status.get("initializationPresent") is False
+            and status.get("transactionPresent") is False
+            and status.get("stagePresent") is False
+        ):
+            return {
+                "status": "finalized",
+                "transactionId": transaction_id,
+                "reconciled": True,
+            }
+        if (
+            status.get("status") != expected
+            or status.get("verified") is not True
+            or transaction_present is not True
+            or status.get("lockCandidatePresent") is not False
+            or status.get("initializationPresent") is not False
+        ):
+            raise BootstrapError("installer_result_ambiguous")
+        return {**status, "reconciled": True}
+
+
+INSTALLER_SOURCE = rb"""#!/usr/bin/env python3
+from __future__ import annotations
+import argparse, ctypes, errno, hashlib, json, os, re, shutil, stat, sys, time
+from pathlib import Path
+
+ROOT=Path("/homeassistant"); COMPONENT=ROOT/"custom_components"/"aurora_deploy"; TRUST=ROOT/"aurora_deploy_trusted_keys.json"; CONFIG=ROOT/"configuration.yaml"; LOCK=ROOT/".aurora-deploy-bootstrap-global.lock"
+STAGE_PREFIX=".aurora-deploy-bootstrap-stage-"; TX_PREFIX=".aurora-deploy-bootstrap-transaction-"; TX_INIT_PREFIX=".aurora-deploy-bootstrap-transaction-init-"; INSTALLER="install-aurora-deploy-bootstrap.py"; MANIFEST="payload-manifest.json"; FILES=("__init__.py","adapter.py","manifest.json"); PAYLOAD=tuple(f"custom_components/aurora_deploy/{name}" for name in FILES)+("aurora_deploy_trusted_keys.json",)
+SHA=re.compile(r"^[0-9a-f]{64}$"); NONCE=re.compile(r"^[0-9a-f]{32}$"); UUID=re.compile(r"^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"); PYCACHE=re.compile(r"^__pycache__/(?:__init__|adapter)\.cpython-\d{3}(?:\.opt-[12])?\.pyc$"); STALE=3600; WINDOW=86400
+
+def fail(code): raise RuntimeError(code)
+def digest(data): return hashlib.sha256(data).hexdigest()
+def canonical(value): return json.dumps(value,sort_keys=True,separators=(",",":")).encode()
+def pairs(values):
+    result={}
+    for key,value in values:
+        if key in result: fail("json_duplicate_key")
+        result[key]=value
+    return result
+def load(path,code):
+    try: value=json.loads(path.read_bytes(),object_pairs_hook=pairs)
+    except RuntimeError: raise
+    except Exception: fail(code)
+    if not isinstance(value,dict): fail(code)
+    return value
+def fsync_dir(path):
+    fd=os.open(path,os.O_RDONLY)
+    try: os.fsync(fd)
+    finally: os.close(fd)
+def kind(path, expected, code):
+    try: info=os.lstat(path)
+    except FileNotFoundError: fail(code)
+    if stat.S_ISLNK(info.st_mode) or (expected=="file" and not stat.S_ISREG(info.st_mode)) or (expected=="dir" and not stat.S_ISDIR(info.st_mode)): fail(code)
+    return info
+def lexists(path): return os.path.lexists(path)
+def file_state(path):
+    if not lexists(path): return {"exists":False}
+    info=kind(path,"file","destination_invalid"); data=path.read_bytes()
+    return {"exists":True,"sha256":digest(data),"size":len(data),"mode":stat.S_IMODE(info.st_mode),"uid":info.st_uid,"gid":info.st_gid}
+def configuration_snapshot():
+    info=kind(CONFIG,"file","destination_invalid"); data=CONFIG.read_bytes()
+    return {"exists":True,"sha256":digest(data),"size":len(data),"mode":stat.S_IMODE(info.st_mode),"uid":info.st_uid,"gid":info.st_gid},data
+def tree_state(path):
+    if not lexists(path): return {"exists":False,"files":{},"directories":{}}
+    root_info=kind(path,"dir","destination_component_invalid"); files={}; directories={".":{"mode":stat.S_IMODE(root_info.st_mode),"uid":root_info.st_uid,"gid":root_info.st_gid}}; count=0; total=0
+    for base,dirs,names in os.walk(path,followlinks=False):
+        basep=Path(base)
+        if len(basep.relative_to(path).parts)>8: fail("component_tree_too_large")
+        for name in dirs:
+            info=kind(basep/name,"dir","destination_symlink_rejected"); directories[(basep/name).relative_to(path).as_posix()]={"mode":stat.S_IMODE(info.st_mode),"uid":info.st_uid,"gid":info.st_gid}; count+=1
+        for name in names:
+            candidate=basep/name; info=kind(candidate,"file","destination_symlink_rejected"); data=candidate.read_bytes(); total+=len(data); count+=1; files[candidate.relative_to(path).as_posix()]={"sha256":digest(data),"size":info.st_size,"mode":stat.S_IMODE(info.st_mode),"uid":info.st_uid,"gid":info.st_gid}
+        if count>128 or total>8388608: fail("component_tree_too_large")
+    return {"exists":True,"files":files,"directories":directories}
+def component_without_generated(state):
+    if not state["exists"]: return state
+    files=dict(state["files"]); directories=dict(state["directories"])
+    for name in tuple(files):
+        if name.startswith("__pycache__/"):
+            if not PYCACHE.fullmatch(name): fail("component_generated_artifact_invalid")
+            del files[name]
+    for name in tuple(directories):
+        if name=="__pycache__": del directories[name]
+        elif name.startswith("__pycache__/"): fail("component_generated_artifact_invalid")
+    return {"exists":True,"files":files,"directories":directories}
+def component_equal(first,second): return component_without_generated(first)==component_without_generated(second)
+def content_tree(state):
+    projected=component_without_generated(state)
+    return digest(canonical({"exists":projected["exists"],"files":{key:value["sha256"] for key,value in projected.get("files",{}).items()},"directories":sorted(key for key in projected.get("directories",{}) if key!=".")}))
+def state_equal(key,first,second): return component_equal(first,second) if key=="component" else first==second
+def states_equal(first,second): return all(state_equal(key,first[key],second[key]) for key in ("configuration","component","trust"))
+def states(): return {"configuration":file_state(CONFIG),"component":tree_state(COMPONENT),"trust":file_state(TRUST)}
+def clean_atomic_temps(path):
+    prefix=path.name+".new-"; matches=[item for item in path.parent.iterdir() if item.name.startswith(prefix)]
+    if len(matches)>16: fail("temporary_path_count_invalid")
+    for item in matches: kind(item,"file","temporary_path_invalid"); os.unlink(item)
+    if matches: fsync_dir(path.parent)
+def write_atomic(path,data,metadata=None):
+    clean_atomic_temps(path); temp=path.with_name(path.name+f".new-{os.getpid()}-{time.time_ns()}")
+    mode=metadata["mode"] if metadata else 0o600; flags=os.O_WRONLY|os.O_CREAT|os.O_EXCL|getattr(os,"O_NOFOLLOW",0); fd=os.open(temp,flags,mode)
+    try:
+        view=memoryview(data)
+        while view:
+            written=os.write(fd,view)
+            if written<=0: fail("atomic_write_failed")
+            view=view[written:]
+        os.fchmod(fd,mode)
+        if metadata:
+            try: os.fchown(fd,metadata["uid"],metadata["gid"])
+            except PermissionError:
+                current=os.fstat(fd)
+                if current.st_uid!=metadata["uid"] or current.st_gid!=metadata["gid"]: fail("configuration_metadata_unpreserved")
+        os.fsync(fd)
+    finally: os.close(fd)
+    os.replace(temp,path); fsync_dir(path.parent)
+def write_journal(tx,value): write_atomic(tx/"transaction.json",canonical(value))
+def lock_candidate(txid): return ROOT/f".aurora-deploy-bootstrap-lock-candidate-{txid}"
+def process_record(pid):
+    if sys.platform!="linux":
+        try: os.kill(pid,0)
+        except ProcessLookupError: return None
+        except PermissionError: return ("R",0)
+        return ("R",0)
+    try: raw=Path(f"/proc/{pid}/stat").read_text()
+    except (FileNotFoundError,ProcessLookupError): return None
+    end=raw.rfind(")")
+    if end<0: fail("process_identity_unavailable")
+    fields=raw[end+2:].split()
+    if len(fields)<20 or not fields[19].isdigit(): fail("process_identity_unavailable")
+    return (fields[0],int(fields[19]))
+def boot_identity():
+    if sys.platform!="linux": return "00000000-0000-4000-8000-000000000000"
+    try: value=Path("/proc/sys/kernel/random/boot_id").read_text().strip()
+    except OSError: fail("process_identity_unavailable")
+    if not re.fullmatch(r"[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}",value): fail("process_identity_unavailable")
+    return value
+def lock_value(txid,installer_sha256):
+    process=process_record(os.getpid())
+    if process is None or process[0] in {"Z","X"}: fail("process_identity_unavailable")
+    return {"schemaVersion":"aurora-deploy-bootstrap-lock-v4","transactionId":txid,"acquiredAt":int(time.time()),"installerSha256":installer_sha256,"processId":os.getpid(),"processStartTicks":process[1],"bootId":boot_identity(),"probeNonce":os.urandom(16).hex()}
+def valid_lock(path,code):
+    value=load(path,code)
+    if value.get("schemaVersion")!="aurora-deploy-bootstrap-lock-v4" or not UUID.fullmatch(str(value.get("transactionId",""))) or not isinstance(value.get("acquiredAt"),int) or not SHA.fullmatch(str(value.get("installerSha256",""))) or not isinstance(value.get("processId"),int) or isinstance(value.get("processId"),bool) or value.get("processId")<=0 or not isinstance(value.get("processStartTicks"),int) or isinstance(value.get("processStartTicks"),bool) or value.get("processStartTicks")<0 or not isinstance(value.get("bootId"),str) or not NONCE.fullmatch(str(value.get("probeNonce",""))): fail(code)
+    return value
+def lock_owner_alive(value):
+    if value["bootId"]!=boot_identity(): return False
+    process=process_record(value["processId"])
+    return process is not None and process[0] not in {"Z","X"} and process[1]==value["processStartTicks"]
+def cleanup_owned_lock_candidate(candidate,created):
+    if not lexists(candidate): return
+    current=kind(candidate,"file","global_lock_candidate_cleanup_failed")
+    if current.st_dev!=created.st_dev or current.st_ino!=created.st_ino: fail("global_lock_candidate_cleanup_failed")
+    os.unlink(candidate); fsync_dir(ROOT)
+def acquire(txid,installer_sha256):
+    candidate=lock_candidate(txid)
+    if lexists(candidate): fail("global_lock_candidate_exists")
+    value=lock_value(txid,installer_sha256); data=canonical(value); flags=os.O_WRONLY|os.O_CREAT|os.O_EXCL|getattr(os,"O_NOFOLLOW",0); fd=os.open(candidate,flags,0o600)
+    created=os.fstat(fd)
+    try:
+        try:
+            view=memoryview(data)
+            while view:
+                written=os.write(fd,view)
+                if written<=0: fail("global_lock_candidate_write_failed")
+                view=view[written:]
+            os.fsync(fd)
+        finally: os.close(fd)
+    except Exception:
+        cleanup_owned_lock_candidate(candidate,created); raise
+    published=False
+    try:
+        os.link(candidate,LOCK,follow_symlinks=False); published=True
+        fsync_dir(ROOT); cleanup_owned_lock_candidate(candidate,created)
+    except FileExistsError:
+        cleanup_owned_lock_candidate(candidate,created); fail("global_lock_held")
+    except Exception:
+        if not published: cleanup_owned_lock_candidate(candidate,created)
+        raise
+    return value["probeNonce"]
+def release(txid):
+    lock=valid_lock(LOCK,"global_lock_invalid")
+    if lock.get("transactionId")!=txid: fail("global_lock_owner_mismatch")
+    candidate=lock_candidate(txid)
+    if lexists(candidate):
+        lock_info=kind(LOCK,"file","global_lock_invalid"); candidate_info=kind(candidate,"file","global_lock_candidate_invalid")
+        if not os.path.samestat(lock_info,candidate_info): fail("global_lock_candidate_invalid")
+        os.unlink(candidate); fsync_dir(ROOT)
+    os.unlink(LOCK); fsync_dir(ROOT)
+def read_payload(stage,expected):
+    kind(stage,"dir","stage_missing"); actual={item.name for item in stage.iterdir()}; required={"custom_components","aurora_deploy_trusted_keys.json",MANIFEST,INSTALLER}
+    if actual!=required: fail("stage_file_set_invalid")
+    component=stage/"custom_components"/"aurora_deploy"; kind(component,"dir","stage_invalid")
+    if {item.name for item in component.iterdir()}!=set(FILES): fail("stage_file_set_invalid")
+    manifest_path=stage/MANIFEST; kind(manifest_path,"file","stage_symlink_rejected"); raw=manifest_path.read_bytes()
+    if digest(raw)!=expected: fail("payload_manifest_hash_mismatch")
+    manifest=load(manifest_path,"payload_manifest_invalid")
+    if manifest.get("schemaVersion")!="aurora-deploy-bootstrap-v2" or not isinstance(manifest.get("files"),list): fail("payload_manifest_invalid")
+    entries=manifest["files"]
+    if [item.get("path") for item in entries if isinstance(item,dict)]!=list(PAYLOAD): fail("payload_manifest_invalid")
+    result={}
+    for item in entries:
+        if not isinstance(item,dict) or set(item)!={"path","sha256","size"}: fail("payload_manifest_invalid")
+        path=stage/item["path"]; info=kind(path,"file","stage_symlink_rejected"); data=path.read_bytes()
+        if info.st_size!=item["size"] or digest(data)!=item["sha256"]: fail("payload_hash_mismatch")
+        result[item["path"]]=data
+    return result
+def configuration_after(data):
+    try: text=data.decode()
+    except UnicodeDecodeError: fail("configuration_invalid")
+    key=re.compile(r"^(?:aurora_deploy|[\"']aurora_deploy[\"'])[ \t]*:(?:\s|$)"); meaningful=[line for line in text.splitlines() if line.strip() and not line.lstrip().startswith("#")]
+    if any(line.startswith(("{","?")) for line in meaningful): fail("configuration_yaml_style_unsupported")
+    count=sum(1 for line in text.splitlines() if key.match(line))
+    if count>1: fail("configuration_key_duplicate")
+    if count==1: return data
+    return data+(b"" if not data or data.endswith(b"\n") else b"\n")+b"aurora_deploy:\n"
+def assert_expected(current,args):
+    if current["configuration"].get("sha256")!=args.expected_configuration_sha256: fail("configuration_drift")
+    if content_tree(current["component"])!=args.expected_component_tree_sha256: fail("component_drift")
+    trust=current["trust"].get("sha256","absent")
+    if trust!=args.expected_trust_sha256: fail("trust_drift")
+def exact(current,expected): return states_equal(current,expected)
+def state_for(key,path): return tree_state(path) if key=="component" else file_state(path)
+def rename_noreplace(source,destination,code):
+    if sys.platform=="linux":
+        libc=ctypes.CDLL(None,use_errno=True); result=libc.syscall(ctypes.c_long(316),ctypes.c_int(-100),ctypes.c_char_p(os.fsencode(source)),ctypes.c_int(-100),ctypes.c_char_p(os.fsencode(destination)),ctypes.c_uint(1))
+        if result==0: return
+        error=ctypes.get_errno()
+        if error in {errno.EEXIST,errno.ENOTEMPTY}: fail(code)
+        if error in {errno.ENOSYS,errno.EINVAL}: fail("atomic_rename_unsupported")
+        raise OSError(error,os.strerror(error))
+    if lexists(destination): fail(code)
+    os.rename(source,destination)
+def create_runtime_probe(path,marker):
+    if lexists(path): fail("runtime_probe_residue")
+    flags=os.O_WRONLY|os.O_CREAT|os.O_EXCL|getattr(os,"O_NOFOLLOW",0); fd=os.open(path,flags,0o600); created=os.fstat(fd)
+    try:
+        try:
+            view=memoryview(marker)
+            while view:
+                written=os.write(fd,view)
+                if written<=0: fail("runtime_probe_write_failed")
+                view=view[written:]
+            os.fsync(fd)
+        finally: os.close(fd)
+    except Exception:
+        if lexists(path):
+            current=kind(path,"file","runtime_probe_invalid")
+            if current.st_dev!=created.st_dev or current.st_ino!=created.st_ino: fail("runtime_probe_invalid")
+            os.unlink(path); fsync_dir(ROOT)
+        raise
+    fsync_dir(ROOT); return created
+def runtime_probe_owned(path,created,marker):
+    if not lexists(path): return False
+    current=kind(path,"file","runtime_probe_invalid")
+    return current.st_dev==created.st_dev and current.st_ino==created.st_ino and path.read_bytes()==marker
+def cleanup_owned_runtime_probe(path,created,marker):
+    if not lexists(path): return False
+    if not runtime_probe_owned(path,created,marker): return False
+    os.unlink(path); fsync_dir(ROOT); return True
+def require_runtime_primitives(txid,nonce):
+    if ROOT!=Path("/homeassistant"): return
+    if sys.platform!="linux": fail("linux_runtime_required")
+    if not NONCE.fullmatch(nonce): fail("runtime_probe_invalid")
+    source=ROOT/f".aurora-deploy-bootstrap-runtime-source-{txid}-{nonce}"; destination=ROOT/f".aurora-deploy-bootstrap-runtime-destination-{txid}-{nonce}"; link_source=ROOT/f".aurora-deploy-bootstrap-runtime-link-source-{txid}-{nonce}"; link_destination=ROOT/f".aurora-deploy-bootstrap-runtime-link-destination-{txid}-{nonce}"; marker=canonical({"transactionId":txid,"probeNonce":nonce})
+    if any(lexists(path) for path in (source,destination,link_source,link_destination)): fail("runtime_probe_residue")
+    created=create_runtime_probe(source,marker); renamed=False
+    try:
+        rename_noreplace(source,destination,"runtime_probe_destination_exists"); renamed=True; fsync_dir(ROOT)
+        if not runtime_probe_owned(destination,created,marker): fail("runtime_probe_invalid")
+    finally:
+        cleanup_owned_runtime_probe(source,created,marker)
+        destination_owned=cleanup_owned_runtime_probe(destination,created,marker)
+        if renamed and not destination_owned: fail("runtime_probe_invalid")
+    linked_created=create_runtime_probe(link_source,marker); linked=False
+    try:
+        try: os.link(link_source,link_destination,follow_symlinks=False); linked=True
+        except FileExistsError: fail("runtime_probe_destination_exists")
+        fsync_dir(ROOT)
+        if not runtime_probe_owned(link_source,linked_created,marker) or not runtime_probe_owned(link_destination,linked_created,marker): fail("runtime_probe_invalid")
+    finally:
+        source_owned=cleanup_owned_runtime_probe(link_source,linked_created,marker)
+        destination_owned=cleanup_owned_runtime_probe(link_destination,linked_created,marker)
+        if linked and (not source_owned or not destination_owned): fail("runtime_probe_invalid")
+def cleanup_runtime_probe(txid,nonce):
+    if not NONCE.fullmatch(nonce): fail("runtime_probe_invalid")
+    marker=canonical({"transactionId":txid,"probeNonce":nonce})
+    for path in (ROOT/f".aurora-deploy-bootstrap-runtime-source-{txid}-{nonce}",ROOT/f".aurora-deploy-bootstrap-runtime-destination-{txid}-{nonce}",ROOT/f".aurora-deploy-bootstrap-runtime-link-source-{txid}-{nonce}",ROOT/f".aurora-deploy-bootstrap-runtime-link-destination-{txid}-{nonce}"):
+        if lexists(path):
+            kind(path,"file","runtime_probe_invalid")
+            data=path.read_bytes()
+            if len(data)>len(marker) or data!=marker[:len(data)]: fail("runtime_probe_invalid")
+            os.unlink(path)
+    fsync_dir(ROOT)
+def fsync_move(source,destination):
+    fsync_dir(source.parent)
+    if destination.parent!=source.parent: fsync_dir(destination.parent)
+def move_verified(key,source,destination,expected,drift_code):
+    if lexists(destination): fail("recovery_path_exists")
+    if not lexists(source): fail(drift_code)
+    rename_noreplace(source,destination,"recovery_path_exists"); fsync_move(source,destination)
+    if not state_equal(key,state_for(key,destination),expected):
+        if not lexists(source): rename_noreplace(destination,source,"destination_recreated"); fsync_move(destination,source)
+        fail(drift_code)
+def publish_verified(key,source,destination,expected):
+    rename_noreplace(source,destination,f"{key}_destination_recreated"); fsync_move(source,destination)
+    if not state_equal(key,state_for(key,destination),expected): fail("post_write_readback_failed")
+def previous_path(tx,key): return tx/("previous-configuration.yaml" if key=="configuration" else f"previous-{key}")
+def displaced_path(tx,key): return tx/f"rollback-displaced-{key}"
+def verify_prestate_artifacts(tx,journal,current):
+    pre=journal["prestate"]; installed=journal.get("installed"); status=journal.get("status")
+    if not isinstance(pre,dict) or not isinstance(installed,dict) or set(pre)!={"configuration","component","trust"} or set(installed)!=set(pre): fail("transaction_invalid")
+    if exact(current,pre): return "already"
+    for key in ("component","trust","configuration"):
+        expected=pre[key]; live=current[key]; previous=previous_path(tx,key); displaced=displaced_path(tx,key); displaced_valid=False
+        if lexists(displaced):
+            if not state_equal(key,state_for(key,displaced),installed[key]): fail("recovery_artifact_hash_mismatch")
+            displaced_valid=True
+        previous_valid=False
+        if expected["exists"]:
+            if lexists(previous):
+                if not state_equal(key,state_for(key,previous),expected): fail("recovery_artifact_hash_mismatch")
+                previous_valid=True
+        elif lexists(previous): fail("unexpected_recovery_artifact")
+        if state_equal(key,live,expected): continue
+        if state_equal(key,live,installed[key]): pass
+        elif live.get("exists") is False and status=="prepared" and previous_valid: pass
+        elif live.get("exists") is False and status=="rollback_prepared" and displaced_valid: pass
+        else: fail("rollback_destination_drift")
+        if expected["exists"] and not previous_valid: fail("recovery_artifact_missing")
+    return "restore"
+def restore(tx,journal):
+    current=states(); action=verify_prestate_artifacts(tx,journal,current)
+    if action=="already": return
+    pre=journal["prestate"]; installed=journal["installed"]
+    for key,destination in (("component",COMPONENT),("trust",TRUST),("configuration",CONFIG)):
+        live=state_for(key,destination)
+        if state_equal(key,live,pre[key]): continue
+        displaced=displaced_path(tx,key)
+        if state_equal(key,live,installed[key]): move_verified(key,destination,displaced,installed[key],"rollback_destination_drift")
+        elif not (live.get("exists") is False and journal.get("status") in {"prepared","rollback_prepared"}): fail("rollback_destination_drift")
+        previous=previous_path(tx,key)
+        if pre[key]["exists"]: publish_verified(key,previous,destination,pre[key])
+        elif lexists(destination): fail("rollback_destination_recreated")
+        fsync_dir(destination.parent); fsync_dir(tx)
+    if not states_equal(states(),pre): fail("rollback_readback_failed")
+def install_destination(key,destination,replacement,tx,pre,installed):
+    previous=previous_path(tx,key)
+    if pre[key]["exists"]: move_verified(key,destination,previous,pre[key],f"{key}_drift")
+    elif lexists(destination): fail(f"{key}_drift")
+    publish_verified(key,replacement,destination,installed[key])
+def install(args,stage,tx,installer_bytes):
+    kind(ROOT,"dir","config_root_invalid"); kind(ROOT/"custom_components","dir","custom_components_invalid"); payload=read_payload(stage,args.payload_manifest_sha256); config_state,config_bytes=configuration_snapshot(); current={"configuration":config_state,"component":tree_state(COMPONENT),"trust":file_state(TRUST)}; assert_expected(current,args)
+    desired_files={name:digest(payload[f"custom_components/aurora_deploy/{name}"]) for name in FILES}; desired_tree=digest(canonical({"exists":True,"files":desired_files,"directories":[]})); divergent=current["component"]["exists"] and content_tree(current["component"])!=desired_tree; trust_divergent=current["trust"]["exists"] and current["trust"]["sha256"]!=digest(payload["aurora_deploy_trusted_keys.json"])
+    if (divergent or trust_divergent) and not args.replace_exact: fail("replace_exact_required")
+    initialization=ROOT/f"{TX_INIT_PREFIX}{args.transaction_id}"
+    if lexists(tx) or lexists(initialization): fail("transaction_exists")
+    initialization.mkdir(mode=0o700); fsync_dir(ROOT); write_atomic(initialization/INSTALLER,installer_bytes)
+    if digest((initialization/INSTALLER).read_bytes())!=args.expected_installer_sha256: fail("installer_hash_mismatch")
+    config_data=configuration_after(config_bytes); new_component=initialization/"new-component"; new_component.mkdir(mode=0o755); fsync_dir(initialization)
+    for name in FILES: write_atomic(new_component/name,payload[f"custom_components/aurora_deploy/{name}"],{"mode":0o644,"uid":os.getuid(),"gid":os.getgid()})
+    new_trust=initialization/"new-trust"; write_atomic(new_trust,payload["aurora_deploy_trusted_keys.json"])
+    new_config=initialization/"new-configuration.yaml"; write_atomic(new_config,config_data,current["configuration"])
+    installed={"component":tree_state(new_component),"trust":file_state(new_trust),"configuration":file_state(new_config)}; now=int(time.time()); journal={"schemaVersion":"aurora-deploy-bootstrap-transaction-v2","transactionId":args.transaction_id,"payloadManifestSha256":args.payload_manifest_sha256,"installerSha256":digest((initialization/INSTALLER).read_bytes()),"replaceExact":args.replace_exact,"status":"prepared","createdAt":now,"rollbackDeadline":now+WINDOW,"prestate":current,"installed":installed}
+    write_journal(initialization,journal); rename_noreplace(initialization,tx,"transaction_exists"); fsync_dir(ROOT); new_component=tx/"new-component"; new_trust=tx/"new-trust"; new_config=tx/"new-configuration.yaml"; assert_expected(states(),args)
+    try:
+        install_destination("component",COMPONENT,new_component,tx,current,installed)
+        install_destination("trust",TRUST,new_trust,tx,current,installed)
+        install_destination("configuration",CONFIG,new_config,tx,current,installed)
+        if not states_equal(states(),installed): fail("post_write_readback_failed")
+        journal["status"]="installed"; journal["configurationSha256"]=installed["configuration"]["sha256"]; journal["componentTreeSha256"]=content_tree(installed["component"]); journal["trustSha256"]=installed["trust"]["sha256"]; write_journal(tx,journal)
+    except Exception:
+        try: restore(tx,journal); journal["status"]="rolled_back_after_failure"; journal["configurationSha256"]=journal["prestate"]["configuration"]["sha256"]; journal["componentTreeSha256"]=content_tree(journal["prestate"]["component"]); journal["trustSha256"]=journal["prestate"]["trust"].get("sha256","absent"); write_journal(tx,journal)
+        except Exception: fail("partial_failure_rollback_failed")
+        fail("install_failed_rolled_back")
+    return journal
+def cleanup_initialization(txid):
+    initialization=ROOT/f"{TX_INIT_PREFIX}{txid}"
+    if not lexists(initialization): return
+    kind(initialization,"dir","transaction_initialization_invalid"); tree_state(initialization); shutil.rmtree(initialization); fsync_dir(ROOT)
+def validate_recovery_pins(journal,args):
+    for value in (args.expected_configuration_sha256,args.expected_component_tree_sha256,args.payload_manifest_sha256):
+        if not isinstance(value,str) or not SHA.fullmatch(value): fail("recovery_pin_invalid")
+    if args.expected_trust_sha256!="absent" and (not isinstance(args.expected_trust_sha256,str) or not SHA.fullmatch(args.expected_trust_sha256)): fail("recovery_pin_invalid")
+    pre=journal.get("prestate")
+    if not isinstance(pre,dict) or journal.get("payloadManifestSha256")!=args.payload_manifest_sha256 or journal.get("replaceExact") is not args.replace_exact or pre.get("configuration",{}).get("sha256")!=args.expected_configuration_sha256 or content_tree(pre.get("component",{}))!=args.expected_component_tree_sha256 or pre.get("trust",{}).get("sha256","absent")!=args.expected_trust_sha256: fail("recovery_pin_mismatch")
+def recover(txid,tx,args):
+    expected_installer_sha256=args.expected_installer_sha256
+    candidate=lock_candidate(txid)
+    if not lexists(LOCK):
+        info=kind(candidate,"file","global_lock_missing")
+        if time.time()-info.st_mtime<STALE: fail("global_lock_not_stale")
+        os.unlink(candidate); fsync_dir(ROOT); return {"status":"lock_recovered","transactionId":txid}
+    kind(LOCK,"file","global_lock_invalid"); lock=valid_lock(LOCK,"global_lock_invalid")
+    if lock.get("transactionId")!=txid or lock.get("installerSha256")!=expected_installer_sha256 or time.time()-lock["acquiredAt"]<STALE: fail("global_lock_not_stale")
+    if lock_owner_alive(lock): fail("global_lock_owner_still_running")
+    if lexists(candidate):
+        lock_info=kind(LOCK,"file","global_lock_invalid"); candidate_info=kind(candidate,"file","global_lock_candidate_invalid")
+        if not os.path.samestat(lock_info,candidate_info):
+            if time.time()-candidate_info.st_mtime<STALE: fail("global_lock_candidate_invalid")
+            os.unlink(candidate); fsync_dir(ROOT)
+    cleanup_runtime_probe(txid,lock["probeNonce"])
+    if lexists(tx):
+        journal=load(tx/"transaction.json","transaction_invalid")
+        if journal.get("installerSha256")!=expected_installer_sha256: fail("installer_hash_mismatch")
+        validate_recovery_pins(journal,args)
+        if journal.get("status") in {"prepared","rollback_prepared"}: restore(tx,journal); journal["status"]="rolled_back_after_recovery"; journal["configurationSha256"]=journal["prestate"]["configuration"]["sha256"]; journal["componentTreeSha256"]=content_tree(journal["prestate"]["component"]); journal["trustSha256"]=journal["prestate"]["trust"].get("sha256","absent"); write_journal(tx,journal)
+        elif journal.get("status") not in {"installed","rolled_back","rolled_back_after_failure","rolled_back_after_recovery","restart_verified","finalize_prepared","rollback_finalize_prepared"}: fail("lock_recovery_state_unsafe")
+    else: cleanup_initialization(txid)
+    release(txid); return {"status":"lock_recovered","transactionId":txid}
+def receipt(status,txid,journal): return {"status":status,"transactionId":txid,"payloadManifestSha256":journal["payloadManifestSha256"],"configurationSha256":journal.get("configurationSha256",journal["prestate"]["configuration"]["sha256"]),"componentTreeSha256":journal.get("componentTreeSha256",content_tree(journal["prestate"]["component"])),"trustSha256":journal.get("trustSha256",journal["prestate"]["trust"].get("sha256","absent")),"rollbackDeadline":journal["rollbackDeadline"]}
+def main():
+    parser=argparse.ArgumentParser(add_help=False); parser.add_argument("mode",choices=("install","rollback","recover-lock","abort-stage","mark-verified","finalize")); parser.add_argument("--transaction-id",required=True); parser.add_argument("--expected-configuration-sha256"); parser.add_argument("--expected-component-tree-sha256"); parser.add_argument("--expected-trust-sha256"); parser.add_argument("--payload-manifest-sha256"); parser.add_argument("--expected-installer-sha256"); parser.add_argument("--replace-exact",action="store_true"); args=parser.parse_args()
+    if not UUID.fullmatch(args.transaction_id): fail("argument_invalid")
+    installer_bytes=Path(__file__).read_bytes()
+    if not isinstance(args.expected_installer_sha256,str) or not SHA.fullmatch(args.expected_installer_sha256) or digest(installer_bytes)!=args.expected_installer_sha256: fail("installer_hash_mismatch")
+    stage=ROOT/f"{STAGE_PREFIX}{args.transaction_id}"; tx=ROOT/f"{TX_PREFIX}{args.transaction_id}"
+    if args.mode=="recover-lock": result=recover(args.transaction_id,tx,args)
+    else:
+        probe_nonce=acquire(args.transaction_id,args.expected_installer_sha256)
+        release_required=True
+        try:
+            if args.mode!="abort-stage": require_runtime_primitives(args.transaction_id,probe_nonce)
+            try:
+                if args.mode=="install":
+                    for value in (args.expected_configuration_sha256,args.expected_component_tree_sha256,args.payload_manifest_sha256,args.expected_installer_sha256):
+                        if not isinstance(value,str) or not SHA.fullmatch(value): fail("argument_invalid")
+                    if args.expected_trust_sha256!="absent" and (not isinstance(args.expected_trust_sha256,str) or not SHA.fullmatch(args.expected_trust_sha256)): fail("argument_invalid")
+                    journal=install(args,stage,tx,installer_bytes); result=receipt("installed",args.transaction_id,journal)
+                elif args.mode=="abort-stage":
+                    if lexists(tx): fail("stage_abort_transaction_exists")
+                    cleanup_initialization(args.transaction_id); kind(stage,"dir","stage_missing"); shutil.rmtree(stage); fsync_dir(ROOT); result={"status":"stage_aborted","transactionId":args.transaction_id}
+                else:
+                    kind(tx,"dir","transaction_missing"); journal=load(tx/"transaction.json","transaction_invalid")
+                    if journal.get("transactionId")!=args.transaction_id: fail("transaction_invalid")
+                    if journal.get("installerSha256")!=args.expected_installer_sha256: fail("installer_hash_mismatch")
+                    validate_recovery_pins(journal,args)
+                    if args.mode=="rollback":
+                        if journal.get("status") not in {"installed","prepared","rolled_back_after_failure","rolled_back_after_recovery"}: fail("rollback_state_invalid")
+                        verify_prestate_artifacts(tx,journal,states()); journal["status"]="rollback_prepared"; journal["configurationSha256"]=journal["installed"]["configuration"]["sha256"]; journal["componentTreeSha256"]=content_tree(journal["installed"]["component"]); journal["trustSha256"]=journal["installed"]["trust"]["sha256"]; write_journal(tx,journal)
+                        try: restore(tx,journal)
+                        except Exception: fail("partial_failure_rollback_failed")
+                        journal["status"]="rolled_back"; journal["configurationSha256"]=journal["prestate"]["configuration"]["sha256"]; journal["componentTreeSha256"]=content_tree(journal["prestate"]["component"]); journal["trustSha256"]=journal["prestate"]["trust"].get("sha256","absent"); write_journal(tx,journal); result=receipt("rolled_back",args.transaction_id,journal)
+                    elif args.mode=="mark-verified":
+                        if journal.get("status") not in {"installed","restart_verified"} or not states_equal(states(),journal["installed"]): fail("restart_readback_mismatch")
+                        journal["status"]="restart_verified"; write_journal(tx,journal); result=receipt("restart_verified",args.transaction_id,journal)
+                    else:
+                        rollback_cleanup=journal.get("status") in {"rolled_back","rolled_back_after_failure","rolled_back_after_recovery","rollback_finalize_prepared"}
+                        if rollback_cleanup:
+                            if not states_equal(states(),journal["prestate"]): fail("finalize_not_allowed")
+                            if journal.get("status")!="rollback_finalize_prepared": journal["status"]="rollback_finalize_prepared"; write_journal(tx,journal)
+                        else:
+                            if journal.get("status") not in {"restart_verified","finalize_prepared"} or time.time()<journal["rollbackDeadline"] or not states_equal(states(),journal["installed"]): fail("finalize_not_allowed")
+                            if journal.get("status")!="finalize_prepared": journal["status"]="finalize_prepared"; write_journal(tx,journal)
+                        result={"status":"finalized","transactionId":args.transaction_id,"payloadManifestSha256":journal["payloadManifestSha256"]}
+                        if lexists(stage): kind(stage,"dir","stage_invalid"); shutil.rmtree(stage); fsync_dir(ROOT)
+                        release(args.transaction_id); release_required=False
+                        shutil.rmtree(tx); fsync_dir(ROOT)
+            except Exception as error:
+                if str(error)=="partial_failure_rollback_failed": release_required=False
+                raise
+        finally:
+            if release_required: release(args.transaction_id)
+    print(json.dumps(result,sort_keys=True,separators=(",",":"))); return 0
+if __name__=="__main__":
+    try: raise SystemExit(main())
+    except Exception as error:
+        code=str(error) if isinstance(error,RuntimeError) and re.fullmatch(r"[a-z0-9_]{1,96}",str(error)) else "operation_failed"
+        print(json.dumps({"status":"failed","error":code},sort_keys=True,separators=(",",":")),file=sys.stderr); raise SystemExit(1)
+"""
+INSTALLER_SHA256 = _digest(INSTALLER_SOURCE)
+
+
+async def _supervisor_snapshot(
+    url: str, token: str, socket_factory: Any
+) -> dict[str, Any]:
+    async with socket_factory(url, token) as socket:
+        calls = {
+            "user": await socket.call("auth/current_user"),
+            "supervisor": await socket.call(
+                "supervisor/api", endpoint="/supervisor/info", method="get"
+            ),
+            "host": await socket.call(
+                "supervisor/api", endpoint="/host/info", method="get"
+            ),
+            "backup": await socket.call("backup/info"),
+            "addon": await socket.call(
+                "supervisor/api",
+                endpoint=f"/addons/{FILE_EDITOR_SLUG}/info",
+                method="get",
+            ),
+            "store": await socket.call(
+                "supervisor/api",
+                endpoint=f"/store/addons/{FILE_EDITOR_SLUG}",
+                method="get",
+            ),
+        }
+    return {key: _supervisor_data(value) for key, value in calls.items()}
+
+
+async def _addon_action(url: str, token: str, action: str, socket_factory: Any) -> None:
+    async with socket_factory(url, token) as socket:
+        await socket.call(
+            "supervisor/api",
+            endpoint=f"/addons/{FILE_EDITOR_SLUG}/{action}",
+            method="post",
+        )
+        expected = "started" if action == "start" else "stopped"
+        for _ in range(120):
+            value = _supervisor_data(
+                await socket.call(
+                    "supervisor/api",
+                    endpoint=f"/addons/{FILE_EDITOR_SLUG}/info",
+                    method="get",
+                )
+            )
+            if value.get("state") == expected:
+                return
+            await asyncio.sleep(0.25)
+    raise BootstrapError("file_editor_lifecycle_unverified")
+
+
+async def _open_editor(  # noqa: C901
+    url: str,
+    token: str,
+    backup_id: str | None,
+    expected_backup_agent_id: str | None,
+    require_backup: bool,
+    operation_mode: str,
+    transaction_id: str | None,
+    socket_factory: Any,
+) -> tuple[str, str, str]:
+    snapshot = await _supervisor_snapshot(url, token, socket_factory)
+    observed_initial = snapshot["addon"].get("state")
+    initial = observed_initial
+    ingress = validate_supervisor_preflight(
+        **snapshot,
+        backup_id=backup_id,
+        expected_backup_agent_id=expected_backup_agent_id,
+        require_backup=require_backup,
+    )
+    lease = _read_lifecycle_lease()
+    adopted = False
+    if lease is not None:
+        if _lifecycle_process_alive(lease["processId"]):
+            raise BootstrapError("file_editor_lifecycle_lease_active")
+        if lease["initialState"] == "started":
+            if observed_initial == "stopped":
+                await _addon_action(url, token, "start", socket_factory)
+            _clear_lifecycle_lease()
+            snapshot = await _supervisor_snapshot(url, token, socket_factory)
+            observed_initial = snapshot["addon"].get("state")
+            initial = observed_initial
+            ingress = validate_supervisor_preflight(
+                **snapshot,
+                backup_id=backup_id,
+                expected_backup_agent_id=expected_backup_agent_id,
+                require_backup=require_backup,
+            )
+        elif observed_initial == "started":
+            _write_lifecycle_lease(operation_mode, transaction_id, create=False)
+            initial = "stopped"
+            adopted = True
+        else:
+            _clear_lifecycle_lease()
+    started_by_us = initial == "stopped"
+    restore_started_on_failure = False
+    try:
+        recovery_cycled = False
+        if operation_mode == "recover-lock" and observed_initial == "started":
+            if not adopted:
+                _write_lifecycle_lease(
+                    operation_mode,
+                    transaction_id,
+                    create=True,
+                    initial_state="started",
+                )
+                restore_started_on_failure = True
+            await _addon_action(url, token, "stop", socket_factory)
+            await _addon_action(url, token, "start", socket_factory)
+            recovery_cycled = True
+            if restore_started_on_failure:
+                _clear_lifecycle_lease()
+                restore_started_on_failure = False
+        if started_by_us:
+            if not adopted and not recovery_cycled:
+                _write_lifecycle_lease(operation_mode, transaction_id, create=True)
+                await _addon_action(url, token, "start", socket_factory)
+        if started_by_us or recovery_cycled:
+            snapshot = await _supervisor_snapshot(url, token, socket_factory)
+            ingress = validate_supervisor_preflight(
+                **snapshot,
+                backup_id=backup_id,
+                expected_backup_agent_id=expected_backup_agent_id,
+                require_backup=require_backup,
+            )
+            if snapshot["addon"].get("state") != "started":
+                raise BootstrapError("file_editor_start_unverified")
+        async with socket_factory(url, token) as socket:
+            session = _supervisor_data(
+                await socket.call(
+                    "supervisor/api",
+                    endpoint="/ingress/session",
+                    method="post",
+                    data={},
+                )
+            ).get("session")
+        if not isinstance(session, str) or SAFE_SESSION.fullmatch(session) is None:
+            raise BootstrapError("ingress_session_invalid")
+        return initial, ingress, session
+    except BaseException as primary:
+        if restore_started_on_failure:
+            try:
+                await _addon_action(url, token, "start", socket_factory)
+                _clear_lifecycle_lease()
+            except BaseException:
+                raise BootstrapError(
+                    "operation_failed_and_file_editor_restore_failed"
+                ) from None
+        elif started_by_us:
+            try:
+                await _addon_action(url, token, "stop", socket_factory)
+                _clear_lifecycle_lease()
+            except BaseException:
+                raise BootstrapError(
+                    "operation_failed_and_file_editor_restore_failed"
+                ) from None
+        raise primary
+
+
+def _stage_payload(
+    client: FileEditorIngressClient, txid: str, payload: Payload
+) -> None:
+    client.create_stage(txid)
+    # The trusted installer is first so every later partial upload can be
+    # resumed or explicitly removed. Existing bytes must match; source drift
+    # never silently overwrites a partially staged transaction.
+    staged = (
+        (INSTALLER_NAME, INSTALLER_SOURCE, INSTALLER_SHA256),
+        *((item.relative_path, item.content, item.sha256) for item in payload.files),
+        (PAYLOAD_MANIFEST_NAME, payload.manifest, payload.manifest_sha256),
+    )
+    for relative, content, expected in staged:
+        if client.stage_file_exists(txid, relative):
+            if _digest(client.download_stage(txid, relative)) != expected:
+                raise BootstrapError("remote_stage_conflict")
+        else:
+            client.upload(txid, relative, content)
+        if _digest(client.download_stage(txid, relative)) != expected:
+            raise BootstrapError("remote_stage_readback_mismatch")
+
+
+def _ensure_stage_abort_installer(
+    client: FileEditorIngressClient,
+    txid: str,
+    expected_installer_sha256: str,
+    installer_bytes: bytes,
+) -> None:
+    client.create_stage(txid)
+    if _digest(installer_bytes) != expected_installer_sha256:
+        raise BootstrapError("local_installer_pin_mismatch")
+    if (
+        not client.stage_file_exists(txid, INSTALLER_NAME)
+        or _digest(client.download_stage(txid, INSTALLER_NAME))
+        != expected_installer_sha256
+    ):
+        client.upload(txid, INSTALLER_NAME, installer_bytes)
+    if (
+        _digest(client.download_stage(txid, INSTALLER_NAME))
+        != expected_installer_sha256
+    ):
+        raise BootstrapError("remote_installer_hash_mismatch")
+
+
+def _write_local_record(  # noqa: C901
+    txid: str, value: dict[str, Any], *, create: bool
+) -> None:
+    directory = APPROVED_STATE_DIRECTORY
+    local_root = directory.parent
+    if local_root.exists() and local_root.is_symlink():
+        raise BootstrapError("local_state_invalid")
+    directory.mkdir(mode=0o700, parents=True, exist_ok=True)
+    directory_info = directory.lstat()
+    if (
+        stat.S_ISLNK(directory_info.st_mode)
+        or not stat.S_ISDIR(directory_info.st_mode)
+        or stat.S_IMODE(directory_info.st_mode) != 0o700
+    ):
+        raise BootstrapError("local_state_invalid")
+    path = directory / f"{txid}.json"
+    if os.path.lexists(path):
+        path_info = path.lstat()
+        if (
+            stat.S_ISLNK(path_info.st_mode)
+            or not stat.S_ISREG(path_info.st_mode)
+            or stat.S_IMODE(path_info.st_mode) != 0o600
+        ):
+            raise BootstrapError("local_state_invalid")
+        if create:
+            raise BootstrapError("local_transaction_exists")
+    elif not create:
+        raise BootstrapError("local_transaction_missing")
+    prefix = f".{txid}.new-"
+    residue = [item for item in directory.iterdir() if item.name.startswith(prefix)]
+    if len(residue) > 128:
+        raise BootstrapError("local_state_invalid")
+    residue_pattern = re.compile(rf"^{re.escape(prefix)}([1-9][0-9]*)-[0-9a-f]{{16}}$")
+    for item in residue:
+        info = item.lstat()
+        match = residue_pattern.fullmatch(item.name)
+        if (
+            match is None
+            or stat.S_ISLNK(info.st_mode)
+            or not stat.S_ISREG(info.st_mode)
+            or stat.S_IMODE(info.st_mode) != 0o600
+        ):
+            raise BootstrapError("local_state_invalid")
+        process_id = int(match.group(1))
+        try:
+            os.kill(process_id, 0)
+        except ProcessLookupError:
+            item.unlink()
+        except PermissionError:
+            pass
+    temp = directory / f"{prefix}{os.getpid()}-{secrets.token_hex(8)}"
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0)
+    fd = os.open(temp, flags, 0o600)
+    temp_info = os.fstat(fd)
+    try:
+        try:
+            remaining = memoryview(_canonical(value))
+            while remaining:
+                written = os.write(fd, remaining)
+                if written <= 0:
+                    raise BootstrapError("local_state_write_failed")
+                remaining = remaining[written:]
+            os.fsync(fd)
+        finally:
+            os.close(fd)
+        if create:
+            try:
+                os.link(temp, path, follow_symlinks=False)
+            except FileExistsError:
+                raise BootstrapError("local_transaction_exists") from None
+        else:
+            os.replace(temp, path)
+        _fsync_local_directory(directory)
+    finally:
+        if os.path.lexists(temp):
+            current = temp.lstat()
+            if (
+                stat.S_ISLNK(current.st_mode)
+                or not stat.S_ISREG(current.st_mode)
+                or current.st_dev != temp_info.st_dev
+                or current.st_ino != temp_info.st_ino
+            ):
+                raise BootstrapError("local_state_invalid") from None
+            temp.unlink()
+            _fsync_local_directory(directory)
+
+
+def _fsync_local_directory(directory: Path) -> None:
+    directory_fd = os.open(directory, os.O_RDONLY)
+    try:
+        os.fsync(directory_fd)
+    finally:
+        os.close(directory_fd)
+
+
+def _read_local_record(txid: str) -> dict[str, Any]:
+    path = APPROVED_STATE_DIRECTORY / f"{txid}.json"
+    try:
+        info = path.lstat()
+    except OSError:
+        raise BootstrapError("local_transaction_missing") from None
+    if (
+        stat.S_ISLNK(info.st_mode)
+        or not stat.S_ISREG(info.st_mode)
+        or stat.S_IMODE(info.st_mode) != 0o600
+    ):
+        raise BootstrapError("local_state_invalid")
+    return _json_object(path.read_bytes(), "local_state_invalid")
+
+
+def _prepare_install_record(txid: str, value: dict[str, Any]) -> None:
+    """Atomically create, or safely resume, one identically pinned install."""
+    try:
+        _write_local_record(txid, value, create=True)
+        return
+    except BootstrapError as error:
+        if str(error) != "local_transaction_exists":
+            raise
+    existing = _read_local_record(txid)
+    immutable = {
+        "schemaVersion",
+        "transactionId",
+        "payloadManifestSha256",
+        "sourceRevision",
+        "sourceRoot",
+        "installerSha256",
+        "installerSourceBase64",
+        "replaceExact",
+        "expectedConfigurationSha256",
+        "expectedComponentTreeSha256",
+        "expectedTrustSha256",
+    }
+    if existing.get("status") not in {"prepared", "installed"} or {
+        key: existing.get(key) for key in immutable
+    } != {key: value.get(key) for key in immutable}:
+        raise BootstrapError("local_transaction_collision") from None
+
+
+def _persist_local_request(txid: str, mode: str) -> dict[str, str | bool]:
+    local = _read_local_record(txid)
+    if (
+        local.get("schemaVersion") != "aurora-deploy-bootstrap-local-v1"
+        or local.get("transactionId") != txid
+    ):
+        raise BootstrapError("local_state_invalid")
+    installer_sha256 = _validate_hash(
+        local.get("installerSha256"), "local_installer_pin_required"
+    )
+    _local_installer_bytes(local)
+    payload_manifest_sha256 = _validate_hash(
+        local.get("payloadManifestSha256"), "local_payload_pin_required"
+    )
+    configuration_sha256 = _validate_hash(
+        local.get("expectedConfigurationSha256"), "local_prestate_pin_required"
+    )
+    component_tree_sha256 = _validate_hash(
+        local.get("expectedComponentTreeSha256"), "local_prestate_pin_required"
+    )
+    trust_sha256 = _validate_hash(
+        local.get("expectedTrustSha256"),
+        "local_prestate_pin_required",
+        absent=True,
+    )
+    replace_exact = local.get("replaceExact")
+    if not isinstance(replace_exact, bool):
+        raise BootstrapError("local_replace_exact_pin_required")
+    if not (
+        mode == "finalize"
+        and local.get("status") in {"finalize_authorized", "finalized"}
+    ):
+        local["status"] = f"{mode}_requested"
+        _write_local_record(txid, local, create=False)
+    result: dict[str, str | bool] = {
+        "expected-installer-sha256": installer_sha256,
+        "payload-manifest-sha256": payload_manifest_sha256,
+        "expected-configuration-sha256": configuration_sha256,
+        "expected-component-tree-sha256": component_tree_sha256,
+        "expected-trust-sha256": trust_sha256,
+    }
+    if replace_exact:
+        result["replace-exact"] = True
+    return result
+
+
+def _local_installer_bytes(local: dict[str, Any]) -> bytes:
+    encoded = local.get("installerSourceBase64")
+    if not isinstance(encoded, str) or len(encoded) > 256 * 1024:
+        raise BootstrapError("local_installer_bytes_invalid")
+    try:
+        content = base64.b64decode(encoded, validate=True)
+    except (ValueError, TypeError):
+        raise BootstrapError("local_installer_bytes_invalid") from None
+    if base64.b64encode(content).decode() != encoded or _digest(
+        content
+    ) != _validate_hash(local.get("installerSha256"), "local_installer_pin_required"):
+        raise BootstrapError("local_installer_pin_mismatch")
+    return content
+
+
+def _bind_status_to_local(
+    status: dict[str, Any], txid: str, *, required: bool
+) -> dict[str, Any]:
+    path = APPROVED_STATE_DIRECTORY / f"{txid}.json"
+    if not path.exists() and not path.is_symlink():
+        if required:
+            raise BootstrapError("local_transaction_missing")
+        return status
+    local = _read_local_record(txid)
+    if (
+        local.get("schemaVersion") != "aurora-deploy-bootstrap-local-v1"
+        or local.get("transactionId") != txid
+        or status.get("transactionId") != txid
+    ):
+        raise BootstrapError("local_state_invalid")
+    transaction_present = status.get("transactionPresent") is True
+    artifact_only = {
+        "not_found": (False, False, False),
+        "staged_partial": (True, False, False),
+        "lock_candidate": (False, True, False),
+        "initializing": (False, False, True),
+    }
+    if transaction_present and (
+        status.get("installerSha256")
+        != _validate_hash(local.get("installerSha256"), "local_installer_pin_required")
+        or status.get("payloadManifestSha256")
+        != _validate_hash(
+            local.get("payloadManifestSha256"), "local_payload_pin_required"
+        )
+        or status.get("prestateConfigurationSha256")
+        != _validate_hash(
+            local.get("expectedConfigurationSha256"),
+            "local_prestate_pin_required",
+        )
+        or status.get("prestateComponentTreeSha256")
+        != _validate_hash(
+            local.get("expectedComponentTreeSha256"),
+            "local_prestate_pin_required",
+        )
+        or status.get("prestateTrustSha256")
+        != _validate_hash(
+            local.get("expectedTrustSha256"),
+            "local_prestate_pin_required",
+            absent=True,
+        )
+        or status.get("replaceExact") is not local.get("replaceExact")
+    ):
+        raise BootstrapError("remote_local_pin_mismatch")
+    if not transaction_present:
+        expected_topology = artifact_only.get(status.get("status"))
+        if (
+            expected_topology is None
+            or status.get("transactionPresent") is not False
+            or (
+                status.get("stagePresent"),
+                status.get("lockCandidatePresent"),
+                status.get("initializationPresent"),
+            )
+            != expected_topology
+            or any(
+                key in status
+                for key in {
+                    "installerSha256",
+                    "payloadManifestSha256",
+                    "prestateConfigurationSha256",
+                    "prestateComponentTreeSha256",
+                    "prestateTrustSha256",
+                    "replaceExact",
+                }
+            )
+        ):
+            raise BootstrapError("remote_local_pin_mismatch")
+    return status
+
+
+LIFECYCLE_RECORD_ID = "file-editor-lifecycle"
+
+
+def _read_lifecycle_lease() -> dict[str, Any] | None:
+    path = APPROVED_STATE_DIRECTORY / f"{LIFECYCLE_RECORD_ID}.json"
+    if not path.exists() and not path.is_symlink():
+        return None
+    lease = _read_local_record(LIFECYCLE_RECORD_ID)
+    if (
+        lease.get("schemaVersion") != "aurora-deploy-file-editor-lease-v1"
+        or lease.get("initialState") not in {"started", "stopped"}
+        or not isinstance(lease.get("processId"), int)
+        or isinstance(lease.get("processId"), bool)
+        or lease["processId"] <= 0
+        or not isinstance(lease.get("createdAt"), int)
+        or lease.get("operationMode")
+        not in {
+            "preflight",
+            "install",
+            "status",
+            "readback",
+            "rollback",
+            "recover-lock",
+            "abort-stage",
+            "finalize",
+        }
+        or (
+            lease.get("transactionId") is not None
+            and _validate_uuid(lease.get("transactionId")) != lease.get("transactionId")
+        )
+    ):
+        raise BootstrapError("file_editor_lifecycle_lease_invalid")
+    return lease
+
+
+def _lifecycle_process_alive(process_id: int) -> bool:
+    if process_id == os.getpid():
+        return False
+    try:
+        os.kill(process_id, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
+def _write_lifecycle_lease(
+    operation_mode: str,
+    transaction_id: str | None,
+    *,
+    create: bool,
+    initial_state: str = "stopped",
+) -> None:
+    _write_local_record(
+        LIFECYCLE_RECORD_ID,
+        {
+            "schemaVersion": "aurora-deploy-file-editor-lease-v1",
+            "initialState": initial_state,
+            "processId": os.getpid(),
+            "createdAt": int(time.time()),
+            "operationMode": operation_mode,
+            "transactionId": transaction_id,
+        },
+        create=create,
+    )
+
+
+def _clear_lifecycle_lease() -> None:
+    lease = _read_lifecycle_lease()
+    if lease is None:
+        return
+    path = APPROVED_STATE_DIRECTORY / f"{LIFECYCLE_RECORD_ID}.json"
+    path.unlink()
+    directory_fd = os.open(APPROVED_STATE_DIRECTORY, os.O_RDONLY)
+    try:
+        os.fsync(directory_fd)
+    finally:
+        os.close(directory_fd)
+
+
+def home_assistant_config_check(url: str, token: str) -> None:
+    request = urllib.request.Request(
+        f"{url}/api/config/core/check_config",
+        data=b"{}",
+        method="POST",
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+        },
+    )
+    opener = urllib.request.build_opener(urllib.request.ProxyHandler({}), _NoRedirect())
+    try:
+        with opener.open(request, timeout=90) as response:
+            content = response.read(MAX_RESPONSE_BYTES + 1)
+    except Exception:
+        raise BootstrapError("configuration_check_failed") from None
+    result = _json_object(content, "configuration_check_failed")
+    if result.get("result") != "valid" or result.get("errors") not in {None, ""}:
+        raise BootstrapError("configuration_check_failed")
+
+
+def verify_component_route(url: str, token: str, txid: str) -> None:
+    request = urllib.request.Request(
+        f"{url}/api/aurora/deploy-preview/v1/{txid}/readback",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    opener = urllib.request.build_opener(urllib.request.ProxyHandler({}), _NoRedirect())
+    try:
+        opener.open(request, timeout=30)
+    except urllib.error.HTTPError as error:
+        content = error.read(MAX_RESPONSE_BYTES + 1)
+        if (
+            error.code == 404
+            and _json_object(content, "component_route_unverified").get("error_code")
+            == "transaction_not_found"
+        ):
+            return
+    except Exception:
+        pass
+    raise BootstrapError("component_route_unverified")
+
+
+def _redacted_status(
+    client: FileEditorIngressClient, txid: str, *, readback: bool = False
+) -> dict[str, Any]:
+    result = client.readback(txid) if readback else client.status(txid)
+    allowed = {
+        "status",
+        "transactionId",
+        "payloadManifestSha256",
+        "configurationSha256",
+        "componentTreeSha256",
+        "trustSha256",
+        "rollbackDeadline",
+        "installerSha256",
+        "replaceExact",
+        "prestateConfigurationSha256",
+        "prestateComponentTreeSha256",
+        "prestateTrustSha256",
+        "lockHeld",
+        "lockOwnerMatches",
+        "verified",
+        "stagePresent",
+        "lockCandidatePresent",
+        "transactionPresent",
+        "initializationPresent",
+    }
+    return {key: value for key, value in result.items() if key in allowed}
+
+
+def _credential_transport_receipt(url: str) -> dict[str, str]:
+    validated = _validate_url(url)
+    return {
+        "status": "credential_transport_ready",
+        "credentialSource": "approved_root_env",
+        "transport": "https"
+        if urlparse(validated).scheme == "https"
+        else "loopback_http",
+    }
+
+
+async def bootstrap(  # noqa: C901
+    *,
+    mode: str,
+    source_root: Path,
+    backup_id: str | None = None,
+    expected_backup_agent_id: str | None = None,
+    transaction_id: str | None = None,
+    expected_configuration_sha256: str | None = None,
+    expected_component_tree_sha256: str | None = None,
+    expected_trust_sha256: str | None = None,
+    expected_payload_manifest_sha256: str | None = None,
+    expected_release_key_sha256: str | None = None,
+    expected_validation_key_sha256: str | None = None,
+    expected_source_revision: str | None = None,
+    replace_exact: bool = False,
+    socket_factory: Any = HomeAssistantSocket,
+    ingress_client_factory: Any = FileEditorIngressClient,
+    config_check: Any = home_assistant_config_check,
+    component_route_check: Any = verify_component_route,
+    credential_loader: Any = _load_credentials,
+) -> dict[str, Any]:
+    if mode not in {
+        "credential-check",
+        "preflight",
+        "install",
+        "status",
+        "readback",
+        "rollback",
+        "recover-lock",
+        "abort-stage",
+        "finalize",
+    }:
+        raise BootstrapError("mode_invalid")
+    url, token = credential_loader()
+    if mode == "credential-check":
+        return _credential_transport_receipt(url)
+    txid = (
+        None
+        if mode == "preflight" and transaction_id is None
+        else _validate_uuid(transaction_id)
+    )
+    payload = None
+    if mode in {"preflight", "install"}:
+        payload = validate_local_payload(
+            source_root,
+            expected_manifest_sha256=_validate_hash(
+                expected_payload_manifest_sha256,
+                "expected_payload_manifest_hash_required",
+            ),
+            expected_release_key_sha256=_validate_hash(
+                expected_release_key_sha256, "expected_release_key_fingerprint_required"
+            ),
+            expected_validation_key_sha256=_validate_hash(
+                expected_validation_key_sha256,
+                "expected_validation_key_fingerprint_required",
+            ),
+            expected_source_revision=expected_source_revision or "",
+        )
+        config_check(url, token)
+    recovery_arguments: dict[str, str | bool] = {}
+    if mode == "install":
+        expected_configuration_sha256 = _validate_hash(
+            expected_configuration_sha256, "expected_configuration_hash_required"
+        )
+        expected_component_tree_sha256 = _validate_hash(
+            expected_component_tree_sha256, "expected_component_tree_hash_required"
+        )
+        expected_trust_sha256 = _validate_hash(
+            expected_trust_sha256, "expected_trust_hash_required", absent=True
+        )
+        _prepare_install_record(
+            txid,
+            {
+                "schemaVersion": "aurora-deploy-bootstrap-local-v1",
+                "status": "prepared",
+                "transactionId": txid,
+                "payloadManifestSha256": payload.manifest_sha256,
+                "sourceRevision": payload.source_revision,
+                "sourceRoot": str(source_root.resolve(strict=True)),  # noqa: ASYNC240
+                "installerSha256": INSTALLER_SHA256,
+                "installerSourceBase64": base64.b64encode(INSTALLER_SOURCE).decode(),
+                "replaceExact": replace_exact,
+                "expectedConfigurationSha256": expected_configuration_sha256,
+                "expectedComponentTreeSha256": expected_component_tree_sha256,
+                "expectedTrustSha256": expected_trust_sha256,
+            },
+        )
+        recovery_arguments = {
+            "expected-installer-sha256": INSTALLER_SHA256,
+            "payload-manifest-sha256": payload.manifest_sha256,
+            "expected-configuration-sha256": expected_configuration_sha256,
+            "expected-component-tree-sha256": expected_component_tree_sha256,
+            "expected-trust-sha256": expected_trust_sha256,
+        }
+    elif mode in {"rollback", "recover-lock", "abort-stage", "finalize"}:
+        recovery_arguments = _persist_local_request(txid, mode)
+    initial = None
+    primary: BaseException | None = None
+    result: dict[str, Any] | None = None
+    try:
+        initial, ingress, session = await _open_editor(
+            url,
+            token,
+            backup_id,
+            expected_backup_agent_id,
+            mode in {"preflight", "install"},
+            mode,
+            txid,
+            socket_factory,
+        )
+        client = ingress_client_factory(url, ingress, session)
+        if mode in {"status", "readback"}:
+            result = _bind_status_to_local(
+                _redacted_status(client, txid, readback=mode == "readback"),
+                txid,
+                required=False,
+            )
+        elif mode == "preflight":
+            result = {
+                "status": "preflight_ready",
+                "configurationSha256": _digest(client.configuration_bytes()),
+                "componentTreeSha256": client.component_tree_sha256(),
+                "trustSha256": client.trust_sha256(),
+                "payloadManifestSha256": payload.manifest_sha256,
+                "releaseKeySha256": payload.release_key_sha256,
+                "validationKeySha256": payload.validation_key_sha256,
+                "sourceRevision": payload.source_revision,
+                "installerSha256": INSTALLER_SHA256,
+            }
+        elif mode == "install":
+            config_check(url, token)
+            if (
+                _digest(client.configuration_bytes()) != expected_configuration_sha256
+                or client.component_tree_sha256() != expected_component_tree_sha256
+                or client.trust_sha256() != expected_trust_sha256
+            ):
+                raise BootstrapError("prestage_cas_mismatch")
+            _stage_payload(client, txid, payload)
+            result = client.execute(
+                mode="install",
+                transaction_id=txid,
+                arguments={
+                    "expected-configuration-sha256": expected_configuration_sha256,
+                    "expected-component-tree-sha256": expected_component_tree_sha256,
+                    "expected-trust-sha256": expected_trust_sha256,
+                    "payload-manifest-sha256": payload.manifest_sha256,
+                    "expected-installer-sha256": INSTALLER_SHA256,
+                    **({"replace-exact": True} if replace_exact else {}),
+                },
+            )
+            try:
+                config_check(url, token)
+                if (
+                    _digest(client.configuration_bytes())
+                    != result.get("configurationSha256")
+                    or client.component_tree_sha256()
+                    != result.get("componentTreeSha256")
+                    or client.trust_sha256() != result.get("trustSha256")
+                ):
+                    raise BootstrapError("post_install_readback_mismatch")
+            except BaseException:
+                try:
+                    rollback = client.execute(
+                        mode="rollback",
+                        transaction_id=txid,
+                        arguments=recovery_arguments,
+                    )
+                    config_check(url, token)
+                    if (
+                        _digest(client.configuration_bytes())
+                        != rollback.get("configurationSha256")
+                        or client.component_tree_sha256()
+                        != rollback.get("componentTreeSha256")
+                        or client.trust_sha256() != rollback.get("trustSha256")
+                    ):
+                        raise BootstrapError("rollback_readback_mismatch")
+                except BaseException:
+                    raise BootstrapError(
+                        "post_install_validation_failed_rollback_unverified"
+                    ) from None
+                raise BootstrapError(
+                    "post_install_validation_failed_rolled_back"
+                ) from None
+            result["restartRequired"] = True
+        elif mode == "rollback":
+            result = client.execute(
+                mode="rollback",
+                transaction_id=txid,
+                arguments=recovery_arguments,
+            )
+            config_check(url, token)
+            if (
+                _digest(client.configuration_bytes())
+                != result.get("configurationSha256")
+                or client.component_tree_sha256() != result.get("componentTreeSha256")
+                or client.trust_sha256() != result.get("trustSha256")
+            ):
+                raise BootstrapError("rollback_readback_mismatch")
+            result["restartRequired"] = True
+        elif mode == "recover-lock":
+            result = client.execute(
+                mode="recover-lock",
+                transaction_id=txid,
+                arguments=recovery_arguments,
+            )
+        elif mode == "abort-stage":
+            if client.transaction_exists(txid):
+                raise BootstrapError("stage_abort_transaction_exists")
+            _ensure_stage_abort_installer(
+                client,
+                txid,
+                recovery_arguments["expected-installer-sha256"],
+                _local_installer_bytes(_read_local_record(txid)),
+            )
+            result = client.execute(
+                mode="abort-stage",
+                transaction_id=txid,
+                arguments={
+                    "expected-installer-sha256": recovery_arguments[
+                        "expected-installer-sha256"
+                    ]
+                },
+            )
+        else:
+            status = _bind_status_to_local(
+                _redacted_status(client, txid, readback=True), txid, required=True
+            )
+            local = _read_local_record(txid)
+            if status.get("status") == "not_found":
+                if (
+                    local.get("status") not in {"finalize_authorized", "finalized"}
+                    or status.get("lockHeld") is not False
+                    or status.get("lockOwnerMatches") is not False
+                    or status.get("stagePresent") is not False
+                    or status.get("lockCandidatePresent") is not False
+                    or status.get("transactionPresent") is not False
+                    or status.get("initializationPresent") is not False
+                ):
+                    raise BootstrapError("finalize_not_allowed")
+                expected_configuration = _validate_hash(
+                    local.get("finalizeConfigurationSha256"),
+                    "finalize_authorization_invalid",
+                )
+                expected_component = _validate_hash(
+                    local.get("finalizeComponentTreeSha256"),
+                    "finalize_authorization_invalid",
+                )
+                expected_trust = _validate_hash(
+                    local.get("finalizeTrustSha256"),
+                    "finalize_authorization_invalid",
+                    absent=True,
+                )
+                config_check(url, token)
+                if (
+                    _digest(client.configuration_bytes()) != expected_configuration
+                    or client.component_tree_sha256() != expected_component
+                    or client.trust_sha256() != expected_trust
+                ):
+                    raise BootstrapError("finalize_readback_mismatch")
+                result = {
+                    "status": "finalized",
+                    "transactionId": txid,
+                    "payloadManifestSha256": _validate_hash(
+                        local.get("payloadManifestSha256"),
+                        "local_payload_pin_required",
+                    ),
+                    "reconciled": True,
+                }
+                status = None
+            if status is None:
+                pass
+            elif status.get("status") not in {
+                "installed",
+                "restart_verified",
+                "finalize_prepared",
+                "rolled_back",
+                "rolled_back_after_failure",
+                "rolled_back_after_recovery",
+                "rollback_finalize_prepared",
+            }:
+                raise BootstrapError("finalize_not_allowed")
+            elif status.get("verified") is not True:
+                raise BootstrapError("restart_readback_mismatch")
+            else:
+                config_check(url, token)
+                if (
+                    _digest(client.configuration_bytes())
+                    != status.get("configurationSha256")
+                    or client.component_tree_sha256()
+                    != status.get("componentTreeSha256")
+                    or client.trust_sha256() != status.get("trustSha256")
+                ):
+                    raise BootstrapError("restart_readback_mismatch")
+            if status is not None and status.get("status") not in {
+                "rolled_back",
+                "rolled_back_after_failure",
+                "rolled_back_after_recovery",
+                "rollback_finalize_prepared",
+            }:
+                component_route_check(url, token, txid)
+                if status.get("status") == "installed":
+                    client.execute(
+                        mode="mark-verified",
+                        transaction_id=txid,
+                        arguments=recovery_arguments,
+                    )
+            if status is not None:
+                local["status"] = "finalize_authorized"
+                local["finalizeConfigurationSha256"] = status["configurationSha256"]
+                local["finalizeComponentTreeSha256"] = status["componentTreeSha256"]
+                local["finalizeTrustSha256"] = status["trustSha256"]
+                local["finalizeRemoteStatus"] = status["status"]
+                _write_local_record(txid, local, create=False)
+                result = client.execute(
+                    mode="finalize",
+                    transaction_id=txid,
+                    arguments=recovery_arguments,
+                )
+    except BaseException as error:
+        primary = error
+    cleanup: BaseException | None = None
+    if initial == "stopped":
+        try:
+            await _addon_action(url, token, "stop", socket_factory)
+            _clear_lifecycle_lease()
+        except BaseException as error:
+            cleanup = error
+    if primary is not None and cleanup is not None:
+        raise BootstrapError(
+            "operation_failed_and_file_editor_restore_failed"
+        ) from None
+    if cleanup is not None:
+        raise BootstrapError("file_editor_restore_failed") from None
+    if primary is not None:
+        if isinstance(primary, (BootstrapError, asyncio.CancelledError)):
+            raise primary
+        raise BootstrapError("operation_failed") from None
+    if result is None:
+        raise BootstrapError("operation_failed")
+    if txid is not None and mode in {
+        "install",
+        "rollback",
+        "recover-lock",
+        "abort-stage",
+        "finalize",
+    }:
+        local = _read_local_record(txid)
+        local["status"] = str(result.get("status"))
+        local["receiptSha256"] = _digest(_canonical(result))
+        _write_local_record(txid, local, create=False)
+    return result
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    modes = parser.add_mutually_exclusive_group(required=True)
+    for name in (
+        "credential-check",
+        "preflight",
+        "install",
+        "status",
+        "readback",
+        "rollback",
+        "recover-lock",
+        "abort-stage",
+        "finalize",
+    ):
+        modes.add_argument(f"--{name}", action="store_true")
+    parser.add_argument(
+        "--source-root", type=Path, default=Path(__file__).resolve().parents[1]
+    )
+    parser.add_argument("--backup-id")
+    parser.add_argument("--expected-backup-agent-id")
+    parser.add_argument("--transaction-id")
+    parser.add_argument("--expected-configuration-sha256")
+    parser.add_argument("--expected-component-tree-sha256")
+    parser.add_argument("--expected-trust-sha256")
+    parser.add_argument("--expected-payload-manifest-sha256")
+    parser.add_argument("--expected-release-key-sha256")
+    parser.add_argument("--expected-validation-key-sha256")
+    parser.add_argument("--expected-source-revision")
+    parser.add_argument("--replace-exact", action="store_true")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    mode = next(
+        name
+        for name in (
+            "credential_check",
+            "preflight",
+            "install",
+            "status",
+            "readback",
+            "rollback",
+            "recover_lock",
+            "abort_stage",
+            "finalize",
+        )
+        if getattr(args, name)
+    )
+    mode = mode.replace("_", "-")
+    try:
+        result = asyncio.run(
+            bootstrap(
+                mode=mode,
+                source_root=args.source_root,
+                backup_id=args.backup_id,
+                expected_backup_agent_id=args.expected_backup_agent_id,
+                transaction_id=args.transaction_id,
+                expected_configuration_sha256=args.expected_configuration_sha256,
+                expected_component_tree_sha256=args.expected_component_tree_sha256,
+                expected_trust_sha256=args.expected_trust_sha256,
+                expected_payload_manifest_sha256=args.expected_payload_manifest_sha256,
+                expected_release_key_sha256=args.expected_release_key_sha256,
+                expected_validation_key_sha256=args.expected_validation_key_sha256,
+                expected_source_revision=args.expected_source_revision,
+                replace_exact=args.replace_exact,
+            )
+        )
+    except BootstrapError as error:
+        print(_canonical({"status": "failed", "error": str(error)}).decode())
+        return 1
+    except Exception:
+        print(_canonical({"status": "failed", "error": "operation_failed"}).decode())
+        return 1
+    print(_canonical(result).decode())
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/bootstrap_aurora_deploy_via_file_editor.py
+++ b/scripts/bootstrap_aurora_deploy_via_file_editor.py
@@ -45,6 +45,7 @@ TRANSACTION_PREFIX = ".aurora-deploy-bootstrap-transaction-"
 TRANSACTION_INIT_PREFIX = ".aurora-deploy-bootstrap-transaction-init-"
 INSTALLER_NAME = "install-aurora-deploy-bootstrap.py"
 PAYLOAD_MANIFEST_NAME = "payload-manifest.json"
+CAPABILITY_PROBE_NAME = "fixed-root-capability-probe.json"
 COMPONENT_FILES = ("__init__.py", "adapter.py", "manifest.json")
 SOURCE_PATHS = tuple(
     f"custom_components/aurora_deploy/{name}" for name in COMPONENT_FILES
@@ -66,9 +67,12 @@ SAFE_INGRESS_ENTRY = re.compile(r"^/api/hassio_ingress/[A-Za-z0-9_-]+$")
 SAFE_SESSION = re.compile(r"^[A-Za-z0-9._~+/=-]{16,1024}$")
 SAFE_BACKUP_ID = re.compile(r"^[A-Za-z0-9._-]{1,160}$")
 SAFE_KEY_ID = re.compile(r"^(?=.{8,64}$)(?:release|validation)-[A-Za-z0-9._-]+$")
+SAFE_HAOS_VERSION = re.compile(r"^[0-9][A-Za-z0-9._+-]{0,31}$")
+SAFE_OS_AGENT_VERSION = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._+-]{0,63}$")
 SAFE_PYCACHE = re.compile(
     r"^__pycache__/(?:__init__|adapter)\.cpython-\d{3}(?:\.opt-[12])?\.pyc$"
 )
+REQUIRED_HAOS_FEATURES = frozenset({"haos", "os_agent"})
 SHA256 = re.compile(r"^[0-9a-f]{64}$")
 REVISION = re.compile(r"^[0-9a-f]{40,64}$")
 
@@ -425,19 +429,6 @@ def _fresh_ha_recovery_backup(
     return item
 
 
-def _homeassistant_config_rw(value: Any) -> bool:
-    if not isinstance(value, list):
-        return False
-    for item in value:
-        if item == "homeassistant_config:rw":
-            return True
-        if isinstance(item, dict):
-            name = item.get("type", item.get("name"))
-            if name == "homeassistant_config" and item.get("read_only") is False:
-                return True
-    return False
-
-
 def validate_supervisor_preflight(  # noqa: C901
     *,
     user: dict[str, Any],
@@ -456,11 +447,38 @@ def validate_supervisor_preflight(  # noqa: C901
     if (
         supervisor.get("healthy") is not True
         or supervisor.get("supported") is not True
-        or supervisor.get("state") != "running"
+        or ("state" in supervisor and supervisor["state"] != "running")
     ):
         raise BootstrapError("supervisor_not_ready")
-    if supervisor.get("arch") != "amd64" or host.get("arch") != "amd64":
+    if supervisor.get("arch") != "amd64":
         raise BootstrapError("unsupported_architecture")
+    host_arch_fields = [key for key in ("arch", "architecture") if key in host]
+    if host_arch_fields:
+        if any(host[key] != "amd64" for key in host_arch_fields):
+            raise BootstrapError("unsupported_architecture")
+    else:
+        operating_system = host.get("operating_system")
+        agent_version = host.get("agent_version")
+        features = host.get("features")
+        if (
+            host.get("deployment") != "production"
+            or not isinstance(operating_system, str)
+            or not operating_system.startswith("Home Assistant OS ")
+            or SAFE_HAOS_VERSION.fullmatch(
+                operating_system.removeprefix("Home Assistant OS ")
+            )
+            is None
+            or not isinstance(agent_version, str)
+            or SAFE_OS_AGENT_VERSION.fullmatch(agent_version) is None
+            or not isinstance(features, list)
+            or len(features) > 64
+            or any(
+                not isinstance(feature, str) or not feature or len(feature) > 64
+                for feature in features
+            )
+            or not REQUIRED_HAOS_FEATURES.issubset(features)
+        ):
+            raise BootstrapError("host_metadata_invalid")
     if host.get("features") is not None and not isinstance(host["features"], list):
         raise BootstrapError("host_metadata_invalid")
     if require_backup:
@@ -492,7 +510,9 @@ def validate_supervisor_preflight(  # noqa: C901
     ingress = addon.get("ingress_entry")
     if not isinstance(ingress, str) or SAFE_INGRESS_ENTRY.fullmatch(ingress) is None:
         raise BootstrapError("ingress_entry_invalid")
-    if addon.get("host_network") is not False or addon.get("network") != {}:
+    if addon.get("host_network") is not False or (
+        "network" in addon and addon["network"] is not None
+    ):
         raise BootstrapError("file_editor_network_exposed")
     if addon.get("repository") != "core":
         raise BootstrapError("file_editor_not_official")
@@ -503,12 +523,13 @@ def validate_supervisor_preflight(  # noqa: C901
         or store_version != FILE_EDITOR_VERSION
         or store.get("repository") != "core"
         or store.get("ingress") is not True
-        or store.get("network") != {}
-        or "amd64" not in (store.get("arch") or [])
+        or not isinstance(store.get("arch"), list)
+        or "amd64" not in store["arch"]
         or store.get("available") is not True
-        or not _homeassistant_config_rw(store.get("map"))
     ):
         raise BootstrapError("file_editor_store_mismatch")
+    if "network" in store and store["network"] is not None:
+        raise BootstrapError("file_editor_network_exposed")
     return ingress
 
 
@@ -813,6 +834,7 @@ class FileEditorIngressClient:
             "/api/listdir",
             "/api/newfolder",
             "/api/upload",
+            "/api/delete",
             "/api/file",
             "/api/exec_command",
         }:
@@ -913,7 +935,12 @@ class FileEditorIngressClient:
         return self._exists(self._stage(transaction_id), expected_type="dir")
 
     def stage_file_exists(self, transaction_id: str, relative: str) -> bool:
-        if relative not in {*PAYLOAD_PATHS, PAYLOAD_MANIFEST_NAME, INSTALLER_NAME}:
+        if relative not in {
+            *PAYLOAD_PATHS,
+            PAYLOAD_MANIFEST_NAME,
+            INSTALLER_NAME,
+            CAPABILITY_PROBE_NAME,
+        }:
             raise BootstrapError("stage_target_invalid")
         return self._exists(self._stage(transaction_id, relative), expected_type="file")
 
@@ -934,7 +961,12 @@ class FileEditorIngressClient:
                 self._mkdir(directory)
 
     def upload(self, transaction_id: str, relative: str, content: bytes) -> None:
-        if relative not in {*PAYLOAD_PATHS, PAYLOAD_MANIFEST_NAME, INSTALLER_NAME}:
+        if relative not in {
+            *PAYLOAD_PATHS,
+            PAYLOAD_MANIFEST_NAME,
+            INSTALLER_NAME,
+            CAPABILITY_PROBE_NAME,
+        }:
             raise BootstrapError("upload_target_invalid")
         target = self._stage(transaction_id, relative)
         destination, filename = (
@@ -978,9 +1010,52 @@ class FileEditorIngressClient:
         )
 
     def download_stage(self, transaction_id: str, relative: str) -> bytes:
-        if relative not in {*PAYLOAD_PATHS, PAYLOAD_MANIFEST_NAME, INSTALLER_NAME}:
+        if relative not in {
+            *PAYLOAD_PATHS,
+            PAYLOAD_MANIFEST_NAME,
+            INSTALLER_NAME,
+            CAPABILITY_PROBE_NAME,
+        }:
             raise BootstrapError("download_target_invalid")
         return self._download_path(self._stage(transaction_id, relative))
+
+    def _delete_stage_capability_probe(self, transaction_id: str) -> None:
+        target = self._stage(transaction_id, CAPABILITY_PROBE_NAME)
+        result = self._request("/api/delete", form={"path": target})
+        if (
+            set(result) != {"error", "message", "path"}
+            or result["error"] is not False
+            or result["message"] != "Deletion successful"
+            or result["path"] != target
+        ):
+            raise BootstrapError("fixed_root_capability_cleanup_failed")
+        if self.stage_file_exists(transaction_id, CAPABILITY_PROBE_NAME):
+            raise BootstrapError("fixed_root_capability_cleanup_failed")
+
+    def verify_fixed_root_write_capability(self, transaction_id: str) -> None:
+        marker = _canonical(
+            {
+                "schemaVersion": "aurora-deploy-fixed-root-capability-v1",
+                "transactionId": _validate_uuid(transaction_id),
+                "installerSha256": INSTALLER_SHA256,
+            }
+        )
+        expected = _digest(marker)
+        if self.stage_file_exists(transaction_id, CAPABILITY_PROBE_NAME):
+            if (
+                _digest(self.download_stage(transaction_id, CAPABILITY_PROBE_NAME))
+                != expected
+            ):
+                raise BootstrapError("fixed_root_capability_conflict")
+            self._delete_stage_capability_probe(transaction_id)
+        self.upload(transaction_id, CAPABILITY_PROBE_NAME, marker)
+        if (
+            not self.stage_file_exists(transaction_id, CAPABILITY_PROBE_NAME)
+            or _digest(self.download_stage(transaction_id, CAPABILITY_PROBE_NAME))
+            != expected
+        ):
+            raise BootstrapError("fixed_root_write_capability_required")
+        self._delete_stage_capability_probe(transaction_id)
 
     def configuration_bytes(self) -> bytes:
         if not self._exists(REMOTE_CONFIGURATION, expected_type="file"):
@@ -2007,6 +2082,10 @@ def _stage_payload(
     client: FileEditorIngressClient, txid: str, payload: Payload
 ) -> None:
     client.create_stage(txid)
+    # Store metadata does not expose the add-on mount map on current HAOS.
+    # Prove the fixed root is writable using a transaction-owned marker, exact
+    # readback, and deletion before any installer execution.
+    client.verify_fixed_root_write_capability(txid)
     # The trusted installer is first so every later partial upload can be
     # resumed or explicitly removed. Existing bytes must match; source drift
     # never silently overwrites a partially staged transaction.

--- a/tests/src/unit/test_aurora_deploy_adapter.py
+++ b/tests/src/unit/test_aurora_deploy_adapter.py
@@ -192,8 +192,12 @@ def test_manifest_requires_explicit_preview_and_privacy_binding(tmp_path: Path) 
 
 
 def test_archive_rejects_traversal_links_nested_and_unapproved_members() -> None:
-    for name in ("../escape", "custom_components/other/file.py", "nested.tgz"):
-        with pytest.raises(ValueError):
+    for name, expected in (
+        ("../escape", "package_path"),
+        ("custom_components/other/file.py", "package_member"),
+        ("nested.tgz", "package_member"),
+    ):
+        with pytest.raises(ValueError, match=expected):
             _validate_package(_package(name=name))
 
     output = io.BytesIO()
@@ -246,7 +250,7 @@ def test_archive_requires_complete_reviewed_component_source() -> None:
 
 
 def test_privacy_functionality_is_rejected_before_staging() -> None:
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="privacy"):
         _validate_package(_package(content=b"biometric identity inference"))
 
 @pytest.mark.asyncio

--- a/tests/src/unit/test_aurora_deploy_adapter.py
+++ b/tests/src/unit/test_aurora_deploy_adapter.py
@@ -206,18 +206,41 @@ def test_archive_rejects_traversal_links_nested_and_unapproved_members() -> None
         _validate_package(output.getvalue())
 
 
+def test_archive_accepts_declared_synthetic_fixture_but_rejects_other_extras() -> None:
+    synthetic = b"safe-synthetic-fixture"
+
+    reviewed = _validate_package(
+        _package(
+            name=adapter.PACKAGE_ROOT + "synthetic_fixture.py",
+            content=synthetic,
+        )
+    )
+
+    assert reviewed["synthetic_fixture.py"] == synthetic
+    assert set(reviewed) == adapter.APPROVED_COMPONENT_FILES
+    with pytest.raises(ValueError, match="package_member"):
+        _validate_package(
+            _package(
+                name=adapter.PACKAGE_ROOT + "undeclared_fixture.py",
+                content=b"undeclared",
+            )
+        )
+
+
 def test_archive_requires_complete_reviewed_component_source() -> None:
     raw = _package()
     source = io.BytesIO(raw)
     output = io.BytesIO()
     missing = adapter.PACKAGE_ROOT + "coordinator.py"
-    with tarfile.open(fileobj=source, mode="r:gz") as original:
-        with tarfile.open(fileobj=output, mode="w:gz") as rebuilt:
-            for member in original.getmembers():
-                if member.name == missing:
-                    continue
-                stream = original.extractfile(member)
-                rebuilt.addfile(member, stream)
+    with (
+        tarfile.open(fileobj=source, mode="r:gz") as original,
+        tarfile.open(fileobj=output, mode="w:gz") as rebuilt,
+    ):
+        for member in original.getmembers():
+            if member.name == missing:
+                continue
+            stream = original.extractfile(member)
+            rebuilt.addfile(member, stream)
     with pytest.raises(ValueError, match="package_source_missing"):
         _validate_package(output.getvalue())
 

--- a/tests/src/unit/test_aurora_deploy_adapter.py
+++ b/tests/src/unit/test_aurora_deploy_adapter.py
@@ -1,0 +1,257 @@
+"""TDD coverage for the fixed-scope Aurora deployment adapter."""
+from __future__ import annotations
+
+import base64
+import hashlib
+import io
+import json
+import tarfile
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from custom_components.aurora_deploy import adapter
+from custom_components.aurora_deploy.adapter import (
+    _canonical_manifest,
+    _validate_manifest,
+    _validate_package,
+)
+
+
+def _package(*, name: str | None = None, content: bytes = b"{}") -> bytes:
+    if name is None and content != b"{}":
+        name = adapter.PACKAGE_ROOT + "manifest.json"
+    component_files = {
+        filename: (
+            json.dumps(
+                {"domain": adapter.COMPONENT_DOMAIN, "version": adapter.COMPONENT_VERSION}
+            ).encode()
+            if filename == "manifest.json"
+            else f"safe-{filename}".encode()
+        )
+        for filename in adapter.APPROVED_COMPONENT_FILES
+    }
+    if name is not None and name.startswith(adapter.PACKAGE_ROOT):
+        component_files[name.removeprefix(adapter.PACKAGE_ROOT)] = content
+    component_entries = [
+        {
+            "path": adapter.PACKAGE_ROOT + filename,
+            "sha256": hashlib.sha256(data).hexdigest(),
+            "size": len(data),
+        }
+        for filename, data in sorted(component_files.items())
+    ]
+    component_manifest = json.dumps(
+        {
+            "schemaVersion": "1.0",
+            "domain": adapter.COMPONENT_DOMAIN,
+            "version": adapter.COMPONENT_VERSION,
+            "configurationKey": adapter.COMPONENT_DOMAIN,
+            "restartRequired": True,
+            "files": component_entries,
+            "installation": {
+                "mode": "transactional-atomic-rename",
+                "installer": "install-aurora-camera-ai-component.py",
+                "configurationHashGuardRequired": True,
+                "prestateCapture": "exact-bytes",
+            },
+            "rollback": {
+                "mode": "restore-exact-prestate",
+                "configurationHashGuardRequired": True,
+                "restartRequired": True,
+            },
+        },
+        sort_keys=True,
+    ).encode()
+    activation = b'{"safe":true}'
+    installer = b"safe-installer"
+    package_manifest = json.dumps(
+        {
+            "entry": "activation-manifest.json",
+            "sha256": hashlib.sha256(activation).hexdigest(),
+            "componentManifestEntry": "custom-component-manifest.json",
+            "componentManifestSha256": hashlib.sha256(component_manifest).hexdigest(),
+            "installer": {
+                "entry": "install-aurora-camera-ai-component.py",
+                "sha256": hashlib.sha256(installer).hexdigest(),
+                "size": len(installer),
+            },
+        },
+        sort_keys=True,
+    ).encode()
+    files = {
+        "manifest.json": package_manifest,
+        "activation-manifest.json": activation,
+        "custom-component-manifest.json": component_manifest,
+        "install-aurora-camera-ai-component.py": installer,
+        **{
+            adapter.PACKAGE_ROOT + filename: data
+            for filename, data in component_files.items()
+        },
+    }
+    if name is not None and not name.startswith(adapter.PACKAGE_ROOT):
+        files[name] = content
+    output = io.BytesIO()
+    with tarfile.open(fileobj=output, mode="w:gz") as archive:
+        for filename, data in files.items():
+            item = tarfile.TarInfo(filename)
+            item.size = len(data)
+            archive.addfile(item, io.BytesIO(data))
+    return output.getvalue()
+
+
+def _hass(tmp_path: Path, public_key: bytes):
+    config_dir = tmp_path / "config"
+    config_dir.mkdir(exist_ok=True)
+    (config_dir / "aurora_deploy_trusted_keys.json").write_text(
+        json.dumps({"release-test": base64.b64encode(public_key).decode()}),
+        encoding="utf-8",
+    )
+    return SimpleNamespace(config=SimpleNamespace(path=lambda value: str(config_dir / value)))
+
+
+def _manifest(private_key, package: bytes, dashboard: bytes, *, expires: datetime | None = None) -> dict:
+    now = datetime.now(UTC)
+    document = {
+        "schema_version": 1,
+        "target": "aurora-v9-preview",
+        "dashboard_target": "home-command-preview",
+        "preview_only": True,
+        "target_release": "0.1.16",
+        "privacy_policy": "no-sensitive-inference-v1",
+        "key_id": "release-test",
+        "signer": "release-test",
+        "issued_at": now.isoformat(),
+        "expires_at": (expires or now + timedelta(hours=1)).isoformat(),
+        "nonce": "nonce-test-123",
+        "artifact_sha256": hashlib.sha256(package).hexdigest(),
+        "dashboard_sha256": hashlib.sha256(dashboard).hexdigest(),
+        "assets": [
+            {"name": "aurora-preview-package", "sha256": hashlib.sha256(package).hexdigest()},
+            {"name": "aurora-preview-dashboard", "sha256": hashlib.sha256(dashboard).hexdigest()},
+        ],
+    }
+    document["signature"] = base64.b64encode(private_key.sign(_canonical_manifest(document))).decode()
+    return document
+
+
+def test_signed_manifest_and_fixed_archive_are_accepted(tmp_path: Path) -> None:
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+    private = Ed25519PrivateKey.generate()
+    package = _package()
+    dashboard = b"export const AuroraPreview = true;"
+    manifest = _manifest(private, package, dashboard)
+    result = _validate_manifest(_hass(tmp_path, private.public_key().public_bytes_raw()), manifest, package, dashboard)
+    assert result == (
+        hashlib.sha256(_canonical_manifest(manifest)).hexdigest(),
+        hashlib.sha256(package).hexdigest(),
+        hashlib.sha256(dashboard).hexdigest(),
+    )
+
+
+def test_wrong_signature_and_expired_manifest_fail_closed(tmp_path: Path) -> None:
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+    private = Ed25519PrivateKey.generate()
+    package = _package()
+    dashboard = b"safe"
+    expired = _manifest(private, package, dashboard, expires=datetime.now(UTC) - timedelta(minutes=1))
+    with pytest.raises(ValueError, match="expiry"):
+        _validate_manifest(_hass(tmp_path, private.public_key().public_bytes_raw()), expired, package, dashboard)
+    expired["expires_at"] = (datetime.now(UTC) + timedelta(hours=1)).isoformat()
+    expired["signature"] = base64.b64encode(Ed25519PrivateKey.generate().sign(_canonical_manifest(expired))).decode()
+    with pytest.raises(ValueError, match="signature"):
+        _validate_manifest(_hass(tmp_path, private.public_key().public_bytes_raw()), expired, package, dashboard)
+
+
+def test_manifest_requires_explicit_preview_and_privacy_binding(tmp_path: Path) -> None:
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+    private = Ed25519PrivateKey.generate()
+    package = _package()
+    dashboard = b"safe"
+    manifest = _manifest(private, package, dashboard)
+    for field, value, expected in (
+        ("preview_only", False, "dashboard"),
+        ("privacy_policy", "other-policy", "privacy_policy"),
+    ):
+        candidate = {**manifest, field: value}
+        candidate["signature"] = base64.b64encode(
+            private.sign(_canonical_manifest(candidate))
+        ).decode()
+        with pytest.raises(ValueError, match=expected):
+            _validate_manifest(
+                _hass(tmp_path, private.public_key().public_bytes_raw()),
+                candidate,
+                package,
+                dashboard,
+            )
+
+
+def test_archive_rejects_traversal_links_nested_and_unapproved_members() -> None:
+    for name in ("../escape", "custom_components/other/file.py", "nested.tgz"):
+        with pytest.raises(ValueError):
+            _validate_package(_package(name=name))
+
+    output = io.BytesIO()
+    with tarfile.open(fileobj=output, mode="w:gz") as archive:
+        item = tarfile.TarInfo("custom_components/aurora_camera_ai/link.py")
+        item.type = tarfile.SYMTYPE
+        item.linkname = "/etc/passwd"
+        archive.addfile(item)
+    with pytest.raises(ValueError, match="package_link"):
+        _validate_package(output.getvalue())
+
+
+def test_archive_requires_complete_reviewed_component_source() -> None:
+    raw = _package()
+    source = io.BytesIO(raw)
+    output = io.BytesIO()
+    missing = adapter.PACKAGE_ROOT + "coordinator.py"
+    with tarfile.open(fileobj=source, mode="r:gz") as original:
+        with tarfile.open(fileobj=output, mode="w:gz") as rebuilt:
+            for member in original.getmembers():
+                if member.name == missing:
+                    continue
+                stream = original.extractfile(member)
+                rebuilt.addfile(member, stream)
+    with pytest.raises(ValueError, match="package_source_missing"):
+        _validate_package(output.getvalue())
+
+
+def test_privacy_functionality_is_rejected_before_staging() -> None:
+    with pytest.raises(ValueError):
+        _validate_package(_package(content=b"biometric identity inference"))
+
+@pytest.mark.asyncio
+async def test_setup_registers_only_authenticated_fixed_views(tmp_path: Path) -> None:
+    from custom_components import aurora_deploy
+
+    class Http:
+        def __init__(self) -> None:
+            self.views = []
+
+        def register_view(self, view) -> None:
+            self.views.append(view)
+
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    hass = SimpleNamespace(
+        config=SimpleNamespace(path=lambda value: str(config_dir / value)),
+        http=Http(),
+        data={},
+    )
+
+    async def executor(fn, *args):
+        return fn(*args)
+
+    hass.async_add_executor_job = executor
+    assert await aurora_deploy.async_setup(hass, {}) is True
+    assert [view.url for view in hass.http.views] == [
+        "/api/aurora/deploy-preview/v1/{operation}",
+        "/api/aurora/deploy-preview/v1/{transaction_id}/{operation}",
+    ]
+    assert all(view.requires_auth for view in hass.http.views)

--- a/tests/src/unit/test_aurora_deploy_adapter.py
+++ b/tests/src/unit/test_aurora_deploy_adapter.py
@@ -117,7 +117,7 @@ def _manifest(private_key, package: bytes, dashboard: bytes, *, expires: datetim
     document = {
         "schema_version": 1,
         "target": "aurora-v9-preview",
-        "dashboard_target": "home-command-preview",
+        "dashboard_target": "aurora-preview",
         "preview_only": True,
         "target_release": "0.1.16",
         "privacy_policy": "no-sensitive-inference-v1",

--- a/tests/src/unit/test_aurora_deploy_bootstrap.py
+++ b/tests/src/unit/test_aurora_deploy_bootstrap.py
@@ -1044,154 +1044,114 @@ def _write_stage(remote: Path, txid: str, payload: bootstrap.Payload) -> Path:
     return stage
 
 
-def _installer_source(  # noqa: C901
-    remote: Path, *, failure: str | None = None
-) -> str:
+def _installer_source(remote: Path, *, failure: str | None = None) -> str:
     source = bootstrap.INSTALLER_SOURCE.decode().replace(
         'ROOT=Path("/homeassistant")', f"ROOT=Path({str(remote)!r})"
     )
-    if failure == "after_component":
-        source = source.replace(
-            'install_destination("component",COMPONENT,new_component,tx,current,installed)',
-            'install_destination("component",COMPONENT,new_component,tx,current,installed); raise OSError("injected")',
-        )
-    elif failure in {"post_cas_component", "post_cas_trust", "post_cas_config"}:
-        mutation = {
+    mutations = {
             "post_cas_component": 'COMPONENT.mkdir(); (COMPONENT/"writer.py").write_bytes(b"external-writer")',
             "post_cas_trust": 'TRUST.write_bytes(b"external-writer")',
             "post_cas_config": 'CONFIG.write_bytes(b"external-writer-config\\n")',
-        }[failure]
-        source = source.replace(
+    }
+    replacements: dict[str, list[tuple[str, str]]] = {
+        "after_component": [(
+            'install_destination("component",COMPONENT,new_component,tx,current,installed)',
+            'install_destination("component",COMPONENT,new_component,tx,current,installed); raise OSError("injected")',
+        )],
+        **{
+            name: [(
             'new_config=tx/"new-configuration.yaml"; assert_expected(states(),args)',
             f'new_config=tx/"new-configuration.yaml"; assert_expected(states(),args); {mutation}',
-        )
-    elif failure == "install_recreate_config":
-        source = source.replace(
+            )]
+            for name, mutation in mutations.items()
+        },
+        "install_recreate_config": [(
             "publish_verified(key,replacement,destination,installed[key])",
             'if key=="configuration": destination.write_bytes(b"external-recreated-config\\n")\n    publish_verified(key,replacement,destination,installed[key])',
-        )
-    elif failure == "rollback_recreate_config":
-        source = source.replace(
+        )],
+        "rollback_recreate_config": [(
             'if pre[key]["exists"]: publish_verified(key,previous,destination,pre[key])',
             'if pre[key]["exists"]:\n            if key=="configuration": destination.write_bytes(b"external-rollback-config\\n")\n            publish_verified(key,previous,destination,pre[key])',
-        )
-    elif failure == "lock_hold":
-        source = source.replace(
+        )],
+        "lock_hold": [(
             "fsync_dir(ROOT); cleanup_owned_lock_candidate(candidate,created)",
             "fsync_dir(ROOT); cleanup_owned_lock_candidate(candidate,created); time.sleep(1)",
-            1,
-        )
-    elif failure == "lock_link_failure":
-        source = source.replace(
+        )],
+        "lock_link_failure": [(
             "os.link(candidate,LOCK,follow_symlinks=False); published=True",
             '(_ for _ in ()).throw(OSError("injected-link-failure")); published=True',
-            1,
-        )
-    elif failure == "lock_partial_write":
-        source = source.replace(
+        )],
+        "lock_partial_write": [(
             'written=os.write(fd,view)\n                if written<=0: fail("global_lock_candidate_write_failed")',
             'written=os.write(fd,view[:1]); fail("global_lock_candidate_write_failed")\n                if written<=0: fail("global_lock_candidate_write_failed")',
-            1,
-        )
-    elif failure == "runtime_foreign_destination":
-        source = (
-            source.replace(
-                'if ROOT!=Path("/homeassistant"): return', "if False: return", 1
-            )
-            .replace(
-                'if sys.platform!="linux": fail("linux_runtime_required")',
-                'if False: fail("linux_runtime_required")',
-                1,
-            )
-            .replace(
+        )],
+        "runtime_foreign_destination": [
+            ('if ROOT!=Path("/homeassistant"): return', "if False: return"),
+            ('if sys.platform!="linux": fail("linux_runtime_required")', 'if False: fail("linux_runtime_required")'),
+            (
                 "created=create_runtime_probe(source,marker); renamed=False",
                 'created=create_runtime_probe(source,marker); renamed=False; destination.write_bytes(b"foreign-runtime-writer")',
-                1,
-            )
-        )
-    elif failure == "runtime_hardlink_failure":
-        source = (
-            source.replace(
-                'if ROOT!=Path("/homeassistant"): return', "if False: return", 1
-            )
-            .replace(
-                'if sys.platform!="linux": fail("linux_runtime_required")',
-                'if False: fail("linux_runtime_required")',
-                1,
-            )
-            .replace(
+            ),
+        ],
+        "runtime_hardlink_failure": [
+            ('if ROOT!=Path("/homeassistant"): return', "if False: return"),
+            ('if sys.platform!="linux": fail("linux_runtime_required")', 'if False: fail("linux_runtime_required")'),
+            (
                 "try: os.link(link_source,link_destination,follow_symlinks=False); linked=True",
                 'try: (_ for _ in ()).throw(OSError("injected-runtime-link")); linked=True',
-                1,
-            )
-        )
-    elif failure == "runtime_probe_partial_exit":
-        source = (
-            source.replace(
-                'if ROOT!=Path("/homeassistant"): return', "if False: return", 1
-            )
-            .replace(
-                'if sys.platform!="linux": fail("linux_runtime_required")',
-                'if False: fail("linux_runtime_required")',
-                1,
-            )
-            .replace(
+            ),
+        ],
+        "runtime_probe_partial_exit": [
+            ('if ROOT!=Path("/homeassistant"): return', "if False: return"),
+            ('if sys.platform!="linux": fail("linux_runtime_required")', 'if False: fail("linux_runtime_required")'),
+            (
                 'written=os.write(fd,view)\n                if written<=0: fail("runtime_probe_write_failed")',
                 'written=os.write(fd,view[:1]); os._exit(74)\n                if written<=0: fail("runtime_probe_write_failed")',
-                1,
-            )
-        )
-    elif failure in {
-        "init_exit_after_mkdir",
-        "init_exit_after_installer",
-        "init_exit_after_replacements",
-    }:
-        marker = {
+            ),
+        ],
+        **{
+            name: [(marker, f"{marker}; os._exit(71)")]
+            for name, marker in {
             "init_exit_after_mkdir": "initialization.mkdir(mode=0o700); fsync_dir(ROOT)",
             "init_exit_after_installer": "write_atomic(initialization/INSTALLER,installer_bytes)",
             "init_exit_after_replacements": 'write_atomic(new_config,config_data,current["configuration"])',
-        }[failure]
-        source = source.replace(marker, f"{marker}; os._exit(71)", 1)
-    elif failure == "journal_exit_initial":
-        source = source.replace(
+            }.items()
+        },
+        "journal_exit_initial": [(
             "os.replace(temp,path); fsync_dir(path.parent)",
             'if path.name=="transaction.json" and not lexists(path): os._exit(72)\n    os.replace(temp,path); fsync_dir(path.parent)',
-        )
-    elif failure == "journal_exit_later":
-        source = source.replace(
+        )],
+        "journal_exit_later": [(
             "os.replace(temp,path); fsync_dir(path.parent)",
             'marker=ROOT/f".test-later-journal-{args.transaction_id}" if "args" in globals() else ROOT/".test-unused"\n    if path.name=="transaction.json" and lexists(path) and not lexists(marker): marker.write_text("once"); os._exit(73)\n    os.replace(temp,path); fsync_dir(path.parent)',
-        )
-    elif failure == "init_raise_after_replacements":
-        source = source.replace(
+        )],
+        "init_raise_after_replacements": [(
             'write_atomic(new_config,config_data,current["configuration"])',
             'write_atomic(new_config,config_data,current["configuration"]); raise OSError("injected-init")',
-        )
-    elif failure == "config_aba":
-        source = source.replace(
+        )],
+        "config_aba": [(
             "config_state,config_bytes=configuration_snapshot()",
             'config_state,config_bytes=configuration_snapshot(); CONFIG.write_bytes(b"transient-b\\n"); CONFIG.write_bytes(config_bytes)',
-        )
-    elif failure == "finalize_after_prepared":
-        source = source.replace(
+        )],
+        "finalize_after_prepared": [(
             'if journal.get("status")!="finalize_prepared": journal["status"]="finalize_prepared"; write_journal(tx,journal)',
             'if journal.get("status")!="finalize_prepared": journal["status"]="finalize_prepared"; write_journal(tx,journal); raise OSError("injected_finalize_after_prepared")',
-        )
-    elif failure == "finalize_after_stage":
-        source = source.replace(
+        )],
+        "finalize_after_stage": [(
             'if lexists(stage): kind(stage,"dir","stage_invalid"); shutil.rmtree(stage); fsync_dir(ROOT)',
             'if lexists(stage): kind(stage,"dir","stage_invalid"); shutil.rmtree(stage); fsync_dir(ROOT); raise OSError("injected_finalize_after_stage")',
-        )
-    elif failure == "finalize_after_release":
-        source = source.replace(
+        )],
+        "finalize_after_release": [(
             "release(args.transaction_id); release_required=False",
             'release(args.transaction_id); release_required=False; marker=ROOT/f".test-finalize-release-{args.transaction_id}"; marker_preexisting=lexists(marker); marker.write_text("once"); (None if marker_preexisting else (_ for _ in ()).throw(OSError("injected_finalize_after_release")))',
-        )
-    elif failure == "finalize_after_tx":
-        source = source.replace(
+        )],
+        "finalize_after_tx": [(
             "shutil.rmtree(tx); fsync_dir(ROOT)",
             'shutil.rmtree(tx); fsync_dir(ROOT); raise OSError("injected_finalize_after_tx")',
-        )
+        )],
+    }
+    for old, new in replacements.get(failure or "", []):
+        source = source.replace(old, new, 1)
     return source
 
 
@@ -2076,14 +2036,69 @@ def test_finalize_crash_boundaries_never_leave_unrecoverable_lock(
 
 
 @pytest.mark.asyncio
-async def test_finalize_authorization_reconciles_process_death_after_remote_commit(  # noqa: C901
+class _FinalizeDeathIngress:
+    def __init__(
+        self,
+        local: dict[str, Any],
+        configuration: bytes,
+        component_sha: str,
+        trust_sha: str,
+    ) -> None:
+        self.local = local
+        self.configuration = configuration
+        self.component_sha = component_sha
+        self.trust_sha = trust_sha
+        self.finalized = False
+        self.execute_modes: list[str] = []
+
+    def readback(self, transaction_id: str) -> dict[str, Any]:
+        if self.finalized:
+            return {
+                "status": "not_found", "transactionId": transaction_id,
+                "stagePresent": False, "lockCandidatePresent": False,
+                "transactionPresent": False, "initializationPresent": False,
+                "lockHeld": False, "lockOwnerMatches": False, "verified": False,
+            }
+        local = self.local
+        return {
+            "status": "installed", "transactionId": transaction_id,
+            "payloadManifestSha256": local["payloadManifestSha256"],
+            "installerSha256": local["installerSha256"], "replaceExact": False,
+            "prestateConfigurationSha256": local["expectedConfigurationSha256"],
+            "prestateComponentTreeSha256": local["expectedComponentTreeSha256"],
+            "prestateTrustSha256": "absent",
+            "configurationSha256": hashlib.sha256(self.configuration).hexdigest(),
+            "componentTreeSha256": self.component_sha, "trustSha256": self.trust_sha,
+            "rollbackDeadline": int(time.time()) - 1, "stagePresent": True,
+            "lockCandidatePresent": False, "transactionPresent": True,
+            "initializationPresent": False, "lockHeld": False,
+            "lockOwnerMatches": False, "verified": True,
+        }
+
+    def configuration_bytes(self) -> bytes:
+        return self.configuration
+
+    def component_tree_sha256(self) -> str:
+        return self.component_sha
+
+    def trust_sha256(self) -> str:
+        return self.trust_sha
+
+    def execute(self, *, mode: str, transaction_id: str, **_kwargs: Any) -> dict[str, Any]:
+        self.execute_modes.append(mode)
+        if mode == "mark-verified":
+            return {"status": "restart_verified", "transactionId": transaction_id}
+        self.finalized = True
+        raise RuntimeError("simulated local process death after remote finalize")
+
+
+async def test_finalize_authorization_reconciles_process_death_after_remote_commit(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     txid = str(uuid.uuid4())
     local = _local_record_value(txid)
     bootstrap._write_local_record(txid, local, create=True)
     configuration = b"verified-config\n"
-    configuration_sha = hashlib.sha256(configuration).hexdigest()
     component_sha = "4" * 64
     trust_sha = "5" * 64
 
@@ -2092,65 +2107,7 @@ async def test_finalize_authorization_reconciles_process_death_after_remote_comm
 
     monkeypatch.setattr(bootstrap, "_open_editor", open_editor)
 
-    class Ingress:
-        def __init__(self) -> None:
-            self.finalized = False
-            self.execute_modes: list[str] = []
-
-        def readback(self, transaction_id: str) -> dict[str, Any]:
-            if self.finalized:
-                return {
-                    "status": "not_found",
-                    "transactionId": transaction_id,
-                    "stagePresent": False,
-                    "lockCandidatePresent": False,
-                    "transactionPresent": False,
-                    "initializationPresent": False,
-                    "lockHeld": False,
-                    "lockOwnerMatches": False,
-                    "verified": False,
-                }
-            return {
-                "status": "installed",
-                "transactionId": transaction_id,
-                "payloadManifestSha256": local["payloadManifestSha256"],
-                "installerSha256": local["installerSha256"],
-                "replaceExact": False,
-                "prestateConfigurationSha256": local["expectedConfigurationSha256"],
-                "prestateComponentTreeSha256": local["expectedComponentTreeSha256"],
-                "prestateTrustSha256": "absent",
-                "configurationSha256": configuration_sha,
-                "componentTreeSha256": component_sha,
-                "trustSha256": trust_sha,
-                "rollbackDeadline": int(time.time()) - 1,
-                "stagePresent": True,
-                "lockCandidatePresent": False,
-                "transactionPresent": True,
-                "initializationPresent": False,
-                "lockHeld": False,
-                "lockOwnerMatches": False,
-                "verified": True,
-            }
-
-        def configuration_bytes(self) -> bytes:
-            return configuration
-
-        def component_tree_sha256(self) -> str:
-            return component_sha
-
-        def trust_sha256(self) -> str:
-            return trust_sha
-
-        def execute(
-            self, *, mode: str, transaction_id: str, **_kwargs: Any
-        ) -> dict[str, Any]:
-            self.execute_modes.append(mode)
-            if mode == "mark-verified":
-                return {"status": "restart_verified", "transactionId": transaction_id}
-            self.finalized = True
-            raise RuntimeError("simulated local process death after remote finalize")
-
-    ingress = Ingress()
+    ingress = _FinalizeDeathIngress(local, configuration, component_sha, trust_sha)
 
     async def run() -> dict[str, Any]:
         return await bootstrap.bootstrap(
@@ -2573,68 +2530,66 @@ def test_status_exposes_and_locally_binds_exact_partial_topology(
 
 
 @pytest.mark.asyncio
-async def test_read_only_status_needs_no_payload_or_stage_and_restores_addon_state(  # noqa: C901
+class _StatusSocket:
+    state = "stopped"
+
+    def __init__(self, *_args: Any) -> None:
+        pass
+
+    async def __aenter__(self) -> _StatusSocket:
+        return self
+
+    async def __aexit__(self, *_args: Any) -> None:
+        return None
+
+    async def call(self, command: str, **fields: Any) -> dict[str, Any]:
+        values = _preflight_values()
+        if command == "auth/current_user":
+            return values["user"]
+        if command == "backup/info":
+            return values["backup"]
+        endpoint = fields["endpoint"]
+        if endpoint.endswith("/start"):
+            type(self).state = "started"
+        if endpoint.endswith("/stop"):
+            type(self).state = "stopped"
+        data = {
+            "/supervisor/info": values["supervisor"],
+            "/host/info": values["host"],
+            f"/store/addons/{bootstrap.FILE_EDITOR_SLUG}": values["store"],
+            f"/addons/{bootstrap.FILE_EDITOR_SLUG}/info": {
+                **values["addon"], "state": type(self).state
+            },
+            f"/addons/{bootstrap.FILE_EDITOR_SLUG}/start": {},
+            f"/addons/{bootstrap.FILE_EDITOR_SLUG}/stop": {},
+            "/ingress/session": {"session": "A" * 32},
+        }.get(endpoint)
+        if data is None:
+            raise AssertionError(endpoint)
+        return {"result": "ok", "data": data}
+
+
+class _NotFoundIngress:
+    def __init__(self, *_args: Any) -> None:
+        pass
+
+    def status(self, transaction_id: str) -> dict[str, Any]:
+        return {"status": "not_found", "transactionId": transaction_id, "lockHeld": False}
+
+
+async def test_read_only_status_needs_no_payload_or_stage_and_restores_addon_state(
     tmp_path: Path,
 ) -> None:
     root = _source_root(tmp_path)
     txid = str(uuid.uuid4())
 
-    class Socket:
-        state = "stopped"
-
-        def __init__(self, *_args: Any) -> None:
-            pass
-
-        async def __aenter__(self) -> Socket:
-            return self
-
-        async def __aexit__(self, *_args: Any) -> None:
-            return None
-
-        async def call(self, command: str, **fields: Any) -> dict[str, Any]:
-            values = _preflight_values()
-            if command == "auth/current_user":
-                return values["user"]
-            if command == "backup/info":
-                return values["backup"]
-            endpoint = fields["endpoint"]
-            if endpoint == "/supervisor/info":
-                data = values["supervisor"]
-            elif endpoint == "/host/info":
-                data = values["host"]
-            elif endpoint == f"/store/addons/{bootstrap.FILE_EDITOR_SLUG}":
-                data = values["store"]
-            elif endpoint == f"/addons/{bootstrap.FILE_EDITOR_SLUG}/info":
-                data = {**values["addon"], "state": type(self).state}
-            elif endpoint == f"/addons/{bootstrap.FILE_EDITOR_SLUG}/start":
-                type(self).state = "started"
-                data = {}
-            elif endpoint == f"/addons/{bootstrap.FILE_EDITOR_SLUG}/stop":
-                type(self).state = "stopped"
-                data = {}
-            elif endpoint == "/ingress/session":
-                data = {"session": "A" * 32}
-            else:
-                raise AssertionError(endpoint)
-            return {"result": "ok", "data": data}
-
-    class Ingress:
-        def __init__(self, *_args: Any) -> None:
-            pass
-
-        def status(self, transaction_id: str) -> dict[str, Any]:
-            return {
-                "status": "not_found",
-                "transactionId": transaction_id,
-                "lockHeld": False,
-            }
-
+    _StatusSocket.state = "stopped"
     result = await bootstrap.bootstrap(
         mode="status",
         source_root=root,
         transaction_id=txid,
-        socket_factory=Socket,
-        ingress_client_factory=Ingress,
+        socket_factory=_StatusSocket,
+        ingress_client_factory=_NotFoundIngress,
         credential_loader=_test_credentials,
     )
     assert result == {
@@ -2642,7 +2597,7 @@ async def test_read_only_status_needs_no_payload_or_stage_and_restores_addon_sta
         "transactionId": txid,
         "lockHeld": False,
     }
-    assert Socket.state == "stopped"
+    assert _StatusSocket.state == "stopped"
 
 
 @pytest.mark.asyncio
@@ -2777,7 +2732,66 @@ async def test_transaction_is_persisted_before_any_remote_mutation(
 
 
 @pytest.mark.asyncio
-async def test_partial_upload_resumes_same_exact_local_transaction(  # noqa: C901
+class _PartialUploadIngress:
+    def __init__(
+        self,
+        payload: bootstrap.Payload,
+        before: bytes,
+        after: bytes,
+        installed_tree: str,
+        installed_trust: str,
+    ) -> None:
+        self.payload = payload
+        self.before = before
+        self.after = after
+        self.installed_tree = installed_tree
+        self.installed_trust = installed_trust
+        self.staged: dict[str, bytes] = {}
+        self.upload_counts: dict[str, int] = {}
+        self.failed = False
+        self.installed = False
+
+    def configuration_bytes(self) -> bytes:
+        return self.after if self.installed else self.before
+
+    def component_tree_sha256(self) -> str:
+        return self.installed_tree if self.installed else _empty_component_digest()
+
+    def trust_sha256(self) -> str:
+        return self.installed_trust if self.installed else "absent"
+
+    def create_stage(self, _txid: str) -> None:
+        return None
+
+    def verify_fixed_root_write_capability(self, _txid: str) -> None:
+        return None
+
+    def stage_file_exists(self, _txid: str, relative: str) -> bool:
+        return relative in self.staged
+
+    def download_stage(self, _txid: str, relative: str) -> bytes:
+        return self.staged[relative]
+
+    def upload(self, _txid: str, relative: str, content: bytes) -> None:
+        if len(self.staged) == 2 and not self.failed:
+            self.failed = True
+            raise bootstrap.BootstrapError("remote_upload_failed")
+        self.upload_counts[relative] = self.upload_counts.get(relative, 0) + 1
+        self.staged[relative] = content
+
+    def execute(self, *, mode: str, transaction_id: str, **_kwargs: Any) -> dict[str, Any]:
+        assert mode == "install"
+        self.installed = True
+        return {
+            "status": "installed", "transactionId": transaction_id,
+            "payloadManifestSha256": self.payload.manifest_sha256,
+            "configurationSha256": hashlib.sha256(self.after).hexdigest(),
+            "componentTreeSha256": self.installed_tree,
+            "trustSha256": self.installed_trust,
+        }
+
+
+async def test_partial_upload_resumes_same_exact_local_transaction(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     root = _source_root(tmp_path)
@@ -2810,56 +2824,9 @@ async def test_partial_upload_resumes_same_exact_local_transaction(  # noqa: C90
 
     monkeypatch.setattr(bootstrap, "_open_editor", open_editor)
 
-    class Ingress:
-        def __init__(self) -> None:
-            self.staged: dict[str, bytes] = {}
-            self.upload_counts: dict[str, int] = {}
-            self.failed = False
-            self.installed = False
-
-        def configuration_bytes(self) -> bytes:
-            return after if self.installed else before
-
-        def component_tree_sha256(self) -> str:
-            return installed_tree if self.installed else _empty_component_digest()
-
-        def trust_sha256(self) -> str:
-            return installed_trust if self.installed else "absent"
-
-        def create_stage(self, _txid: str) -> None:
-            return None
-
-        def verify_fixed_root_write_capability(self, _txid: str) -> None:
-            return None
-
-        def stage_file_exists(self, _txid: str, relative: str) -> bool:
-            return relative in self.staged
-
-        def download_stage(self, _txid: str, relative: str) -> bytes:
-            return self.staged[relative]
-
-        def upload(self, _txid: str, relative: str, content: bytes) -> None:
-            if len(self.staged) == 2 and not self.failed:
-                self.failed = True
-                raise bootstrap.BootstrapError("remote_upload_failed")
-            self.upload_counts[relative] = self.upload_counts.get(relative, 0) + 1
-            self.staged[relative] = content
-
-        def execute(
-            self, *, mode: str, transaction_id: str, **_kwargs: Any
-        ) -> dict[str, Any]:
-            assert mode == "install"
-            self.installed = True
-            return {
-                "status": "installed",
-                "transactionId": transaction_id,
-                "payloadManifestSha256": payload.manifest_sha256,
-                "configurationSha256": hashlib.sha256(after).hexdigest(),
-                "componentTreeSha256": installed_tree,
-                "trustSha256": installed_trust,
-            }
-
-    ingress = Ingress()
+    ingress = _PartialUploadIngress(
+        payload, before, after, installed_tree, installed_trust
+    )
 
     async def run(*, replace_exact: bool = False) -> dict[str, Any]:
         return await bootstrap.bootstrap(
@@ -2995,7 +2962,68 @@ async def test_invalid_prestate_config_check_has_zero_remote_or_local_mutation(
 
 
 @pytest.mark.asyncio
-async def test_failed_config_check_uses_remote_transaction_rollback(  # noqa: C901
+class _RollbackOnFailureIngress:
+    def __init__(
+        self,
+        payload: bootstrap.Payload,
+        before: bytes,
+        after: bytes,
+        installed_tree: str,
+        installed_trust: str,
+    ) -> None:
+        self.payload = payload
+        self.before = before
+        self.after = after
+        self.installed_tree = installed_tree
+        self.installed_trust = installed_trust
+        self.state = "prestate"
+        self.staged: dict[str, bytes] = {}
+        self.executions: list[str] = []
+
+    def configuration_bytes(self) -> bytes:
+        return self.before if self.state == "prestate" else self.after
+
+    def component_tree_sha256(self) -> str:
+        return _empty_component_digest() if self.state == "prestate" else self.installed_tree
+
+    def trust_sha256(self) -> str:
+        return "absent" if self.state == "prestate" else self.installed_trust
+
+    def stage_exists(self, _txid: str) -> bool:
+        return False
+
+    def stage_file_exists(self, _txid: str, relative: str) -> bool:
+        return relative in self.staged
+
+    def create_stage(self, _txid: str) -> None:
+        return None
+
+    def verify_fixed_root_write_capability(self, _txid: str) -> None:
+        return None
+
+    def upload(self, _txid: str, relative: str, content: bytes) -> None:
+        self.staged[relative] = content
+
+    def download_stage(self, _txid: str, relative: str) -> bytes:
+        return self.staged[relative]
+
+    def execute(self, *, mode: str, transaction_id: str, **_kwargs: Any) -> dict[str, Any]:
+        self.executions.append(mode)
+        installed = mode == "install"
+        self.state = "installed" if installed else "prestate"
+        return {
+            "status": "installed" if installed else "rolled_back",
+            "transactionId": transaction_id,
+            "payloadManifestSha256": self.payload.manifest_sha256,
+            "configurationSha256": hashlib.sha256(
+                self.after if installed else self.before
+            ).hexdigest(),
+            "componentTreeSha256": self.installed_tree if installed else _empty_component_digest(),
+            "trustSha256": self.installed_trust if installed else "absent",
+        }
+
+
+async def test_failed_config_check_uses_remote_transaction_rollback(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     root = _source_root(tmp_path)
@@ -3028,62 +3056,9 @@ async def test_failed_config_check_uses_remote_transaction_rollback(  # noqa: C9
 
     monkeypatch.setattr(bootstrap, "_open_editor", open_editor)
 
-    class Ingress:
-        def __init__(self, *_args: Any) -> None:
-            self.state = "prestate"
-            self.staged: dict[str, bytes] = {}
-            self.executions: list[str] = []
-
-        def configuration_bytes(self) -> bytes:
-            return before if self.state == "prestate" else after
-
-        def component_tree_sha256(self) -> str:
-            return (
-                _empty_component_digest()
-                if self.state == "prestate"
-                else installed_tree
-            )
-
-        def trust_sha256(self) -> str:
-            return "absent" if self.state == "prestate" else installed_trust
-
-        def stage_exists(self, _txid: str) -> bool:
-            return False
-
-        def stage_file_exists(self, _txid: str, relative: str) -> bool:
-            return relative in self.staged
-
-        def create_stage(self, _txid: str) -> None:
-            return None
-
-        def verify_fixed_root_write_capability(self, _txid: str) -> None:
-            return None
-
-        def upload(self, _txid: str, relative: str, content: bytes) -> None:
-            self.staged[relative] = content
-
-        def download_stage(self, _txid: str, relative: str) -> bytes:
-            return self.staged[relative]
-
-        def execute(
-            self, *, mode: str, transaction_id: str, **_kwargs: Any
-        ) -> dict[str, Any]:
-            self.executions.append(mode)
-            self.state = "installed" if mode == "install" else "prestate"
-            return {
-                "status": "installed" if mode == "install" else "rolled_back",
-                "transactionId": transaction_id,
-                "payloadManifestSha256": payload.manifest_sha256,
-                "configurationSha256": hashlib.sha256(
-                    after if mode == "install" else before
-                ).hexdigest(),
-                "componentTreeSha256": (
-                    installed_tree if mode == "install" else _empty_component_digest()
-                ),
-                "trustSha256": installed_trust if mode == "install" else "absent",
-            }
-
-    ingress = Ingress()
+    ingress = _RollbackOnFailureIngress(
+        payload, before, after, installed_tree, installed_trust
+    )
     checks = 0
 
     def check(*_args: Any) -> None:

--- a/tests/src/unit/test_aurora_deploy_bootstrap.py
+++ b/tests/src/unit/test_aurora_deploy_bootstrap.py
@@ -1,0 +1,2919 @@
+"""Failure-oriented tests for the Aurora File editor bootstrap."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import os
+import shutil
+import subprocess
+import sys
+import time
+import uuid
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from scripts import bootstrap_aurora_deploy_via_file_editor as bootstrap
+
+
+@pytest.fixture(autouse=True)
+def _fixed_approved_state_directory(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        bootstrap,
+        "APPROVED_STATE_DIRECTORY",
+        tmp_path / "approved-main-repository" / "local" / "aurora-deploy-state",
+    )
+
+
+def _git(root: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", "-C", str(root), *args], check=True, capture_output=True, text=True
+    )
+    return result.stdout.strip()
+
+
+def _source_root(tmp_path: Path) -> Path:
+    root = tmp_path / "source"
+    component = root / "custom_components" / "aurora_deploy"
+    component.mkdir(parents=True)
+    (component / "__init__.py").write_text("DOMAIN = 'aurora_deploy'\n")
+    (component / "adapter.py").write_text("SAFE = True\n")
+    (component / "manifest.json").write_text(
+        '{"domain":"aurora_deploy","version":"1.0.0"}\n'
+    )
+    keys = {
+        "release-test": base64.b64encode(b"r" * 32).decode(),
+        "validation-test": base64.b64encode(b"v" * 32).decode(),
+    }
+    (root / bootstrap.TRUST_PATH).write_text(json.dumps(keys, sort_keys=True))
+    (root / ".gitignore").write_text("local/\n")
+    _git(root, "init", "-q")
+    _git(root, "add", ".gitignore", "custom_components", bootstrap.TRUST_PATH)
+    _git(
+        root,
+        "-c",
+        "user.name=Test",
+        "-c",
+        "user.email=test@example.invalid",
+        "commit",
+        "-qm",
+        "fixture",
+    )
+    return root
+
+
+def _pins(root: Path) -> dict[str, str]:
+    revision = _git(root, "rev-parse", "HEAD")
+    files = []
+    for relative in bootstrap.PAYLOAD_PATHS:
+        content = (root / relative).read_bytes()
+        files.append(
+            {
+                "path": relative,
+                "sha256": hashlib.sha256(content).hexdigest(),
+                "size": len(content),
+            }
+        )
+    release = hashlib.sha256(b"r" * 32).hexdigest()
+    validation = hashlib.sha256(b"v" * 32).hexdigest()
+    manifest = bootstrap._canonical(
+        {
+            "schemaVersion": "aurora-deploy-bootstrap-v2",
+            "component": "aurora_deploy",
+            "configurationKey": "aurora_deploy",
+            "sourceRevision": revision,
+            "files": files,
+            "trust": {
+                "releaseKeySha256": release,
+                "validationKeySha256": validation,
+            },
+        }
+    )
+    return {
+        "expected_manifest_sha256": hashlib.sha256(manifest).hexdigest(),
+        "expected_release_key_sha256": release,
+        "expected_validation_key_sha256": validation,
+        "expected_source_revision": revision,
+    }
+
+
+def _payload(root: Path) -> bootstrap.Payload:
+    return bootstrap.validate_local_payload(root, **_pins(root))
+
+
+def _file_editor_client() -> bootstrap.FileEditorIngressClient:
+    return bootstrap.FileEditorIngressClient(
+        "https://ha.example.test",
+        "/api/hassio_ingress/file-editor-test",
+        "fixed-test-session",
+    )
+
+
+def _test_credentials() -> tuple[str, str]:
+    return "https://ha.example.test", "test-secret-token"
+
+
+def _local_record_value(
+    txid: str,
+    *,
+    installer: bytes | None = None,
+    replace_exact: bool = False,
+) -> dict[str, Any]:
+    installer = bootstrap.INSTALLER_SOURCE if installer is None else installer
+    return {
+        "schemaVersion": "aurora-deploy-bootstrap-local-v1",
+        "status": "prepared",
+        "transactionId": txid,
+        "payloadManifestSha256": "2" * 64,
+        "sourceRevision": "3" * 40,
+        "sourceRoot": "/removed/feature-worktree",
+        "installerSha256": hashlib.sha256(installer).hexdigest(),
+        "installerSourceBase64": base64.b64encode(installer).decode(),
+        "replaceExact": replace_exact,
+        "expectedConfigurationSha256": "0" * 64,
+        "expectedComponentTreeSha256": "1" * 64,
+        "expectedTrustSha256": "absent",
+    }
+
+
+def test_credentials_only_from_root_env_and_http_only_for_loopback(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    source_root = _source_root(tmp_path / "feature-worktree")
+    repository_root = tmp_path / "main-repository"
+    repository_root.mkdir()
+    root_env = repository_root / ".env"
+    root_env.write_text(
+        "HOMEASSISTANT_URL=https://ha.example.test\n"
+        "HOMEASSISTANT_TOKEN=test-secret-token\n"
+    )
+    root_env.chmod(0o600)
+    (source_root / ".env").write_text(
+        "HOMEASSISTANT_URL=https://attacker.invalid\n"
+        "HOMEASSISTANT_TOKEN=worktree-copy\n"
+    )
+    (source_root / ".env").chmod(0o600)
+    (repository_root / ".env.local").write_text(
+        "HOMEASSISTANT_URL=https://override.invalid\n"
+        "HOMEASSISTANT_TOKEN=override-copy\n"
+    )
+    monkeypatch.setattr(bootstrap, "APPROVED_REPOSITORY_ROOT", repository_root)
+    monkeypatch.setattr(bootstrap, "APPROVED_CREDENTIAL_ENV", root_env)
+
+    assert source_root != repository_root
+    assert bootstrap._load_credentials() == (
+        "https://ha.example.test",
+        "test-secret-token",
+    )
+    assert bootstrap._validate_url("http://127.0.0.1:8123") == "http://127.0.0.1:8123"
+    with pytest.raises(bootstrap.BootstrapError, match="https_required"):
+        bootstrap._validate_url("http://ha.example.test:8123")
+    root_env.write_text(
+        "HOMEASSISTANT_TOKEN=a\nHOMEASSISTANT_TOKEN=b\nHOMEASSISTANT_URL=https://ha\n"
+    )
+    with pytest.raises(bootstrap.BootstrapError, match="duplicate"):
+        bootstrap._load_credentials()
+
+    root_env.write_text(
+        "HOMEASSISTANT_URL=https://ha.example.test\n"
+        "HOMEASSISTANT_TOKEN=test-secret-token\n"
+    )
+    root_env.chmod(0o644)
+    with pytest.raises(bootstrap.BootstrapError, match="permissions_unsafe"):
+        bootstrap._load_credentials()
+    root_env.chmod(0o400)
+    with pytest.raises(bootstrap.BootstrapError, match="permissions_unsafe"):
+        bootstrap._load_credentials()
+
+    root_env.unlink()
+    credential_copy = repository_root / "credential-copy"
+    credential_copy.write_text(
+        "HOMEASSISTANT_URL=https://ha.example.test\n"
+        "HOMEASSISTANT_TOKEN=test-secret-token\n"
+    )
+    credential_copy.chmod(0o600)
+    root_env.symlink_to(credential_copy)
+    with pytest.raises(bootstrap.BootstrapError, match="root_env_invalid"):
+        bootstrap._load_credentials()
+
+
+@pytest.mark.asyncio
+async def test_credential_diagnostic_is_transport_only_and_fail_closed(
+    tmp_path: Path,
+) -> None:
+    result = await bootstrap.bootstrap(
+        mode="credential-check",
+        source_root=tmp_path / "unused-feature-worktree",
+        credential_loader=_test_credentials,
+    )
+    assert result == {
+        "status": "credential_transport_ready",
+        "credentialSource": "approved_root_env",
+        "transport": "https",
+    }
+    serialized = json.dumps(result)
+    assert "ha.example.test" not in serialized
+    assert "test-secret-token" not in serialized
+
+    with pytest.raises(bootstrap.BootstrapError, match="https_required"):
+        await bootstrap.bootstrap(
+            mode="credential-check",
+            source_root=tmp_path / "unused-feature-worktree",
+            credential_loader=lambda: (
+                "http://non-loopback.example.test:8123",
+                "must-not-leak",
+            ),
+        )
+
+
+def test_committed_source_and_independent_hashes_are_mandatory(tmp_path: Path) -> None:
+    root = _source_root(tmp_path)
+    pins = _pins(root)
+    payload = bootstrap.validate_local_payload(root, **pins)
+    assert payload.source_revision == pins["expected_source_revision"]
+
+    bad = {**pins, "expected_manifest_sha256": "0" * 64}
+    with pytest.raises(bootstrap.BootstrapError, match="manifest_hash_mismatch"):
+        bootstrap.validate_local_payload(root, **bad)
+    (root / "custom_components/aurora_deploy/adapter.py").write_text("DRIFT = True\n")
+    with pytest.raises(bootstrap.BootstrapError, match="not_clean"):
+        bootstrap.validate_local_payload(root, **pins)
+
+
+def test_duplicate_json_keys_and_bad_trust_roles_fail_closed(tmp_path: Path) -> None:
+    root = _source_root(tmp_path)
+    trust = root / bootstrap.TRUST_PATH
+    trust.write_text('{"release-a":"x","release-a":"y","validation-a":"z"}')
+    _git(root, "add", bootstrap.TRUST_PATH)
+    _git(
+        root,
+        "-c",
+        "user.name=Test",
+        "-c",
+        "user.email=test@example.invalid",
+        "commit",
+        "-qm",
+        "duplicate",
+    )
+    with pytest.raises(bootstrap.BootstrapError, match="duplicate"):
+        bootstrap.validate_local_payload(root, **_pins(root))
+
+    duplicate = base64.b64encode(b"a" * 32).decode()
+    with pytest.raises(bootstrap.BootstrapError, match="not_distinct"):
+        bootstrap.validate_trust_store(
+            json.dumps({"release-a": duplicate, "validation-a": duplicate}).encode()
+        )
+
+
+@pytest.mark.parametrize("too_long_role", ("release", "validation"))
+def test_trust_key_ids_match_adapter_total_length_contract(
+    too_long_role: str,
+) -> None:
+    release_id = "release-" + "r" * (64 - len("release-"))
+    validation_id = "validation-" + "v" * (64 - len("validation-"))
+    valid = {
+        release_id: base64.b64encode(b"r" * 32).decode(),
+        validation_id: base64.b64encode(b"v" * 32).decode(),
+    }
+    bootstrap.validate_trust_store(bootstrap._canonical(valid))
+
+    invalid = dict(valid)
+    key = release_id if too_long_role == "release" else validation_id
+    invalid[f"{key}x"] = invalid.pop(key)
+    with pytest.raises(bootstrap.BootstrapError, match="trust_store_invalid"):
+        bootstrap.validate_trust_store(bootstrap._canonical(invalid))
+
+
+def test_broken_source_and_destination_symlinks_are_rejected(tmp_path: Path) -> None:
+    root = _source_root(tmp_path)
+    adapter = root / "custom_components/aurora_deploy/adapter.py"
+    adapter.unlink()
+    adapter.symlink_to(root / "missing.py")
+    _git(root, "add", "custom_components/aurora_deploy/adapter.py")
+    _git(
+        root,
+        "-c",
+        "user.name=Test",
+        "-c",
+        "user.email=test@example.invalid",
+        "commit",
+        "-qm",
+        "broken-link",
+    )
+    broken_pins = {
+        "expected_manifest_sha256": "0" * 64,
+        "expected_release_key_sha256": "1" * 64,
+        "expected_validation_key_sha256": "2" * 64,
+        "expected_source_revision": _git(root, "rev-parse", "HEAD"),
+    }
+    with pytest.raises(bootstrap.BootstrapError, match="source_"):
+        bootstrap.validate_local_payload(root, **broken_pins)
+
+    safe_root = _source_root(tmp_path / "safe")
+    remote, txid, payload = _prepare_remote(tmp_path / "link", safe_root)
+    (remote / "custom_components/aurora_deploy").symlink_to(remote / "missing")
+    result = _run(remote, txid, payload, "install")
+    assert result.returncode == 1
+    assert "destination_component_invalid" in result.stderr
+
+
+def _preflight_values(now: datetime | None = None) -> dict[str, Any]:
+    current = now or datetime.now(UTC)
+    return {
+        "user": {"is_admin": True},
+        "supervisor": {
+            "healthy": True,
+            "supported": True,
+            "state": "running",
+            "arch": "amd64",
+        },
+        "host": {"arch": "amd64", "features": []},
+        "backup": {
+            "state": "idle",
+            "failed_agent_ids": [],
+            "agent_errors": {},
+            "backups": [
+                {
+                    "backup_id": "backup-1",
+                    "name": "Aurora HA recovery backup",
+                    "date": (current - timedelta(minutes=5)).isoformat(),
+                    "database_included": True,
+                    "homeassistant_included": True,
+                    "folders": ["ssl", "media", "share"],
+                    "addons": ["core_configurator"],
+                    "failed_agent_ids": [],
+                    "agent_errors": {},
+                    "agents": {
+                        "hassio.local": {
+                            "protected": True,
+                            "size": 1024.5,
+                            "status": "available",
+                        }
+                    },
+                }
+            ],
+        },
+        "addon": {
+            "slug": bootstrap.FILE_EDITOR_SLUG,
+            "name": "File editor",
+            "version": bootstrap.FILE_EDITOR_VERSION,
+            "state": "stopped",
+            "protected": True,
+            "ingress": True,
+            "ingress_entry": "/api/hassio_ingress/fixed-session",
+            "host_network": False,
+            "network": {},
+            "repository": "core",
+        },
+        "store": {
+            "slug": bootstrap.FILE_EDITOR_SLUG,
+            "name": "File editor",
+            "version_latest": bootstrap.FILE_EDITOR_VERSION,
+            "repository": "core",
+            "ingress": True,
+            "network": {},
+            "arch": ["amd64"],
+            "available": True,
+            "map": ["homeassistant_config:rw"],
+        },
+        "backup_id": "backup-1",
+        "expected_backup_agent_id": bootstrap.APPROVED_BACKUP_AGENT_ID,
+        "require_backup": True,
+        "now": current,
+    }
+
+
+def test_preflight_requires_explicit_safe_supervisor_and_strong_backup_metadata() -> (
+    None
+):
+    values = _preflight_values()
+    assert bootstrap.validate_supervisor_preflight(**values).startswith("/api/")
+    mutations = (
+        ("supervisor", "state", "degraded"),
+        ("addon", "name", "Impostor"),
+        ("addon", "host_network", True),
+        ("store", "repository", "third-party"),
+        ("backup_item", "database_included", False),
+        ("backup_item", "agents", {}),
+        (
+            "backup_item",
+            "agents",
+            {
+                "hassio.local": {"protected": True, "size": 10},
+                "cloud.remote": {"protected": True, "size": 10},
+            },
+        ),
+        (
+            "backup_item",
+            "agents",
+            {
+                "cloud.remote": {
+                    "protected": True,
+                    "size": 10,
+                    "status": "available",
+                }
+            },
+        ),
+        ("backup", "failed_agent_ids", ["hassio.local"]),
+        ("backup", "agent_errors", {"hassio.local": "unavailable"}),
+    )
+    for section, field, value in mutations:
+        candidate = _preflight_values()
+        target = (
+            candidate["backup"]["backups"][0]
+            if section == "backup_item"
+            else candidate[section]
+        )
+        target[field] = value
+        with pytest.raises(bootstrap.BootstrapError):
+            bootstrap.validate_supervisor_preflight(**candidate)
+
+
+def test_reconstructed_live_c5168fb8_backup_schema_is_accepted() -> None:
+    now = datetime(2026, 8, 11, 9, 30, tzinfo=UTC)
+    # Reconstructed from the observed backup/info schema. The ID and field layout
+    # are provenance-backed; name, timestamp, and size are sanitized test values.
+    live_shape = {
+        "backup_id": "c5168fb8",
+        "name": "Full backup 2026-08-11",
+        "date": "2026-08-11T08:45:00+00:00",
+        "addons": ["core_configurator", "a0d7b954_vscode"],
+        "folders": ["addons/local", "media", "share", "ssl"],
+        "homeassistant_included": True,
+        "database_included": True,
+        "failed_agent_ids": [],
+        "agent_errors": {},
+        "agents": {
+            "hassio.local": {
+                "protected": True,
+                "size": 1_284_892_160,
+            }
+        },
+    }
+    assert (
+        bootstrap._fresh_ha_recovery_backup(
+            [live_shape],
+            "c5168fb8",
+            bootstrap.APPROVED_BACKUP_AGENT_ID,
+            now=now,
+        )
+        == live_shape
+    )
+
+
+@pytest.mark.parametrize(
+    "agent",
+    (
+        {"protected": False, "size": 1024, "status": "available"},
+        {"protected": True, "size": 0, "status": "available"},
+        {"protected": True, "size": float("inf"), "status": "available"},
+        {"protected": True, "size": True, "status": "available"},
+        {"protected": True, "size": 1024, "status": "failed"},
+    ),
+)
+def test_backup_rejects_unhealthy_or_inaccessible_agent_copy(
+    agent: dict[str, Any],
+) -> None:
+    values = _preflight_values()
+    values["backup"]["backups"][0]["agents"] = {"hassio.local": agent}
+    with pytest.raises(bootstrap.BootstrapError, match="protected_ha_recovery_backup"):
+        bootstrap.validate_supervisor_preflight(**values)
+
+
+def _empty_component_digest() -> str:
+    return hashlib.sha256(
+        bootstrap._canonical({"exists": False, "files": {}, "directories": []})
+    ).hexdigest()
+
+
+@pytest.mark.parametrize(
+    "record_id", (str(uuid.uuid4()), bootstrap.LIFECYCLE_RECORD_ID)
+)
+def test_local_record_create_is_atomic_no_replace(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    record_id: str,
+) -> None:
+    value = _local_record_value(record_id)
+    original_link = os.link
+    competitor = b'{"competitor":"first-writer"}'
+
+    def race_link(source: str | Path, destination: str | Path, **kwargs: Any) -> None:
+        target = Path(destination)
+        target.write_bytes(competitor)
+        target.chmod(0o600)
+        original_link(source, destination, **kwargs)
+
+    monkeypatch.setattr(bootstrap.os, "link", race_link)
+    with pytest.raises(bootstrap.BootstrapError, match="local_transaction_exists"):
+        bootstrap._write_local_record(record_id, value, create=True)
+
+    path = bootstrap.APPROVED_STATE_DIRECTORY / f"{record_id}.json"
+    assert path.read_bytes() == competitor
+    assert not list(bootstrap.APPROVED_STATE_DIRECTORY.glob(f".{record_id}.new-*"))
+
+
+def test_local_record_loops_partial_writes_and_cleans_owned_temps(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    txid = str(uuid.uuid4())
+    value = _local_record_value(txid)
+    original_write = os.write
+
+    with monkeypatch.context() as patch:
+        patch.setattr(
+            bootstrap.os,
+            "write",
+            lambda fd, data: original_write(fd, bytes(data[:3])),
+        )
+        bootstrap._write_local_record(txid, value, create=True)
+    assert bootstrap._read_local_record(txid) == value
+
+    failed_txid = str(uuid.uuid4())
+    calls = 0
+
+    def fail_partial(fd: int, data: Any) -> int:
+        nonlocal calls
+        calls += 1
+        if calls > 1:
+            return 0
+        return original_write(fd, bytes(data[:3]))
+
+    with monkeypatch.context() as patch:
+        patch.setattr(bootstrap.os, "write", fail_partial)
+        with pytest.raises(bootstrap.BootstrapError, match="local_state_write_failed"):
+            bootstrap._write_local_record(
+                failed_txid, _local_record_value(failed_txid), create=True
+            )
+    assert not list(bootstrap.APPROVED_STATE_DIRECTORY.glob(f".{failed_txid}.new-*"))
+
+    residue = (
+        bootstrap.APPROVED_STATE_DIRECTORY / f".{failed_txid}.new-2000000000-{'a' * 16}"
+    )
+    residue.write_bytes(b"dead owned temp")
+    residue.chmod(0o600)
+    bootstrap._write_local_record(
+        failed_txid, _local_record_value(failed_txid), create=True
+    )
+    assert not residue.exists()
+
+
+def test_partial_stage_resume_skips_exact_files_and_rejects_conflicts(
+    tmp_path: Path,
+) -> None:
+    payload = _payload(_source_root(tmp_path))
+    txid = str(uuid.uuid4())
+
+    class StageClient:
+        def __init__(self) -> None:
+            self.files = {bootstrap.INSTALLER_NAME: bootstrap.INSTALLER_SOURCE}
+            self.uploaded: list[str] = []
+
+        def create_stage(self, _txid: str) -> None:
+            return None
+
+        def stage_file_exists(self, _txid: str, relative: str) -> bool:
+            return relative in self.files
+
+        def download_stage(self, _txid: str, relative: str) -> bytes:
+            return self.files[relative]
+
+        def upload(self, _txid: str, relative: str, content: bytes) -> None:
+            self.uploaded.append(relative)
+            self.files[relative] = content
+
+    client = StageClient()
+    bootstrap._stage_payload(client, txid, payload)
+    assert bootstrap.INSTALLER_NAME not in client.uploaded
+    assert set(client.files) == {
+        bootstrap.INSTALLER_NAME,
+        *bootstrap.PAYLOAD_PATHS,
+        bootstrap.PAYLOAD_MANIFEST_NAME,
+    }
+
+    conflict = StageClient()
+    conflict.files[bootstrap.SOURCE_PATHS[0]] = b"external-stage-writer"
+    with pytest.raises(bootstrap.BootstrapError, match="remote_stage_conflict"):
+        bootstrap._stage_payload(conflict, txid, payload)
+    assert conflict.files[bootstrap.SOURCE_PATHS[0]] == b"external-stage-writer"
+    assert bootstrap.SOURCE_PATHS[1] not in conflict.files
+
+
+def test_upload_accepts_exact_hass_configurator_0_6_0_success_schema(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = _file_editor_client()
+    requests: list[Any] = []
+
+    def open_upload(request: Any, _timeout: float = 30) -> bytes:
+        requests.append(request)
+        return b'{"error":false,"message":"Upload successful"}'
+
+    monkeypatch.setattr(client, "_open", open_upload)
+    client.upload(
+        str(uuid.uuid4()),
+        bootstrap.INSTALLER_NAME,
+        bootstrap.INSTALLER_SOURCE,
+    )
+
+    assert len(requests) == 1
+    assert requests[0].get_method() == "POST"
+    assert requests[0].full_url.endswith("/api/upload")
+
+
+@pytest.mark.parametrize(
+    "response",
+    [
+        {"error": False},
+        {"message": "Upload successful"},
+        {"error": True, "message": "Upload successful"},
+        {"error": 0, "message": "Upload successful"},
+        {"error": False, "message": "upload successful"},
+        {
+            "error": False,
+            "message": "Upload successful",
+            "path": "/homeassistant/attacker-selected",
+        },
+        {"error": False, "message": "Upload successful", "extra": None},
+    ],
+    ids=(
+        "missing-message",
+        "missing-error",
+        "error",
+        "non-boolean-error",
+        "wrong-message",
+        "path",
+        "extra",
+    ),
+)
+def test_upload_rejects_nonexact_hass_configurator_response(
+    response: dict[str, Any], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    client = _file_editor_client()
+    monkeypatch.setattr(
+        client,
+        "_open",
+        lambda *_args, **_kwargs: json.dumps(response).encode(),
+    )
+
+    with pytest.raises(bootstrap.BootstrapError, match="remote_upload_failed"):
+        client.upload(
+            str(uuid.uuid4()),
+            bootstrap.INSTALLER_NAME,
+            bootstrap.INSTALLER_SOURCE,
+        )
+
+
+def test_listdir_accepts_upstream_schema_and_binds_absolute_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = _file_editor_client()
+    response = {
+        "content": [],
+        "abspath": "/homeassistant",
+        "parent": "/",
+        "branches": [],
+        "activebranch": None,
+        "dirty": False,
+        "error": None,
+    }
+    monkeypatch.setattr(client, "_request", lambda *_args, **_kwargs: response)
+    assert client._list("/homeassistant") == []
+
+    response["abspath"] = "/attacker-selected"
+    with pytest.raises(bootstrap.BootstrapError, match="remote_path_mismatch"):
+        client._list("/homeassistant")
+
+
+def test_configuration_download_requires_listed_fixed_file(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = _file_editor_client()
+    monkeypatch.setattr(client, "_exists", lambda *_args, **_kwargs: False)
+    monkeypatch.setattr(
+        client,
+        "_download_path",
+        lambda *_args: pytest.fail("missing configuration must not be downloaded"),
+    )
+
+    with pytest.raises(bootstrap.BootstrapError, match="remote_configuration_missing"):
+        client.configuration_bytes()
+
+
+def test_exec_accepts_complete_hass_configurator_0_6_0_success_schema(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = _file_editor_client()
+    txid = str(uuid.uuid4())
+    monkeypatch.setattr(
+        client,
+        "_stage",
+        lambda _txid, _relative="": "/homeassistant/stage/installer.py",
+    )
+    monkeypatch.setattr(
+        client, "_download_path", lambda _path: bootstrap.INSTALLER_SOURCE
+    )
+
+    def request(
+        endpoint: str, *, form: dict[str, str], **_kwargs: Any
+    ) -> dict[str, Any]:
+        assert endpoint == "/api/exec_command"
+        command = form["command"]
+        return {
+            "error": False,
+            "message": f"Command executed: {command}",
+            "returncode": 0,
+            "stdout": json.dumps({"status": "stage_aborted", "transactionId": txid}),
+            "stderr": "",
+        }
+
+    monkeypatch.setattr(client, "_request", request)
+    assert client.execute(
+        mode="abort-stage",
+        transaction_id=txid,
+        arguments={"expected-installer-sha256": bootstrap.INSTALLER_SHA256},
+    ) == {"status": "stage_aborted", "transactionId": txid}
+
+
+@pytest.mark.parametrize(
+    "malformation", ("missing-message", "wrong-message", "boolean-returncode", "extra")
+)
+def test_exec_malformed_upstream_wrapper_fails_closed(
+    malformation: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    client = _file_editor_client()
+    txid = str(uuid.uuid4())
+    monkeypatch.setattr(
+        client,
+        "_stage",
+        lambda _txid, _relative="": "/homeassistant/stage/installer.py",
+    )
+    monkeypatch.setattr(
+        client, "_download_path", lambda _path: bootstrap.INSTALLER_SOURCE
+    )
+
+    def request(
+        _endpoint: str, *, form: dict[str, str], **_kwargs: Any
+    ) -> dict[str, Any]:
+        wrapper: dict[str, Any] = {
+            "error": False,
+            "message": f"Command executed: {form['command']}",
+            "returncode": 0,
+            "stdout": json.dumps({"status": "stage_aborted", "transactionId": txid}),
+            "stderr": "",
+        }
+        if malformation == "missing-message":
+            del wrapper["message"]
+        elif malformation == "wrong-message":
+            wrapper["message"] = "Command executed: attacker-selected"
+        elif malformation == "boolean-returncode":
+            wrapper["returncode"] = False
+        else:
+            wrapper["extra"] = None
+        return wrapper
+
+    monkeypatch.setattr(client, "_request", request)
+    monkeypatch.setattr(
+        client,
+        "_reconcile_lost_response",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            bootstrap.BootstrapError("installer_result_ambiguous")
+        ),
+    )
+    with pytest.raises(bootstrap.BootstrapError, match="installer_result_ambiguous"):
+        client.execute(
+            mode="abort-stage",
+            transaction_id=txid,
+            arguments={"expected-installer-sha256": bootstrap.INSTALLER_SHA256},
+        )
+
+
+def _prepare_remote(tmp_path: Path, root: Path) -> tuple[Path, str, bootstrap.Payload]:
+    remote = tmp_path / "remote"
+    (remote / "custom_components").mkdir(parents=True)
+    (remote / "configuration.yaml").write_bytes(b"default_config:\n")
+    txid = str(uuid.uuid4())
+    payload = _payload(root)
+    _write_stage(remote, txid, payload)
+    return remote, txid, payload
+
+
+def _write_stage(remote: Path, txid: str, payload: bootstrap.Payload) -> Path:
+    stage = remote / f"{bootstrap.STAGE_PREFIX}{txid}"
+    stage.mkdir()
+    for item in payload.files:
+        target = stage / item.relative_path
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(item.content)
+    (stage / bootstrap.PAYLOAD_MANIFEST_NAME).write_bytes(payload.manifest)
+    return stage
+
+
+def _installer_source(  # noqa: C901
+    remote: Path, *, failure: str | None = None
+) -> str:
+    source = bootstrap.INSTALLER_SOURCE.decode().replace(
+        'ROOT=Path("/homeassistant")', f"ROOT=Path({str(remote)!r})"
+    )
+    if failure == "after_component":
+        source = source.replace(
+            'install_destination("component",COMPONENT,new_component,tx,current,installed)',
+            'install_destination("component",COMPONENT,new_component,tx,current,installed); raise OSError("injected")',
+        )
+    elif failure in {"post_cas_component", "post_cas_trust", "post_cas_config"}:
+        mutation = {
+            "post_cas_component": 'COMPONENT.mkdir(); (COMPONENT/"writer.py").write_bytes(b"external-writer")',
+            "post_cas_trust": 'TRUST.write_bytes(b"external-writer")',
+            "post_cas_config": 'CONFIG.write_bytes(b"external-writer-config\\n")',
+        }[failure]
+        source = source.replace(
+            'new_config=tx/"new-configuration.yaml"; assert_expected(states(),args)',
+            f'new_config=tx/"new-configuration.yaml"; assert_expected(states(),args); {mutation}',
+        )
+    elif failure == "install_recreate_config":
+        source = source.replace(
+            "publish_verified(key,replacement,destination,installed[key])",
+            'if key=="configuration": destination.write_bytes(b"external-recreated-config\\n")\n    publish_verified(key,replacement,destination,installed[key])',
+        )
+    elif failure == "rollback_recreate_config":
+        source = source.replace(
+            'if pre[key]["exists"]: publish_verified(key,previous,destination,pre[key])',
+            'if pre[key]["exists"]:\n            if key=="configuration": destination.write_bytes(b"external-rollback-config\\n")\n            publish_verified(key,previous,destination,pre[key])',
+        )
+    elif failure == "lock_hold":
+        source = source.replace(
+            "fsync_dir(ROOT); cleanup_owned_lock_candidate(candidate,created)",
+            "fsync_dir(ROOT); cleanup_owned_lock_candidate(candidate,created); time.sleep(1)",
+            1,
+        )
+    elif failure == "lock_link_failure":
+        source = source.replace(
+            "os.link(candidate,LOCK,follow_symlinks=False); published=True",
+            '(_ for _ in ()).throw(OSError("injected-link-failure")); published=True',
+            1,
+        )
+    elif failure == "lock_partial_write":
+        source = source.replace(
+            'written=os.write(fd,view)\n                if written<=0: fail("global_lock_candidate_write_failed")',
+            'written=os.write(fd,view[:1]); fail("global_lock_candidate_write_failed")\n                if written<=0: fail("global_lock_candidate_write_failed")',
+            1,
+        )
+    elif failure == "runtime_foreign_destination":
+        source = (
+            source.replace(
+                'if ROOT!=Path("/homeassistant"): return', "if False: return", 1
+            )
+            .replace(
+                'if sys.platform!="linux": fail("linux_runtime_required")',
+                'if False: fail("linux_runtime_required")',
+                1,
+            )
+            .replace(
+                "created=create_runtime_probe(source,marker); renamed=False",
+                'created=create_runtime_probe(source,marker); renamed=False; destination.write_bytes(b"foreign-runtime-writer")',
+                1,
+            )
+        )
+    elif failure == "runtime_hardlink_failure":
+        source = (
+            source.replace(
+                'if ROOT!=Path("/homeassistant"): return', "if False: return", 1
+            )
+            .replace(
+                'if sys.platform!="linux": fail("linux_runtime_required")',
+                'if False: fail("linux_runtime_required")',
+                1,
+            )
+            .replace(
+                "try: os.link(link_source,link_destination,follow_symlinks=False); linked=True",
+                'try: (_ for _ in ()).throw(OSError("injected-runtime-link")); linked=True',
+                1,
+            )
+        )
+    elif failure == "runtime_probe_partial_exit":
+        source = (
+            source.replace(
+                'if ROOT!=Path("/homeassistant"): return', "if False: return", 1
+            )
+            .replace(
+                'if sys.platform!="linux": fail("linux_runtime_required")',
+                'if False: fail("linux_runtime_required")',
+                1,
+            )
+            .replace(
+                'written=os.write(fd,view)\n                if written<=0: fail("runtime_probe_write_failed")',
+                'written=os.write(fd,view[:1]); os._exit(74)\n                if written<=0: fail("runtime_probe_write_failed")',
+                1,
+            )
+        )
+    elif failure in {
+        "init_exit_after_mkdir",
+        "init_exit_after_installer",
+        "init_exit_after_replacements",
+    }:
+        marker = {
+            "init_exit_after_mkdir": "initialization.mkdir(mode=0o700); fsync_dir(ROOT)",
+            "init_exit_after_installer": "write_atomic(initialization/INSTALLER,installer_bytes)",
+            "init_exit_after_replacements": 'write_atomic(new_config,config_data,current["configuration"])',
+        }[failure]
+        source = source.replace(marker, f"{marker}; os._exit(71)", 1)
+    elif failure == "journal_exit_initial":
+        source = source.replace(
+            "os.replace(temp,path); fsync_dir(path.parent)",
+            'if path.name=="transaction.json" and not lexists(path): os._exit(72)\n    os.replace(temp,path); fsync_dir(path.parent)',
+        )
+    elif failure == "journal_exit_later":
+        source = source.replace(
+            "os.replace(temp,path); fsync_dir(path.parent)",
+            'marker=ROOT/f".test-later-journal-{args.transaction_id}" if "args" in globals() else ROOT/".test-unused"\n    if path.name=="transaction.json" and lexists(path) and not lexists(marker): marker.write_text("once"); os._exit(73)\n    os.replace(temp,path); fsync_dir(path.parent)',
+        )
+    elif failure == "init_raise_after_replacements":
+        source = source.replace(
+            'write_atomic(new_config,config_data,current["configuration"])',
+            'write_atomic(new_config,config_data,current["configuration"]); raise OSError("injected-init")',
+        )
+    elif failure == "config_aba":
+        source = source.replace(
+            "config_state,config_bytes=configuration_snapshot()",
+            'config_state,config_bytes=configuration_snapshot(); CONFIG.write_bytes(b"transient-b\\n"); CONFIG.write_bytes(config_bytes)',
+        )
+    elif failure == "finalize_after_prepared":
+        source = source.replace(
+            'if journal.get("status")!="finalize_prepared": journal["status"]="finalize_prepared"; write_journal(tx,journal)',
+            'if journal.get("status")!="finalize_prepared": journal["status"]="finalize_prepared"; write_journal(tx,journal); raise OSError("injected_finalize_after_prepared")',
+        )
+    elif failure == "finalize_after_stage":
+        source = source.replace(
+            'if lexists(stage): kind(stage,"dir","stage_invalid"); shutil.rmtree(stage); fsync_dir(ROOT)',
+            'if lexists(stage): kind(stage,"dir","stage_invalid"); shutil.rmtree(stage); fsync_dir(ROOT); raise OSError("injected_finalize_after_stage")',
+        )
+    elif failure == "finalize_after_release":
+        source = source.replace(
+            "release(args.transaction_id); release_required=False",
+            'release(args.transaction_id); release_required=False; marker=ROOT/f".test-finalize-release-{args.transaction_id}"; marker_preexisting=lexists(marker); marker.write_text("once"); (None if marker_preexisting else (_ for _ in ()).throw(OSError("injected_finalize_after_release")))',
+        )
+    elif failure == "finalize_after_tx":
+        source = source.replace(
+            "shutil.rmtree(tx); fsync_dir(ROOT)",
+            'shutil.rmtree(tx); fsync_dir(ROOT); raise OSError("injected_finalize_after_tx")',
+        )
+    return source
+
+
+def _write_lock(remote: Path, transaction_id: str, acquired_at: int) -> Path:
+    lock = remote / ".aurora-deploy-bootstrap-global.lock"
+    transaction_installer = (
+        remote
+        / f"{bootstrap.TRANSACTION_PREFIX}{transaction_id}"
+        / bootstrap.INSTALLER_NAME
+    )
+    stage_installer = (
+        remote / f"{bootstrap.STAGE_PREFIX}{transaction_id}" / bootstrap.INSTALLER_NAME
+    )
+    installer = (
+        transaction_installer if transaction_installer.exists() else stage_installer
+    )
+    installer_sha256 = (
+        hashlib.sha256(installer.read_bytes()).hexdigest()
+        if installer.exists()
+        else "0" * 64
+    )
+    lock.write_text(
+        json.dumps(
+            {
+                "schemaVersion": "aurora-deploy-bootstrap-lock-v4",
+                "transactionId": transaction_id,
+                "acquiredAt": acquired_at,
+                "installerSha256": installer_sha256,
+                "processId": 2_000_000_000,
+                "processStartTicks": 0,
+                "bootId": "00000000-0000-4000-8000-000000000000",
+                "probeNonce": "a" * 32,
+            },
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+    )
+    return lock
+
+
+def _age_lock(lock: Path) -> None:
+    record = json.loads(lock.read_text())
+    record["acquiredAt"] = int(time.time()) - bootstrap.STALE_LOCK_SECONDS - 1
+    lock.write_text(json.dumps(record, sort_keys=True, separators=(",", ":")))
+
+
+def _command(
+    remote: Path,
+    txid: str,
+    payload: bootstrap.Payload,
+    mode: str,
+    *,
+    replace: bool = False,
+    failure: str | None = None,
+) -> list[str]:
+    stage = remote / f"{bootstrap.STAGE_PREFIX}{txid}"
+    tx = remote / f"{bootstrap.TRANSACTION_PREFIX}{txid}"
+    installer = (
+        stage
+        if mode in {"install", "abort-stage"}
+        or (mode == "recover-lock" and not tx.exists())
+        else tx
+    ) / bootstrap.INSTALLER_NAME
+    if mode == "install" or not installer.exists():
+        installer.write_text(_installer_source(remote, failure=failure))
+    command = [sys.executable, str(installer), mode, "--transaction-id", txid]
+    if mode == "install":
+        command += [
+            "--expected-configuration-sha256",
+            hashlib.sha256((remote / "configuration.yaml").read_bytes()).hexdigest(),
+            "--expected-component-tree-sha256",
+            _empty_component_digest(),
+            "--expected-trust-sha256",
+            "absent",
+            "--payload-manifest-sha256",
+            payload.manifest_sha256,
+            "--expected-installer-sha256",
+            hashlib.sha256(installer.read_bytes()).hexdigest(),
+        ]
+        if replace:
+            command.append("--replace-exact")
+    else:
+        command += [
+            "--expected-installer-sha256",
+            hashlib.sha256(installer.read_bytes()).hexdigest(),
+        ]
+        if mode != "abort-stage":
+            journal_path = tx / "transaction.json"
+            if journal_path.exists():
+                journal = json.loads(journal_path.read_text())
+                prestate = journal["prestate"]
+                configuration_sha256 = prestate["configuration"]["sha256"]
+                component_tree_sha256 = bootstrap._component_state_digest(
+                    prestate["component"]
+                )
+                trust_sha256 = prestate["trust"].get("sha256", "absent")
+                payload_manifest_sha256 = journal["payloadManifestSha256"]
+            else:
+                configuration_sha256 = hashlib.sha256(
+                    (remote / "configuration.yaml").read_bytes()
+                ).hexdigest()
+                component_tree_sha256 = _empty_component_digest()
+                trust_sha256 = "absent"
+                payload_manifest_sha256 = payload.manifest_sha256
+            command += [
+                "--expected-configuration-sha256",
+                configuration_sha256,
+                "--expected-component-tree-sha256",
+                component_tree_sha256,
+                "--expected-trust-sha256",
+                trust_sha256,
+                "--payload-manifest-sha256",
+                payload_manifest_sha256,
+            ]
+            if journal_path.exists() and journal.get("replaceExact") is True:
+                command.append("--replace-exact")
+    return command
+
+
+def _run(
+    remote: Path,
+    txid: str,
+    payload: bootstrap.Payload,
+    mode: str,
+    *,
+    replace: bool = False,
+    failure: str | None = None,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        _command(
+            remote,
+            txid,
+            payload,
+            mode,
+            replace=replace,
+            failure=failure,
+        ),
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_install_uses_global_lock_immediate_cas_and_exact_post_readback(
+    tmp_path: Path,
+) -> None:
+    root = _source_root(tmp_path)
+    remote, txid, payload = _prepare_remote(tmp_path, root)
+    result = _run(remote, txid, payload, "install")
+    assert result.returncode == 0, result.stderr
+    receipt = json.loads(result.stdout)
+    assert receipt["status"] == "installed"
+    expected_tree = hashlib.sha256(
+        bootstrap._canonical(
+            {
+                "exists": True,
+                "files": {
+                    Path(item.relative_path).name: item.sha256
+                    for item in payload.files
+                    if item.relative_path.startswith("custom_components/")
+                },
+                "directories": [],
+            }
+        )
+    ).hexdigest()
+    assert receipt["componentTreeSha256"] == expected_tree
+    assert (remote / "configuration.yaml").read_text().count("aurora_deploy:") == 1
+    assert not (remote / ".aurora-deploy-bootstrap-global.lock").exists()
+
+    remote2, txid2, payload2 = _prepare_remote(tmp_path / "second", root)
+    _write_lock(remote2, str(uuid.uuid4()), int(time.time()))
+    blocked = _run(remote2, txid2, payload2, "install")
+    assert blocked.returncode == 1
+    assert "global_lock_held" in blocked.stderr
+    assert not (remote2 / "custom_components/aurora_deploy").exists()
+
+
+def test_configuration_snapshot_prevents_transient_aba_bytes_from_installing(
+    tmp_path: Path,
+) -> None:
+    root = _source_root(tmp_path)
+    remote, txid, payload = _prepare_remote(tmp_path, root)
+    installed = _run(remote, txid, payload, "install", failure="config_aba")
+    assert installed.returncode == 0, installed.stderr
+    configuration = (remote / "configuration.yaml").read_bytes()
+    assert configuration == b"default_config:\naurora_deploy:\n"
+    assert b"transient-b" not in configuration
+
+
+def test_extra_component_directory_requires_replace_exact_and_is_preserved(
+    tmp_path: Path,
+) -> None:
+    root = _source_root(tmp_path)
+    remote, txid, payload = _prepare_remote(tmp_path, root)
+    component = remote / "custom_components/aurora_deploy"
+    component.mkdir()
+    for item in payload.files:
+        if item.relative_path.startswith("custom_components/"):
+            (component / Path(item.relative_path).name).write_bytes(item.content)
+    (component / "external-empty-directory").mkdir()
+    expected_tree = hashlib.sha256(
+        bootstrap._canonical(
+            {
+                "exists": True,
+                "files": {
+                    Path(item.relative_path).name: item.sha256
+                    for item in payload.files
+                    if item.relative_path.startswith("custom_components/")
+                },
+                "directories": ["external-empty-directory"],
+            }
+        )
+    ).hexdigest()
+    command = _command(remote, txid, payload, "install")
+    command[command.index("--expected-component-tree-sha256") + 1] = expected_tree
+    rejected = subprocess.run(command, check=False, capture_output=True, text=True)
+    assert rejected.returncode == 1
+    assert "replace_exact_required" in rejected.stderr
+    assert (component / "external-empty-directory").is_dir()
+
+
+def test_duplicate_top_level_configuration_key_never_mutates_prestate(
+    tmp_path: Path,
+) -> None:
+    root = _source_root(tmp_path)
+    remote, txid, payload = _prepare_remote(tmp_path, root)
+    before = b"aurora_deploy:\ndefault_config:\naurora_deploy:\n"
+    (remote / "configuration.yaml").write_bytes(before)
+    failed = _run(remote, txid, payload, "install")
+    assert failed.returncode == 1
+    assert "configuration_key_duplicate" in failed.stderr
+    assert (remote / "configuration.yaml").read_bytes() == before
+    assert not (remote / ".aurora-deploy-bootstrap-global.lock").exists()
+
+
+def test_atomic_lock_orphan_recovery_and_concurrent_exclusion(tmp_path: Path) -> None:
+    root = _source_root(tmp_path)
+    orphan_remote, orphan_txid, orphan_payload = _prepare_remote(
+        tmp_path / "orphan", root
+    )
+    orphan = orphan_remote / (f".aurora-deploy-bootstrap-lock-candidate-{orphan_txid}")
+    orphan.write_bytes(b"interrupted-before-publish")
+    stale = time.time() - bootstrap.STALE_LOCK_SECONDS - 1
+    os.utime(orphan, (stale, stale))
+    recovered = _run(
+        orphan_remote,
+        orphan_txid,
+        orphan_payload,
+        "recover-lock",
+    )
+    assert recovered.returncode == 0, recovered.stderr
+    assert json.loads(recovered.stdout)["status"] == "lock_recovered"
+    assert not orphan.exists()
+    assert not (orphan_remote / ".aurora-deploy-bootstrap-global.lock").exists()
+
+    remote, first_txid, payload = _prepare_remote(tmp_path / "concurrent", root)
+    second_txid = str(uuid.uuid4())
+    _write_stage(remote, second_txid, payload)
+    first_command = _command(
+        remote,
+        first_txid,
+        payload,
+        "install",
+        failure="lock_hold",
+    )
+    second_command = _command(
+        remote,
+        second_txid,
+        payload,
+        "install",
+        failure="lock_hold",
+    )
+    first = subprocess.Popen(
+        first_command,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    lock = remote / ".aurora-deploy-bootstrap-global.lock"
+    deadline = time.monotonic() + 5
+    while not lock.exists() and time.monotonic() < deadline:
+        time.sleep(0.01)
+    assert lock.is_file()
+    lock_record = json.loads(lock.read_text())
+    assert lock_record["transactionId"] == first_txid
+
+    second = subprocess.run(
+        second_command,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    first_stdout, first_stderr = first.communicate(timeout=10)
+    assert first.returncode == 0, first_stderr
+    assert json.loads(first_stdout)["status"] == "installed"
+    assert second.returncode == 1
+    assert "global_lock_held" in second.stderr
+    assert not lock.exists()
+    assert not list(remote.glob(".aurora-deploy-bootstrap-lock-candidate-*"))
+
+
+def test_lock_link_failure_cleans_candidate_and_is_immediately_retryable(
+    tmp_path: Path,
+) -> None:
+    root = _source_root(tmp_path)
+    remote, txid, payload = _prepare_remote(tmp_path, root)
+    failed = _run(remote, txid, payload, "install", failure="lock_link_failure")
+    assert failed.returncode == 1
+    assert not (remote / ".aurora-deploy-bootstrap-global.lock").exists()
+    assert not list(remote.glob(".aurora-deploy-bootstrap-lock-candidate-*"))
+    retried = _run(remote, txid, payload, "install")
+    assert retried.returncode == 0, retried.stderr
+
+
+def test_partial_lock_write_cleans_candidate_and_is_immediately_retryable(
+    tmp_path: Path,
+) -> None:
+    root = _source_root(tmp_path)
+    remote, txid, payload = _prepare_remote(tmp_path, root)
+    failed = _run(remote, txid, payload, "install", failure="lock_partial_write")
+    assert failed.returncode == 1
+    assert not (remote / ".aurora-deploy-bootstrap-global.lock").exists()
+    assert not list(remote.glob(".aurora-deploy-bootstrap-lock-candidate-*"))
+    assert _run(remote, txid, payload, "install").returncode == 0
+
+
+def test_crashed_partial_runtime_probe_is_authenticated_by_lock_and_recovered(
+    tmp_path: Path,
+) -> None:
+    root = _source_root(tmp_path)
+    remote, txid, payload = _prepare_remote(tmp_path, root)
+    interrupted = _run(
+        remote, txid, payload, "install", failure="runtime_probe_partial_exit"
+    )
+    assert interrupted.returncode == 74
+    lock = remote / ".aurora-deploy-bootstrap-global.lock"
+    assert lock.is_file()
+    partial = list(remote.glob(f".aurora-deploy-bootstrap-runtime-source-{txid}-*"))
+    assert len(partial) == 1
+    assert len(partial[0].read_bytes()) == 1
+    _age_lock(lock)
+    recovered = _run(remote, txid, payload, "recover-lock")
+    assert recovered.returncode == 0, recovered.stderr
+    assert not lock.exists()
+    assert not partial[0].exists()
+
+
+def test_stale_age_never_recovers_a_still_running_lock_owner(tmp_path: Path) -> None:
+    root = _source_root(tmp_path)
+    remote, txid, payload = _prepare_remote(tmp_path, root)
+    assert _run(remote, txid, payload, "install").returncode == 0
+    lock = _write_lock(
+        remote, txid, int(time.time()) - bootstrap.STALE_LOCK_SECONDS - 1
+    )
+    record = json.loads(lock.read_text())
+    record["processId"] = os.getpid()
+    if sys.platform == "linux":
+        raw = Path(f"/proc/{os.getpid()}/stat").read_text()
+        record["processStartTicks"] = int(raw[raw.rfind(")") + 2 :].split()[19])
+        record["bootId"] = Path("/proc/sys/kernel/random/boot_id").read_text().strip()
+    else:
+        record["processStartTicks"] = 0
+        record["bootId"] = "00000000-0000-4000-8000-000000000000"
+    lock.write_text(json.dumps(record, sort_keys=True, separators=(",", ":")))
+    rejected = _run(remote, txid, payload, "recover-lock")
+    assert rejected.returncode == 1
+    assert "global_lock_owner_still_running" in rejected.stderr
+    assert lock.is_file()
+
+
+@pytest.mark.parametrize(
+    "failure", ("runtime_foreign_destination", "runtime_hardlink_failure")
+)
+def test_runtime_probe_preserves_foreign_paths_and_cleans_owned_residue(
+    tmp_path: Path, failure: str
+) -> None:
+    root = _source_root(tmp_path)
+    remote, txid, payload = _prepare_remote(tmp_path / failure, root)
+    failed = _run(remote, txid, payload, "install", failure=failure)
+    assert failed.returncode == 1
+    assert not (remote / ".aurora-deploy-bootstrap-global.lock").exists()
+    assert not list(remote.glob(".aurora-deploy-bootstrap-lock-candidate-*"))
+    if failure == "runtime_foreign_destination":
+        foreign_paths = list(
+            remote.glob(f".aurora-deploy-bootstrap-runtime-destination-{txid}-*")
+        )
+        assert len(foreign_paths) == 1
+        foreign = foreign_paths[0]
+        assert foreign.read_bytes() == b"foreign-runtime-writer"
+    assert not list(remote.glob(f".aurora-deploy-bootstrap-runtime-source-{txid}-*"))
+    assert not list(remote.glob(f".aurora-deploy-bootstrap-runtime-link-*-{txid}-*"))
+
+    aborted = _run(remote, txid, payload, "abort-stage")
+    assert aborted.returncode == 0, aborted.stderr
+    assert not (remote / f"{bootstrap.STAGE_PREFIX}{txid}").exists()
+    assert (remote / "configuration.yaml").read_bytes() == b"default_config:\n"
+    assert not (remote / "custom_components/aurora_deploy").exists()
+
+
+@pytest.mark.parametrize(
+    ("failure", "destination"),
+    (
+        ("post_cas_component", "component"),
+        ("post_cas_trust", "trust"),
+        ("post_cas_config", "configuration"),
+    ),
+)
+def test_post_cas_external_writer_is_never_overwritten(
+    tmp_path: Path, failure: str, destination: str
+) -> None:
+    root = _source_root(tmp_path)
+    remote, txid, payload = _prepare_remote(tmp_path / failure, root)
+    failed = _run(remote, txid, payload, "install", failure=failure)
+    assert failed.returncode == 1
+    assert "partial_failure_rollback_failed" in failed.stderr
+    if destination == "component":
+        assert (remote / "custom_components/aurora_deploy/writer.py").read_bytes() == (
+            b"external-writer"
+        )
+    elif destination == "trust":
+        assert (remote / bootstrap.TRUST_PATH).read_bytes() == b"external-writer"
+    else:
+        assert (remote / "configuration.yaml").read_bytes() == (
+            b"external-writer-config\n"
+        )
+    lock = remote / ".aurora-deploy-bootstrap-global.lock"
+    assert json.loads(lock.read_text())["transactionId"] == txid
+
+
+@pytest.mark.parametrize(
+    ("phase", "failure", "expected"),
+    (
+        ("install", "install_recreate_config", b"external-recreated-config\n"),
+        ("rollback", "rollback_recreate_config", b"external-rollback-config\n"),
+    ),
+)
+def test_writer_recreation_after_verified_move_is_not_clobbered(
+    tmp_path: Path, phase: str, failure: str, expected: bytes
+) -> None:
+    root = _source_root(tmp_path)
+    remote, txid, payload = _prepare_remote(tmp_path / phase, root)
+    installed = _run(remote, txid, payload, "install", failure=failure)
+    if phase == "install":
+        failed = installed
+    else:
+        assert installed.returncode == 0, installed.stderr
+        failed = _run(remote, txid, payload, "rollback")
+    assert failed.returncode == 1
+    assert "partial_failure_rollback_failed" in failed.stderr
+    assert (remote / "configuration.yaml").read_bytes() == expected
+    lock = remote / ".aurora-deploy-bootstrap-global.lock"
+    assert json.loads(lock.read_text())["transactionId"] == txid
+
+
+def test_partial_failure_restores_prestate_and_stale_lock_recovery_is_explicit(
+    tmp_path: Path,
+) -> None:
+    root = _source_root(tmp_path)
+    remote, txid, payload = _prepare_remote(tmp_path, root)
+    before = (remote / "configuration.yaml").read_bytes()
+    failed = _run(remote, txid, payload, "install", failure="after_component")
+    assert failed.returncode == 1
+    assert "install_failed_rolled_back" in failed.stderr
+    assert (remote / "configuration.yaml").read_bytes() == before
+    assert not (remote / "custom_components/aurora_deploy").exists()
+
+    remote2, txid2, payload2 = _prepare_remote(tmp_path / "recover", root)
+    assert _run(remote2, txid2, payload2, "install").returncode == 0
+    lock = _write_lock(
+        remote2,
+        txid2,
+        int(time.time()) - bootstrap.STALE_LOCK_SECONDS - 1,
+    )
+    recovered = _run(remote2, txid2, payload2, "recover-lock")
+    assert recovered.returncode == 0, recovered.stderr
+    assert json.loads(recovered.stdout)["status"] == "lock_recovered"
+    assert not lock.exists()
+
+
+@pytest.mark.parametrize(
+    "failure",
+    (
+        "init_exit_after_mkdir",
+        "init_exit_after_installer",
+        "init_exit_after_replacements",
+        "journal_exit_initial",
+    ),
+)
+def test_prepublication_crashes_have_strict_stale_recovery(
+    tmp_path: Path, failure: str
+) -> None:
+    root = _source_root(tmp_path)
+    remote, txid, payload = _prepare_remote(tmp_path / failure, root)
+    interrupted = _run(remote, txid, payload, "install", failure=failure)
+    assert interrupted.returncode in {71, 72}
+    lock = remote / ".aurora-deploy-bootstrap-global.lock"
+    assert lock.is_file()
+    initialization = remote / f"{bootstrap.TRANSACTION_INIT_PREFIX}{txid}"
+    assert initialization.is_dir()
+    assert not (remote / f"{bootstrap.TRANSACTION_PREFIX}{txid}").exists()
+    _age_lock(lock)
+
+    recovered = _run(remote, txid, payload, "recover-lock")
+    assert recovered.returncode == 0, recovered.stderr
+    assert json.loads(recovered.stdout)["status"] == "lock_recovered"
+    assert not lock.exists()
+    assert not initialization.exists()
+    assert (remote / "configuration.yaml").read_bytes() == b"default_config:\n"
+    assert not (remote / "custom_components/aurora_deploy").exists()
+    assert not (remote / bootstrap.TRUST_PATH).exists()
+
+
+def test_later_journal_temp_crash_is_recovered_without_truncation(
+    tmp_path: Path,
+) -> None:
+    root = _source_root(tmp_path)
+    remote, txid, payload = _prepare_remote(tmp_path, root)
+    interrupted = _run(remote, txid, payload, "install", failure="journal_exit_later")
+    assert interrupted.returncode == 73
+    lock = remote / ".aurora-deploy-bootstrap-global.lock"
+    _age_lock(lock)
+    tx = remote / f"{bootstrap.TRANSACTION_PREFIX}{txid}"
+    assert list(tx.glob("transaction.json.new-*"))
+
+    recovered = _run(remote, txid, payload, "recover-lock")
+    assert recovered.returncode == 0, recovered.stderr
+    assert not lock.exists()
+    assert not list(tx.glob("transaction.json.new-*"))
+    journal = json.loads((tx / "transaction.json").read_text())
+    assert journal["status"] == "rolled_back_after_recovery"
+    assert (remote / "configuration.yaml").read_bytes() == b"default_config:\n"
+
+
+def test_abort_stage_cleans_released_lock_initialization_residue(
+    tmp_path: Path,
+) -> None:
+    root = _source_root(tmp_path)
+    remote, txid, payload = _prepare_remote(tmp_path, root)
+    failed = _run(
+        remote,
+        txid,
+        payload,
+        "install",
+        failure="init_raise_after_replacements",
+    )
+    assert failed.returncode == 1
+    assert not (remote / ".aurora-deploy-bootstrap-global.lock").exists()
+    initialization = remote / f"{bootstrap.TRANSACTION_INIT_PREFIX}{txid}"
+    assert initialization.is_dir()
+
+    aborted = _run(remote, txid, payload, "abort-stage")
+    assert aborted.returncode == 0, aborted.stderr
+    assert json.loads(aborted.stdout)["status"] == "stage_aborted"
+    assert not initialization.exists()
+    assert not (remote / f"{bootstrap.STAGE_PREFIX}{txid}").exists()
+    assert (remote / "configuration.yaml").read_bytes() == b"default_config:\n"
+
+
+def test_rollback_needs_only_remote_transaction_and_fails_on_missing_prestate(
+    tmp_path: Path,
+) -> None:
+    root = _source_root(tmp_path)
+    remote, txid, payload = _prepare_remote(tmp_path, root)
+    component = remote / "custom_components/aurora_deploy"
+    component.mkdir()
+    (component / "legacy.py").write_bytes(b"legacy")
+    trust = remote / bootstrap.TRUST_PATH
+    trust.write_bytes(b"legacy trust")
+    # Pin this divergent prestate for the installer invocation.
+    stage_installer = (
+        remote / f"{bootstrap.STAGE_PREFIX}{txid}" / bootstrap.INSTALLER_NAME
+    )
+    stage_installer.write_text(_installer_source(remote))
+    # Invoke directly with digests matching the divergent current state.
+    tree = {
+        "exists": True,
+        "files": {"legacy.py": hashlib.sha256(b"legacy").hexdigest()},
+        "directories": [],
+    }
+    command = [
+        sys.executable,
+        str(stage_installer),
+        "install",
+        "--transaction-id",
+        txid,
+        "--expected-configuration-sha256",
+        hashlib.sha256((remote / "configuration.yaml").read_bytes()).hexdigest(),
+        "--expected-component-tree-sha256",
+        hashlib.sha256(bootstrap._canonical(tree)).hexdigest(),
+        "--expected-trust-sha256",
+        hashlib.sha256(b"legacy trust").hexdigest(),
+        "--payload-manifest-sha256",
+        payload.manifest_sha256,
+        "--expected-installer-sha256",
+        hashlib.sha256(stage_installer.read_bytes()).hexdigest(),
+        "--replace-exact",
+    ]
+    assert subprocess.run(command, check=False).returncode == 0
+    tx = remote / f"{bootstrap.TRANSACTION_PREFIX}{txid}"
+    (tx / "previous-trust").unlink()
+    shutil.rmtree(remote / f"{bootstrap.STAGE_PREFIX}{txid}")
+    current_component = {item.name: item.read_bytes() for item in component.iterdir()}
+    rollback = _run(remote, txid, payload, "rollback")
+    assert rollback.returncode == 1
+    assert "recovery_artifact_missing" in rollback.stderr
+    assert {
+        item.name: item.read_bytes() for item in component.iterdir()
+    } == current_component
+
+
+def test_recovery_rejects_remote_journal_prestate_tampering(
+    tmp_path: Path,
+) -> None:
+    root = _source_root(tmp_path)
+    remote, txid, payload = _prepare_remote(tmp_path, root)
+    assert _run(remote, txid, payload, "install").returncode == 0
+    journal_path = remote / f"{bootstrap.TRANSACTION_PREFIX}{txid}" / "transaction.json"
+    journal = json.loads(journal_path.read_text())
+    original_configuration = journal["prestate"]["configuration"]["sha256"]
+    journal["prestate"]["configuration"]["sha256"] = "f" * 64
+    journal_path.write_text(json.dumps(journal, sort_keys=True, separators=(",", ":")))
+    command = _command(remote, txid, payload, "rollback")
+    command[command.index("--expected-configuration-sha256") + 1] = (
+        original_configuration
+    )
+    rejected = subprocess.run(command, check=False, capture_output=True, text=True)
+    assert rejected.returncode == 1
+    assert "recovery_pin_mismatch" in rejected.stderr
+    assert (remote / "custom_components/aurora_deploy").is_dir()
+
+
+@pytest.mark.parametrize(
+    ("field", "replacement"),
+    (
+        ("schemaVersion", "wrong-schema"),
+        ("transactionId", str(uuid.uuid4())),
+        ("status", "unknown"),
+        ("payloadManifestSha256", 7),
+        ("replaceExact", "false"),
+    ),
+)
+def test_remote_journal_summary_validation_is_strict(
+    tmp_path: Path, field: str, replacement: Any
+) -> None:
+    root = _source_root(tmp_path)
+    remote, txid, payload = _prepare_remote(tmp_path / field, root)
+    assert _run(remote, txid, payload, "install").returncode == 0
+    journal = json.loads(
+        (
+            remote / f"{bootstrap.TRANSACTION_PREFIX}{txid}" / "transaction.json"
+        ).read_text()
+    )
+    journal[field] = replacement
+    with pytest.raises(bootstrap.BootstrapError, match="transaction_invalid"):
+        bootstrap._validated_transaction_journal(journal, txid)
+
+
+@pytest.mark.parametrize(
+    "status",
+    (
+        "installed",
+        "restart_verified",
+        "finalize_prepared",
+        "rollback_prepared",
+        "rolled_back",
+        "rolled_back_after_failure",
+        "rolled_back_after_recovery",
+        "rollback_finalize_prepared",
+    ),
+)
+def test_journal_summary_hashes_are_status_dependent(
+    tmp_path: Path, status: str
+) -> None:
+    root = _source_root(tmp_path)
+    remote, txid, payload = _prepare_remote(tmp_path / status, root)
+    assert _run(remote, txid, payload, "install").returncode == 0
+    journal = json.loads(
+        (
+            remote / f"{bootstrap.TRANSACTION_PREFIX}{txid}" / "transaction.json"
+        ).read_text()
+    )
+    journal["status"] = status
+    source = (
+        journal["installed"]
+        if status
+        in {"installed", "restart_verified", "finalize_prepared", "rollback_prepared"}
+        else journal["prestate"]
+    )
+    journal["configurationSha256"] = source["configuration"]["sha256"]
+    journal["componentTreeSha256"] = bootstrap._component_state_digest(
+        source["component"]
+    )
+    journal["trustSha256"] = source["trust"].get("sha256", "absent")
+    bootstrap._validated_transaction_journal(journal, txid)
+    journal["configurationSha256"] = "f" * 64
+    with pytest.raises(bootstrap.BootstrapError, match="transaction_invalid"):
+        bootstrap._validated_transaction_journal(journal, txid)
+
+    journal["status"] = "prepared"
+    with pytest.raises(bootstrap.BootstrapError, match="transaction_invalid"):
+        bootstrap._validated_transaction_journal(journal, txid)
+
+
+@pytest.mark.parametrize(
+    "field",
+    (
+        "installerSha256",
+        "payloadManifestSha256",
+        "prestateConfigurationSha256",
+        "prestateComponentTreeSha256",
+        "prestateTrustSha256",
+        "replaceExact",
+    ),
+)
+def test_remote_status_must_match_every_independent_local_pin(
+    field: str,
+) -> None:
+    txid = str(uuid.uuid4())
+    local = _local_record_value(txid)
+    bootstrap._write_local_record(txid, local, create=True)
+    status: dict[str, Any] = {
+        "status": "installed",
+        "transactionId": txid,
+        "transactionPresent": True,
+        "stagePresent": True,
+        "lockCandidatePresent": False,
+        "initializationPresent": False,
+        "installerSha256": local["installerSha256"],
+        "payloadManifestSha256": local["payloadManifestSha256"],
+        "prestateConfigurationSha256": local["expectedConfigurationSha256"],
+        "prestateComponentTreeSha256": local["expectedComponentTreeSha256"],
+        "prestateTrustSha256": local["expectedTrustSha256"],
+        "replaceExact": False,
+    }
+    bootstrap._bind_status_to_local(status, txid, required=True)
+    status[field] = True if field == "replaceExact" else "f" * 64
+    with pytest.raises(bootstrap.BootstrapError, match="remote_local_pin_mismatch"):
+        bootstrap._bind_status_to_local(status, txid, required=True)
+
+
+@pytest.mark.parametrize("destination", ("component", "trust", "configuration"))
+def test_rollback_rejects_and_preserves_third_state_destination_drift(
+    tmp_path: Path, destination: str
+) -> None:
+    root = _source_root(tmp_path)
+    remote, txid, payload = _prepare_remote(tmp_path / destination, root)
+    installed = _run(remote, txid, payload, "install")
+    assert installed.returncode == 0, installed.stderr
+    if destination == "component":
+        drift_path = remote / "custom_components/aurora_deploy/adapter.py"
+    elif destination == "trust":
+        drift_path = remote / bootstrap.TRUST_PATH
+    else:
+        drift_path = remote / "configuration.yaml"
+    drift = f"external-{destination}-drift\n".encode()
+    drift_path.write_bytes(drift)
+    tx = remote / f"{bootstrap.TRANSACTION_PREFIX}{txid}"
+    artifacts_before = {
+        item.relative_to(tx).as_posix(): item.read_bytes()
+        for item in tx.rglob("*")
+        if item.is_file()
+    }
+
+    rolled_back = _run(remote, txid, payload, "rollback")
+    assert rolled_back.returncode == 1
+    assert "rollback_destination_drift" in rolled_back.stderr
+    assert drift_path.read_bytes() == drift
+    assert {
+        item.relative_to(tx).as_posix(): item.read_bytes()
+        for item in tx.rglob("*")
+        if item.is_file()
+    } == artifacts_before
+    assert not (remote / ".aurora-deploy-bootstrap-global.lock").exists()
+
+
+def test_successful_rollback_can_finalize_all_recovery_artifacts(
+    tmp_path: Path,
+) -> None:
+    root = _source_root(tmp_path)
+    remote, txid, payload = _prepare_remote(tmp_path, root)
+    assert _run(remote, txid, payload, "install").returncode == 0
+    rolled_back = _run(remote, txid, payload, "rollback")
+    assert rolled_back.returncode == 0, rolled_back.stderr
+    tx = remote / f"{bootstrap.TRANSACTION_PREFIX}{txid}"
+    assert (tx / "rollback-displaced-configuration").is_file()
+
+    finalized = _run(remote, txid, payload, "finalize")
+    assert finalized.returncode == 0, finalized.stderr
+    assert not tx.exists()
+    assert not (remote / f"{bootstrap.STAGE_PREFIX}{txid}").exists()
+    assert (remote / "configuration.yaml").read_bytes() == b"default_config:\n"
+
+
+@pytest.mark.parametrize("terminal_mode", ("rollback", "finalize"))
+def test_generated_pycache_does_not_strand_recovery_or_finalize(
+    tmp_path: Path, terminal_mode: str
+) -> None:
+    root = _source_root(tmp_path)
+    remote, txid, payload = _prepare_remote(tmp_path / terminal_mode, root)
+    assert _run(remote, txid, payload, "install").returncode == 0
+    pycache = remote / "custom_components/aurora_deploy/__pycache__"
+    pycache.mkdir()
+    (pycache / "adapter.cpython-313.pyc").write_bytes(b"generated-bytecode")
+    if terminal_mode == "rollback":
+        result = _run(remote, txid, payload, "rollback")
+        assert result.returncode == 0, result.stderr
+        assert not (remote / "custom_components/aurora_deploy").exists()
+    else:
+        assert _run(remote, txid, payload, "mark-verified").returncode == 0
+        tx = remote / f"{bootstrap.TRANSACTION_PREFIX}{txid}"
+        journal_path = tx / "transaction.json"
+        journal = json.loads(journal_path.read_text())
+        journal["rollbackDeadline"] = int(time.time()) - 1
+        journal_path.write_text(
+            json.dumps(journal, sort_keys=True, separators=(",", ":"))
+        )
+        result = _run(remote, txid, payload, "finalize")
+        assert result.returncode == 0, result.stderr
+        assert not tx.exists()
+
+
+def test_finalize_requires_restart_verified_readback_and_expired_rollback_window(
+    tmp_path: Path,
+) -> None:
+    root = _source_root(tmp_path)
+    remote, txid, payload = _prepare_remote(tmp_path, root)
+    assert _run(remote, txid, payload, "install").returncode == 0
+    marked = _run(remote, txid, payload, "mark-verified")
+    assert marked.returncode == 0, marked.stderr
+    early = _run(remote, txid, payload, "finalize")
+    assert early.returncode == 1
+    assert "finalize_not_allowed" in early.stderr
+    tx = remote / f"{bootstrap.TRANSACTION_PREFIX}{txid}"
+    journal_path = tx / "transaction.json"
+    journal = json.loads(journal_path.read_text())
+    journal["rollbackDeadline"] = int(time.time()) - 1
+    journal_path.write_text(json.dumps(journal, sort_keys=True, separators=(",", ":")))
+    finalized = _run(remote, txid, payload, "finalize")
+    assert finalized.returncode == 0, finalized.stderr
+    assert not tx.exists()
+    assert not (remote / f"{bootstrap.STAGE_PREFIX}{txid}").exists()
+
+
+@pytest.mark.parametrize(
+    "failure",
+    (
+        "finalize_after_prepared",
+        "finalize_after_stage",
+        "finalize_after_release",
+        "finalize_after_tx",
+    ),
+)
+def test_finalize_crash_boundaries_never_leave_unrecoverable_lock(
+    tmp_path: Path, failure: str
+) -> None:
+    root = _source_root(tmp_path)
+    remote, txid, payload = _prepare_remote(tmp_path / failure, root)
+    installed = _run(remote, txid, payload, "install", failure=failure)
+    assert installed.returncode == 0, installed.stderr
+    marked = _run(remote, txid, payload, "mark-verified")
+    assert marked.returncode == 0, marked.stderr
+    tx = remote / f"{bootstrap.TRANSACTION_PREFIX}{txid}"
+    stage = remote / f"{bootstrap.STAGE_PREFIX}{txid}"
+    journal_path = tx / "transaction.json"
+    journal = json.loads(journal_path.read_text())
+    journal["rollbackDeadline"] = int(time.time()) - 1
+    journal_path.write_text(json.dumps(journal, sort_keys=True, separators=(",", ":")))
+
+    interrupted = _run(remote, txid, payload, "finalize")
+    assert interrupted.returncode == 1
+    assert not (remote / ".aurora-deploy-bootstrap-global.lock").exists()
+    if failure == "finalize_after_tx":
+        assert not tx.exists()
+        assert not stage.exists()
+    else:
+        assert (tx / bootstrap.INSTALLER_NAME).is_file()
+        retried = _run(remote, txid, payload, "finalize")
+        assert retried.returncode == 0, retried.stderr
+        assert json.loads(retried.stdout)["status"] == "finalized"
+        assert not tx.exists()
+        assert not stage.exists()
+
+
+@pytest.mark.asyncio
+async def test_finalize_authorization_reconciles_process_death_after_remote_commit(  # noqa: C901
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    txid = str(uuid.uuid4())
+    local = _local_record_value(txid)
+    bootstrap._write_local_record(txid, local, create=True)
+    configuration = b"verified-config\n"
+    configuration_sha = hashlib.sha256(configuration).hexdigest()
+    component_sha = "4" * 64
+    trust_sha = "5" * 64
+
+    async def open_editor(*_args: Any) -> tuple[str, str, str]:
+        return "started", "/api/hassio_ingress/fixed", "A" * 32
+
+    monkeypatch.setattr(bootstrap, "_open_editor", open_editor)
+
+    class Ingress:
+        def __init__(self) -> None:
+            self.finalized = False
+            self.execute_modes: list[str] = []
+
+        def readback(self, transaction_id: str) -> dict[str, Any]:
+            if self.finalized:
+                return {
+                    "status": "not_found",
+                    "transactionId": transaction_id,
+                    "stagePresent": False,
+                    "lockCandidatePresent": False,
+                    "transactionPresent": False,
+                    "initializationPresent": False,
+                    "lockHeld": False,
+                    "lockOwnerMatches": False,
+                    "verified": False,
+                }
+            return {
+                "status": "installed",
+                "transactionId": transaction_id,
+                "payloadManifestSha256": local["payloadManifestSha256"],
+                "installerSha256": local["installerSha256"],
+                "replaceExact": False,
+                "prestateConfigurationSha256": local["expectedConfigurationSha256"],
+                "prestateComponentTreeSha256": local["expectedComponentTreeSha256"],
+                "prestateTrustSha256": "absent",
+                "configurationSha256": configuration_sha,
+                "componentTreeSha256": component_sha,
+                "trustSha256": trust_sha,
+                "rollbackDeadline": int(time.time()) - 1,
+                "stagePresent": True,
+                "lockCandidatePresent": False,
+                "transactionPresent": True,
+                "initializationPresent": False,
+                "lockHeld": False,
+                "lockOwnerMatches": False,
+                "verified": True,
+            }
+
+        def configuration_bytes(self) -> bytes:
+            return configuration
+
+        def component_tree_sha256(self) -> str:
+            return component_sha
+
+        def trust_sha256(self) -> str:
+            return trust_sha
+
+        def execute(
+            self, *, mode: str, transaction_id: str, **_kwargs: Any
+        ) -> dict[str, Any]:
+            self.execute_modes.append(mode)
+            if mode == "mark-verified":
+                return {"status": "restart_verified", "transactionId": transaction_id}
+            self.finalized = True
+            raise RuntimeError("simulated local process death after remote finalize")
+
+    ingress = Ingress()
+
+    async def run() -> dict[str, Any]:
+        return await bootstrap.bootstrap(
+            mode="finalize",
+            source_root=tmp_path / "removed-worktree",
+            transaction_id=txid,
+            ingress_client_factory=lambda *_args: ingress,
+            config_check=lambda *_args: None,
+            component_route_check=lambda *_args: None,
+            credential_loader=_test_credentials,
+        )
+
+    with pytest.raises(bootstrap.BootstrapError, match="operation_failed"):
+        await run()
+    assert bootstrap._read_local_record(txid)["status"] == "finalize_authorized"
+    result = await run()
+    assert result == {
+        "status": "finalized",
+        "transactionId": txid,
+        "payloadManifestSha256": local["payloadManifestSha256"],
+        "reconciled": True,
+    }
+    assert await run() == result
+    assert ingress.execute_modes == ["mark-verified", "finalize"]
+
+
+def test_lost_exec_response_reconciles_from_remote_status(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = object.__new__(bootstrap.FileEditorIngressClient)
+    monkeypatch.setattr(
+        client,
+        "_stage",
+        lambda _txid, _relative="": "/homeassistant/stage/installer.py",
+    )
+    monkeypatch.setattr(
+        client,
+        "_request",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            bootstrap.BootstrapError("file_editor_transport_failure")
+        ),
+    )
+    monkeypatch.setattr(
+        client, "_download_path", lambda _path: bootstrap.INSTALLER_SOURCE
+    )
+    monkeypatch.setattr(client, "lock_candidate_exists", lambda _txid: False)
+    monkeypatch.setattr(
+        client,
+        "readback",
+        lambda txid: {
+            "status": "installed",
+            "transactionId": txid,
+            "payloadManifestSha256": "2" * 64,
+            "installerSha256": bootstrap.INSTALLER_SHA256,
+            "replaceExact": False,
+            "prestateConfigurationSha256": "0" * 64,
+            "prestateComponentTreeSha256": "1" * 64,
+            "prestateTrustSha256": "absent",
+            "stagePresent": True,
+            "lockCandidatePresent": False,
+            "transactionPresent": True,
+            "initializationPresent": False,
+            "lockHeld": False,
+            "lockOwnerMatches": False,
+            "verified": True,
+        },
+    )
+    result = client.execute(
+        mode="install",
+        transaction_id=str(uuid.uuid4()),
+        arguments={
+            "expected-configuration-sha256": "0" * 64,
+            "expected-component-tree-sha256": "1" * 64,
+            "expected-trust-sha256": "absent",
+            "payload-manifest-sha256": "2" * 64,
+            "expected-installer-sha256": bootstrap.INSTALLER_SHA256,
+        },
+    )
+    assert result["reconciled"] is True
+
+
+def test_lost_finalize_response_requires_transaction_and_lock_absent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = object.__new__(bootstrap.FileEditorIngressClient)
+    monkeypatch.setattr(
+        client,
+        "_transaction",
+        lambda _txid, _relative="": "/homeassistant/transaction/installer.py",
+    )
+    monkeypatch.setattr(
+        client,
+        "_download_path",
+        lambda _path: bootstrap.INSTALLER_SOURCE,
+    )
+    monkeypatch.setattr(
+        client,
+        "_request",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            bootstrap.BootstrapError("file_editor_transport_failure")
+        ),
+    )
+    monkeypatch.setattr(client, "lock_candidate_exists", lambda _txid: False)
+    monkeypatch.setattr(client, "transaction_exists", lambda _txid: False)
+    monkeypatch.setattr(client, "stage_exists", lambda _txid: False)
+    txid = str(uuid.uuid4())
+    monkeypatch.setattr(
+        client,
+        "readback",
+        lambda _txid: {
+            "status": "not_found",
+            "transactionId": txid,
+            "stagePresent": False,
+            "lockCandidatePresent": False,
+            "transactionPresent": False,
+            "initializationPresent": False,
+            "lockHeld": True,
+            "lockOwnerMatches": False,
+            "verified": False,
+        },
+    )
+    with pytest.raises(bootstrap.BootstrapError, match="installer_result_ambiguous"):
+        client.execute(
+            mode="finalize",
+            transaction_id=txid,
+            arguments={"expected-installer-sha256": bootstrap.INSTALLER_SHA256},
+        )
+
+    monkeypatch.setattr(
+        client,
+        "readback",
+        lambda _txid: {
+            "status": "not_found",
+            "transactionId": txid,
+            "stagePresent": False,
+            "lockCandidatePresent": False,
+            "transactionPresent": False,
+            "initializationPresent": False,
+            "lockHeld": False,
+            "lockOwnerMatches": False,
+            "verified": False,
+        },
+    )
+    assert client.execute(
+        mode="finalize",
+        transaction_id=txid,
+        arguments={"expected-installer-sha256": bootstrap.INSTALLER_SHA256},
+    ) == {
+        "status": "finalized",
+        "transactionId": txid,
+        "reconciled": True,
+    }
+
+
+@pytest.mark.parametrize(
+    ("mode", "terminal", "wrapper_kind"),
+    (
+        ("install", "installed", "nonzero"),
+        ("rollback", "rolled_back", "nonzero"),
+        ("recover-lock", "installed", "nonzero"),
+        ("finalize", "not_found", "nonzero"),
+        ("install", "installed", "malformed"),
+        ("install", "installed", "stderr"),
+        ("install", "installed", "surrogate"),
+    ),
+)
+def test_every_post_exec_unknown_outcome_uses_exact_reconciliation(
+    monkeypatch: pytest.MonkeyPatch,
+    mode: str,
+    terminal: str,
+    wrapper_kind: str,
+) -> None:
+    txid = str(uuid.uuid4())
+    client = object.__new__(bootstrap.FileEditorIngressClient)
+    monkeypatch.setattr(
+        client,
+        "_stage",
+        lambda _txid, _relative="": "/homeassistant/stage/installer.py",
+    )
+    monkeypatch.setattr(
+        client,
+        "_transaction",
+        lambda _txid, _relative="": "/homeassistant/transaction/installer.py",
+    )
+    monkeypatch.setattr(client, "transaction_exists", lambda _txid: True)
+    monkeypatch.setattr(
+        client, "_download_path", lambda _path: bootstrap.INSTALLER_SOURCE
+    )
+    wrappers = {
+        "nonzero": {"error": False, "returncode": 1, "stdout": "", "stderr": ""},
+        "malformed": {
+            "error": False,
+            "returncode": 0,
+            "stdout": "{",
+            "stderr": "",
+        },
+        "stderr": {
+            "error": False,
+            "returncode": 0,
+            "stdout": "{}",
+            "stderr": "late-wrapper-error",
+        },
+        "surrogate": {
+            "error": False,
+            "returncode": 0,
+            "stdout": "\ud800",
+            "stderr": "",
+        },
+    }
+    monkeypatch.setattr(
+        client,
+        "_request",
+        lambda *_args, **kwargs: {
+            **wrappers[wrapper_kind],
+            "message": f"Command executed: {kwargs['form']['command']}",
+        },
+    )
+    transaction_present = terminal != "not_found"
+    status: dict[str, Any] = {
+        "status": terminal,
+        "transactionId": txid,
+        "stagePresent": transaction_present,
+        "lockCandidatePresent": False,
+        "transactionPresent": transaction_present,
+        "initializationPresent": False,
+        "lockHeld": False,
+        "lockOwnerMatches": False,
+        "verified": transaction_present,
+    }
+    if transaction_present:
+        status.update(
+            {
+                "installerSha256": bootstrap.INSTALLER_SHA256,
+                "payloadManifestSha256": "2" * 64,
+                "replaceExact": False,
+                "prestateConfigurationSha256": "0" * 64,
+                "prestateComponentTreeSha256": "1" * 64,
+                "prestateTrustSha256": "absent",
+            }
+        )
+    monkeypatch.setattr(client, "readback", lambda _txid: dict(status))
+    result = client.execute(
+        mode=mode,
+        transaction_id=txid,
+        arguments={
+            "expected-configuration-sha256": "0" * 64,
+            "expected-component-tree-sha256": "1" * 64,
+            "expected-trust-sha256": "absent",
+            "payload-manifest-sha256": "2" * 64,
+            "expected-installer-sha256": bootstrap.INSTALLER_SHA256,
+        },
+    )
+    assert result["reconciled"] is True
+    assert (
+        result["status"]
+        == {
+            "install": "installed",
+            "rollback": "rolled_back",
+            "recover-lock": "lock_recovered",
+            "finalize": "finalized",
+        }[mode]
+    )
+
+
+@pytest.mark.parametrize(
+    ("mode", "terminal"),
+    (("rollback", "rolled_back"), ("recover-lock", "installed")),
+)
+def test_lost_recovery_response_preserves_true_replace_exact_pin(
+    monkeypatch: pytest.MonkeyPatch,
+    mode: str,
+    terminal: str,
+) -> None:
+    txid = str(uuid.uuid4())
+    local = _local_record_value(txid, replace_exact=True)
+    bootstrap._write_local_record(txid, local, create=True)
+    arguments = bootstrap._persist_local_request(txid, mode)
+    assert arguments["replace-exact"] is True
+
+    client = object.__new__(bootstrap.FileEditorIngressClient)
+    monkeypatch.setattr(
+        client,
+        "_transaction",
+        lambda _txid, _relative="": "/homeassistant/transaction/installer.py",
+    )
+    monkeypatch.setattr(client, "transaction_exists", lambda _txid: True)
+    monkeypatch.setattr(
+        client, "_download_path", lambda _path: bootstrap.INSTALLER_SOURCE
+    )
+    monkeypatch.setattr(
+        client,
+        "_request",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            bootstrap.BootstrapError("file_editor_transport_failure")
+        ),
+    )
+    status = {
+        "status": terminal,
+        "transactionId": txid,
+        "installerSha256": local["installerSha256"],
+        "payloadManifestSha256": local["payloadManifestSha256"],
+        "replaceExact": True,
+        "prestateConfigurationSha256": local["expectedConfigurationSha256"],
+        "prestateComponentTreeSha256": local["expectedComponentTreeSha256"],
+        "prestateTrustSha256": local["expectedTrustSha256"],
+        "stagePresent": True,
+        "lockCandidatePresent": False,
+        "transactionPresent": True,
+        "initializationPresent": False,
+        "lockHeld": False,
+        "lockOwnerMatches": False,
+        "verified": True,
+    }
+    monkeypatch.setattr(client, "readback", lambda _txid: dict(status))
+    result = client.execute(mode=mode, transaction_id=txid, arguments=arguments)
+    assert result["reconciled"] is True
+    assert result["status"] == (
+        "rolled_back" if mode == "rollback" else "lock_recovered"
+    )
+
+
+@pytest.mark.parametrize(
+    ("mismatch", "lock_owner"),
+    (("manifest", False), ("replace", False), ("lock", False), ("lock", True)),
+)
+def test_lost_response_never_accepts_request_collision_or_live_lock(
+    monkeypatch: pytest.MonkeyPatch,
+    mismatch: str,
+    lock_owner: bool,
+) -> None:
+    txid = str(uuid.uuid4())
+    client = object.__new__(bootstrap.FileEditorIngressClient)
+    monkeypatch.setattr(client, "_stage", lambda *_args: "/fixed/installer.py")
+    monkeypatch.setattr(
+        client, "_download_path", lambda _path: bootstrap.INSTALLER_SOURCE
+    )
+    monkeypatch.setattr(
+        client,
+        "_request",
+        lambda *_args, **kwargs: {
+            "error": False,
+            "message": f"Command executed: {kwargs['form']['command']}",
+            "returncode": 1,
+            "stdout": "",
+            "stderr": "",
+        },
+    )
+    status = {
+        "status": "installed",
+        "transactionId": txid,
+        "installerSha256": bootstrap.INSTALLER_SHA256,
+        "payloadManifestSha256": "f" * 64 if mismatch == "manifest" else "2" * 64,
+        "replaceExact": mismatch == "replace",
+        "prestateConfigurationSha256": "0" * 64,
+        "prestateComponentTreeSha256": "1" * 64,
+        "prestateTrustSha256": "absent",
+        "stagePresent": True,
+        "lockCandidatePresent": False,
+        "transactionPresent": True,
+        "initializationPresent": False,
+        "lockHeld": mismatch == "lock",
+        "lockOwnerMatches": lock_owner,
+        "verified": True,
+    }
+    monkeypatch.setattr(client, "readback", lambda _txid: dict(status))
+    with pytest.raises(bootstrap.BootstrapError, match="installer_result_ambiguous"):
+        client.execute(
+            mode="install",
+            transaction_id=txid,
+            arguments={
+                "expected-configuration-sha256": "0" * 64,
+                "expected-component-tree-sha256": "1" * 64,
+                "expected-trust-sha256": "absent",
+                "payload-manifest-sha256": "2" * 64,
+                "expected-installer-sha256": bootstrap.INSTALLER_SHA256,
+            },
+        )
+
+
+@pytest.mark.parametrize(
+    ("status_name", "stage", "candidate", "initialization"),
+    (
+        ("not_found", False, False, False),
+        ("staged_partial", True, False, False),
+        ("lock_candidate", False, True, False),
+        ("initializing", False, False, True),
+    ),
+)
+def test_status_exposes_and_locally_binds_exact_partial_topology(
+    monkeypatch: pytest.MonkeyPatch,
+    status_name: str,
+    stage: bool,
+    candidate: bool,
+    initialization: bool,
+) -> None:
+    txid = str(uuid.uuid4())
+    client = object.__new__(bootstrap.FileEditorIngressClient)
+    monkeypatch.setattr(client, "transaction_exists", lambda _txid: False)
+    monkeypatch.setattr(client, "stage_exists", lambda _txid: stage)
+    monkeypatch.setattr(client, "lock_candidate_exists", lambda _txid: candidate)
+    monkeypatch.setattr(client, "initialization_exists", lambda _txid: initialization)
+    monkeypatch.setattr(client, "lock_status", lambda: None)
+    status = client.status(txid)
+    assert status == {
+        "status": status_name,
+        "transactionId": txid,
+        "stagePresent": stage,
+        "lockCandidatePresent": candidate,
+        "transactionPresent": False,
+        "initializationPresent": initialization,
+        "lockHeld": False,
+        "lockOwnerMatches": False,
+    }
+    bootstrap._write_local_record(txid, _local_record_value(txid), create=True)
+    assert bootstrap._bind_status_to_local(status, txid, required=True) == status
+
+    contradictory = {**status, "stagePresent": not stage}
+    with pytest.raises(bootstrap.BootstrapError, match="remote_local_pin_mismatch"):
+        bootstrap._bind_status_to_local(contradictory, txid, required=True)
+
+
+@pytest.mark.asyncio
+async def test_read_only_status_needs_no_payload_or_stage_and_restores_addon_state(  # noqa: C901
+    tmp_path: Path,
+) -> None:
+    root = _source_root(tmp_path)
+    txid = str(uuid.uuid4())
+
+    class Socket:
+        state = "stopped"
+
+        def __init__(self, *_args: Any) -> None:
+            pass
+
+        async def __aenter__(self) -> Socket:
+            return self
+
+        async def __aexit__(self, *_args: Any) -> None:
+            return None
+
+        async def call(self, command: str, **fields: Any) -> dict[str, Any]:
+            values = _preflight_values()
+            if command == "auth/current_user":
+                return values["user"]
+            if command == "backup/info":
+                return values["backup"]
+            endpoint = fields["endpoint"]
+            if endpoint == "/supervisor/info":
+                data = values["supervisor"]
+            elif endpoint == "/host/info":
+                data = values["host"]
+            elif endpoint == f"/store/addons/{bootstrap.FILE_EDITOR_SLUG}":
+                data = values["store"]
+            elif endpoint == f"/addons/{bootstrap.FILE_EDITOR_SLUG}/info":
+                data = {**values["addon"], "state": type(self).state}
+            elif endpoint == f"/addons/{bootstrap.FILE_EDITOR_SLUG}/start":
+                type(self).state = "started"
+                data = {}
+            elif endpoint == f"/addons/{bootstrap.FILE_EDITOR_SLUG}/stop":
+                type(self).state = "stopped"
+                data = {}
+            elif endpoint == "/ingress/session":
+                data = {"session": "A" * 32}
+            else:
+                raise AssertionError(endpoint)
+            return {"result": "ok", "data": data}
+
+    class Ingress:
+        def __init__(self, *_args: Any) -> None:
+            pass
+
+        def status(self, transaction_id: str) -> dict[str, Any]:
+            return {
+                "status": "not_found",
+                "transactionId": transaction_id,
+                "lockHeld": False,
+            }
+
+    result = await bootstrap.bootstrap(
+        mode="status",
+        source_root=root,
+        transaction_id=txid,
+        socket_factory=Socket,
+        ingress_client_factory=Ingress,
+        credential_loader=_test_credentials,
+    )
+    assert result == {
+        "status": "not_found",
+        "transactionId": txid,
+        "lockHeld": False,
+    }
+    assert Socket.state == "stopped"
+
+
+@pytest.mark.asyncio
+async def test_recover_lock_verifiably_cycles_file_editor_and_repairs_crash_lease(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    state = "started"
+    actions: list[str] = []
+
+    async def snapshot(*_args: Any) -> dict[str, Any]:
+        values = _preflight_values()
+        for key in (
+            "backup_id",
+            "expected_backup_agent_id",
+            "require_backup",
+            "now",
+        ):
+            values.pop(key)
+        values["addon"]["state"] = state
+        return values
+
+    async def action(
+        _url: str, _token: str, requested: str, _socket_factory: Any
+    ) -> None:
+        nonlocal state
+        actions.append(requested)
+        state = "started" if requested == "start" else "stopped"
+
+    class Socket:
+        def __init__(self, *_args: Any) -> None:
+            pass
+
+        async def __aenter__(self) -> Socket:
+            return self
+
+        async def __aexit__(self, *_args: Any) -> None:
+            return None
+
+        async def call(self, command: str, **_fields: Any) -> dict[str, Any]:
+            assert command == "supervisor/api"
+            return {"session": "A" * 32}
+
+    monkeypatch.setattr(bootstrap, "_supervisor_snapshot", snapshot)
+    monkeypatch.setattr(bootstrap, "_addon_action", action)
+    txid = str(uuid.uuid4())
+    initial, _ingress, _session = await bootstrap._open_editor(
+        "https://ha.example.test",
+        "token",
+        None,
+        None,
+        False,
+        "recover-lock",
+        txid,
+        Socket,
+    )
+    assert initial == "started"
+    assert actions == ["stop", "start"]
+    assert state == "started"
+    assert bootstrap._read_lifecycle_lease() is None
+
+    # Simulate a hard kill after recording an originally-started recovery
+    # cycle but before the restart. The next invocation restores it first.
+    bootstrap._write_lifecycle_lease(
+        "recover-lock", txid, create=True, initial_state="started"
+    )
+    state = "stopped"
+    actions.clear()
+    initial, _ingress, _session = await bootstrap._open_editor(
+        "https://ha.example.test",
+        "token",
+        None,
+        None,
+        False,
+        "status",
+        txid,
+        Socket,
+    )
+    assert initial == "started"
+    assert actions == ["start"]
+    assert bootstrap._read_lifecycle_lease() is None
+
+    bootstrap._write_lifecycle_lease("status", txid, create=True)
+    lease = bootstrap._read_local_record(bootstrap.LIFECYCLE_RECORD_ID)
+    lease["processId"] = 1
+    bootstrap._write_local_record(bootstrap.LIFECYCLE_RECORD_ID, lease, create=False)
+    actions.clear()
+    with pytest.raises(bootstrap.BootstrapError, match="lifecycle_lease_active"):
+        await bootstrap._open_editor(
+            "https://ha.example.test",
+            "token",
+            None,
+            None,
+            False,
+            "status",
+            txid,
+            Socket,
+        )
+    assert actions == []
+
+
+@pytest.mark.asyncio
+async def test_transaction_is_persisted_before_any_remote_mutation(
+    tmp_path: Path,
+) -> None:
+    root = _source_root(tmp_path)
+    pins = _pins(root)
+    txid = str(uuid.uuid4())
+
+    class FailingSocket:
+        def __init__(self, *_args: Any) -> None:
+            raise AssertionError("factory must only run after local persistence")
+
+    with pytest.raises(bootstrap.BootstrapError, match="operation_failed"):
+        await bootstrap.bootstrap(
+            mode="install",
+            source_root=root,
+            backup_id="backup-1",
+            transaction_id=txid,
+            expected_configuration_sha256="0" * 64,
+            expected_component_tree_sha256="1" * 64,
+            expected_trust_sha256="absent",
+            expected_payload_manifest_sha256=pins["expected_manifest_sha256"],
+            expected_release_key_sha256=pins["expected_release_key_sha256"],
+            expected_validation_key_sha256=pins["expected_validation_key_sha256"],
+            expected_source_revision=pins["expected_source_revision"],
+            socket_factory=FailingSocket,
+            config_check=lambda *_args: None,
+            credential_loader=_test_credentials,
+        )
+    record = bootstrap.APPROVED_STATE_DIRECTORY / f"{txid}.json"
+    assert json.loads(record.read_text())["status"] == "prepared"
+
+
+@pytest.mark.asyncio
+async def test_partial_upload_resumes_same_exact_local_transaction(  # noqa: C901
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = _source_root(tmp_path)
+    pins = _pins(root)
+    payload = _payload(root)
+    txid = str(uuid.uuid4())
+    before = b"default_config:\n"
+    after = before + b"aurora_deploy:\n"
+    installed_tree = hashlib.sha256(
+        bootstrap._canonical(
+            {
+                "exists": True,
+                "files": {
+                    Path(item.relative_path).name: item.sha256
+                    for item in payload.files
+                    if item.relative_path.startswith("custom_components/")
+                },
+                "directories": [],
+            }
+        )
+    ).hexdigest()
+    installed_trust = next(
+        item.sha256
+        for item in payload.files
+        if item.relative_path == bootstrap.TRUST_PATH
+    )
+
+    async def open_editor(*_args: Any) -> tuple[str, str, str]:
+        return "started", "/api/hassio_ingress/fixed", "A" * 32
+
+    monkeypatch.setattr(bootstrap, "_open_editor", open_editor)
+
+    class Ingress:
+        def __init__(self) -> None:
+            self.staged: dict[str, bytes] = {}
+            self.upload_counts: dict[str, int] = {}
+            self.failed = False
+            self.installed = False
+
+        def configuration_bytes(self) -> bytes:
+            return after if self.installed else before
+
+        def component_tree_sha256(self) -> str:
+            return installed_tree if self.installed else _empty_component_digest()
+
+        def trust_sha256(self) -> str:
+            return installed_trust if self.installed else "absent"
+
+        def create_stage(self, _txid: str) -> None:
+            return None
+
+        def stage_file_exists(self, _txid: str, relative: str) -> bool:
+            return relative in self.staged
+
+        def download_stage(self, _txid: str, relative: str) -> bytes:
+            return self.staged[relative]
+
+        def upload(self, _txid: str, relative: str, content: bytes) -> None:
+            if len(self.staged) == 2 and not self.failed:
+                self.failed = True
+                raise bootstrap.BootstrapError("remote_upload_failed")
+            self.upload_counts[relative] = self.upload_counts.get(relative, 0) + 1
+            self.staged[relative] = content
+
+        def execute(
+            self, *, mode: str, transaction_id: str, **_kwargs: Any
+        ) -> dict[str, Any]:
+            assert mode == "install"
+            self.installed = True
+            return {
+                "status": "installed",
+                "transactionId": transaction_id,
+                "payloadManifestSha256": payload.manifest_sha256,
+                "configurationSha256": hashlib.sha256(after).hexdigest(),
+                "componentTreeSha256": installed_tree,
+                "trustSha256": installed_trust,
+            }
+
+    ingress = Ingress()
+
+    async def run(*, replace_exact: bool = False) -> dict[str, Any]:
+        return await bootstrap.bootstrap(
+            mode="install",
+            source_root=root,
+            backup_id="backup-1",
+            transaction_id=txid,
+            expected_configuration_sha256=hashlib.sha256(before).hexdigest(),
+            expected_component_tree_sha256=_empty_component_digest(),
+            expected_trust_sha256="absent",
+            expected_payload_manifest_sha256=pins["expected_manifest_sha256"],
+            expected_release_key_sha256=pins["expected_release_key_sha256"],
+            expected_validation_key_sha256=pins["expected_validation_key_sha256"],
+            expected_source_revision=pins["expected_source_revision"],
+            replace_exact=replace_exact,
+            ingress_client_factory=lambda *_args: ingress,
+            config_check=lambda *_args: None,
+            credential_loader=_test_credentials,
+        )
+
+    with pytest.raises(bootstrap.BootstrapError, match="remote_upload_failed"):
+        await run()
+    first_exact = dict(ingress.staged)
+    with pytest.raises(bootstrap.BootstrapError, match="local_transaction_collision"):
+        await run(replace_exact=True)
+    result = await run()
+    assert result["status"] == "installed"
+    assert all(ingress.upload_counts[name] == 1 for name in first_exact)
+    assert set(ingress.staged) == {
+        bootstrap.INSTALLER_NAME,
+        *bootstrap.PAYLOAD_PATHS,
+        bootstrap.PAYLOAD_MANIFEST_NAME,
+    }
+
+
+@pytest.mark.asyncio
+async def test_abort_uses_persisted_old_installer_when_source_checkout_is_gone(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    txid = str(uuid.uuid4())
+    old_installer = bootstrap.INSTALLER_SOURCE
+    local = _local_record_value(txid, installer=old_installer)
+    bootstrap._write_local_record(txid, local, create=True)
+    removed_source = tmp_path / "removed-source-worktree"
+    monkeypatch.setattr(bootstrap, "INSTALLER_SOURCE", b"new-current-installer")
+    monkeypatch.setattr(
+        bootstrap,
+        "INSTALLER_SHA256",
+        hashlib.sha256(b"new-current-installer").hexdigest(),
+    )
+
+    async def open_editor(*_args: Any) -> tuple[str, str, str]:
+        return "started", "/api/hassio_ingress/fixed", "A" * 32
+
+    monkeypatch.setattr(bootstrap, "_open_editor", open_editor)
+
+    class Ingress:
+        def __init__(self, *_args: Any) -> None:
+            self.files: dict[str, bytes] = {}
+
+        def transaction_exists(self, _txid: str) -> bool:
+            return False
+
+        def create_stage(self, _txid: str) -> None:
+            return None
+
+        def stage_file_exists(self, _txid: str, relative: str) -> bool:
+            return relative in self.files
+
+        def download_stage(self, _txid: str, relative: str) -> bytes:
+            return self.files[relative]
+
+        def upload(self, _txid: str, relative: str, content: bytes) -> None:
+            self.files[relative] = content
+
+        def execute(
+            self,
+            *,
+            mode: str,
+            transaction_id: str,
+            arguments: dict[str, Any],
+        ) -> dict[str, Any]:
+            assert mode == "abort-stage"
+            assert arguments["expected-installer-sha256"] == local["installerSha256"]
+            assert self.files[bootstrap.INSTALLER_NAME] == old_installer
+            return {"status": "stage_aborted", "transactionId": transaction_id}
+
+    ingress = Ingress()
+    result = await bootstrap.bootstrap(
+        mode="abort-stage",
+        source_root=removed_source,
+        transaction_id=txid,
+        ingress_client_factory=lambda *_args: ingress,
+        credential_loader=_test_credentials,
+    )
+    assert result["status"] == "stage_aborted"
+    assert ingress.files[bootstrap.INSTALLER_NAME] == old_installer
+
+
+@pytest.mark.asyncio
+async def test_invalid_prestate_config_check_has_zero_remote_or_local_mutation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = _source_root(tmp_path)
+    pins = _pins(root)
+
+    async def forbidden_open(*_args: Any) -> tuple[str, str, str]:
+        raise AssertionError("File Editor must not be opened")
+
+    monkeypatch.setattr(bootstrap, "_open_editor", forbidden_open)
+    with pytest.raises(bootstrap.BootstrapError, match="configuration_check_failed"):
+        await bootstrap.bootstrap(
+            mode="install",
+            source_root=root,
+            backup_id="backup-1",
+            transaction_id=str(uuid.uuid4()),
+            expected_configuration_sha256="0" * 64,
+            expected_component_tree_sha256="1" * 64,
+            expected_trust_sha256="absent",
+            expected_payload_manifest_sha256=pins["expected_manifest_sha256"],
+            expected_release_key_sha256=pins["expected_release_key_sha256"],
+            expected_validation_key_sha256=pins["expected_validation_key_sha256"],
+            expected_source_revision=pins["expected_source_revision"],
+            config_check=lambda *_args: (_ for _ in ()).throw(
+                bootstrap.BootstrapError("configuration_check_failed")
+            ),
+            credential_loader=_test_credentials,
+        )
+    assert not bootstrap.APPROVED_STATE_DIRECTORY.exists()
+
+
+@pytest.mark.asyncio
+async def test_failed_config_check_uses_remote_transaction_rollback(  # noqa: C901
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = _source_root(tmp_path)
+    pins = _pins(root)
+    payload = _payload(root)
+    txid = str(uuid.uuid4())
+    before = b"default_config:\n"
+    after = before + b"aurora_deploy:\n"
+    installed_tree = hashlib.sha256(
+        bootstrap._canonical(
+            {
+                "exists": True,
+                "files": {
+                    Path(item.relative_path).name: item.sha256
+                    for item in payload.files
+                    if item.relative_path.startswith("custom_components/")
+                },
+                "directories": [],
+            }
+        )
+    ).hexdigest()
+    installed_trust = next(
+        item.sha256
+        for item in payload.files
+        if item.relative_path == bootstrap.TRUST_PATH
+    )
+
+    async def open_editor(*_args: Any) -> tuple[str, str, str]:
+        return "started", "/api/hassio_ingress/fixed", "A" * 32
+
+    monkeypatch.setattr(bootstrap, "_open_editor", open_editor)
+
+    class Ingress:
+        def __init__(self, *_args: Any) -> None:
+            self.state = "prestate"
+            self.staged: dict[str, bytes] = {}
+            self.executions: list[str] = []
+
+        def configuration_bytes(self) -> bytes:
+            return before if self.state == "prestate" else after
+
+        def component_tree_sha256(self) -> str:
+            return (
+                _empty_component_digest()
+                if self.state == "prestate"
+                else installed_tree
+            )
+
+        def trust_sha256(self) -> str:
+            return "absent" if self.state == "prestate" else installed_trust
+
+        def stage_exists(self, _txid: str) -> bool:
+            return False
+
+        def stage_file_exists(self, _txid: str, relative: str) -> bool:
+            return relative in self.staged
+
+        def create_stage(self, _txid: str) -> None:
+            return None
+
+        def upload(self, _txid: str, relative: str, content: bytes) -> None:
+            self.staged[relative] = content
+
+        def download_stage(self, _txid: str, relative: str) -> bytes:
+            return self.staged[relative]
+
+        def execute(
+            self, *, mode: str, transaction_id: str, **_kwargs: Any
+        ) -> dict[str, Any]:
+            self.executions.append(mode)
+            self.state = "installed" if mode == "install" else "prestate"
+            return {
+                "status": "installed" if mode == "install" else "rolled_back",
+                "transactionId": transaction_id,
+                "payloadManifestSha256": payload.manifest_sha256,
+                "configurationSha256": hashlib.sha256(
+                    after if mode == "install" else before
+                ).hexdigest(),
+                "componentTreeSha256": (
+                    installed_tree if mode == "install" else _empty_component_digest()
+                ),
+                "trustSha256": installed_trust if mode == "install" else "absent",
+            }
+
+    ingress = Ingress()
+    checks = 0
+
+    def check(*_args: Any) -> None:
+        nonlocal checks
+        checks += 1
+        if checks == 3:
+            raise bootstrap.BootstrapError("configuration_check_failed")
+
+    with pytest.raises(bootstrap.BootstrapError, match="failed_rolled_back"):
+        await bootstrap.bootstrap(
+            mode="install",
+            source_root=root,
+            backup_id="backup-1",
+            transaction_id=txid,
+            expected_configuration_sha256=hashlib.sha256(before).hexdigest(),
+            expected_component_tree_sha256=_empty_component_digest(),
+            expected_trust_sha256="absent",
+            expected_payload_manifest_sha256=pins["expected_manifest_sha256"],
+            expected_release_key_sha256=pins["expected_release_key_sha256"],
+            expected_validation_key_sha256=pins["expected_validation_key_sha256"],
+            expected_source_revision=pins["expected_source_revision"],
+            ingress_client_factory=lambda *_args: ingress,
+            config_check=check,
+            credential_loader=_test_credentials,
+        )
+    assert ingress.executions == ["install", "rollback"]
+    assert ingress.state == "prestate"
+    assert checks == 4
+
+
+@pytest.mark.asyncio
+async def test_primary_and_lifecycle_cleanup_failures_are_safely_combined(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = _source_root(tmp_path)
+
+    async def open_editor(*_args: Any) -> tuple[str, str, str]:
+        return "stopped", "/api/hassio_ingress/fixed", "A" * 32
+
+    async def failed_cleanup(*_args: Any) -> None:
+        raise RuntimeError("sensitive cleanup detail")
+
+    monkeypatch.setattr(bootstrap, "_open_editor", open_editor)
+    monkeypatch.setattr(bootstrap, "_addon_action", failed_cleanup)
+
+    class Ingress:
+        def __init__(self, *_args: Any) -> None:
+            pass
+
+        def status(self, _txid: str) -> dict[str, Any]:
+            raise bootstrap.BootstrapError("transaction_invalid")
+
+    with pytest.raises(
+        bootstrap.BootstrapError,
+        match="operation_failed_and_file_editor_restore_failed",
+    ):
+        await bootstrap.bootstrap(
+            mode="status",
+            source_root=root,
+            transaction_id=str(uuid.uuid4()),
+            ingress_client_factory=Ingress,
+            credential_loader=_test_credentials,
+        )
+
+
+def test_cli_has_no_token_or_remote_path_command_url_arguments() -> None:
+    help_text = bootstrap._parser().format_help()
+    assert "--token" not in help_text
+    assert "remote-path" not in help_text
+    assert "--command" not in help_text
+    assert "--home-assistant-url" not in help_text

--- a/tests/src/unit/test_aurora_deploy_bootstrap.py
+++ b/tests/src/unit/test_aurora_deploy_bootstrap.py
@@ -330,10 +330,27 @@ def _preflight_values(now: datetime | None = None) -> dict[str, Any]:
         "supervisor": {
             "healthy": True,
             "supported": True,
-            "state": "running",
             "arch": "amd64",
         },
-        "host": {"arch": "amd64", "features": []},
+        "host": {
+            "deployment": "production",
+            "operating_system": "Home Assistant OS 18.2",
+            "agent_version": "1.10.0",
+            "features": [
+                "reboot",
+                "shutdown",
+                "services",
+                "network",
+                "hostname",
+                "timedate",
+                "os_agent",
+                "haos",
+                "resolved",
+                "journal",
+                "disk",
+                "mount",
+            ],
+        },
         "backup": {
             "state": "idle",
             "failed_agent_ids": [],
@@ -368,7 +385,7 @@ def _preflight_values(now: datetime | None = None) -> dict[str, Any]:
             "ingress": True,
             "ingress_entry": "/api/hassio_ingress/fixed-session",
             "host_network": False,
-            "network": {},
+            "network": None,
             "repository": "core",
         },
         "store": {
@@ -377,16 +394,123 @@ def _preflight_values(now: datetime | None = None) -> dict[str, Any]:
             "version_latest": bootstrap.FILE_EDITOR_VERSION,
             "repository": "core",
             "ingress": True,
-            "network": {},
+            "network": None,
             "arch": ["amd64"],
             "available": True,
-            "map": ["homeassistant_config:rw"],
         },
         "backup_id": "backup-1",
         "expected_backup_agent_id": bootstrap.APPROVED_BACKUP_AGENT_ID,
         "require_backup": True,
         "now": current,
     }
+
+
+def test_current_live_haos_2026_8_1_supervisor_host_schema_is_accepted() -> None:
+    values = _preflight_values()
+    # These retain the security-significant shape observed from the raw live
+    # endpoints: Supervisor omits state; Host omits both architecture fields.
+    assert "state" not in values["supervisor"]
+    assert {"arch", "architecture"}.isdisjoint(values["host"])
+    assert values["host"]["agent_version"] == "1.10.0"
+    assert values["host"]["features"] == [
+        "reboot",
+        "shutdown",
+        "services",
+        "network",
+        "hostname",
+        "timedate",
+        "os_agent",
+        "haos",
+        "resolved",
+        "journal",
+        "disk",
+        "mount",
+    ]
+    assert values["addon"]["network"] is None
+    assert values["store"]["network"] is None
+    assert "map" not in values["addon"]
+    assert "map" not in values["store"]
+    assert bootstrap.validate_supervisor_preflight(**values).startswith("/api/")
+
+
+def test_present_supervisor_state_and_architecture_remain_fail_closed() -> None:
+    wrong_state = _preflight_values()
+    wrong_state["supervisor"]["state"] = "degraded"
+    with pytest.raises(bootstrap.BootstrapError, match="supervisor_not_ready"):
+        bootstrap.validate_supervisor_preflight(**wrong_state)
+
+    null_state = _preflight_values()
+    null_state["supervisor"]["state"] = None
+    with pytest.raises(bootstrap.BootstrapError, match="supervisor_not_ready"):
+        bootstrap.validate_supervisor_preflight(**null_state)
+
+    wrong_arch = _preflight_values()
+    wrong_arch["supervisor"]["arch"] = "aarch64"
+    with pytest.raises(bootstrap.BootstrapError, match="unsupported_architecture"):
+        bootstrap.validate_supervisor_preflight(**wrong_arch)
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "error"),
+    (
+        ("deployment", "development", "host_metadata_invalid"),
+        ("operating_system", "Ubuntu 26.04", "host_metadata_invalid"),
+        ("operating_system", "Home Assistant OS ", "host_metadata_invalid"),
+        (
+            "operating_system",
+            f"Home Assistant OS 18.2{'a' * 64}",
+            "host_metadata_invalid",
+        ),
+        ("agent_version", "", "host_metadata_invalid"),
+        ("agent_version", " " * 65, "host_metadata_invalid"),
+        ("features", ["haos"], "host_metadata_invalid"),
+        ("features", ["os_agent"], "host_metadata_invalid"),
+        ("features", ["haos", "os_agent", 1], "host_metadata_invalid"),
+        ("arch", "aarch64", "unsupported_architecture"),
+        ("architecture", "armv7", "unsupported_architecture"),
+    ),
+)
+def test_host_identity_fallback_rejects_fake_or_contradictory_metadata(
+    field: str, value: Any, error: str
+) -> None:
+    values = _preflight_values()
+    values["host"][field] = value
+    with pytest.raises(bootstrap.BootstrapError, match=error):
+        bootstrap.validate_supervisor_preflight(**values)
+
+
+@pytest.mark.parametrize("field", ("arch", "architecture"))
+def test_present_amd64_host_architecture_is_accepted_as_authoritative(
+    field: str,
+) -> None:
+    values = _preflight_values()
+    values["host"] = {field: "amd64"}
+    assert bootstrap.validate_supervisor_preflight(**values).startswith("/api/")
+
+
+def test_absent_file_editor_network_fields_are_accepted() -> None:
+    values = _preflight_values()
+    values["addon"].pop("network")
+    values["store"].pop("network")
+    assert bootstrap.validate_supervisor_preflight(**values).startswith("/api/")
+
+
+@pytest.mark.parametrize(
+    ("section", "network"),
+    (
+        ("addon", {}),
+        ("store", {}),
+        ("addon", {"3218/tcp": 3218}),
+        ("store", {"3218/tcp": 3218}),
+    ),
+)
+def test_present_file_editor_network_mapping_is_rejected(
+    section: str, network: dict[str, int]
+) -> None:
+    values = _preflight_values()
+    values[section]["network"] = network
+    with pytest.raises(bootstrap.BootstrapError, match="file_editor_network_exposed"):
+        bootstrap.validate_supervisor_preflight(**values)
 
 
 def test_preflight_requires_explicit_safe_supervisor_and_strong_backup_metadata() -> (
@@ -578,6 +702,9 @@ def test_partial_stage_resume_skips_exact_files_and_rejects_conflicts(
         def create_stage(self, _txid: str) -> None:
             return None
 
+        def verify_fixed_root_write_capability(self, _txid: str) -> None:
+            return None
+
         def stage_file_exists(self, _txid: str, relative: str) -> bool:
             return relative in self.files
 
@@ -603,6 +730,108 @@ def test_partial_stage_resume_skips_exact_files_and_rejects_conflicts(
         bootstrap._stage_payload(conflict, txid, payload)
     assert conflict.files[bootstrap.SOURCE_PATHS[0]] == b"external-stage-writer"
     assert bootstrap.SOURCE_PATHS[1] not in conflict.files
+
+
+def test_fixed_root_capability_probe_is_read_back_and_cleaned(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = _file_editor_client()
+    txid = str(uuid.uuid4())
+    staged: dict[str, bytes] = {}
+    uploaded: list[str] = []
+    uploaded_content: list[bytes] = []
+
+    monkeypatch.setattr(
+        client,
+        "stage_file_exists",
+        lambda _txid, relative: relative in staged,
+    )
+    monkeypatch.setattr(
+        client,
+        "download_stage",
+        lambda _txid, relative: staged[relative],
+    )
+
+    def upload(_txid: str, relative: str, content: bytes) -> None:
+        uploaded.append(relative)
+        uploaded_content.append(content)
+        staged[relative] = content
+
+    def request(
+        endpoint: str, *, form: dict[str, str], **_kwargs: Any
+    ) -> dict[str, Any]:
+        assert endpoint == "/api/delete"
+        assert form["path"].endswith(f"/{bootstrap.CAPABILITY_PROBE_NAME}")
+        del staged[bootstrap.CAPABILITY_PROBE_NAME]
+        return {
+            "error": False,
+            "message": "Deletion successful",
+            "path": form["path"],
+        }
+
+    monkeypatch.setattr(client, "upload", upload)
+    monkeypatch.setattr(client, "_request", request)
+    client.verify_fixed_root_write_capability(txid)
+
+    assert uploaded == [bootstrap.CAPABILITY_PROBE_NAME]
+    assert staged == {}
+
+    # A crash after marker publication remains transaction-owned and resumable.
+    staged[bootstrap.CAPABILITY_PROBE_NAME] = uploaded_content[0]
+    client.verify_fixed_root_write_capability(txid)
+    assert uploaded == [
+        bootstrap.CAPABILITY_PROBE_NAME,
+        bootstrap.CAPABILITY_PROBE_NAME,
+    ]
+    assert staged == {}
+
+
+def test_missing_fixed_root_write_capability_stops_before_payload_upload(
+    tmp_path: Path,
+) -> None:
+    payload = _payload(_source_root(tmp_path))
+
+    class MissingCapabilityClient:
+        payload_upload_attempted = False
+
+        def create_stage(self, _txid: str) -> None:
+            return None
+
+        def verify_fixed_root_write_capability(self, _txid: str) -> None:
+            raise bootstrap.BootstrapError("fixed_root_write_capability_required")
+
+        def upload(self, *_args: Any) -> None:
+            self.payload_upload_attempted = True
+
+    client = MissingCapabilityClient()
+    with pytest.raises(
+        bootstrap.BootstrapError, match="fixed_root_write_capability_required"
+    ):
+        bootstrap._stage_payload(client, str(uuid.uuid4()), payload)
+    assert client.payload_upload_attempted is False
+
+
+def test_fixed_root_capability_probe_preserves_foreign_conflict(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = _file_editor_client()
+    staged = {bootstrap.CAPABILITY_PROBE_NAME: b"foreign-writer"}
+    monkeypatch.setattr(
+        client,
+        "stage_file_exists",
+        lambda _txid, relative: relative in staged,
+    )
+    monkeypatch.setattr(
+        client,
+        "download_stage",
+        lambda _txid, relative: staged[relative],
+    )
+
+    with pytest.raises(
+        bootstrap.BootstrapError, match="fixed_root_capability_conflict"
+    ):
+        client.verify_fixed_root_write_capability(str(uuid.uuid4()))
+    assert staged == {bootstrap.CAPABILITY_PROBE_NAME: b"foreign-writer"}
 
 
 def test_upload_accepts_exact_hass_configurator_0_6_0_success_schema(
@@ -2600,6 +2829,9 @@ async def test_partial_upload_resumes_same_exact_local_transaction(  # noqa: C90
         def create_stage(self, _txid: str) -> None:
             return None
 
+        def verify_fixed_root_write_capability(self, _txid: str) -> None:
+            return None
+
         def stage_file_exists(self, _txid: str, relative: str) -> bool:
             return relative in self.staged
 
@@ -2692,6 +2924,9 @@ async def test_abort_uses_persisted_old_installer_when_source_checkout_is_gone(
             return False
 
         def create_stage(self, _txid: str) -> None:
+            return None
+
+        def verify_fixed_root_write_capability(self, _txid: str) -> None:
             return None
 
         def stage_file_exists(self, _txid: str, relative: str) -> bool:
@@ -2819,6 +3054,9 @@ async def test_failed_config_check_uses_remote_transaction_rollback(  # noqa: C9
             return relative in self.staged
 
         def create_stage(self, _txid: str) -> None:
+            return None
+
+        def verify_fixed_root_write_capability(self, _txid: str) -> None:
             return None
 
         def upload(self, _txid: str, relative: str, content: bytes) -> None:

--- a/tests/src/unit/test_aurora_deploy_redteam_regressions.py
+++ b/tests/src/unit/test_aurora_deploy_redteam_regressions.py
@@ -275,10 +275,8 @@ async def test_activation_path_failure_has_no_side_effects(tmp_path, monkeypatch
         {"transactions": {transaction["transaction_id"]: transaction}},
     )
     ensure_preview = AsyncMock()
-    activate_component = Mock()
     save_asset = AsyncMock()
     monkeypatch.setattr(adapter, "_ensure_preview", ensure_preview)
-    monkeypatch.setattr(adapter, "_activate_component_package", activate_component)
     monkeypatch.setattr(adapter, "_save_preview_asset", save_asset)
 
     response = await adapter.TransactionView(state.hass, state).post(
@@ -288,7 +286,6 @@ async def test_activation_path_failure_has_no_side_effects(tmp_path, monkeypatch
     assert response.status == 500
     assert json.loads(response.body) == {"error_code": "activation_failed"}
     ensure_preview.assert_not_awaited()
-    activate_component.assert_not_called()
     save_asset.assert_not_awaited()
 
 
@@ -298,6 +295,11 @@ async def test_preview_assets_are_immutable_and_revision_specific(
 ):
     config = {"resources": []}
     dashboard = _Dashboard(config)
+    async def save_config(updated):
+        config.clear()
+        config.update(copy.deepcopy(updated))
+
+    dashboard.async_save = AsyncMock(side_effect=save_config)
     monkeypatch.setattr(
         adapter,
         "_load_dashboard",
@@ -364,6 +366,16 @@ def _promotion_fixture(tmp_path):
 
 
 def _bind_receipt_configs(receipt, preview_config, production_config):
+    dashboard_sha = receipt["dashboard_sha256"]
+    preview_config["resources"] = [
+        {
+            "url": (
+                adapter.DASHBOARD_URL_PREFIX
+                + f"aurora-preview-dashboard-{dashboard_sha}.js"
+            ),
+            "res_type": "module",
+        }
+    ]
     receipt["preview_config_sha256"] = adapter._config_sha256(preview_config)
     receipt["expected_production_config_sha256"] = adapter._config_sha256(
         production_config
@@ -379,6 +391,12 @@ async def test_promotion_journals_prepared_state_before_dashboard_save(
     production_config = {"views": [{"title": "Production"}]}
     preview = _Dashboard(preview_config)
     production = _Dashboard(production_config)
+
+    async def save_production(next_config):
+        production_config.clear()
+        production_config.update(copy.deepcopy(next_config))
+
+    production.async_save = AsyncMock(side_effect=save_production)
     _bind_receipt_configs(receipt, preview_config, production_config)
     snapshots = []
     state.save = Mock(side_effect=lambda: snapshots.append(copy.deepcopy(state.journal)))
@@ -394,6 +412,20 @@ async def test_promotion_journals_prepared_state_before_dashboard_save(
     monkeypatch.setattr(adapter, "_verify_signature", Mock())
     monkeypatch.setattr(adapter, "_verify_active_transaction", AsyncMock())
     monkeypatch.setattr(
+        adapter,
+        "_active_resource_context",
+        Mock(
+            return_value={
+                "preview_resource_url": (
+                    adapter.DASHBOARD_URL_PREFIX
+                    + f"aurora-preview-dashboard-{transaction['dashboard_sha256']}.js"
+                ),
+                "preview_resource_sha256": transaction["dashboard_sha256"],
+                "preview_resource_size": 123,
+            }
+        ),
+    )
+    monkeypatch.setattr(
         adapter, "_now", lambda: datetime(2030, 1, 1, tzinfo=UTC)
     )
 
@@ -402,6 +434,7 @@ async def test_promotion_journals_prepared_state_before_dashboard_save(
             {
                 "preview_revision": transaction["revision"],
                 "expected_production_revision": "revision-before",
+                "operation_id": "018f3f77-4d52-4cd2-9ce0-b9e9b547b101",
                 "receipt": receipt,
             }
         ),
@@ -409,8 +442,12 @@ async def test_promotion_journals_prepared_state_before_dashboard_save(
     )
 
     assert response.status == 200
-    assert snapshots[0]["production_transition"]["status"] == "prepared"
-    assert snapshots[0]["production_revision"] == "revision-before"
+    prepared = next(
+        snapshot
+        for snapshot in snapshots
+        if snapshot.get("production_transition", {}).get("status") == "prepared"
+    )
+    assert prepared["production_revision"] == "revision-before"
     assert snapshots[-1]["production_transition"]["status"] == "committed"
     assert snapshots[-1]["production_revision"] == transaction["revision"]
 
@@ -434,6 +471,20 @@ async def test_promotion_cas_rejects_stale_expected_revision(tmp_path, monkeypat
     monkeypatch.setattr(adapter, "_verify_signature", Mock())
     monkeypatch.setattr(adapter, "_verify_active_transaction", AsyncMock())
     monkeypatch.setattr(
+        adapter,
+        "_active_resource_context",
+        Mock(
+            return_value={
+                "preview_resource_url": (
+                    adapter.DASHBOARD_URL_PREFIX
+                    + f"aurora-preview-dashboard-{transaction['dashboard_sha256']}.js"
+                ),
+                "preview_resource_sha256": transaction["dashboard_sha256"],
+                "preview_resource_size": 123,
+            }
+        ),
+    )
+    monkeypatch.setattr(
         adapter, "_now", lambda: datetime(2030, 1, 1, tzinfo=UTC)
     )
 
@@ -442,6 +493,7 @@ async def test_promotion_cas_rejects_stale_expected_revision(tmp_path, monkeypat
             {
                 "preview_revision": transaction["revision"],
                 "expected_production_revision": "stale-revision",
+                "operation_id": "018f3f77-4d52-4cd2-9ce0-b9e9b547b102",
                 "receipt": {**receipt, "expected_production_revision": "stale-revision"},
             }
         ),
@@ -475,6 +527,20 @@ async def test_failed_dashboard_save_leaves_durable_prepared_transition(
     monkeypatch.setattr(adapter, "_verify_signature", Mock())
     monkeypatch.setattr(adapter, "_verify_active_transaction", AsyncMock())
     monkeypatch.setattr(
+        adapter,
+        "_active_resource_context",
+        Mock(
+            return_value={
+                "preview_resource_url": (
+                    adapter.DASHBOARD_URL_PREFIX
+                    + f"aurora-preview-dashboard-{transaction['dashboard_sha256']}.js"
+                ),
+                "preview_resource_sha256": transaction["dashboard_sha256"],
+                "preview_resource_size": 123,
+            }
+        ),
+    )
+    monkeypatch.setattr(
         adapter, "_now", lambda: datetime(2030, 1, 1, tzinfo=UTC)
     )
 
@@ -483,6 +549,7 @@ async def test_failed_dashboard_save_leaves_durable_prepared_transition(
             {
                 "preview_revision": transaction["revision"],
                 "expected_production_revision": "revision-before",
+                "operation_id": "018f3f77-4d52-4cd2-9ce0-b9e9b547b103",
                 "receipt": receipt,
             }
         ),
@@ -501,22 +568,66 @@ async def test_prepared_transition_recovers_committed_live_config(
 ):
     state, transaction, _receipt = _promotion_fixture(tmp_path)
     previous_config = {"views": [{"title": "Before"}]}
-    next_config = {"views": [{"title": "After"}]}
+    dashboard_bytes = b"recovered-dashboard"
+    dashboard_sha = hashlib.sha256(dashboard_bytes).hexdigest()
+    asset_name = f"aurora-preview-dashboard-{dashboard_sha}.js"
+    resource_url = adapter.DASHBOARD_URL_PREFIX + asset_name
+    asset_path = tmp_path / "www" / "aurora" / "revisions" / asset_name
+    asset_path.parent.mkdir(parents=True)
+    asset_path.write_bytes(dashboard_bytes)
+    next_config = {
+        "views": [{"title": "After"}],
+        "resources": [{"url": resource_url, "res_type": "module"}],
+    }
+    previous_sha = adapter._config_sha256(previous_config)
+    next_sha = adapter._config_sha256(next_config)
+    receipt_sha = "1" * 64
+    request_sha = "2" * 64
+    transaction["dashboard_sha256"] = dashboard_sha
+    transaction["active_dashboard_asset"] = asset_name
+    state.journal["production_config_sha256"] = previous_sha
+    state.journal["receipt_nonces"] = {
+        "validation-recovery-nonce": transaction["transaction_id"]
+    }
     state.journal["production_transition"] = {
         "transition_id": "promotion-recovery",
+        "operation_id": "operation-recovery",
         "status": "prepared",
         "expected_revision": "revision-before",
-        "expected_config_sha256": adapter._config_sha256(previous_config),
+        "expected_config_sha256": previous_sha,
         "to_revision": transaction["revision"],
         "transaction_id": transaction["transaction_id"],
         "receipt_nonce": "validation-recovery-nonce",
+        "receipt_sha256": receipt_sha,
+        "request_sha256": request_sha,
         "previous": {
             "revision": "revision-before",
             "config": previous_config,
-            "config_sha256": adapter._config_sha256(previous_config),
+            "config_sha256": previous_sha,
         },
         "next_config": next_config,
-        "next_config_sha256": adapter._config_sha256(next_config),
+        "next_config_sha256": next_sha,
+        "dashboard_resource_url": resource_url,
+        "dashboard_sha256": dashboard_sha,
+        "dashboard_size": len(dashboard_bytes),
+    }
+    state.journal["operations"] = {
+        "operation-recovery": {
+            "operation_id": "operation-recovery",
+            "action": "promote_home_command",
+            "status": "prepared",
+            "transaction_id": transaction["transaction_id"],
+            "preview_revision": transaction["revision"],
+            "target_revision": transaction["revision"],
+            "expected_production_revision": "revision-before",
+            "expected_production_config_sha256": previous_sha,
+            "preview_config_sha256": next_sha,
+            "receipt_sha256": receipt_sha,
+            "request_sha256": request_sha,
+            "dashboard_resource_url": resource_url,
+            "dashboard_sha256": dashboard_sha,
+            "dashboard_size": len(dashboard_bytes),
+        }
     }
     state.journal["production_recovery_required"] = True
     monkeypatch.setattr(

--- a/tests/src/unit/test_aurora_deploy_redteam_regressions.py
+++ b/tests/src/unit/test_aurora_deploy_redteam_regressions.py
@@ -1,0 +1,537 @@
+"""Red-team regressions for Aurora staged integrity and durable promotion."""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+import shutil
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from custom_components.aurora_deploy import adapter
+
+
+class _Content:
+    def __init__(self, body: dict | None = None) -> None:
+        self.raw = json.dumps(body or {}).encode()
+
+    async def read(self, _limit: int) -> bytes:
+        return self.raw
+
+
+class _Request(dict):
+    def __init__(self, body: dict | None = None) -> None:
+        super().__init__(hass_user=SimpleNamespace(is_admin=True))
+        self.content = _Content(body)
+        self.content_length = len(self.content.raw)
+
+
+class _Dashboard:
+    def __init__(self, config: dict) -> None:
+        self.config = config
+        self.async_load = AsyncMock(return_value=config)
+        self.async_save = AsyncMock()
+
+
+class _Response:
+    def __init__(self, payload: dict, status: int) -> None:
+        self.status = status
+        self.body = json.dumps(payload).encode()
+
+
+@pytest.fixture(autouse=True)
+def _standalone_web_response(monkeypatch):
+    if not hasattr(adapter.web, "json_response"):
+        monkeypatch.setattr(
+            adapter.web,
+            "json_response",
+            lambda payload, status=200: _Response(payload, status),
+            raising=False,
+        )
+
+
+def _hass(tmp_path):
+    return SimpleNamespace(
+        config=SimpleNamespace(path=lambda relative: str(tmp_path / relative)),
+        data={},
+    )
+
+
+def _staged_transaction(tmp_path) -> tuple[dict, dict[str, bytes]]:
+    manifest = {"schema_version": 1, "nonce": "redteam-nonce", "signature": "x"}
+    artifacts = {
+        "manifest.json": adapter._json_bytes(manifest),
+        "aurora-preview-package.tar.gz": b"package-bytes",
+        "aurora-preview-dashboard.js": b"dashboard-bytes",
+    }
+    hashes = {
+        "manifest_sha256": hashlib.sha256(
+            adapter._canonical_manifest(manifest)
+        ).hexdigest(),
+        "package_sha256": hashlib.sha256(
+            artifacts["aurora-preview-package.tar.gz"]
+        ).hexdigest(),
+        "dashboard_sha256": hashlib.sha256(
+            artifacts["aurora-preview-dashboard.js"]
+        ).hexdigest(),
+    }
+    revision = hashlib.sha256(
+        (
+            hashes["manifest_sha256"]
+            + hashes["package_sha256"]
+            + hashes["dashboard_sha256"]
+        ).encode()
+    ).hexdigest()[:32]
+    revision_dir = tmp_path / "staged" / revision
+    revision_dir.mkdir(parents=True)
+    for name, raw in artifacts.items():
+        (revision_dir / name).write_bytes(raw)
+    transaction = {
+        "transaction_id": "tx-redteam",
+        "revision": revision,
+        "status": "verified",
+        "target": adapter.PREVIEW,
+        "revision_dir": str(revision_dir),
+        **hashes,
+    }
+    return transaction, artifacts
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "artifact_name",
+    [
+        "manifest.json",
+        "aurora-preview-package.tar.gz",
+        "aurora-preview-dashboard.js",
+    ],
+)
+async def test_readback_rehashes_every_staged_artifact(tmp_path, artifact_name):
+    transaction, _artifacts = _staged_transaction(tmp_path)
+    (Path(transaction["revision_dir"]) / artifact_name).write_bytes(b"tampered")
+    state = adapter.AuroraState(
+        _hass(tmp_path),
+        tmp_path,
+        {"transactions": {transaction["transaction_id"]: transaction}},
+    )
+
+    response = await adapter.TransactionView(state.hass, state).get(
+        _Request(), transaction["transaction_id"], "readback"
+    )
+
+    assert response.status == 409
+    assert json.loads(response.body) == {"error_code": "staged_integrity_failed"}
+
+
+@pytest.mark.asyncio
+async def test_readback_rejects_out_of_root_legacy_revision_dir(tmp_path):
+    transaction, artifacts = _staged_transaction(tmp_path)
+    canonical = Path(transaction["revision_dir"])
+    shutil.rmtree(canonical)
+    outside = tmp_path / "outside-revision"
+    outside.mkdir()
+    for name, raw in artifacts.items():
+        (outside / name).write_bytes(raw)
+    transaction["revision_dir"] = str(outside)
+    state = adapter.AuroraState(
+        _hass(tmp_path),
+        tmp_path,
+        {"transactions": {transaction["transaction_id"]: transaction}},
+    )
+
+    response = await adapter.TransactionView(state.hass, state).get(
+        _Request(), transaction["transaction_id"], "readback"
+    )
+
+    assert response.status == 409
+    assert json.loads(response.body) == {"error_code": "staged_integrity_failed"}
+
+
+@pytest.mark.asyncio
+async def test_readback_rejects_symlinked_staged_root(tmp_path):
+    transaction, artifacts = _staged_transaction(tmp_path)
+    shutil.rmtree(tmp_path / "staged")
+    outside = tmp_path / "outside-staged"
+    revision_dir = outside / transaction["revision"]
+    revision_dir.mkdir(parents=True)
+    for name, raw in artifacts.items():
+        (revision_dir / name).write_bytes(raw)
+    (tmp_path / "staged").symlink_to(outside, target_is_directory=True)
+    state = adapter.AuroraState(
+        _hass(tmp_path),
+        tmp_path,
+        {"transactions": {transaction["transaction_id"]: transaction}},
+    )
+
+    response = await adapter.TransactionView(state.hass, state).get(
+        _Request(), transaction["transaction_id"], "readback"
+    )
+
+    assert response.status == 409
+    assert json.loads(response.body) == {"error_code": "staged_integrity_failed"}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "artifact_name",
+    [
+        "manifest.json",
+        "aurora-preview-package.tar.gz",
+        "aurora-preview-dashboard.js",
+    ],
+)
+async def test_readback_rejects_symlinked_staged_artifact(tmp_path, artifact_name):
+    transaction, _artifacts = _staged_transaction(tmp_path)
+    artifact_path = Path(transaction["revision_dir"]) / artifact_name
+    outside = tmp_path / f"outside-{artifact_name.replace('.', '-') }"
+    outside.write_bytes(artifact_path.read_bytes())
+    artifact_path.unlink()
+    artifact_path.symlink_to(outside)
+    state = adapter.AuroraState(
+        _hass(tmp_path),
+        tmp_path,
+        {"transactions": {transaction["transaction_id"]: transaction}},
+    )
+
+    response = await adapter.TransactionView(state.hass, state).get(
+        _Request(), transaction["transaction_id"], "readback"
+    )
+
+    assert response.status == 409
+    assert json.loads(response.body) == {"error_code": "staged_integrity_failed"}
+
+
+@pytest.mark.asyncio
+async def test_malformed_revision_never_falls_back_to_legacy_revision_dir(tmp_path):
+    transaction, artifacts = _staged_transaction(tmp_path)
+    shutil.rmtree(Path(transaction["revision_dir"]))
+    outside = tmp_path / "outside-malformed"
+    outside.mkdir()
+    for name, raw in artifacts.items():
+        (outside / name).write_bytes(raw)
+    transaction["revision"] = "../outside-malformed"
+    transaction["revision_dir"] = str(outside)
+    state = adapter.AuroraState(
+        _hass(tmp_path),
+        tmp_path,
+        {"transactions": {transaction["transaction_id"]: transaction}},
+    )
+
+    response = await adapter.TransactionView(state.hass, state).get(
+        _Request(), transaction["transaction_id"], "readback"
+    )
+
+    assert response.status == 409
+    assert json.loads(response.body) == {"error_code": "staged_integrity_failed"}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "artifact_name",
+    [
+        "manifest.json",
+        "aurora-preview-package.tar.gz",
+        "aurora-preview-dashboard.js",
+    ],
+)
+async def test_activation_rehashes_every_staged_artifact(
+    tmp_path, monkeypatch, artifact_name
+):
+    transaction, _artifacts = _staged_transaction(tmp_path)
+    (Path(transaction["revision_dir"]) / artifact_name).write_bytes(b"tampered")
+    state = adapter.AuroraState(
+        _hass(tmp_path),
+        tmp_path,
+        {"transactions": {transaction["transaction_id"]: transaction}},
+    )
+    ensure_preview = AsyncMock()
+    monkeypatch.setattr(adapter, "_ensure_preview", ensure_preview)
+
+    response = await adapter.TransactionView(state.hass, state).post(
+        _Request(), transaction["transaction_id"], "activate"
+    )
+
+    assert response.status == 500
+    assert json.loads(response.body) == {"error_code": "activation_failed"}
+    ensure_preview.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_activation_path_failure_has_no_side_effects(tmp_path, monkeypatch):
+    transaction, _artifacts = _staged_transaction(tmp_path)
+    artifact_path = Path(transaction["revision_dir"]) / "aurora-preview-dashboard.js"
+    outside = tmp_path / "outside-dashboard.js"
+    outside.write_bytes(artifact_path.read_bytes())
+    artifact_path.unlink()
+    artifact_path.symlink_to(outside)
+    state = adapter.AuroraState(
+        _hass(tmp_path),
+        tmp_path,
+        {"transactions": {transaction["transaction_id"]: transaction}},
+    )
+    ensure_preview = AsyncMock()
+    activate_component = Mock()
+    save_asset = AsyncMock()
+    monkeypatch.setattr(adapter, "_ensure_preview", ensure_preview)
+    monkeypatch.setattr(adapter, "_activate_component_package", activate_component)
+    monkeypatch.setattr(adapter, "_save_preview_asset", save_asset)
+
+    response = await adapter.TransactionView(state.hass, state).post(
+        _Request(), transaction["transaction_id"], "activate"
+    )
+
+    assert response.status == 500
+    assert json.loads(response.body) == {"error_code": "activation_failed"}
+    ensure_preview.assert_not_awaited()
+    activate_component.assert_not_called()
+    save_asset.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_preview_assets_are_immutable_and_revision_specific(
+    tmp_path, monkeypatch
+):
+    config = {"resources": []}
+    dashboard = _Dashboard(config)
+    monkeypatch.setattr(
+        adapter,
+        "_load_dashboard",
+        AsyncMock(return_value=(dashboard, config)),
+    )
+    hass = _hass(tmp_path)
+
+    await adapter._save_preview_asset(hass, b"revision-one")
+    first_url = config["resources"][0]["url"]
+    first_path = tmp_path / "www" / first_url.removeprefix("/local/")
+    promoted_config = copy.deepcopy(config)
+
+    await adapter._save_preview_asset(hass, b"revision-two")
+    second_url = config["resources"][0]["url"]
+
+    assert first_url != second_url
+    assert first_path.read_bytes() == b"revision-one"
+    assert promoted_config["resources"][0]["url"] == first_url
+
+
+def _promotion_fixture(tmp_path):
+    revision = "revision-promote"
+    transaction = {
+        "transaction_id": "tx-promote",
+        "revision": revision,
+        "status": "activated",
+        "manifest_sha256": "a" * 64,
+        "package_sha256": "b" * 64,
+        "dashboard_sha256": "c" * 64,
+    }
+    state = adapter.AuroraState(
+        _hass(tmp_path),
+        tmp_path,
+        {
+            "transactions": {"tx-promote": transaction},
+            "active_preview": revision,
+            "production_revision": "revision-before",
+        },
+    )
+    receipt = {
+        "schema_version": 1,
+        "preview_revision": revision,
+        "dashboard_target": adapter.PREVIEW,
+        "physical_validation": True,
+        "issued_at": datetime(2030, 1, 1, tzinfo=UTC).isoformat(),
+        "nonce": "validation-nonce-redteam-001",
+        "signer": "validation-redteam",
+        "signature": "fixture-signature",
+        "expected_production_revision": "revision-before",
+        "preview_config_sha256": "d" * 64,
+        "expected_production_config_sha256": "e" * 64,
+        "device_results": [
+            {"device_id": device, "passed": True}
+            for device in ("mobile", "kiosk", "tablet", "laptop", "desktop")
+        ],
+        "expires_at": (
+            datetime(2030, 1, 1, tzinfo=UTC) + timedelta(hours=1)
+        ).isoformat(),
+        "manifest_sha256": transaction["manifest_sha256"],
+        "package_sha256": transaction["package_sha256"],
+        "dashboard_sha256": transaction["dashboard_sha256"],
+    }
+    return state, transaction, receipt
+
+
+def _bind_receipt_configs(receipt, preview_config, production_config):
+    receipt["preview_config_sha256"] = adapter._config_sha256(preview_config)
+    receipt["expected_production_config_sha256"] = adapter._config_sha256(
+        production_config
+    )
+
+
+@pytest.mark.asyncio
+async def test_promotion_journals_prepared_state_before_dashboard_save(
+    tmp_path, monkeypatch
+):
+    state, transaction, receipt = _promotion_fixture(tmp_path)
+    preview_config = {"views": [{"title": "Preview"}]}
+    production_config = {"views": [{"title": "Production"}]}
+    preview = _Dashboard(preview_config)
+    production = _Dashboard(production_config)
+    _bind_receipt_configs(receipt, preview_config, production_config)
+    snapshots = []
+    state.save = Mock(side_effect=lambda: snapshots.append(copy.deepcopy(state.journal)))
+
+    async def load_dashboard(_hass, url_path):
+        return (
+            (preview, preview_config)
+            if url_path == adapter.PREVIEW
+            else (production, production_config)
+        )
+
+    monkeypatch.setattr(adapter, "_load_dashboard", load_dashboard)
+    monkeypatch.setattr(adapter, "_verify_signature", Mock())
+    monkeypatch.setattr(adapter, "_verify_active_transaction", AsyncMock())
+    monkeypatch.setattr(
+        adapter, "_now", lambda: datetime(2030, 1, 1, tzinfo=UTC)
+    )
+
+    response = await adapter.RootView(state.hass, state).post(
+        _Request(
+            {
+                "preview_revision": transaction["revision"],
+                "expected_production_revision": "revision-before",
+                "receipt": receipt,
+            }
+        ),
+        "promote-home-command",
+    )
+
+    assert response.status == 200
+    assert snapshots[0]["production_transition"]["status"] == "prepared"
+    assert snapshots[0]["production_revision"] == "revision-before"
+    assert snapshots[-1]["production_transition"]["status"] == "committed"
+    assert snapshots[-1]["production_revision"] == transaction["revision"]
+
+
+@pytest.mark.asyncio
+async def test_promotion_cas_rejects_stale_expected_revision(tmp_path, monkeypatch):
+    state, transaction, receipt = _promotion_fixture(tmp_path)
+    preview_config = {"views": [{"title": "Preview"}]}
+    production_config = {"views": [{"title": "Production"}]}
+    _bind_receipt_configs(receipt, preview_config, production_config)
+    monkeypatch.setattr(
+        adapter,
+        "_load_dashboard",
+        AsyncMock(
+            side_effect=[
+                (_Dashboard(preview_config), preview_config),
+                (_Dashboard(production_config), production_config),
+            ]
+        ),
+    )
+    monkeypatch.setattr(adapter, "_verify_signature", Mock())
+    monkeypatch.setattr(adapter, "_verify_active_transaction", AsyncMock())
+    monkeypatch.setattr(
+        adapter, "_now", lambda: datetime(2030, 1, 1, tzinfo=UTC)
+    )
+
+    response = await adapter.RootView(state.hass, state).post(
+        _Request(
+            {
+                "preview_revision": transaction["revision"],
+                "expected_production_revision": "stale-revision",
+                "receipt": {**receipt, "expected_production_revision": "stale-revision"},
+            }
+        ),
+        "promote-home-command",
+    )
+
+    assert response.status == 409
+    assert json.loads(response.body) == {
+        "error_code": "production_revision_conflict"
+    }
+    assert "production_transition" not in state.journal
+
+
+@pytest.mark.asyncio
+async def test_failed_dashboard_save_leaves_durable_prepared_transition(
+    tmp_path, monkeypatch
+):
+    state, transaction, receipt = _promotion_fixture(tmp_path)
+    preview_config = {"views": [{"title": "Preview"}]}
+    production_config = {"views": [{"title": "Production"}]}
+    _bind_receipt_configs(receipt, preview_config, production_config)
+    production = _Dashboard(production_config)
+    production.async_save = AsyncMock(side_effect=RuntimeError("storage failure"))
+
+    async def load_dashboard(_hass, url_path):
+        if url_path == adapter.PREVIEW:
+            return _Dashboard(preview_config), preview_config
+        return production, production_config
+
+    monkeypatch.setattr(adapter, "_load_dashboard", load_dashboard)
+    monkeypatch.setattr(adapter, "_verify_signature", Mock())
+    monkeypatch.setattr(adapter, "_verify_active_transaction", AsyncMock())
+    monkeypatch.setattr(
+        adapter, "_now", lambda: datetime(2030, 1, 1, tzinfo=UTC)
+    )
+
+    response = await adapter.RootView(state.hass, state).post(
+        _Request(
+            {
+                "preview_revision": transaction["revision"],
+                "expected_production_revision": "revision-before",
+                "receipt": receipt,
+            }
+        ),
+        "promote-home-command",
+    )
+
+    assert response.status == 500
+    assert state.journal["production_transition"]["status"] == "prepared"
+    assert state.journal["production_revision"] == "revision-before"
+    assert transaction["status"] == "activated"
+
+
+@pytest.mark.asyncio
+async def test_prepared_transition_recovers_committed_live_config(
+    tmp_path, monkeypatch
+):
+    state, transaction, _receipt = _promotion_fixture(tmp_path)
+    previous_config = {"views": [{"title": "Before"}]}
+    next_config = {"views": [{"title": "After"}]}
+    state.journal["production_transition"] = {
+        "transition_id": "promotion-recovery",
+        "status": "prepared",
+        "expected_revision": "revision-before",
+        "expected_config_sha256": adapter._config_sha256(previous_config),
+        "to_revision": transaction["revision"],
+        "transaction_id": transaction["transaction_id"],
+        "receipt_nonce": "validation-recovery-nonce",
+        "previous": {
+            "revision": "revision-before",
+            "config": previous_config,
+            "config_sha256": adapter._config_sha256(previous_config),
+        },
+        "next_config": next_config,
+        "next_config_sha256": adapter._config_sha256(next_config),
+    }
+    state.journal["production_recovery_required"] = True
+    monkeypatch.setattr(
+        adapter,
+        "_load_dashboard",
+        AsyncMock(return_value=(_Dashboard(next_config), next_config)),
+    )
+
+    await adapter._reconcile_production_transition(state.hass, state)
+
+    assert state.journal["production_transition"]["status"] == "committed"
+    assert state.journal["production_transition"]["recovered"] is True
+    assert state.journal["production_revision"] == transaction["revision"]
+    assert state.journal["production_config_sha256"] == adapter._config_sha256(
+        next_config
+    )
+    assert transaction["status"] == "promoted"
+    assert "production_recovery_required" not in state.journal

--- a/tests/src/unit/test_aurora_deploy_redteam_regressions.py
+++ b/tests/src/unit/test_aurora_deploy_redteam_regressions.py
@@ -107,6 +107,24 @@ def _staged_transaction(tmp_path) -> tuple[dict, dict[str, bytes]]:
 
 
 @pytest.mark.asyncio
+async def test_readback_accepts_untouched_staged_artifacts(tmp_path, monkeypatch):
+    transaction, _artifacts = _staged_transaction(tmp_path)
+    monkeypatch.setattr(adapter, "_verify_signature", Mock())
+    state = adapter.AuroraState(
+        _hass(tmp_path),
+        tmp_path,
+        {"transactions": {transaction["transaction_id"]: transaction}},
+    )
+
+    response = await adapter.TransactionView(state.hass, state).get(
+        _Request(), transaction["transaction_id"], "readback"
+    )
+
+    assert response.status == 200
+    assert json.loads(response.body)["status"] == "verified"
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "artifact_name",
     [
@@ -352,14 +370,14 @@ async def test_preview_assets_are_immutable_and_revision_specific(
     await adapter._save_preview_asset(hass, b"revision-one")
     first_url = config["resources"][0]["url"]
     first_path = tmp_path / "www" / first_url.removeprefix("/local/")
-    promoted_config = copy.deepcopy(config)
 
     await adapter._save_preview_asset(hass, b"revision-two")
     second_url = config["resources"][0]["url"]
+    second_path = tmp_path / "www" / second_url.removeprefix("/local/")
 
     assert first_url != second_url
     assert first_path.read_bytes() == b"revision-one"
-    assert promoted_config["resources"][0]["url"] == first_url
+    assert second_path.read_bytes() == b"revision-two"
 
 
 def _promotion_fixture(tmp_path):

--- a/tests/src/unit/test_aurora_deploy_redteam_regressions.py
+++ b/tests/src/unit/test_aurora_deploy_redteam_regressions.py
@@ -19,8 +19,12 @@ from custom_components.aurora_deploy import adapter
 class _Content:
     def __init__(self, body: dict | None = None) -> None:
         self.raw = json.dumps(body or {}).encode()
+        self._read = False
 
     async def read(self, _limit: int) -> bytes:
+        if self._read:
+            return b""
+        self._read = True
         return self.raw
 
 

--- a/tests/src/unit/test_aurora_deploy_redteam_regressions.py
+++ b/tests/src/unit/test_aurora_deploy_redteam_regressions.py
@@ -132,6 +132,44 @@ async def test_readback_rehashes_every_staged_artifact(tmp_path, artifact_name):
     assert json.loads(response.body) == {"error_code": "staged_integrity_failed"}
 
 
+def test_staged_readback_reverifies_release_signature(tmp_path, monkeypatch):
+    transaction, _artifacts = _staged_transaction(tmp_path)
+    verify_signature = Mock()
+    monkeypatch.setattr(adapter, "_verify_signature", verify_signature)
+
+    adapter._verify_staged_artifacts(
+        transaction,
+        tmp_path,
+        _hass(tmp_path),
+    )
+
+    verify_signature.assert_called_once()
+    passed_hass, document = verify_signature.call_args.args
+    assert passed_hass is not None
+    assert document["signature"] == "x"
+    assert verify_signature.call_args.kwargs == {"prefix": "release-"}
+
+
+def test_staged_artifact_quota_bounds_revision_count_and_bytes(
+    tmp_path, monkeypatch
+):
+    staged = tmp_path / "staged"
+    first = staged / "first-revision"
+    first.mkdir(parents=True)
+    (first / "manifest.json").write_bytes(b"1234")
+    monkeypatch.setattr(adapter, "MAX_STAGED_REVISIONS", 1)
+    monkeypatch.setattr(adapter, "MAX_STAGED_TOTAL_BYTES", 6)
+
+    with pytest.raises(ValueError, match="staged_capacity_exceeded"):
+        adapter._reserve_staged_capacity(tmp_path, "second-revision", 1)
+
+    monkeypatch.setattr(adapter, "MAX_STAGED_REVISIONS", 2)
+    with pytest.raises(ValueError, match="staged_capacity_exceeded"):
+        adapter._reserve_staged_capacity(tmp_path, "second-revision", 3)
+
+    adapter._reserve_staged_capacity(tmp_path, "second-revision", 2)
+
+
 @pytest.mark.asyncio
 async def test_readback_rejects_out_of_root_legacy_revision_dir(tmp_path):
     transaction, artifacts = _staged_transaction(tmp_path)

--- a/tests/src/unit/test_aurora_deploy_routes.py
+++ b/tests/src/unit/test_aurora_deploy_routes.py
@@ -198,7 +198,7 @@ def _v2_receipt(
         {
             "schema_version": 2,
             "preview_revision": inspection["preview_revision"],
-            "transaction_id": inspection["transaction_id"],
+            "transaction_id": inspection["active_preview_transaction_id"],
             "operation_id": "operation-" + nonce,
             "expected_production_revision": inspection["production_revision"],
             "preview_config_sha256": inspection["preview_config_sha256"],
@@ -1121,9 +1121,11 @@ async def test_promotion_inspection_is_non_mutating_and_promotion_requires_recei
     )
 
     assert inspection.status == 200
-    assert _payload(inspection) == {
+    inspection_payload = _payload(inspection)
+    assert inspection_payload == {
         "preview_revision": revision,
         "transaction_id": transaction["transaction_id"],
+        "active_preview_transaction_id": transaction["transaction_id"],
         "status": "activated",
         "active_revision": revision,
         "dashboard_target": adapter.PREVIEW,
@@ -1138,6 +1140,10 @@ async def test_promotion_inspection_is_non_mutating_and_promotion_requires_recei
         "verified": True,
         **resource_context,
     }
+    assert (
+        inspection_payload["active_preview_transaction_id"]
+        == inspection_payload["transaction_id"]
+    )
     production.async_save.assert_not_awaited()
     assert state.journal["production_revision"] == "revision-before"
 
@@ -1193,6 +1199,7 @@ async def test_promotion_inspection_is_non_mutating_and_promotion_requires_recei
         "verified": True,
         "dashboard_resource_present": True,
     }
+    assert "active_preview_transaction_id" not in promoted_payload
     verify_signature.assert_called_once_with(state.hass, receipt, prefix="validation-")
     production.async_save.assert_awaited_once_with(preview_config)
     assert state.journal["previous_production"] == {

--- a/tests/src/unit/test_aurora_deploy_routes.py
+++ b/tests/src/unit/test_aurora_deploy_routes.py
@@ -19,10 +19,18 @@ from custom_components.aurora_deploy import adapter
 
 class _Content:
     def __init__(self, raw: bytes) -> None:
-        self._raw = raw
+        self._chunks = [raw, b""]
+        self.read_limits: list[int] = []
 
-    async def read(self, _limit: int) -> bytes:
-        return self._raw
+    async def read(self, limit: int) -> bytes:
+        self.read_limits.append(limit)
+        return self._chunks.pop(0) if self._chunks else b""
+
+
+class _ChunkedContent(_Content):
+    def __init__(self, *chunks: bytes) -> None:
+        self._chunks = [*chunks, b""]
+        self.read_limits = []
 
 
 class _Request(dict):
@@ -74,6 +82,75 @@ def _state(tmp_path, journal: dict | None = None):
 
 def _payload(response) -> dict:
     return json.loads(response.body.decode())
+
+
+@pytest.mark.asyncio
+async def test_body_reads_chunked_signed_stage_payload_to_eof():
+    payload = {"manifest": {"signature": "x" * (600 * 1024)}}
+    raw = json.dumps(payload).encode()
+    content = _ChunkedContent(
+        raw[:73_219],
+        raw[73_219:311_111],
+        raw[311_111:],
+    )
+    request = SimpleNamespace(content=content, content_length=len(raw))
+
+    assert await adapter._body(request) == payload
+    assert len(content.read_limits) == 4
+    assert all(0 < limit <= adapter.MAX_BODY + 1 for limit in content.read_limits)
+
+
+@pytest.mark.asyncio
+async def test_body_accepts_exact_limit_and_rejects_streamed_extra_byte(monkeypatch):
+    raw = b'{"a":"123"}'
+    monkeypatch.setattr(adapter, "MAX_BODY", len(raw))
+
+    exact = SimpleNamespace(
+        content=_ChunkedContent(raw[:4], raw[4:]),
+        content_length=len(raw),
+    )
+    assert await adapter._body(exact) == {"a": "123"}
+
+    oversized_content = _ChunkedContent(raw, b"x")
+    oversized = SimpleNamespace(content=oversized_content, content_length=None)
+    assert await adapter._body(oversized) is None
+    assert len(oversized_content.read_limits) == 2
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("content_length", [True, -1, "12", object()])
+async def test_body_rejects_invalid_content_length_without_reading(content_length):
+    content = _ChunkedContent(b"{}")
+    request = SimpleNamespace(content=content, content_length=content_length)
+
+    assert await adapter._body(request) is None
+    assert content.read_limits == []
+
+
+@pytest.mark.asyncio
+async def test_body_rejects_declared_oversize_without_reading(monkeypatch):
+    monkeypatch.setattr(adapter, "MAX_BODY", 8)
+    content = _ChunkedContent(b"{}")
+    request = SimpleNamespace(content=content, content_length=9)
+
+    assert await adapter._body(request) is None
+    assert content.read_limits == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "raw",
+    [
+        b"\xff",
+        b"{",
+        b"[]",
+        b'"scalar"',
+    ],
+)
+async def test_body_rejects_malformed_or_non_object_json(raw):
+    request = SimpleNamespace(content=_ChunkedContent(raw), content_length=len(raw))
+
+    assert await adapter._body(request) is None
 
 
 def _validation_signer(state, signer: str = "validation-e2e") -> Ed25519PrivateKey:

--- a/tests/src/unit/test_aurora_deploy_routes.py
+++ b/tests/src/unit/test_aurora_deploy_routes.py
@@ -1,0 +1,759 @@
+"""Route-level tests for the fixed-scope Aurora deployment adapter."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from custom_components.aurora_deploy import adapter
+
+
+class _Content:
+    def __init__(self, raw: bytes) -> None:
+        self._raw = raw
+
+    async def read(self, _limit: int) -> bytes:
+        return self._raw
+
+
+class _Request(dict):
+    def __init__(self, body: dict | None = None, *, admin: bool = True) -> None:
+        raw = json.dumps(body or {}).encode()
+        super().__init__(hass_user=SimpleNamespace(is_admin=admin))
+        self.content = _Content(raw)
+        self.content_length = len(raw)
+
+
+class _Dashboard:
+    def __init__(self, config: dict) -> None:
+        self.config = config
+        self.async_load = AsyncMock(return_value=config)
+        self.async_save = AsyncMock()
+
+
+class _Response:
+    def __init__(self, payload: dict, status: int) -> None:
+        self.status = status
+        self.body = json.dumps(payload).encode()
+
+
+@pytest.fixture(autouse=True)
+def _standalone_web_response(monkeypatch):
+    if not hasattr(adapter.web, "json_response"):
+        monkeypatch.setattr(
+            adapter.web,
+            "json_response",
+            lambda payload, status=200: _Response(payload, status),
+            raising=False,
+        )
+
+
+def _hass(tmp_path):
+    return SimpleNamespace(
+        config=SimpleNamespace(path=lambda relative: str(tmp_path / relative)),
+        data={},
+    )
+
+
+def _state(tmp_path, journal: dict | None = None):
+    return adapter.AuroraState(_hass(tmp_path), tmp_path, journal or {})
+
+
+def _payload(response) -> dict:
+    return json.loads(response.body.decode())
+
+
+@pytest.mark.asyncio
+async def test_root_and_transaction_views_require_admin(tmp_path):
+    state = _state(tmp_path)
+    root = adapter.RootView(state.hass, state)
+    transaction = adapter.TransactionView(state.hass, state)
+    request = _Request(admin=False)
+
+    assert root.requires_auth is True
+    assert transaction.requires_auth is True
+
+    root_response = await root.post(request, "bootstrap")
+    get_response = await transaction.get(request, "tx-missing", "readback")
+    post_response = await transaction.post(request, "tx-missing", "activate")
+
+    for response in (root_response, get_response, post_response):
+        assert response.status == 403
+        assert _payload(response) == {"error_code": "admin_required"}
+
+
+@pytest.mark.asyncio
+async def test_bootstrap_rejects_existing_dashboard_metadata_collision(
+    tmp_path, monkeypatch
+):
+    state = _state(tmp_path)
+    ensure_preview = AsyncMock(side_effect=ValueError("preview_collision"))
+    monkeypatch.setattr(adapter, "_ensure_preview", ensure_preview)
+
+    response = await adapter.RootView(state.hass, state).post(
+        _Request(), "bootstrap"
+    )
+
+    assert response.status == 422
+    assert _payload(response) == {"error_code": "preview_collision"}
+    ensure_preview.assert_awaited_once_with(state.hass)
+
+
+@pytest.mark.asyncio
+async def test_bootstrap_rejects_legacy_aurora_dashboard_without_creating_a_third_target(
+    tmp_path, monkeypatch
+):
+    legacy = _Dashboard({adapter.CONF_URL_PATH: adapter.LEGACY_PREVIEW})
+    monkeypatch.setattr(
+        adapter,
+        "_dashboards",
+        AsyncMock(return_value=(SimpleNamespace(), {adapter.LEGACY_PREVIEW: legacy})),
+    )
+
+    with pytest.raises(ValueError, match="legacy_preview_collision"):
+        await adapter._ensure_preview(_hass(tmp_path))
+
+
+@pytest.mark.asyncio
+async def test_stage_persists_verified_transaction_and_rejects_nonce_replay(
+    tmp_path, monkeypatch
+):
+    state = _state(tmp_path)
+    manifest_sha = "1" * 64
+    package_sha = "2" * 64
+    dashboard_sha = "3" * 64
+    package = b"signed-package"
+    dashboard = b"export const aurora = true;"
+    manifest = {"nonce": "nonce-unique-001", "expires_at": "2099-01-01T00:00:00Z"}
+    validate = Mock(return_value=(manifest_sha, package_sha, dashboard_sha))
+    monkeypatch.setattr(adapter, "_validate_manifest", validate)
+    body = {
+        "dashboard_target": adapter.PREVIEW,
+        "preview_only": True,
+        "manifest": manifest,
+        "artifacts": {
+            "package": base64.b64encode(package).decode(),
+            "dashboard": base64.b64encode(dashboard).decode(),
+        },
+    }
+
+    view = adapter.RootView(state.hass, state)
+    staged = await view.post(_Request(body), "stage")
+
+    assert staged.status == 200
+    staged_body = _payload(staged)
+    expected_revision = hashlib.sha256(
+        (manifest_sha + package_sha + dashboard_sha).encode()
+    ).hexdigest()[:32]
+    assert staged_body["status"] == "verified"
+    assert staged_body["revision"] == expected_revision
+    assert staged_body["staged_revision"] == expected_revision
+    transaction_id = staged_body["transaction_id"]
+    transaction = state.tx(transaction_id)
+    assert transaction is not None
+    assert state.journal["nonces"][manifest["nonce"]] == transaction_id
+    revision_dir = tmp_path / "staged" / expected_revision
+    assert (revision_dir / "aurora-preview-package.tar.gz").read_bytes() == package
+    assert (revision_dir / "aurora-preview-dashboard.js").read_bytes() == dashboard
+    validate.assert_called_once_with(state.hass, manifest, package, dashboard)
+
+    replay = await view.post(_Request(body), "stage")
+
+    assert replay.status == 409
+    assert _payload(replay) == {"error_code": "manifest_replay"}
+    assert len(state.journal["transactions"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_transaction_readback_exposes_verification_hashes_only(tmp_path):
+    import hashlib
+
+    manifest = b'{"schema_version":1}'
+    package = b"package-readback"
+    dashboard = b"dashboard-readback"
+    manifest_sha = hashlib.sha256(manifest).hexdigest()
+    package_sha = hashlib.sha256(package).hexdigest()
+    dashboard_sha = hashlib.sha256(dashboard).hexdigest()
+    revision = hashlib.sha256((manifest_sha + package_sha + dashboard_sha).encode()).hexdigest()[:32]
+    revision_dir = tmp_path / "staged" / revision
+    revision_dir.mkdir(parents=True)
+    (revision_dir / "manifest.json").write_bytes(manifest)
+    (revision_dir / "aurora-preview-package.tar.gz").write_bytes(package)
+    (revision_dir / "aurora-preview-dashboard.js").write_bytes(dashboard)
+    transaction = {
+        "transaction_id": "tx-readback",
+        "revision": revision,
+        "status": "verified",
+        "manifest_sha256": manifest_sha,
+        "package_sha256": package_sha,
+        "dashboard_sha256": dashboard_sha,
+        "target": adapter.PREVIEW,
+        "revision_dir": str(revision_dir),
+    }
+    state = _state(tmp_path, {"transactions": {"tx-readback": transaction}})
+
+    response = await adapter.TransactionView(state.hass, state).get(
+        _Request(), "tx-readback", "readback"
+    )
+
+    assert response.status == 200
+    assert _payload(response) == {
+        key: transaction[key]
+        for key in (
+            "transaction_id",
+            "revision",
+            "status",
+            "manifest_sha256",
+            "package_sha256",
+            "dashboard_sha256",
+            "target",
+        )
+    } | {"verified": True}
+
+
+@pytest.mark.asyncio
+async def test_activate_revalidates_and_installs_exact_staged_revision(
+    tmp_path, monkeypatch
+):
+    manifest = {"schema_version": 1}
+    manifest_raw = adapter._json_bytes(manifest)
+    package = b"staged-package-bytes"
+    dashboard = b"staged-dashboard-bytes"
+    manifest_sha = hashlib.sha256(adapter._canonical_manifest(manifest)).hexdigest()
+    package_sha = hashlib.sha256(package).hexdigest()
+    dashboard_sha = hashlib.sha256(dashboard).hexdigest()
+    revision = hashlib.sha256(
+        (manifest_sha + package_sha + dashboard_sha).encode()
+    ).hexdigest()[:32]
+    revision_dir = tmp_path / "staged" / revision
+    revision_dir.mkdir(parents=True)
+    (revision_dir / "manifest.json").write_bytes(manifest_raw)
+    (revision_dir / "aurora-preview-package.tar.gz").write_bytes(package)
+    (revision_dir / "aurora-preview-dashboard.js").write_bytes(dashboard)
+    transaction = {
+        "transaction_id": "tx-active",
+        "revision": revision,
+        "status": "verified",
+        "manifest_sha256": manifest_sha,
+        "package_sha256": package_sha,
+        "dashboard_sha256": dashboard_sha,
+        "revision_dir": str(revision_dir),
+    }
+    state = _state(tmp_path, {"transactions": {"tx-active": transaction}})
+    validate_package = Mock()
+    component_members = {
+        filename: f"component-{filename}".encode()
+        for filename in adapter.APPROVED_COMPONENT_FILES
+    }
+    validate_package = Mock(return_value=component_members)
+    activate_component = Mock(return_value="component-binding")
+    ensure_preview = AsyncMock(return_value=(False, adapter.PREVIEW))
+    save_preview_asset = AsyncMock(
+        return_value="aurora-preview-dashboard-dashboardhash.js"
+    )
+    load_preview = AsyncMock(return_value=(_Dashboard({"views": []}), {"views": []}))
+    monkeypatch.setattr(adapter, "_validate_package", validate_package)
+    monkeypatch.setattr(adapter, "_activate_component_package", activate_component)
+    monkeypatch.setattr(adapter, "_ensure_preview", ensure_preview)
+    monkeypatch.setattr(adapter, "_save_preview_asset", save_preview_asset)
+    monkeypatch.setattr(adapter, "_load_dashboard", load_preview)
+
+    response = await adapter.TransactionView(state.hass, state).post(
+        _Request(), "tx-active", "activate"
+    )
+
+    assert response.status == 200
+    assert _payload(response) == {
+        "activated": True,
+        "active_revision": revision,
+        "status": "activated",
+    }
+    validate_package.assert_called_once_with(package)
+    activate_component.assert_called_once_with(
+        state.hass, state, transaction, component_members
+    )
+    ensure_preview.assert_awaited_once_with(state.hass)
+    save_preview_asset.assert_awaited_once_with(state.hass, dashboard)
+    assert state.journal["active_preview"] == revision
+    assert transaction["status"] == "activated"
+    assert "activated_at" in transaction
+
+
+def test_component_activation_is_fixed_scope_and_rollback_restores_prestate(tmp_path):
+    state = _state(tmp_path)
+    transaction = {"transaction_id": "tx-component-fixed-scope"}
+    destination = tmp_path / "custom_components" / adapter.COMPONENT_DOMAIN
+    destination.mkdir(parents=True)
+    (destination / "legacy.py").write_bytes(b"legacy")
+    members = {
+        filename: f"candidate-{filename}".encode()
+        for filename in adapter.APPROVED_COMPONENT_FILES
+    }
+
+    binding = adapter._activate_component_package(
+        state.hass, state, transaction, members
+    )
+
+    assert binding == adapter._component_binding(members)
+    assert {path.name for path in destination.iterdir()} == set(
+        adapter.APPROVED_COMPONENT_FILES
+    )
+    assert all(
+        (destination / filename).read_bytes() == data
+        for filename, data in members.items()
+    )
+
+    adapter._restore_component_prestate(state.hass, state, transaction)
+
+    assert {path.name for path in destination.iterdir()} == {"legacy.py"}
+    assert (destination / "legacy.py").read_bytes() == b"legacy"
+    assert transaction["component_activation_attempt"] == 1
+
+    adapter._activate_component_package(state.hass, state, transaction, members)
+    assert transaction["component_activation_attempt"] == 2
+    adapter._restore_component_prestate(state.hass, state, transaction)
+    assert (destination / "legacy.py").read_bytes() == b"legacy"
+
+
+@pytest.mark.asyncio
+async def test_dashboard_activation_failure_restores_component_and_is_retryable(
+    tmp_path, monkeypatch
+):
+    manifest = {"schema_version": 1}
+    manifest_raw = adapter._json_bytes(manifest)
+    package = b"retry-package"
+    dashboard = b"retry-dashboard"
+    manifest_sha = hashlib.sha256(adapter._canonical_manifest(manifest)).hexdigest()
+    package_sha = hashlib.sha256(package).hexdigest()
+    dashboard_sha = hashlib.sha256(dashboard).hexdigest()
+    revision = hashlib.sha256(
+        (manifest_sha + package_sha + dashboard_sha).encode()
+    ).hexdigest()[:32]
+    revision_dir = tmp_path / "staged" / revision
+    revision_dir.mkdir(parents=True)
+    (revision_dir / "manifest.json").write_bytes(manifest_raw)
+    (revision_dir / "aurora-preview-package.tar.gz").write_bytes(package)
+    (revision_dir / "aurora-preview-dashboard.js").write_bytes(dashboard)
+    transaction = {
+        "transaction_id": "tx-activation-retry",
+        "revision": revision,
+        "status": "verified",
+        "manifest_sha256": manifest_sha,
+        "package_sha256": package_sha,
+        "dashboard_sha256": dashboard_sha,
+        "revision_dir": str(revision_dir),
+    }
+    state = _state(
+        tmp_path,
+        {"transactions": {transaction["transaction_id"]: transaction}},
+    )
+    destination = tmp_path / "custom_components" / adapter.COMPONENT_DOMAIN
+    destination.mkdir(parents=True)
+    (destination / "legacy.py").write_bytes(b"legacy")
+    members = {
+        filename: f"retry-{filename}".encode()
+        for filename in adapter.APPROVED_COMPONENT_FILES
+    }
+    preview = _Dashboard({"resources": []})
+    monkeypatch.setattr(adapter, "_validate_package", Mock(return_value=members))
+    monkeypatch.setattr(adapter, "_ensure_preview", AsyncMock())
+    monkeypatch.setattr(
+        adapter,
+        "_load_dashboard",
+        AsyncMock(return_value=(preview, {"resources": []})),
+    )
+    save_asset = AsyncMock(
+        side_effect=[
+            RuntimeError("dashboard-save-failed"),
+            "aurora-preview-dashboard-retry.js",
+        ]
+    )
+    monkeypatch.setattr(adapter, "_save_preview_asset", save_asset)
+    view = adapter.TransactionView(state.hass, state)
+
+    failed = await view.post(
+        _Request(), transaction["transaction_id"], "activate"
+    )
+
+    assert failed.status == 500
+    assert transaction["status"] == "verified"
+    assert (destination / "legacy.py").read_bytes() == b"legacy"
+    assert transaction["component_activation_attempt"] == 1
+
+    retried = await view.post(
+        _Request(), transaction["transaction_id"], "activate"
+    )
+
+    assert retried.status == 200
+    assert transaction["status"] == "activated"
+    assert transaction["component_activation_attempt"] == 2
+    assert all(
+        (destination / filename).read_bytes() == data
+        for filename, data in members.items()
+    )
+
+
+@pytest.mark.asyncio
+async def test_active_readback_binds_component_bytes_and_dashboard_resource(
+    tmp_path, monkeypatch
+):
+    manifest = {"schema_version": 1}
+    manifest_raw = adapter._json_bytes(manifest)
+    package = b"bound-package"
+    dashboard_bytes = b"bound-dashboard"
+    manifest_sha = hashlib.sha256(adapter._canonical_manifest(manifest)).hexdigest()
+    package_sha = hashlib.sha256(package).hexdigest()
+    dashboard_sha = hashlib.sha256(dashboard_bytes).hexdigest()
+    revision = hashlib.sha256(
+        (manifest_sha + package_sha + dashboard_sha).encode()
+    ).hexdigest()[:32]
+    revision_dir = tmp_path / "staged" / revision
+    revision_dir.mkdir(parents=True)
+    (revision_dir / "manifest.json").write_bytes(manifest_raw)
+    (revision_dir / "aurora-preview-package.tar.gz").write_bytes(package)
+    (revision_dir / "aurora-preview-dashboard.js").write_bytes(dashboard_bytes)
+
+    members = {
+        filename: f"bound-{filename}".encode()
+        for filename in adapter.APPROVED_COMPONENT_FILES
+    }
+    component_root = tmp_path / "custom_components" / adapter.COMPONENT_DOMAIN
+    component_root.mkdir(parents=True)
+    for filename, data in members.items():
+        (component_root / filename).write_bytes(data)
+    asset_name = f"aurora-preview-dashboard-{dashboard_sha}.js"
+    asset_path = tmp_path / "www" / "aurora" / "revisions" / asset_name
+    asset_path.parent.mkdir(parents=True)
+    asset_path.write_bytes(dashboard_bytes)
+    dashboard_config = {
+        "resources": [
+            {
+                "url": adapter.DASHBOARD_URL_PREFIX + asset_name,
+                "res_type": "module",
+            }
+        ]
+    }
+    transaction = {
+        "transaction_id": "tx-active-readback",
+        "revision": revision,
+        "status": "activated",
+        "manifest_sha256": manifest_sha,
+        "package_sha256": package_sha,
+        "dashboard_sha256": dashboard_sha,
+        "target": adapter.PREVIEW,
+        "revision_dir": str(revision_dir),
+        "component_binding_sha256": adapter._component_binding(members),
+        "active_dashboard_asset": asset_name,
+    }
+    state = _state(
+        tmp_path,
+        {"transactions": {transaction["transaction_id"]: transaction}},
+    )
+    monkeypatch.setattr(adapter, "_validate_package", Mock(return_value=members))
+    monkeypatch.setattr(
+        adapter,
+        "_load_dashboard",
+        AsyncMock(return_value=(_Dashboard(dashboard_config), dashboard_config)),
+    )
+
+    response = await adapter.TransactionView(state.hass, state).get(
+        _Request(), transaction["transaction_id"], "readback"
+    )
+
+    assert response.status == 200
+    payload = _payload(response)
+    assert payload["active_package_sha256"] == adapter._component_binding(members)
+    assert payload["active_package_verified"] is True
+    assert payload["active_dashboard_verified"] is True
+
+    (component_root / "coordinator.py").write_bytes(b"tampered")
+    tampered = await adapter.TransactionView(state.hass, state).get(
+        _Request(), transaction["transaction_id"], "readback"
+    )
+    assert tampered.status == 409
+    assert _payload(tampered) == {"error_code": "active_integrity_failed"}
+
+
+@pytest.mark.asyncio
+async def test_promotion_inspection_is_non_mutating_and_promotion_requires_receipt(
+    tmp_path, monkeypatch
+):
+    revision = "revision-promote"
+    transaction = {
+        "transaction_id": "tx-promote",
+        "revision": revision,
+        "status": "activated",
+        "manifest_sha256": "a" * 64,
+        "package_sha256": "b" * 64,
+        "dashboard_sha256": "c" * 64,
+    }
+    state = _state(
+        tmp_path,
+        {
+            "transactions": {"tx-promote": transaction},
+            "active_preview": revision,
+            "production_revision": "revision-before",
+        },
+    )
+    preview_config = {"views": [{"title": "Verified preview"}]}
+    production_config = {"views": [{"title": "Current production"}]}
+    preview = _Dashboard(preview_config)
+    production = _Dashboard(production_config)
+
+    async def load_dashboard(_hass, url_path):
+        if url_path == adapter.PREVIEW:
+            return preview, preview_config
+        assert url_path == adapter.PRODUCTION
+        return production, production_config
+
+    verify_signature = Mock()
+    now = datetime(2030, 1, 1, tzinfo=UTC)
+    monkeypatch.setattr(adapter, "_load_dashboard", load_dashboard)
+    monkeypatch.setattr(adapter, "_verify_signature", verify_signature)
+    monkeypatch.setattr(adapter, "_verify_active_transaction", AsyncMock())
+    monkeypatch.setattr(adapter, "_now", lambda: now)
+    view = adapter.RootView(state.hass, state)
+
+    inspection = await view.post(
+        _Request({"preview_revision": revision, "inspect": True}),
+        "promote-home-command",
+    )
+
+    assert inspection.status == 200
+    assert _payload(inspection) == {
+        "preview_revision": revision,
+        "status": "activated",
+        "active_revision": revision,
+        "target_dashboard": adapter.PRODUCTION,
+        "preview_config_sha256": adapter._config_sha256(preview_config),
+        "production_revision": "revision-before",
+        "expected_production_config_sha256": adapter._config_sha256(production_config),
+        "verified": True,
+    }
+    production.async_save.assert_not_awaited()
+    assert state.journal["production_revision"] == "revision-before"
+
+    missing_receipt = await view.post(
+        _Request({"preview_revision": revision}), "promote-home-command"
+    )
+    assert missing_receipt.status == 422
+    assert _payload(missing_receipt) == {
+        "error_code": "validation_receipt_required"
+    }
+
+    receipt = {
+        "schema_version": 1,
+        "preview_revision": revision,
+        "dashboard_target": adapter.PREVIEW,
+        "physical_validation": True,
+        "issued_at": now.isoformat(),
+        "nonce": "validation-nonce-route-001",
+        "signer": "validation-route",
+        "signature": "fixture-signature",
+        "expected_production_revision": "revision-before",
+        "preview_config_sha256": adapter._config_sha256(preview_config),
+        "expected_production_config_sha256": adapter._config_sha256(
+            production_config
+        ),
+        "device_results": [
+            {"device_id": device, "passed": True}
+            for device in ("mobile", "kiosk", "tablet", "laptop", "desktop")
+        ],
+        "expires_at": (now + timedelta(hours=1)).isoformat(),
+        "manifest_sha256": transaction["manifest_sha256"],
+        "package_sha256": transaction["package_sha256"],
+        "dashboard_sha256": transaction["dashboard_sha256"],
+    }
+    promoted = await view.post(
+        _Request(
+            {
+                "preview_revision": revision,
+                "expected_production_revision": "revision-before",
+                "receipt": receipt,
+            }
+        ),
+        "promote-home-command",
+    )
+
+    assert promoted.status == 200
+    assert _payload(promoted) == {
+        "promoted": True,
+        "active_revision": revision,
+        "previous_revision": "revision-before",
+        "preview_config_sha256": adapter._config_sha256(preview_config),
+        "expected_production_config_sha256": adapter._config_sha256(production_config),
+    }
+    verify_signature.assert_called_once_with(
+        state.hass, receipt, prefix="validation-"
+    )
+    production.async_save.assert_awaited_once_with(preview_config)
+    assert state.journal["previous_production"] == {
+        "revision": "revision-before",
+        "config": production_config,
+        "config_sha256": adapter._config_sha256(production_config),
+    }
+    assert state.journal["production_revision"] == revision
+    assert state.journal["production_config_sha256"] == adapter._config_sha256(
+        preview_config
+    )
+    assert transaction["status"] == "promoted"
+
+
+@pytest.mark.asyncio
+async def test_promotion_inspection_fails_when_active_bytes_are_not_verified(
+    tmp_path, monkeypatch
+):
+    revision = "revision-inspection-tampered"
+    transaction = {
+        "transaction_id": "tx-inspection-tampered",
+        "revision": revision,
+        "status": "activated",
+    }
+    state = _state(
+        tmp_path,
+        {
+            "transactions": {transaction["transaction_id"]: transaction},
+            "active_preview": revision,
+        },
+    )
+    monkeypatch.setattr(
+        adapter,
+        "_verify_active_transaction",
+        AsyncMock(side_effect=ValueError("tampered")),
+    )
+
+    response = await adapter.RootView(state.hass, state).post(
+        _Request({"preview_revision": revision, "inspect": True}),
+        "promote-home-command",
+    )
+
+    assert response.status == 409
+    assert _payload(response) == {"error_code": "preview_integrity_failed"}
+
+
+@pytest.mark.asyncio
+async def test_rollback_restores_and_rotates_immediate_prior_production(
+    tmp_path, monkeypatch
+):
+    prior_config = {"views": [{"title": "Prior production"}]}
+    current_config = {"views": [{"title": "Current production"}]}
+    production = _Dashboard(current_config)
+    state = _state(
+        tmp_path,
+        {
+            "production_revision": "revision-current",
+            "production_config_sha256": adapter._config_sha256(current_config),
+            "previous_production": {
+                "revision": "revision-prior",
+                "config": prior_config,
+                "config_sha256": adapter._config_sha256(prior_config),
+            },
+        },
+    )
+    load_dashboard = AsyncMock(return_value=(production, current_config))
+    monkeypatch.setattr(adapter, "_load_dashboard", load_dashboard)
+
+    response = await adapter.RootView(state.hass, state).post(
+        _Request(), "rollback-home-command"
+    )
+
+    assert response.status == 200
+    assert _payload(response) == {
+        "rolled_back": True,
+        "active_revision": "revision-prior",
+    }
+    load_dashboard.assert_awaited_once_with(state.hass, adapter.PRODUCTION)
+    production.async_save.assert_awaited_once_with(prior_config)
+    assert state.journal["production_revision"] == "revision-prior"
+    assert state.journal["production_config_sha256"] == adapter._config_sha256(
+        prior_config
+    )
+    assert state.journal["previous_production"] is None
+
+    repeated = await adapter.RootView(state.hass, state).post(
+        _Request(), "rollback-home-command"
+    )
+    assert repeated.status == 409
+    assert _payload(repeated) == {"error_code": "no_prior_production_revision"}
+
+
+def test_corrupt_journal_fails_closed(tmp_path):
+    root = tmp_path / ".storage" / "aurora_deploy_preview"
+    root.mkdir(parents=True)
+    (root / "journal.json").write_text("{not-json", encoding="utf-8")
+
+    with pytest.raises(RuntimeError, match="aurora_deploy_journal_corrupt"):
+        adapter.AuroraState._create_sync(_hass(tmp_path))
+
+
+@pytest.mark.asyncio
+async def test_request_rate_limit_fails_closed(tmp_path):
+    state = _state(tmp_path)
+    state.request_times.extend([adapter.time.monotonic()] * adapter.MAX_REQUESTS_PER_MINUTE)
+
+    response = await adapter.RootView(state.hass, state).post(_Request(), "bootstrap")
+
+    assert response.status == 429
+    assert _payload(response) == {"error_code": "rate_limited"}
+
+
+@pytest.mark.asyncio
+async def test_transaction_rollback_restores_preview_snapshot(tmp_path, monkeypatch):
+    transaction = {
+        "transaction_id": "tx-preview-rollback",
+        "revision": "revision-preview",
+        "status": "activated",
+        "preview_before": {"views": [{"title": "Before"}]},
+        "preview_revision_before": "revision-before-preview",
+    }
+    state = _state(
+        tmp_path,
+        {
+            "transactions": {transaction["transaction_id"]: transaction},
+            "active_preview": transaction["revision"],
+        },
+    )
+    preview = _Dashboard({"views": [{"title": "After"}]})
+    monkeypatch.setattr(
+        adapter,
+        "_load_dashboard",
+        AsyncMock(return_value=(preview, {"views": [{"title": "After"}]})),
+    )
+
+    response = await adapter.TransactionView(state.hass, state).post(
+        _Request(), transaction["transaction_id"], "rollback"
+    )
+
+    assert response.status == 200
+    assert _payload(response) == {
+        "rolled_back": True,
+        "active_revision": "revision-before-preview",
+        "preview_active": True,
+        "status": "rolled_back",
+    }
+    preview.async_save.assert_awaited_once_with(transaction["preview_before"])
+    assert state.journal["active_preview"] == "revision-before-preview"
+    assert transaction["status"] == "rolled_back"
+
+
+@pytest.mark.asyncio
+async def test_reload_without_registered_backend_fails_closed(tmp_path):
+    transaction = {
+        "transaction_id": "tx-reload",
+        "revision": "revision-reload",
+        "status": "activated",
+    }
+    state = _state(tmp_path, {"transactions": {transaction["transaction_id"]: transaction}})
+
+    response = await adapter.TransactionView(state.hass, state).post(
+        _Request(), transaction["transaction_id"], "reload"
+    )
+
+    assert response.status == 409
+    assert _payload(response) == {"error_code": "restart_required"}

--- a/tests/src/unit/test_aurora_deploy_routes.py
+++ b/tests/src/unit/test_aurora_deploy_routes.py
@@ -872,6 +872,14 @@ async def test_transaction_readback_reconciles_lost_preview_outcome_without_resa
     assert transaction[transition_key]["status"] == (
         "committed" if applied else "aborted"
     )
+    if transition_kind == "rollback" and applied:
+        assert payload["dashboard_resource_present"] is True
+        assert payload["active_dashboard_verified"] is True
+        assert payload["active_dashboard_resource_url"] == (
+            adapter.DASHBOARD_URL_PREFIX + prior_asset_name
+        )
+        assert payload["active_dashboard_sha256"] == prior_dashboard_sha
+        assert payload["active_dashboard_size"] == len(prior_dashboard)
     assert preview.async_save.await_count == 0
     assert state.save.call_count == 1
 

--- a/tests/src/unit/test_aurora_deploy_routes.py
+++ b/tests/src/unit/test_aurora_deploy_routes.py
@@ -1062,6 +1062,7 @@ async def test_transaction_readback_reconciles_lost_preview_outcome_without_resa
     assert transaction[transition_key]["status"] == (
         "committed" if applied else "aborted"
     )
+    assert "dashboard_resource_present" in payload
     if transition_kind == "rollback" and applied:
         assert payload["dashboard_resource_present"] is True
         assert payload["active_dashboard_verified"] is True
@@ -1070,6 +1071,14 @@ async def test_transaction_readback_reconciles_lost_preview_outcome_without_resa
         )
         assert payload["active_dashboard_sha256"] == prior_dashboard_sha
         assert payload["active_dashboard_size"] == len(prior_dashboard)
+    if transition_kind == "activate" and applied:
+        assert payload["dashboard_resource_present"] is True
+        assert payload["active_dashboard_verified"] is True
+        assert payload["active_dashboard_resource_url"] == (
+            adapter.DASHBOARD_URL_PREFIX + asset_name
+        )
+        assert payload["active_dashboard_sha256"] == dashboard_sha
+        assert payload["active_dashboard_size"] == len(dashboard)
     assert preview.async_save.await_count == 0
     assert state.save.call_count == 1
 

--- a/tests/src/unit/test_aurora_deploy_routes.py
+++ b/tests/src/unit/test_aurora_deploy_routes.py
@@ -237,6 +237,98 @@ async def test_bootstrap_rejects_existing_dashboard_metadata_collision(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("title", "icon"),
+    [
+        ("Aurora Preview", "mdi:aurora"),
+        ("Aurora V9 Preview", "mdi:home-analytics"),
+    ],
+)
+async def test_bootstrap_accepts_closed_preview_metadata_compatibility_without_mutation(
+    tmp_path, monkeypatch, title, icon
+):
+    state = _state(tmp_path)
+    metadata = {
+        adapter.CONF_URL_PATH: adapter.PREVIEW,
+        adapter.CONF_TITLE: title,
+        adapter.CONF_ICON: icon,
+        adapter.CONF_SHOW_IN_SIDEBAR: False,
+        adapter.CONF_REQUIRE_ADMIN: True,
+    }
+    existing = _Dashboard(metadata)
+    dashboards = {adapter.PREVIEW: existing}
+    monkeypatch.setattr(
+        adapter,
+        "_dashboards",
+        AsyncMock(return_value=(SimpleNamespace(), dashboards)),
+    )
+
+    response = await adapter.RootView(state.hass, state).post(_Request(), "bootstrap")
+
+    assert response.status == 200
+    assert _payload(response) == {
+        "dashboard_target": adapter.PREVIEW,
+        "created": False,
+        "production_unchanged": True,
+    }
+    assert existing.config == metadata
+    existing.async_save.assert_not_awaited()
+    assert dashboards == {adapter.PREVIEW: existing}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("title", "icon", "url_path", "show_in_sidebar", "require_admin"),
+    [
+        ("Aurora Preview (drift)", "mdi:aurora", adapter.PREVIEW, False, True),
+        ("Aurora Preview", "mdi:weather-sunny", adapter.PREVIEW, False, True),
+        ("Aurora V9 Preview", "mdi:aurora", adapter.PREVIEW, False, True),
+        ("Aurora Preview", "mdi:aurora", adapter.PREVIEW, True, True),
+        ("Aurora V9 Preview", "mdi:home-analytics", adapter.PREVIEW, False, False),
+        (
+            "Aurora V9 Preview",
+            "mdi:home-analytics",
+            "aurora-preview-copy",
+            False,
+            True,
+        ),
+    ],
+)
+async def test_bootstrap_rejects_preview_metadata_outside_closed_compatibility(
+    tmp_path,
+    monkeypatch,
+    title,
+    icon,
+    url_path,
+    show_in_sidebar,
+    require_admin,
+):
+    state = _state(tmp_path)
+    metadata = {
+        adapter.CONF_URL_PATH: url_path,
+        adapter.CONF_TITLE: title,
+        adapter.CONF_ICON: icon,
+        adapter.CONF_SHOW_IN_SIDEBAR: show_in_sidebar,
+        adapter.CONF_REQUIRE_ADMIN: require_admin,
+    }
+    existing = _Dashboard(metadata)
+    dashboards = {adapter.PREVIEW: existing}
+    monkeypatch.setattr(
+        adapter,
+        "_dashboards",
+        AsyncMock(return_value=(SimpleNamespace(), dashboards)),
+    )
+
+    response = await adapter.RootView(state.hass, state).post(_Request(), "bootstrap")
+
+    assert response.status == 422
+    assert _payload(response) == {"error_code": "preview_collision"}
+    assert existing.config == metadata
+    existing.async_save.assert_not_awaited()
+    assert dashboards == {adapter.PREVIEW: existing}
+
+
+@pytest.mark.asyncio
 async def test_bootstrap_rejects_legacy_aurora_dashboard_without_creating_a_third_target(
     tmp_path, monkeypatch
 ):

--- a/tests/src/unit/test_aurora_deploy_routes.py
+++ b/tests/src/unit/test_aurora_deploy_routes.py
@@ -69,6 +69,19 @@ def _standalone_web_response(monkeypatch):
         )
 
 
+@pytest.fixture(autouse=True)
+def _allow_legacy_unsigned_staged_fixtures(monkeypatch):
+    """Keep route fixtures focused while production manifests remain signed."""
+    verify_signature = adapter._verify_signature
+
+    def verify(hass, document, *, prefix):
+        if prefix == "release-" and "signature" not in document:
+            return None
+        return verify_signature(hass, document, prefix=prefix)
+
+    monkeypatch.setattr(adapter, "_verify_signature", verify)
+
+
 def _hass(tmp_path):
     return SimpleNamespace(
         config=SimpleNamespace(path=lambda relative: str(tmp_path / relative)),
@@ -433,6 +446,7 @@ async def test_stage_persists_verified_transaction_and_rejects_nonce_replay(
     dashboard_sha = hashlib.sha256(dashboard).hexdigest()
     validate = Mock(return_value=(manifest_sha, package_sha, dashboard_sha))
     monkeypatch.setattr(adapter, "_validate_manifest", validate)
+    monkeypatch.setattr(adapter, "_verify_signature", Mock())
     body = {
         "transaction_id": "transaction-stage-route-001",
         "dashboard_target": adapter.PREVIEW,
@@ -490,8 +504,9 @@ async def test_stage_persists_verified_transaction_and_rejects_nonce_replay(
 @pytest.mark.asyncio
 @pytest.mark.parametrize("staged_state", ["complete", "partial", "absent"])
 async def test_transaction_readback_reconciles_lost_stage_outcome(
-    tmp_path, staged_state
+    tmp_path, monkeypatch, staged_state
 ):
+    monkeypatch.setattr(adapter, "_verify_signature", Mock())
     manifest = {"schema_version": 1}
     package = b"lost-stage-package"
     dashboard = b"lost-stage-dashboard"
@@ -559,8 +574,12 @@ async def test_transaction_readback_reconciles_lost_stage_outcome(
 
 
 @pytest.mark.asyncio
-async def test_transaction_readback_exposes_verification_hashes_only(tmp_path):
+async def test_transaction_readback_exposes_verification_hashes_only(
+    tmp_path, monkeypatch
+):
     import hashlib
+
+    monkeypatch.setattr(adapter, "_verify_signature", Mock())
 
     manifest = b'{"schema_version":1}'
     package = b"package-readback"
@@ -647,6 +666,7 @@ async def test_activate_revalidates_dashboard_without_mutating_backend(
     load_preview = AsyncMock(side_effect=lambda *_args: (preview, preview.config))
     save_preview_asset = AsyncMock(wraps=adapter._save_preview_asset)
     monkeypatch.setattr(adapter, "_validate_package", validate_package)
+    monkeypatch.setattr(adapter, "_verify_signature", Mock())
     monkeypatch.setattr(adapter, "_ensure_preview", ensure_preview)
     monkeypatch.setattr(adapter, "_save_preview_asset", save_preview_asset)
     monkeypatch.setattr(adapter, "_load_dashboard", load_preview)
@@ -725,6 +745,7 @@ async def test_activation_rejects_untracked_aurora_resource_prestate(
         }
     )
     monkeypatch.setattr(adapter, "_validate_package", Mock(return_value={}))
+    monkeypatch.setattr(adapter, "_verify_signature", Mock())
     monkeypatch.setattr(
         adapter, "_ensure_preview", AsyncMock(return_value=(False, adapter.PREVIEW))
     )
@@ -1220,6 +1241,12 @@ async def test_promotion_inspection_is_non_mutating_and_promotion_requires_recei
     assert _payload(repeated)["verified"] is True
     assert production.async_save.await_count == 1
 
+    inexact_retry = await view.post(
+        _Request({"preview_revision": revision}), "promote-home-command"
+    )
+    assert inexact_retry.status == 422
+    assert _payload(inexact_retry) == {"error_code": "validation_receipt_required"}
+
     collision_receipt = json.loads(json.dumps(receipt))
     collision_receipt["nonce"] = "validation-nonce-route-collision-001"
     collision = await view.post(
@@ -1647,6 +1674,63 @@ async def test_promotion_inspection_fails_when_active_bytes_are_not_verified(
 
     assert response.status == 409
     assert _payload(response) == {"error_code": "preview_integrity_failed"}
+
+
+@pytest.mark.asyncio
+async def test_promotion_reconciles_prepared_rollback_before_dispatch(
+    tmp_path, monkeypatch
+):
+    state = _state(tmp_path)
+    reconcile_production = AsyncMock()
+    reconcile_rollback = AsyncMock(side_effect=ValueError("recovery conflict"))
+    promote = AsyncMock()
+    monkeypatch.setattr(adapter, "_reconcile_production_transition", reconcile_production)
+    monkeypatch.setattr(adapter, "_reconcile_rollback_transition", reconcile_rollback)
+    monkeypatch.setattr(adapter.RootView, "_promote", promote)
+
+    response = await adapter.RootView(state.hass, state).post(
+        _Request({"preview_revision": "candidate"}), "promote-home-command"
+    )
+
+    assert response.status == 409
+    assert _payload(response) == {"error_code": "production_recovery_required"}
+    reconcile_production.assert_awaited_once_with(state.hass, state)
+    reconcile_rollback.assert_awaited_once_with(state.hass, state)
+    promote.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_inspection_refreshes_drifted_production_baseline(
+    tmp_path, monkeypatch
+):
+    state, transaction, _preview, production, _now = _promotion_context(
+        tmp_path, monkeypatch, "drift-refresh"
+    )
+    old_revision = state.journal["production_revision"]
+    old_config = json.loads(json.dumps(production.config))
+    old_sha = adapter._config_sha256(old_config)
+    state.journal["production_config_sha256"] = old_sha
+    state.journal["previous_production"] = {
+        "revision": "older-production",
+        "config": {"views": []},
+        "config_sha256": adapter._config_sha256({"views": []}),
+    }
+    production.config = {"views": [{"title": "Operator edit"}]}
+    new_sha = adapter._config_sha256(production.config)
+
+    response = await adapter.RootView(state.hass, state).post(
+        _Request({"preview_revision": transaction["revision"], "inspect": True}),
+        "promote-home-command",
+    )
+
+    assert response.status == 200
+    payload = _payload(response)
+    assert payload["production_revision"] == "baseline-" + new_sha
+    assert payload["production_revision"] != old_revision
+    assert payload["expected_production_config_sha256"] == new_sha
+    assert state.journal["production_revision"] == "baseline-" + new_sha
+    assert state.journal["production_config_sha256"] == new_sha
+    assert state.journal["previous_production"] is None
 
 
 @pytest.mark.asyncio

--- a/tests/src/unit/test_aurora_deploy_routes.py
+++ b/tests/src/unit/test_aurora_deploy_routes.py
@@ -6,10 +6,13 @@ import base64
 import hashlib
 import json
 from datetime import UTC, datetime, timedelta
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock
 
 import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
 
 from custom_components.aurora_deploy import adapter
 
@@ -33,8 +36,12 @@ class _Request(dict):
 class _Dashboard:
     def __init__(self, config: dict) -> None:
         self.config = config
-        self.async_load = AsyncMock(return_value=config)
-        self.async_save = AsyncMock()
+        self.async_load = AsyncMock(side_effect=lambda *_args: self.config)
+
+        async def save(updated: dict) -> None:
+            self.config = json.loads(json.dumps(updated))
+
+        self.async_save = AsyncMock(side_effect=save)
 
 
 class _Response:
@@ -69,6 +76,132 @@ def _payload(response) -> dict:
     return json.loads(response.body.decode())
 
 
+def _validation_signer(state, signer: str = "validation-e2e") -> Ed25519PrivateKey:
+    private = Ed25519PrivateKey.generate()
+    public = private.public_key().public_bytes(
+        encoding=serialization.Encoding.Raw,
+        format=serialization.PublicFormat.Raw,
+    )
+    trusted_path = Path(state.hass.config.path("aurora_deploy_trusted_keys.json"))
+    trusted_path.write_text(
+        json.dumps({signer: base64.b64encode(public).decode()}), encoding="utf-8"
+    )
+    return private
+
+
+def _sign_receipt(receipt: dict, private: Ed25519PrivateKey) -> dict:
+    signed = json.loads(json.dumps(receipt))
+    signed["signature"] = base64.b64encode(
+        private.sign(adapter._canonical_manifest(signed))
+    ).decode()
+    return signed
+
+
+def _v2_profiles() -> list[dict]:
+    return [
+        {
+            "profile_id": profile_id,
+            "width": width,
+            "height": height,
+            "passed": True,
+            "screenshot_sha256": hashlib.sha256(profile_id.encode()).hexdigest(),
+        }
+        for profile_id, width, height in adapter.AUTOMATED_E2E_PROFILES
+    ]
+
+
+def _v2_receipt(
+    inspection: dict,
+    now: datetime,
+    private: Ed25519PrivateKey,
+    *,
+    nonce: str,
+) -> dict:
+    return _sign_receipt(
+        {
+            "schema_version": 2,
+            "preview_revision": inspection["preview_revision"],
+            "transaction_id": inspection["transaction_id"],
+            "operation_id": "operation-" + nonce,
+            "expected_production_revision": inspection["production_revision"],
+            "preview_config_sha256": inspection["preview_config_sha256"],
+            "expected_production_config_sha256": inspection[
+                "expected_production_config_sha256"
+            ],
+            "dashboard_target": adapter.PREVIEW,
+            "validation_kind": "automated_e2e",
+            "e2e_evidence_sha256": hashlib.sha256(
+                b"canonical-e2e-evidence"
+            ).hexdigest(),
+            "profile_results": _v2_profiles(),
+            "manifest_sha256": inspection["manifest_sha256"],
+            "package_sha256": inspection["package_sha256"],
+            "dashboard_sha256": inspection["dashboard_sha256"],
+            "audience": inspection["audience"],
+            "action": "promote_home_command",
+            "issued_at": now.isoformat(),
+            "expires_at": (now + timedelta(minutes=5)).isoformat(),
+            "nonce": nonce,
+            "signer": "validation-e2e",
+        },
+        private,
+    )
+
+
+def _promotion_context(tmp_path, monkeypatch, suffix: str):
+    revision = f"revision-{suffix}"
+    dashboard_sha = hashlib.sha256(f"dashboard-{suffix}".encode()).hexdigest()
+    transaction = {
+        "transaction_id": f"tx-{suffix}",
+        "revision": revision,
+        "status": "activated",
+        "manifest_sha256": hashlib.sha256(f"manifest-{suffix}".encode()).hexdigest(),
+        "package_sha256": hashlib.sha256(f"package-{suffix}".encode()).hexdigest(),
+        "dashboard_sha256": dashboard_sha,
+        "active_dashboard_asset": f"aurora-preview-dashboard-{dashboard_sha}.js",
+    }
+    state = _state(
+        tmp_path,
+        {
+            "transactions": {transaction["transaction_id"]: transaction},
+            "active_preview": revision,
+            "production_revision": f"production-{suffix}",
+        },
+    )
+    asset = (
+        tmp_path
+        / "www"
+        / "aurora"
+        / "revisions"
+        / transaction["active_dashboard_asset"]
+    )
+    asset.parent.mkdir(parents=True)
+    asset.write_bytes(f"dashboard-{suffix}".encode())
+    preview = _Dashboard(
+        {
+            "views": [{"title": f"Preview {suffix}"}],
+            "resources": [
+                {
+                    "url": adapter.DASHBOARD_URL_PREFIX
+                    + transaction["active_dashboard_asset"],
+                    "res_type": "module",
+                }
+            ],
+        }
+    )
+    production = _Dashboard({"views": [{"title": f"Production {suffix}"}]})
+
+    async def load_dashboard(_hass, url_path):
+        selected = preview if url_path == adapter.PREVIEW else production
+        return selected, selected.config
+
+    now = datetime(2031, 2, 3, tzinfo=UTC)
+    monkeypatch.setattr(adapter, "_load_dashboard", load_dashboard)
+    monkeypatch.setattr(adapter, "_verify_active_transaction", AsyncMock())
+    monkeypatch.setattr(adapter, "_now", lambda: now)
+    return state, transaction, preview, production, now
+
+
 @pytest.mark.asyncio
 async def test_root_and_transaction_views_require_admin(tmp_path):
     state = _state(tmp_path)
@@ -96,9 +229,7 @@ async def test_bootstrap_rejects_existing_dashboard_metadata_collision(
     ensure_preview = AsyncMock(side_effect=ValueError("preview_collision"))
     monkeypatch.setattr(adapter, "_ensure_preview", ensure_preview)
 
-    response = await adapter.RootView(state.hass, state).post(
-        _Request(), "bootstrap"
-    )
+    response = await adapter.RootView(state.hass, state).post(_Request(), "bootstrap")
 
     assert response.status == 422
     assert _payload(response) == {"error_code": "preview_collision"}
@@ -124,16 +255,17 @@ async def test_bootstrap_rejects_legacy_aurora_dashboard_without_creating_a_thir
 async def test_stage_persists_verified_transaction_and_rejects_nonce_replay(
     tmp_path, monkeypatch
 ):
-    state = _state(tmp_path)
-    manifest_sha = "1" * 64
-    package_sha = "2" * 64
-    dashboard_sha = "3" * 64
+    state = _state(tmp_path, {"active_preview": "revision-before-stage"})
     package = b"signed-package"
     dashboard = b"export const aurora = true;"
     manifest = {"nonce": "nonce-unique-001", "expires_at": "2099-01-01T00:00:00Z"}
+    manifest_sha = hashlib.sha256(adapter._canonical_manifest(manifest)).hexdigest()
+    package_sha = hashlib.sha256(package).hexdigest()
+    dashboard_sha = hashlib.sha256(dashboard).hexdigest()
     validate = Mock(return_value=(manifest_sha, package_sha, dashboard_sha))
     monkeypatch.setattr(adapter, "_validate_manifest", validate)
     body = {
+        "transaction_id": "transaction-stage-route-001",
         "dashboard_target": adapter.PREVIEW,
         "preview_only": True,
         "manifest": manifest,
@@ -154,9 +286,11 @@ async def test_stage_persists_verified_transaction_and_rejects_nonce_replay(
     assert staged_body["status"] == "verified"
     assert staged_body["revision"] == expected_revision
     assert staged_body["staged_revision"] == expected_revision
+    assert staged_body["previous_revision"] == "revision-before-stage"
     transaction_id = staged_body["transaction_id"]
     transaction = state.tx(transaction_id)
     assert transaction is not None
+    assert transaction["stage_transition"]["status"] == "committed"
     assert state.journal["nonces"][manifest["nonce"]] == transaction_id
     revision_dir = tmp_path / "staged" / expected_revision
     assert (revision_dir / "aurora-preview-package.tar.gz").read_bytes() == package
@@ -165,9 +299,94 @@ async def test_stage_persists_verified_transaction_and_rejects_nonce_replay(
 
     replay = await view.post(_Request(body), "stage")
 
-    assert replay.status == 409
-    assert _payload(replay) == {"error_code": "manifest_replay"}
+    assert replay.status == 200
+    assert _payload(replay)["idempotent"] is True
     assert len(state.journal["transactions"]) == 1
+
+    collision_body = json.loads(json.dumps(body))
+    collision_body["artifacts"]["dashboard"] = base64.b64encode(
+        b"different-dashboard"
+    ).decode()
+    collision = await view.post(_Request(collision_body), "stage")
+    assert collision.status == 409
+    assert _payload(collision) == {"error_code": "transaction_id_conflict"}
+
+    nonce_replay_body = json.loads(json.dumps(body))
+    nonce_replay_body["transaction_id"] = "transaction-stage-route-002"
+    nonce_replay = await view.post(_Request(nonce_replay_body), "stage")
+    assert nonce_replay.status == 409
+    assert _payload(nonce_replay) == {"error_code": "manifest_replay"}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("staged_state", ["complete", "partial", "absent"])
+async def test_transaction_readback_reconciles_lost_stage_outcome(
+    tmp_path, staged_state
+):
+    manifest = {"schema_version": 1}
+    package = b"lost-stage-package"
+    dashboard = b"lost-stage-dashboard"
+    manifest_sha = hashlib.sha256(adapter._canonical_manifest(manifest)).hexdigest()
+    package_sha = hashlib.sha256(package).hexdigest()
+    dashboard_sha = hashlib.sha256(dashboard).hexdigest()
+    revision = hashlib.sha256(
+        (manifest_sha + package_sha + dashboard_sha).encode()
+    ).hexdigest()[:32]
+    transaction_id = f"transaction-lost-stage-{staged_state}"
+    request_sha = "d" * 64
+    transaction = {
+        "transaction_id": transaction_id,
+        "revision": revision,
+        "status": "staging",
+        "manifest_sha256": manifest_sha,
+        "package_sha256": package_sha,
+        "dashboard_sha256": dashboard_sha,
+        "target": adapter.PREVIEW,
+        "stage_request_sha256": request_sha,
+        "stage_previous_revision": "revision-before-stage",
+        "stage_transition": {
+            "status": "prepared",
+            "transaction_id": transaction_id,
+            "revision": revision,
+            "request_sha256": request_sha,
+            "manifest_sha256": manifest_sha,
+            "package_sha256": package_sha,
+            "dashboard_sha256": dashboard_sha,
+        },
+    }
+    revision_dir = tmp_path / "staged" / revision
+    if staged_state != "absent":
+        revision_dir.mkdir(parents=True)
+        (revision_dir / "manifest.json").write_bytes(adapter._json_bytes(manifest))
+        (revision_dir / "aurora-preview-package.tar.gz").write_bytes(package)
+    if staged_state == "complete":
+        (revision_dir / "aurora-preview-dashboard.js").write_bytes(dashboard)
+    state = _state(
+        tmp_path,
+        {"transactions": {transaction_id: transaction}},
+    )
+    original_save = state.save
+    state.save = Mock(wraps=original_save)
+    view = adapter.TransactionView(state.hass, state)
+
+    response = await view.get(_Request(), transaction_id, "readback")
+
+    assert response.status == 200
+    payload = _payload(response)
+    staged_bytes_complete = staged_state == "complete"
+    expected_status = "verified" if staged_bytes_complete else "aborted"
+    assert payload["status"] == expected_status
+    assert payload["stage_status"] == (
+        "committed" if staged_bytes_complete else "aborted"
+    )
+    assert payload["verified"] is staged_bytes_complete
+    assert payload["previous_revision"] == "revision-before-stage"
+    assert state.save.call_count == 1
+
+    repeated = await view.get(_Request(), transaction_id, "readback")
+    assert repeated.status == 200
+    assert _payload(repeated)["status"] == expected_status
+    assert state.save.call_count == 1
 
 
 @pytest.mark.asyncio
@@ -180,7 +399,9 @@ async def test_transaction_readback_exposes_verification_hashes_only(tmp_path):
     manifest_sha = hashlib.sha256(manifest).hexdigest()
     package_sha = hashlib.sha256(package).hexdigest()
     dashboard_sha = hashlib.sha256(dashboard).hexdigest()
-    revision = hashlib.sha256((manifest_sha + package_sha + dashboard_sha).encode()).hexdigest()[:32]
+    revision = hashlib.sha256(
+        (manifest_sha + package_sha + dashboard_sha).encode()
+    ).hexdigest()[:32]
     revision_dir = tmp_path / "staged" / revision
     revision_dir.mkdir(parents=True)
     (revision_dir / "manifest.json").write_bytes(manifest)
@@ -214,11 +435,16 @@ async def test_transaction_readback_exposes_verification_hashes_only(tmp_path):
             "dashboard_sha256",
             "target",
         )
-    } | {"verified": True}
+    } | {
+        "verified": True,
+        "staged_package_verified": True,
+        "previous_revision": None,
+        "dashboard_resource_present": False,
+    }
 
 
 @pytest.mark.asyncio
-async def test_activate_revalidates_and_installs_exact_staged_revision(
+async def test_activate_revalidates_dashboard_without_mutating_backend(
     tmp_path, monkeypatch
 ):
     manifest = {"schema_version": 1}
@@ -246,23 +472,21 @@ async def test_activate_revalidates_and_installs_exact_staged_revision(
         "revision_dir": str(revision_dir),
     }
     state = _state(tmp_path, {"transactions": {"tx-active": transaction}})
-    validate_package = Mock()
-    component_members = {
-        filename: f"component-{filename}".encode()
-        for filename in adapter.APPROVED_COMPONENT_FILES
-    }
-    validate_package = Mock(return_value=component_members)
-    activate_component = Mock(return_value="component-binding")
+    validate_package = Mock(return_value={})
     ensure_preview = AsyncMock(return_value=(False, adapter.PREVIEW))
-    save_preview_asset = AsyncMock(
-        return_value="aurora-preview-dashboard-dashboardhash.js"
-    )
-    load_preview = AsyncMock(return_value=(_Dashboard({"views": []}), {"views": []}))
+    preview = _Dashboard({"views": []})
+    load_preview = AsyncMock(side_effect=lambda *_args: (preview, preview.config))
+    save_preview_asset = AsyncMock(wraps=adapter._save_preview_asset)
     monkeypatch.setattr(adapter, "_validate_package", validate_package)
-    monkeypatch.setattr(adapter, "_activate_component_package", activate_component)
     monkeypatch.setattr(adapter, "_ensure_preview", ensure_preview)
     monkeypatch.setattr(adapter, "_save_preview_asset", save_preview_asset)
     monkeypatch.setattr(adapter, "_load_dashboard", load_preview)
+    verify_active = AsyncMock(return_value=dashboard_sha)
+    monkeypatch.setattr(adapter, "_verify_active_bindings", verify_active)
+    backend = tmp_path / "custom_components" / adapter.COMPONENT_DOMAIN
+    backend.mkdir(parents=True)
+    sentinel = backend / "sentinel.py"
+    sentinel.write_bytes(b"backend-lifecycle-owned-elsewhere")
 
     response = await adapter.TransactionView(state.hass, state).post(
         _Request(), "tx-active", "activate"
@@ -272,57 +496,89 @@ async def test_activate_revalidates_and_installs_exact_staged_revision(
     assert _payload(response) == {
         "activated": True,
         "active_revision": revision,
+        "previous_revision": None,
         "status": "activated",
+        "restart_required": False,
+        "backend_unchanged": True,
     }
     validate_package.assert_called_once_with(package)
-    activate_component.assert_called_once_with(
-        state.hass, state, transaction, component_members
-    )
     ensure_preview.assert_awaited_once_with(state.hass)
     save_preview_asset.assert_awaited_once_with(state.hass, dashboard)
+    assert sentinel.read_bytes() == b"backend-lifecycle-owned-elsewhere"
     assert state.journal["active_preview"] == revision
     assert transaction["status"] == "activated"
     assert "activated_at" in transaction
 
-
-def test_component_activation_is_fixed_scope_and_rollback_restores_prestate(tmp_path):
-    state = _state(tmp_path)
-    transaction = {"transaction_id": "tx-component-fixed-scope"}
-    destination = tmp_path / "custom_components" / adapter.COMPONENT_DOMAIN
-    destination.mkdir(parents=True)
-    (destination / "legacy.py").write_bytes(b"legacy")
-    members = {
-        filename: f"candidate-{filename}".encode()
-        for filename in adapter.APPROVED_COMPONENT_FILES
-    }
-
-    binding = adapter._activate_component_package(
-        state.hass, state, transaction, members
+    repeated = await adapter.TransactionView(state.hass, state).post(
+        _Request(), "tx-active", "activate"
     )
-
-    assert binding == adapter._component_binding(members)
-    assert {path.name for path in destination.iterdir()} == set(
-        adapter.APPROVED_COMPONENT_FILES
-    )
-    assert all(
-        (destination / filename).read_bytes() == data
-        for filename, data in members.items()
-    )
-
-    adapter._restore_component_prestate(state.hass, state, transaction)
-
-    assert {path.name for path in destination.iterdir()} == {"legacy.py"}
-    assert (destination / "legacy.py").read_bytes() == b"legacy"
-    assert transaction["component_activation_attempt"] == 1
-
-    adapter._activate_component_package(state.hass, state, transaction, members)
-    assert transaction["component_activation_attempt"] == 2
-    adapter._restore_component_prestate(state.hass, state, transaction)
-    assert (destination / "legacy.py").read_bytes() == b"legacy"
+    assert repeated.status == 200
+    assert _payload(repeated)["idempotent"] is True
+    assert save_preview_asset.await_count == 1
 
 
 @pytest.mark.asyncio
-async def test_dashboard_activation_failure_restores_component_and_is_retryable(
+async def test_activation_rejects_untracked_aurora_resource_prestate(
+    tmp_path, monkeypatch
+):
+    manifest = {"schema_version": 1}
+    package = b"prestate-package"
+    dashboard = b"prestate-dashboard"
+    manifest_sha = hashlib.sha256(adapter._canonical_manifest(manifest)).hexdigest()
+    package_sha = hashlib.sha256(package).hexdigest()
+    dashboard_sha = hashlib.sha256(dashboard).hexdigest()
+    revision = hashlib.sha256(
+        (manifest_sha + package_sha + dashboard_sha).encode()
+    ).hexdigest()[:32]
+    revision_dir = tmp_path / "staged" / revision
+    revision_dir.mkdir(parents=True)
+    (revision_dir / "manifest.json").write_bytes(adapter._json_bytes(manifest))
+    (revision_dir / "aurora-preview-package.tar.gz").write_bytes(package)
+    (revision_dir / "aurora-preview-dashboard.js").write_bytes(dashboard)
+    transaction = {
+        "transaction_id": "tx-untracked-prestate",
+        "revision": revision,
+        "status": "verified",
+        "manifest_sha256": manifest_sha,
+        "package_sha256": package_sha,
+        "dashboard_sha256": dashboard_sha,
+        "target": adapter.PREVIEW,
+    }
+    state = _state(
+        tmp_path,
+        {"transactions": {transaction["transaction_id"]: transaction}},
+    )
+    preview = _Dashboard(
+        {
+            "resources": [
+                {"url": adapter.DASHBOARD_URL, "res_type": "module"}
+            ]
+        }
+    )
+    monkeypatch.setattr(adapter, "_validate_package", Mock(return_value={}))
+    monkeypatch.setattr(
+        adapter, "_ensure_preview", AsyncMock(return_value=(False, adapter.PREVIEW))
+    )
+    monkeypatch.setattr(
+        adapter,
+        "_load_dashboard",
+        AsyncMock(side_effect=lambda *_args: (preview, preview.config)),
+    )
+    save_preview_asset = AsyncMock()
+    monkeypatch.setattr(adapter, "_save_preview_asset", save_preview_asset)
+
+    response = await adapter.TransactionView(state.hass, state).post(
+        _Request(), transaction["transaction_id"], "activate"
+    )
+
+    assert response.status == 409
+    assert _payload(response) == {"error_code": "preview_prestate_invalid"}
+    save_preview_asset.assert_not_awaited()
+    assert transaction["status"] == "verified"
+
+
+@pytest.mark.asyncio
+async def test_dashboard_activation_failure_is_retryable_and_backend_unchanged(
     tmp_path, monkeypatch
 ):
     manifest = {"schema_version": 1}
@@ -356,53 +612,51 @@ async def test_dashboard_activation_failure_restores_component_and_is_retryable(
     destination = tmp_path / "custom_components" / adapter.COMPONENT_DOMAIN
     destination.mkdir(parents=True)
     (destination / "legacy.py").write_bytes(b"legacy")
-    members = {
-        filename: f"retry-{filename}".encode()
-        for filename in adapter.APPROVED_COMPONENT_FILES
-    }
     preview = _Dashboard({"resources": []})
-    monkeypatch.setattr(adapter, "_validate_package", Mock(return_value=members))
+    monkeypatch.setattr(adapter, "_validate_package", Mock(return_value={}))
     monkeypatch.setattr(adapter, "_ensure_preview", AsyncMock())
     monkeypatch.setattr(
         adapter,
         "_load_dashboard",
-        AsyncMock(return_value=(preview, {"resources": []})),
+        AsyncMock(side_effect=lambda *_args: (preview, preview.config)),
     )
-    save_asset = AsyncMock(
-        side_effect=[
-            RuntimeError("dashboard-save-failed"),
-            "aurora-preview-dashboard-retry.js",
-        ]
-    )
+    save_attempts = 0
+
+    async def save_asset_effect(_hass, dashboard_bytes):
+        nonlocal save_attempts
+        save_attempts += 1
+        if save_attempts == 1:
+            raise RuntimeError("dashboard-save-failed")
+        asset_name = (
+            f"aurora-preview-dashboard-{hashlib.sha256(dashboard_bytes).hexdigest()}.js"
+        )
+        await preview.async_save(
+            adapter._dashboard_config_with_asset(preview.config, asset_name)
+        )
+        return asset_name
+
+    save_asset = AsyncMock(side_effect=save_asset_effect)
     monkeypatch.setattr(adapter, "_save_preview_asset", save_asset)
+    monkeypatch.setattr(
+        adapter, "_verify_active_bindings", AsyncMock(return_value=dashboard_sha)
+    )
     view = adapter.TransactionView(state.hass, state)
 
-    failed = await view.post(
-        _Request(), transaction["transaction_id"], "activate"
-    )
+    failed = await view.post(_Request(), transaction["transaction_id"], "activate")
 
     assert failed.status == 500
     assert transaction["status"] == "verified"
     assert (destination / "legacy.py").read_bytes() == b"legacy"
-    assert transaction["component_activation_attempt"] == 1
 
-    retried = await view.post(
-        _Request(), transaction["transaction_id"], "activate"
-    )
+    retried = await view.post(_Request(), transaction["transaction_id"], "activate")
 
     assert retried.status == 200
     assert transaction["status"] == "activated"
-    assert transaction["component_activation_attempt"] == 2
-    assert all(
-        (destination / filename).read_bytes() == data
-        for filename, data in members.items()
-    )
+    assert (destination / "legacy.py").read_bytes() == b"legacy"
 
 
 @pytest.mark.asyncio
-async def test_active_readback_binds_component_bytes_and_dashboard_resource(
-    tmp_path, monkeypatch
-):
+async def test_active_readback_binds_dashboard_resource_only(tmp_path, monkeypatch):
     manifest = {"schema_version": 1}
     manifest_raw = adapter._json_bytes(manifest)
     package = b"bound-package"
@@ -419,14 +673,6 @@ async def test_active_readback_binds_component_bytes_and_dashboard_resource(
     (revision_dir / "aurora-preview-package.tar.gz").write_bytes(package)
     (revision_dir / "aurora-preview-dashboard.js").write_bytes(dashboard_bytes)
 
-    members = {
-        filename: f"bound-{filename}".encode()
-        for filename in adapter.APPROVED_COMPONENT_FILES
-    }
-    component_root = tmp_path / "custom_components" / adapter.COMPONENT_DOMAIN
-    component_root.mkdir(parents=True)
-    for filename, data in members.items():
-        (component_root / filename).write_bytes(data)
     asset_name = f"aurora-preview-dashboard-{dashboard_sha}.js"
     asset_path = tmp_path / "www" / "aurora" / "revisions" / asset_name
     asset_path.parent.mkdir(parents=True)
@@ -448,14 +694,17 @@ async def test_active_readback_binds_component_bytes_and_dashboard_resource(
         "dashboard_sha256": dashboard_sha,
         "target": adapter.PREVIEW,
         "revision_dir": str(revision_dir),
-        "component_binding_sha256": adapter._component_binding(members),
         "active_dashboard_asset": asset_name,
+        "active_preview_config_sha256": adapter._config_sha256(dashboard_config),
     }
     state = _state(
         tmp_path,
-        {"transactions": {transaction["transaction_id"]: transaction}},
+        {
+            "transactions": {transaction["transaction_id"]: transaction},
+            "active_preview": revision,
+        },
     )
-    monkeypatch.setattr(adapter, "_validate_package", Mock(return_value=members))
+    monkeypatch.setattr(adapter, "_validate_package", Mock(return_value={}))
     monkeypatch.setattr(
         adapter,
         "_load_dashboard",
@@ -468,16 +717,170 @@ async def test_active_readback_binds_component_bytes_and_dashboard_resource(
 
     assert response.status == 200
     payload = _payload(response)
-    assert payload["active_package_sha256"] == adapter._component_binding(members)
-    assert payload["active_package_verified"] is True
+    assert payload["staged_package_verified"] is True
+    assert payload["active_dashboard_sha256"] == dashboard_sha
     assert payload["active_dashboard_verified"] is True
+    assert payload["dashboard_resource_present"] is True
+    assert payload["active_dashboard_resource_url"] == (
+        adapter.DASHBOARD_URL_PREFIX + asset_name
+    )
+    assert payload["active_dashboard_size"] == len(dashboard_bytes)
 
-    (component_root / "coordinator.py").write_bytes(b"tampered")
+    asset_path.write_bytes(b"tampered")
     tampered = await adapter.TransactionView(state.hass, state).get(
         _Request(), transaction["transaction_id"], "readback"
     )
     assert tampered.status == 409
     assert _payload(tampered) == {"error_code": "active_integrity_failed"}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("transition_kind", "applied"),
+    [
+        ("activate", True),
+        ("activate", False),
+        ("rollback", True),
+        ("rollback", False),
+    ],
+)
+async def test_transaction_readback_reconciles_lost_preview_outcome_without_resave(
+    tmp_path, monkeypatch, transition_kind, applied
+):
+    manifest = {"schema_version": 1}
+    package = b"transaction-recovery-package"
+    dashboard = b"transaction-recovery-dashboard"
+    manifest_sha = hashlib.sha256(adapter._canonical_manifest(manifest)).hexdigest()
+    package_sha = hashlib.sha256(package).hexdigest()
+    dashboard_sha = hashlib.sha256(dashboard).hexdigest()
+    revision = hashlib.sha256(
+        (manifest_sha + package_sha + dashboard_sha).encode()
+    ).hexdigest()[:32]
+    revision_dir = tmp_path / "staged" / revision
+    revision_dir.mkdir(parents=True)
+    (revision_dir / "manifest.json").write_bytes(adapter._json_bytes(manifest))
+    (revision_dir / "aurora-preview-package.tar.gz").write_bytes(package)
+    (revision_dir / "aurora-preview-dashboard.js").write_bytes(dashboard)
+    asset_name = f"aurora-preview-dashboard-{dashboard_sha}.js"
+    active_asset_path = tmp_path / "www" / "aurora" / "revisions" / asset_name
+    active_asset_path.parent.mkdir(parents=True)
+    active_asset_path.write_bytes(dashboard)
+    prior_dashboard = b"prior-transaction-dashboard"
+    prior_dashboard_sha = hashlib.sha256(prior_dashboard).hexdigest()
+    prior_asset_name = f"aurora-preview-dashboard-{prior_dashboard_sha}.js"
+    prior_asset_path = (
+        tmp_path / "www" / "aurora" / "revisions" / prior_asset_name
+    )
+    prior_asset_path.parent.mkdir(parents=True, exist_ok=True)
+    prior_asset_path.write_bytes(prior_dashboard)
+    before_config = adapter._dashboard_config_with_asset(
+        {"views": [{"title": "Preview before"}]}, prior_asset_name
+    )
+    active_config = adapter._dashboard_config_with_asset(before_config, asset_name)
+    prior_transaction = {
+        "transaction_id": "tx-prior-preview",
+        "revision": "revision-before-preview",
+        "status": "activated",
+        "dashboard_sha256": prior_dashboard_sha,
+        "active_dashboard_asset": prior_asset_name,
+        "active_preview_config_sha256": adapter._config_sha256(before_config),
+    }
+    transaction = {
+        "transaction_id": f"tx-{transition_kind}-{int(applied)}",
+        "revision": revision,
+        "status": "verified" if transition_kind == "activate" else "activated",
+        "manifest_sha256": manifest_sha,
+        "package_sha256": package_sha,
+        "dashboard_sha256": dashboard_sha,
+        "target": adapter.PREVIEW,
+        "active_dashboard_asset": asset_name,
+        "preview_before": before_config,
+        "preview_config_sha256_before": adapter._config_sha256(before_config),
+        "preview_revision_before": "revision-before-preview",
+        "active_preview_config_sha256": adapter._config_sha256(active_config),
+    }
+    if transition_kind == "activate":
+        transaction["activation_transition"] = {
+            "status": "prepared",
+            "action": "activate",
+            "transaction_id": transaction["transaction_id"],
+            "previous_revision": "revision-before-preview",
+            "next_revision": revision,
+            "previous_config_sha256": adapter._config_sha256(before_config),
+            "next_config_sha256": adapter._config_sha256(active_config),
+            "asset_name": asset_name,
+        }
+        live_config = active_config if applied else before_config
+        journal = {
+            "transactions": {
+                prior_transaction["transaction_id"]: prior_transaction,
+                transaction["transaction_id"]: transaction,
+            },
+            "active_preview": "revision-before-preview",
+        }
+        transition_key = "activation_transition"
+        expected_status = "activated" if applied else "verified"
+    else:
+        transaction["preview_rollback_transition"] = {
+            "status": "prepared",
+            "action": "rollback",
+            "transaction_id": transaction["transaction_id"],
+            "from_status": "activated",
+            "from_revision": revision,
+            "to_revision": "revision-before-preview",
+            "previous_config_sha256": adapter._config_sha256(active_config),
+            "next_config_sha256": adapter._config_sha256(before_config),
+            "asset_name": asset_name,
+        }
+        live_config = before_config if applied else active_config
+        journal = {
+            "transactions": {
+                prior_transaction["transaction_id"]: prior_transaction,
+                transaction["transaction_id"]: transaction,
+            },
+            "active_preview": revision,
+        }
+        transition_key = "preview_rollback_transition"
+        expected_status = "rolled_back" if applied else "activated"
+    state = _state(tmp_path, journal)
+    preview = _Dashboard(live_config)
+    monkeypatch.setattr(
+        adapter,
+        "_load_dashboard",
+        AsyncMock(side_effect=lambda *_args: (preview, preview.config)),
+    )
+    monkeypatch.setattr(adapter, "_validate_package", Mock(return_value={}))
+    monkeypatch.setattr(
+        adapter, "_verify_active_transaction", AsyncMock(return_value=dashboard_sha)
+    )
+    monkeypatch.setattr(
+        adapter, "_verify_active_bindings", AsyncMock(return_value=dashboard_sha)
+    )
+    original_save = state.save
+    state.save = Mock(wraps=original_save)
+
+    response = await adapter.TransactionView(state.hass, state).get(
+        _Request(), transaction["transaction_id"], "readback"
+    )
+
+    assert response.status == 200
+    payload = _payload(response)
+    assert payload["status"] == expected_status
+    assert payload[
+        "activation_status" if transition_kind == "activate" else "rollback_status"
+    ] == ("committed" if applied else "aborted")
+    assert transaction[transition_key]["status"] == (
+        "committed" if applied else "aborted"
+    )
+    assert preview.async_save.await_count == 0
+    assert state.save.call_count == 1
+
+    repeated = await adapter.TransactionView(state.hass, state).get(
+        _Request(), transaction["transaction_id"], "readback"
+    )
+    assert repeated.status == 200
+    assert _payload(repeated)["status"] == expected_status
+    assert state.save.call_count == 1
 
 
 @pytest.mark.asyncio
@@ -501,22 +904,37 @@ async def test_promotion_inspection_is_non_mutating_and_promotion_requires_recei
             "production_revision": "revision-before",
         },
     )
-    preview_config = {"views": [{"title": "Verified preview"}]}
+    resource_url = (
+        adapter.DASHBOARD_URL_PREFIX
+        + f"aurora-preview-dashboard-{transaction['dashboard_sha256']}.js"
+    )
+    preview_config = {
+        "views": [{"title": "Verified preview"}],
+        "resources": [{"url": resource_url, "res_type": "module"}],
+    }
     production_config = {"views": [{"title": "Current production"}]}
     preview = _Dashboard(preview_config)
     production = _Dashboard(production_config)
 
     async def load_dashboard(_hass, url_path):
         if url_path == adapter.PREVIEW:
-            return preview, preview_config
+            return preview, preview.config
         assert url_path == adapter.PRODUCTION
-        return production, production_config
+        return production, production.config
 
     verify_signature = Mock()
     now = datetime(2030, 1, 1, tzinfo=UTC)
     monkeypatch.setattr(adapter, "_load_dashboard", load_dashboard)
     monkeypatch.setattr(adapter, "_verify_signature", verify_signature)
     monkeypatch.setattr(adapter, "_verify_active_transaction", AsyncMock())
+    resource_context = {
+        "preview_resource_url": resource_url,
+        "preview_resource_sha256": transaction["dashboard_sha256"],
+        "preview_resource_size": 123,
+    }
+    monkeypatch.setattr(
+        adapter, "_active_resource_context", Mock(return_value=resource_context)
+    )
     monkeypatch.setattr(adapter, "_now", lambda: now)
     view = adapter.RootView(state.hass, state)
 
@@ -528,13 +946,20 @@ async def test_promotion_inspection_is_non_mutating_and_promotion_requires_recei
     assert inspection.status == 200
     assert _payload(inspection) == {
         "preview_revision": revision,
+        "transaction_id": transaction["transaction_id"],
         "status": "activated",
         "active_revision": revision,
+        "dashboard_target": adapter.PREVIEW,
         "target_dashboard": adapter.PRODUCTION,
         "preview_config_sha256": adapter._config_sha256(preview_config),
         "production_revision": "revision-before",
         "expected_production_config_sha256": adapter._config_sha256(production_config),
+        "manifest_sha256": transaction["manifest_sha256"],
+        "package_sha256": transaction["package_sha256"],
+        "dashboard_sha256": transaction["dashboard_sha256"],
+        "audience": state.journal["audience"],
         "verified": True,
+        **resource_context,
     }
     production.async_save.assert_not_awaited()
     assert state.journal["production_revision"] == "revision-before"
@@ -543,9 +968,7 @@ async def test_promotion_inspection_is_non_mutating_and_promotion_requires_recei
         _Request({"preview_revision": revision}), "promote-home-command"
     )
     assert missing_receipt.status == 422
-    assert _payload(missing_receipt) == {
-        "error_code": "validation_receipt_required"
-    }
+    assert _payload(missing_receipt) == {"error_code": "validation_receipt_required"}
 
     receipt = {
         "schema_version": 1,
@@ -558,9 +981,7 @@ async def test_promotion_inspection_is_non_mutating_and_promotion_requires_recei
         "signature": "fixture-signature",
         "expected_production_revision": "revision-before",
         "preview_config_sha256": adapter._config_sha256(preview_config),
-        "expected_production_config_sha256": adapter._config_sha256(
-            production_config
-        ),
+        "expected_production_config_sha256": adapter._config_sha256(production_config),
         "device_results": [
             {"device_id": device, "passed": True}
             for device in ("mobile", "kiosk", "tablet", "laptop", "desktop")
@@ -570,28 +991,32 @@ async def test_promotion_inspection_is_non_mutating_and_promotion_requires_recei
         "package_sha256": transaction["package_sha256"],
         "dashboard_sha256": transaction["dashboard_sha256"],
     }
-    promoted = await view.post(
-        _Request(
-            {
-                "preview_revision": revision,
-                "expected_production_revision": "revision-before",
-                "receipt": receipt,
-            }
-        ),
-        "promote-home-command",
-    )
+    promotion_body = {
+        "preview_revision": revision,
+        "expected_production_revision": "revision-before",
+        "operation_id": "018f3f77-4d52-4cd2-9ce0-b9e9b547b001",
+        "receipt": receipt,
+    }
+    promoted = await view.post(_Request(promotion_body), "promote-home-command")
 
     assert promoted.status == 200
-    assert _payload(promoted) == {
+    promoted_payload = _payload(promoted)
+    assert promoted_payload == {
         "promoted": True,
+        "operation_id": "018f3f77-4d52-4cd2-9ce0-b9e9b547b001",
+        "status": "committed",
         "active_revision": revision,
         "previous_revision": "revision-before",
         "preview_config_sha256": adapter._config_sha256(preview_config),
         "expected_production_config_sha256": adapter._config_sha256(production_config),
+        "dashboard_resource_url": resource_url,
+        "dashboard_sha256": transaction["dashboard_sha256"],
+        "dashboard_size": 123,
+        "applied": True,
+        "verified": True,
+        "dashboard_resource_present": True,
     }
-    verify_signature.assert_called_once_with(
-        state.hass, receipt, prefix="validation-"
-    )
+    verify_signature.assert_called_once_with(state.hass, receipt, prefix="validation-")
     production.async_save.assert_awaited_once_with(preview_config)
     assert state.journal["previous_production"] == {
         "revision": "revision-before",
@@ -603,6 +1028,409 @@ async def test_promotion_inspection_is_non_mutating_and_promotion_requires_recei
         preview_config
     )
     assert transaction["status"] == "promoted"
+    assert promoted_payload["operation_id"] == "018f3f77-4d52-4cd2-9ce0-b9e9b547b001"
+
+    repeated = await view.post(_Request(promotion_body), "promote-home-command")
+    assert repeated.status == 200
+    assert _payload(repeated)["idempotent"] is True
+    assert _payload(repeated)["verified"] is True
+    assert production.async_save.await_count == 1
+
+    collision_receipt = json.loads(json.dumps(receipt))
+    collision_receipt["nonce"] = "validation-nonce-route-collision-001"
+    collision = await view.post(
+        _Request(promotion_body | {"receipt": collision_receipt}),
+        "promote-home-command",
+    )
+    assert collision.status == 409
+    assert _payload(collision) == {"error_code": "operation_id_conflict"}
+
+    body_collision = await view.post(
+        _Request(promotion_body | {"expected_production_revision": "different-cas"}),
+        "promote-home-command",
+    )
+    assert body_collision.status == 409
+    assert _payload(body_collision) == {"error_code": "operation_id_conflict"}
+
+    invalid_id = await view.post(
+        _Request(promotion_body | {"operation_id": "not-a-uuid"}),
+        "promote-home-command",
+    )
+    assert invalid_id.status == 422
+    assert _payload(invalid_id) == {"error_code": "operation_id_uuid_required"}
+
+
+@pytest.mark.asyncio
+async def test_v2_ed25519_promotion_status_readback_idempotency_and_replay(
+    tmp_path, monkeypatch
+):
+    state, transaction, _preview, production, now = _promotion_context(
+        tmp_path, monkeypatch, "v2-happy"
+    )
+    private = _validation_signer(state)
+    view = adapter.RootView(state.hass, state)
+    inspected = await view.post(
+        _Request({"preview_revision": transaction["revision"], "inspect": True}),
+        "promote-home-command",
+    )
+    inspection = _payload(inspected)
+    assert inspected.status == 200
+    assert inspection["transaction_id"] == transaction["transaction_id"]
+    assert inspection["dashboard_target"] == "aurora-preview"
+    assert inspection["target_dashboard"] == "home-command"
+    assert inspection["preview_resource_sha256"] == transaction["dashboard_sha256"]
+    assert inspection["preview_resource_size"] > 0
+    assert inspection["preview_resource_url"].startswith(adapter.DASHBOARD_URL_PREFIX)
+    receipt = _v2_receipt(inspection, now, private, nonce="validation-v2-happy-001")
+
+    promoted = await view.post(
+        _Request(
+            {
+                "preview_revision": transaction["revision"],
+                "operation_id": receipt["operation_id"],
+                "expected_production_revision": inspection["production_revision"],
+                "receipt": receipt,
+            }
+        ),
+        "promote-home-command",
+    )
+
+    promoted_payload = _payload(promoted)
+    assert promoted.status == 200
+    assert promoted_payload["status"] == "committed"
+    operation_id = promoted_payload["operation_id"]
+    assert operation_id == receipt["operation_id"]
+    assert production.config["views"] == [{"title": "Preview v2-happy"}]
+
+    operation_view = adapter.TransactionView(state.hass, state)
+    status = await operation_view.get(_Request(), operation_id, "status")
+    assert status.status == 200
+    assert _payload(status) == {
+        "operation_id": operation_id,
+        "action": "promote_home_command",
+        "status": "committed",
+        "transaction_id": transaction["transaction_id"],
+        "preview_revision": transaction["revision"],
+        "target_revision": transaction["revision"],
+        "expected_production_revision": inspection["production_revision"],
+        "expected_production_config_sha256": inspection[
+            "expected_production_config_sha256"
+        ],
+        "preview_config_sha256": inspection["preview_config_sha256"],
+        "production_config_sha256": inspection["preview_config_sha256"],
+        "created_at": now.isoformat(),
+        "completed_at": now.isoformat(),
+    }
+    readback = await operation_view.get(_Request(), operation_id, "readback")
+    assert readback.status == 200
+    readback_payload = _payload(readback)
+    assert readback_payload["verified"] is True
+    assert readback_payload["active_revision"] == transaction["revision"]
+    assert (
+        readback_payload["live_production_config_sha256"]
+        == inspection["preview_config_sha256"]
+    )
+    assert readback_payload["applied"] is True
+    assert (
+        readback_payload["dashboard_resource_url"] == inspection["preview_resource_url"]
+    )
+    assert readback_payload["dashboard_sha256"] == inspection["dashboard_sha256"]
+    assert readback_payload["dashboard_size"] == inspection["preview_resource_size"]
+    assert readback_payload["dashboard_resource_present"] is True
+
+    original_config = json.loads(json.dumps(production.config))
+    operation_record = state.journal["operations"][operation_id]
+    original_operation_sha = operation_record["production_config_sha256"]
+    wrong_resource_config = json.loads(json.dumps(original_config))
+    wrong_resource_config["resources"][0]["url"] = (
+        adapter.DASHBOARD_URL_PREFIX + "aurora-preview-dashboard-" + "f" * 64 + ".js"
+    )
+    production.config = wrong_resource_config
+    operation_record["production_config_sha256"] = adapter._config_sha256(
+        wrong_resource_config
+    )
+    wrong_resource = await operation_view.get(_Request(), operation_id, "readback")
+    assert wrong_resource.status == 409
+    assert _payload(wrong_resource) == {"error_code": "operation_readback_mismatch"}
+    production.config = original_config
+    operation_record["production_config_sha256"] = original_operation_sha
+
+    asset_path = (
+        tmp_path
+        / "www"
+        / "aurora"
+        / "revisions"
+        / transaction["active_dashboard_asset"]
+    )
+    original_asset = asset_path.read_bytes()
+    asset_path.unlink()
+    missing_asset = await operation_view.get(_Request(), operation_id, "readback")
+    assert missing_asset.status == 409
+    assert _payload(missing_asset) == {"error_code": "operation_readback_mismatch"}
+    asset_path.write_bytes(original_asset)
+
+    asset_path.write_bytes(b"tampered-dashboard-resource")
+    tampered_asset = await operation_view.get(_Request(), operation_id, "readback")
+    assert tampered_asset.status == 409
+    assert _payload(tampered_asset) == {"error_code": "operation_readback_mismatch"}
+    asset_path.write_bytes(original_asset)
+    assert production.async_save.await_count == 1
+
+    retried = await view.post(
+        _Request(
+            {
+                "preview_revision": transaction["revision"],
+                "operation_id": receipt["operation_id"],
+                "expected_production_revision": inspection["production_revision"],
+                "receipt": receipt,
+            }
+        ),
+        "promote-home-command",
+    )
+    assert retried.status == 200
+    assert _payload(retried)["idempotent"] is True
+
+    collision_receipt = _v2_receipt(
+        inspection, now, private, nonce="validation-v2-collision-001"
+    )
+    collision_receipt["operation_id"] = operation_id
+    collision_receipt = _sign_receipt(collision_receipt, private)
+    collision = await view.post(
+        _Request(
+            {
+                "preview_revision": transaction["revision"],
+                "operation_id": collision_receipt["operation_id"],
+                "expected_production_revision": inspection["production_revision"],
+                "receipt": collision_receipt,
+            }
+        ),
+        "promote-home-command",
+    )
+    assert collision.status == 409
+    assert _payload(collision) == {"error_code": "operation_id_conflict"}
+
+    replay_receipt = json.loads(json.dumps(receipt))
+    replay_receipt["operation_id"] = "operation-replay-new-001"
+    replay_receipt = _sign_receipt(replay_receipt, private)
+    replay = await view.post(
+        _Request(
+            {
+                "preview_revision": transaction["revision"],
+                "operation_id": replay_receipt["operation_id"],
+                "expected_production_revision": inspection["production_revision"],
+                "receipt": replay_receipt,
+            }
+        ),
+        "promote-home-command",
+    )
+    assert replay.status == 409
+    assert _payload(replay) == {"error_code": "validation_receipt_replay"}
+
+
+@pytest.mark.asyncio
+async def test_v2_ed25519_receipt_tamper_and_cas_fail_closed(tmp_path, monkeypatch):
+    state, transaction, _preview, _production, now = _promotion_context(
+        tmp_path, monkeypatch, "v2-failures"
+    )
+    private = _validation_signer(state)
+    view = adapter.RootView(state.hass, state)
+    inspected = await view.post(
+        _Request({"preview_revision": transaction["revision"], "inspect": True}),
+        "promote-home-command",
+    )
+    inspection = _payload(inspected)
+    receipt = _v2_receipt(inspection, now, private, nonce="validation-v2-tamper-001")
+    receipt["profile_results"][0]["screenshot_sha256"] = "f" * 64
+
+    tampered = await view.post(
+        _Request(
+            {
+                "preview_revision": transaction["revision"],
+                "operation_id": receipt["operation_id"],
+                "expected_production_revision": inspection["production_revision"],
+                "receipt": receipt,
+            }
+        ),
+        "promote-home-command",
+    )
+    assert tampered.status == 422
+    assert _payload(tampered) == {"error_code": "signature"}
+
+    cas_receipt = _v2_receipt(inspection, now, private, nonce="validation-v2-cas-001")
+    state.journal["production_revision"] = "concurrent-production-revision"
+    state.save()
+    cas_failed = await view.post(
+        _Request(
+            {
+                "preview_revision": transaction["revision"],
+                "operation_id": cas_receipt["operation_id"],
+                "expected_production_revision": inspection["production_revision"],
+                "receipt": cas_receipt,
+            }
+        ),
+        "promote-home-command",
+    )
+    assert cas_failed.status == 409
+    assert _payload(cas_failed) == {"error_code": "production_revision_conflict"}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("action", "applied"),
+    [
+        ("promote_home_command", True),
+        ("promote_home_command", False),
+        ("rollback_home_command", True),
+        ("rollback_home_command", False),
+    ],
+)
+async def test_operation_get_reconciles_lost_response_without_duplicate_save(
+    tmp_path, monkeypatch, action, applied
+):
+    old_config = {"views": [{"title": "Old production"}]}
+    dashboard_bytes = b"durable-operation-dashboard"
+    dashboard_sha = hashlib.sha256(dashboard_bytes).hexdigest()
+    asset_name = f"aurora-preview-dashboard-{dashboard_sha}.js"
+    resource_url = adapter.DASHBOARD_URL_PREFIX + asset_name
+    new_config = {
+        "views": [{"title": "New production"}],
+        "resources": [{"url": resource_url, "res_type": "module"}],
+    }
+    operation_id = f"operation-{action}-{int(applied)}"
+    journal = {"operations": {}, "transactions": {}}
+    if action == "promote_home_command":
+        transaction = {
+            "transaction_id": "tx-lost-promotion",
+            "revision": "revision-new",
+            "status": "activated",
+            "dashboard_sha256": dashboard_sha,
+            "active_dashboard_asset": asset_name,
+        }
+        operation = {
+            "operation_id": operation_id,
+            "action": action,
+            "status": "prepared",
+            "transaction_id": transaction["transaction_id"],
+            "preview_revision": transaction["revision"],
+            "target_revision": transaction["revision"],
+            "expected_production_revision": "revision-old",
+            "expected_production_config_sha256": adapter._config_sha256(old_config),
+            "preview_config_sha256": adapter._config_sha256(new_config),
+            "dashboard_resource_url": resource_url,
+            "dashboard_sha256": dashboard_sha,
+            "dashboard_size": len(dashboard_bytes),
+            "receipt_sha256": "a" * 64,
+            "request_sha256": "b" * 64,
+        }
+        journal.update(
+            {
+                "transactions": {transaction["transaction_id"]: transaction},
+                "production_revision": "revision-old",
+                "production_config_sha256": adapter._config_sha256(old_config),
+                "active_preview": transaction["revision"],
+                "receipt_nonces": {
+                    "lost-promotion-nonce-001": transaction["transaction_id"]
+                },
+                "production_transition": {
+                    "operation_id": operation_id,
+                    "status": "prepared",
+                    "previous": {
+                        "revision": "revision-old",
+                        "config": old_config,
+                        "config_sha256": adapter._config_sha256(old_config),
+                    },
+                    "next_config": new_config,
+                    "next_config_sha256": adapter._config_sha256(new_config),
+                    "expected_revision": "revision-old",
+                    "expected_config_sha256": adapter._config_sha256(old_config),
+                    "to_revision": transaction["revision"],
+                    "transaction_id": transaction["transaction_id"],
+                    "receipt_nonce": "lost-promotion-nonce-001",
+                    "receipt_sha256": "a" * 64,
+                    "request_sha256": "b" * 64,
+                    "dashboard_resource_url": resource_url,
+                    "dashboard_sha256": dashboard_sha,
+                    "dashboard_size": len(dashboard_bytes),
+                },
+            }
+        )
+        live_config = new_config if applied else old_config
+        expected_revision = "revision-new" if applied else "revision-old"
+        asset_path = tmp_path / "www" / "aurora" / "revisions" / asset_name
+        asset_path.parent.mkdir(parents=True)
+        asset_path.write_bytes(dashboard_bytes)
+    else:
+        operation = {
+            "operation_id": operation_id,
+            "action": action,
+            "status": "prepared",
+            "target_revision": "revision-old",
+            "expected_production_revision": "revision-new",
+            "expected_production_config_sha256": adapter._config_sha256(new_config),
+            "request_sha256": "c" * 64,
+            "expected_dashboard_resource_url": resource_url,
+            "expected_dashboard_sha256": dashboard_sha,
+            "expected_dashboard_size": len(dashboard_bytes),
+        }
+        journal.update(
+            {
+                "production_revision": "revision-new",
+                "production_config_sha256": adapter._config_sha256(new_config),
+                "previous_production": {
+                    "revision": "revision-old",
+                    "config": old_config,
+                    "config_sha256": adapter._config_sha256(old_config),
+                },
+                "rollback_transition": {
+                    "operation_id": operation_id,
+                    "status": "prepared",
+                    "from_revision": "revision-new",
+                    "to_revision": "revision-old",
+                    "expected_config_sha256": adapter._config_sha256(new_config),
+                    "next_config": old_config,
+                    "next_config_sha256": adapter._config_sha256(old_config),
+                    "request_sha256": "c" * 64,
+                    "expected_dashboard_resource_url": resource_url,
+                    "expected_dashboard_sha256": dashboard_sha,
+                    "expected_dashboard_size": len(dashboard_bytes),
+                },
+            }
+        )
+        live_config = old_config if applied else new_config
+        expected_revision = "revision-old" if applied else "revision-new"
+        asset_path = tmp_path / "www" / "aurora" / "revisions" / asset_name
+        asset_path.parent.mkdir(parents=True)
+        asset_path.write_bytes(dashboard_bytes)
+    journal["operations"][operation_id] = operation
+    state = _state(tmp_path, journal)
+    production = _Dashboard(live_config)
+    monkeypatch.setattr(
+        adapter,
+        "_load_dashboard",
+        AsyncMock(side_effect=lambda *_args: (production, production.config)),
+    )
+    original_save = state.save
+    state.save = Mock(wraps=original_save)
+
+    response = await adapter.TransactionView(state.hass, state).get(
+        _Request(), operation_id, "readback"
+    )
+
+    assert response.status == 200
+    payload = _payload(response)
+    assert payload["status"] == ("committed" if applied else "aborted")
+    assert payload["applied"] is applied
+    assert payload["verified"] is True
+    assert payload["active_revision"] == expected_revision
+    assert production.async_save.await_count == 0
+    assert state.save.call_count == 1
+
+    repeated = await adapter.TransactionView(state.hass, state).get(
+        _Request(), operation_id, "status"
+    )
+    assert repeated.status == 200
+    assert _payload(repeated)["status"] == payload["status"]
+    assert state.save.call_count == 1
 
 
 @pytest.mark.asyncio
@@ -656,19 +1484,36 @@ async def test_rollback_restores_and_rotates_immediate_prior_production(
             },
         },
     )
-    load_dashboard = AsyncMock(return_value=(production, current_config))
+    load_dashboard = AsyncMock(
+        side_effect=lambda *_args: (production, production.config)
+    )
     monkeypatch.setattr(adapter, "_load_dashboard", load_dashboard)
 
     response = await adapter.RootView(state.hass, state).post(
-        _Request(), "rollback-home-command"
+        _Request(
+            {
+                "operation_id": "rollback-operation-route-001",
+                "expected_current_revision": "revision-current",
+                "expected_current_config_sha256": adapter._config_sha256(
+                    current_config
+                ),
+            }
+        ),
+        "rollback-home-command",
     )
 
     assert response.status == 200
     assert _payload(response) == {
         "rolled_back": True,
+        "operation_id": "rollback-operation-route-001",
+        "status": "committed",
         "active_revision": "revision-prior",
+        "production_config_sha256": adapter._config_sha256(prior_config),
+        "applied": True,
+        "verified": True,
+        "dashboard_resource_present": False,
     }
-    load_dashboard.assert_awaited_once_with(state.hass, adapter.PRODUCTION)
+    assert load_dashboard.await_count == 2
     production.async_save.assert_awaited_once_with(prior_config)
     assert state.journal["production_revision"] == "revision-prior"
     assert state.journal["production_config_sha256"] == adapter._config_sha256(
@@ -677,10 +1522,171 @@ async def test_rollback_restores_and_rotates_immediate_prior_production(
     assert state.journal["previous_production"] is None
 
     repeated = await adapter.RootView(state.hass, state).post(
-        _Request(), "rollback-home-command"
+        _Request(
+            {
+                "operation_id": "rollback-operation-route-001",
+                "expected_current_revision": "revision-current",
+                "expected_current_config_sha256": adapter._config_sha256(
+                    current_config
+                ),
+            }
+        ),
+        "rollback-home-command",
     )
-    assert repeated.status == 409
-    assert _payload(repeated) == {"error_code": "no_prior_production_revision"}
+    assert repeated.status == 200
+    assert _payload(repeated)["idempotent"] is True
+
+    operation_view = adapter.TransactionView(state.hass, state)
+    status = await operation_view.get(
+        _Request(), "rollback-operation-route-001", "status"
+    )
+    assert status.status == 200
+    assert _payload(status)["action"] == "rollback_home_command"
+    assert _payload(status)["target_revision"] == "revision-prior"
+    readback = await operation_view.get(
+        _Request(), "rollback-operation-route-001", "readback"
+    )
+    assert readback.status == 200
+    assert _payload(readback)["verified"] is True
+
+    collision = await adapter.RootView(state.hass, state).post(
+        _Request(
+            {
+                "operation_id": "rollback-operation-route-001",
+                "expected_current_revision": "revision-prior",
+                "expected_current_config_sha256": adapter._config_sha256(prior_config),
+            }
+        ),
+        "rollback-home-command",
+    )
+    assert collision.status == 409
+    assert _payload(collision) == {"error_code": "operation_id_conflict"}
+
+
+@pytest.mark.asyncio
+async def test_production_rollback_readback_rehashes_restored_dashboard_asset(
+    tmp_path, monkeypatch
+):
+    current_asset = b"current-production-dashboard"
+    current_sha = hashlib.sha256(current_asset).hexdigest()
+    current_name = f"aurora-preview-dashboard-{current_sha}.js"
+    prior_asset = b"prior-production-dashboard"
+    prior_sha = hashlib.sha256(prior_asset).hexdigest()
+    prior_name = f"aurora-preview-dashboard-{prior_sha}.js"
+    asset_root = tmp_path / "www" / "aurora" / "revisions"
+    asset_root.mkdir(parents=True)
+    (asset_root / current_name).write_bytes(current_asset)
+    prior_path = asset_root / prior_name
+    prior_path.write_bytes(prior_asset)
+    current_config = adapter._dashboard_config_with_asset(
+        {"views": [{"title": "Current production"}]}, current_name
+    )
+    prior_config = adapter._dashboard_config_with_asset(
+        {"views": [{"title": "Prior production"}]}, prior_name
+    )
+    production = _Dashboard(current_config)
+    state = _state(
+        tmp_path,
+        {
+            "production_revision": "revision-current-resource",
+            "production_config_sha256": adapter._config_sha256(current_config),
+            "previous_production": {
+                "revision": "revision-prior-resource",
+                "config": prior_config,
+                "config_sha256": adapter._config_sha256(prior_config),
+            },
+        },
+    )
+    monkeypatch.setattr(
+        adapter,
+        "_load_dashboard",
+        AsyncMock(side_effect=lambda *_args: (production, production.config)),
+    )
+    operation_id = "rollback-operation-resource-001"
+    body = {
+        "operation_id": operation_id,
+        "expected_current_revision": "revision-current-resource",
+        "expected_current_config_sha256": adapter._config_sha256(current_config),
+    }
+
+    response = await adapter.RootView(state.hass, state).post(
+        _Request(body), "rollback-home-command"
+    )
+
+    assert response.status == 200
+    assert _payload(response)["dashboard_resource_url"] == (
+        adapter.DASHBOARD_URL_PREFIX + prior_name
+    )
+    readback = await adapter.TransactionView(state.hass, state).get(
+        _Request(), operation_id, "readback"
+    )
+    assert readback.status == 200
+    assert _payload(readback)["dashboard_sha256"] == prior_sha
+    assert _payload(readback)["expected_current_revision"] == (
+        "revision-current-resource"
+    )
+
+    prior_path.write_bytes(b"tampered-prior-production-dashboard")
+    tampered = await adapter.TransactionView(state.hass, state).get(
+        _Request(), operation_id, "readback"
+    )
+    assert tampered.status == 409
+    assert _payload(tampered) == {"error_code": "operation_readback_mismatch"}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("asset_state", ["missing", "tampered"])
+async def test_production_rollback_rejects_unverifiable_prior_asset(
+    tmp_path, monkeypatch, asset_state
+):
+    prior_asset = b"prior-production-dashboard"
+    prior_sha = hashlib.sha256(prior_asset).hexdigest()
+    prior_name = f"aurora-preview-dashboard-{prior_sha}.js"
+    prior_config = adapter._dashboard_config_with_asset(
+        {"views": [{"title": "Prior production"}]}, prior_name
+    )
+    prior_path = tmp_path / "www" / "aurora" / "revisions" / prior_name
+    prior_path.parent.mkdir(parents=True)
+    if asset_state == "tampered":
+        prior_path.write_bytes(b"tampered")
+    current_config = {"views": [{"title": "Current production"}]}
+    production = _Dashboard(current_config)
+    state = _state(
+        tmp_path,
+        {
+            "production_revision": "revision-current",
+            "production_config_sha256": adapter._config_sha256(current_config),
+            "previous_production": {
+                "revision": "revision-prior",
+                "config": prior_config,
+                "config_sha256": adapter._config_sha256(prior_config),
+            },
+        },
+    )
+    monkeypatch.setattr(
+        adapter,
+        "_load_dashboard",
+        AsyncMock(side_effect=lambda *_args: (production, production.config)),
+    )
+
+    response = await adapter.RootView(state.hass, state).post(
+        _Request(
+            {
+                "operation_id": f"rollback-unverifiable-{asset_state}",
+                "expected_current_revision": "revision-current",
+                "expected_current_config_sha256": adapter._config_sha256(
+                    current_config
+                ),
+            }
+        ),
+        "rollback-home-command",
+    )
+
+    assert response.status == 409
+    assert _payload(response) == {
+        "error_code": "production_rollback_evidence_invalid"
+    }
+    production.async_save.assert_not_awaited()
 
 
 def test_corrupt_journal_fails_closed(tmp_path):
@@ -695,7 +1701,9 @@ def test_corrupt_journal_fails_closed(tmp_path):
 @pytest.mark.asyncio
 async def test_request_rate_limit_fails_closed(tmp_path):
     state = _state(tmp_path)
-    state.request_times.extend([adapter.time.monotonic()] * adapter.MAX_REQUESTS_PER_MINUTE)
+    state.request_times.extend(
+        [adapter.time.monotonic()] * adapter.MAX_REQUESTS_PER_MINUTE
+    )
 
     response = await adapter.RootView(state.hass, state).post(_Request(), "bootstrap")
 
@@ -705,25 +1713,61 @@ async def test_request_rate_limit_fails_closed(tmp_path):
 
 @pytest.mark.asyncio
 async def test_transaction_rollback_restores_preview_snapshot(tmp_path, monkeypatch):
+    prior_dashboard = b"prior-preview-dashboard"
+    prior_dashboard_sha = hashlib.sha256(prior_dashboard).hexdigest()
+    prior_asset_name = f"aurora-preview-dashboard-{prior_dashboard_sha}.js"
+    prior_asset_path = (
+        tmp_path / "www" / "aurora" / "revisions" / prior_asset_name
+    )
+    prior_asset_path.parent.mkdir(parents=True)
+    prior_asset_path.write_bytes(prior_dashboard)
+    previous_config = adapter._dashboard_config_with_asset(
+        {"views": [{"title": "Before"}]}, prior_asset_name
+    )
+    current_dashboard_sha = hashlib.sha256(b"current-preview-dashboard").hexdigest()
+    current_asset_name = f"aurora-preview-dashboard-{current_dashboard_sha}.js"
+    current_config = adapter._dashboard_config_with_asset(
+        previous_config, current_asset_name
+    )
+    prior_transaction = {
+        "transaction_id": "tx-prior-preview-rollback",
+        "revision": "revision-before-preview",
+        "status": "activated",
+        "dashboard_sha256": prior_dashboard_sha,
+        "active_dashboard_asset": prior_asset_name,
+        "active_preview_config_sha256": adapter._config_sha256(previous_config),
+    }
     transaction = {
         "transaction_id": "tx-preview-rollback",
         "revision": "revision-preview",
         "status": "activated",
-        "preview_before": {"views": [{"title": "Before"}]},
+        "dashboard_sha256": current_dashboard_sha,
+        "active_dashboard_asset": current_asset_name,
+        "preview_before": previous_config,
+        "preview_config_sha256_before": adapter._config_sha256(previous_config),
+        "active_preview_config_sha256": adapter._config_sha256(current_config),
         "preview_revision_before": "revision-before-preview",
     }
     state = _state(
         tmp_path,
         {
-            "transactions": {transaction["transaction_id"]: transaction},
+            "transactions": {
+                prior_transaction["transaction_id"]: prior_transaction,
+                transaction["transaction_id"]: transaction,
+            },
             "active_preview": transaction["revision"],
         },
     )
-    preview = _Dashboard({"views": [{"title": "After"}]})
+    preview = _Dashboard(current_config)
     monkeypatch.setattr(
         adapter,
         "_load_dashboard",
-        AsyncMock(return_value=(preview, {"views": [{"title": "After"}]})),
+        AsyncMock(side_effect=lambda *_args: (preview, preview.config)),
+    )
+    monkeypatch.setattr(
+        adapter,
+        "_verify_active_transaction",
+        AsyncMock(return_value=current_dashboard_sha),
     )
 
     response = await adapter.TransactionView(state.hass, state).post(
@@ -734,6 +1778,7 @@ async def test_transaction_rollback_restores_preview_snapshot(tmp_path, monkeypa
     assert _payload(response) == {
         "rolled_back": True,
         "active_revision": "revision-before-preview",
+        "previous_revision": "revision-before-preview",
         "preview_active": True,
         "status": "rolled_back",
     }
@@ -741,19 +1786,66 @@ async def test_transaction_rollback_restores_preview_snapshot(tmp_path, monkeypa
     assert state.journal["active_preview"] == "revision-before-preview"
     assert transaction["status"] == "rolled_back"
 
+    repeated = await adapter.TransactionView(state.hass, state).post(
+        _Request(), transaction["transaction_id"], "rollback"
+    )
+    assert repeated.status == 200
+    assert _payload(repeated)["idempotent"] is True
+    assert preview.async_save.await_count == 1
+
+    prior_asset_path.write_bytes(b"tampered-prior-preview-dashboard")
+    tampered = await adapter.TransactionView(state.hass, state).post(
+        _Request(), transaction["transaction_id"], "rollback"
+    )
+    assert tampered.status == 409
+    assert _payload(tampered) == {
+        "error_code": "preview_rollback_readback_failed"
+    }
+
 
 @pytest.mark.asyncio
-async def test_reload_without_registered_backend_fails_closed(tmp_path):
+async def test_reload_is_verified_dashboard_only_noop(tmp_path, monkeypatch):
+    active_config = {"views": [{"title": "Active preview"}]}
     transaction = {
         "transaction_id": "tx-reload",
         "revision": "revision-reload",
         "status": "activated",
+        "active_preview_config_sha256": adapter._config_sha256(active_config),
     }
-    state = _state(tmp_path, {"transactions": {transaction["transaction_id"]: transaction}})
+    state = _state(
+        tmp_path,
+        {
+            "transactions": {transaction["transaction_id"]: transaction},
+            "active_preview": transaction["revision"],
+        },
+    )
+    verify_active = AsyncMock(return_value="f" * 64)
+    monkeypatch.setattr(adapter, "_verify_active_transaction", verify_active)
+    monkeypatch.setattr(
+        adapter,
+        "_load_dashboard",
+        AsyncMock(return_value=(_Dashboard(active_config), active_config)),
+    )
 
     response = await adapter.TransactionView(state.hass, state).post(
         _Request(), transaction["transaction_id"], "reload"
     )
 
-    assert response.status == 409
-    assert _payload(response) == {"error_code": "restart_required"}
+    assert response.status == 200
+    assert _payload(response) == {
+        "reloaded": True,
+        "verified": True,
+        "active_revision": transaction["revision"],
+        "previous_revision": None,
+        "status": "reloaded",
+        "restart_required": False,
+        "backend_unchanged": True,
+    }
+    verify_active.assert_awaited_once_with(state.hass, transaction, state.root)
+
+    repeated = await adapter.TransactionView(state.hass, state).post(
+        _Request(), transaction["transaction_id"], "reload"
+    )
+    assert repeated.status == 200
+    assert _payload(repeated)["idempotent"] is True
+    assert verify_active.await_count == 2


### PR DESCRIPTION
## Summary

- add the bounded authenticated Aurora deployment adapter
- preserve exact-candidate staging, promotion, rollback, and readback contracts
- include bootstrap hardening and credential-safe regression coverage

## Validation

- ruff check src/ tests/
- mypy src/
- 217 focused Aurora adapter/bootstrap tests
- full E2E: 1121 passed, 77 guarded HAOS-only skips

## Scope

This branch is based on current upstream master. Stale dashboard documentation and proof-only worktrees were intentionally excluded.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added authenticated Aurora dashboard administration.
  * Supports preview, staging, activation, promotion, rollback, status, and recovery workflows.
  * Added signed release validation, privacy safeguards, archive integrity checks, and protected production changes.
  * Added Home Assistant integration support for managing Aurora deployments.

* **Documentation**
  * Added the Aurora server integration contract covering operations, validation, and response behavior.

* **Tests**
  * Added comprehensive coverage for authorization, signing, replay protection, rollback, recovery, integrity validation, and failure handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->