### PR TITLE
fix: add restart action to legacy OAuth repair

### DIFF
--- a/custom_components/ha_mcp_tools/embedded_setup.py
+++ b/custom_components/ha_mcp_tools/embedded_setup.py
@@ -519,7 +519,7 @@ def _async_update_legacy_oauth_issue(hass: HomeAssistant, restart_needed: bool) 
             hass,
             DOMAIN,
             ISSUE_LEGACY_OAUTH_RESTART,
-            is_fixable=False,
+            is_fixable=True,
             severity=ir.IssueSeverity.WARNING,
             translation_key=ISSUE_LEGACY_OAUTH_RESTART,
         )

--- a/custom_components/ha_mcp_tools/repairs.py
+++ b/custom_components/ha_mcp_tools/repairs.py
@@ -1,0 +1,51 @@
+"""Repair flows for the HA-MCP Custom Component."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import voluptuous as vol
+from homeassistant import data_entry_flow
+from homeassistant.components.repairs import RepairsFlow
+from homeassistant.core import HomeAssistant
+
+
+class LegacyOAuthRestartRepairFlow(RepairsFlow):
+    """Confirm and apply a legacy OAuth change by restarting Home Assistant."""
+
+    async def async_step_init(
+        self, user_input: dict[str, str] | None = None
+    ) -> data_entry_flow.FlowResult:
+        """Open the restart confirmation step."""
+        return await self.async_step_confirm()
+
+    async def async_step_confirm(
+        self, user_input: dict[str, str] | None = None
+    ) -> data_entry_flow.FlowResult:
+        """Restart Home Assistant after the user confirms the repair."""
+        if user_input is not None:
+            # Wait for HA to accept the restart request so a failed config check
+            # remains visible instead of reporting a successful repair. The issue
+            # is intentionally cleared only after bring-up proves no restart is
+            # pending, so an aborted restart leaves the repair actionable.
+            await self.hass.services.async_call(
+                "homeassistant",
+                "restart",
+                {},
+                blocking=True,
+            )
+            return self.async_create_entry(data={})
+
+        return self.async_show_form(
+            step_id="confirm",
+            data_schema=vol.Schema({}),
+        )
+
+
+async def async_create_fix_flow(
+    hass: HomeAssistant,
+    issue_id: str,
+    data: dict[str, Any] | None,
+) -> RepairsFlow:
+    """Create the click-to-restart flow for the legacy OAuth repair."""
+    return LegacyOAuthRestartRepairFlow()

--- a/custom_components/ha_mcp_tools/repairs.py
+++ b/custom_components/ha_mcp_tools/repairs.py
@@ -24,10 +24,10 @@ class LegacyOAuthRestartRepairFlow(RepairsFlow):
     ) -> data_entry_flow.FlowResult:
         """Restart Home Assistant after the user confirms the repair."""
         if user_input is not None:
-            # Wait for HA to accept the restart request so a failed config check
-            # remains visible instead of reporting a successful repair. The issue
-            # is intentionally cleared only after bring-up proves no restart is
-            # pending, so an aborted restart leaves the repair actionable.
+            # Wait for HA to validate the config and schedule the restart. If the
+            # service rejects the request, the exception prevents flow completion
+            # and the repair remains registered. The next startup independently
+            # re-evaluates whether the OAuth change is still pending.
             await self.hass.services.async_call(
                 "homeassistant",
                 "restart",

--- a/custom_components/ha_mcp_tools/strings.json
+++ b/custom_components/ha_mcp_tools/strings.json
@@ -108,7 +108,15 @@
         },
         "legacy_oauth_restart": {
             "title": "Restart Home Assistant to apply the legacy OAuth change",
-            "description": "The legacy OAuth authentication mode registers its own /authorize and /token web endpoints, which Home Assistant can only bind or release when it fully restarts - whether you just turned this mode on, turned it off, or changed its Client ID/Secret. Restart Home Assistant (Settings - System - Restart) to apply the change; until then the previous behavior stays in effect."
+            "description": "Home Assistant must restart before the legacy OAuth change takes effect. Until then, the previous behavior remains active.",
+            "fix_flow": {
+                "step": {
+                    "confirm": {
+                        "title": "Restart Home Assistant?",
+                        "description": "Submitting this form will restart Home Assistant and apply the legacy OAuth change.\n\nClick **Submit** to restart now."
+                    }
+                }
+            }
         }
     },
     "selector": {

--- a/custom_components/ha_mcp_tools/strings.json
+++ b/custom_components/ha_mcp_tools/strings.json
@@ -108,7 +108,6 @@
         },
         "legacy_oauth_restart": {
             "title": "Restart Home Assistant to apply the legacy OAuth change",
-            "description": "Home Assistant must restart before the legacy OAuth change takes effect. Until then, the previous behavior remains active.",
             "fix_flow": {
                 "step": {
                     "confirm": {

--- a/custom_components/ha_mcp_tools/translations/en.json
+++ b/custom_components/ha_mcp_tools/translations/en.json
@@ -108,7 +108,15 @@
         },
         "legacy_oauth_restart": {
             "title": "Restart Home Assistant to apply the legacy OAuth change",
-            "description": "The legacy OAuth authentication mode registers its own /authorize and /token web endpoints, which Home Assistant can only bind or release when it fully restarts - whether you just turned this mode on, turned it off, or changed its Client ID/Secret. Restart Home Assistant (Settings - System - Restart) to apply the change; until then the previous behavior stays in effect."
+            "description": "Home Assistant must restart before the legacy OAuth change takes effect. Until then, the previous behavior remains active.",
+            "fix_flow": {
+                "step": {
+                    "confirm": {
+                        "title": "Restart Home Assistant?",
+                        "description": "Submitting this form will restart Home Assistant and apply the legacy OAuth change.\n\nClick **Submit** to restart now."
+                    }
+                }
+            }
         }
     },
     "selector": {

--- a/custom_components/ha_mcp_tools/translations/en.json
+++ b/custom_components/ha_mcp_tools/translations/en.json
@@ -108,7 +108,6 @@
         },
         "legacy_oauth_restart": {
             "title": "Restart Home Assistant to apply the legacy OAuth change",
-            "description": "Home Assistant must restart before the legacy OAuth change takes effect. Until then, the previous behavior remains active.",
             "fix_flow": {
                 "step": {
                     "confirm": {

--- a/tests/src/unit/test_component_repairs.py
+++ b/tests/src/unit/test_component_repairs.py
@@ -1,0 +1,104 @@
+"""Regression tests for the HA-MCP component's actionable restart repair.
+
+Issue #2210: the legacy OAuth restart warning must offer a fix flow that
+restarts Home Assistant instead of only allowing the issue to be ignored.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from types import ModuleType
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from ._embedded_stubs import install
+
+install()
+
+
+class _RepairsFlow:
+    """Small HA RepairsFlow stand-in with real flow-result behavior."""
+
+    def async_show_form(self, *, step_id, data_schema):
+        return {"type": "form", "step_id": step_id, "data_schema": data_schema}
+
+    def async_create_entry(self, *, data):
+        return {"type": "create_entry", "data": data}
+
+
+data_entry_flow = ModuleType("homeassistant.data_entry_flow")
+data_entry_flow.FlowResult = dict
+sys.modules["homeassistant.data_entry_flow"] = data_entry_flow
+sys.modules["homeassistant"].data_entry_flow = data_entry_flow
+
+repairs_platform = ModuleType("homeassistant.components.repairs")
+repairs_platform.RepairsFlow = _RepairsFlow
+sys.modules["homeassistant.components.repairs"] = repairs_platform
+
+
+def _load_repairs_module():
+    from custom_components.ha_mcp_tools import repairs
+
+    return repairs
+
+
+async def test_legacy_oauth_fix_flow_restarts_home_assistant_blocking():
+    """A missing/wrong restart service call would leave the repair unresolved."""
+    repairs = _load_repairs_module()
+    hass = MagicMock()
+    hass.services.async_call = AsyncMock()
+    flow = await repairs.async_create_fix_flow(
+        hass,
+        "legacy_oauth_restart",
+        None,
+    )
+    flow.hass = hass
+
+    result = await flow.async_step_confirm({})
+
+    hass.services.async_call.assert_awaited_once_with(
+        "homeassistant",
+        "restart",
+        {},
+        blocking=True,
+    )
+    assert result == {"type": "create_entry", "data": {}}
+
+
+async def test_legacy_oauth_fix_flow_prompts_before_restart():
+    """Opening the repair must show confirmation without restarting HA."""
+    repairs = _load_repairs_module()
+    hass = MagicMock()
+    hass.services.async_call = AsyncMock()
+    flow = await repairs.async_create_fix_flow(
+        hass,
+        "legacy_oauth_restart",
+        None,
+    )
+    flow.hass = hass
+
+    result = await flow.async_step_init()
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "confirm"
+    hass.services.async_call.assert_not_awaited()
+
+
+@pytest.mark.parametrize(
+    "catalog_path",
+    [
+        "custom_components/ha_mcp_tools/strings.json",
+        "custom_components/ha_mcp_tools/translations/en.json",
+    ],
+)
+def test_legacy_oauth_repair_catalog_has_fix_flow(catalog_path):
+    """Both HA English catalogs must render the actionable confirmation flow."""
+    root = Path(__file__).parents[3]
+    catalog = json.loads((root / catalog_path).read_text())
+
+    confirm = catalog["issues"]["legacy_oauth_restart"]["fix_flow"]["step"]["confirm"]
+    assert confirm["title"]
+    assert confirm["description"]

