### PR TITLE
fix: support history_stats and mold_indicator helpers in ha_config_set_helper

### DIFF
--- a/src/ha_mcp/server.py
+++ b/src/ha_mcp/server.py
@@ -603,14 +603,15 @@ class HomeAssistantSmartMCPServer:
             "conditions actions get show detail"
         ),
         # s09: "create helper" → ha_config_set_helper should outrank remove_helper
-        # Covers all 27 helper types (12 simple + 15 flow-based, unified in #967).
+        # Covers all 29 helper types (12 simple + 17 flow-based, unified in #967).
         "ha_config_set_helper": (
             "create update new add helper "
             "input_boolean input_button input_number input_text input_datetime "
             "input_select counter timer schedule zone person tag "
             "template group utility_meter derivative min_max threshold "
             "integration statistics trend random filter tod "
-            "generic_thermostat switch_as_x generic_hygrostat"
+            "generic_thermostat switch_as_x generic_hygrostat "
+            "history_stats mold_indicator"
         ),
         # Boost tools that compete with ha_search for common queries
         "ha_config_get_script": (

--- a/src/ha_mcp/settings_ui/locales/zh-Hans.json
+++ b/src/ha_mcp/settings_ui/locales/zh-Hans.json
@@ -608,7 +608,7 @@
     },
     "ha_config_set_helper": {
       "title": "创建或更新辅助实体",
-      "description": "创建或更新 Home Assistant 辅助实体与配置子条目（28 种类型，统一接口）。"
+      "description": "创建或更新 Home Assistant 辅助实体与配置子条目（30 种类型，统一接口）。"
     },
     "ha_config_set_label": {
       "title": "创建或更新标签",

--- a/src/ha_mcp/tools/config_entry_flow.py
+++ b/src/ha_mcp/tools/config_entry_flow.py
@@ -7,7 +7,7 @@ Config Entry Flow API.
 
 The create/update entry point is the unified ha_config_set_helper tool in
 tools_config_helpers.py, which routes to create_flow_helper / update_flow_helper
-for the 15 helper types listed in FLOW_HELPER_TYPES.
+for the 17 helper types listed in FLOW_HELPER_TYPES.
 
 The same flow walkers drive every other config-entry surface, not just
 helpers: ``ha_set_integration`` creates entries for arbitrary domains through
@@ -65,7 +65,10 @@ def _reject_redaction_sentinels(config_dict: dict[str, Any]) -> None:
         )
 
 
-# 15 helpers that use Config Entry Flow API (Issue #324).
+# 17 helpers that use Config Entry Flow API (Issue #324, #2187).
+# `otp` is the one helper-typed config flow deliberately left out: its confirm
+# step demands a live TOTP code derived from the secret, which no flow walker
+# can supply. It stays reachable through ha_set_integration(domain="otp").
 SUPPORTED_HELPERS = Literal[
     "template",
     "group",
@@ -82,6 +85,8 @@ SUPPORTED_HELPERS = Literal[
     "generic_thermostat",
     "switch_as_x",
     "generic_hygrostat",
+    "history_stats",
+    "mold_indicator",
 ]
 
 # Value-set form of SUPPORTED_HELPERS for runtime routing checks.
@@ -103,6 +108,8 @@ FLOW_HELPER_TYPES: frozenset[str] = frozenset(
         "generic_thermostat",
         "switch_as_x",
         "generic_hygrostat",
+        "history_stats",
+        "mold_indicator",
     }
 )
 

--- a/src/ha_mcp/tools/tools_config_helpers.py
+++ b/src/ha_mcp/tools/tools_config_helpers.py
@@ -4398,6 +4398,7 @@ class HelperConfigTools:
                 "generic_hygrostat",
                 "generic_thermostat",
                 "group",
+                "history_stats",
                 "input_boolean",
                 "input_button",
                 "input_datetime",
@@ -4406,6 +4407,7 @@ class HelperConfigTools:
                 "input_text",
                 "integration",
                 "min_max",
+                "mold_indicator",
                 "person",
                 "random",
                 "schedule",
