### PR TITLE
feat: add the Czech (cs) locale across all four translated surfaces

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -746,7 +746,7 @@ identity holds by construction.
 
 A language ships on all four surfaces or not at all —
 `tests/src/unit/test_locale_parity.py` enforces it. The same Home Assistant
-language code (`de`, `eo`, `es`, `fr`, `it`, `nl`, `pl`, `ru`, `sv`, `zh-Hans`) names every file:
+language code (`cs`, `de`, `eo`, `es`, `fr`, `it`, `nl`, `pl`, `ru`, `sv`, `zh-Hans`) names every file:
 `src/ha_mcp/settings_ui/locales/<code>.json`,
 `custom_components/ha_mcp_tools/translations/<code>.json`, and
 `homeassistant-addon{,-dev}/translations/<code>.yaml`.

--- a/custom_components/ha_mcp_tools/translations/cs.json
+++ b/custom_components/ha_mcp_tools/translations/cs.json
@@ -1,0 +1,15 @@
+{
+  "common": {
+    "oauth_not_serving": "Legacy OAuth je zatím neposkytuje — restartujte Home Assistanta, až vás o to požádá, abyste je aktivovali."
+  },
+  "options": {
+    "step": {
+      "init": {
+        "data_description": {
+          "server_port": "Port, na kterém tento server naslouchá. Doplněk ha-mcp používá 9583, takže zde je výchozí hodnota 9584, aby mohly běžet oba vedle sebe – pokud doplněk nepoužíváte, funguje jakýkoli volný port.",
+          "server_url": "Adresa URL, kterou server běžící ve stejném procesu používá k připojení k vašemu Home Assistantovi (obvykle k této instanci samotné). Ponechte prázdné, aby se odvodila z portu a nastavení SSL této instance; hodnotu nastavte pouze tehdy, když server potřebuje jinou cestu."
+        }
+      }
+    }
+  }
+}