--- a/tests/src/unit/test_component_repairs.py
+++ b/tests/src/unit/test_component_repairs.py
@@ -99,6 +99,8 @@ def test_legacy_oauth_repair_catalog_has_fix_flow(catalog_path):
     root = Path(__file__).parents[3]
     catalog = json.loads((root / catalog_path).read_text())
 
-    confirm = catalog["issues"]["legacy_oauth_restart"]["fix_flow"]["step"]["confirm"]
+    issue = catalog["issues"]["legacy_oauth_restart"]
+    assert "description" not in issue
+    confirm = issue["fix_flow"]["step"]["confirm"]
     assert confirm["title"]
     assert confirm["description"]

--- a/tests/src/unit/test_component_repairs.py
+++ b/tests/src/unit/test_component_repairs.py
@@ -87,6 +87,25 @@ async def test_legacy_oauth_fix_flow_prompts_before_restart():
     hass.services.async_call.assert_not_awaited()
 
 
+async def test_legacy_oauth_fix_flow_does_not_complete_rejected_restart():
+    """A rejected restart must leave the repair flow—and issue—unfinished."""
+    repairs = _load_repairs_module()
+    hass = MagicMock()
+    hass.services.async_call = AsyncMock(side_effect=RuntimeError("restart rejected"))
+    flow = await repairs.async_create_fix_flow(
+        hass,
+        "legacy_oauth_restart",
+        None,
+    )
+    flow.hass = hass
+    flow.async_create_entry = MagicMock()
+
+    with pytest.raises(RuntimeError, match="restart rejected"):
+        await flow.async_step_confirm({})
+
+    flow.async_create_entry.assert_not_called()
+
+
 @pytest.mark.parametrize(
     "catalog_path",
     [

--- a/tests/src/unit/test_embedded_setup.py
+++ b/tests/src/unit/test_embedded_setup.py
@@ -173,6 +173,8 @@ class TestBringUp:
         ]
         assert created, "legacy-OAuth restart repair was not filed"
         assert created[0].kwargs["is_fixable"] is True
+        cleared = {c.args[2] for c in esetup.ir.async_delete_issue.call_args_list}
+        assert esetup.ISSUE_LEGACY_OAUTH_RESTART not in cleared
         # The same restart-needed verdict must thread into the connect-URL
         # surfacing so the log carries the first-enable "not live" caveat --
         # deleting that kwarg would silently drop the caveat.

--- a/tests/src/unit/test_embedded_setup.py
+++ b/tests/src/unit/test_embedded_setup.py
@@ -172,6 +172,7 @@ class TestBringUp:
             if esetup.ISSUE_LEGACY_OAUTH_RESTART in c.args
         ]
         assert created, "legacy-OAuth restart repair was not filed"
+        assert created[0].kwargs["is_fixable"] is True
         # The same restart-needed verdict must thread into the connect-URL
         # surfacing so the log carries the first-enable "not live" caveat --
         # deleting that kwarg would silently drop the caveat.


### PR DESCRIPTION
## What does this PR do?

Closes #2210.

- Marks the legacy OAuth restart repair as fixable.
- Adds a confirmation flow that calls `homeassistant.restart` with `blocking=True`.
- Replaces the manual restart instructions with concise repair and confirmation copy.
- Keeps restart failure handling explicit: a rejected restart leaves the flow unfinished, and the next component bring-up clears or re-files the repair from the current webhook verdict.
- Adds focused regression coverage for confirmation, restart behavior, repair lifecycle, fixability, and English catalog wiring.

## Type of change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

## Checklist
- [x] I have updated documentation if needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a repair flow for legacy OAuth changes.
  * Users can confirm an immediate Home Assistant restart to apply the changes.
  * Repairs are cleared after a successful restart.

* **Bug Fixes**
  * Legacy OAuth restart issues are now correctly marked as fixable.
  * Updated messaging clarifies that changes take effect after restarting Home Assistant.

* **Tests**
  * Added coverage for confirmation, restart failures, repair completion, and translated text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->