### PR TITLE
Switch Locale Sync default model to Gemini 3.5 Flash-Lite

### DIFF
--- a/scripts/translate_locales.py
+++ b/scripts/translate_locales.py
@@ -91,7 +91,7 @@ SETTINGS_SURFACE = "src/ha_mcp/settings_ui/locales"
 COMPONENT_SURFACE = "custom_components/ha_mcp_tools/translations"
 TOOLS_SURFACE = "settings UI tool titles and descriptions"
 
-DEFAULT_MODEL = "gemini-2.5-flash"
+DEFAULT_MODEL = "gemini-3.5-flash-lite"
 # Free-tier pacing: stay comfortably under the strictest published RPM.
 _SECONDS_BETWEEN_REQUESTS = 7.0
 # Self-imposed wall-clock bound, kept below the workflow's job timeout: when


### PR DESCRIPTION
## What changed

This switches the Locale Sync translation pipeline default model from `gemini-2.5-flash` to `gemini-3.5-flash-lite`.

## Why

`Locale Sync` is a structured JSON translation workflow, not a deep reasoning or coding workflow. `gemini-3.5-flash-lite` is positioned by Google as the cost-efficient GA model for translation, high-volume execution, and simple data processing, which is a better fit for this path than keeping the older default.

This keeps the change intentionally minimal:
- no workflow changes
- no secret changes
- no provider swap
- no reasoning/tuning parameter changes

## Pricing

Per Google's official Gemini API pricing on August 13, 2026, the **Standard** paid-tier pricing for these two models is currently the same:

- Old default: `gemini-2.5-flash`
  - input: **$0.30 / 1M tokens**
  - output: **$2.50 / 1M tokens**
- New default: `gemini-3.5-flash-lite`
  - input: **$0.30 / 1M tokens**
  - output: **$2.50 / 1M tokens**

So this change is primarily about using the newer translation-oriented GA model, not about lowering the current Standard-tier token price.

Official source:
- https://ai.google.dev/gemini-api/docs/pricing

## Impact

The pipeline keeps the same code path and API surface, but future translation runs will use the newer default model unless `GEMINI_MODEL` is explicitly overridden.

## Validation

Ran:

```bash
/home/julien/github/ha-mcp/.venv/bin/python -m pytest tests/src/unit/test_translate_locales.py -q
```

Result:
- `78 passed, 1 skipped`

Also validated the model slug live against the same `generateContent` endpoint used by `Locale Sync`:
- `gemini-3.5-flash-lite` -> HTTP 200
- `gemini-2.5-flash` -> HTTP 200