--- a/homeassistant-addon-dev/translations/cs.yaml
+++ b/homeassistant-addon-dev/translations/cs.yaml
@@ -1,0 +1,265 @@
+---
+# GENERATED FILE — do not edit. Translations live in
+# src/ha_mcp/settings_ui/locales/cs.json (keys addon.*, features.*,
+# addon_dev.*); regenerate with: python scripts/generate_locales.py
+configuration:
+  backup_hint:
+    name: Full-HA snapshot suggestion level (LLM-facing)
+    description: 'Tunes the wording of the hint the LLM sees in the
+
+      `ha_manage_backup(scope=''snapshot'')` tool description for when to
+
+      suggest a full Home Assistant tarball backup before risky operations
+
+      (e.g. mass device deletes). Affects ONLY this one LLM-facing prompt
+
+      sentence.
+
+
+      For per-edit automatic snapshots of automations / scripts / helpers /
+
+      etc., use the separate **Enable auto-backup of edits** toggle below.'
+  secret_path:
+    name: Secret path override
+    description: 'Optional custom HTTP path for the MCP server. Leave empty to use
+      the auto-generated secure path.
+
+      '
+  enable_tool_search:
+    name: Enable tool search
+    description: 'Replace the full tool catalog with search-based discovery. Reduces
+      idle context by roughly 90%, to about 5K tokens. ⚠️ Do NOT enable this in clients
+      with their own built-in tool search / deferred tools (claude.ai, Claude Desktop,
+      Claude Code) — the two search layers conflict, and the client''s built-in tool
+      search is the better choice there; leave this off. Whether tools are deferred
+      depends on your client and model combination: use this when your setup loads
+      the full catalog up front — models without native deferred tools (e.g. Gemini,
+      OpenAI-compatible local models, Claude Haiku), clients that inline all tool
+      schemas regardless of model (e.g. GitHub Copilot CLI), or smaller context windows.
+      Some Codex models and ChatGPT include deferred tools too — check your client/model
+      directly to confirm its features so you don''t leave this enabled unnecessarily.
+      Tools are found via ha_search_tools and executed via categorized proxies (read/write/delete).
+      Requires restart to take effect.'
+  enable_tool_security_policies:
+    name: Enable Tool Security Policies (advanced)
+    description: Gate high-stakes tool calls (lock/alarm control, automation writes,
+      etc.) behind user approval. When a guarded tool is called, the agent tells the
+      user to open the Tool Security Policies tab in the web UI and click Approve
+      before the call proceeds. Per-tool rules with optional argument conditions are
+      configured in the Tool Security Policies tab. Off by default. Requires restart
+      to take effect.
+  enable_security_policy_tool:
+    name: Let AI agents edit tool security policies
+    description: 'Registers the ha_manage_security_policy tool, which lets connected
+      AI agents read and rewrite the tool security policies — including removing approval
+      gates. Off by default. Independent of the Tool Security Policies option above:
+      this controls who can edit the rules, not whether they are enforced. The tool
+      cannot see or decide pending approvals. To keep a human in the loop, gate the
+      tool before enabling it: switch on "security gated" for Manage Security Policy
+      in the Tools tab of the web UI. Requires restart to take effect.'
+  read_only_mode:
+    name: Read Only Mode
+    description: Toggles all write tools off, and removes ability for tools to make
+      any write or destructive calls. Mixed read/write tools (backups, add-ons, energy
+      preferences, voice pipelines, and code mode when enabled) stay available with
+      their write operations blocked. Same toggle as the web UI Tools tab. Off by
+      default. Requires restart to take effect.
+  redact_secrets:
+    name: Redact Secrets
+    description: Redacts secrets from tool responses before they reach the AI assistant.
+      Add-on options and integration fields marked as passwords are replaced with
+      a set/empty marker (so "is this credential configured?" stays answerable), and
+      other tool responses are scrubbed of secret values the server has already seen
+      (values shorter than 6 characters are skipped, since replacing tiny fragments
+      would corrupt unrelated output). Fields not marked as passwords by their schema
+      cannot be detected. Off by default.
+  enable_beta_features:
+    name: Enable beta features (master)
+    description: ⚠ DANGER — these tools can PERMANENTLY DAMAGE your Home Assistant
+      installation. They write to your YAML config, your filesystem, install custom
+      components, run arbitrary sandboxed Python, and edit tool docstrings the AI
+      sees. There is no warranty and no support guarantee — you enable them at your
+      OWN RISK. Take a Home Assistant backup before turning this on, and never enable
+      in production without one. Master gate for the experimental sub-flags below;
+      sub-flags are ignored at runtime while this master is off, even when explicitly
+      set to true. The same toggle is also surfaced in the web settings UI under "Beta
+      features (dangerous)" — either surface reflects the other on restart.
+  enable_yaml_config_editing:
+    name: Enable YAML config editing (beta)
+    description: Beta feature. Allows AI assistants to add, replace, or remove top-level
+      keys in configuration.yaml and packages/*.yaml. Only whitelisted keys are allowed
+      (e.g., template, sensor, command_line, mqtt, knx); core keys like homeassistant,
+      http, and recorder are blocked. Each edit validates YAML syntax, runs a config
+      check, and creates an automatic backup. Changes to most keys require a full
+      HA restart to take effect. See docs/beta.md for known limitations. Dedicated
+      tools (automations, scripts, scenes, helpers, template sensors) should be preferred
+      when available. REQUIRES the master "Enable beta features" toggle above (and
+      in the web UI) to be on — otherwise this sub-flag is ignored at runtime regardless
+      of its value here.
+  enable_yaml_packages_automation:
+    name: Allow automation in packages/*.yaml
+    description: Sub-toggle of YAML config editing. When on, ha_config_set_yaml accepts
+      yaml_path='automation' inside packages/*.yaml. When off, the call is rejected
+      both client-side and server-side. The storage-mode tool (ha_config_set_automation)
+      is unaffected. Default OFF; only takes effect when "Enable YAML config editing"
+      above is also on.
+  enable_yaml_packages_script:
+    name: Allow script in packages/*.yaml
+    description: Sub-toggle of YAML config editing. When on, ha_config_set_yaml accepts
+      yaml_path='script' inside packages/*.yaml. When off, the call is rejected both
+      client-side and server-side. The storage-mode tool (ha_config_set_script) is
+      unaffected. Default OFF; only takes effect when "Enable YAML config editing"
+      above is also on.
+  enable_yaml_packages_scene:
+    name: Allow scene in packages/*.yaml
+    description: Sub-toggle of YAML config editing. When on, ha_config_set_yaml accepts
+      yaml_path='scene' inside packages/*.yaml. When off, the call is rejected both
+      client-side and server-side. The storage-mode tool (ha_config_set_scene) is
+      unaffected. Default OFF; only takes effect when "Enable YAML config editing"
+      above is also on.
+  enable_yaml_edit_confirm:
+    name: Require confirmation for YAML edits (diff preview)
+    description: 'Sub-toggle of YAML config editing, ON by default (recommended).
+      The first ha_config_set_yaml call returns a unified diff of exactly what would
+      change on disk plus a confirm token and writes nothing; the edit only lands
+      when the call is repeated with that token. Exists so unintended changes outside
+      the requested edit are caught before they reach disk (issue #1720). Turn off
+      only to save one round-trip per edit.'
+  enable_code_mode:
+    name: Enable custom tool sandbox (beta)
+    description: Beta feature. Enables the ha_manage_custom_tool tool, which lets
+      AI assistants create, run, save, and delete custom Python code in a secure sandbox
+      when no built-in tool can handle the request. Code runs in an isolated interpreter
+      with no filesystem or arbitrary network access. Sandbox code can hit the HA
+      REST API (api_get/api_post), send WebSocket commands (ws_send), call existing
+      MCP tools (call_tool), or remove a saved tool (delete_saved_tool). Saved tools
+      persist to /data/saved_tools.json by default so they survive add-on restarts,
+      and are visible to any client that can connect. See docs/beta.md for known limitations.
+      Requires restart to take effect. REQUIRES the master "Enable beta features"
+      toggle above (and in the web UI) to be on — otherwise this sub-flag is ignored
+      at runtime regardless of its value here.
+  enable_lite_docstrings:
+    name: Enable lite tool docstrings (beta)
+    description: 'Beta feature. Replaces the docstrings on a handful of heavy ha-mcp
+      tools (automations, scripts, scenes, helpers, dashboards, ha_call_service, ha_config_set_yaml)
+      with shorter variants that defer schema and example detail to the ha_get_skill_guide
+      tool (or its skill:// resource). WARNING: this reduces idle token usage, but
+      may degrade LLM performance — the trimmed descriptions rely on the LLM actually
+      calling the skill tool or reading the skill resource for detail, which is not
+      guaranteed (some models will skip the extra tool call and end up with less guidance
+      than they had before). Best paired with a client that supports MCP resources
+      or with enable_tool_search. Requires restart to take effect. REQUIRES the master
+      "Enable beta features" toggle above (and in the web UI) to be on — otherwise
+      this sub-flag is ignored at runtime regardless of its value here.'
+  enable_mandatory_bps:
+    name: Attach best-practice skills on writes
+    description: 'Master switch for the write-tool skill content delivery feature
+      (issue #1182). When enabled (default), the six config write tools (automations,
+      scripts, scenes, helpers, dashboards, raw YAML) attach the canonical Home Assistant
+      best-practice reference files under `skill_content` on every successful write,
+      plus auto-embed any reference sections cited by best-practice warnings. Each
+      tool also exposes a per-call `MandatoryBPS` parameter the agent can set to false
+      on subsequent calls once it has the content. When this master switch is off,
+      NO skill_content goes out regardless of the per-call parameter or BP warnings.
+      Recommended ON as the first choice; disable only for models with very small
+      context windows. Turning this off may degrade write accuracy. Requires restart
+      to take effect.'
+  enable_strict_mandatory_bps:
+    name: Strict best-practices mode
+    description: 'Strict mode: prevents the client from using the tool until it can
+      prove that it read the best practices. While on, the six best-practice write
+      tools (automations, scripts, scenes, helpers, dashboards, raw YAML) are blocked
+      and return an error directing the client to read the best-practices skill via
+      ha_get_skill_guide and pass back the acknowledgment key it obtains there. While
+      on, the ha_get_skill_guide tool is locked enabled — it is the only publisher
+      of the acknowledgment key. Child of the "Attach best-practice skills on writes"
+      option above and inert while that parent is off. Requires restart to take effect.'
+  enable_filesystem_tools:
+    name: Enable filesystem tools (beta)
+    description: 'Sets HAMCP_ENABLE_FILESYSTEM_TOOLS=true. Enables direct file read/write
+      access to your Home Assistant filesystem. WARNING: This gives the MCP server
+      sensitive direct file access to your system. Only enable if you trust the AI
+      assistant with file operations. Requires restart to take effect. REQUIRES the
+      master "Enable beta features" toggle above (and in the web UI) to be on — otherwise
+      this sub-flag is ignored at runtime regardless of its value here.'
+  enable_dashboard_screenshot:
+    name: Enable dashboard screenshot mode (beta)
+    description: Beta feature — disabled by default. Adds the ha_get_dashboard_screenshot
+      tool plus include_screenshot / return_screenshot options on the dashboard get/set
+      tools, so AI assistants can inspect one or more responsive Lovelace images (e.g.
+      to verify a dashboard they just created). Supports stable named views, mobile/tablet/desktop
+      batches, and PNG/JPEG/WebP/BMP output. Rendering runs in a separate, opt-in
+      engine — balloob's "Puppet" add-on (headless Chromium) — which you install once
+      (add balloob's add-on repository, then install "Puppet") and give a long-lived
+      access token; on Docker/Container deployments you run that engine as a sidecar
+      and set HAMCP_DASHBOARD_SCREENSHOT_ENGINE_URL. Nothing heavy is installed unless
+      you both enable this and install the engine. Requires restart to take effect.
+      REQUIRES the master "Enable beta features" toggle above (and in the web UI)
+      to be on — otherwise this sub-flag is ignored at runtime regardless of its value
+      here.
+  enable_auto_backup:
+    name: Enable auto-backup of edits
+    description: 'Captures a per-entity snapshot before every wrapped write/destructive
+      MCP tool call (automation, script, scene, helper, dashboard, dashboard resource,
+      label, category, group, zone, area, calendar, todo, entity, device, integration,
+      and sibling remove/delete tools). The auto-backup throttle bounds how often
+      that happens: 0 (default) captures on every such call, N>0 at most one snapshot
+      per N minutes per entity. Snapshots are saved as YAML files under /data/ha_mcp_backups/
+      (override via HAMCP_BACKUP_DIR) and listed, restored, or deleted via the Backups
+      tab in the web settings UI or via ha_manage_backup(scope=''edits'', ...). For
+      those domains the capture is best-effort — a failure logs a WARNING and the
+      write proceeds. The file and raw-YAML tools are the exception: ha_write_file,
+      ha_delete_file and ha_config_set_yaml treat the snapshot as a precondition,
+      so a write through them is refused while this is off, and a failed capture blocks
+      it. On by default; unchecking opts out of the best-effort captures and takes
+      the file and raw-YAML tools out of service with them. Requires restart to take
+      effect.'
+  auto_backup_throttle_minutes:
+    name: Auto-backup throttle (minutes)
+    description: Per-entity throttle window. 0 (default) captures a snapshot on every
+      wrapped write. N>0 captures at most one snapshot per N minutes per entity. Range
+      0–1440.
+  auto_backup_retain_per_entity:
+    name: Auto-backup retention (per entity)
+    description: Maximum number of snapshots kept per entity. Older snapshots beyond
+      this cap are rotated out on each successful capture. Default 100, range 1–10000.
+  enable_snapshot_delete:
+    name: Allow snapshot deletion
+    description: Lets ha_manage_backup delete full HA snapshot tarballs (scope='snapshot',
+      action='delete'). Off by default — a snapshot may be the last recovery point
+      after a mistaken change, so a human must opt in here. Even when on, scheduled
+      backups, the newest remaining snapshot, and anything younger than the age floor
+      below stay protected.
+  snapshot_delete_min_age_days:
+    name: Minimum snapshot age to delete (days)
+    description: A snapshot must be at least this old before it can be deleted. Range
+      0–365; 0 disables the floor (the newest-snapshot and scheduled-backup protections
+      still apply). Default 7.
+  tool_search_max_results:
+    name: Tool search max results
+    description: 'Maximum number of tools returned by ha_search_tools when tool search
+      is enabled. Lower values (2-3) save context tokens but may miss relevant tools.
+      Range: 2-10. Requires restart.'
+  disabled_tools:
+    name: Disabled tools (comma-separated)
+    description: Tools listed here are forced off and locked in the web Settings UI
+      (Tools tab) — they cannot be re-enabled there without unsetting this option
+      first. A small set of mandatory tools (ha_search, ha_get_overview, ha_get_state,
+      ha_report_issue, ha_manage_backup) cannot be disabled and keep running even
+      if listed here. ha_get_skill_guide can be disabled only while strict best-practices
+      mode (enable_strict_mandatory_bps) is off. Comma-separated tool names (e.g.
+      ha_call_event,ha_eval_template).
+  pinned_tools:
+    name: Pinned tools (comma-separated)
+    description: Tools listed here are locked pinned — they appear at the top of the
+      Tools tab and cannot be unpinned from the web Settings UI without unsetting
+      this option first. Useful in combination with Tool Search. Comma-separated tool
+      names.
+  verify_ssl:
+    name: Verify TLS certificate
+    description: Verify the Home Assistant server's TLS certificate. The add-on connects
+      via the Supervisor proxy, so this normally has no effect and should stay enabled.
+      Disable only if you've reconfigured the add-on to talk to HA over a public HTTPS
+      hostname with a self-signed certificate or hostname mismatch. Disabling weakens
+      transport security — leave on unless you know you need it. Requires restart
+      to take effect.

--- a/homeassistant-addon/translations/cs.yaml
+++ b/homeassistant-addon/translations/cs.yaml
@@ -1,0 +1,167 @@
+---
+# GENERATED FILE — do not edit. Translations live in
+# src/ha_mcp/settings_ui/locales/cs.json (keys addon.*, features.*,
+# addon_stable.*); regenerate with: python scripts/generate_locales.py
+configuration:
+  backup_hint:
+    name: Full-HA snapshot suggestion level (LLM-facing)
+    description: 'Tunes the wording of the hint the LLM sees in the
+
+      `ha_manage_backup(scope=''snapshot'')` tool description for when to
+
+      suggest a full Home Assistant tarball backup before risky operations
+
+      (e.g. mass device deletes). Affects ONLY this one LLM-facing prompt
+
+      sentence.
+
+
+      For per-edit automatic snapshots of automations / scripts / helpers /
+
+      etc., use the separate **Enable auto-backup of edits** toggle below.'
+  secret_path:
+    name: Secret path override
+    description: 'Optional custom HTTP path for the MCP server. Leave empty to use
+      the auto-generated secure path.
+
+      '
+  enable_tool_search:
+    name: Enable tool search
+    description: 'Replace the full tool catalog with search-based discovery. Reduces
+      idle context by roughly 90%, to about 5K tokens. ⚠️ Do NOT enable this in clients
+      with their own built-in tool search / deferred tools (claude.ai, Claude Desktop,
+      Claude Code) — the two search layers conflict, and the client''s built-in tool
+      search is the better choice there; leave this off. Whether tools are deferred
+      depends on your client and model combination: use this when your setup loads
+      the full catalog up front — models without native deferred tools (e.g. Gemini,
+      OpenAI-compatible local models, Claude Haiku), clients that inline all tool
+      schemas regardless of model (e.g. GitHub Copilot CLI), or smaller context windows.
+      Some Codex models and ChatGPT include deferred tools too — check your client/model
+      directly to confirm its features so you don''t leave this enabled unnecessarily.
+      Tools are found via ha_search_tools and executed via categorized proxies (read/write/delete).
+      Requires an add-on restart to take effect — then reconnect or refresh the MCP
+      server in your AI client so it reloads the tool list. Restarting the add-on
+      alone does NOT refresh a client''s cached tool list; this applies after changing
+      any setting here.'
+  tool_search_max_results:
+    name: Tool search max results
+    description: 'Maximum number of tools returned by ha_search_tools when tool search
+      is enabled. Lower values (2-3) save context tokens but may miss relevant tools.
+      Range: 2-10. Requires restart.'
+  enable_tool_security_policies:
+    name: Enable Tool Security Policies (advanced)
+    description: Gate high-stakes tool calls (lock/alarm control, automation writes,
+      etc.) behind user approval. When a guarded tool is called, the agent tells the
+      user to open the Tool Security Policies tab in the web UI and click Approve
+      before the call proceeds. Per-tool rules with optional argument conditions are
+      configured in the Tool Security Policies tab. Off by default. Requires restart
+      to take effect.
+  enable_security_policy_tool:
+    name: Let AI agents edit tool security policies
+    description: 'Registers the ha_manage_security_policy tool, which lets connected
+      AI agents read and rewrite the tool security policies — including removing approval
+      gates. Off by default. Independent of the Tool Security Policies option above:
+      this controls who can edit the rules, not whether they are enforced. The tool
+      cannot see or decide pending approvals. To keep a human in the loop, gate the
+      tool before enabling it: switch on "security gated" for Manage Security Policy
+      in the Tools tab of the web UI. Requires restart to take effect.'
+  read_only_mode:
+    name: Read Only Mode
+    description: Toggles all write tools off, and removes ability for tools to make
+      any write or destructive calls. Mixed read/write tools (backups, add-ons, energy
+      preferences, voice pipelines, and code mode when enabled) stay available with
+      their write operations blocked. Same toggle as the web UI Tools tab. Off by
+      default. Requires restart to take effect.
+  redact_secrets:
+    name: Redact Secrets
+    description: Redacts secrets from tool responses before they reach the AI assistant.
+      Add-on options and integration fields marked as passwords are replaced with
+      a set/empty marker (so "is this credential configured?" stays answerable), and
+      other tool responses are scrubbed of secret values the server has already seen
+      (values shorter than 6 characters are skipped, since replacing tiny fragments
+      would corrupt unrelated output). Fields not marked as passwords by their schema
+      cannot be detected. Off by default.
+  enable_mandatory_bps:
+    name: Attach best-practice skills on writes
+    description: 'Master switch for the write-tool skill content delivery feature
+      (issue #1182). When enabled (default), the six config write tools (automations,
+      scripts, scenes, helpers, dashboards, raw YAML) attach the canonical Home Assistant
+      best-practice reference files under `skill_content` on every successful write,
+      plus auto-embed any reference sections cited by best-practice warnings. Each
+      tool also exposes a per-call `MandatoryBPS` parameter the agent can set to false
+      on subsequent calls once it has the content. When this master switch is off,
+      NO skill_content goes out regardless of the per-call parameter or BP warnings.
+      Recommended ON as the first choice; disable only for models with very small
+      context windows. Turning this off may degrade write accuracy. Requires restart
+      to take effect.'
+  enable_strict_mandatory_bps:
+    name: Strict best-practices mode
+    description: 'Strict mode: prevents the client from using the tool until it can
+      prove that it read the best practices. While on, the six best-practice write
+      tools (automations, scripts, scenes, helpers, dashboards, raw YAML) are blocked
+      and return an error directing the client to read the best-practices skill via
+      ha_get_skill_guide and pass back the acknowledgment key it obtains there. While
+      on, the ha_get_skill_guide tool is locked enabled — it is the only publisher
+      of the acknowledgment key. Child of the "Attach best-practice skills on writes"
+      option above and inert while that parent is off. Requires restart to take effect.'
+  disabled_tools:
+    name: Disabled tools (comma-separated)
+    description: Tools listed here are forced off and locked in the web Settings UI
+      (Tools tab) — they cannot be re-enabled there without unsetting this option
+      first. A small set of mandatory tools (ha_search, ha_get_overview, ha_get_state,
+      ha_report_issue, ha_manage_backup) cannot be disabled and keep running even
+      if listed here. ha_get_skill_guide can be disabled only while strict best-practices
+      mode (enable_strict_mandatory_bps) is off. Comma-separated tool names (e.g.
+      ha_call_event,ha_eval_template).
+  pinned_tools:
+    name: Pinned tools (comma-separated)
+    description: Tools listed here are locked pinned — they appear at the top of the
+      Tools tab and cannot be unpinned from the web Settings UI without unsetting
+      this option first. Useful in combination with Tool Search. Comma-separated tool
+      names.
+  enable_auto_backup:
+    name: Enable auto-backup of edits
+    description: 'Captures a per-entity snapshot before every wrapped write/destructive
+      MCP tool call (automation, script, scene, helper, dashboard, dashboard resource,
+      label, category, group, zone, area, calendar, todo, entity, device, integration,
+      and sibling remove/delete tools). The auto-backup throttle bounds how often
+      that happens: 0 (default) captures on every such call, N>0 at most one snapshot
+      per N minutes per entity. Snapshots are saved as YAML files under /data/ha_mcp_backups/
+      (override via HAMCP_BACKUP_DIR) and listed, restored, or deleted via the Backups
+      tab in the web settings UI or via ha_manage_backup(scope=''edits'', ...). For
+      those domains the capture is best-effort — a failure logs a WARNING and the
+      write proceeds. The file and raw-YAML tools are the exception: ha_write_file,
+      ha_delete_file and ha_config_set_yaml treat the snapshot as a precondition,
+      so a write through them is refused while this is off, and a failed capture blocks
+      it. On by default; unchecking opts out of the best-effort captures and takes
+      the file and raw-YAML tools out of service with them. Requires restart to take
+      effect.'
+  auto_backup_throttle_minutes:
+    name: Auto-backup throttle (minutes)
+    description: Per-entity throttle window. 0 (default) captures a snapshot on every
+      wrapped write. N>0 captures at most one snapshot per N minutes per entity. Range
+      0–1440.
+  auto_backup_retain_per_entity:
+    name: Auto-backup retention (per entity)
+    description: Maximum number of snapshots kept per entity. Older snapshots beyond
+      this cap are rotated out on each successful capture. Default 100, range 1–10000.
+  enable_snapshot_delete:
+    name: Allow snapshot deletion
+    description: Lets ha_manage_backup delete full HA snapshot tarballs (scope='snapshot',
+      action='delete'). Off by default — a snapshot may be the last recovery point
+      after a mistaken change, so a human must opt in here. Even when on, scheduled
+      backups, the newest remaining snapshot, and anything younger than the age floor
+      below stay protected.
+  snapshot_delete_min_age_days:
+    name: Minimum snapshot age to delete (days)
+    description: A snapshot must be at least this old before it can be deleted. Range
+      0–365; 0 disables the floor (the newest-snapshot and scheduled-backup protections
+      still apply). Default 7.
+  verify_ssl:
+    name: Verify TLS certificate
+    description: Verify the Home Assistant server's TLS certificate. The add-on connects
+      via the Supervisor proxy, so this normally has no effect and should stay enabled.
+      Disable only if you've reconfigured the add-on to talk to HA over a public HTTPS
+      hostname with a self-signed certificate or hostname mismatch. Disabling weakens
+      transport security — leave on unless you know you need it. Requires restart
+      to take effect.

--- a/src/ha_mcp/settings_ui/locales/cs.json
+++ b/src/ha_mcp/settings_ui/locales/cs.json
@@ -1,0 +1,26 @@
+{
+  "meta": {
+    "native_name": "Čeština",
+    "dir": "ltr"
+  },
+  "messages": {
+    "accessibility.storage_blocked": "Váš prohlížeč blokuje ukládání dat webu; vaše volby platí pouze pro tuto relaci.",
+    "actions.approve": "Schválit",
+    "actions.deny": "Zamítnout",
+    "notice.restart.standalone": "⚠ Změny uloženy. Restartujte proces ha-mcp a poté obnovte seznam nástrojů MCP ve vašem AI klientovi.",
+    "policies.operators.exists": "existuje",
+    "policies.operators.exists_long": "existuje (jakákoli hodnota)",
+    "policies.operators.eq": "rovná se",
+    "policies.operators.neq": "nerovná se",
+    "policies.operators.in": "je jedním z",
+    "policies.operators.not_in": "není jedním z",
+    "policies.operators.contains": "obsahuje",
+    "policies.operators.regex": "odpovídá regulárnímu výrazu",
+    "policies.operators.gt": "je větší než",
+    "policies.operators.lt": "je menší než",
+    "policies.pending.already_decided": "Toto schválení již bylo {decision}, pravděpodobně z jiné karty nebo relace.",
+    "policies.pending.decision.approved": "schváleno",
+    "policies.pending.decision.denied": "zamítnuto",
+    "visibility.errors.conflict": "Konfigurace byla změněna na jiné kartě nebo v jiné relaci. Znovu načtěte stránku a poté znovu použijte své změny."
+  }
+}


### PR DESCRIPTION
## What does this PR do?

Adds Czech as a shipped locale code: it names a file on each of the four translated surfaces — the canonical settings store, the component config-flow catalog, and both add-on YAML flavors.

What those files contain at this commit is the anchor set, not a translation. The settings catalog holds 18 of 453 keys, the component catalog 3 of 93, and both add-on YAMLs are still English throughout, because they project add-on keys the settings catalog does not carry yet. Filling the rest is the post-merge sync's job; a dry run plans 730 strings across exactly one locale, which is also the evidence that the pipeline discovers `cs` without any change to it. The gated completeness checks therefore fail for `cs` until that run — 7 of them, plus the sync's own no-op invariant, which is red by construction whenever a language is waiting to be filled.

Czech is the largest remaining gap on the installation-base ranking the earlier locales were chosen from. Home Assistant publishes no language dimension in its analytics, only country codes, so that ranking is a derivation from country installs rather than a published statistic — Czech lands at roughly 10k estimated installations, ahead of pt-BR and da.

## Czech is formal, and that was measured rather than assumed

French is the only Latin-script locale shipped so far that addresses the reader formally; German, Spanish, Italian, Dutch, Polish and Swedish are all informal, and Esperanto has no T–V distinction to choose from. The default guess would therefore have been wrong. Measured against Home Assistant's own Czech frontend catalogue (8045 strings, frontend wheel `20260128.6`):

| locale | informal markers | formal markers | verdict |
|---|---|---|---|
| `de` (control) | 1108 | 9 | informal |
| `cs` | 0 | 389 | **formal** |

The control is not decorative: a marker set that structurally matches nothing is indistinguishable from a language with no formal address. German must come out informal or the measurement is discarded.

One Czech-specific trap is worth recording for whoever measures the next Slavic locale. The obvious informal marker is the nominative pronoun `ty`, and it is unusable: `ty` is a homograph of the demonstrative *ty* ("those"), which is common in UI text. Counting it would have inflated the informal side with strings that address nobody. The informal side is carried by the possessive `tvůj` paradigm and the oblique pronouns instead, and the pattern set was checked against synthetic informal and formal Czech in both directions before the real corpus was touched — informal patterns must fire on informal input and stay silent on formal input, and vice versa.

## The capitalised-negation convention does not port to Czech

All eight shipped Latin-script catalogs mark the negated operators with a capitalised negation word — `NICHT gleich`, `NO es igual a`, `NIE równa się`, `är INTE lika med`. Russian and Chinese do not, and Czech cannot follow the convention as the other eight state it: Czech negates verbs with a bound prefix `ne-`, so there is no separable word to carry the capitals. Capitalising inside a word would be possible — `NErovná se` — but no shipped catalog uses intra-word capitals for emphasis; the 55 that occur are all brand names (`ChatGPT`, `OpenAI`, `MandatoryBPS`). That is a statement about the twelve catalogs in this directory, not about Czech UI convention at large, which nothing measured here establishes either way.

Home Assistant's own Czech catalogue answers the question directly, on this exact operator pair:

- `condition.state.state_equal` → `Stav se rovná`
- `condition.state.state_not_equal` → `Stav se nerovná`

So `eq`/`neq` read `rovná se` / `nerovná se`, lowercase. `in`/`not_in` keep the distinction visible at the first word instead, `je jedním z` / `není jedním z`.

## One string was changed after a blind back-translation

`policies.pending.already_decided` first read `pravděpodobně na jiné kartě nebo v jiné relaci` — locative, "in another tab". A back-translation run against the Czech alone, with no English and no key names in view, rendered it that way, and the English source says something else: "possibly **by** another tab or session".

Reading that key across every shipped catalog, nine of ten render agent or source — `von`, `de`, `desde`, `par`, `da`, `door`, `przez`, `из`, `由` — against Swedish's lone locative. The Czech now reads `pravděpodobně z jiné karty nebo relace`, which matches the majority and matches how Home Assistant's Czech catalogue phrases a source under a passive (`jsou importovány z jiného pohledu`).

The back-translation carries a positive control: three deliberately corrupted strings — a negation inserted, the two port numbers swapped, a polarity flipped — are mixed in unlabelled. All three came back with the corruption intact rather than smoothed away, so the faithful rendering of the other strings means something.

## The model cross-read produced eight findings and none was adopted

The anchors were cross-read by two models before committing, deliberately not the engine the sync uses. Each finding was then measured against Home Assistant's Czech catalogue and against the ten catalogs that ship today, and all eight were declined on that evidence. The models are the generator; the measurement is what decides.

- **`existuje` → a bare copula.** No shipped catalog renders that operator as a bare copula; all ten use an existence or presence verb. The rendering forbids it too: `exists` is concatenated straight after the attribute path (`settings.js`, the predicate summary line), so a bare "is" would render `attributes.foo je` and stop mid-clause.
- **`exists_long` reworded to break its tie to `exists`.** Here the catalogs genuinely split five to five — German, Esperanto, Russian, Swedish and Chinese repeat the short form (`ist vorhanden` / `ist vorhanden (beliebiger Wert)`), while Spanish, French, Italian, Dutch and Polish switch to an "is present" verb. Czech has a reason to join the repeating half rather than a preference, though the reason constrains less than it first looks: the short form sits after an attribute path of unknown gender, so whatever goes there should avoid committing to a specific grammatical gender, and `je přítomno` commits to neuter. That is a design judgment rather than a grammatical necessity — neuter can serve as a default for an abstract referent, so `je přítomno` would read as inconsistent rather than as an error. A gender-invariant verb is one way around it; a nominalisation like `má hodnotu` is another, at the cost of saying "has a value" where the English says "is present". `existuje` is the choice, not the only possibility. Keeping one verb across the dropdown label and the summary line then keeps them reading as the same operator.
- **`použijte změny` → `aplikujte změny`.** Here the corpus is thin and I want to be exact about what it does and does not settle: it carries one instance of each lemma — `aplikují` in a reflexive-passive sentence about changes being applied automatically, and `použít` in the transitive collocation this string needs, `Nelze použít změny: {error}`. So the corpus does not rule `aplikovat` out; it does show `použít změny` as the form Home Assistant uses when a verb takes `změny` as its object, which is the construction here. Declined on that narrower basis.
- **`ukládání dat webu` → `úložiště webu`.** Polish, which went through this same review, reads `przechowywanie danych witryny` — storing site data, the same construction.
- **`ve vašem` → `ve svém`.** Prescriptively defensible, but Home Assistant's Czech catalogue does not enforce the reflexive rule: over strings that pair a second-person-plural imperative with a possessive referring to the reader, it uses the non-reflexive form 15 times against 10 reflexive. The exact ratio moves with which imperatives the probe enumerates; the direction did not across the two verb lists I ran.
- **`volby` → `nastavení`**, on the grounds that `volby` is too formal. The catalogue uses `volby` 35 times, including `Nastavit jako výchozí volby`.
- **`Home Assistantovi` → `Home Assistantu`**, asserted as a declension error. It is the reverse: the catalogue writes `Home Assistantovi` 18 times against 2, and carries the exact phrase `Vaše připojení k Home Assistantovi`.
- **A grammar fix from `aby jste` to `abyste`.** The catalog never contained `aby jste`; the proposed replacement was byte-identical to the string it claimed to correct.

The one question measurement could not answer is the preposition Czech takes with a browser tab in `visibility.errors.conflict` (`na jiné kartě` versus `v jiné kartě`). Home Assistant's Czech catalogue has no browser-tab string at all — searching it by key name returns nothing while a control search returns 165 hits, so the corpus is silent rather than agreeing. `na kartě` follows Czech browser convention; I am flagging it as a judgment call rather than a measured one.

## Type of change
- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [ ] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

No agent testing: this adds catalog data and one documentation line, neither of which an agent exercises at runtime. No Python file changes, so the lint surface is unchanged.

The test box is left unchecked deliberately rather than as an oversight. `tests/pytest.ini` sets `testpaths = src`, so `uv run pytest` selects the e2e tests alongside the unit ones, and I ran only `tests/src/unit`. That run ends 10185 passed / 105 skipped / 0 failed plus 5 errors in `TestAiohttpClientTimeoutContract`, which reproduce identically on pristine master with the same selection — `aiohttp` is a dev dependency missing from my local environment, and the check exists to fail loudly when it cannot introspect the real class. So: no failures, no errors this branch introduces, and a suite selection narrower than the box claims. CI runs the full set.

`ruff check` was run over the paths CI uses, not over the diff, and passes. CI's format check runs only on changed Python files and skips outright when there are none, which is this PR's case; I ran it across the same paths anyway, and its single hit is a Markdown document with embedded Python inside the vendored `skills-vendor` submodule, reported identically on pristine master. All three mypy invocations CI runs were run here: the two webhook-proxy ones are clean on this branch, and the first one produces a byte-identical error set on this branch and on master (152 each, no new entries) — that set is stub-resolution noise from running mypy outside the project environment, so the comparison rather than the count is the evidence.

Beyond the suite:

- The branch collects 18 more test IDs than master over the locale modules (575 against 557), and every one of them carries `[cs]`; nothing master collects disappears. Two of those are the `[cs-approved]` / `[cs-denied]` behaviour tests, which run here because `tests/js` has its npm dependencies installed — without them they skip silently.
- Gated (`LOCALE_COMPLETENESS_CHECKS=1`), both arms were run with identical test selection against a pristine-master control. Master is clean; this branch fails 8. Seven carry `[cs]`; the eighth is `test_clean_tree_plans_no_work`, whose plan holds 730 items, all `cs`.
- Counting IDs understates the anchors, so each guard was confirmed by injection — break the condition, require red, restore, require green:

  | injection | guard | injected | restored |
  |---|---|---|---|
  | `contains` spelled as the backend literal | `test_every_predicate_operator_has_a_catalog_word` | RED | GREEN |
  | component catalog left with one non-addressing key | `..._component_catalog_gets_reader_addressing_samples[cs]` | RED | GREEN |
  | component anchors present but blank | same guard, non-blank rule | RED | GREEN |
  | all three settings anchors removed | `..._shipped_catalog_gets_reader_addressing_samples[cs]` | RED | GREEN |
  | `9583` rewritten to `9585` | `test_translations_keep_english_numbers_and_identifiers[cs]` | RED | GREEN |

- The two-anchor floor was confirmed separately, because a count alone cannot show it. Cutting the settings surface to exactly **one** addressing key leaves `..._gets_reader_addressing_samples[cs]` green and turns `test_settings_samples_survive_their_own_anchor_being_queued[cs]` red; cutting the component surface to one turns its twin red the same way. Both surfaces ship three anchors, so both clear the floor with margin.
- `generate_locales.py` reports no further updates after generating the two YAMLs, so the projections are byte-exact generator output.

## Checklist
- [x] I have updated documentation if needed