@@ -4702,7 +4704,8 @@ class HelperConfigTools:
                     "helper_type='config_subentry' "
                     "(template, group, utility_meter, derivative, min_max, threshold, "
                     "integration, statistics, trend, random, filter, tod, "
-                    "generic_thermostat, switch_as_x, generic_hygrostat). "
+                    "generic_thermostat, switch_as_x, generic_hygrostat, "
+                    "history_stats, mold_indicator). "
                     "Ignored for simple helper types. "
                     "Field set is delivered as data_schema on the first validation error."
                 ),
@@ -4739,7 +4742,7 @@ class HelperConfigTools:
     ) -> dict[str, Any]:
         """
         Create or update Home Assistant helper entities and config subentries
-        (28 types, unified interface).
+        (30 types, unified interface).
 
         MUST call ha_get_skill_guide OR refer to your locally installed skills first.
 
@@ -4753,9 +4756,13 @@ class HelperConfigTools:
 
         FLOW types (pass `config` dict, Config Entry Flow API): template, group,
         utility_meter, derivative, min_max, threshold, integration, statistics, trend,
-        random, filter, tod, generic_thermostat, switch_as_x, generic_hygrostat.
+        random, filter, tod, generic_thermostat, switch_as_x, generic_hygrostat,
+        history_stats, mold_indicator.
         Note: `tod` is the purpose-built "is-current-time-in-range" indicator
         (supports cross-midnight ranges, unlike `schedule`).
+        Note: `otp` is a helper in the HA UI but is not offered here — its flow
+        requires a live TOTP code. Create it with ha_set_integration(domain="otp"),
+        as with any other helper-domain flow outside this list.
 
         CONFIG_SUBENTRY type (Config Subentry Flow API): config_subentry.
         Pass `entry_id`, `subentry_type`, and `config`. Pass `subentry_id` to

--- a/src/ha_mcp/tools/tools_integrations.py
+++ b/src/ha_mcp/tools/tools_integrations.py
@@ -104,7 +104,7 @@ HelperTypeLiteral = Literal[
     "tag",
     # config-entry subentries
     "config_subentry",
-    # 15 FLOW
+    # 17 FLOW
     "template",
     "group",
     "utility_meter",
@@ -120,6 +120,8 @@ HelperTypeLiteral = Literal[
     "generic_thermostat",
     "switch_as_x",
     "generic_hygrostat",
+    "history_stats",
+    "mold_indicator",
 ]
 assert set(get_args(HelperTypeLiteral)) == (
     SIMPLE_HELPER_TYPES | FLOW_HELPER_TYPES | {"config_subentry"}
@@ -1846,7 +1848,9 @@ class IntegrationTools:
 
         WHEN NOT TO USE:
         - Helpers (template, group, utility_meter, ...): use
-          ha_config_set_helper.
+          ha_config_set_helper. The exception is `otp`, which is a helper in
+          the HA UI but is created HERE via domain="otp" — its flow needs a
+          live TOTP code, so ha_config_set_helper deliberately omits it.
         - Config subentries: use
           ha_config_set_helper(helper_type='config_subentry').
         - Removing an entry: use ha_remove_helpers_integrations.
@@ -2110,10 +2114,10 @@ class IntegrationTools:
         - SIMPLE (12, websocket-delete): input_button, input_boolean,
           input_select, input_number, input_text, input_datetime, counter,
           timer, schedule, zone, person, tag.
-        - FLOW (15, config-entry-delete via entity lookup): template, group,
+        - FLOW (17, config-entry-delete via entity lookup): template, group,
           utility_meter, derivative, min_max, threshold, integration,
           statistics, trend, random, filter, tod, generic_thermostat,
-          switch_as_x, generic_hygrostat.
+          switch_as_x, generic_hygrostat, history_stats, mold_indicator.
 
         ROUTING:
         - SIMPLE helper_type + bare helper_id or entity_id → websocket delete.

--- a/src/ha_mcp/tools/tools_yaml_config.py
+++ b/src/ha_mcp/tools/tools_yaml_config.py
@@ -403,7 +403,7 @@ class YamlConfigTools:
         - Automations (storage-mode) -> ha_config_set_automation
         - Scripts (storage-mode) -> ha_config_set_script
         - Scenes (storage-mode) -> ha_config_set_scene
-        - All 28 helper types (input_*, counter, timer, schedule, zone, person,
+        - All 30 helper types (input_*, counter, timer, schedule, zone, person,
           tag, group, min_max, threshold, derivative, statistics, utility_meter,
           trend, filter, switch_as_x, etc.) -> ha_config_set_helper
 

--- a/tests/initial_test_state/configuration.yaml
+++ b/tests/initial_test_state/configuration.yaml
@@ -75,3 +75,13 @@ template:
         device_class: temperature
         state_class: measurement
         unit_of_measurement: "°C"
+      # mold_indicator's flow requires a humidity source alongside the two
+      # temperature ones. HA's EntitySelector validates only the entity_id
+      # shape, so a temperature sensor would be accepted here and then log
+      # "unsupported unit" and hold the helper at unknown forever.
+      - name: demo Humidity
+        unique_id: e2e_demo_humidity
+        state: "{{ 45.0 }}"
+        device_class: humidity
+        state_class: measurement
+        unit_of_measurement: "%"

--- a/tests/src/e2e/workflows/config/test_config_entry_flow.py
+++ b/tests/src/e2e/workflows/config/test_config_entry_flow.py
@@ -440,33 +440,34 @@ class TestConfigEntryFlow:
             mcp_client, "min_max", config, "min_max helper for update test"
         )
 
-        # Update via options flow
-        updated_config = {
-            "entity_ids": [
-                "sensor.demo_temperature",
-                "sensor.demo_outside_temperature",
-            ],
-            "type": "max",
-        }
-        async with MCPAssertions(mcp_client) as mcp:
-            update_data = await mcp.call_tool_success(
-                "ha_config_set_helper",
-                {
-                    "helper_type": "min_max",
-                    "name": "test_min_max_update_e2e",
-                    "config": updated_config,
-                    # unified tool normalizes entry_id -> helper_id for flow helpers
-                    "helper_id": entry_id,
-                },
+        try:
+            # Update via options flow
+            updated_config = {
+                "entity_ids": [
+                    "sensor.demo_temperature",
+                    "sensor.demo_outside_temperature",
+                ],
+                "type": "max",
+            }
+            async with MCPAssertions(mcp_client) as mcp:
+                update_data = await mcp.call_tool_success(
+                    "ha_config_set_helper",
+                    {
+                        "helper_type": "min_max",
+                        "name": "test_min_max_update_e2e",
+                        "config": updated_config,
+                        # unified tool normalizes entry_id -> helper_id
+                        # for flow helpers
+                        "helper_id": entry_id,
+                    },
+                )
+            assert update_data.get("updated") is True
+        finally:
+            await safe_call_tool(
+                mcp_client,
+                "ha_remove_helpers_integrations",
+                {"target": entry_id, "confirm": True},
             )
-        assert update_data.get("updated") is True
-
-        # Cleanup
-        await safe_call_tool(
-            mcp_client,
-            "ha_remove_helpers_integrations",
-            {"target": entry_id, "confirm": True},
-        )
 
     async def test_get_integration_include_schema(self, mcp_client):
         """ha_get_integration with include_schema=True returns options_schema for eligible entries."""

--- a/tests/src/e2e/workflows/config/test_config_entry_flow.py
+++ b/tests/src/e2e/workflows/config/test_config_entry_flow.py
@@ -21,11 +21,7 @@ import logging
 
 import pytest
 
-from ...utilities.assertions import (
-    MCPAssertions,
-    assert_mcp_success,
-    safe_call_tool,
-)
+from ...utilities.assertions import MCPAssertions, safe_call_tool
 from ...utilities.wait_helpers import wait_for_tool_result
 
 logger = logging.getLogger(__name__)
@@ -40,11 +36,15 @@ async def _create_config_entry_helper(
     in the `config` dict. The test fixtures place `name` inside `config`, so
     we forward it as-is. Polls until the new entry is registered, returns entry_id.
     """
-    result = await mcp_client.call_tool(
-        "ha_config_set_helper",
-        {"helper_type": helper_type, "name": config.get("name", ""), "config": config},
-    )
-    data = assert_mcp_success(result, f"Create {description}")
+    async with MCPAssertions(mcp_client) as mcp:
+        data = await mcp.call_tool_success(
+            "ha_config_set_helper",
+            {
+                "helper_type": helper_type,
+                "name": config.get("name", ""),
+                "config": config,
+            },
+        )
     assert data.get("success") is True
     entry_id = data.get("entry_id")
     assert entry_id is not None
@@ -114,10 +114,10 @@ class TestConfigEntryFlow:
         assert data.get("success") is True
         entry_id = data.get("entry_id")
         assert entry_id is not None
-        entity_ids = data.get("entity_ids") or []
-        assert entity_ids, f"No entity_ids in response: {data}"
 
         try:
+            entity_ids = data.get("entity_ids") or []
+            assert entity_ids, f"No entity_ids in response: {data}"
             await wait_for_tool_result(
                 mcp_client,
                 tool_name="ha_get_state",
@@ -156,10 +156,10 @@ class TestConfigEntryFlow:
         assert data.get("success") is True
         entry_id = data.get("entry_id")
         assert entry_id is not None
-        entity_ids = data.get("entity_ids") or []
-        assert entity_ids, f"No entity_ids in response: {data}"
 
         try:
+            entity_ids = data.get("entity_ids") or []
+            assert entity_ids, f"No entity_ids in response: {data}"
             await wait_for_tool_result(
                 mcp_client,
                 tool_name="ha_get_state",
@@ -222,34 +222,30 @@ class TestConfigEntryFlow:
         availability = "{{ has_value('sensor.demo_temperature') }}"
 
         try:
-            update_result = await mcp_client.call_tool(
-                "ha_config_set_helper",
-                {
-                    "helper_type": "template",
-                    "helper_id": entry_id,
-                    "action": "update",
-                    "config": {
-                        "state": "{{ 1 }}",
-                        "availability": availability,
-                        "availabilty": "{{ false }}",
+            async with MCPAssertions(mcp_client) as mcp:
+                update_data = await mcp.call_tool_success(
+                    "ha_config_set_helper",
+                    {
+                        "helper_type": "template",
+                        "helper_id": entry_id,
+                        "action": "update",
+                        "config": {
+                            "state": "{{ 1 }}",
+                            "availability": availability,
+                            "availabilty": "{{ false }}",
+                        },
                     },
-                },
-            )
-            update_data = assert_mcp_success(
-                update_result, "Update template sensor availability"
-            )
+                )
             assert update_data.get("warnings") == [
                 "Ignored config keys not declared by the Home Assistant flow "
                 "schema: availabilty"
             ]
 
-            integration_result = await mcp_client.call_tool(
-                "ha_get_integration",
-                {"entry_id": entry_id, "include_options": True},
-            )
-            integration_data = assert_mcp_success(
-                integration_result, "Read template sensor availability"
-            )
+            async with MCPAssertions(mcp_client) as mcp:
+                integration_data = await mcp.call_tool_success(
+                    "ha_get_integration",
+                    {"entry_id": entry_id, "include_options": True},
+                )
             options = (integration_data.get("entry") or {}).get("options") or {}
             assert options.get("availability") == availability, (
                 "Nested availability option was not persisted or read back; "
@@ -288,31 +284,31 @@ class TestConfigEntryFlow:
         template sensor is created with an icon and HA's own state for the
         entity must report that icon.
         """
-        result = await mcp_client.call_tool(
-            "ha_config_set_helper",
-            {
-                "helper_type": "template",
-                "name": "e2e icon template",
-                "config": {
-                    "next_step_id": "sensor",
+        async with MCPAssertions(mcp_client) as mcp:
+            data = await mcp.call_tool_success(
+                "ha_config_set_helper",
+                {
+                    "helper_type": "template",
                     "name": "e2e icon template",
-                    "state": "{{ states('sun.sun') }}",
+                    "config": {
+                        "next_step_id": "sensor",
+                        "name": "e2e icon template",
+                        "state": "{{ states('sun.sun') }}",
+                    },
+                    "icon": "mdi:flash",
+                    "wait": True,
                 },
-                "icon": "mdi:flash",
-                "wait": True,
-            },
-        )
-        data = assert_mcp_success(result, "Create template sensor with icon")
+            )
         assert data.get("success") is True
-        # icon is echoed back in the flow response (applied registry override).
-        assert data.get("icon") == "mdi:flash", f"icon not echoed: {data}"
         entry_id = data.get("entry_id")
         assert entry_id is not None
-        entity_ids = data.get("entity_ids") or []
-        assert entity_ids, f"No entity_ids in response: {data}"
-        entity_id = entity_ids[0]
 
         try:
+            # icon is echoed back in the flow response (applied registry override).
+            assert data.get("icon") == "mdi:flash", f"icon not echoed: {data}"
+            entity_ids = data.get("entity_ids") or []
+            assert entity_ids, f"No entity_ids in response: {data}"
+            entity_id = entity_ids[0]
             # HA surfaces the entity-registry icon override in the entity's
             # state attributes — poll until it propagates.
             await wait_for_tool_result(
@@ -379,11 +375,11 @@ class TestConfigEntryFlow:
 
             # Optimal read path: include_options surfaces the template body via
             # the options-flow probe (description.suggested_value).
-            gi = await mcp_client.call_tool(
-                "ha_get_integration",
-                {"entry_id": entry_id, "include_options": True},
-            )
-            gi_data = assert_mcp_success(gi, "get integration include_options")
+            async with MCPAssertions(mcp_client) as mcp:
+                gi_data = await mcp.call_tool_success(
+                    "ha_get_integration",
+                    {"entry_id": entry_id, "include_options": True},
+                )
             assert body_marker in str(gi_data), (
                 "include_options should surface the template body for a "
                 "UI-created template helper"
@@ -415,11 +411,11 @@ class TestConfigEntryFlow:
             mcp_client, "group", config, "light group helper (hide_members=True)"
         )
         try:
-            gi = await mcp_client.call_tool(
-                "ha_get_integration",
-                {"entry_id": entry_id, "include_options": True},
-            )
-            gi_data = assert_mcp_success(gi, "get integration include_options")
+            async with MCPAssertions(mcp_client) as mcp:
+                gi_data = await mcp.call_tool_success(
+                    "ha_get_integration",
+                    {"entry_id": entry_id, "include_options": True},
+                )
             options = (gi_data.get("entry") or {}).get("options") or {}
             assert options.get("hide_members") is True, (
                 "include_options must report the stored hide_members=True, "
@@ -452,16 +448,17 @@ class TestConfigEntryFlow:
             ],
             "type": "max",
         }
-        update_result = await mcp_client.call_tool(
-            "ha_config_set_helper",
-            {
-                "helper_type": "min_max",
-                "name": "test_min_max_update_e2e",
-                "config": updated_config,
-                "helper_id": entry_id,  # unified tool normalizes entry_id -> helper_id for flow helpers
-            },
-        )
-        update_data = assert_mcp_success(update_result, "Update min_max helper")
+        async with MCPAssertions(mcp_client) as mcp:
+            update_data = await mcp.call_tool_success(
+                "ha_config_set_helper",
+                {
+                    "helper_type": "min_max",
+                    "name": "test_min_max_update_e2e",
+                    "config": updated_config,
+                    # unified tool normalizes entry_id -> helper_id for flow helpers
+                    "helper_id": entry_id,
+                },
+            )
         assert update_data.get("updated") is True
 
         # Cleanup
@@ -474,8 +471,8 @@ class TestConfigEntryFlow:
     async def test_get_integration_include_schema(self, mcp_client):
         """ha_get_integration with include_schema=True returns options_schema for eligible entries."""
         # Find an entry that supports options
-        list_result = await mcp_client.call_tool("ha_get_integration", {})
-        list_data = assert_mcp_success(list_result, "List integrations")
+        async with MCPAssertions(mcp_client) as mcp:
+            list_data = await mcp.call_tool_success("ha_get_integration", {})
         entry = next(
             (e for e in list_data.get("entries", []) if e.get("supports_options")),
             None,
@@ -485,11 +482,11 @@ class TestConfigEntryFlow:
                 "No config entries with supports_options=true in test environment"
             )
 
-        result = await mcp_client.call_tool(
-            "ha_get_integration",
-            {"entry_id": entry["entry_id"], "include_schema": True},
-        )
-        data = assert_mcp_success(result, "Get integration with schema")
+        async with MCPAssertions(mcp_client) as mcp:
+            data = await mcp.call_tool_success(
+                "ha_get_integration",
+                {"entry_id": entry["entry_id"], "include_schema": True},
+            )
         assert "options_schema" in data, "Expected options_schema in response"
         schema = data["options_schema"]
         assert schema.get("flow_type") in ("form", "menu")

--- a/tests/src/e2e/workflows/config/test_config_entry_flow.py
+++ b/tests/src/e2e/workflows/config/test_config_entry_flow.py
@@ -21,7 +21,11 @@ import logging
 
 import pytest
 
-from ...utilities.assertions import assert_mcp_success, safe_call_tool
+from ...utilities.assertions import (
+    MCPAssertions,
+    assert_mcp_success,
+    safe_call_tool,
+)
 from ...utilities.wait_helpers import wait_for_tool_result
 
 logger = logging.getLogger(__name__)
@@ -91,22 +95,22 @@ class TestConfigEntryFlow:
         `entity_id`/`state`/`type` it redeclares read-only are already in the
         flow's options, so nothing is resubmitted to them.
         """
-        result = await mcp_client.call_tool(
-            "ha_config_set_helper",
-            {
-                "helper_type": "history_stats",
-                "name": "test_history_stats_e2e",
-                "config": {
+        async with MCPAssertions(mcp_client) as mcp:
+            data = await mcp.call_tool_success(
+                "ha_config_set_helper",
+                {
+                    "helper_type": "history_stats",
                     "name": "test_history_stats_e2e",
-                    "entity_id": "sensor.demo_temperature",
-                    "type": "time",
-                    "state": ["22.5"],
-                    "start": "{{ today_at('00:00') }}",
-                    "end": "{{ now() }}",
+                    "config": {
+                        "name": "test_history_stats_e2e",
+                        "entity_id": "sensor.demo_temperature",
+                        "type": "time",
+                        "state": ["22.5"],
+                        "start": "{{ today_at('00:00') }}",
+                        "end": "{{ now() }}",
+                    },
                 },
-            },
-        )
-        data = assert_mcp_success(result, "Create history_stats helper")
+            )
         assert data.get("success") is True
         entry_id = data.get("entry_id")
         assert entry_id is not None
@@ -134,21 +138,21 @@ class TestConfigEntryFlow:
         Single form step taking three source entities plus a calibration
         factor, which HA rejects at zero.
         """
-        result = await mcp_client.call_tool(
-            "ha_config_set_helper",
-            {
-                "helper_type": "mold_indicator",
-                "name": "test_mold_indicator_e2e",
-                "config": {
+        async with MCPAssertions(mcp_client) as mcp:
+            data = await mcp.call_tool_success(
+                "ha_config_set_helper",
+                {
+                    "helper_type": "mold_indicator",
                     "name": "test_mold_indicator_e2e",
-                    "indoor_temp_sensor": "sensor.demo_temperature",
-                    "indoor_humidity_sensor": "sensor.demo_humidity",
-                    "outdoor_temp_sensor": "sensor.demo_outside_temperature",
-                    "calibration_factor": 2.0,
+                    "config": {
+                        "name": "test_mold_indicator_e2e",
+                        "indoor_temp_sensor": "sensor.demo_temperature",
+                        "indoor_humidity_sensor": "sensor.demo_humidity",
+                        "outdoor_temp_sensor": "sensor.demo_outside_temperature",
+                        "calibration_factor": 2.0,
+                    },
                 },
-            },
-        )
-        data = assert_mcp_success(result, "Create mold_indicator helper")
+            )
         assert data.get("success") is True
         entry_id = data.get("entry_id")
         assert entry_id is not None

--- a/tests/src/e2e/workflows/config/test_config_entry_flow.py
+++ b/tests/src/e2e/workflows/config/test_config_entry_flow.py
@@ -2,7 +2,8 @@
 E2E tests for Config Entry Flow API.
 
 Covers:
-- Creating a form-only helper (min_max)
+- Creating a form-only helper (min_max, mold_indicator)
+- Creating a multi-step form helper (history_stats — user, state, options)
 - Creating a menu-based helper (group — menu then form)
 - Error feedback on missing menu selection (data_schema_unavailable_reason
   marker + menu_options inline on validation errors)
@@ -80,6 +81,94 @@ class TestConfigEntryFlow:
             "ha_remove_helpers_integrations",
             {"target": entry_id, "confirm": True},
         )
+
+    async def test_create_history_stats_helper(self, mcp_client):
+        """Create a history_stats helper (issue #2187).
+
+        Three form steps — user, state, options — driven from one flat config:
+        each step pops the keys its own schema declares and leaves the rest for
+        the next. The options step takes exactly two of start/end/duration; the
+        `entity_id`/`state`/`type` it redeclares read-only are already in the
+        flow's options, so nothing is resubmitted to them.
+        """
+        result = await mcp_client.call_tool(
+            "ha_config_set_helper",
+            {
+                "helper_type": "history_stats",
+                "name": "test_history_stats_e2e",
+                "config": {
+                    "name": "test_history_stats_e2e",
+                    "entity_id": "sensor.demo_temperature",
+                    "type": "time",
+                    "state": ["22.5"],
+                    "start": "{{ today_at('00:00') }}",
+                    "end": "{{ now() }}",
+                },
+            },
+        )
+        data = assert_mcp_success(result, "Create history_stats helper")
+        assert data.get("success") is True
+        entry_id = data.get("entry_id")
+        assert entry_id is not None
+        entity_ids = data.get("entity_ids") or []
+        assert entity_ids, f"No entity_ids in response: {data}"
+
+        try:
+            await wait_for_tool_result(
+                mcp_client,
+                tool_name="ha_get_state",
+                arguments={"entity_id": entity_ids[0]},
+                predicate=lambda d: d.get("data", {}).get("entity_id") == entity_ids[0],
+                description="history_stats helper entity is queryable",
+            )
+        finally:
+            await safe_call_tool(
+                mcp_client,
+                "ha_remove_helpers_integrations",
+                {"target": entry_id, "confirm": True},
+            )
+
+    async def test_create_mold_indicator_helper(self, mcp_client):
+        """Create a mold_indicator helper (issue #2187).
+
+        Single form step taking three source entities plus a calibration
+        factor, which HA rejects at zero.
+        """
+        result = await mcp_client.call_tool(
+            "ha_config_set_helper",
+            {
+                "helper_type": "mold_indicator",
+                "name": "test_mold_indicator_e2e",
+                "config": {
+                    "name": "test_mold_indicator_e2e",
+                    "indoor_temp_sensor": "sensor.demo_temperature",
+                    "indoor_humidity_sensor": "sensor.demo_humidity",
+                    "outdoor_temp_sensor": "sensor.demo_outside_temperature",
+                    "calibration_factor": 2.0,
+                },
+            },
+        )
+        data = assert_mcp_success(result, "Create mold_indicator helper")
+        assert data.get("success") is True
+        entry_id = data.get("entry_id")
+        assert entry_id is not None
+        entity_ids = data.get("entity_ids") or []
+        assert entity_ids, f"No entity_ids in response: {data}"
+
+        try:
+            await wait_for_tool_result(
+                mcp_client,
+                tool_name="ha_get_state",
+                arguments={"entity_id": entity_ids[0]},
+                predicate=lambda d: d.get("data", {}).get("entity_id") == entity_ids[0],
+                description="mold_indicator helper entity is queryable",
+            )
+        finally:
+            await safe_call_tool(
+                mcp_client,
+                "ha_remove_helpers_integrations",
+                {"target": entry_id, "confirm": True},
+            )
 
     async def test_create_group_helper_light(self, mcp_client):
         """Create a light group helper (menu then form flow)."""

--- a/tests/src/unit/locale_source_baseline.json
+++ b/tests/src/unit/locale_source_baseline.json
@@ -154,7 +154,7 @@
     "ha_config_set_dashboard_resource.title": "af331cb18e4fe3d4",
     "ha_config_set_group.description": "d2e4e23ad266ff07",
     "ha_config_set_group.title": "3a0142e4e8142c5e",
-    "ha_config_set_helper.description": "4643b704ddedec21",
+    "ha_config_set_helper.description": "db2b49392c9ccdb6",
     "ha_config_set_helper.title": "1b7e4b0dd4292fc8",
     "ha_config_set_label.description": "1275fc40f9541cd7",
     "ha_config_set_label.title": "6535f8c94a624e30",

--- a/tests/src/unit/test_locale_parity.py
+++ b/tests/src/unit/test_locale_parity.py
@@ -316,7 +316,7 @@ def _english_tool_sources() -> dict[str, str]:
     first physical line cut at 120 characters — the same text for 84 of the 88
     tools. ``ha_config_set_helper`` wraps its summary and the Chinese catalog
     translates the half that wraps off, so hashing the displayed text would
-    leave "(28 types, unified interface)" free to move while a shipped
+    leave "(30 types, unified interface)" free to move while a shipped
     translation states it. The copy checks stay on the displayed text, because
     a paste is of what was on screen.
     """
@@ -1216,9 +1216,9 @@ LITERAL_PARITY_EXCEPTIONS: dict[
         "ha_config_set_helper.description",
     ): (
         Counter(),
-        Counter({("28",): 1}),
+        Counter({("30",): 1}),
         "The Chinese catalog translates the tool's full summary, including the "
-        '"(28 types, unified interface)" clause that sits on the second line '
+        '"(30 types, unified interface)" clause that sits on the second line '
         "of the docstring. The rendering the engine sends is the first line "
         "alone, so the catalog states more than its source, not something else.",
     ),


### PR DESCRIPTION
## What does this PR do?

Fixes #2187. `ha_config_set_helper` rejected `helper_type="history_stats"` even though HA's Helpers UI has created history_stats via config flow since 2024.7 — the flow-helper list was never re-audited after #324. Auditing HA core's generated integration metadata (`integration_type: helper` + `config_flow: true`) found exactly three missing domains: `history_stats`, `mold_indicator`, and `otp`.

- Adds `history_stats` and `mold_indicator` end to end: `SUPPORTED_HELPERS` / `FLOW_HELPER_TYPES`, the mirrored `helper_type` literals, tool docstrings, and search boost keywords (28 → 30 unified types).
- `otp` is deliberately excluded — its confirm step requires a live TOTP code computed from the secret. Both tool docstrings now document the exclusion and route it (and any helper-domain flow outside the enum) to `ha_set_integration(domain="otp")`, closing the routing dead-end that made the reporter's agent fall back to suggesting configuration.yaml.
- No custom component change: `FLOW_HELPER_DOMAINS` already lists both domains, so no version bump.
- Locale handling: the summary count change moves the English under the translation baseline; zh-Hans is the only catalog translating that clause, so it is hand-updated and the baseline repinned per the hand-translation path in AGENTS.md. `generate_locales.py` owes nothing; the gated completeness suite passes locally.

## Type of change
- [x] 🐛 Bug fix

## Testing
- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`) — targeted unit suites (locale parity incl. gated checks, helper schema, component parity, pagination, list-helpers routing), ruff, and mypy locally; new e2e lifecycle tests for both helper types run in CI
- [x] Code follows style guidelines (`uv run ruff check`)

## Checklist
- [x] I have updated documentation if needed — tool docstrings updated; README/tools.json regenerate on merge


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for creating `history_stats` and `mold_indicator` helpers through configuration flows.
  * Expanded helper configuration support to 30 helper types.
  * Clarified that OTP helpers must be created through the integration configuration flow.

* **Tests**
  * Added end-to-end coverage for the new helper types.
  * Added a humidity sensor fixture for test scenarios.

* **Documentation**
  * Updated localized helper descriptions and supported-type counts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->