### PR TITLE
feat(webhook-proxy): mirror the unified OAuth surface onto the dev flavor and gate it on backend liveness

### DIFF
--- a/custom_components/ha_mcp_tools/oauth_dcr.py
+++ b/custom_components/ha_mcp_tools/oauth_dcr.py
@@ -11,6 +11,14 @@ problems the MCP maintainers deprecated it over).
 
 Served only in ``none`` and ``ha_auth`` modes: legacy mode's whole purpose is a
 pasted static credential, so it advertises no ``registration_endpoint``.
+
+MIRROR: ``homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/oauth_dcr.py`` is
+the near-verbatim twin of this module. Keep behavioural changes on the two
+sides in step; that file's header names the pair's intended deltas (identity
+rename, the flat ``hass.data[DOMAIN]`` layout in place of this side's
+``cfg[DATA_WEBHOOK]`` nesting, the ``oauth_mode == ha_auth`` test in
+``_active_grant_types`` where this side checks for a resource server, and the
+``_addon_alive`` gate on the register view).
 """
 
 from __future__ import annotations

--- a/custom_components/ha_mcp_tools/oauth_ha_auth.py
+++ b/custom_components/ha_mcp_tools/oauth_ha_auth.py
@@ -27,6 +27,12 @@ forwarded UNCHANGED and core's own checks apply. The CIMD fetch itself is the
 only outbound request: https-only, no redirects, 10 KiB cap, 5 s timeout, and
 DNS pinned to pre-validated globally routable addresses (SSRF floor per the MCP
 security considerations page).
+
+MIRROR: ``homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/oauth_indirect.py``
+is the near-verbatim twin of this module. Keep behavioural changes on the two
+sides in step; that file's header names the pair's one intended delta (the
+loopback and redirect-shape helpers come from ``oauth_legacy.py`` here and
+``oauth.py`` there).
 """
 
 from __future__ import annotations

--- a/homeassistant-addon-webhook-proxy-dev/DOCS.md
+++ b/homeassistant-addon-webhook-proxy-dev/DOCS.md
@@ -74,6 +74,7 @@ automatically on the next clean start.
 | `mcp_server_url` | Full MCP server URL override (auto-detects if blank) | `""` |
 | `mcp_port` | MCP server port used during auto-discovery | `9583` |
 | `enable_oauth` | **Beta.** Require OAuth 2.1 on the webhook URL | `false` |
+| `oauth_mode` | **Beta.** Bearer-protection mode: `ha_auth` or `legacy` | unset |
 | `oauth_client_id` | OAuth Client ID (auto-generated if blank) | `""` |
 | `oauth_client_secret` | OAuth Client Secret (auto-generated if blank) | `""` |
 | `regenerate_oauth_creds` | One-shot: wipe stored OAuth creds and generate fresh ones on next start | `false` |
@@ -129,10 +130,11 @@ The old webhook ID is not retained anywhere on disk after the file is deleted, a
 
 #### Enable OAuth (Beta) for stronger protection
 
-If you want a real auth layer on top of the URL secret, turn on **Enable OAuth (Beta)**. It is OFF by default; leaving it off keeps the webhook working exactly as before with no auth check.
+If you want a real auth layer on top of the URL secret, turn on **Enable OAuth (Beta)**. It is OFF by default; leaving it off keeps the webhook working with no auth check. The proxy still serves a none-mode OAuth compatibility surface so clients that insist on OAuth discovery can connect, but its token is cosmetic and grants no access by itself.
 
-There are two modes, chosen with the **OAuth Mode (Beta)** option:
+The proxy has three live OAuth behaviors. When OAuth protection is enabled, choose one of the two protected modes with **OAuth Mode (Beta)**:
 
+- **None mode (OAuth protection off)** — the secret webhook URL remains the only credential. OAuth discovery, stateless registration, and an invisible public-PKCE exchange are available for client compatibility, but the resulting token is not checked by the webhook.
 - **`ha_auth` (recommended, the default for a first-time enable)** — Home Assistant itself is the authorization server. You sign in with your Home Assistant account and **leave the connector's OAuth fields blank**. No Client ID or Client Secret, works with any hostname/URL, and no Home Assistant restart is needed to enable or disable it.
 - **`legacy` (deprecated)** — the previous flow, where the add-on generates a Client ID + Secret you paste into the connector.
 
@@ -147,7 +149,7 @@ There are two modes, chosen with the **OAuth Mode (Beta)** option:
    - **Claude.ai:** if its UI insists on a Client Secret, any value works — Home Assistant ignores it.
 5. **Revoking access:** open your Home Assistant profile and remove the session/refresh token for the connector (Settings → your user → Security). No add-on action needed.
 
-Why this mode is host-agnostic: the add-on serves the OAuth discovery documents itself, so they work on any hostname even when Home Assistant's own metadata would not (e.g. an external URL mismatch). All the actual OAuth protocol steps are Home Assistant core's own `/auth/authorize` + `/auth/token`.
+Why this mode is host-agnostic: the add-on serves the OAuth discovery and protocol endpoints itself, so they work on any hostname even when Home Assistant's own metadata would not. Its scoped handlers translate validated CIMD or DCR client identities, then redirect or relay into Home Assistant core for the actual login and token issuance.
 
 ##### Legacy mode (client id + secret)
 
@@ -176,20 +178,29 @@ The generated values are persisted at `/data/oauth_creds.json` inside the addon,
 2. **Get fresh random values via the UI** (no filesystem access needed): turn on **Regenerate OAuth Credentials on Next Start** in the addon configuration, save, restart. The addon wipes the stored creds, generates a fresh pair, prints them in the log, and flips the regenerate toggle back to off. Update your MCP client to match.
 3. **Get fresh random values manually:** stop the addon, delete `/data/oauth_creds.json` (e.g. via SSH/Terminal addon), start the addon. Equivalent to option 2 but requires filesystem access.
 
-**To disable OAuth (either mode):** set **Enable OAuth (Beta)** back to off and restart the addon. The webhook returns to plain unauthenticated behavior — the URL works as before with no token required.
+**To disable OAuth protection:** set **Enable OAuth (Beta)** back to off and restart the addon. The webhook returns to unauthenticated URL-as-secret behavior. The none-mode compatibility endpoints remain available, but their cosmetic token is not required by the webhook.
 
-**Endpoints exposed when enabled:**
+**OAuth endpoints:**
 
-Both modes serve the discovery documents from the add-on's own host, so they work on any hostname:
+All three behaviors advertise proxy-owned endpoints under `/api/mcp_proxy_dev/oauth`, so a cached client configuration remains on the proxy across mode switches:
 
-- `/.../api/webhook/<id>` — MCP webhook (now bearer-protected)
-- `/.../api/mcp_proxy_dev/oauth/protected-resource` — RFC 9728 metadata
-- `/.../api/mcp_proxy_dev/oauth/authorization-server` — RFC 8414 metadata (contents differ per mode)
+- `/api/mcp_proxy_dev/oauth/protected-resource` — RFC 9728 protected-resource metadata
+- `/api/mcp_proxy_dev/oauth/authorization-server` — RFC 8414 authorization-server metadata
+- `/api/mcp_proxy_dev/oauth/authorize` — mode-dispatched authorization endpoint
+- `/api/mcp_proxy_dev/oauth/token` — mode-dispatched token endpoint
+- `/api/mcp_proxy_dev/oauth/register` — stateless DCR endpoint, advertised in `ha_auth` and none mode
 
-The authorize/token endpoints depend on the mode:
+The same authorize/token URLs behave according to the active mode:
 
-- **`ha_auth`:** Home Assistant core's own `/auth/authorize` + `/auth/token`. The add-on registers no root routes and needs no HA restart.
-- **`legacy`:** the add-on's own `/.../authorize` (consent screen) + `/.../token` at the host root, where Claude.ai expects them.
+- **None mode:** accepts any valid HTTPS or RFC 8252 loopback redirect, auto-approves without a page, and issues a cosmetic token. DCR registrations advertise only the authorization-code grant.
+- **`ha_auth`:** validates CIMD or signed DCR identities before sending the browser/token exchange into Home Assistant core. DCR advertises refresh only when the registered redirects have one reproducible web origin.
+- **`legacy`:** serves the existing consent and credentialed token flow on the scoped URLs. The host-root `/authorize` and `/token` routes remain compatibility aliases but are not advertised; legacy does not advertise DCR.
+
+**Hosted Claude environment requirements:** Hosted Claude surfaces reach your server from Anthropic's backend, not from your browser. Three environment rules apply that no server-side setting can work around:
+
+1. **Port 443 only (hosted Claude connectors).** The connector URL must use standard HTTPS with no explicit port. Anthropic's backend only connects on port 443, so `https://ha.example.com:8123/...` is not reachable from hosted Claude connectors — put a reverse proxy or port-forward on 443 in front and keep 8123 internal.
+2. **Allowlist Anthropic's egress range.** Backend traffic originates from `160.79.104.0/21`. A WAF, geo-block, or bot filter (Cloudflare "AI crawl" rules included) that blocks that range breaks registration, token exchange, and the post-OAuth handshake even though your browser works fine.
+3. **Answer fast.** Claude waits at most 10 seconds for discovery, registration, and token responses (30 for refresh) per [Anthropic's connector authentication documentation](https://claude.com/docs/connectors/building/authentication). Slow reverse proxies or cold paths cause intermittent connection failures.
 
 **Notes (legacy mode):**
 
@@ -197,28 +208,28 @@ The authorize/token endpoints depend on the mode:
 - Rotating the Client ID invalidates all outstanding tokens (the client_id is part of the token's signed payload).
 - The signing key is generated once and persisted at `/config/.mcp_proxy_dev_oauth_secret`. Delete that file to invalidate every token in one shot.
 
-**Beta status:** OAuth is Beta in both modes; the URL-as-secret mode (default) is the stable, documented path. `ha_auth` delegates all protocol steps to Home Assistant's own OAuth (validated live against claude.ai); `legacy` is implemented against the [MCP 2025-06-18 spec](https://modelcontextprotocol.io/specification/2025-06-18/basic/authorization). Real-world MCP-client coverage varies, so treat OAuth as opt-in until tested with your client, and report problems on GitHub.
+**Beta status:** OAuth protection is Beta in both protected modes; the URL-as-secret mode (default) is the stable, documented path. `ha_auth` delegates authentication and token issuance to Home Assistant's own OAuth (validated live against claude.ai); `legacy` is implemented against the [MCP 2025-06-18 spec](https://modelcontextprotocol.io/specification/2025-06-18/basic/authorization). Real-world MCP-client coverage varies, so treat OAuth as opt-in until tested with your client, and report problems on GitHub.
 
-### End-to-end flow (what happens when Claude.ai connects)
+### Legacy end-to-end flow (what happens when Claude.ai connects)
 
 When OAuth is enabled and you paste the webhook URL + Client ID + Client Secret into Claude.ai's connector setup, here's what happens after you click **Connect** on the connector:
 
-1. **Claude.ai's browser session** is redirected to `https://<your-host>/authorize?response_type=code&client_id=...&redirect_uri=...&code_challenge=...&code_challenge_method=S256&state=...&resource=https://<your-host>/api/webhook/<id>`.
+1. **Claude.ai's browser session** is redirected to `https://<your-host>/api/mcp_proxy_dev/oauth/authorize?response_type=code&client_id=...&redirect_uri=...&code_challenge=...&code_challenge_method=S256&state=...&resource=https://<your-host>/api/webhook/<id>`.
 2. The addon serves a **consent page** (Allow / Deny) showing the redirect destination so you can verify it's Claude.ai's callback URL before proceeding.
 3. You click **Allow** → the addon issues a one-time auth code and redirects the browser back to Claude.ai's callback (`redirect_uri`).
-4. Claude.ai's backend exchanges the auth code at `https://<your-host>/token` using the configured Client ID and Client Secret (Basic auth or form body) plus the PKCE `code_verifier`. The addon validates all of these, then issues:
+4. Claude.ai's backend exchanges the auth code at `https://<your-host>/api/mcp_proxy_dev/oauth/token` using the configured Client ID and Client Secret (Basic auth or form body) plus the PKCE `code_verifier`. The addon validates all of these, then issues:
    - An **access token** (1-hour HMAC-signed bearer)
    - A **refresh token** (30-day HMAC-signed bearer)
 5. Claude.ai stores the tokens. From then on, every MCP request includes `Authorization: Bearer <access-token>`. The webhook handler validates the bearer; expired tokens are refreshed automatically using the refresh token.
 
-### Threat model and the role of the Client Secret
+### Legacy threat model and the role of the Client Secret
 
-The `/authorize` consent page is reachable without being logged into Home Assistant or Nabu Casa. **This is intentional and matches how mainstream OAuth servers work** — the consent page must be reachable by the browser session being redirected from the OAuth client (Claude.ai), which has no Home Assistant credentials of its own.
+The scoped `/api/mcp_proxy_dev/oauth/authorize` consent page is reachable without being logged into Home Assistant or Nabu Casa. **This is intentional and matches how mainstream OAuth servers work** — the consent page must be reachable by the browser session being redirected from the OAuth client (Claude.ai), which has no Home Assistant credentials of its own.
 
 What stops an attacker who can reach the consent page from gaining access:
 
 - Clicking **Allow** on a maliciously-crafted authorize URL only mints a one-time auth code bound to the attacker's `redirect_uri` and PKCE `code_challenge`.
-- That code is **useless without the OAuth Client Secret**, which is required at the `/token` endpoint to complete the exchange.
+- That code is **useless without the OAuth Client Secret**, which is required at the scoped `/api/mcp_proxy_dev/oauth/token` endpoint to complete the exchange.
 - PKCE binds the code to the original `code_verifier`, which only the legitimate client (Claude.ai) generated.
 
 **This means: the OAuth Client Secret is the actual security boundary.** Treat it like a password.

--- a/homeassistant-addon-webhook-proxy-dev/DOCS.md
+++ b/homeassistant-addon-webhook-proxy-dev/DOCS.md
@@ -252,7 +252,7 @@ What stops an attacker who can reach the consent page from gaining access:
 
 If a client (e.g. Claude.ai) can't connect and you can't tell whether its requests are even reaching Home Assistant, turn on **Log inbound requests** (the `debug_logging` option on the main Configuration page) and **restart the addon**.
 
-When it's on, every request that hits the webhook is logged to the **Home Assistant log** (requests reach Home Assistant directly rather than passing through the addon process). View them at **Settings → System → Logs** (or filter for `mcp_proxy_dev`). The same lines are also **mirrored into this addon's own log**, so you can watch them on the addon's Log tab without leaving the addon page. Each line shows the method, a masked webhook path, the source address, whether an `Authorization` header was present, and the upstream response status:
+When it's on, every request that hits the webhook is logged to the **Home Assistant log** (along with Home Assistant's own webhook lines, which are otherwise hidden — that is what distinguishes a request that never arrived from one that arrived for an unregistered id) (requests reach Home Assistant directly rather than passing through the addon process). View them at **Settings → System → Logs** (or filter for `mcp_proxy_dev`). The same lines are also **mirrored into this addon's own log**, so you can watch them on the addon's Log tab without leaving the addon page. Each line shows the method, a masked webhook path, the source address, whether an `Authorization` header was present, and the upstream response status:
 
 ```
 MCP Proxy [inbound]: POST /api/webhook/mcp_3e... from 203.0.113.4 (Authorization header: present)
@@ -262,7 +262,8 @@ MCP Proxy [inbound]: -> upstream responded 200 (text/event-stream)
 How to read it:
 
 - **You see inbound lines** → the client is reaching the server; the problem is downstream (auth, the client's config, or the MCP server itself).
-- **You see nothing** → the request never arrived. The problem is network reachability — the public URL, DNS, TLS, or your reverse proxy — not this addon. See the reachability check under [Setup](#connecting-from-claudeai-web).
+- **You see `Received message for unregistered webhook`** (Home Assistant's own line, surfaced only while this toggle is on) → the request DID arrive, but nothing is registered for that webhook id, so Home Assistant answered an empty `200` without ever reaching this addon. Usually a stale URL: compare the id in the URL your client uses against the `webhook endpoint = /api/webhook/mcp_…` line this addon logs at startup, and restart Home Assistant if a restart Repair is pending.
+- **You see nothing at all** → the request never arrived. The problem is network reachability — the public URL, DNS, TLS, or your reverse proxy — not this addon. See the reachability check under [Setup](#connecting-from-claudeai-web).
 
 Turn it back off for normal operation (restart the addon after changing it).
 

--- a/homeassistant-addon-webhook-proxy-dev/DOCS.md
+++ b/homeassistant-addon-webhook-proxy-dev/DOCS.md
@@ -184,7 +184,7 @@ The generated values are persisted at `/data/oauth_creds.json` inside the addon,
 
 All three behaviors advertise proxy-owned endpoints under `/api/mcp_proxy_dev/oauth`, so a cached client configuration remains on the proxy across mode switches:
 
-- `/api/mcp_proxy_dev/oauth/protected-resource` — RFC 9728 protected-resource metadata
+- `/api/mcp_proxy_dev/oauth/protected-resource` — RFC 9728 protected-resource metadata (`legacy` and `ha_auth` only: in none mode this fixed route returns 404, because its metadata would reveal the credential-bearing webhook URL — none-mode clients use the webhook-ID-scoped `.well-known` route instead)
 - `/api/mcp_proxy_dev/oauth/authorization-server` — RFC 8414 authorization-server metadata
 - `/api/mcp_proxy_dev/oauth/authorize` — mode-dispatched authorization endpoint
 - `/api/mcp_proxy_dev/oauth/token` — mode-dispatched token endpoint

--- a/homeassistant-addon-webhook-proxy-dev/config.yaml
+++ b/homeassistant-addon-webhook-proxy-dev/config.yaml
@@ -1,6 +1,6 @@
 name: "Nabu Casa - Webhook Proxy for HA MCP (Dev)"
 description: "DEV CHANNEL (unstable) — remote access proxy via Nabu Casa or any reverse proxy. Cannot run alongside the stable Webhook Proxy add-on."
-version: "2.1.1.dev4"
+version: "2.1.1.dev5"
 slug: "ha_mcp_webhook_proxy_dev"
 url: "https://github.com/homeassistant-ai/ha-mcp"
 stage: experimental

--- a/homeassistant-addon-webhook-proxy-dev/config.yaml
+++ b/homeassistant-addon-webhook-proxy-dev/config.yaml
@@ -1,6 +1,6 @@
 name: "Nabu Casa - Webhook Proxy for HA MCP (Dev)"
 description: "DEV CHANNEL (unstable) — remote access proxy via Nabu Casa or any reverse proxy. Cannot run alongside the stable Webhook Proxy add-on."
-version: "2.1.1.dev3"
+version: "2.1.1.dev4"
 slug: "ha_mcp_webhook_proxy_dev"
 url: "https://github.com/homeassistant-ai/ha-mcp"
 stage: experimental

--- a/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/__init__.py
+++ b/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/__init__.py
@@ -54,6 +54,17 @@ _LOGGER = logging.getLogger(__name__)
 # must survive a config-entry reload, during which hass.data[DOMAIN] is gone.
 _LOGGER_LEVEL_RAISED = False
 
+# Home Assistant's OWN webhook component logs "Received message for
+# unregistered webhook <id> from <ip>" at INFO and then answers an empty 200
+# ("Always respond successfully to not give away if a hook exists or not").
+# That line is the difference between "the request reached HA but nothing is
+# registered for this id" and "the request never arrived at all" — precisely
+# the question the inbound log exists to answer, and invisible by default
+# because it belongs to HA's logger rather than ours (#2220). Raise it
+# alongside our own for as long as the toggle is on.
+_WEBHOOK_LOGGER = logging.getLogger("homeassistant.components.webhook")
+_WEBHOOK_LOGGER_LEVEL_RAISED = False
+
 DOMAIN = "mcp_proxy_dev"
 CONFIG_FILE = Path("/config/.mcp_proxy_dev_config.json")
 DCR_SECRET_FILE = Path("/config/.mcp_proxy_dev_dcr_secret")
@@ -343,6 +354,25 @@ def _validate_and_mask_target(target_url: str, webhook_id: str) -> str:
     return masked_wh
 
 
+def _apply_logger_level(logger: logging.Logger, raised: bool, enable: bool) -> bool:
+    """Raise ``logger`` to INFO while the toggle is on; return the new flag.
+
+    Only raises when the effective level is less verbose, so an explicit
+    DEBUG/INFO from the user's `logger:` config is never overridden, and only
+    undoes a raise WE made. (If a user had set a level quieter than INFO then
+    toggled debug on and off, this resets to NOTSET rather than their original
+    level; restoring that would need durable per-level state, not worth it for
+    a debug aid.)
+    """
+    if enable and logger.getEffectiveLevel() > logging.INFO:
+        logger.setLevel(logging.INFO)
+        return True
+    if not enable and raised:
+        logger.setLevel(logging.NOTSET)
+        return False
+    return raised
+
+
 def _apply_debug_logging(proxy_config: dict) -> bool:
     """Apply the inbound-request debug-logging toggle to this integration's
     logger and return whether it is enabled."""
@@ -353,18 +383,14 @@ def _apply_debug_logging(proxy_config: dict) -> bool:
     # explicit DEBUG/INFO the user set via Home Assistant's `logger:` config. We
     # track whether WE raised it and, when the toggle is off, undo only our own
     # raise — never a level the user set themselves.
-    global _LOGGER_LEVEL_RAISED
+    global _LOGGER_LEVEL_RAISED, _WEBHOOK_LOGGER_LEVEL_RAISED
     debug_logging = bool(proxy_config.get("debug_logging", False))
-    if debug_logging and _LOGGER.getEffectiveLevel() > logging.INFO:
-        _LOGGER.setLevel(logging.INFO)
-        _LOGGER_LEVEL_RAISED = True
-    elif not debug_logging and _LOGGER_LEVEL_RAISED:
-        # Undo only the INFO we raised. (If a user had set an explicit level
-        # quieter than INFO — ERROR/CRITICAL — then toggled debug on then off,
-        # this resets to NOTSET rather than their original level; restoring that
-        # would need durable per-level state, not worth it for a debug aid.)
-        _LOGGER.setLevel(logging.NOTSET)
-        _LOGGER_LEVEL_RAISED = False
+    _LOGGER_LEVEL_RAISED = _apply_logger_level(
+        _LOGGER, _LOGGER_LEVEL_RAISED, debug_logging
+    )
+    _WEBHOOK_LOGGER_LEVEL_RAISED = _apply_logger_level(
+        _WEBHOOK_LOGGER, _WEBHOOK_LOGGER_LEVEL_RAISED, debug_logging
+    )
     return debug_logging
 
 

--- a/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/__init__.py
+++ b/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/__init__.py
@@ -475,9 +475,7 @@ async def _setup_ha_auth_oauth(
         from .oauth_autoapprove import register_autoapprove_views
         from .oauth_dcr import bind_dcr_view
 
-        dcr_signing_key = await hass.async_add_executor_job(
-            load_or_create_dcr_secret
-        )
+        dcr_signing_key = await hass.async_add_executor_job(load_or_create_dcr_secret)
         cimd_session = aiohttp.ClientSession(
             connector=aiohttp.TCPConnector(limit=_CIMD_CONNECTOR_LIMIT)
         )
@@ -665,9 +663,7 @@ async def _setup_none_autoapprove(
         )
         from .oauth_dcr import bind_dcr_view
 
-        dcr_signing_key = await hass.async_add_executor_job(
-            load_or_create_dcr_secret
-        )
+        dcr_signing_key = await hass.async_add_executor_job(load_or_create_dcr_secret)
         # Host-derived base URLs (public_base_url=None), like ha_auth: the same
         # install must work via any external URL.
         provider = AutoApproveProvider(hass, webhook_id, None)

--- a/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/__init__.py
+++ b/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/__init__.py
@@ -435,6 +435,7 @@ async def _setup_ha_auth_oauth(
     try:
         from .auth_native import ResourceServer
         from .oauth import register_metadata_views
+        from .oauth_autoapprove import register_autoapprove_views
 
         resource_server = ResourceServer(hass, webhook_id, None)
         # Registers the seven discovery-document views at most once per HA
@@ -448,6 +449,7 @@ async def _setup_ha_auth_oauth(
         # and no restart concept — hence oauth_restart_needed stays False and
         # the marker-CLEAR path runs below.
         register_metadata_views(hass, resource_server)
+        register_autoapprove_views(hass)
     except Exception as err:
         _LOGGER.exception(
             "MCP Proxy: failed to initialise ha_auth OAuth (%s)",
@@ -557,6 +559,9 @@ async def _setup_legacy_oauth(
         oauth_restart_needed = _bind_legacy_oauth_views(
             hass, oauth_provider, route_owner, fingerprint
         )
+        from .oauth_autoapprove import register_autoapprove_views
+
+        register_autoapprove_views(hass)
     except ConfigEntryError:
         # The post-await collision re-check above already tore down (webhook
         # unregistered, session closed) — re-raise as-is so the generic

--- a/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/__init__.py
+++ b/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/__init__.py
@@ -6,11 +6,11 @@ MCP requests to the ha-mcp addon, allowing remote access via any reverse
 proxy (Nabu Casa, Cloudflare, DuckDNS, nginx, etc.). The webhook URL itself
 is the shared secret in this default mode.
 
-Authentication: when the addon's "Enable OAuth" toggle is on, the addon
-writes OAuth client credentials into the config file and this integration
-lazy-imports `oauth.py` to register the OAuth 2.1 endpoints + bearer-token
-gate. When the toggle is off, no OAuth code is loaded and the proxy behaves
-exactly like the original unauthenticated webhook.
+Authentication is selected by the add-on's OAuth mode. All three modes expose
+the proxy-owned scoped discovery and authorization surface: ha_auth validates
+Home Assistant bearer tokens, legacy uses the proxy's embedded provider, and
+none mode keeps the secret webhook URL as the only credential while completing
+client-mandated OAuth invisibly with a cosmetic token.
 
 Configuration is read from /config/.mcp_proxy_dev_config.json, which is written
 by the proxy addon's startup script. No manual configuration is needed — the
@@ -23,8 +23,10 @@ import hashlib
 import json
 import logging
 import re
+import secrets
 import threading
 from collections.abc import Callable, Coroutine
+from contextlib import suppress
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 from urllib.parse import urlparse
@@ -54,6 +56,12 @@ _LOGGER_LEVEL_RAISED = False
 
 DOMAIN = "mcp_proxy_dev"
 CONFIG_FILE = Path("/config/.mcp_proxy_dev_config.json")
+DCR_SECRET_FILE = Path("/config/.mcp_proxy_dev_dcr_secret")
+
+# Anonymous CIMD lookups get a separate, deliberately small connection pool.
+# Slow public metadata endpoints must never consume the authenticated relay
+# session's capacity.
+_CIMD_CONNECTOR_LIMIT = 4
 
 # OAuth mode markers written into hass.data["oauth_mode"] and read by the
 # webhook gate + the mode-aware discovery views. Mirrored as
@@ -139,6 +147,34 @@ CONFIG_SCHEMA = vol.Schema(
     {vol.Optional(DOMAIN): vol.Any(None, dict)},
     extra=vol.ALLOW_EXTRA,
 )
+
+
+def load_or_create_dcr_secret() -> bytes:
+    """Persist the 32-byte HMAC key used for stateless DCR client ids."""
+    from .oauth import _atomic_write_0600
+
+    if DCR_SECRET_FILE.exists():
+        data = DCR_SECRET_FILE.read_bytes()
+        if len(data) >= 32:
+            return data
+        _LOGGER.warning(
+            "MCP Proxy DCR: existing signing key at %s is shorter than "
+            "32 bytes (got %d). Regenerating — previously registered "
+            "OAuth clients will need to re-authorize.",
+            DCR_SECRET_FILE,
+            len(data),
+        )
+    new_secret = secrets.token_bytes(32)
+    DCR_SECRET_FILE.parent.mkdir(parents=True, exist_ok=True)
+    if not _atomic_write_0600(DCR_SECRET_FILE, new_secret):
+        DCR_SECRET_FILE.write_bytes(new_secret)
+        _LOGGER.warning(
+            "MCP Proxy DCR: could not create the signing key file with "
+            "restricted permissions at %s. The key may have wider "
+            "permissions than intended.",
+            DCR_SECRET_FILE,
+        )
+    return new_secret
 
 
 def _oauth_route_fingerprint(
@@ -421,9 +457,9 @@ async def _setup_ha_auth_oauth(
         _hass_version = "unknown"
     _LOGGER.info(
         "MCP Proxy: OAuth mode 'ha_auth' — Home Assistant (version %s) is "
-        "the authorization server; this add-on serves only the OAuth "
-        "discovery documents and validates bearer tokens via hass.auth. No "
-        "HA restart is needed to enable or disable this mode.",
+        "the authorization server behind this add-on's scoped OAuth surface; "
+        "bearer tokens are validated via hass.auth. No HA restart is needed "
+        "to enable or disable this mode.",
         _hass_version,
     )
     # ha_auth is ALWAYS host-derived: the SAME install must work via the
@@ -432,24 +468,30 @@ async def _setup_ha_auth_oauth(
     # and ignore any public_base_url a hand-edited config might carry (the
     # ambiguity guard above only rejects stray client_id/client_secret keys,
     # so a stray public_base_url would otherwise wrongly pin the base URL).
+    cimd_session: aiohttp.ClientSession | None = None
     try:
         from .auth_native import ResourceServer
         from .oauth import register_metadata_views
         from .oauth_autoapprove import register_autoapprove_views
+        from .oauth_dcr import bind_dcr_view
 
+        dcr_signing_key = await hass.async_add_executor_job(
+            load_or_create_dcr_secret
+        )
+        cimd_session = aiohttp.ClientSession(
+            connector=aiohttp.TCPConnector(limit=_CIMD_CONNECTOR_LIMIT)
+        )
         resource_server = ResourceServer(hass, webhook_id, None)
         # Registers the seven discovery-document views at most once per HA
         # session (register_metadata_views no-ops when either mode already
         # bound them — see oauth._METADATA_VIEWS_REGISTERED_KEY), so a
-        # config-entry reload or a live legacy->ha_auth switch doesn't
-        # stack shadowed duplicates. ha_auth binds NO root views (HA core is
-        # the authorization server, serving its own /auth/authorize +
-        # /auth/token; the bare /authorize + /token are the legacy flavor's
-        # own root views), so there is no owner-key / fingerprint bookkeeping
-        # and no restart concept — hence oauth_restart_needed stays False and
-        # the marker-CLEAR path runs below.
+        # config-entry reload or a live legacy->ha_auth switch doesn't stack
+        # shadowed duplicates. The scoped handlers redirect/relay into core;
+        # the bare /authorize + /token remain legacy-only aliases, so there is
+        # no owner-key / fingerprint bookkeeping and no restart concept.
         register_metadata_views(hass, resource_server)
         register_autoapprove_views(hass)
+        bind_dcr_view(hass)
     except Exception as err:
         _LOGGER.exception(
             "MCP Proxy: failed to initialise ha_auth OAuth (%s)",
@@ -458,7 +500,11 @@ async def _setup_ha_auth_oauth(
         # OAuth setup failed — unregister the webhook async_setup_entry registered so
         # we don't leave an unauthenticated endpoint live.
         async_unregister(hass, webhook_id)
-        await session.close()
+        if cimd_session is not None:
+            with suppress(Exception):
+                await cimd_session.close()
+        with suppress(Exception):
+            await session.close()
         raise ConfigEntryError(
             f"Failed to enable OAuth on the MCP webhook: {err}. "
             "Auth is not being enforced — refusing to start the "
@@ -467,6 +513,8 @@ async def _setup_ha_auth_oauth(
         ) from err
     hass_data["oauth"] = resource_server
     hass_data["oauth_mode"] = OAUTH_MODE_HA_AUTH
+    hass_data["dcr_signing_key"] = dcr_signing_key
+    hass_data["cimd_session"] = cimd_session
 
 
 async def _setup_legacy_oauth(
@@ -591,7 +639,7 @@ async def _setup_legacy_oauth(
     return oauth_restart_needed
 
 
-def _setup_none_autoapprove(
+async def _setup_none_autoapprove(
     hass: HomeAssistant, webhook_id: str, hass_data: dict
 ) -> None:
     """Set up none-mode auto-approve discovery (OAuth off — issue #1969).
@@ -615,14 +663,19 @@ def _setup_none_autoapprove(
             AutoApproveProvider,
             register_autoapprove_views,
         )
+        from .oauth_dcr import bind_dcr_view
 
+        dcr_signing_key = await hass.async_add_executor_job(
+            load_or_create_dcr_secret
+        )
         # Host-derived base URLs (public_base_url=None), like ha_auth: the same
         # install must work via any external URL.
         provider = AutoApproveProvider(hass, webhook_id, None)
-        # Both view bundles bind at most once per HA session (guarded); a
+        # All three view bundles bind at most once per HA session (guarded); a
         # none<->ha_auth switch reuses them, so no restart is needed.
         register_metadata_views(hass, provider)
         register_autoapprove_views(hass)
+        bind_dcr_view(hass)
     except Exception:
         _LOGGER.exception(
             "MCP Proxy: failed to set up none-mode auto-approve discovery; "
@@ -631,6 +684,7 @@ def _setup_none_autoapprove(
             "unassisted)."
         )
         return
+    hass_data["dcr_signing_key"] = dcr_signing_key
     hass_data[AUTOAPPROVE_PROVIDER_KEY] = provider
     hass_data["oauth_mode"] = OAUTH_MODE_NONE_AUTOAPPROVE
     _LOGGER.info(
@@ -649,13 +703,10 @@ async def _setup_oauth_section(
 ) -> bool:
     """Set up the optional OAuth section, dispatching by mode. Returns
     oauth_restart_needed; raises ConfigEntryError on malformed config."""
-    # OAuth is opt-in. When the addon writes an `oauth` section into the
-    # config file (only when enable_oauth is on AND both creds are non-empty,
-    # validated by start.py), we lazy-import the provider and register its
-    # views. When the section is absent, this entire branch is skipped —
-    # nothing about hass.data, imports, or registered HTTP views changes
-    # from the no-auth baseline. That is the load-bearing guarantee for
-    # users who don't opt into OAuth.
+    # An `oauth` section selects ha_auth or legacy. When it is absent, the
+    # proxy stays unauthenticated but exposes the none-mode compatibility
+    # surface so OAuth-mandating clients can still connect; its token remains
+    # cosmetic and never enables the webhook's bearer gate.
     #
     # If the OAuth section IS present but malformed — blank creds, or view
     # registration fails — we fail loudly via ConfigEntryError. The user
@@ -690,7 +741,7 @@ async def _setup_oauth_section(
     # forwarder stays unauthenticated and never 401s (see _setup_none_autoapprove
     # / the AUTOAPPROVE_PROVIDER_KEY-not-"oauth" split). No restart is ever
     # needed, so oauth_restart_needed stays False.
-    _setup_none_autoapprove(hass, webhook_id, hass_data)
+    await _setup_none_autoapprove(hass, webhook_id, hass_data)
     return False
 
 
@@ -1022,4 +1073,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     session = data.get("session")
     if session:
         await session.close()
+    cimd_session = data.get("cimd_session")
+    if cimd_session:
+        await cimd_session.close()
     return True

--- a/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/auth_native.py
+++ b/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/auth_native.py
@@ -58,23 +58,17 @@ AUTH_V2 = True
 def authorization_server_document(base: str) -> dict:
     """Return the RFC 8414 authorization-server metadata for ha_auth mode.
 
-    Points MCP clients at Home Assistant core's own OAuth endpoints
-    (`/auth/authorize` + `/auth/token`) while keeping the issuer on the add-on's
-    host-agnostic `OAUTH_BASE`. `token_endpoint_auth_methods_supported` is
-    `["none"]` (a public client — HA ignores `client_secret`) and
-    `client_id_metadata_document_supported` is advertised so clients such as
-    claude.ai and ChatGPT present a URL-shaped `client_id` (CIMD). The flag is
-    advertisement-only: HA never fetches a CIMD document — a same-origin
-    URL-shaped `client_id` plus redirect is long-standing IndieAuth behavior
-    (home-assistant/core#153820 is field evidence of claude.ai and ChatGPT
-    working against it, not a dependency). No `registration_endpoint`:
-    dynamic client registration would hit Home Assistant, which offers none —
-    CIMD replaces it. The field contents were validated live against claude.ai.
+    HA core still authenticates the user, but every cacheable endpoint belongs
+    to this proxy. The scoped handlers dispatch per live mode, translate CIMD
+    or signed DCR identities for core, and remain valid across mode switches.
+    Public clients use PKCE without a client secret; the registration endpoint
+    provides the DCR fallback when a client does not use CIMD.
     """
     return {
         "issuer": f"{base}{OAUTH_BASE}",
-        "authorization_endpoint": f"{base}/auth/authorize",
-        "token_endpoint": f"{base}/auth/token",
+        "authorization_endpoint": f"{base}{OAUTH_BASE}/authorize",
+        "token_endpoint": f"{base}{OAUTH_BASE}/token",
+        "registration_endpoint": f"{base}{OAUTH_BASE}/register",
         "response_types_supported": ["code"],
         "grant_types_supported": ["authorization_code", "refresh_token"],
         "code_challenge_methods_supported": ["S256"],

--- a/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/manifest.json
+++ b/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/manifest.json
@@ -7,5 +7,5 @@
   "dependencies": ["webhook"],
   "documentation": "https://github.com/homeassistant-ai/ha-mcp",
   "iot_class": "local_push",
-  "version": "2.1.1.dev4"
+  "version": "2.1.1.dev5"
 }

--- a/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/manifest.json
+++ b/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/manifest.json
@@ -7,5 +7,5 @@
   "dependencies": ["webhook"],
   "documentation": "https://github.com/homeassistant-ai/ha-mcp",
   "iot_class": "local_push",
-  "version": "2.1.1.dev3"
+  "version": "2.1.1.dev4"
 }

--- a/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/oauth.py
+++ b/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/oauth.py
@@ -24,7 +24,6 @@ without a server-side store, so the integration survives restarts.
 
 from __future__ import annotations
 
-import asyncio
 import base64
 import binascii
 import hashlib
@@ -384,52 +383,38 @@ def _active_oauth_mode(provider: object) -> str | None:
     return domain_data.get("oauth_mode")
 
 
-# hass.data persists after the add-on stops, so bound OAuth views must also
-# verify that the forwarding backend is reachable. Cache by target host/port to
-# avoid opening a TCP connection for every discovery or token request.
-_BACKEND_ALIVE_TTL = 15.0
-_backend_alive_cache: dict[str, tuple[float, bool]] = {}
+# hass.data persists after the add-on stops (and the persisted proxy config
+# re-populates it at HA boot), so bound OAuth views must verify the add-on
+# itself is running. TCP-probing target_url cannot do that (#2218 review):
+# target_url is the INDEPENDENT ha-mcp server add-on, which keeps accepting
+# connections after this proxy add-on stops. The signal is proxy-owned
+# instead: start.py touches HEARTBEAT_FILE every keep-alive iteration (~30 s)
+# and deletes it on clean shutdown, so a fresh mtime means the add-on process
+# is alive right now — including after a crash bypassed cleanup, where the
+# file simply goes stale.
+HEARTBEAT_FILE = Path("/config/.mcp_proxy_dev_heartbeat")
+_HEARTBEAT_MAX_AGE = 90.0  # three missed 30-second touches
+_ADDON_ALIVE_TTL = 15.0
+_addon_alive_cache: tuple[float, bool] | None = None
 
 
-async def _backend_alive(hass: HomeAssistant) -> bool:
-    """Return whether the add-on's forwarding target accepts TCP connections."""
-    domain_data = hass.data.get(DOMAIN)
-    if not isinstance(domain_data, dict):
-        return False
-    target_url = domain_data.get("target_url", "")
-    if not isinstance(target_url, str):
-        return False
+def _heartbeat_fresh() -> bool:
+    """Blocking mtime check — run in the executor."""
     try:
-        parsed = urlparse(target_url)
-        port = parsed.port
-    except ValueError:
+        age = time.time() - HEARTBEAT_FILE.stat().st_mtime
+    except OSError:
         return False
-    if not parsed.hostname or port is None or port == 0:
-        return False
+    return age < _HEARTBEAT_MAX_AGE
 
-    key = f"{parsed.hostname}:{port}"
+
+async def _addon_alive(hass: HomeAssistant) -> bool:
+    """Return whether the proxy add-on's heartbeat file is fresh."""
+    global _addon_alive_cache
     now = time.monotonic()
-    cached = _backend_alive_cache.get(key)
-    if cached is not None and cached[0] > now:
-        return cached[1]
-
-    try:
-        _reader, writer = await asyncio.wait_for(
-            asyncio.open_connection(parsed.hostname, port), 1.0
-        )
-    except (TimeoutError, OSError):
-        alive = False
-    else:
-        alive = True
-        writer.close()
-        try:
-            await writer.wait_closed()
-        except OSError:
-            # Best-effort cleanup: the probe connection already succeeded, so
-            # a failure while closing the socket does not change the verdict.
-            pass
-
-    _backend_alive_cache[key] = (time.monotonic() + _BACKEND_ALIVE_TTL, alive)
+    if _addon_alive_cache is not None and _addon_alive_cache[0] > now:
+        return _addon_alive_cache[1]
+    alive = await hass.async_add_executor_job(_heartbeat_fresh)
+    _addon_alive_cache = (time.monotonic() + _ADDON_ALIVE_TTL, alive)
     return alive
 
 
@@ -517,7 +502,7 @@ class PKCECodeStore:
         # be rejected explicitly rather than silently hashing junk.
         if not (PKCE_VERIFIER_MIN <= len(code_verifier) <= PKCE_VERIFIER_MAX):
             return False
-        if not _PKCE_VERIFIER_RE.match(code_verifier):
+        if not _PKCE_VERIFIER_RE.fullmatch(code_verifier):
             return False
         entry = self._codes.pop(code, None)
         if entry is None:
@@ -730,7 +715,7 @@ class OAuthProvider:
             return _text_error(400, "unsupported_response_type")
         if code_challenge_method != "S256":
             return _text_error(400, "invalid code_challenge_method (S256 required)")
-        if not _PKCE_CHALLENGE_RE.match(code_challenge):
+        if not _PKCE_CHALLENGE_RE.fullmatch(code_challenge):
             return _text_error(
                 400, "invalid code_challenge (must be 43-char base64url)"
             )
@@ -766,7 +751,7 @@ class ProtectedResourceMetadataView(HomeAssistantView):
 
     async def get(self, request: web.Request) -> web.Response:
         hass = getattr(self._provider, "_hass", None)
-        if hass is None or not await _backend_alive(hass):
+        if hass is None or not await _addon_alive(hass):
             return _json_not_found()
         # The protected-resource document has the same shape in every OAuth
         # mode; 404 when no mode is live (entry unloaded / OAuth off) so a
@@ -809,7 +794,7 @@ class AuthorizationServerMetadataView(HomeAssistantView):
 
     async def get(self, request: web.Request) -> web.Response:
         hass = getattr(self._provider, "_hass", None)
-        if hass is None or not await _backend_alive(hass):
+        if hass is None or not await _addon_alive(hass):
             return _json_not_found()
         mode = _active_oauth_mode(self._provider)
         if mode is None:
@@ -1107,7 +1092,7 @@ class AuthorizeView(HomeAssistantView):
         self._provider = provider
 
     async def get(self, request: web.Request) -> web.Response:
-        if not await _backend_alive(self._provider._hass):
+        if not await _addon_alive(self._provider._hass):
             return _json_not_found()
         if _active_oauth_mode(self._provider) != MODE_LEGACY:
             # Serve ONLY when legacy is the live mode. Both ha_auth (HA core is
@@ -1120,7 +1105,7 @@ class AuthorizeView(HomeAssistantView):
         return await handle_legacy_authorize_get(self._provider, request)
 
     async def post(self, request: web.Request) -> web.Response:
-        if not await _backend_alive(self._provider._hass):
+        if not await _addon_alive(self._provider._hass):
             return _json_not_found()
         if _active_oauth_mode(self._provider) != MODE_LEGACY:
             # Serve ONLY when legacy is live (see the GET defense above): ha_auth
@@ -1143,7 +1128,7 @@ class TokenView(HomeAssistantView):
         self._provider = provider
 
     async def post(self, request: web.Request) -> web.Response:
-        if not await _backend_alive(self._provider._hass):
+        if not await _addon_alive(self._provider._hass):
             return _json_not_found()
         if _active_oauth_mode(self._provider) != MODE_LEGACY:
             # Serve ONLY when legacy is live. Both ha_auth (HA core is the

--- a/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/oauth.py
+++ b/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/oauth.py
@@ -394,8 +394,13 @@ def _active_oauth_mode(provider: object) -> str | None:
 # file simply goes stale.
 HEARTBEAT_FILE = Path("/config/.mcp_proxy_dev_heartbeat")
 _HEARTBEAT_MAX_AGE = 90.0  # three missed 30-second touches
-_ADDON_ALIVE_TTL = 15.0
-_addon_alive_cache: tuple[float, bool] | None = None
+# Only the NEGATIVE verdict is cached (#2218 review): a clean shutdown deletes
+# the heartbeat file but cannot clear a cache in the integration process, so a
+# cached True would keep the surface serving after the stop. A fresh stat per
+# request while alive is microseconds in the executor; the cache exists so an
+# anonymous flood against a STOPPED install does not stat per request.
+_ADDON_DOWN_TTL = 15.0
+_addon_down_until: float = 0.0
 
 
 def _heartbeat_fresh() -> bool:
@@ -409,12 +414,12 @@ def _heartbeat_fresh() -> bool:
 
 async def _addon_alive(hass: HomeAssistant) -> bool:
     """Return whether the proxy add-on's heartbeat file is fresh."""
-    global _addon_alive_cache
-    now = time.monotonic()
-    if _addon_alive_cache is not None and _addon_alive_cache[0] > now:
-        return _addon_alive_cache[1]
+    global _addon_down_until
+    if time.monotonic() < _addon_down_until:
+        return False
     alive = bool(await hass.async_add_executor_job(_heartbeat_fresh))
-    _addon_alive_cache = (time.monotonic() + _ADDON_ALIVE_TTL, alive)
+    if not alive:
+        _addon_down_until = time.monotonic() + _ADDON_DOWN_TTL
     return alive
 
 

--- a/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/oauth.py
+++ b/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/oauth.py
@@ -1007,8 +1007,15 @@ async def handle_legacy_authorize_post(
 
 def _extract_client_creds(
     request: web.Request, form: dict
-) -> tuple[str | None, str | None]:
-    """Pull form-decoded client credentials from Basic auth or the form body."""
+) -> list[tuple[str | None, str | None]]:
+    """Candidate client credentials from Basic auth or the form body.
+
+    RFC 6749 §2.3.1 form-urlencodes Basic credentials before base64, but many
+    clients skip that step — and the add-on accepts arbitrary CONFIGURED
+    values (``oauth_client_id``/``oauth_client_secret``), so a raw ``+`` or
+    ``%XX`` in a real credential would be mangled by decoding (#2218 review).
+    Both the decoded and the raw split are offered; either may authenticate.
+    """
     header = request.headers.get("Authorization", "")
     if header.lower().startswith("basic "):
         try:
@@ -1016,12 +1023,17 @@ def _extract_client_creds(
                 "utf-8"
             )
         except (ValueError, UnicodeDecodeError, binascii.Error):
-            return None, None
-        if ":" in decoded:
-            client_id, _, client_secret = decoded.partition(":")
-            return unquote_plus(client_id), unquote_plus(client_secret)
-        return None, None
-    return form.get("client_id"), form.get("client_secret")
+            return []
+        if ":" not in decoded:
+            return []
+        client_id, _, client_secret = decoded.partition(":")
+        candidates: list[tuple[str | None, str | None]] = [
+            (unquote_plus(client_id), unquote_plus(client_secret))
+        ]
+        if (client_id, client_secret) != candidates[0]:
+            candidates.append((client_id, client_secret))
+        return candidates
+    return [(form.get("client_id"), form.get("client_secret"))]
 
 
 async def _handle_authorization_code(
@@ -1065,8 +1077,11 @@ async def handle_legacy_token_post(
 ) -> web.Response:
     """Serve the proxy's legacy token exchange from either token route."""
     form = dict(await request.post())
-    client_id, client_secret = _extract_client_creds(request, form)
-    if not provider.authenticate_client(client_id, client_secret):
+    candidates = _extract_client_creds(request, form)
+    if not any(
+        provider.authenticate_client(client_id, client_secret)
+        for client_id, client_secret in candidates
+    ):
         return _json_error(
             "invalid_client",
             401,

--- a/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/oauth.py
+++ b/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/oauth.py
@@ -29,6 +29,7 @@ import base64
 import binascii
 import hashlib
 import hmac
+import ipaddress
 import json
 import logging
 import os
@@ -116,6 +117,7 @@ PKCE_VERIFIER_MAX = 128
 PKCE_S256_CHALLENGE_LEN = 43
 _PKCE_VERIFIER_RE = re.compile(r"^[A-Za-z0-9._~-]+$")
 _PKCE_CHALLENGE_RE = re.compile(r"^[A-Za-z0-9_-]{43}$")
+_LOOPBACK_HOSTNAMES = frozenset({"localhost"})
 
 # Pending-code dict cap. An attacker spamming /authorize with valid params
 # could grow the dict between the prune passes that run on each issuance.
@@ -282,20 +284,31 @@ def load_or_create_secret() -> bytes:
     return new_secret
 
 
+def _is_loopback_host(hostname: str) -> bool:
+    """Return whether RFC 8252 permits the host on a plain-http callback."""
+    if hostname in _LOOPBACK_HOSTNAMES:
+        return True
+    try:
+        return ipaddress.ip_address(hostname).is_loopback
+    except ValueError:
+        return False
+
+
 def _is_valid_redirect_uri(redirect_uri: str) -> bool:
-    """Spec-floor validation for OAuth redirect_uri: must be an https:// URL
-    with a non-empty host and no fragment. Single-tenant addon — we don't
-    maintain a per-client allowlist, but reject the obvious bad shapes that
-    would let an attacker direct the auth flow to an empty/malformed URL."""
+    """Validate an HTTPS callback or RFC 8252 plain-HTTP loopback callback."""
     if not redirect_uri:
         return False
     try:
         parsed = urlparse(redirect_uri)
+        _ = parsed.port
     except ValueError:
         return False
-    if parsed.scheme != "https":
-        return False
     if not parsed.hostname:
+        return False
+    if parsed.scheme == "http":
+        if not _is_loopback_host(parsed.hostname):
+            return False
+    elif parsed.scheme != "https":
         return False
     # Fragments are not allowed in OAuth redirect URIs (RFC 6749 §3.1.2).
     return not parsed.fragment

--- a/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/oauth.py
+++ b/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/oauth.py
@@ -425,6 +425,8 @@ async def _backend_alive(hass: HomeAssistant) -> bool:
         try:
             await writer.wait_closed()
         except OSError:
+            # Best-effort cleanup: the probe connection already succeeded, so
+            # a failure while closing the socket does not change the verdict.
             pass
 
     _backend_alive_cache[key] = (time.monotonic() + _BACKEND_ALIVE_TTL, alive)

--- a/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/oauth.py
+++ b/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/oauth.py
@@ -118,6 +118,11 @@ _PKCE_VERIFIER_RE = re.compile(r"^[A-Za-z0-9._~-]+$")
 _PKCE_CHALLENGE_RE = re.compile(r"^[A-Za-z0-9_-]{43}$")
 _LOOPBACK_HOSTNAMES = frozenset({"localhost"})
 
+# RFC 3986 §3.2 authority charset (unreserved / pct-encoded / sub-delims /
+# ':' '@' and IPv6 brackets). Anything outside it (a backslash, a space, raw
+# unicode) is an illegal authority that downstream URL builders may reject.
+_AUTHORITY_CHARS_RE = re.compile(r"[A-Za-z0-9._~%!$&'()*+,;=:@\[\]-]*")
+
 # Pending-code dict cap. An attacker spamming /authorize with valid params
 # could grow the dict between the prune passes that run on each issuance.
 # 1000 codes is well past anything legitimate (5-min TTL, single-tenant).
@@ -303,6 +308,13 @@ def _is_valid_redirect_uri(redirect_uri: str) -> bool:
     except ValueError:
         return False
     if not parsed.hostname:
+        return False
+    if not _AUTHORITY_CHARS_RE.fullmatch(parsed.netloc):
+        # urlparse and yarl split authorities differently (e.g. a backslash
+        # before '@', which urlparse tolerates and yarl rejects per RFC 3986).
+        # Every accepted redirect later flows through yarl in _redirect_with,
+        # so an RFC 3986-illegal authority must 400 HERE, never 500 there
+        # (#2218 review — same contract as the .port access above).
         return False
     if parsed.scheme == "http":
         if not _is_loopback_host(parsed.hostname):

--- a/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/oauth.py
+++ b/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/oauth.py
@@ -38,7 +38,7 @@ import time
 from html import escape
 from pathlib import Path
 from typing import Protocol, TypedDict
-from urllib.parse import urlparse
+from urllib.parse import unquote_plus, urlparse
 
 from aiohttp import web
 from homeassistant.components.http import HomeAssistantView
@@ -107,6 +107,7 @@ REFRESH_TOKEN_TTL = 30 * 24 * 60 * 60  # 30 days
 AUTH_CODE_TTL = 5 * 60  # 5 minutes
 TOKEN_KIND_ACCESS = "access"
 TOKEN_KIND_REFRESH = "refresh"
+_TOKEN_RESPONSE_HEADERS = {"Cache-Control": "no-store", "Pragma": "no-cache"}
 
 # RFC 7636 §4.1: code_verifier is 43-128 chars from the unreserved URL set.
 PKCE_VERIFIER_MIN = 43
@@ -704,6 +705,30 @@ class OAuthProvider:
             client_id.encode(), self._client_id.encode()
         ) and hmac.compare_digest(client_secret.encode(), self._client_secret.encode())
 
+    def validate_authorize_params(
+        self,
+        *,
+        response_type: str,
+        client_id: str,
+        redirect_uri: str,
+        code_challenge: str,
+        code_challenge_method: str,
+    ) -> web.Response | None:
+        """Return an error response when an authorization request is invalid."""
+        if response_type != "code":
+            return _text_error(400, "unsupported_response_type")
+        if code_challenge_method != "S256":
+            return _text_error(400, "invalid code_challenge_method (S256 required)")
+        if not _PKCE_CHALLENGE_RE.match(code_challenge):
+            return _text_error(
+                400, "invalid code_challenge (must be 43-char base64url)"
+            )
+        if client_id != self._client_id:
+            return _text_error(400, "invalid client_id", restart_hint=True)
+        if not _is_valid_redirect_uri(redirect_uri):
+            return _text_error(400, "redirect_uri must be a valid OAuth callback")
+        return None
+
 
 # ---------------------------------------------------------------------------
 # Views
@@ -884,60 +909,37 @@ class WellKnownAuthorizationServerMetadataView(AuthorizationServerMetadataView):
         self.name = name
 
 
-class AuthorizeView(HomeAssistantView):
-    """OAuth /authorize endpoint with a minimal consent page."""
+def _redirect_with_params(redirect_uri: str, **params: str) -> web.Response:
+    """Build a correctly encoded authorization redirect."""
+    import yarl
 
-    requires_auth = False
-    url = AUTHORIZE_PATH
-    name = "mcp_proxy_dev:oauth:authorize"
+    url = yarl.URL(redirect_uri).update_query(params)
+    return web.Response(status=302, headers={"Location": str(url)})
 
-    def __init__(self, provider: OAuthProvider) -> None:
-        self._provider = provider
 
-    @staticmethod
-    def _redirect_with(redirect_uri: str, **params: str) -> web.Response:
-        # yarl ships with aiohttp and handles existing-query-string merging
-        # plus parameter encoding correctly — safer than hand-rolling.
-        import yarl
+async def handle_legacy_authorize_get(
+    provider: OAuthProvider, request: web.Request
+) -> web.Response:
+    """Serve the proxy's legacy consent page from either authorize route."""
+    params = request.query
+    client_id = params.get("client_id", "")
+    redirect_uri = params.get("redirect_uri", "")
+    state = params.get("state", "")
+    code_challenge = params.get("code_challenge", "")
+    code_challenge_method = params.get("code_challenge_method", "")
+    response_type = params.get("response_type", "")
 
-        url = yarl.URL(redirect_uri).update_query(params)
-        return web.Response(
-            status=302,
-            headers={"Location": str(url)},
-        )
+    err = provider.validate_authorize_params(
+        response_type=response_type,
+        client_id=client_id,
+        redirect_uri=redirect_uri,
+        code_challenge=code_challenge,
+        code_challenge_method=code_challenge_method,
+    )
+    if err is not None:
+        return err
 
-    async def get(self, request: web.Request) -> web.Response:
-        if not await _backend_alive(self._provider._hass):
-            return _json_not_found()
-        if _active_oauth_mode(self._provider) != MODE_LEGACY:
-            # Serve ONLY when legacy is the live mode. Both ha_auth (HA core is
-            # the authorization server on its own /auth/authorize; this bare
-            # /authorize is the add-on's own legacy view) and None (entry
-            # unloaded / OAuth off) mean this stale-bound root view must not
-            # serve: HA can't rebind or drop root views without a restart, so a
-            # legacy->ha_auth switch OR an unload leaves it bound. Refuse it.
-            return _text_error(404, "not found")
-        params = request.query
-        client_id = params.get("client_id", "")
-        redirect_uri = params.get("redirect_uri", "")
-        state = params.get("state", "")
-        code_challenge = params.get("code_challenge", "")
-        code_challenge_method = params.get("code_challenge_method", "")
-        response_type = params.get("response_type", "")
-
-        err = self._validate_authorize_params(
-            response_type=response_type,
-            client_id=client_id,
-            redirect_uri=redirect_uri,
-            code_challenge=code_challenge,
-            code_challenge_method=code_challenge_method,
-        )
-        if err is not None:
-            return err
-
-        # Render minimal consent page. Showing the redirect_uri lets the user
-        # verify the flow goes back to a domain they recognize (claude.ai etc).
-        html = f"""<!DOCTYPE html>
+    html = f"""<!DOCTYPE html>
 <html>
 <head>
   <meta charset="utf-8">
@@ -955,7 +957,7 @@ class AuthorizeView(HomeAssistantView):
   <p>An MCP client is requesting access to your Home Assistant MCP server.</p>
   <p>It will redirect to:<br><code>{escape(redirect_uri)}</code></p>
   <p>Only allow this if you started this connection yourself.</p>
-  <form method="POST" action="{AUTHORIZE_PATH}">
+  <form method="POST" action="{escape(request.path)}">
     <input type="hidden" name="client_id" value="{escape(client_id)}">
     <input type="hidden" name="redirect_uri" value="{escape(redirect_uri)}">
     <input type="hidden" name="state" value="{escape(state)}">
@@ -965,7 +967,147 @@ class AuthorizeView(HomeAssistantView):
   </form>
 </body>
 </html>"""
-        return web.Response(text=html, content_type="text/html")
+    return web.Response(text=html, content_type="text/html")
+
+
+async def handle_legacy_authorize_post(
+    provider: OAuthProvider, request: web.Request
+) -> web.Response:
+    """Consume legacy consent and redirect with a one-time authorization code."""
+    data = await request.post()
+    action = str(data.get("action", ""))
+    client_id = str(data.get("client_id", ""))
+    redirect_uri = str(data.get("redirect_uri", ""))
+    state = str(data.get("state", ""))
+    code_challenge = str(data.get("code_challenge", ""))
+
+    err = provider.validate_authorize_params(
+        response_type="code",
+        client_id=client_id,
+        redirect_uri=redirect_uri,
+        code_challenge=code_challenge,
+        code_challenge_method="S256",
+    )
+    if err is not None:
+        return err
+
+    active_provider = _active_provider(provider)
+    iss = active_provider.authorization_server_url(
+        active_provider.base_url_for(request)
+    )
+    if action == "deny":
+        return _redirect_with_params(
+            redirect_uri, error="access_denied", state=state, iss=iss
+        )
+    if action != "approve":
+        return _text_error(400, "invalid action")
+
+    code = provider.issue_code(redirect_uri, code_challenge)
+    if code is None:
+        return _redirect_with_params(
+            redirect_uri, error="temporarily_unavailable", state=state, iss=iss
+        )
+    return _redirect_with_params(redirect_uri, code=code, state=state, iss=iss)
+
+
+def _extract_client_creds(
+    request: web.Request, form: dict
+) -> tuple[str | None, str | None]:
+    """Pull form-decoded client credentials from Basic auth or the form body."""
+    header = request.headers.get("Authorization", "")
+    if header.lower().startswith("basic "):
+        try:
+            decoded = base64.b64decode(header[6:].strip(), validate=True).decode(
+                "utf-8"
+            )
+        except (ValueError, UnicodeDecodeError, binascii.Error):
+            return None, None
+        if ":" in decoded:
+            client_id, _, client_secret = decoded.partition(":")
+            return unquote_plus(client_id), unquote_plus(client_secret)
+        return None, None
+    return form.get("client_id"), form.get("client_secret")
+
+
+async def _handle_authorization_code(
+    provider: OAuthProvider, form: dict
+) -> web.Response:
+    code = str(form.get("code", ""))
+    redirect_uri = str(form.get("redirect_uri", ""))
+    code_verifier = str(form.get("code_verifier", ""))
+    if not (code and redirect_uri and code_verifier):
+        return _json_error("invalid_request", 400)
+    if not provider.consume_code(code, redirect_uri, code_verifier):
+        return _json_error("invalid_grant", 400)
+    return web.json_response(
+        {
+            "access_token": provider.issue_access_token(),
+            "token_type": "Bearer",
+            "expires_in": ACCESS_TOKEN_TTL,
+            "refresh_token": provider.issue_refresh_token(),
+        },
+        headers=_TOKEN_RESPONSE_HEADERS,
+    )
+
+
+async def _handle_refresh(provider: OAuthProvider, form: dict) -> web.Response:
+    refresh = str(form.get("refresh_token", ""))
+    if not refresh or not provider.validate_refresh_token(refresh):
+        return _json_error("invalid_grant", 400)
+    return web.json_response(
+        {
+            "access_token": provider.issue_access_token(),
+            "token_type": "Bearer",
+            "expires_in": ACCESS_TOKEN_TTL,
+            "refresh_token": provider.issue_refresh_token(),
+        },
+        headers=_TOKEN_RESPONSE_HEADERS,
+    )
+
+
+async def handle_legacy_token_post(
+    provider: OAuthProvider, request: web.Request
+) -> web.Response:
+    """Serve the proxy's legacy token exchange from either token route."""
+    form = dict(await request.post())
+    client_id, client_secret = _extract_client_creds(request, form)
+    if not provider.authenticate_client(client_id, client_secret):
+        return _json_error(
+            "invalid_client",
+            401,
+            headers={"WWW-Authenticate": 'Basic realm="MCP Proxy OAuth"'},
+            restart_hint=True,
+        )
+    grant_type = form.get("grant_type", "")
+    if grant_type == "authorization_code":
+        return await _handle_authorization_code(provider, form)
+    if grant_type == "refresh_token":
+        return await _handle_refresh(provider, form)
+    return _json_error("unsupported_grant_type", 400)
+
+
+class AuthorizeView(HomeAssistantView):
+    """OAuth /authorize endpoint with a minimal consent page."""
+
+    requires_auth = False
+    url = AUTHORIZE_PATH
+    name = "mcp_proxy_dev:oauth:authorize"
+
+    def __init__(self, provider: OAuthProvider) -> None:
+        self._provider = provider
+
+    async def get(self, request: web.Request) -> web.Response:
+        if not await _backend_alive(self._provider._hass):
+            return _json_not_found()
+        if _active_oauth_mode(self._provider) != MODE_LEGACY:
+            # Serve ONLY when legacy is the live mode. Both ha_auth (HA core is
+            # the authorization server on its own /auth/authorize; this bare
+            # /authorize is the add-on's own legacy view) and None (entry
+            # unloaded / OAuth off) mean this stale-bound root view must not
+            # serve: HA can't rebind or drop root views without a restart, so a
+            # legacy->ha_auth switch OR an unload leaves it bound. Refuse it.
+            return _text_error(404, "not found")
+        return await handle_legacy_authorize_get(self._provider, request)
 
     async def post(self, request: web.Request) -> web.Response:
         if not await _backend_alive(self._provider._hass):
@@ -976,77 +1118,7 @@ class AuthorizeView(HomeAssistantView):
             # this bare /authorize is the add-on's own legacy view) and the
             # unloaded/None case both 404.
             return _text_error(404, "not found")
-        data = await request.post()
-        action = str(data.get("action", ""))
-        client_id = str(data.get("client_id", ""))
-        redirect_uri = str(data.get("redirect_uri", ""))
-        state = str(data.get("state", ""))
-        code_challenge = str(data.get("code_challenge", ""))
-
-        # Re-validate everything from the form — never trust hidden fields.
-        # response_type/method aren't carried on the POST so we hard-code
-        # the spec values here; the validator still applies all the same
-        # rules to the user-influenceable fields.
-        err = self._validate_authorize_params(
-            response_type="code",
-            client_id=client_id,
-            redirect_uri=redirect_uri,
-            code_challenge=code_challenge,
-            code_challenge_method="S256",
-        )
-        if err is not None:
-            return err
-
-        # RFC 9207: every authorization response — success or error — names the
-        # issuer that produced it, so a client registered with several
-        # authorization servers cannot be fed a response minted by another one.
-        # Resolved through the ACTIVE mode's provider, exactly as
-        # AuthorizationServerMetadataView builds the `issuer` this must match.
-        provider = _active_provider(self._provider)
-        iss = provider.authorization_server_url(provider.base_url_for(request))
-
-        if action == "deny":
-            return self._redirect_with(
-                redirect_uri, error="access_denied", state=state, iss=iss
-            )
-        if action != "approve":
-            return _text_error(400, "invalid action")
-
-        code = self._provider.issue_code(redirect_uri, code_challenge)
-        if code is None:
-            # Pending-code store at cap → signal back to the client per
-            # RFC 6749 §4.1.2.1 instead of silently failing.
-            return self._redirect_with(
-                redirect_uri, error="temporarily_unavailable", state=state, iss=iss
-            )
-        return self._redirect_with(redirect_uri, code=code, state=state, iss=iss)
-
-    def _validate_authorize_params(
-        self,
-        *,
-        response_type: str,
-        client_id: str,
-        redirect_uri: str,
-        code_challenge: str,
-        code_challenge_method: str,
-    ) -> web.Response | None:
-        """Return a 400 web.Response if any /authorize param is invalid,
-        or None if all checks pass. Centralized so GET and POST share
-        identical validation — the POST path explicitly re-validates the
-        hidden form fields rather than trusting them."""
-        if response_type != "code":
-            return _text_error(400, "unsupported_response_type")
-        if code_challenge_method != "S256":
-            return _text_error(400, "invalid code_challenge_method (S256 required)")
-        if not _PKCE_CHALLENGE_RE.match(code_challenge):
-            return _text_error(
-                400, "invalid code_challenge (must be 43-char base64url)"
-            )
-        if client_id != self._provider.client_id:
-            return _text_error(400, "invalid client_id", restart_hint=True)
-        if not _is_valid_redirect_uri(redirect_uri):
-            return _text_error(400, "redirect_uri must be an https:// URL with a host")
-        return None
+        return await handle_legacy_authorize_post(self._provider, request)
 
 
 class TokenView(HomeAssistantView):
@@ -1060,25 +1132,6 @@ class TokenView(HomeAssistantView):
     def __init__(self, provider: OAuthProvider) -> None:
         self._provider = provider
 
-    @staticmethod
-    def _extract_client_creds(
-        request: web.Request, form: dict
-    ) -> tuple[str | None, str | None]:
-        """Pull client_id/secret from Basic auth header OR form body."""
-        header = request.headers.get("Authorization", "")
-        if header.lower().startswith("basic "):
-            try:
-                decoded = base64.b64decode(header[6:].strip(), validate=True).decode(
-                    "utf-8"
-                )
-            except (ValueError, UnicodeDecodeError, binascii.Error):
-                return None, None
-            if ":" in decoded:
-                cid, _, sec = decoded.partition(":")
-                return cid, sec
-            return None, None
-        return form.get("client_id"), form.get("client_secret")
-
     async def post(self, request: web.Request) -> web.Response:
         if not await _backend_alive(self._provider._hass):
             return _json_not_found()
@@ -1089,52 +1142,7 @@ class TokenView(HomeAssistantView):
             # mint tokens from this stale-bound view (see AuthorizeView for the
             # switch scenario).
             return _json_not_found()
-        form = dict(await request.post())
-        client_id, client_secret = self._extract_client_creds(request, form)
-        if not self._provider.authenticate_client(client_id, client_secret):
-            return _json_error(
-                "invalid_client",
-                401,
-                headers={"WWW-Authenticate": 'Basic realm="MCP Proxy OAuth"'},
-                restart_hint=True,
-            )
-
-        grant_type = form.get("grant_type", "")
-        if grant_type == "authorization_code":
-            return await self._handle_authorization_code(form)
-        if grant_type == "refresh_token":
-            return await self._handle_refresh(form)
-        return _json_error("unsupported_grant_type", 400)
-
-    async def _handle_authorization_code(self, form: dict) -> web.Response:
-        code = str(form.get("code", ""))
-        redirect_uri = str(form.get("redirect_uri", ""))
-        code_verifier = str(form.get("code_verifier", ""))
-        if not (code and redirect_uri and code_verifier):
-            return _json_error("invalid_request", 400)
-        if not self._provider.consume_code(code, redirect_uri, code_verifier):
-            return _json_error("invalid_grant", 400)
-        return web.json_response(
-            {
-                "access_token": self._provider.issue_access_token(),
-                "token_type": "Bearer",
-                "expires_in": ACCESS_TOKEN_TTL,
-                "refresh_token": self._provider.issue_refresh_token(),
-            }
-        )
-
-    async def _handle_refresh(self, form: dict) -> web.Response:
-        refresh = str(form.get("refresh_token", ""))
-        if not refresh or not self._provider.validate_refresh_token(refresh):
-            return _json_error("invalid_grant", 400)
-        return web.json_response(
-            {
-                "access_token": self._provider.issue_access_token(),
-                "token_type": "Bearer",
-                "expires_in": ACCESS_TOKEN_TTL,
-                "refresh_token": self._provider.issue_refresh_token(),
-            }
-        )
+        return await handle_legacy_token_post(self._provider, request)
 
 
 # ---------------------------------------------------------------------------

--- a/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/oauth.py
+++ b/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/oauth.py
@@ -400,7 +400,7 @@ _HEARTBEAT_MAX_AGE = 90.0  # three missed 30-second touches
 # request while alive is microseconds in the executor; the cache exists so an
 # anonymous flood against a STOPPED install does not stat per request.
 _ADDON_DOWN_TTL = 15.0
-_addon_down_until: float = 0.0
+_addon_down_state = {"until": 0.0}
 
 
 def _heartbeat_fresh() -> bool:
@@ -414,12 +414,11 @@ def _heartbeat_fresh() -> bool:
 
 async def _addon_alive(hass: HomeAssistant) -> bool:
     """Return whether the proxy add-on's heartbeat file is fresh."""
-    global _addon_down_until
-    if time.monotonic() < _addon_down_until:
+    if time.monotonic() < _addon_down_state["until"]:
         return False
     alive = bool(await hass.async_add_executor_job(_heartbeat_fresh))
     if not alive:
-        _addon_down_until = time.monotonic() + _ADDON_DOWN_TTL
+        _addon_down_state["until"] = time.monotonic() + _ADDON_DOWN_TTL
     return alive
 
 

--- a/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/oauth.py
+++ b/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/oauth.py
@@ -24,6 +24,7 @@ without a server-side store, so the integration survives restarts.
 
 from __future__ import annotations
 
+import asyncio
 import base64
 import binascii
 import hashlib
@@ -369,6 +370,53 @@ def _active_oauth_mode(provider: object) -> str | None:
     return domain_data.get("oauth_mode")
 
 
+# hass.data persists after the add-on stops, so bound OAuth views must also
+# verify that the forwarding backend is reachable. Cache by target host/port to
+# avoid opening a TCP connection for every discovery or token request.
+_BACKEND_ALIVE_TTL = 15.0
+_backend_alive_cache: dict[str, tuple[float, bool]] = {}
+
+
+async def _backend_alive(hass: HomeAssistant) -> bool:
+    """Return whether the add-on's forwarding target accepts TCP connections."""
+    domain_data = hass.data.get(DOMAIN)
+    if not isinstance(domain_data, dict):
+        return False
+    target_url = domain_data.get("target_url", "")
+    if not isinstance(target_url, str):
+        return False
+    try:
+        parsed = urlparse(target_url)
+        port = parsed.port
+    except ValueError:
+        return False
+    if not parsed.hostname or port is None or port == 0:
+        return False
+
+    key = f"{parsed.hostname}:{port}"
+    now = time.monotonic()
+    cached = _backend_alive_cache.get(key)
+    if cached is not None and cached[0] > now:
+        return cached[1]
+
+    try:
+        _reader, writer = await asyncio.wait_for(
+            asyncio.open_connection(parsed.hostname, port), 1.0
+        )
+    except (TimeoutError, OSError):
+        alive = False
+    else:
+        alive = True
+        writer.close()
+        try:
+            await writer.wait_closed()
+        except OSError:
+            pass
+
+    _backend_alive_cache[key] = (time.monotonic() + _BACKEND_ALIVE_TTL, alive)
+    return alive
+
+
 def _active_provider(bound_provider: MetadataProvider) -> MetadataProvider:
     """Return the provider whose base-URL policy is active right now.
 
@@ -681,6 +729,9 @@ class ProtectedResourceMetadataView(HomeAssistantView):
         self._provider = provider
 
     async def get(self, request: web.Request) -> web.Response:
+        hass = getattr(self._provider, "_hass", None)
+        if hass is None or not await _backend_alive(hass):
+            return _json_not_found()
         # The protected-resource document has the same shape in every OAuth
         # mode; 404 when no mode is live (entry unloaded / OAuth off) so a
         # stale-bound view acts like an unregistered route. URLs are built via
@@ -721,6 +772,9 @@ class AuthorizationServerMetadataView(HomeAssistantView):
         self._provider = provider
 
     async def get(self, request: web.Request) -> web.Response:
+        hass = getattr(self._provider, "_hass", None)
+        if hass is None or not await _backend_alive(hass):
+            return _json_not_found()
         mode = _active_oauth_mode(self._provider)
         if mode is None:
             # No mode is live (entry unloaded / OAuth off) but HA can't drop
@@ -853,6 +907,8 @@ class AuthorizeView(HomeAssistantView):
         )
 
     async def get(self, request: web.Request) -> web.Response:
+        if not await _backend_alive(self._provider._hass):
+            return _json_not_found()
         if _active_oauth_mode(self._provider) != MODE_LEGACY:
             # Serve ONLY when legacy is the live mode. Both ha_auth (HA core is
             # the authorization server on its own /auth/authorize; this bare
@@ -912,6 +968,8 @@ class AuthorizeView(HomeAssistantView):
         return web.Response(text=html, content_type="text/html")
 
     async def post(self, request: web.Request) -> web.Response:
+        if not await _backend_alive(self._provider._hass):
+            return _json_not_found()
         if _active_oauth_mode(self._provider) != MODE_LEGACY:
             # Serve ONLY when legacy is live (see the GET defense above): ha_auth
             # (HA core is the authorization server on its own /auth/authorize;
@@ -1022,6 +1080,8 @@ class TokenView(HomeAssistantView):
         return form.get("client_id"), form.get("client_secret")
 
     async def post(self, request: web.Request) -> web.Response:
+        if not await _backend_alive(self._provider._hass):
+            return _json_not_found()
         if _active_oauth_mode(self._provider) != MODE_LEGACY:
             # Serve ONLY when legacy is live. Both ha_auth (HA core is the
             # authorization server on its own /auth/token; this bare /token is

--- a/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/oauth.py
+++ b/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/oauth.py
@@ -604,17 +604,13 @@ class OAuthProvider:
         Delegates the seven discovery-document views to the shared,
         flag-guarded `register_metadata_views` (which binds them at most once
         per HA session — see `_METADATA_VIEWS_REGISTERED_KEY`), then registers
-        ONLY the two root views (`AuthorizeView` + `TokenView`). ha_auth mode
-        registers just the seven metadata views (HA core is the authorization
-        server, serving its own `/auth/authorize` + `/auth/token`, so the
-        add-on binds no root views); the bare `/authorize` + `/token` here are
-        this add-on's OWN legacy root views. Routing both modes through the same
-        registrar means a legacy<->ha_auth switch or a same-mode reload reuses
-        the already-bound seven instead of stacking silently-shadowed duplicate
-        routes (a duplicate registration does not raise — aiohttp lets the
-        first-registered path win — and HA can't unregister a bound view until
-        it restarts). The two root views stay gated by the caller's route-owner
-        / fingerprint logic in __init__.py.
+        ONLY the two root views (`AuthorizeView` + `TokenView`). The unified
+        scoped authorize/token views are bound separately for every mode and
+        dispatch through these handlers when legacy is live; the bare routes
+        remain compatibility aliases. Routing every mode through the shared
+        metadata registrar avoids silently-shadowed duplicate discovery views.
+        The two root aliases stay gated by the caller's route-owner/fingerprint
+        logic in __init__.py.
         """
         register_metadata_views(self._hass, self)
         for view in (AuthorizeView(self), TokenView(self)):
@@ -825,9 +821,8 @@ class AuthorizationServerMetadataView(HomeAssistantView):
         provider = _active_provider(self._provider)
         base = provider.base_url_for(request)
         if mode == MODE_HA_AUTH:
-            # HA core is the authorization server: advertise its /auth/* endpoints
-            # + CIMD. Built in auth_native, imported lazily to avoid an import
-            # cycle (auth_native imports this module at load).
+            # HA core authenticates the user behind proxy-owned scoped endpoints.
+            # Built in auth_native, imported lazily to avoid an import cycle.
             from .auth_native import authorization_server_document
 
             return web.json_response(authorization_server_document(base))
@@ -847,8 +842,8 @@ class AuthorizationServerMetadataView(HomeAssistantView):
                 # AuthorizeView redirects); omission reads as "not supported"
                 # to discovery clients.
                 "authorization_response_iss_parameter_supported": True,
-                "authorization_endpoint": f"{base}{AUTHORIZE_PATH}",
-                "token_endpoint": f"{base}{TOKEN_PATH}",
+                "authorization_endpoint": f"{base}{OAUTH_BASE}/authorize",
+                "token_endpoint": f"{base}{OAUTH_BASE}/token",
                 "response_types_supported": ["code"],
                 "grant_types_supported": [
                     "authorization_code",
@@ -1203,12 +1198,8 @@ def _metadata_views(provider: MetadataProvider) -> list[HomeAssistantView]:
 
 
 def register_metadata_views(hass: HomeAssistant, provider: MetadataProvider) -> None:
-    """Register ONLY the seven discovery-document views (ha_auth mode).
+    """Register the seven shared OAuth discovery-document views.
 
-    ha_auth serves just these — Home Assistant core is the authorization server,
-    serving its own `/auth/authorize` + `/auth/token`, so the add-on binds no
-    root views (the bare `/authorize` + `/token` are the legacy flavor's own
-    root views) and no HA restart is ever needed to enable or disable the mode.
     ``provider`` is an `auth_native.ResourceServer` (ha_auth) or an
     `OAuthProvider` (legacy, which routes its seven views through here); the
     views read its `base_url_for`, `resource_url`, `authorization_server_url`,

--- a/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/oauth.py
+++ b/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/oauth.py
@@ -37,7 +37,7 @@ import secrets
 import time
 from html import escape
 from pathlib import Path
-from typing import Protocol, TypedDict
+from typing import Any, Protocol, TypedDict
 from urllib.parse import unquote_plus, urlparse
 
 from aiohttp import web
@@ -985,7 +985,9 @@ async def handle_legacy_authorize_post(
     provider: OAuthProvider, request: web.Request
 ) -> web.Response:
     """Consume legacy consent and redirect with a one-time authorization code."""
-    data = await request.post()
+    data = await read_form(request)
+    if data is None:
+        return _text_error(400, "Invalid form submission")
     action = str(data.get("action", ""))
     client_id = str(data.get("client_id", ""))
     redirect_uri = str(data.get("redirect_uri", ""))
@@ -1021,6 +1023,19 @@ async def handle_legacy_authorize_post(
     return _redirect_with_params(redirect_uri, code=code, state=state, iss=iss)
 
 
+async def read_form(request: web.Request) -> Any | None:
+    """Parse a form body, or None when the request body is undecodable.
+
+    aiohttp raises LookupError — NOT ValueError — when the Content-Type names
+    an unknown charset, and these views are ANONYMOUS, so an unguarded parse
+    turns one header into a 500 with a traceback (#2219 review round 3).
+    """
+    try:
+        return await request.post()
+    except (ValueError, LookupError):
+        return None
+
+
 def _extract_client_creds(
     request: web.Request, form: dict
 ) -> list[tuple[str | None, str | None]]:
@@ -1049,7 +1064,11 @@ def _extract_client_creds(
         if (client_id, client_secret) != candidates[0]:
             candidates.append((client_id, client_secret))
         return candidates
-    return [(form.get("client_id"), form.get("client_secret"))]
+    # str()-wrapped like every sibling site: request.post() yields
+    # str | bytes | FileField, and the non-str shapes are truthy, so they
+    # would slip past authenticate_client's emptiness guard and raise
+    # AttributeError on .encode() (#2219 review round 3).
+    return [(str(form.get("client_id", "")), str(form.get("client_secret", "")))]
 
 
 async def _handle_authorization_code(
@@ -1092,7 +1111,10 @@ async def handle_legacy_token_post(
     provider: OAuthProvider, request: web.Request
 ) -> web.Response:
     """Serve the proxy's legacy token exchange from either token route."""
-    form = dict(await request.post())
+    raw_form = await read_form(request)
+    if raw_form is None:
+        return _json_error("invalid_request", 400)
+    form = dict(raw_form)
     candidates = _extract_client_creds(request, form)
     if not any(
         provider.authenticate_client(client_id, client_secret)

--- a/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/oauth.py
+++ b/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/oauth.py
@@ -413,7 +413,7 @@ async def _addon_alive(hass: HomeAssistant) -> bool:
     now = time.monotonic()
     if _addon_alive_cache is not None and _addon_alive_cache[0] > now:
         return _addon_alive_cache[1]
-    alive = await hass.async_add_executor_job(_heartbeat_fresh)
+    alive = bool(await hass.async_add_executor_job(_heartbeat_fresh))
     _addon_alive_cache = (time.monotonic() + _ADDON_ALIVE_TTL, alive)
     return alive
 

--- a/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/oauth.py
+++ b/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/oauth.py
@@ -411,7 +411,14 @@ _HEARTBEAT_MAX_AGE = 90.0  # three missed 30-second touches
 # cached True would keep the surface serving after the stop. A fresh stat per
 # request while alive is microseconds in the executor; the cache exists so an
 # anonymous flood against a STOPPED install does not stat per request.
-_ADDON_DOWN_TTL = 15.0
+#
+# The lease MUST stay shorter than start.py's `_probe_oauth_active` delay
+# (2 s between 3 attempts): that probe drives a DESTRUCTIVE path — it tears
+# down a working webhook and demands an HA restart when the metadata endpoint
+# looks absent. A request arriving while the add-on was stopped would
+# otherwise leave a lease covering every probe of the next start, so a healthy
+# entry got removed on restart (#2219 codex review).
+_ADDON_DOWN_TTL = 1.0
 _addon_down_state = {"until": 0.0}
 
 

--- a/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/oauth_autoapprove.py
+++ b/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/oauth_autoapprove.py
@@ -135,9 +135,7 @@ def _validate_autoapprove_authorize(params: Any) -> web.Response | None:
     if params.get("response_type", "") != "code":
         return _json_error("unsupported_response_type", 400)
     if params.get("code_challenge_method", "") != "S256":
-        return _json_error(
-            "invalid_request", 400, "code_challenge_method must be S256"
-        )
+        return _json_error("invalid_request", 400, "code_challenge_method must be S256")
     if not _PKCE_CHALLENGE_RE.fullmatch(params.get("code_challenge", "")):
         return _json_error(
             "invalid_request", 400, "invalid code_challenge (43-char base64url)"
@@ -285,7 +283,12 @@ class AutoApproveAuthorizeView(HomeAssistantView):
         provider = data.get(AUTOAPPROVE_PROVIDER_KEY)
         if not isinstance(provider, AutoApproveProvider):
             return _json_not_found()
+        return self._autoapprove_authorize(provider, request)
 
+    def _autoapprove_authorize(
+        self, provider: AutoApproveProvider, request: web.Request
+    ) -> web.Response:
+        """Issue a code invisibly for any structurally valid none-mode request."""
         params = request.query
         redirect_uri = params.get("redirect_uri", "")
         state = params.get("state", "")
@@ -388,7 +391,12 @@ class AutoApproveTokenView(HomeAssistantView):
         provider = data.get(AUTOAPPROVE_PROVIDER_KEY)
         if not isinstance(provider, AutoApproveProvider):
             return _json_not_found()
+        return await self._autoapprove_token(provider, request)
 
+    async def _autoapprove_token(
+        self, provider: AutoApproveProvider, request: web.Request
+    ) -> web.Response:
+        """Exchange a none-mode code for a cosmetic bearer under PKCE proof."""
         form: dict[str, Any] = dict(await request.post())
         if form.get("grant_type", "") != "authorization_code":
             return _json_error("unsupported_grant_type", 400)

--- a/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/oauth_autoapprove.py
+++ b/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/oauth_autoapprove.py
@@ -58,6 +58,7 @@ from .oauth import (
     handle_legacy_authorize_get,
     handle_legacy_authorize_post,
     handle_legacy_token_post,
+    read_form,
 )
 
 # Dedicated session for anonymous CIMD lookups. Keeping it separate prevents a
@@ -397,7 +398,10 @@ class AutoApproveTokenView(HomeAssistantView):
         self, provider: AutoApproveProvider, request: web.Request
     ) -> web.Response:
         """Exchange a none-mode code for a cosmetic bearer under PKCE proof."""
-        form: dict[str, Any] = dict(await request.post())
+        raw_form = await read_form(request)
+        if raw_form is None:
+            return _json_error("invalid_request", 400)
+        form: dict[str, Any] = dict(raw_form)
         if form.get("grant_type", "") != "authorization_code":
             return _json_error("unsupported_grant_type", 400)
 
@@ -432,7 +436,10 @@ class AutoApproveTokenView(HomeAssistantView):
             translated_client_id_for_refresh,
         )
 
-        form = MultiDict(await request.post())
+        raw_form = await read_form(request)
+        if raw_form is None:
+            return _json_error("invalid_request", 400)
+        form = MultiDict(raw_form)
         grant_type = str(form.get("grant_type", ""))
         client_id = str(form.get("client_id", ""))
         redirect_uri = str(form.get("redirect_uri", ""))

--- a/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/oauth_autoapprove.py
+++ b/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/oauth_autoapprove.py
@@ -63,6 +63,7 @@ from .oauth import (
     DOMAIN,
     OAUTH_BASE,
     PKCECodeStore,
+    _backend_alive,
     _build_base_url,
     _is_valid_redirect_uri,
 )
@@ -277,6 +278,8 @@ class AutoApproveAuthorizeView(HomeAssistantView):
 
     async def get(self, request: web.Request) -> web.Response:
         """Auto-approve the authorization request or reject with a 400/404."""
+        if not await _backend_alive(self._hass):
+            return _json_not_found()
         provider = _active_autoapprove_provider(self._hass)
         if provider is None:
             return _json_not_found()
@@ -343,6 +346,8 @@ class AutoApproveTokenView(HomeAssistantView):
 
     async def post(self, request: web.Request) -> web.Response:
         """Exchange a PKCE authorization code for an opaque access token."""
+        if not await _backend_alive(self._hass):
+            return _json_not_found()
         provider = _active_autoapprove_provider(self._hass)
         if provider is None:
             return _json_not_found()

--- a/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/oauth_autoapprove.py
+++ b/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/oauth_autoapprove.py
@@ -1,4 +1,4 @@
-"""None-mode auto-approve OAuth authorization server (issue #1969, dev-only).
+"""Unified scoped OAuth endpoints for every proxy authentication mode.
 
 When OAuth is OFF the secret webhook URL *is* the credential, so no bearer is
 required and the proxy forwards everything with a 200. But claude.ai's connector
@@ -11,11 +11,10 @@ falls through to Home Assistant *core*'s own origin-root
 ``registration_endpoint``. claude.ai then can neither use CIMD nor do dynamic
 client registration and shows "Automatic client registration isn't supported…".
 
-This module is the none-mode fix's authorization-server half: a pair of
-path-scoped ``OAUTH_BASE`` endpoints that complete OAuth *invisibly* — no login,
-no consent — so a connector that does run discovery resolves against our own
-corrected documents (the mode-aware discovery views in :mod:`oauth`) instead of
-HA core's broken root doc, and connects with zero HA login:
+The path-scoped ``OAUTH_BASE`` authorize and token routes dispatch per request
+to legacy, ha_auth, or none-autoapprove. Cached clients therefore keep calling
+proxy-owned endpoints across mode switches. In none mode the exchange remains
+invisible and its access token remains cosmetic:
 
 * ``GET  {OAUTH_BASE}/authorize`` issues a PKCE-bound one-time code and
   immediately 302-redirects back to the client with ``?code=…&state=…`` — no
@@ -25,26 +24,11 @@ HA core's broken root doc, and connects with zero HA login:
   mode ignores bearers entirely — but is a real random string so a spec-strict
   client is satisfied.
 
-Both views are gated per request off ``hass.data`` (they 404 unless
-none-autoapprove is the live mode), mirroring the discovery views, so a
-none ↔ ha_auth switch needs no restart. The PKCE code store, the redirect-URI
-floor, and the base-URL helper are reused from :mod:`oauth` rather than copied.
-The forwarder never sees this provider (it is stored under
-``AUTOAPPROVE_PROVIDER_KEY``, never ``"oauth"``), so the OAuth-off path keeps
-returning 200 with no bearer required and no 401 — URL-only clients keep working.
-
-**Open-redirect defence.** ``/authorize`` 302-redirects to a caller-supplied
-``redirect_uri`` on the Home Assistant origin, so an unvalidated target would be
-an open redirector. On top of :func:`oauth._is_valid_redirect_uri`'s https floor,
-the redirect must EXACTLY match a known MCP callback
-(:data:`_AUTOAPPROVE_REDIRECT_ALLOWLIST`). Anything else is a hard 400 (no
-redirect). A "same origin as the client_id" rule was deliberately NOT used: the
-client_id is fully attacker-controlled, so ``client_id == redirect_uri origin``
-still lets an attacker bounce a victim to any site of their choosing (a real
-open redirect on a public HA origin). Properly honouring an arbitrary CIMD client
-would require fetching the attacker-supplied client_id URL — an SSRF vector — so
-the allowlist is both the safe and the simple choice. Add a client's callback
-here to support it.
+In none mode the secret webhook URL remains the only credential and the OAuth
+token grants nothing. By maintainer decision, authorize therefore accepts any
+spec-valid HTTPS or RFC 8252 loopback callback; malformed targets still fail in
+place. The resulting crafted-link redirect behavior is accepted within that
+secret-URL trust model.
 """
 
 from __future__ import annotations
@@ -52,28 +36,33 @@ from __future__ import annotations
 import secrets
 from typing import Any
 
+import aiohttp
 from aiohttp import web
 from homeassistant.components.http import HomeAssistantView
 from homeassistant.core import HomeAssistant
 
 from .oauth import (
     _PKCE_CHALLENGE_RE,
+    _TOKEN_RESPONSE_HEADERS,
     ACCESS_TOKEN_TTL,
     AUTOAPPROVE_PROVIDER_KEY,
     DOMAIN,
+    MODE_HA_AUTH,
+    MODE_LEGACY,
+    MODE_NONE_AUTOAPPROVE,
     OAUTH_BASE,
     PKCECodeStore,
     _backend_alive,
     _build_base_url,
     _is_valid_redirect_uri,
+    handle_legacy_authorize_get,
+    handle_legacy_authorize_post,
+    handle_legacy_token_post,
 )
 
-# RFC 6749 §5.1: a /token response body carries access credentials, so it MUST
-# NOT be cached by any intermediary (reverse proxy, Nabu Casa, etc.). Defined
-# here — the only user — rather than in oauth.py: the add-on's legacy token views
-# don't set no-store, so a constant living in oauth.py would be flagged unused
-# (#1976 review). Parity with the component's auto-approve token response.
-_TOKEN_RESPONSE_HEADERS = {"Cache-Control": "no-store", "Pragma": "no-cache"}
+# Dedicated session for anonymous CIMD lookups. Keeping it separate prevents a
+# slow public metadata host from consuming the authenticated relay pool.
+CFG_CIMD_SESSION = "cimd_session"
 
 # TOP-LEVEL hass.data flag recording that the two auto-approve views are bound
 # for this HA session. Not under DOMAIN so it survives async_unload_entry's
@@ -83,16 +72,6 @@ _TOKEN_RESPONSE_HEADERS = {"Cache-Control": "no-store", "Pragma": "no-cache"}
 # oauth._METADATA_VIEWS_REGISTERED_KEY).
 _AUTOAPPROVE_VIEWS_REGISTERED_KEY = (
     f"webhook_proxy_oauth_autoapprove_views_registered_{DOMAIN}"
-)
-
-# Known MCP OAuth callback URLs always accepted as a redirect target. claude.ai's
-# connector onboarding posts its authorization code here. Exact-match only (never
-# a prefix test, so ``https://claude.ai/api/mcp/auth_callback.evil.example``
-# cannot slip through).
-_AUTOAPPROVE_REDIRECT_ALLOWLIST = frozenset(
-    {
-        "https://claude.ai/api/mcp/auth_callback",
-    }
 )
 
 
@@ -150,18 +129,21 @@ def _json_error(
     return web.json_response(body, status=status, headers=_TOKEN_RESPONSE_HEADERS)
 
 
-def _is_valid_autoapprove_redirect(redirect_uri: str) -> bool:
-    """Open-redirect gate for the auto-approve ``/authorize`` view.
-
-    Exact-match allowlist only, on top of :func:`oauth._is_valid_redirect_uri`'s
-    https floor. The ``client_id`` is NOT consulted: it is attacker-controlled,
-    so validating the redirect against it (even "same origin") would not
-    constrain the redirect target to a trusted host. See the module docstring.
-    """
-    return (
-        _is_valid_redirect_uri(redirect_uri)
-        and redirect_uri in _AUTOAPPROVE_REDIRECT_ALLOWLIST
-    )
+def _validate_autoapprove_authorize(params: Any) -> web.Response | None:
+    """Validate the none-mode authorization request without a client allowlist."""
+    if params.get("response_type", "") != "code":
+        return _json_error("unsupported_response_type", 400)
+    if params.get("code_challenge_method", "") != "S256":
+        return _json_error(
+            "invalid_request", 400, "code_challenge_method must be S256"
+        )
+    if not _PKCE_CHALLENGE_RE.fullmatch(params.get("code_challenge", "")):
+        return _json_error(
+            "invalid_request", 400, "invalid code_challenge (43-char base64url)"
+        )
+    if not _is_valid_redirect_uri(params.get("redirect_uri", "")):
+        return _json_error("invalid_request", 400, "invalid redirect_uri")
+    return None
 
 
 def _redirect_with(redirect_uri: str, **params: str) -> web.Response:
@@ -246,8 +228,14 @@ def _active_autoapprove_provider(hass: HomeAssistant) -> AutoApproveProvider | N
     return provider if isinstance(provider, AutoApproveProvider) else None
 
 
+def _domain_data(hass: HomeAssistant) -> dict[str, Any] | None:
+    """Return the live proxy data used for per-request mode dispatch."""
+    data = hass.data.get(DOMAIN)
+    return data if isinstance(data, dict) else None
+
+
 class AutoApproveAuthorizeView(HomeAssistantView):
-    """None-mode auto-approve ``/authorize`` — issues a code, 302s, no UI.
+    """Unified scoped authorization dispatcher for all three proxy modes.
 
     Validates ``response_type=code``, PKCE S256, and the redirect_uri
     open-redirect gate, then issues a PKCE-bound one-time code and redirects
@@ -277,36 +265,32 @@ class AutoApproveAuthorizeView(HomeAssistantView):
         self._hass = hass
 
     async def get(self, request: web.Request) -> web.Response:
-        """Auto-approve the authorization request or reject with a 400/404."""
+        """Dispatch an authorization request to the currently active mode."""
         if not await _backend_alive(self._hass):
             return _json_not_found()
-        provider = _active_autoapprove_provider(self._hass)
-        if provider is None:
+        data = _domain_data(self._hass)
+        if data is None:
+            return _json_not_found()
+        mode = data.get("oauth_mode")
+        if mode == MODE_LEGACY:
+            provider = data.get("oauth")
+            if provider is None:
+                return _json_not_found()
+            return await handle_legacy_authorize_get(provider, request)
+        if mode == MODE_HA_AUTH:
+            return await self._ha_auth_authorize(data, request)
+        if mode != MODE_NONE_AUTOAPPROVE:
+            return _json_not_found()
+        provider = data.get(AUTOAPPROVE_PROVIDER_KEY)
+        if not isinstance(provider, AutoApproveProvider):
             return _json_not_found()
 
         params = request.query
-        response_type = params.get("response_type", "")
         redirect_uri = params.get("redirect_uri", "")
         state = params.get("state", "")
         code_challenge = params.get("code_challenge", "")
-        code_challenge_method = params.get("code_challenge_method", "")
-
-        if response_type != "code":
-            return _json_error("unsupported_response_type", 400)
-        if code_challenge_method != "S256":
-            return _json_error(
-                "invalid_request", 400, "code_challenge_method must be S256"
-            )
-        if not _PKCE_CHALLENGE_RE.match(code_challenge):
-            return _json_error(
-                "invalid_request", 400, "invalid code_challenge (43-char base64url)"
-            )
-        # SECURITY: an unvalidated redirect_uri would be an open redirector on
-        # the HA origin. Reject in-place (never redirect) unless it exactly
-        # matches a known MCP callback (client_id is attacker-controlled and is
-        # deliberately not consulted — see module docstring).
-        if not _is_valid_autoapprove_redirect(redirect_uri):
-            return _json_error("invalid_request", 400, "invalid redirect_uri")
+        if error := _validate_autoapprove_authorize(params):
+            return error
 
         # RFC 9207: every authorization response — success or error — names the
         # issuer that produced it, so a client registered with several
@@ -325,9 +309,48 @@ class AutoApproveAuthorizeView(HomeAssistantView):
             redirect_params["state"] = state
         return _redirect_with(redirect_uri, **redirect_params)
 
+    async def _ha_auth_authorize(
+        self, data: dict[str, Any], request: web.Request
+    ) -> web.Response:
+        """Redirect the browser into core after CIMD or DCR translation."""
+        from multidict import MultiDict
+
+        from .oauth_dcr import CFG_DCR_SIGNING_KEY
+        from .oauth_indirect import resolve_forward_client_id
+
+        params = MultiDict(request.query)
+        client_id = params.get("client_id", "")
+        redirect_uri = params.get("redirect_uri", "")
+        forward_id = await resolve_forward_client_id(
+            data.get(CFG_CIMD_SESSION),
+            data.get(CFG_DCR_SIGNING_KEY),
+            client_id,
+            redirect_uri,
+        )
+        if forward_id != client_id:
+            params.popall("client_id", None)
+            params["client_id"] = forward_id
+
+        import yarl
+
+        target = yarl.URL("/auth/authorize").with_query(params)
+        return web.Response(status=302, headers={"Location": str(target)})
+
+    async def post(self, request: web.Request) -> web.Response:
+        """Handle legacy consent submissions on the scoped authorize route."""
+        if not await _backend_alive(self._hass):
+            return _json_not_found()
+        data = _domain_data(self._hass)
+        if data is None or data.get("oauth_mode") != MODE_LEGACY:
+            return _json_not_found()
+        provider = data.get("oauth")
+        if provider is None:
+            return _json_not_found()
+        return await handle_legacy_authorize_post(provider, request)
+
 
 class AutoApproveTokenView(HomeAssistantView):
-    """None-mode auto-approve ``/token`` — PKCE code → opaque access token.
+    """Unified scoped token dispatcher for all three proxy modes.
 
     Public client (no ``client_secret``): the PKCE code_verifier is the only
     proof required. The returned access token is cosmetic (none mode ignores
@@ -345,11 +368,24 @@ class AutoApproveTokenView(HomeAssistantView):
         self._hass = hass
 
     async def post(self, request: web.Request) -> web.Response:
-        """Exchange a PKCE authorization code for an opaque access token."""
+        """Dispatch a token request to the currently active mode."""
         if not await _backend_alive(self._hass):
             return _json_not_found()
-        provider = _active_autoapprove_provider(self._hass)
-        if provider is None:
+        data = _domain_data(self._hass)
+        if data is None:
+            return _json_not_found()
+        mode = data.get("oauth_mode")
+        if mode == MODE_LEGACY:
+            provider = data.get("oauth")
+            if provider is None:
+                return _json_not_found()
+            return await handle_legacy_token_post(provider, request)
+        if mode == MODE_HA_AUTH:
+            return await self._ha_auth_token(data, request)
+        if mode != MODE_NONE_AUTOAPPROVE:
+            return _json_not_found()
+        provider = data.get(AUTOAPPROVE_PROVIDER_KEY)
+        if not isinstance(provider, AutoApproveProvider):
             return _json_not_found()
 
         form: dict[str, Any] = dict(await request.post())
@@ -373,16 +409,86 @@ class AutoApproveTokenView(HomeAssistantView):
             headers=_TOKEN_RESPONSE_HEADERS,
         )
 
+    async def _ha_auth_token(
+        self, data: dict[str, Any], request: web.Request
+    ) -> web.Response:
+        """Redirect unchanged grants to core or proxy translated identities."""
+        from multidict import MultiDict
+
+        from .oauth_dcr import CFG_DCR_SIGNING_KEY
+        from .oauth_indirect import (
+            RefreshDisposition,
+            core_token_base_url,
+            resolve_forward_client_id,
+            translated_client_id_for_refresh,
+        )
+
+        form = MultiDict(await request.post())
+        grant_type = str(form.get("grant_type", ""))
+        client_id = str(form.get("client_id", ""))
+        redirect_uri = str(form.get("redirect_uri", ""))
+        forward_id = client_id
+        if client_id:
+            if grant_type == "refresh_token" and not redirect_uri:
+                translated = await translated_client_id_for_refresh(
+                    data.get(CFG_CIMD_SESSION),
+                    data.get(CFG_DCR_SIGNING_KEY),
+                    client_id,
+                )
+                if translated is RefreshDisposition.UNREPRODUCIBLE:
+                    return _json_error(
+                        "invalid_grant",
+                        400,
+                        "re-authorize: this client's registration has no "
+                        "single reproducible web origin, so a refresh "
+                        "without redirect_uri is unavailable",
+                    )
+                if translated is not RefreshDisposition.PASSTHROUGH:
+                    forward_id = translated
+            else:
+                forward_id = await resolve_forward_client_id(
+                    data.get(CFG_CIMD_SESSION),
+                    data.get(CFG_DCR_SIGNING_KEY),
+                    client_id,
+                    redirect_uri,
+                )
+
+        if forward_id == client_id:
+            return web.Response(
+                status=307,
+                headers={"Location": "/auth/token", "Cache-Control": "no-store"},
+            )
+
+        form.popall("client_id", None)
+        form["client_id"] = forward_id
+        session = data.get("session")
+        if session is None:
+            return _json_error("temporarily_unavailable", 503)
+        base = core_token_base_url(self._hass)
+        try:
+            async with session.post(
+                f"{base}/auth/token",
+                data=form,
+                timeout=aiohttp.ClientTimeout(total=25),
+            ) as response:
+                body = await response.read()
+                return web.Response(
+                    status=response.status,
+                    body=body,
+                    content_type=response.content_type or "application/json",
+                    headers=_TOKEN_RESPONSE_HEADERS,
+                )
+        except (TimeoutError, aiohttp.ClientError):
+            return _json_error("temporarily_unavailable", 503)
+
 
 def register_autoapprove_views(hass: HomeAssistant) -> None:
-    """Bind the two auto-approve views at most once per HA session.
+    """Bind the two unified scoped views at most once per HA session.
 
     aiohttp cannot unregister a bound view, so a reload / re-enable / mode switch
-    must reuse the already-bound views — they resolve the active provider from
-    ``hass.data`` per request (see :func:`_active_autoapprove_provider`), so they
-    serve only while none-autoapprove is live and 404 otherwise. The guard flag
-    lives at a top-level ``hass.data`` key that survives config-entry teardown
-    (mirrors :func:`oauth.register_metadata_views`).
+    must reuse the already-bound views. They resolve the active mode from
+    ``hass.data`` on every request, so the same URLs serve legacy, ha_auth, or
+    none-autoapprove without rebinding.
     """
     if hass.data.get(_AUTOAPPROVE_VIEWS_REGISTERED_KEY):
         return

--- a/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/oauth_autoapprove.py
+++ b/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/oauth_autoapprove.py
@@ -52,7 +52,7 @@ from .oauth import (
     MODE_NONE_AUTOAPPROVE,
     OAUTH_BASE,
     PKCECodeStore,
-    _backend_alive,
+    _addon_alive,
     _build_base_url,
     _is_valid_redirect_uri,
     handle_legacy_authorize_get,
@@ -265,7 +265,7 @@ class AutoApproveAuthorizeView(HomeAssistantView):
 
     async def get(self, request: web.Request) -> web.Response:
         """Dispatch an authorization request to the currently active mode."""
-        if not await _backend_alive(self._hass):
+        if not await _addon_alive(self._hass):
             return _json_not_found()
         data = _domain_data(self._hass)
         if data is None:
@@ -342,7 +342,7 @@ class AutoApproveAuthorizeView(HomeAssistantView):
 
     async def post(self, request: web.Request) -> web.Response:
         """Handle legacy consent submissions on the scoped authorize route."""
-        if not await _backend_alive(self._hass):
+        if not await _addon_alive(self._hass):
             return _json_not_found()
         data = _domain_data(self._hass)
         if data is None or data.get("oauth_mode") != MODE_LEGACY:
@@ -373,7 +373,7 @@ class AutoApproveTokenView(HomeAssistantView):
 
     async def post(self, request: web.Request) -> web.Response:
         """Dispatch a token request to the currently active mode."""
-        if not await _backend_alive(self._hass):
+        if not await _addon_alive(self._hass):
             return _json_not_found()
         data = _domain_data(self._hass)
         if data is None:

--- a/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/oauth_autoapprove.py
+++ b/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/oauth_autoapprove.py
@@ -106,6 +106,7 @@ def authorization_server_document(base: str) -> dict:
         "authorization_response_iss_parameter_supported": True,
         "authorization_endpoint": f"{base}{OAUTH_BASE}/authorize",
         "token_endpoint": f"{base}{OAUTH_BASE}/token",
+        "registration_endpoint": f"{base}{OAUTH_BASE}/register",
         "response_types_supported": ["code"],
         "grant_types_supported": ["authorization_code"],
         "code_challenge_methods_supported": ["S256"],

--- a/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/oauth_dcr.py
+++ b/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/oauth_dcr.py
@@ -165,6 +165,25 @@ def _active_grant_types(hass: HomeAssistant, redirect_uris: list[str]) -> list[s
     return ["authorization_code"]
 
 
+async def _read_capped_body(request: web.Request) -> bytes | None:
+    """The request body, or None when it exceeds ``MAX_DCR_BODY_BYTES``.
+
+    Reads to EOF rather than taking one ``StreamReader.read(n)``: that call
+    may return a short chunk before EOF on a fragmented body, which would
+    parse a truncated document (#2219 review round 3).
+    """
+    chunks: list[bytes] = []
+    remaining = MAX_DCR_BODY_BYTES + 1
+    while remaining > 0:
+        chunk = await request.content.read(remaining)
+        if not chunk:
+            break
+        chunks.append(chunk)
+        remaining -= len(chunk)
+    raw = b"".join(chunks)
+    return None if len(raw) > MAX_DCR_BODY_BYTES else raw
+
+
 def _dcr_error(error: str, description: str) -> web.Response:
     """Return an RFC 7591 registration error response."""
     return web.json_response(
@@ -190,8 +209,8 @@ class DcrRegisterView(HomeAssistantView):
         key = _active_dcr_key(self._hass)
         if key is None:
             return web.json_response({"error": "not_found"}, status=404)
-        raw = await request.content.read(MAX_DCR_BODY_BYTES + 1)
-        if len(raw) > MAX_DCR_BODY_BYTES:
+        raw = await _read_capped_body(request)
+        if raw is None:
             return _dcr_error("invalid_client_metadata", "body is too large")
         try:
             body: Any = json.loads(raw)

--- a/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/oauth_dcr.py
+++ b/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/oauth_dcr.py
@@ -5,6 +5,13 @@ HMAC-signed blob containing the registered redirect URIs, making verification
 restart-safe without allowing an anonymous registration endpoint to grow
 persistent state. DCR is live only in ha_auth and none-autoapprove modes;
 legacy mode continues to use its configured static credential.
+
+MIRROR: this module is the near-verbatim twin of
+``custom_components/ha_mcp_tools/oauth_dcr.py``. Keep behavioural changes on
+the two sides in step — the identity rename, the flat ``hass.data[DOMAIN]``
+layout, the ``oauth_mode == ha_auth`` test in ``_active_grant_types`` where the
+component checks for a resource server, and the ``_addon_alive`` gate on the
+register view are the intended deltas; anything else is drift.
 """
 
 from __future__ import annotations
@@ -88,7 +95,13 @@ _DEFAULT_PORTS = {"https": 443, "http": 80}
 
 
 def normalized_origin(uri: str) -> tuple[str, str, int] | None:
-    """Return a canonical scheme, host, and explicit/default port identity."""
+    """(scheme, host, port) origin identity with the scheme default applied.
+
+    The ONE normalizer shared by registration validation and client-id
+    translation (#2213 review by Patch76): ``https://h/a`` and
+    ``https://h:443/b`` are the same origin everywhere, or nowhere.
+    None for unparseable/hostless URIs.
+    """
     parsed = urlparse(uri)
     if not parsed.scheme or parsed.hostname is None:
         return None

--- a/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/oauth_dcr.py
+++ b/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/oauth_dcr.py
@@ -36,6 +36,10 @@ CFG_DCR_SIGNING_KEY = "dcr_signing_key"
 _DCR_VIEW_REGISTERED_KEY = "mcp_proxy_dev_oauth_dcr_view_registered"
 _CLIENT_ID_PREFIX = "hamcp-dcr-"
 
+# A conforming registration is a few KB; HA's own 16 MiB client_max_size is
+# no bound for an anonymous endpoint, so cap the read like the sibling CIMD
+# fetch does (#2219 review round 3).
+MAX_DCR_BODY_BYTES = 64 * 1024
 MAX_REDIRECT_URIS = 10
 MAX_REDIRECT_URI_LEN = 512
 
@@ -186,11 +190,17 @@ class DcrRegisterView(HomeAssistantView):
         key = _active_dcr_key(self._hass)
         if key is None:
             return web.json_response({"error": "not_found"}, status=404)
+        raw = await request.content.read(MAX_DCR_BODY_BYTES + 1)
+        if len(raw) > MAX_DCR_BODY_BYTES:
+            return _dcr_error("invalid_client_metadata", "body is too large")
         try:
-            body: Any = await request.json()
+            body: Any = json.loads(raw)
         except (ValueError, RecursionError):
             # RecursionError: json.loads on a deeply nested body (#2218
-            # review) — malformed metadata, not a server error.
+            # review) — malformed metadata, not a server error. Reading the
+            # bytes ourselves also sidesteps request.json()'s charset lookup,
+            # which raises LookupError on a bogus Content-Type charset
+            # (#2219 review round 3); JSON is UTF-8 by RFC 8259 anyway.
             return _dcr_error("invalid_client_metadata", "body must be JSON")
         if not isinstance(body, dict):
             return _dcr_error("invalid_client_metadata", "body must be an object")

--- a/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/oauth_dcr.py
+++ b/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/oauth_dcr.py
@@ -1,0 +1,224 @@
+"""Stateless RFC 7591 Dynamic Client Registration compatibility endpoint.
+
+The proxy keeps no registration database. Each minted ``client_id`` is an
+HMAC-signed blob containing the registered redirect URIs, making verification
+restart-safe without allowing an anonymous registration endpoint to grow
+persistent state. DCR is live only in ha_auth and none-autoapprove modes;
+legacy mode continues to use its configured static credential.
+"""
+
+from __future__ import annotations
+
+import binascii
+import hashlib
+import hmac
+import json
+import time
+from typing import Any, cast
+from urllib.parse import urlparse
+
+from aiohttp import web
+from homeassistant.components.http import HomeAssistantView
+from homeassistant.core import HomeAssistant
+
+from .oauth import (
+    DOMAIN,
+    MODE_HA_AUTH,
+    OAUTH_BASE,
+    _b64url_decode,
+    _b64url_encode,
+    _backend_alive,
+    _is_loopback_host,
+    _is_valid_redirect_uri,
+)
+
+CFG_DCR_SIGNING_KEY = "dcr_signing_key"
+_DCR_VIEW_REGISTERED_KEY = "mcp_proxy_dev_oauth_dcr_view_registered"
+_CLIENT_ID_PREFIX = "hamcp-dcr-"
+
+MAX_REDIRECT_URIS = 10
+MAX_REDIRECT_URI_LEN = 512
+
+
+def mint_client_id(signing_key: bytes, redirect_uris: list[str]) -> str:
+    """Mint a stateless client_id embedding ``redirect_uris``."""
+    payload = {"r": redirect_uris, "iat": int(time.time())}
+    body = _b64url_encode(json.dumps(payload, separators=(",", ":")).encode())
+    signature = hmac.new(
+        signing_key, body.encode("ascii"), hashlib.sha256
+    ).digest()
+    return f"{_CLIENT_ID_PREFIX}{body}.{_b64url_encode(signature)}"
+
+
+def client_redirect_uris(signing_key: bytes, client_id: str) -> list[str] | None:
+    """Return the redirect URIs embedded in a valid minted client_id."""
+    if not client_id.startswith(_CLIENT_ID_PREFIX):
+        return None
+    blob = client_id[len(_CLIENT_ID_PREFIX) :]
+    body, separator, signature = blob.rpartition(".")
+    if not separator or not body:
+        return None
+    try:
+        expected = hmac.new(
+            signing_key, body.encode("ascii"), hashlib.sha256
+        ).digest()
+        if not hmac.compare_digest(_b64url_decode(signature), expected):
+            return None
+        payload = json.loads(_b64url_decode(body))
+    except (ValueError, binascii.Error, UnicodeEncodeError):
+        return None
+    if not isinstance(payload, dict):
+        return None
+    uris = payload.get("r")
+    if not isinstance(uris, list) or not all(isinstance(uri, str) for uri in uris):
+        return None
+    return uris
+
+
+def _active_dcr_key(hass: HomeAssistant) -> bytes | None:
+    """Return the live signing key, or None when registration is unavailable."""
+    domain_data = hass.data.get(DOMAIN)
+    if not isinstance(domain_data, dict):
+        return None
+    key = domain_data.get(CFG_DCR_SIGNING_KEY)
+    return key if isinstance(key, bytes) else None
+
+
+_DEFAULT_PORTS = {"https": 443, "http": 80}
+
+
+def normalized_origin(uri: str) -> tuple[str, str, int] | None:
+    """Return a canonical scheme, host, and explicit/default port identity."""
+    parsed = urlparse(uri)
+    if not parsed.scheme or parsed.hostname is None:
+        return None
+    port = parsed.port
+    if port is None:
+        port = _DEFAULT_PORTS.get(parsed.scheme, 0)
+    return (parsed.scheme, parsed.hostname, port)
+
+
+def canonical_origin_url(origin: tuple[str, str, int]) -> str:
+    """Render a normalized origin, omitting scheme-default ports."""
+    scheme, host, port = origin
+    url_host = f"[{host}]" if ":" in host else host
+    if _DEFAULT_PORTS.get(scheme) == port:
+        return f"{scheme}://{url_host}"
+    return f"{scheme}://{url_host}:{port}"
+
+
+def _non_loopback_origins(redirect_uris: list[str]) -> set[tuple[str, str, int]]:
+    """Return the normalized web origins represented by redirects."""
+    origins: set[tuple[str, str, int]] = set()
+    for uri in redirect_uris:
+        parsed = urlparse(uri)
+        if parsed.hostname is None or _is_loopback_host(parsed.hostname):
+            continue
+        origin = normalized_origin(uri)
+        if origin is not None:
+            origins.add(origin)
+    return origins
+
+
+def _refresh_identity_is_reproducible(redirect_uris: list[str]) -> bool:
+    """Return whether every callback maps to one stable non-loopback origin."""
+    if len(_non_loopback_origins(redirect_uris)) != 1:
+        return False
+    return not any(
+        (hostname := urlparse(uri).hostname) is None or _is_loopback_host(hostname)
+        for uri in redirect_uris
+    )
+
+
+def _redirect_uris_error(value: Any) -> tuple[str, str] | None:
+    """Return an RFC 7591 error for invalid redirect metadata."""
+    if not isinstance(value, list) or not value:
+        return "invalid_redirect_uri", "redirect_uris must be a non-empty array"
+    if len(value) > MAX_REDIRECT_URIS:
+        return (
+            "invalid_redirect_uri",
+            f"at most {MAX_REDIRECT_URIS} redirect_uris are accepted",
+        )
+    if any(
+        not isinstance(uri, str)
+        or len(uri) > MAX_REDIRECT_URI_LEN
+        or not _is_valid_redirect_uri(uri)
+        for uri in value
+    ):
+        return (
+            "invalid_redirect_uri",
+            "redirect_uris must be https URLs or http loopback URLs "
+            "(RFC 8252) without fragments",
+        )
+    return None
+
+
+def _active_grant_types(hass: HomeAssistant, redirect_uris: list[str]) -> list[str]:
+    """Return only grant types implemented by the active proxy mode."""
+    domain_data = hass.data.get(DOMAIN)
+    if (
+        isinstance(domain_data, dict)
+        and domain_data.get("oauth_mode") == MODE_HA_AUTH
+        and _refresh_identity_is_reproducible(redirect_uris)
+    ):
+        return ["authorization_code", "refresh_token"]
+    return ["authorization_code"]
+
+
+def _dcr_error(error: str, description: str) -> web.Response:
+    """Return an RFC 7591 registration error response."""
+    return web.json_response(
+        {"error": error, "error_description": description}, status=400
+    )
+
+
+class DcrRegisterView(HomeAssistantView):
+    """Mint stateless public-client registrations for the active proxy."""
+
+    requires_auth = False
+    cors_allowed = True
+    url = f"{OAUTH_BASE}/register"
+    name = "mcp_proxy_dev:oauth:dcr-register"
+
+    def __init__(self, hass: HomeAssistant) -> None:
+        self._hass = hass
+
+    async def post(self, request: web.Request) -> web.Response:
+        """Validate redirect metadata and return a signed client_id."""
+        if not await _backend_alive(self._hass):
+            return web.json_response({"error": "not_found"}, status=404)
+        key = _active_dcr_key(self._hass)
+        if key is None:
+            return web.json_response({"error": "not_found"}, status=404)
+        try:
+            body: Any = await request.json()
+        except ValueError:
+            return _dcr_error("invalid_client_metadata", "body must be JSON")
+        if not isinstance(body, dict):
+            return _dcr_error("invalid_client_metadata", "body must be an object")
+
+        raw_uris = body.get("redirect_uris")
+        if error := _redirect_uris_error(raw_uris):
+            return _dcr_error(*error)
+        uris = cast(list[str], raw_uris)
+
+        response: dict[str, Any] = {
+            "client_id": mint_client_id(key, uris),
+            "client_id_issued_at": int(time.time()),
+            "redirect_uris": uris,
+            "token_endpoint_auth_method": "none",
+            "grant_types": _active_grant_types(self._hass, uris),
+            "response_types": ["code"],
+        }
+        for field in ("client_name", "application_type", "scope"):
+            if isinstance(body.get(field), str):
+                response[field] = body[field]
+        return web.json_response(response, status=201)
+
+
+def bind_dcr_view(hass: HomeAssistant) -> None:
+    """Bind the per-request-gated registration view once per HA session."""
+    if hass.data.get(_DCR_VIEW_REGISTERED_KEY):
+        return
+    hass.http.register_view(DcrRegisterView(hass))
+    hass.data[_DCR_VIEW_REGISTERED_KEY] = True

--- a/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/oauth_dcr.py
+++ b/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/oauth_dcr.py
@@ -25,9 +25,9 @@ from .oauth import (
     DOMAIN,
     MODE_HA_AUTH,
     OAUTH_BASE,
+    _addon_alive,
     _b64url_decode,
     _b64url_encode,
-    _backend_alive,
     _is_loopback_host,
     _is_valid_redirect_uri,
 )
@@ -181,14 +181,16 @@ class DcrRegisterView(HomeAssistantView):
 
     async def post(self, request: web.Request) -> web.Response:
         """Validate redirect metadata and return a signed client_id."""
-        if not await _backend_alive(self._hass):
+        if not await _addon_alive(self._hass):
             return web.json_response({"error": "not_found"}, status=404)
         key = _active_dcr_key(self._hass)
         if key is None:
             return web.json_response({"error": "not_found"}, status=404)
         try:
             body: Any = await request.json()
-        except ValueError:
+        except (ValueError, RecursionError):
+            # RecursionError: json.loads on a deeply nested body (#2218
+            # review) — malformed metadata, not a server error.
             return _dcr_error("invalid_client_metadata", "body must be JSON")
         if not isinstance(body, dict):
             return _dcr_error("invalid_client_metadata", "body must be an object")

--- a/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/oauth_dcr.py
+++ b/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/oauth_dcr.py
@@ -44,9 +44,7 @@ def mint_client_id(signing_key: bytes, redirect_uris: list[str]) -> str:
     """Mint a stateless client_id embedding ``redirect_uris``."""
     payload = {"r": redirect_uris, "iat": int(time.time())}
     body = _b64url_encode(json.dumps(payload, separators=(",", ":")).encode())
-    signature = hmac.new(
-        signing_key, body.encode("ascii"), hashlib.sha256
-    ).digest()
+    signature = hmac.new(signing_key, body.encode("ascii"), hashlib.sha256).digest()
     return f"{_CLIENT_ID_PREFIX}{body}.{_b64url_encode(signature)}"
 
 
@@ -59,9 +57,7 @@ def client_redirect_uris(signing_key: bytes, client_id: str) -> list[str] | None
     if not separator or not body:
         return None
     try:
-        expected = hmac.new(
-            signing_key, body.encode("ascii"), hashlib.sha256
-        ).digest()
+        expected = hmac.new(signing_key, body.encode("ascii"), hashlib.sha256).digest()
         if not hmac.compare_digest(_b64url_decode(signature), expected):
             return None
         payload = json.loads(_b64url_decode(body))

--- a/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/oauth_indirect.py
+++ b/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/oauth_indirect.py
@@ -288,13 +288,14 @@ async def resolve_forward_client_id(
     # path must pass such identities through for core to reject, not 500.
     parsed_client = urlparse(client_id)
     parsed_redirect = urlparse(redirect_uri)
-    # RAW, case-sensitive netloc equality — the same comparison core's own
-    # IndieAuth rule applies to what we forward (#2219 review, second round):
-    # a pair differing only in host casing must MISS this fast path so it
-    # takes the validated translation to an origin core accepts.
+    # Case-insensitive netloc equality, matching core's own authorize rule:
+    # indieauth._parse_url lowercases the netloc of BOTH the client_id and
+    # the redirect_uri before comparing. (Core's REFRESH leg is byte-exact
+    # instead, which is why the derivation below must reproduce what THIS
+    # leg forwarded, verbatim.)
     if parsed_client.scheme in ("http", "https") and (
-        (parsed_client.scheme, parsed_client.netloc)
-        == (parsed_redirect.scheme, parsed_redirect.netloc)
+        (parsed_client.scheme, parsed_client.netloc.lower())
+        == (parsed_redirect.scheme, parsed_redirect.netloc.lower())
     ):
         return client_id
 
@@ -336,20 +337,27 @@ async def translated_client_id_for_refresh(
         return RefreshDisposition.UNREPRODUCIBLE
     stable = stable_translation_origin(registered)
     assert stable is not None
-    # Passthrough exactly when the authorize fast path COULD have fired
-    # (#2218/#2219 reviews): that fast path compares the client_id's raw
-    # netloc against the PRESENTED redirect's, so refresh reconstructs it
-    # against the registered redirects (reproducible ⇒ all web, one canonical
-    # origin — but their RAW netlocs may still differ from the client_id's by
-    # an explicit default port or by host casing, where the fast path missed
-    # and the token was minted under the TRANSLATED origin). Raw and
-    # case-sensitive, exactly like the fast path itself.
+    # Reproduce what the authorize leg forwarded, or admit we cannot. That
+    # leg's fast path keys off the PRESENTED redirect, which the redirect-less
+    # refresh grant does not carry, so the registered list is all we have:
+    # every registered redirect shares the client_id's origin → the fast path
+    # fired whichever was presented → PASSTHROUGH; none do → it was
+    # translated to the one canonical origin; some but not all → the answer
+    # depends on which was presented and nothing records that →
+    # UNREPRODUCIBLE. The split case is real even under
+    # _refresh_identity_is_reproducible, which normalizes ports:
+    # ["https://h/a", "https://h:443/b"] is ONE canonical origin, yet
+    # authorize on /a passes through while /b translates (#2219 round 3).
     parsed = urlparse(client_id)
-    client_origin = (parsed.scheme, parsed.netloc)
-    for uri in registered:
-        parsed_redirect = urlparse(uri)
-        if (parsed_redirect.scheme, parsed_redirect.netloc) == client_origin:
-            return RefreshDisposition.PASSTHROUGH
+    client_origin = (parsed.scheme, parsed.netloc.lower())
+    matched = [
+        (urlparse(uri).scheme, urlparse(uri).netloc.lower()) == client_origin
+        for uri in registered
+    ]
+    if all(matched):
+        return RefreshDisposition.PASSTHROUGH
+    if any(matched):
+        return RefreshDisposition.UNREPRODUCIBLE
     return stable
 
 

--- a/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/oauth_indirect.py
+++ b/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/oauth_indirect.py
@@ -7,9 +7,15 @@ client identities into the same-origin form accepted by core.
 
 MIRROR: this module is the near-verbatim twin of
 ``custom_components/ha_mcp_tools/oauth_ha_auth.py``. Keep behavioural changes
-on the two sides in step — the identity rename, the flat ``hass.data[DOMAIN]``
-layout instead of the component's ``cfg[DATA_WEBHOOK]`` nesting, and the
-``_addon_alive`` gate are the intended deltas; anything else is drift.
+on the two sides in step. This pair has exactly ONE intended delta and it is
+not behavioural: the loopback and redirect-shape helpers are imported from
+``oauth.py`` here and from ``oauth_legacy.py`` in the component. Those two
+definitions are equivalent today, ``_LOOPBACK_HOSTNAMES`` and
+``_AUTHORITY_CHARS_RE`` included — named here so it is noticed if that ever
+stops being true. Everything else that differs is drift, including the deltas
+the sibling ``oauth_dcr.py`` pair legitimately carries (the
+``hass.data[DOMAIN]`` layout, the ``_addon_alive`` gate): neither appears in
+either file of THIS pair.
 
 CIMD fetches are HTTPS-only, redirect-free, size- and time-bounded, and pinned
 to prevalidated globally routable DNS answers. Invalid identities pass through

--- a/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/oauth_indirect.py
+++ b/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/oauth_indirect.py
@@ -44,6 +44,10 @@ _CIMD_CACHE_MAX = 64
 _ALLOWED_SCHEMES = ("https",)
 _cimd_cache: dict[str, tuple[float, list[str] | None]] = {}
 
+# Admission for the whole cache-miss lookup (DNS + fetch). Matches the
+# dedicated CIMD connector limit so the two bounds cannot disagree.
+_CIMD_LOOKUP_SLOTS = asyncio.Semaphore(4)
+
 
 def _reject_json_constant(constant: str) -> None:
     """Reject NaN and Infinity, which RFC 8259 JSON does not permit."""
@@ -205,7 +209,14 @@ async def fetch_cimd_redirects(
 
     try:
         async with asyncio.timeout(CIMD_TOTAL_LOOKUP_TIMEOUT):
-            return await _lookup_cimd(session, client_id, parsed, now)
+            # The dedicated connector caps concurrent HTTP, but DNS runs in
+            # the executor BEFORE any connection is taken, so unique
+            # attacker-chosen client_ids could pile getaddrinfo() calls onto
+            # the shared pool (#2219 codex review). Admission covers the whole
+            # cache-miss path and waits inside the deadline above, so a
+            # legitimate lookup queues rather than failing.
+            async with _CIMD_LOOKUP_SLOTS:
+                return await _lookup_cimd(session, client_id, parsed, now)
     except TimeoutError:
         _LOGGER.debug("CIMD lookup: total deadline exceeded for %s", client_id)
         _cache_cimd(client_id, now, None)
@@ -286,8 +297,16 @@ async def resolve_forward_client_id(
     # client_id is unvalidated here, and normalized_origin() reads
     # parsed.port, which raises ValueError on a malformed port — the fast
     # path must pass such identities through for core to reject, not 500.
-    parsed_client = urlparse(client_id)
-    parsed_redirect = urlparse(redirect_uri)
+    # urlparse defers some validation until access and raises outright on
+    # shapes like "https://[" (unterminated IPv6). These views are ANONYMOUS,
+    # so a malformed client_id must pass through for core to reject rather
+    # than traceback (#2219 codex review) — the same contract the redirect
+    # validator states for its own .port access.
+    try:
+        parsed_client = urlparse(client_id)
+        parsed_redirect = urlparse(redirect_uri)
+    except ValueError:
+        return client_id
     # Case-insensitive netloc equality, matching core's own authorize rule:
     # indieauth._parse_url lowercases the netloc of BOTH the client_id and
     # the redirect_uri before comparing. (Core's REFRESH leg is byte-exact
@@ -328,7 +347,12 @@ async def translated_client_id_for_refresh(
     if dcr_key is not None:
         registered = client_redirect_uris(dcr_key, client_id)
     if registered is None:
-        parsed = urlparse(client_id)
+        try:
+            parsed = urlparse(client_id)
+        except ValueError:
+            # Malformed identity: core stays the authority (see the authorize
+            # leg's note); never a traceback on an anonymous view.
+            return RefreshDisposition.PASSTHROUGH
         if parsed.scheme == "https" and session is not None:
             registered = await fetch_cimd_redirects(session, client_id)
     if not registered:
@@ -348,7 +372,10 @@ async def translated_client_id_for_refresh(
     # _refresh_identity_is_reproducible, which normalizes ports:
     # ["https://h/a", "https://h:443/b"] is ONE canonical origin, yet
     # authorize on /a passes through while /b translates (#2219 round 3).
-    parsed = urlparse(client_id)
+    try:
+        parsed = urlparse(client_id)
+    except ValueError:
+        return RefreshDisposition.PASSTHROUGH
     client_origin = (parsed.scheme, parsed.netloc.lower())
     matched = [
         (urlparse(uri).scheme, urlparse(uri).netloc.lower()) == client_origin

--- a/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/oauth_indirect.py
+++ b/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/oauth_indirect.py
@@ -282,13 +282,15 @@ async def resolve_forward_client_id(
     """Return the validated translated identity to present to core."""
     if not client_id or not _is_valid_redirect_uri(redirect_uri):
         return client_id
+    # Raw-netloc comparison exactly like the component (#2218 review): the
+    # client_id is unvalidated here, and normalized_origin() reads
+    # parsed.port, which raises ValueError on a malformed port — the fast
+    # path must pass such identities through for core to reject, not 500.
     parsed_client = urlparse(client_id)
-    client_origin = normalized_origin(client_id)
-    redirect_origin = normalized_origin(redirect_uri)
-    if (
-        parsed_client.scheme in ("http", "https")
-        and client_origin is not None
-        and client_origin == redirect_origin
+    parsed_redirect = urlparse(redirect_uri)
+    if parsed_client.scheme in ("http", "https") and (
+        (parsed_client.scheme, parsed_client.netloc)
+        == (parsed_redirect.scheme, parsed_redirect.netloc)
     ):
         return client_id
 
@@ -330,7 +332,15 @@ async def translated_client_id_for_refresh(
         return RefreshDisposition.UNREPRODUCIBLE
     stable = stable_translation_origin(registered)
     assert stable is not None
-    if origin_client_id(client_id) == stable:
+    # RAW netloc comparison, deliberately mirroring the authorize fast path
+    # (#2218 review): passthrough is only consistent when authorize ALSO
+    # passed the full client_id through, and that fast path compares raw
+    # netlocs. A client_id with an explicit scheme-default port missed the
+    # fast path, so its token was minted under the TRANSLATED origin — a
+    # canonical comparison here would pass the raw client_id through and
+    # guarantee the core rejection this derivation exists to avoid.
+    parsed = urlparse(client_id)
+    if f"{parsed.scheme}://{parsed.netloc}" == stable:
         return RefreshDisposition.PASSTHROUGH
     return stable
 

--- a/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/oauth_indirect.py
+++ b/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/oauth_indirect.py
@@ -223,9 +223,7 @@ async def _lookup_cimd(
         parsed.hostname or "", parsed.port or 443
     )
     for address in addresses:
-        reached, result = await _fetch_pinned_cimd(
-            session, client_id, parsed, address
-        )
+        reached, result = await _fetch_pinned_cimd(session, client_id, parsed, address)
         if not reached:
             continue
         if result is None:
@@ -253,9 +251,7 @@ def _cache_cimd(client_id: str, now: float, result: list[str] | None) -> None:
 def _parse_cimd(raw: bytes, client_id: str) -> list[str] | None:
     """Strictly parse a CIMD body and return its validated redirect URIs."""
     try:
-        document = json.loads(
-            raw.decode("utf-8"), parse_constant=_reject_json_constant
-        )
+        document = json.loads(raw.decode("utf-8"), parse_constant=_reject_json_constant)
     except (UnicodeDecodeError, ValueError, RecursionError):
         return None
     if (

--- a/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/oauth_indirect.py
+++ b/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/oauth_indirect.py
@@ -288,12 +288,13 @@ async def resolve_forward_client_id(
     # path must pass such identities through for core to reject, not 500.
     parsed_client = urlparse(client_id)
     parsed_redirect = urlparse(redirect_uri)
-    # Netlocs casefold: hostnames are case-insensitive (RFC 4343), and the
-    # refresh leg reconstructs this comparison against the lowercased
-    # canonical origin (#2219 review).
+    # RAW, case-sensitive netloc equality — the same comparison core's own
+    # IndieAuth rule applies to what we forward (#2219 review, second round):
+    # a pair differing only in host casing must MISS this fast path so it
+    # takes the validated translation to an origin core accepts.
     if parsed_client.scheme in ("http", "https") and (
-        (parsed_client.scheme, parsed_client.netloc.lower())
-        == (parsed_redirect.scheme, parsed_redirect.netloc.lower())
+        (parsed_client.scheme, parsed_client.netloc)
+        == (parsed_redirect.scheme, parsed_redirect.netloc)
     ):
         return client_id
 
@@ -340,14 +341,14 @@ async def translated_client_id_for_refresh(
     # netloc against the PRESENTED redirect's, so refresh reconstructs it
     # against the registered redirects (reproducible ⇒ all web, one canonical
     # origin — but their RAW netlocs may still differ from the client_id's by
-    # an explicit default port, where the fast path missed and the token was
-    # minted under the TRANSLATED origin). Netlocs casefold because hostnames
-    # are case-insensitive (RFC 4343).
+    # an explicit default port or by host casing, where the fast path missed
+    # and the token was minted under the TRANSLATED origin). Raw and
+    # case-sensitive, exactly like the fast path itself.
     parsed = urlparse(client_id)
-    client_origin = (parsed.scheme, parsed.netloc.lower())
+    client_origin = (parsed.scheme, parsed.netloc)
     for uri in registered:
         parsed_redirect = urlparse(uri)
-        if (parsed_redirect.scheme, parsed_redirect.netloc.lower()) == client_origin:
+        if (parsed_redirect.scheme, parsed_redirect.netloc) == client_origin:
             return RefreshDisposition.PASSTHROUGH
     return stable
 

--- a/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/oauth_indirect.py
+++ b/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/oauth_indirect.py
@@ -5,6 +5,12 @@ while Home Assistant core remains the authorization server. This module also
 validates cross-origin Client ID Metadata Documents before translating their
 client identities into the same-origin form accepted by core.
 
+MIRROR: this module is the near-verbatim twin of
+``custom_components/ha_mcp_tools/oauth_ha_auth.py``. Keep behavioural changes
+on the two sides in step — the identity rename, the flat ``hass.data[DOMAIN]``
+layout instead of the component's ``cfg[DATA_WEBHOOK]`` nesting, and the
+``_addon_alive`` gate are the intended deltas; anything else is drift.
+
 CIMD fetches are HTTPS-only, redirect-free, size- and time-bounded, and pinned
 to prevalidated globally routable DNS answers. Invalid identities pass through
 unchanged so Home Assistant remains the final authority.
@@ -42,6 +48,10 @@ CIMD_CACHE_TTL = 300.0
 CIMD_NEGATIVE_TTL = 60.0
 _CIMD_CACHE_MAX = 64
 _ALLOWED_SCHEMES = ("https",)
+# client_id URL -> (expires_monotonic, redirect_uris). Draft -00 section 4.4.3
+# forbids caching error responses and invalid documents; both return with
+# reached=True before any cache write. Unreachable-host and resolution outcomes
+# are outside section 4.4.3 and are negative-cached for CIMD_NEGATIVE_TTL.
 _cimd_cache: dict[str, tuple[float, list[str] | None]] = {}
 
 # Admission for the whole cache-miss lookup (DNS + fetch). Matches the
@@ -193,7 +203,7 @@ async def fetch_cimd_redirects(
     if not _valid_cimd_client_id(client_id):
         return None
     parsed = urlparse(client_id)
-    assert parsed.hostname is not None
+    assert parsed.hostname is not None  # established by _valid_cimd_client_id
     if _is_loopback_host(parsed.hostname):
         return None
     try:
@@ -238,6 +248,11 @@ async def _lookup_cimd(
         if not reached:
             continue
         if result is None:
+            # INVALID document: deliberately NOT cached — a client that fixes
+            # its metadata recovers on the next request (pinned by
+            # test_invalid_cimd_document_is_not_negative_cached; the component
+            # twin pins the same policy as
+            # test_invalid_cimd_is_not_negative_cached).
             _LOGGER.debug("CIMD lookup: document at %s failed validation", client_id)
             return None
         _cache_cimd(client_id, now, result)

--- a/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/oauth_indirect.py
+++ b/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/oauth_indirect.py
@@ -288,9 +288,12 @@ async def resolve_forward_client_id(
     # path must pass such identities through for core to reject, not 500.
     parsed_client = urlparse(client_id)
     parsed_redirect = urlparse(redirect_uri)
+    # Netlocs casefold: hostnames are case-insensitive (RFC 4343), and the
+    # refresh leg reconstructs this comparison against the lowercased
+    # canonical origin (#2219 review).
     if parsed_client.scheme in ("http", "https") and (
-        (parsed_client.scheme, parsed_client.netloc)
-        == (parsed_redirect.scheme, parsed_redirect.netloc)
+        (parsed_client.scheme, parsed_client.netloc.lower())
+        == (parsed_redirect.scheme, parsed_redirect.netloc.lower())
     ):
         return client_id
 
@@ -332,16 +335,20 @@ async def translated_client_id_for_refresh(
         return RefreshDisposition.UNREPRODUCIBLE
     stable = stable_translation_origin(registered)
     assert stable is not None
-    # RAW netloc comparison, deliberately mirroring the authorize fast path
-    # (#2218 review): passthrough is only consistent when authorize ALSO
-    # passed the full client_id through, and that fast path compares raw
-    # netlocs. A client_id with an explicit scheme-default port missed the
-    # fast path, so its token was minted under the TRANSLATED origin — a
-    # canonical comparison here would pass the raw client_id through and
-    # guarantee the core rejection this derivation exists to avoid.
+    # Passthrough exactly when the authorize fast path COULD have fired
+    # (#2218/#2219 reviews): that fast path compares the client_id's raw
+    # netloc against the PRESENTED redirect's, so refresh reconstructs it
+    # against the registered redirects (reproducible ⇒ all web, one canonical
+    # origin — but their RAW netlocs may still differ from the client_id's by
+    # an explicit default port, where the fast path missed and the token was
+    # minted under the TRANSLATED origin). Netlocs casefold because hostnames
+    # are case-insensitive (RFC 4343).
     parsed = urlparse(client_id)
-    if f"{parsed.scheme}://{parsed.netloc}" == stable:
-        return RefreshDisposition.PASSTHROUGH
+    client_origin = (parsed.scheme, parsed.netloc.lower())
+    for uri in registered:
+        parsed_redirect = urlparse(uri)
+        if (parsed_redirect.scheme, parsed_redirect.netloc.lower()) == client_origin:
+            return RefreshDisposition.PASSTHROUGH
     return stable
 
 

--- a/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/oauth_indirect.py
+++ b/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/oauth_indirect.py
@@ -1,0 +1,359 @@
+"""ha_auth-mode OAuth indirection in front of Home Assistant core.
+
+The proxy-owned authorize and token routes keep client endpoint caches stable
+while Home Assistant core remains the authorization server. This module also
+validates cross-origin Client ID Metadata Documents before translating their
+client identities into the same-origin form accepted by core.
+
+CIMD fetches are HTTPS-only, redirect-free, size- and time-bounded, and pinned
+to prevalidated globally routable DNS answers. Invalid identities pass through
+unchanged so Home Assistant remains the final authority.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import ipaddress
+import json
+import logging
+import socket
+import time
+from enum import Enum
+from urllib.parse import ParseResult, urlparse, urlunparse
+
+import aiohttp
+from homeassistant.core import HomeAssistant
+
+from .oauth import _is_loopback_host, _is_valid_redirect_uri
+from .oauth_dcr import (
+    _refresh_identity_is_reproducible,
+    canonical_origin_url,
+    client_redirect_uris,
+    normalized_origin,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+CIMD_MAX_BYTES = 10 * 1024
+CIMD_FETCH_TIMEOUT = aiohttp.ClientTimeout(total=5)
+CIMD_RESOLVE_TIMEOUT = 5.0
+CIMD_TOTAL_LOOKUP_TIMEOUT = 12.0
+CIMD_CACHE_TTL = 300.0
+CIMD_NEGATIVE_TTL = 60.0
+_CIMD_CACHE_MAX = 64
+_ALLOWED_SCHEMES = ("https",)
+_cimd_cache: dict[str, tuple[float, list[str] | None]] = {}
+
+
+def _reject_json_constant(constant: str) -> None:
+    """Reject NaN and Infinity, which RFC 8259 JSON does not permit."""
+    raise ValueError(f"Invalid JSON constant: {constant}")
+
+
+def _valid_cimd_client_id(client_id: str) -> bool:
+    """Return whether a client_id satisfies the CIMD URL-shape requirements."""
+    try:
+        parsed = urlparse(client_id)
+        _ = parsed.port
+    except ValueError:
+        return False
+    return (
+        parsed.scheme in _ALLOWED_SCHEMES
+        and bool(parsed.hostname)
+        and bool(parsed.path)
+        and parsed.path != "/"
+        and "#" not in client_id
+        and parsed.username is None
+        and parsed.password is None
+        and not any(segment in (".", "..") for segment in parsed.path.split("/"))
+    )
+
+
+async def _resolve_public_addresses(hostname: str, port: int) -> list[str]:
+    """Resolve once and accept the result only when every address is public."""
+    try:
+        infos = await asyncio.wait_for(
+            asyncio.get_running_loop().getaddrinfo(
+                hostname,
+                port,
+                family=socket.AF_UNSPEC,
+                type=socket.SOCK_STREAM,
+            ),
+            timeout=CIMD_RESOLVE_TIMEOUT,
+        )
+    except (OSError, ValueError, TimeoutError):
+        _LOGGER.debug("CIMD lookup: resolution failed for %s", hostname)
+        return []
+    addresses = {str(sockaddr[0]) for *_, sockaddr in infos}
+    if not addresses:
+        return []
+    try:
+        if any(not ipaddress.ip_address(address).is_global for address in addresses):
+            return []
+    except ValueError:
+        return []
+    return sorted(addresses)
+
+
+def _pinned_url(parsed: ParseResult, address: str) -> str:
+    """Replace a parsed URL host with a validated numeric address."""
+    host = f"[{address}]" if ":" in address else address
+    netloc = f"{host}:{parsed.port}" if parsed.port is not None else host
+    return urlunparse(parsed._replace(netloc=netloc))
+
+
+async def _fetch_pinned_cimd(
+    session: aiohttp.ClientSession,
+    client_id: str,
+    parsed: ParseResult,
+    address: str,
+) -> tuple[bool, list[str] | None]:
+    """Fetch one pinned address and report whether the server was reached."""
+    try:
+        async with session.get(
+            _pinned_url(parsed, address),
+            allow_redirects=False,
+            timeout=CIMD_FETCH_TIMEOUT,
+            headers={"Host": parsed.netloc},
+            server_hostname=parsed.hostname if parsed.scheme == "https" else None,
+        ) as response:
+            if response.status != 200:
+                return True, None
+            raw = bytearray()
+            async for chunk in response.content.iter_chunked(1024):
+                raw.extend(chunk)
+                if len(raw) > CIMD_MAX_BYTES:
+                    return True, None
+            return True, _parse_cimd(bytes(raw), client_id)
+    except (TimeoutError, aiohttp.ClientError):
+        return False, None
+
+
+def origin_client_id(redirect_uri: str) -> str:
+    """Return the callback origin in the URL-shaped form accepted by core."""
+    origin = normalized_origin(redirect_uri)
+    if origin is None:
+        parsed = urlparse(redirect_uri)
+        return f"{parsed.scheme}://{parsed.netloc}"
+    return canonical_origin_url(origin)
+
+
+def redirect_matches(registered: list[str], redirect_uri: str) -> bool:
+    """Apply exact matching plus RFC 8252 port-agnostic loopback matching."""
+    if redirect_uri in registered:
+        return True
+    requested = urlparse(redirect_uri)
+    if requested.hostname is None or not _is_loopback_host(requested.hostname):
+        return False
+    for entry in registered:
+        candidate = urlparse(entry)
+        if (
+            candidate.scheme == requested.scheme
+            and candidate.hostname is not None
+            and _is_loopback_host(candidate.hostname)
+            and candidate.hostname == requested.hostname
+            and candidate.path == requested.path
+            and candidate.params == requested.params
+            and candidate.query == requested.query
+        ):
+            return True
+    return False
+
+
+def stable_translation_origin(registered: list[str]) -> str | None:
+    """Return the one web origin shared by every non-loopback redirect."""
+    origins: set[str] = set()
+    for uri in registered:
+        parsed = urlparse(uri)
+        if parsed.hostname is None or _is_loopback_host(parsed.hostname):
+            continue
+        origin = normalized_origin(uri)
+        if origin is not None:
+            origins.add(canonical_origin_url(origin))
+    if len(origins) == 1:
+        return origins.pop()
+    return None
+
+
+def _translation_for(registered: list[str], client_id: str, redirect_uri: str) -> str:
+    """Translate a verified registration using the presented redirect origin."""
+    if not redirect_matches(registered, redirect_uri):
+        return client_id
+    return origin_client_id(redirect_uri)
+
+
+async def fetch_cimd_redirects(
+    session: aiohttp.ClientSession, client_id: str
+) -> list[str] | None:
+    """Fetch and validate a Client ID Metadata Document."""
+    if not _valid_cimd_client_id(client_id):
+        return None
+    parsed = urlparse(client_id)
+    assert parsed.hostname is not None
+    if _is_loopback_host(parsed.hostname):
+        return None
+    try:
+        ipaddress.ip_address(parsed.hostname)
+        return None
+    except ValueError:
+        pass
+
+    now = time.monotonic()
+    cached = _cimd_cache.get(client_id)
+    if cached is not None and cached[0] > now:
+        return cached[1]
+
+    try:
+        async with asyncio.timeout(CIMD_TOTAL_LOOKUP_TIMEOUT):
+            return await _lookup_cimd(session, client_id, parsed, now)
+    except TimeoutError:
+        _LOGGER.debug("CIMD lookup: total deadline exceeded for %s", client_id)
+        _cache_cimd(client_id, now, None)
+        return None
+
+
+async def _lookup_cimd(
+    session: aiohttp.ClientSession,
+    client_id: str,
+    parsed: ParseResult,
+    now: float,
+) -> list[str] | None:
+    """Resolve and fetch under the total deadline, then cache the outcome."""
+    addresses = await _resolve_public_addresses(
+        parsed.hostname or "", parsed.port or 443
+    )
+    for address in addresses:
+        reached, result = await _fetch_pinned_cimd(
+            session, client_id, parsed, address
+        )
+        if not reached:
+            continue
+        if result is None:
+            _LOGGER.debug("CIMD lookup: document at %s failed validation", client_id)
+            return None
+        _cache_cimd(client_id, now, result)
+        return result
+    _LOGGER.debug("CIMD lookup: no reachable address for %s", client_id)
+    _cache_cimd(client_id, now, None)
+    return None
+
+
+def _cache_cimd(client_id: str, now: float, result: list[str] | None) -> None:
+    """Cache positive and unreachable-host outcomes with bounded storage."""
+    _cimd_cache.pop(client_id, None)
+    if len(_cimd_cache) >= _CIMD_CACHE_MAX:
+        for key in [key for key, (exp, _) in _cimd_cache.items() if exp <= now]:
+            del _cimd_cache[key]
+    while len(_cimd_cache) >= _CIMD_CACHE_MAX:
+        del _cimd_cache[next(iter(_cimd_cache))]
+    ttl = CIMD_CACHE_TTL if result is not None else CIMD_NEGATIVE_TTL
+    _cimd_cache[client_id] = (now + ttl, result)
+
+
+def _parse_cimd(raw: bytes, client_id: str) -> list[str] | None:
+    """Strictly parse a CIMD body and return its validated redirect URIs."""
+    try:
+        document = json.loads(
+            raw.decode("utf-8"), parse_constant=_reject_json_constant
+        )
+    except (UnicodeDecodeError, ValueError, RecursionError):
+        return None
+    if (
+        not isinstance(document, dict)
+        or document.get("client_id") != client_id
+        or not isinstance(document.get("client_name"), str)
+        or not document["client_name"].strip()
+        or "client_secret" in document
+        or "client_secret_expires_at" in document
+        or document.get("token_endpoint_auth_method")
+        in ("client_secret_basic", "client_secret_jwt", "client_secret_post")
+    ):
+        return None
+    uris = document.get("redirect_uris")
+    if not isinstance(uris, list) or not uris:
+        return None
+    if not all(isinstance(uri, str) and _is_valid_redirect_uri(uri) for uri in uris):
+        return None
+    return uris
+
+
+async def resolve_forward_client_id(
+    session: aiohttp.ClientSession | None,
+    dcr_key: bytes | None,
+    client_id: str,
+    redirect_uri: str,
+) -> str:
+    """Return the validated translated identity to present to core."""
+    if not client_id or not _is_valid_redirect_uri(redirect_uri):
+        return client_id
+    parsed_client = urlparse(client_id)
+    client_origin = normalized_origin(client_id)
+    redirect_origin = normalized_origin(redirect_uri)
+    if (
+        parsed_client.scheme in ("http", "https")
+        and client_origin is not None
+        and client_origin == redirect_origin
+    ):
+        return client_id
+
+    if dcr_key is not None:
+        registered = client_redirect_uris(dcr_key, client_id)
+        if registered is not None:
+            return _translation_for(registered, client_id, redirect_uri)
+
+    if parsed_client.scheme == "https" and session is not None:
+        registered = await fetch_cimd_redirects(session, client_id)
+        if registered is not None:
+            return _translation_for(registered, client_id, redirect_uri)
+    return client_id
+
+
+class RefreshDisposition(Enum):
+    """Refresh identities that have no translated origin string."""
+
+    PASSTHROUGH = "passthrough"
+    UNREPRODUCIBLE = "unreproducible"
+
+
+async def translated_client_id_for_refresh(
+    session: aiohttp.ClientSession | None,
+    dcr_key: bytes | None,
+    client_id: str,
+) -> str | RefreshDisposition:
+    """Return a refresh identity, passthrough, or unreproducible disposition."""
+    registered: list[str] | None = None
+    if dcr_key is not None:
+        registered = client_redirect_uris(dcr_key, client_id)
+    if registered is None:
+        parsed = urlparse(client_id)
+        if parsed.scheme == "https" and session is not None:
+            registered = await fetch_cimd_redirects(session, client_id)
+    if not registered:
+        return RefreshDisposition.PASSTHROUGH
+    if not _refresh_identity_is_reproducible(registered):
+        return RefreshDisposition.UNREPRODUCIBLE
+    stable = stable_translation_origin(registered)
+    assert stable is not None
+    if origin_client_id(client_id) == stable:
+        return RefreshDisposition.PASSTHROUGH
+    return stable
+
+
+def core_token_base_url(hass: HomeAssistant) -> str:
+    """Return a trusted base URL for forwarding to core's token endpoint."""
+    api = getattr(hass.config, "api", None)
+    if api is not None and not getattr(api, "use_ssl", False):
+        return f"http://127.0.0.1:{api.port}"
+    from homeassistant.helpers.network import NoURLAvailableError, get_url
+
+    try:
+        return str(
+            get_url(
+                hass,
+                prefer_external=False,
+                allow_cloud=False,
+                require_ssl=True,
+            )
+        ).rstrip("/")
+    except NoURLAvailableError:
+        return f"https://127.0.0.1:{getattr(api, 'port', 8123)}"

--- a/homeassistant-addon-webhook-proxy-dev/start.py
+++ b/homeassistant-addon-webhook-proxy-dev/start.py
@@ -185,6 +185,11 @@ def _refuse_if_sibling_running() -> bool:
 # not only in Settings -> System -> Logs. Path kept in sync with
 # mcp_proxy_dev/__init__.py:INBOUND_LOG_FILE.
 INBOUND_LOG_FILE = Path("/config/.mcp_proxy_dev_inbound.log")
+# Touched every keep-alive iteration; the bundled integration's OAuth views
+# serve only while this file's mtime is fresh (see mcp_proxy_dev/oauth.py
+# _addon_alive) — the proxy-owned liveness signal that survives a crash where
+# _shutdown_cleanup never ran.
+HEARTBEAT_FILE = Path("/config/.mcp_proxy_dev_heartbeat")
 
 
 def _supervisor_get(path: str) -> dict | None:
@@ -1086,6 +1091,12 @@ def _shutdown_cleanup(reason: str | None) -> None:
     log_info(f"Shutting down (reason: {reason or 'unknown'})...")
     _remove_config_entry()
     try:
+        # Take the OAuth surface dark immediately on a clean stop; a crash
+        # skips this and the integration sees the mtime go stale instead.
+        HEARTBEAT_FILE.unlink(missing_ok=True)
+    except OSError as e:
+        log_error(f"Could not remove heartbeat file ({type(e).__name__}): {e}")
+    try:
         INBOUND_LOG_FILE.unlink(missing_ok=True)
     except OSError as e:
         log_error(f"Could not remove inbound log file ({type(e).__name__}): {e}")
@@ -1791,8 +1802,18 @@ def _keep_alive_loop(
     inbound_tail: dict[str, int] = {"offset": _initial_tail_offset()}
     consecutive_failures = 0
     last_health = 0.0
+    heartbeat_warned = False
     try:
         while True:
+            try:
+                HEARTBEAT_FILE.touch()
+            except OSError as e:
+                if not heartbeat_warned:
+                    heartbeat_warned = True
+                    log_error(
+                        f"Could not touch heartbeat file ({type(e).__name__}): "
+                        f"{e} — the integration's OAuth views will go dark."
+                    )
             if debug_logging:
                 _emit_new_inbound_lines(inbound_tail)
 

--- a/homeassistant-addon-webhook-proxy-dev/start.py
+++ b/homeassistant-addon-webhook-proxy-dev/start.py
@@ -1890,6 +1890,15 @@ def main() -> int:
 
     _install_integration_and_handle_restart()
 
+    # The integration's OAuth views serve only while the heartbeat is fresh,
+    # and the stale-code probe below hits one of those views — touch it BEFORE
+    # enforcement, or every clean start (the shutdown deleted the file) would
+    # misread the freshly loaded integration as stale and enter restart
+    # recovery (#2218 review).
+    try:
+        HEARTBEAT_FILE.touch()
+    except OSError as e:
+        log_error(f"Could not touch heartbeat file ({type(e).__name__}): {e}")
     _enforce_oauth_or_disable(enable_oauth)
 
     _log_startup_urls(

--- a/homeassistant-addon-webhook-proxy-dev/start.py
+++ b/homeassistant-addon-webhook-proxy-dev/start.py
@@ -1078,7 +1078,8 @@ def _install_shutdown_handlers() -> dict[str, str | None]:
 
 
 def _shutdown_cleanup(reason: str | None) -> None:
-    """Clean shutdown: restore default signal handling first so a second signal
+    """Clean shutdown: unlink the heartbeat so the integration's OAuth surface
+    goes dark immediately, restore default signal handling so a second signal
     can't abort cleanup, log why we exited, remove the config entry to
     unregister the webhook (keeping the config + component files so the next
     start needs no HA restart), and drop the inbound mirror file.
@@ -1086,16 +1087,20 @@ def _shutdown_cleanup(reason: str | None) -> None:
     On full uninstall the user may still need to manually remove
     /config/custom_components/mcp_proxy_dev/, /config/.mcp_proxy_dev_config.json, and
     /config/.mcp_proxy_dev_inbound.log, then restart HA."""
+    # Take the OAuth surface dark FIRST — before default signal handling is
+    # restored (after which a second signal kills the process outright) and
+    # before the slow HA GET/DELETE calls in _remove_config_entry. Unlinking
+    # last left a fresh heartbeat behind whenever the process was terminated
+    # mid-cleanup, keeping the OAuth routes live for the full staleness window
+    # on an add-on that was already gone (#2219 codex review).
+    try:
+        HEARTBEAT_FILE.unlink(missing_ok=True)
+    except OSError as e:
+        log_error(f"Could not remove heartbeat file ({type(e).__name__}): {e}")
     for sig in (signal.SIGTERM, signal.SIGINT):
         signal.signal(sig, signal.SIG_DFL)
     log_info(f"Shutting down (reason: {reason or 'unknown'})...")
     _remove_config_entry()
-    try:
-        # Take the OAuth surface dark immediately on a clean stop; a crash
-        # skips this and the integration sees the mtime go stale instead.
-        HEARTBEAT_FILE.unlink(missing_ok=True)
-    except OSError as e:
-        log_error(f"Could not remove heartbeat file ({type(e).__name__}): {e}")
     try:
         INBOUND_LOG_FILE.unlink(missing_ok=True)
     except OSError as e:

--- a/scripts/codeql_quality_gate.py
+++ b/scripts/codeql_quality_gate.py
@@ -397,7 +397,7 @@ ALLOWLIST: tuple[tuple[str, str, str, str, str], ...] = (
         "py/clear-text-storage-sensitive-data",
         "homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/__init__.py",
         "as clear text",
-        "",
+        "DCR_SECRET_FILE.write_bytes(new_secret)",
         "Warned fallback (DCR signing key, same pattern as the OAuth signing "
         "key in oauth.py): load_or_create_dcr_secret writes via "
         "_atomic_write_0600 first; the flagged plain write only runs when the "

--- a/scripts/codeql_quality_gate.py
+++ b/scripts/codeql_quality_gate.py
@@ -395,6 +395,17 @@ ALLOWLIST: tuple[tuple[str, str, str, str, str], ...] = (
     ),
     (
         "py/clear-text-storage-sensitive-data",
+        "homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/__init__.py",
+        "as clear text",
+        "",
+        "Warned fallback (DCR signing key, same pattern as the OAuth signing "
+        "key in oauth.py): load_or_create_dcr_secret writes via "
+        "_atomic_write_0600 first; the flagged plain write only runs when the "
+        "filesystem cannot honor 0600 and it logs a warning. Persisting the "
+        "key is the feature (registered client_ids must survive restarts).",
+    ),
+    (
+        "py/clear-text-storage-sensitive-data",
         "homeassistant-addon-webhook-proxy/start.py",
         "as clear text",
         "",

--- a/tests/addon/test_webhook_proxy.py
+++ b/tests/addon/test_webhook_proxy.py
@@ -3911,6 +3911,39 @@ class TestTokenView:
             == 'Basic realm="MCP Proxy OAuth"'
         )
 
+    async def test_basic_auth_accepts_raw_unencoded_configured_creds(
+        self, setup, tmp_path
+    ):
+        """#2218 review: configured credentials may contain '+' or '%XX'; a
+        naive client sends them un-encoded in Basic auth, and the decoded
+        candidate alone would mangle them (unquote_plus turns '+' into a
+        space). The raw split must authenticate too."""
+        oauth, _provider, _view = setup
+        provider = oauth.OAuthProvider(
+            hass=MagicMock(),
+            client_id="configured-client+id",
+            client_secret="se%41cret+x",
+            webhook_id="mcp_webhook_id_aaaa",
+            signing_key=b"\x00" * 32,
+            public_base_url=None,
+        )
+        view = oauth.TokenView(provider)
+        request = _make_view_request(
+            method="POST",
+            headers={
+                "Authorization": self._basic_header(
+                    "configured-client+id", "se%41cret+x"
+                )
+            },
+            post_data={"grant_type": "unsupported_probe"},
+        )
+
+        with patch.object(oauth.web, "json_response") as resp_ctor:
+            await view.post(request)
+
+        # Authentication succeeded; the probe grant fails AFTER the gate.
+        assert resp_ctor.call_args.args[0]["error"] == "unsupported_grant_type"
+
     async def test_invalid_client_via_form_returns_401(self, setup):
         oauth, provider, view = setup
         request = _make_view_request(

--- a/tests/addon/test_webhook_proxy.py
+++ b/tests/addon/test_webhook_proxy.py
@@ -411,6 +411,21 @@ def _autoapprove_any_redirect() -> bool:
     return "without a client allowlist" in _component_src("oauth_autoapprove.py")
 
 
+def _require_webhook_logger(mod) -> None:
+    """Skip only a flavor that genuinely predates the webhook-logger raise.
+
+    Feature-detected rather than keyed on the flavor name, so the promote
+    transform starts running these on stable the moment the code lands there
+    — a hard-coded flavor skip would silently stay off forever. Dev always
+    leads stable, so a missing attribute THERE is a real regression, not a
+    not-yet-promoted capability, and must fail rather than skip.
+    """
+    if hasattr(mod, "_WEBHOOK_LOGGER"):
+        return
+    assert CURRENT["key"] != "dev", "dev must ship the webhook-logger raise"
+    pytest.skip("flavor predates the webhook-logger raise")
+
+
 def _none_autoapprove_supported() -> bool:
     """Feature-detect whether the CURRENT flavor ships none-mode auto-approve
     discovery (its `oauth_autoapprove.py` module, issue #1969). The stable
@@ -1835,8 +1850,7 @@ class TestDebugLogging:
         for this id" — HA answers an empty 200 for an unregistered webhook and
         logs the reason on ITS logger, invisible by default. The toggle raises
         that logger too, and undoes only its own raise."""
-        if not hasattr(mod, "_WEBHOOK_LOGGER"):
-            pytest.skip("flavor predates the webhook-logger raise")
+        _require_webhook_logger(mod)
 
         await self._run_setup(mod, hass, debug=True)
         assert mod._WEBHOOK_LOGGER.getEffectiveLevel() <= logging.INFO
@@ -1847,8 +1861,7 @@ class TestDebugLogging:
     async def test_debug_toggle_never_lowers_an_explicit_user_level(self, mod, hass):
         """A user who set DEBUG via HA's `logger:` config keeps it: we only
         ever raise a less-verbose logger, and only undo our own raise."""
-        if not hasattr(mod, "_WEBHOOK_LOGGER"):
-            pytest.skip("flavor predates the webhook-logger raise")
+        _require_webhook_logger(mod)
         mod._WEBHOOK_LOGGER.setLevel(logging.DEBUG)
 
         await self._run_setup(mod, hass, debug=True)

--- a/tests/addon/test_webhook_proxy.py
+++ b/tests/addon/test_webhook_proxy.py
@@ -4,6 +4,7 @@ Structure tests verify addon files and config.yaml.
 Unit tests mock Supervisor API calls to test discovery logic in start.py.
 """
 
+import contextlib
 import importlib
 import importlib.util
 import json
@@ -31,11 +32,6 @@ WEBHOOK_PROXY_VARIANTS = {
         "config_file": "/config/.mcp_proxy_config.json",
         "inbound_log": "/config/.mcp_proxy_inbound.log",
         "oauth_marker": "/config/.mcp_proxy_oauth_restart_required",
-        "autoapprove_any_redirect": False,
-        "unified_oauth_routes": False,
-        "proxy_owned_oauth_endpoints": False,
-        "dcr_registration": False,
-        "dedicated_cimd_session": False,
         "sibling_base": "ha_mcp_webhook_proxy_dev",
         "mutex_id": "mcp_proxy_mutex",
     },
@@ -49,11 +45,6 @@ WEBHOOK_PROXY_VARIANTS = {
         "config_file": "/config/.mcp_proxy_dev_config.json",
         "inbound_log": "/config/.mcp_proxy_dev_inbound.log",
         "oauth_marker": "/config/.mcp_proxy_dev_oauth_restart_required",
-        "autoapprove_any_redirect": True,
-        "unified_oauth_routes": True,
-        "proxy_owned_oauth_endpoints": True,
-        "dcr_registration": True,
-        "dedicated_cimd_session": True,
         "sibling_base": "ha_mcp_webhook_proxy",
         "mutex_id": "mcp_proxy_dev_mutex",
     },
@@ -367,9 +358,57 @@ def test_heartbeat_touch_precedes_oauth_enforcement():
         start_src = Path(variant["addon_dir"], "start.py").read_text()
         if "HEARTBEAT_FILE" not in start_src:
             continue  # flavor predates the heartbeat gate
-        touch = start_src.index("HEARTBEAT_FILE.touch()")
-        enforce = start_src.index("_enforce_oauth_or_disable(enable_oauth)")
+        # Slice main()'s body: _keep_alive_loop is DEFINED earlier in the file
+        # and touches the heartbeat too, so a whole-file index() would be
+        # satisfied by that unrelated touch even with main()'s deleted.
+        body = start_src[start_src.index("\ndef main(") :]
+        assert "HEARTBEAT_FILE.touch()" in body, variant["key"]
+        touch = body.index("HEARTBEAT_FILE.touch()")
+        enforce = body.index("_enforce_oauth_or_disable(enable_oauth)")
         assert touch < enforce, variant["key"]
+
+
+def _component_src(name: str) -> str:
+    """Source of a component module in the CURRENT flavor, "" when absent."""
+    path = os.path.join(PROXY_ADDON_DIR, CURRENT["component"], name)
+    if not os.path.exists(path):
+        return ""
+    with open(path, encoding="utf-8") as fh:
+        return fh.read()
+
+
+def _unified_oauth_routes() -> bool:
+    """Feature-detect the unified scoped authorize/token dispatchers.
+
+    The marker is the legacy handler they dispatch INTO: the scoped URL alone
+    is not distinguishing, because the none-mode-only view that predates
+    unification binds the same path. Stable gains this on promotion — same
+    lockstep-with-code approach as `_ha_auth_supported`."""
+    return "handle_legacy_authorize_get" in _component_src("oauth_autoapprove.py")
+
+
+def _dcr_registration_supported() -> bool:
+    """Feature-detect the stateless DCR registration endpoint."""
+    return "DcrRegisterView" in _component_src("oauth_dcr.py")
+
+
+def _dedicated_cimd_session() -> bool:
+    """Feature-detect the isolated CIMD connector pool."""
+    return "cimd_session" in _component_src("__init__.py")
+
+
+def _proxy_owned_oauth_endpoints() -> bool:
+    """Feature-detect that the ha_auth AS document advertises proxy-owned
+    endpoints under OAUTH_BASE rather than core's own /auth/* routes."""
+    return '"authorization_endpoint": f"{base}{OAUTH_BASE}/authorize"' in (
+        _component_src("auth_native.py")
+    )
+
+
+def _autoapprove_any_redirect() -> bool:
+    """Feature-detect none-mode accepting any valid redirect (the claude.ai
+    client allowlist retired)."""
+    return "without a client allowlist" in _component_src("oauth_autoapprove.py")
 
 
 def _none_autoapprove_supported() -> bool:
@@ -1664,7 +1703,7 @@ class TestOAuthOffPreservesBehavior:
             assert (
                 hass.data[mod.DOMAIN]["oauth_mode"] == mod.OAUTH_MODE_NONE_AUTOAPPROVE
             )
-        if CURRENT["dcr_registration"]:
+        if _dcr_registration_supported():
             # The none-mode surface now serves stateless DCR, keyed by the
             # signing secret loaded at setup.
             expected |= {"dcr_signing_key"}
@@ -1818,7 +1857,7 @@ class TestDebugLogging:
             # Dev's OAuth-off path also serves none-mode auto-approve discovery
             # (issue #1969): provider under "autoapprove" + the mode marker.
             expected |= {"autoapprove", "oauth_mode"}
-        if CURRENT["dcr_registration"]:
+        if _dcr_registration_supported():
             expected |= {"dcr_signing_key"}
         assert set(hass.data[mod.DOMAIN].keys()) == expected
 
@@ -2450,7 +2489,7 @@ class TestOAuthSetupEntry:
         expected_views = (
             4
             + len(_wellknown_oauth_urls(oauth, "mcp_test"))
-            + (2 if CURRENT["unified_oauth_routes"] else 0)
+            + (2 if _unified_oauth_routes() else 0)
         )
         assert hass.http.register_view.call_count == expected_views
         # Successful OAuth setup records that THIS flavor owns the root routes,
@@ -2715,7 +2754,7 @@ class TestOAuthRestartRepairTrigger:
         hass.data[mod.OAUTH_ROUTE_KEY_FINGERPRINT] = mod._oauth_route_fingerprint(
             creds["client_id"], creds["client_secret"], fixed_key
         )
-        if CURRENT["unified_oauth_routes"]:
+        if _unified_oauth_routes():
             # Same premise as the seeded fingerprint: the unified scoped
             # dispatchers were also bound earlier this session (guard key in
             # oauth_autoapprove.py), so the reload must reuse them.
@@ -2777,7 +2816,7 @@ class TestOAuthRestartRepairTrigger:
         # DIFFERENT (now-stale) identity than the creds we're reloading with.
         hass.data[mod.OAUTH_ROUTE_OWNER_KEY] = mod.DOMAIN
         hass.data[mod.OAUTH_ROUTE_KEY_FINGERPRINT] = "stale-fingerprint"
-        if CURRENT["unified_oauth_routes"]:
+        if _unified_oauth_routes():
             hass.data[
                 f"webhook_proxy_oauth_autoapprove_views_registered_{mod.DOMAIN}"
             ] = True
@@ -3433,9 +3472,7 @@ class TestAuthorizationServerView:
         assert body["issuer"].endswith(CURRENT["oauth_base"])
         # The dev mirror advertises its mode-dispatched scoped routes; stable
         # keeps the legacy root aliases until the promote workflow carries it.
-        route_base = (
-            CURRENT["oauth_base"] if CURRENT["proxy_owned_oauth_endpoints"] else ""
-        )
+        route_base = CURRENT["oauth_base"] if _proxy_owned_oauth_endpoints() else ""
         assert body["authorization_endpoint"] == (
             f"https://legit.example{route_base}/authorize"
         )
@@ -3722,14 +3759,38 @@ class TestShutdownAndWebhookErrors:
         log_file.write_text("x\n")
         old = (signal.getsignal(signal.SIGTERM), signal.getsignal(signal.SIGINT))
         logs: list[str] = []
+        # The heartbeat gate is dev-only until promoted — same
+        # lockstep-with-code feature detection as `_ha_auth_supported`.
+        has_heartbeat = hasattr(start, "HEARTBEAT_FILE")
+        heartbeat = tmp_path / "heartbeat"
+        heartbeat.write_text("")
+        seen: dict[str, bool] = {}
+
+        def _record_then_remove():
+            # Captured DURING the slow HA call: the surface must already be
+            # dark by now, so a mid-cleanup kill can't leave it serving.
+            seen["heartbeat_alive"] = heartbeat.exists()
+
         try:
-            with (
-                patch.object(start, "INBOUND_LOG_FILE", log_file),
-                patch.object(start, "_remove_config_entry") as rm,
-                patch.object(start, "log_info", side_effect=logs.append),
-            ):
+            with contextlib.ExitStack() as stack:
+                stack.enter_context(patch.object(start, "INBOUND_LOG_FILE", log_file))
+                rm = stack.enter_context(
+                    patch.object(
+                        start, "_remove_config_entry", side_effect=_record_then_remove
+                    )
+                )
+                stack.enter_context(
+                    patch.object(start, "log_info", side_effect=logs.append)
+                )
+                if has_heartbeat:
+                    stack.enter_context(
+                        patch.object(start, "HEARTBEAT_FILE", heartbeat)
+                    )
                 start._shutdown_cleanup("SIGTERM")
             rm.assert_called_once()
+            if has_heartbeat:
+                assert not heartbeat.exists()  # OAuth surface taken dark
+                assert seen["heartbeat_alive"] is False  # ...before the HA calls
             assert not log_file.exists()  # mirror file dropped
             assert any("reason: SIGTERM" in m for m in logs)
             # Handlers restored to default so a second signal can't abort cleanup.
@@ -4739,7 +4800,7 @@ class TestOAuthSetupEntryRegistersExpectedViews:
             "/authorize",
             "/token",
         } | _wellknown_oauth_urls(oauth, "mcp_test")
-        if CURRENT["unified_oauth_routes"]:
+        if _unified_oauth_routes():
             # The unified scoped dispatchers bind in every mode; the root
             # views above stay as the legacy compatibility aliases.
             expected |= {
@@ -4862,12 +4923,12 @@ class TestHaAuthMode:
             f"{CURRENT['oauth_base']}/protected-resource",
             f"{CURRENT['oauth_base']}/authorization-server",
         } | _wellknown_oauth_urls(oauth, "mcp_test")
-        if CURRENT["unified_oauth_routes"]:
+        if _unified_oauth_routes():
             expected |= {
                 f"{CURRENT['oauth_base']}/authorize",
                 f"{CURRENT['oauth_base']}/token",
             }
-        if CURRENT["dcr_registration"]:
+        if _dcr_registration_supported():
             expected.add(f"{CURRENT['oauth_base']}/register")
         assert registered == expected
         assert len(registered) == len(expected)
@@ -4890,7 +4951,7 @@ class TestHaAuthMode:
         self, hass, tmp_path
     ):
         """The dev parity surface persists DCR and isolates public lookups."""
-        if not CURRENT["dedicated_cimd_session"]:
+        if not _dedicated_cimd_session():
             pytest.skip("dedicated CIMD session has not been promoted")
         mod, _oauth, _auth_native = _import_ha_auth_stack(tmp_secret_dir=tmp_path)
         _bind_repairs(mod, tmp_path)
@@ -4929,7 +4990,7 @@ class TestHaAuthMode:
         cimd_session = MagicMock()
         cimd_session.close = AsyncMock()
         sessions = [relay_session]
-        if CURRENT["dedicated_cimd_session"]:
+        if _dedicated_cimd_session():
             sessions.append(cimd_session)
         with (
             patch.object(mod, "_read_config", return_value=self._ha_auth_config()),
@@ -4949,7 +5010,7 @@ class TestHaAuthMode:
         assert "Failed to enable OAuth" in str(exc_info.value)
         mock_unreg.assert_called_once_with(hass, "mcp_test")
         relay_session.close.assert_awaited_once()
-        if CURRENT["dedicated_cimd_session"]:
+        if _dedicated_cimd_session():
             cimd_session.close.assert_awaited_once()
         else:
             cimd_session.close.assert_not_awaited()
@@ -5014,8 +5075,8 @@ class TestHaAuthMode:
             await mod.async_setup_entry(hass, MagicMock())
         assert first == (
             7
-            + (2 if CURRENT["unified_oauth_routes"] else 0)
-            + (1 if CURRENT["dcr_registration"] else 0)
+            + (2 if _unified_oauth_routes() else 0)
+            + (1 if _dcr_registration_supported() else 0)
         )
         assert hass.http.register_view.call_count == 0
         # The register-once flag lives in oauth.py (a top-level hass.data key),
@@ -5041,8 +5102,8 @@ class TestHaAuthMode:
             await mod.async_setup_entry(hass, MagicMock())
             assert hass.http.register_view.call_count == (
                 7
-                + (2 if CURRENT["unified_oauth_routes"] else 0)
-                + (1 if CURRENT["dcr_registration"] else 0)
+                + (2 if _unified_oauth_routes() else 0)
+                + (1 if _dcr_registration_supported() else 0)
             )
             flag_key = oauth._METADATA_VIEWS_REGISTERED_KEY
             assert hass.data[flag_key] is True
@@ -5091,8 +5152,8 @@ class TestHaAuthMode:
             await mod.async_setup_entry(hass, MagicMock())  # ha_auth discovery
             assert hass.http.register_view.call_count == (
                 7
-                + (2 if CURRENT["unified_oauth_routes"] else 0)
-                + (1 if CURRENT["dcr_registration"] else 0)
+                + (2 if _unified_oauth_routes() else 0)
+                + (1 if _dcr_registration_supported() else 0)
             )
             hass.http.register_view.reset_mock()
             await mod.async_setup_entry(hass, MagicMock())  # legacy: only 2 root
@@ -5122,11 +5183,11 @@ class TestHaAuthMode:
         ):
             await mod.async_setup_entry(hass, MagicMock())  # legacy views + root
             assert hass.http.register_view.call_count == (
-                11 if CURRENT["unified_oauth_routes"] else 9
+                11 if _unified_oauth_routes() else 9
             )
             hass.http.register_view.reset_mock()
             await mod.async_setup_entry(hass, MagicMock())  # ha_auth: reuse all
-        if CURRENT["dcr_registration"]:
+        if _dcr_registration_supported():
             assert [
                 call.args[0].url for call in hass.http.register_view.call_args_list
             ] == [f"{CURRENT['oauth_base']}/register"]
@@ -5261,9 +5322,7 @@ class TestHaAuthMode:
             await oauth.AuthorizationServerMetadataView(rs).get(request)
         doc = jr.call_args.args[0]
         assert doc["issuer"] == f"https://legit.example{oauth.OAUTH_BASE}"
-        route_base = (
-            oauth.OAUTH_BASE if CURRENT["proxy_owned_oauth_endpoints"] else "/auth"
-        )
+        route_base = oauth.OAUTH_BASE if _proxy_owned_oauth_endpoints() else "/auth"
         assert doc["authorization_endpoint"] == (
             f"https://legit.example{route_base}/authorize"
         )
@@ -5273,7 +5332,7 @@ class TestHaAuthMode:
         assert doc["code_challenge_methods_supported"] == ["S256"]
         assert doc["token_endpoint_auth_methods_supported"] == ["none"]
         assert doc["client_id_metadata_document_supported"] is True
-        if CURRENT["dcr_registration"]:
+        if _dcr_registration_supported():
             assert doc["registration_endpoint"] == (
                 f"https://legit.example{oauth.OAUTH_BASE}/register"
             )
@@ -5711,9 +5770,7 @@ class TestHaAuthMode:
         # It is genuinely the ha_auth document (public client + CIMD), not legacy.
         assert canonical["token_endpoint_auth_methods_supported"] == ["none"]
         assert canonical["client_id_metadata_document_supported"] is True
-        route_base = (
-            oauth.OAUTH_BASE if CURRENT["proxy_owned_oauth_endpoints"] else "/auth"
-        )
+        route_base = oauth.OAUTH_BASE if _proxy_owned_oauth_endpoints() else "/auth"
         assert canonical["authorization_endpoint"] == (
             f"https://legit.example{route_base}/authorize"
         )
@@ -5771,9 +5828,7 @@ class TestHaAuthMode:
         assert doc["client_id_metadata_document_supported"] is True
         # Host-derived base from the request, NOT the bound provider's pin.
         assert doc["issuer"] == f"https://switch-host.example{oauth.OAUTH_BASE}"
-        route_base = (
-            oauth.OAUTH_BASE if CURRENT["proxy_owned_oauth_endpoints"] else "/auth"
-        )
+        route_base = oauth.OAUTH_BASE if _proxy_owned_oauth_endpoints() else "/auth"
         assert doc["authorization_endpoint"] == (
             f"https://switch-host.example{route_base}/authorize"
         )
@@ -5811,7 +5866,7 @@ class TestHaAuthMode:
         assert "client_id_metadata_document_supported" not in doc
         # Pinned base from public_base_url, NOT the request Host.
         assert doc["issuer"] == f"https://pinned-legacy.example{oauth.OAUTH_BASE}"
-        route_base = oauth.OAUTH_BASE if CURRENT["proxy_owned_oauth_endpoints"] else ""
+        route_base = oauth.OAUTH_BASE if _proxy_owned_oauth_endpoints() else ""
         assert doc["authorization_endpoint"] == (
             f"https://pinned-legacy.example{route_base}/authorize"
         )
@@ -6339,7 +6394,7 @@ class TestNoneAutoApproveMode:
         # The two fields HA core's root doc lacks — the whole reason for #1969.
         assert doc["token_endpoint_auth_methods_supported"] == ["none"]
         assert doc["client_id_metadata_document_supported"] is True
-        if CURRENT["dcr_registration"]:
+        if _dcr_registration_supported():
             assert doc["registration_endpoint"] == (f"https://x.example{base}/register")
         else:
             assert "registration_endpoint" not in doc
@@ -6418,7 +6473,7 @@ class TestNoneAutoApproveMode:
 
     def test_redirect_gate_matches_flavor_policy(self):
         _mod, _oauth, autoapprove, _an = _import_none_autoapprove_stack()
-        if CURRENT["autoapprove_any_redirect"]:
+        if _autoapprove_any_redirect():
             base = {
                 "response_type": "code",
                 "code_challenge": "A" * 43,
@@ -6541,7 +6596,7 @@ class TestNoneAutoApproveMode:
             patch.object(autoapprove.web, "Response") as resp,
         ):
             await view.get(request)
-        if CURRENT["autoapprove_any_redirect"]:
+        if _autoapprove_any_redirect():
             resp.assert_called_once()
             assert resp.call_args.kwargs["status"] == 302
             jr.assert_not_called()
@@ -6691,7 +6746,7 @@ class TestNoneAutoApproveMode:
             f"{CURRENT['oauth_base']}/authorize",
             f"{CURRENT['oauth_base']}/token",
         }
-        if CURRENT["dcr_registration"]:
+        if _dcr_registration_supported():
             autoapprove_urls.add(f"{CURRENT['oauth_base']}/register")
         assert registered == metadata | autoapprove_urls
         assert len(registered) == len(metadata | autoapprove_urls)
@@ -6700,7 +6755,7 @@ class TestNoneAutoApproveMode:
         assert isinstance(
             hass.data[mod.DOMAIN]["autoapprove"], autoapprove.AutoApproveProvider
         )
-        if CURRENT["dcr_registration"]:
+        if _dcr_registration_supported():
             assert hass.data[mod.DOMAIN]["dcr_signing_key"] == (
                 mod.DCR_SECRET_FILE.read_bytes()
             )
@@ -6775,7 +6830,7 @@ class TestNoneAutoApproveMode:
         hass.data[oauth.DOMAIN] = {"oauth_mode": oauth.MODE_HA_AUTH, "oauth": rs}
         with patch.object(oauth.web, "json_response") as jr:
             await view.get(request)
-        ha_route_base = base if CURRENT["proxy_owned_oauth_endpoints"] else "/auth"
+        ha_route_base = base if _proxy_owned_oauth_endpoints() else "/auth"
         assert jr.call_args.args[0]["authorization_endpoint"] == (
             f"https://legit.example{ha_route_base}/authorize"
         )

--- a/tests/addon/test_webhook_proxy.py
+++ b/tests/addon/test_webhook_proxy.py
@@ -292,6 +292,12 @@ def _import_oauth(tmp_secret_dir=None):
     mod = importlib.util.module_from_spec(spec)
     sys.modules[mod_name] = mod
     spec.loader.exec_module(mod)
+    if hasattr(mod, "_backend_alive"):
+
+        async def _backend_alive(_hass):
+            return True
+
+        mod._backend_alive = _backend_alive
     if tmp_secret_dir is not None:
         mod.SECRET_FILE = Path(tmp_secret_dir) / ".mcp_proxy_oauth_secret"
     return mod
@@ -393,6 +399,12 @@ def _load_pkg_submodule(pkg_name, component_dir, sub):
     m = importlib.util.module_from_spec(spec)
     sys.modules[name] = m
     spec.loader.exec_module(m)
+    if sub == "oauth" and hasattr(m, "_backend_alive"):
+
+        async def _backend_alive(_hass):
+            return True
+
+        m._backend_alive = _backend_alive
     return m
 
 

--- a/tests/addon/test_webhook_proxy.py
+++ b/tests/addon/test_webhook_proxy.py
@@ -357,6 +357,21 @@ def _ha_auth_supported() -> bool:
     )
 
 
+def test_heartbeat_touch_precedes_oauth_enforcement():
+    """#2218 review: main() must touch the heartbeat BEFORE the fail-closed
+    stale-code probe — that probe hits a heartbeat-gated OAuth view, and the
+    clean-shutdown path deletes the file, so probing first would misread
+    every fresh start as stale code and enter restart recovery. Applies to
+    flavors that ship the heartbeat gate (feature-detected)."""
+    for variant in WEBHOOK_PROXY_VARIANTS.values():
+        start_src = Path(variant["addon_dir"], "start.py").read_text()
+        if "HEARTBEAT_FILE" not in start_src:
+            continue  # flavor predates the heartbeat gate
+        touch = start_src.index("HEARTBEAT_FILE.touch()")
+        enforce = start_src.index("_enforce_oauth_or_disable(enable_oauth)")
+        assert touch < enforce, variant["key"]
+
+
 def _none_autoapprove_supported() -> bool:
     """Feature-detect whether the CURRENT flavor ships none-mode auto-approve
     discovery (its `oauth_autoapprove.py` module, issue #1969). The stable

--- a/tests/addon/test_webhook_proxy.py
+++ b/tests/addon/test_webhook_proxy.py
@@ -1819,9 +1819,42 @@ class TestDebugLogging:
         # deterministic.
         mod._LOGGER.setLevel(logging.NOTSET)
         mod._LOGGER_LEVEL_RAISED = False
+        if hasattr(mod, "_WEBHOOK_LOGGER"):
+            mod._WEBHOOK_LOGGER.setLevel(logging.NOTSET)
+            mod._WEBHOOK_LOGGER_LEVEL_RAISED = False
         yield
         mod._LOGGER.setLevel(logging.NOTSET)
         mod._LOGGER_LEVEL_RAISED = False
+        if hasattr(mod, "_WEBHOOK_LOGGER"):
+            mod._WEBHOOK_LOGGER.setLevel(logging.NOTSET)
+            mod._WEBHOOK_LOGGER_LEVEL_RAISED = False
+
+    async def test_debug_on_also_surfaces_has_webhook_logger(self, mod, hass):
+        """#2220: with the toggle on and NO inbound lines, the user still can't
+        tell "request never arrived" from "arrived but nothing is registered
+        for this id" — HA answers an empty 200 for an unregistered webhook and
+        logs the reason on ITS logger, invisible by default. The toggle raises
+        that logger too, and undoes only its own raise."""
+        if not hasattr(mod, "_WEBHOOK_LOGGER"):
+            pytest.skip("flavor predates the webhook-logger raise")
+
+        await self._run_setup(mod, hass, debug=True)
+        assert mod._WEBHOOK_LOGGER.getEffectiveLevel() <= logging.INFO
+
+        await self._run_setup(mod, hass, debug=False)
+        assert mod._WEBHOOK_LOGGER.level == logging.NOTSET
+
+    async def test_debug_toggle_never_lowers_an_explicit_user_level(self, mod, hass):
+        """A user who set DEBUG via HA's `logger:` config keeps it: we only
+        ever raise a less-verbose logger, and only undo our own raise."""
+        if not hasattr(mod, "_WEBHOOK_LOGGER"):
+            pytest.skip("flavor predates the webhook-logger raise")
+        mod._WEBHOOK_LOGGER.setLevel(logging.DEBUG)
+
+        await self._run_setup(mod, hass, debug=True)
+        await self._run_setup(mod, hass, debug=False)
+
+        assert mod._WEBHOOK_LOGGER.level == logging.DEBUG
 
     async def _run_setup(self, mod, hass, debug):
         proxy_config = {

--- a/tests/addon/test_webhook_proxy.py
+++ b/tests/addon/test_webhook_proxy.py
@@ -1649,6 +1649,10 @@ class TestOAuthOffPreservesBehavior:
             assert (
                 hass.data[mod.DOMAIN]["oauth_mode"] == mod.OAUTH_MODE_NONE_AUTOAPPROVE
             )
+        if CURRENT["dcr_registration"]:
+            # The none-mode surface now serves stateless DCR, keyed by the
+            # signing secret loaded at setup.
+            expected |= {"dcr_signing_key"}
         assert set(hass.data[mod.DOMAIN].keys()) == expected
 
     async def test_setup_does_not_import_oauth_module_when_off(self, mod, hass):
@@ -1799,6 +1803,8 @@ class TestDebugLogging:
             # Dev's OAuth-off path also serves none-mode auto-approve discovery
             # (issue #1969): provider under "autoapprove" + the mode marker.
             expected |= {"autoapprove", "oauth_mode"}
+        if CURRENT["dcr_registration"]:
+            expected |= {"dcr_signing_key"}
         assert set(hass.data[mod.DOMAIN].keys()) == expected
 
     async def test_debug_on_stores_flag(self, mod, hass):
@@ -2424,8 +2430,13 @@ class TestOAuthSetupEntry:
         assert provider is not None
         assert provider.client_id == "client-1234567890ABCDEF"
         # 4 core OAuth views, plus the well-known metadata variants on flavors
-        # that ship them (feature-detected — see _wellknown_oauth_urls).
-        expected_views = 4 + len(_wellknown_oauth_urls(oauth, "mcp_test"))
+        # that ship them (feature-detected — see _wellknown_oauth_urls), plus
+        # the two unified scoped dispatchers that legacy mode now also binds.
+        expected_views = (
+            4
+            + len(_wellknown_oauth_urls(oauth, "mcp_test"))
+            + (2 if CURRENT["unified_oauth_routes"] else 0)
+        )
         assert hass.http.register_view.call_count == expected_views
         # Successful OAuth setup records that THIS flavor owns the root routes,
         # so the sibling flavor refuses loudly instead of shadowing them.
@@ -2689,6 +2700,13 @@ class TestOAuthRestartRepairTrigger:
         hass.data[mod.OAUTH_ROUTE_KEY_FINGERPRINT] = mod._oauth_route_fingerprint(
             creds["client_id"], creds["client_secret"], fixed_key
         )
+        if CURRENT["unified_oauth_routes"]:
+            # Same premise as the seeded fingerprint: the unified scoped
+            # dispatchers were also bound earlier this session (guard key in
+            # oauth_autoapprove.py), so the reload must reuse them.
+            hass.data[
+                f"webhook_proxy_oauth_autoapprove_views_registered_{mod.DOMAIN}"
+            ] = True
         repairs.RESTART_MARKER_FILE.write_text('{"reason": "stale"}')
         with (
             patch.object(mod, "_read_config", return_value=self._oauth_config()),
@@ -2744,6 +2762,10 @@ class TestOAuthRestartRepairTrigger:
         # DIFFERENT (now-stale) identity than the creds we're reloading with.
         hass.data[mod.OAUTH_ROUTE_OWNER_KEY] = mod.DOMAIN
         hass.data[mod.OAUTH_ROUTE_KEY_FINGERPRINT] = "stale-fingerprint"
+        if CURRENT["unified_oauth_routes"]:
+            hass.data[
+                f"webhook_proxy_oauth_autoapprove_views_registered_{mod.DOMAIN}"
+            ] = True
         with (
             patch.object(mod, "_read_config", return_value=self._oauth_config()),
             patch.object(mod, "async_register"),
@@ -3302,7 +3324,13 @@ def _provider_for_view_tests(tmp_path, public_base_url=None):
 
 
 def _make_view_request(
-    *, headers=None, query=None, method="GET", post_data=None, scheme="https"
+    *,
+    headers=None,
+    query=None,
+    method="GET",
+    post_data=None,
+    scheme="https",
+    path="/authorize",
 ):
     """Mock a starlette/aiohttp-style web.Request with the bits the views read."""
     req = MagicMock()
@@ -3310,6 +3338,7 @@ def _make_view_request(
     req.query = query or {}
     req.method = method
     req.scheme = scheme
+    req.path = path
     if post_data is not None:
         req.post = AsyncMock(return_value=post_data)
     return req
@@ -4662,6 +4691,13 @@ class TestOAuthSetupEntryRegistersExpectedViews:
             "/authorize",
             "/token",
         } | _wellknown_oauth_urls(oauth, "mcp_test")
+        if CURRENT["unified_oauth_routes"]:
+            # The unified scoped dispatchers bind in every mode; the root
+            # views above stay as the legacy compatibility aliases.
+            expected |= {
+                f"{CURRENT['oauth_base']}/authorize",
+                f"{CURRENT['oauth_base']}/token",
+            }
         assert registered_urls == expected
 
 
@@ -4756,9 +4792,7 @@ class TestHaAuthMode:
 
     # ---- setup registers discovery and dev unified views, no root views ----
 
-    async def test_setup_registers_oauth_surface_and_marks_mode(
-        self, hass, tmp_path
-    ):
+    async def test_setup_registers_oauth_surface_and_marks_mode(self, hass, tmp_path):
         mod, oauth, auth_native = _import_ha_auth_stack(tmp_secret_dir=tmp_path)
         repairs = _bind_repairs(mod, tmp_path)
         repairs.RESTART_MARKER_FILE.write_text('{"reason": "stale"}')
@@ -5046,8 +5080,7 @@ class TestHaAuthMode:
             await mod.async_setup_entry(hass, MagicMock())  # ha_auth: reuse all
         if CURRENT["dcr_registration"]:
             assert [
-                call.args[0].url
-                for call in hass.http.register_view.call_args_list
+                call.args[0].url for call in hass.http.register_view.call_args_list
             ] == [f"{CURRENT['oauth_base']}/register"]
         else:
             assert hass.http.register_view.call_count == 0
@@ -5730,9 +5763,7 @@ class TestHaAuthMode:
         assert "client_id_metadata_document_supported" not in doc
         # Pinned base from public_base_url, NOT the request Host.
         assert doc["issuer"] == f"https://pinned-legacy.example{oauth.OAUTH_BASE}"
-        route_base = (
-            oauth.OAUTH_BASE if CURRENT["proxy_owned_oauth_endpoints"] else ""
-        )
+        route_base = oauth.OAUTH_BASE if CURRENT["proxy_owned_oauth_endpoints"] else ""
         assert doc["authorization_endpoint"] == (
             f"https://pinned-legacy.example{route_base}/authorize"
         )
@@ -6261,9 +6292,7 @@ class TestNoneAutoApproveMode:
         assert doc["token_endpoint_auth_methods_supported"] == ["none"]
         assert doc["client_id_metadata_document_supported"] is True
         if CURRENT["dcr_registration"]:
-            assert doc["registration_endpoint"] == (
-                f"https://x.example{base}/register"
-            )
+            assert doc["registration_endpoint"] == (f"https://x.example{base}/register")
         else:
             assert "registration_endpoint" not in doc
 

--- a/tests/addon/test_webhook_proxy.py
+++ b/tests/addon/test_webhook_proxy.py
@@ -314,12 +314,12 @@ def _import_oauth(tmp_secret_dir=None):
     mod = importlib.util.module_from_spec(spec)
     sys.modules[mod_name] = mod
     spec.loader.exec_module(mod)
-    if hasattr(mod, "_backend_alive"):
+    if hasattr(mod, "_addon_alive"):
 
-        async def _backend_alive(_hass):
+        async def _addon_alive(_hass):
             return True
 
-        mod._backend_alive = _backend_alive
+        mod._addon_alive = _addon_alive
     if tmp_secret_dir is not None:
         mod.SECRET_FILE = Path(tmp_secret_dir) / ".mcp_proxy_oauth_secret"
     return mod
@@ -431,12 +431,12 @@ def _load_pkg_submodule(pkg_name, component_dir, sub):
     m = importlib.util.module_from_spec(spec)
     sys.modules[name] = m
     spec.loader.exec_module(m)
-    if sub == "oauth" and hasattr(m, "_backend_alive"):
+    if sub == "oauth" and hasattr(m, "_addon_alive"):
 
-        async def _backend_alive(_hass):
+        async def _addon_alive(_hass):
             return True
 
-        m._backend_alive = _backend_alive
+        m._addon_alive = _addon_alive
     return m
 
 

--- a/tests/addon/test_webhook_proxy.py
+++ b/tests/addon/test_webhook_proxy.py
@@ -33,6 +33,9 @@ WEBHOOK_PROXY_VARIANTS = {
         "oauth_marker": "/config/.mcp_proxy_oauth_restart_required",
         "autoapprove_any_redirect": False,
         "unified_oauth_routes": False,
+        "proxy_owned_oauth_endpoints": False,
+        "dcr_registration": False,
+        "dedicated_cimd_session": False,
         "sibling_base": "ha_mcp_webhook_proxy_dev",
         "mutex_id": "mcp_proxy_mutex",
     },
@@ -48,6 +51,9 @@ WEBHOOK_PROXY_VARIANTS = {
         "oauth_marker": "/config/.mcp_proxy_dev_oauth_restart_required",
         "autoapprove_any_redirect": True,
         "unified_oauth_routes": True,
+        "proxy_owned_oauth_endpoints": True,
+        "dcr_registration": True,
+        "dedicated_cimd_session": True,
         "sibling_base": "ha_mcp_webhook_proxy",
         "mutex_id": "mcp_proxy_dev_mutex",
     },
@@ -130,6 +136,13 @@ class _FakeClientTimeout:
     ceil_threshold: float = 5
 
 
+@dataclass(frozen=True)
+class _FakeTCPConnector:
+    """Connector stand-in retaining the isolated CIMD pool limit."""
+
+    limit: int = 100
+
+
 def _install_runtime_stubs():
     """Inject homeassistant.* and aiohttp stubs into sys.modules.
 
@@ -157,6 +170,7 @@ def _install_runtime_stubs():
     aiohttp_mod = types.ModuleType("aiohttp")
     aiohttp_mod.ClientSession = MagicMock(name="ClientSession")
     aiohttp_mod.ClientTimeout = _FakeClientTimeout
+    aiohttp_mod.TCPConnector = _FakeTCPConnector
     aiohttp_mod.ClientError = type("ClientError", (Exception,), {})
     aiohttp_web = types.ModuleType("aiohttp.web")
     aiohttp_web.Request = MagicMock
@@ -276,6 +290,10 @@ def _import_mcp_proxy(preload_oauth=None):
     if preload_oauth is not None:
         sys.modules[f"{mod_name}.oauth"] = preload_oauth
     spec.loader.exec_module(mod)
+    if hasattr(mod, "DCR_SECRET_FILE"):
+        dcr_tmp = tempfile.TemporaryDirectory()
+        mod._test_dcr_secret_dir = dcr_tmp
+        mod.DCR_SECRET_FILE = Path(dcr_tmp.name) / ".mcp_proxy_dev_dcr_secret"
     return mod
 
 
@@ -363,7 +381,7 @@ def _rfc9207_iss_supported() -> bool:
         return "def _issuer(" in fh.read()
 
 
-def _import_none_autoapprove_stack():
+def _import_none_autoapprove_stack(tmp_secret_dir=None):
     """Import the integration wired so none-mode auto-approve resolves.
 
     Loads __init__, oauth, oauth_autoapprove, and auth_native as submodules of
@@ -398,6 +416,8 @@ def _import_none_autoapprove_stack():
     autoapprove = _load_pkg_submodule(pkg_name, component_dir, "oauth_autoapprove")
     auth_native = _load_pkg_submodule(pkg_name, component_dir, "auth_native")
     init_spec.loader.exec_module(pkg)
+    if tmp_secret_dir is not None and hasattr(pkg, "DCR_SECRET_FILE"):
+        pkg.DCR_SECRET_FILE = Path(tmp_secret_dir) / ".mcp_proxy_dev_dcr_secret"
     return pkg, oauth, autoapprove, auth_native
 
 
@@ -457,6 +477,8 @@ def _import_ha_auth_stack(tmp_secret_dir=None):
     auth_native = _load_pkg_submodule(pkg_name, component_dir, "auth_native")
     # Execute the package __init__ last; its lazy imports resolve to the above.
     init_spec.loader.exec_module(pkg)
+    if tmp_secret_dir is not None and hasattr(pkg, "DCR_SECRET_FILE"):
+        pkg.DCR_SECRET_FILE = Path(tmp_secret_dir) / ".mcp_proxy_dev_dcr_secret"
     return pkg, oauth, auth_native
 
 
@@ -3365,11 +3387,15 @@ class TestAuthorizationServerView:
 
         body = json_resp.call_args.args[0]
         assert body["issuer"].endswith(CURRENT["oauth_base"])
-        # Authorize/token endpoints live at the root path of the host so
-        # that clients constructing them from the resource host (Claude.ai)
-        # find them.
-        assert body["authorization_endpoint"] == "https://legit.example/authorize"
-        assert body["token_endpoint"] == "https://legit.example/token"
+        # The dev mirror advertises its mode-dispatched scoped routes; stable
+        # keeps the legacy root aliases until the promote workflow carries it.
+        route_base = (
+            CURRENT["oauth_base"] if CURRENT["proxy_owned_oauth_endpoints"] else ""
+        )
+        assert body["authorization_endpoint"] == (
+            f"https://legit.example{route_base}/authorize"
+        )
+        assert body["token_endpoint"] == f"https://legit.example{route_base}/token"
         assert "code" in body["response_types_supported"]
         assert "authorization_code" in body["grant_types_supported"]
         assert "refresh_token" in body["grant_types_supported"]
@@ -4730,7 +4756,7 @@ class TestHaAuthMode:
 
     # ---- setup registers discovery and dev unified views, no root views ----
 
-    async def test_setup_registers_seven_metadata_views_and_marks_mode(
+    async def test_setup_registers_oauth_surface_and_marks_mode(
         self, hass, tmp_path
     ):
         mod, oauth, auth_native = _import_ha_auth_stack(tmp_secret_dir=tmp_path)
@@ -4759,8 +4785,10 @@ class TestHaAuthMode:
                 f"{CURRENT['oauth_base']}/authorize",
                 f"{CURRENT['oauth_base']}/token",
             }
+        if CURRENT["dcr_registration"]:
+            expected.add(f"{CURRENT['oauth_base']}/register")
         assert registered == expected
-        assert len(registered) == (9 if CURRENT["unified_oauth_routes"] else 7)
+        assert len(registered) == len(expected)
         # No root /authorize or /token views in ha_auth mode.
         assert "/authorize" not in registered
         assert "/token" not in registered
@@ -4776,6 +4804,36 @@ class TestHaAuthMode:
         mock_create_issue.assert_not_called()
         mock_write.assert_not_called()
 
+    async def test_ha_auth_wires_dcr_key_and_isolated_cimd_session(
+        self, hass, tmp_path
+    ):
+        """The dev parity surface persists DCR and isolates public lookups."""
+        if not CURRENT["dedicated_cimd_session"]:
+            pytest.skip("dedicated CIMD session has not been promoted")
+        mod, _oauth, _auth_native = _import_ha_auth_stack(tmp_secret_dir=tmp_path)
+        _bind_repairs(mod, tmp_path)
+        relay_session = MagicMock()
+        cimd_session = MagicMock()
+        with (
+            patch.object(mod, "_read_config", return_value=self._ha_auth_config()),
+            patch.object(mod, "async_register"),
+            patch.object(
+                mod.aiohttp,
+                "ClientSession",
+                side_effect=[relay_session, cimd_session],
+            ) as session_factory,
+        ):
+            result = await mod.async_setup_entry(hass, MagicMock())
+
+        assert result is True
+        data = hass.data[mod.DOMAIN]
+        assert data["session"] is relay_session
+        assert data["cimd_session"] is cimd_session
+        assert data["dcr_signing_key"] == mod.DCR_SECRET_FILE.read_bytes()
+        assert len(data["dcr_signing_key"]) >= 32
+        connector = session_factory.call_args_list[1].kwargs["connector"]
+        assert connector.limit == 4
+
     async def test_ha_auth_init_failure_unregisters_and_raises(self, hass, tmp_path):
         """ha_auth mirror of the legacy provider-init-failure teardown: if
         register_metadata_views raises while enabling OAuth, the user opted into
@@ -4784,13 +4842,18 @@ class TestHaAuthMode:
         session (no leak), and leave DOMAIN out of hass.data."""
         mod, oauth, _an = _import_ha_auth_stack(tmp_secret_dir=tmp_path)
         _bind_repairs(mod, tmp_path)
-        session = MagicMock()
-        session.close = AsyncMock()
+        relay_session = MagicMock()
+        relay_session.close = AsyncMock()
+        cimd_session = MagicMock()
+        cimd_session.close = AsyncMock()
+        sessions = [relay_session]
+        if CURRENT["dedicated_cimd_session"]:
+            sessions.append(cimd_session)
         with (
             patch.object(mod, "_read_config", return_value=self._ha_auth_config()),
             patch.object(mod, "async_register"),
             patch.object(mod, "async_unregister") as mock_unreg,
-            patch.object(mod.aiohttp, "ClientSession", return_value=session),
+            patch.object(mod.aiohttp, "ClientSession", side_effect=sessions),
             # The integration lazy-imports register_metadata_views at call time
             # (`from .oauth import register_metadata_views` inside
             # async_setup_entry), so patching the oauth module attribute lands.
@@ -4803,7 +4866,11 @@ class TestHaAuthMode:
 
         assert "Failed to enable OAuth" in str(exc_info.value)
         mock_unreg.assert_called_once_with(hass, "mcp_test")
-        session.close.assert_awaited_once()
+        relay_session.close.assert_awaited_once()
+        if CURRENT["dedicated_cimd_session"]:
+            cimd_session.close.assert_awaited_once()
+        else:
+            cimd_session.close.assert_not_awaited()
         assert mod.DOMAIN not in hass.data
 
     async def test_setup_ignores_stray_public_base_url_host_derived(
@@ -4863,17 +4930,22 @@ class TestHaAuthMode:
             hass.http.register_view.reset_mock()
             # A second setup (config-entry reload) must NOT re-register the views.
             await mod.async_setup_entry(hass, MagicMock())
-        assert first == (9 if CURRENT["unified_oauth_routes"] else 7)
+        assert first == (
+            7
+            + (2 if CURRENT["unified_oauth_routes"] else 0)
+            + (1 if CURRENT["dcr_registration"] else 0)
+        )
         assert hass.http.register_view.call_count == 0
         # The register-once flag lives in oauth.py (a top-level hass.data key),
         # not on the integration package.
         assert hass.data[oauth._METADATA_VIEWS_REGISTERED_KEY] is True
 
     async def test_register_once_flag_survives_unload(self, hass, tmp_path):
-        """The register-once flag lives at a TOP-LEVEL hass.data key so it
-        outlives async_unload_entry's pop(DOMAIN): HA can't drop the seven bound
-        views until it restarts, so a setup -> unload -> setup cycle must NOT
-        re-register them (which would trip aiohttp's duplicate-view ValueError)."""
+        """The register-once flags outlive the config-entry data they gate.
+
+        HA cannot drop bound HTTP views until restart, so setup after unload
+        must reuse the complete discovery/scoped/DCR surface.
+        """
         mod, oauth, auth_native = _import_ha_auth_stack(tmp_secret_dir=tmp_path)
         _bind_repairs(mod, tmp_path)
         session = MagicMock()
@@ -4886,7 +4958,9 @@ class TestHaAuthMode:
         ):
             await mod.async_setup_entry(hass, MagicMock())
             assert hass.http.register_view.call_count == (
-                9 if CURRENT["unified_oauth_routes"] else 7
+                7
+                + (2 if CURRENT["unified_oauth_routes"] else 0)
+                + (1 if CURRENT["dcr_registration"] else 0)
             )
             flag_key = oauth._METADATA_VIEWS_REGISTERED_KEY
             assert hass.data[flag_key] is True
@@ -4934,7 +5008,9 @@ class TestHaAuthMode:
         ):
             await mod.async_setup_entry(hass, MagicMock())  # ha_auth discovery
             assert hass.http.register_view.call_count == (
-                9 if CURRENT["unified_oauth_routes"] else 7
+                7
+                + (2 if CURRENT["unified_oauth_routes"] else 0)
+                + (1 if CURRENT["dcr_registration"] else 0)
             )
             hass.http.register_view.reset_mock()
             await mod.async_setup_entry(hass, MagicMock())  # legacy: only 2 root
@@ -4946,12 +5022,10 @@ class TestHaAuthMode:
         assert not (registered & _wellknown_oauth_urls(oauth, "mcp_test"))
         assert hass.data[mod.DOMAIN]["oauth_mode"] == mod.OAUTH_MODE_LEGACY
 
-    async def test_legacy_then_ha_auth_does_not_reregister_metadata(
+    async def test_legacy_then_ha_auth_only_adds_unbound_dcr_route(
         self, hass, tmp_path
     ):
-        """A live legacy -> ha_auth switch: legacy already bound the seven via
-        the shared registrar, so the ha_auth setup's register_metadata_views
-        no-ops and registers nothing new."""
+        """A switch reuses shared routes and adds only DCR when supported."""
         mod, oauth, auth_native = _import_ha_auth_stack(tmp_secret_dir=tmp_path)
         _bind_repairs(mod, tmp_path)
         hass.is_running = False
@@ -4970,7 +5044,13 @@ class TestHaAuthMode:
             )
             hass.http.register_view.reset_mock()
             await mod.async_setup_entry(hass, MagicMock())  # ha_auth: reuse all
-        assert hass.http.register_view.call_count == 0
+        if CURRENT["dcr_registration"]:
+            assert [
+                call.args[0].url
+                for call in hass.http.register_view.call_args_list
+            ] == [f"{CURRENT['oauth_base']}/register"]
+        else:
+            assert hass.http.register_view.call_count == 0
         assert hass.data[mod.DOMAIN]["oauth_mode"] == mod.OAUTH_MODE_HA_AUTH
 
     async def test_unknown_mode_raises(self, hass, tmp_path):
@@ -5100,14 +5180,24 @@ class TestHaAuthMode:
             await oauth.AuthorizationServerMetadataView(rs).get(request)
         doc = jr.call_args.args[0]
         assert doc["issuer"] == f"https://legit.example{oauth.OAUTH_BASE}"
-        assert doc["authorization_endpoint"] == "https://legit.example/auth/authorize"
-        assert doc["token_endpoint"] == "https://legit.example/auth/token"
+        route_base = (
+            oauth.OAUTH_BASE if CURRENT["proxy_owned_oauth_endpoints"] else "/auth"
+        )
+        assert doc["authorization_endpoint"] == (
+            f"https://legit.example{route_base}/authorize"
+        )
+        assert doc["token_endpoint"] == f"https://legit.example{route_base}/token"
         assert doc["response_types_supported"] == ["code"]
         assert doc["grant_types_supported"] == ["authorization_code", "refresh_token"]
         assert doc["code_challenge_methods_supported"] == ["S256"]
         assert doc["token_endpoint_auth_methods_supported"] == ["none"]
         assert doc["client_id_metadata_document_supported"] is True
-        assert "registration_endpoint" not in doc
+        if CURRENT["dcr_registration"]:
+            assert doc["registration_endpoint"] == (
+                f"https://legit.example{oauth.OAUTH_BASE}/register"
+            )
+        else:
+            assert "registration_endpoint" not in doc
         # A well-known variant serves the SAME document.
         wk = oauth.WellKnownAuthorizationServerMetadataView(
             rs,
@@ -5540,8 +5630,11 @@ class TestHaAuthMode:
         # It is genuinely the ha_auth document (public client + CIMD), not legacy.
         assert canonical["token_endpoint_auth_methods_supported"] == ["none"]
         assert canonical["client_id_metadata_document_supported"] is True
+        route_base = (
+            oauth.OAUTH_BASE if CURRENT["proxy_owned_oauth_endpoints"] else "/auth"
+        )
         assert canonical["authorization_endpoint"] == (
-            "https://legit.example/auth/authorize"
+            f"https://legit.example{route_base}/authorize"
         )
         base = oauth.OAUTH_BASE
         variants = (
@@ -5597,8 +5690,11 @@ class TestHaAuthMode:
         assert doc["client_id_metadata_document_supported"] is True
         # Host-derived base from the request, NOT the bound provider's pin.
         assert doc["issuer"] == f"https://switch-host.example{oauth.OAUTH_BASE}"
+        route_base = (
+            oauth.OAUTH_BASE if CURRENT["proxy_owned_oauth_endpoints"] else "/auth"
+        )
         assert doc["authorization_endpoint"] == (
-            "https://switch-host.example/auth/authorize"
+            f"https://switch-host.example{route_base}/authorize"
         )
         assert "pinned-legacy.example" not in doc["issuer"]
 
@@ -5634,8 +5730,11 @@ class TestHaAuthMode:
         assert "client_id_metadata_document_supported" not in doc
         # Pinned base from public_base_url, NOT the request Host.
         assert doc["issuer"] == f"https://pinned-legacy.example{oauth.OAUTH_BASE}"
+        route_base = (
+            oauth.OAUTH_BASE if CURRENT["proxy_owned_oauth_endpoints"] else ""
+        )
         assert doc["authorization_endpoint"] == (
-            "https://pinned-legacy.example/authorize"
+            f"https://pinned-legacy.example{route_base}/authorize"
         )
         assert "other-host.example" not in doc["issuer"]
 
@@ -6161,8 +6260,12 @@ class TestNoneAutoApproveMode:
         # The two fields HA core's root doc lacks — the whole reason for #1969.
         assert doc["token_endpoint_auth_methods_supported"] == ["none"]
         assert doc["client_id_metadata_document_supported"] is True
-        # No DCR: fixed/auto flow, so no registration endpoint advertised.
-        assert "registration_endpoint" not in doc
+        if CURRENT["dcr_registration"]:
+            assert doc["registration_endpoint"] == (
+                f"https://x.example{base}/register"
+            )
+        else:
+            assert "registration_endpoint" not in doc
 
     async def test_as_view_serves_none_document_when_live(self):
         _mod, oauth, autoapprove, _an = _import_none_autoapprove_stack()
@@ -6481,7 +6584,7 @@ class TestNoneAutoApproveMode:
     # ---- full setup registers the views + marks the mode ----
 
     async def test_setup_registers_metadata_and_autoapprove_views(self, hass, tmp_path):
-        mod, oauth, autoapprove, _an = _import_none_autoapprove_stack()
+        mod, oauth, autoapprove, _an = _import_none_autoapprove_stack(tmp_path)
         repairs = _bind_repairs(mod, tmp_path)
         repairs.RESTART_MARKER_FILE.write_text('{"reason": "stale"}')
         # No "oauth" section = OAuth off = none-mode auto-approve.
@@ -6511,13 +6614,21 @@ class TestNoneAutoApproveMode:
             f"{CURRENT['oauth_base']}/authorize",
             f"{CURRENT['oauth_base']}/token",
         }
+        if CURRENT["dcr_registration"]:
+            autoapprove_urls.add(f"{CURRENT['oauth_base']}/register")
         assert registered == metadata | autoapprove_urls
-        assert len(registered) == 9  # 7 discovery + 2 auto-approve
+        assert len(registered) == len(metadata | autoapprove_urls)
         # Mode marker + provider under the non-"oauth" key.
         assert hass.data[mod.DOMAIN]["oauth_mode"] == mod.OAUTH_MODE_NONE_AUTOAPPROVE
         assert isinstance(
             hass.data[mod.DOMAIN]["autoapprove"], autoapprove.AutoApproveProvider
         )
+        if CURRENT["dcr_registration"]:
+            assert hass.data[mod.DOMAIN]["dcr_signing_key"] == (
+                mod.DCR_SECRET_FILE.read_bytes()
+            )
+        else:
+            assert "dcr_signing_key" not in hass.data[mod.DOMAIN]
         # The bearer-gate key stays off — the webhook is unauthenticated.
         assert "oauth" not in hass.data[mod.DOMAIN]
         # No root /authorize or /token (those are legacy-only).
@@ -6533,7 +6644,7 @@ class TestNoneAutoApproveMode:
         """Unlike ha_auth/legacy, a none-mode auto-approve setup failure must NOT
         tear down the (intentionally unauthenticated) webhook — it just skips the
         discovery enhancement and keeps forwarding."""
-        mod, oauth, _aa, _an = _import_none_autoapprove_stack()
+        mod, oauth, _aa, _an = _import_none_autoapprove_stack(tmp_path)
         _bind_repairs(mod, tmp_path)
         config = {
             "target_url": "http://127.0.0.1:9583/private_zctpwlX7ZkIAr7oqdfLPxw",
@@ -6587,8 +6698,9 @@ class TestNoneAutoApproveMode:
         hass.data[oauth.DOMAIN] = {"oauth_mode": oauth.MODE_HA_AUTH, "oauth": rs}
         with patch.object(oauth.web, "json_response") as jr:
             await view.get(request)
+        ha_route_base = base if CURRENT["proxy_owned_oauth_endpoints"] else "/auth"
         assert jr.call_args.args[0]["authorization_endpoint"] == (
-            "https://legit.example/auth/authorize"
+            f"https://legit.example{ha_route_base}/authorize"
         )
 
         # Flip back to none — the same bound view serves the auto-approve doc.

--- a/tests/addon/test_webhook_proxy.py
+++ b/tests/addon/test_webhook_proxy.py
@@ -31,6 +31,8 @@ WEBHOOK_PROXY_VARIANTS = {
         "config_file": "/config/.mcp_proxy_config.json",
         "inbound_log": "/config/.mcp_proxy_inbound.log",
         "oauth_marker": "/config/.mcp_proxy_oauth_restart_required",
+        "autoapprove_any_redirect": False,
+        "unified_oauth_routes": False,
         "sibling_base": "ha_mcp_webhook_proxy_dev",
         "mutex_id": "mcp_proxy_mutex",
     },
@@ -44,6 +46,8 @@ WEBHOOK_PROXY_VARIANTS = {
         "config_file": "/config/.mcp_proxy_dev_config.json",
         "inbound_log": "/config/.mcp_proxy_dev_inbound.log",
         "oauth_marker": "/config/.mcp_proxy_dev_oauth_restart_required",
+        "autoapprove_any_redirect": True,
+        "unified_oauth_routes": True,
         "sibling_base": "ha_mcp_webhook_proxy",
         "mutex_id": "mcp_proxy_dev_mutex",
     },
@@ -260,8 +264,8 @@ def _import_mcp_proxy(preload_oauth=None):
     component_dir = os.path.join(PROXY_ADDON_DIR, CURRENT["component"])
     init_path = os.path.join(component_dir, "__init__.py")
     mod_name = f"mcp_proxy_init_{CURRENT['key']}"
-    sys.modules.pop(mod_name, None)
-    sys.modules.pop(f"{mod_name}.oauth", None)
+    for suffix in ("", ".oauth", ".oauth_autoapprove", ".oauth_dcr", ".oauth_indirect"):
+        sys.modules.pop(f"{mod_name}{suffix}", None)
     spec = importlib.util.spec_from_file_location(
         mod_name,
         init_path,
@@ -373,7 +377,15 @@ def _import_none_autoapprove_stack():
     _install_runtime_stubs()
     component_dir = os.path.join(PROXY_ADDON_DIR, CURRENT["component"])
     pkg_name = f"mcp_proxy_init_{CURRENT['key']}"
-    for suffix in ("", ".oauth", ".oauth_autoapprove", ".auth_native", ".repairs"):
+    for suffix in (
+        "",
+        ".oauth",
+        ".oauth_autoapprove",
+        ".oauth_dcr",
+        ".oauth_indirect",
+        ".auth_native",
+        ".repairs",
+    ):
         sys.modules.pop(f"{pkg_name}{suffix}", None)
     init_path = os.path.join(component_dir, "__init__.py")
     init_spec = importlib.util.spec_from_file_location(
@@ -421,7 +433,15 @@ def _import_ha_auth_stack(tmp_secret_dir=None):
     _install_runtime_stubs()
     component_dir = os.path.join(PROXY_ADDON_DIR, CURRENT["component"])
     pkg_name = f"mcp_proxy_init_{CURRENT['key']}"
-    for suffix in ("", ".oauth", ".auth_native", ".repairs"):
+    for suffix in (
+        "",
+        ".oauth",
+        ".oauth_autoapprove",
+        ".oauth_dcr",
+        ".oauth_indirect",
+        ".auth_native",
+        ".repairs",
+    ):
         sys.modules.pop(f"{pkg_name}{suffix}", None)
     # Create the package object first so submodules have a parent with __path__.
     init_path = os.path.join(component_dir, "__init__.py")
@@ -4708,7 +4728,7 @@ class TestHaAuthMode:
         assert entry.get("description"), "oauth_mode needs a translation description"
         assert "Beta" in entry["name"]
 
-    # ---- setup registers exactly the 7 metadata views, no root views ----
+    # ---- setup registers discovery and dev unified views, no root views ----
 
     async def test_setup_registers_seven_metadata_views_and_marks_mode(
         self, hass, tmp_path
@@ -4734,8 +4754,13 @@ class TestHaAuthMode:
             f"{CURRENT['oauth_base']}/protected-resource",
             f"{CURRENT['oauth_base']}/authorization-server",
         } | _wellknown_oauth_urls(oauth, "mcp_test")
+        if CURRENT["unified_oauth_routes"]:
+            expected |= {
+                f"{CURRENT['oauth_base']}/authorize",
+                f"{CURRENT['oauth_base']}/token",
+            }
         assert registered == expected
-        assert len(registered) == 7
+        assert len(registered) == (9 if CURRENT["unified_oauth_routes"] else 7)
         # No root /authorize or /token views in ha_auth mode.
         assert "/authorize" not in registered
         assert "/token" not in registered
@@ -4838,7 +4863,7 @@ class TestHaAuthMode:
             hass.http.register_view.reset_mock()
             # A second setup (config-entry reload) must NOT re-register the views.
             await mod.async_setup_entry(hass, MagicMock())
-        assert first == 7
+        assert first == (9 if CURRENT["unified_oauth_routes"] else 7)
         assert hass.http.register_view.call_count == 0
         # The register-once flag lives in oauth.py (a top-level hass.data key),
         # not on the integration package.
@@ -4860,7 +4885,9 @@ class TestHaAuthMode:
             patch.object(mod.aiohttp, "ClientSession", return_value=session),
         ):
             await mod.async_setup_entry(hass, MagicMock())
-            assert hass.http.register_view.call_count == 7
+            assert hass.http.register_view.call_count == (
+                9 if CURRENT["unified_oauth_routes"] else 7
+            )
             flag_key = oauth._METADATA_VIEWS_REGISTERED_KEY
             assert hass.data[flag_key] is True
             await mod.async_unload_entry(hass, MagicMock())
@@ -4905,8 +4932,10 @@ class TestHaAuthMode:
             patch.object(mod, "async_register"),
             patch.object(mod.aiohttp, "ClientSession", return_value=MagicMock()),
         ):
-            await mod.async_setup_entry(hass, MagicMock())  # ha_auth: 7 metadata
-            assert hass.http.register_view.call_count == 7
+            await mod.async_setup_entry(hass, MagicMock())  # ha_auth discovery
+            assert hass.http.register_view.call_count == (
+                9 if CURRENT["unified_oauth_routes"] else 7
+            )
             hass.http.register_view.reset_mock()
             await mod.async_setup_entry(hass, MagicMock())  # legacy: only 2 root
         registered = {
@@ -4935,8 +4964,10 @@ class TestHaAuthMode:
             patch.object(mod, "async_register"),
             patch.object(mod.aiohttp, "ClientSession", return_value=MagicMock()),
         ):
-            await mod.async_setup_entry(hass, MagicMock())  # legacy: 7 + 2 root
-            assert hass.http.register_view.call_count == 9
+            await mod.async_setup_entry(hass, MagicMock())  # legacy views + root
+            assert hass.http.register_view.call_count == (
+                11 if CURRENT["unified_oauth_routes"] else 9
+            )
             hass.http.register_view.reset_mock()
             await mod.async_setup_entry(hass, MagicMock())  # ha_auth: reuse all
         assert hass.http.register_view.call_count == 0
@@ -6203,27 +6234,33 @@ class TestNoneAutoApproveMode:
         assert isinstance(t1, str) and len(t1) >= 20
         assert t1 != t2
 
-    # ---- redirect open-redirect gate (allowlist-only) ----
+    # ---- none-mode redirect policy ----
 
-    def test_redirect_gate_allows_claude_callback_only(self):
+    def test_redirect_gate_matches_flavor_policy(self):
         _mod, _oauth, autoapprove, _an = _import_none_autoapprove_stack()
-        assert autoapprove._is_valid_autoapprove_redirect(self.CLAUDE_REDIRECT) is True
-        # A same-host-different-path or any other https URL is NOT allowlisted.
-        assert (
-            autoapprove._is_valid_autoapprove_redirect("https://claude.ai/evil")
-            is False
-        )
-        assert (
-            autoapprove._is_valid_autoapprove_redirect("https://evil.example/cb")
-            is False
-        )
-        # http (non-https) fails the floor before the allowlist even matters.
-        assert (
-            autoapprove._is_valid_autoapprove_redirect(
-                "http://claude.ai/api/mcp/auth_callback"
+        if CURRENT["autoapprove_any_redirect"]:
+            base = {
+                "response_type": "code",
+                "code_challenge": "A" * 43,
+                "code_challenge_method": "S256",
+            }
+            assert (
+                autoapprove._validate_autoapprove_authorize(
+                    {**base, "redirect_uri": self.CLAUDE_REDIRECT}
+                )
+                is None
             )
-            is False
-        )
+            assert (
+                autoapprove._validate_autoapprove_authorize(
+                    {**base, "redirect_uri": "https://other.example/cb"}
+                )
+                is None
+            )
+        else:
+            assert autoapprove._is_valid_autoapprove_redirect(self.CLAUDE_REDIRECT)
+            assert not autoapprove._is_valid_autoapprove_redirect(
+                "https://other.example/cb"
+            )
 
     # ---- AutoApproveAuthorizeView (GET: issue code, 302, no UI) ----
 
@@ -6304,7 +6341,7 @@ class TestNoneAutoApproveMode:
         assert expected in q
         assert q["iss"] == [advertised]
 
-    async def test_authorize_rejects_non_allowlisted_redirect_with_400(self):
+    async def test_authorize_applies_flavor_redirect_policy(self):
         _mod, oauth, autoapprove, _an = _import_none_autoapprove_stack()
         hass, _provider = self._none_live_hass(oauth, autoapprove)
         view = autoapprove.AutoApproveAuthorizeView(hass)
@@ -6324,9 +6361,13 @@ class TestNoneAutoApproveMode:
             patch.object(autoapprove.web, "Response") as resp,
         ):
             await view.get(request)
-        # 400 in place — NEVER a 302 to an unvalidated target.
-        assert jr.call_args.kwargs["status"] == 400
-        resp.assert_not_called()
+        if CURRENT["autoapprove_any_redirect"]:
+            resp.assert_called_once()
+            assert resp.call_args.kwargs["status"] == 302
+            jr.assert_not_called()
+        else:
+            assert jr.call_args.kwargs["status"] == 400
+            resp.assert_not_called()
 
     async def test_authorize_rejects_non_s256(self):
         _mod, oauth, autoapprove, _an = _import_none_autoapprove_stack()

--- a/tests/src/unit/test_oauth_autoapprove.py
+++ b/tests/src/unit/test_oauth_autoapprove.py
@@ -41,6 +41,10 @@ class _FakeURL:
         query = "&".join(f"{k}={v}" for k, v in params.items())
         return _FakeURL(f"{self._url}{sep}{query}" if query else self._url)
 
+    def with_query(self, params) -> _FakeURL:
+        query = "&".join(f"{k}={v}" for k, v in params.items())
+        return _FakeURL(f"{self._url}?{query}" if query else self._url)
+
     def __str__(self) -> str:
         return self._url
 

--- a/tests/src/unit/test_oauth_legacy_component.py
+++ b/tests/src/unit/test_oauth_legacy_component.py
@@ -44,6 +44,10 @@ class _FakeURL:
         query = "&".join(f"{k}={v}" for k, v in params.items())
         return _FakeURL(f"{self._url}{sep}{query}" if query else self._url)
 
+    def with_query(self, params) -> _FakeURL:
+        query = "&".join(f"{k}={v}" for k, v in params.items())
+        return _FakeURL(f"{self._url}?{query}" if query else self._url)
+
     def __str__(self) -> str:
         return self._url
 

--- a/tests/src/unit/test_webhook_proxy_liveness.py
+++ b/tests/src/unit/test_webhook_proxy_liveness.py
@@ -122,9 +122,13 @@ def test_heartbeat_fresh_only_for_recent_mtime(oauth, monkeypatch, tmp_path):
     assert oauth._heartbeat_fresh() is False
 
 
-async def test_addon_alive_runs_check_in_executor_and_caches(oauth, monkeypatch):
-    """The mtime stat runs off the event loop and the verdict caches briefly."""
+async def test_addon_alive_caches_only_the_negative_verdict(oauth, monkeypatch):
+    """A positive verdict re-stats every request so a clean shutdown's file
+    deletion takes effect immediately (#2218 review); only the down verdict
+    caches, bounding stat traffic from anonymous requests to a stopped
+    install."""
     calls = []
+    fresh = {"value": True}
 
     async def _executor_job(func):
         calls.append(func)
@@ -132,9 +136,14 @@ async def test_addon_alive_runs_check_in_executor_and_caches(oauth, monkeypatch)
 
     hass = MagicMock()
     hass.async_add_executor_job = _executor_job
-    monkeypatch.setattr(oauth, "_heartbeat_fresh", lambda: True)
-    monkeypatch.setattr(oauth, "_addon_alive_cache", None)
+    monkeypatch.setattr(oauth, "_heartbeat_fresh", lambda: fresh["value"])
+    monkeypatch.setattr(oauth, "_addon_down_until", 0.0)
 
     assert await oauth._addon_alive(hass) is True
-    assert await oauth._addon_alive(hass) is True  # second hit served cached
-    assert len(calls) == 1
+    assert await oauth._addon_alive(hass) is True
+    assert len(calls) == 2  # alive verdicts are never cached
+
+    fresh["value"] = False
+    assert await oauth._addon_alive(hass) is False
+    assert await oauth._addon_alive(hass) is False  # served from the down cache
+    assert len(calls) == 3

--- a/tests/src/unit/test_webhook_proxy_liveness.py
+++ b/tests/src/unit/test_webhook_proxy_liveness.py
@@ -9,9 +9,7 @@ from unittest.mock import MagicMock
 import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
-COMPONENT_DIR = (
-    REPO_ROOT / "homeassistant-addon-webhook-proxy-dev" / "mcp_proxy_dev"
-)
+COMPONENT_DIR = REPO_ROOT / "homeassistant-addon-webhook-proxy-dev" / "mcp_proxy_dev"
 
 
 @pytest.fixture
@@ -67,9 +65,7 @@ def _provider(oauth, mode: str):
         {
             "_hass": hass,
             "base_url_for": lambda self, request: "https://ha.example",
-            "authorization_server_url": lambda self, base: (
-                f"{base}{oauth.OAUTH_BASE}"
-            ),
+            "authorization_server_url": lambda self, base: f"{base}{oauth.OAUTH_BASE}",
         },
     )()
 
@@ -81,9 +77,7 @@ async def test_mode_none_when_backend_down(oauth, monkeypatch):
         return False
 
     monkeypatch.setattr(oauth, "_backend_alive", _down)
-    view = oauth.AuthorizationServerMetadataView(
-        _provider(oauth, oauth.MODE_HA_AUTH)
-    )
+    view = oauth.AuthorizationServerMetadataView(_provider(oauth, oauth.MODE_HA_AUTH))
 
     await view.get(MagicMock())
 
@@ -97,9 +91,7 @@ async def test_mode_served_when_backend_up(oauth, monkeypatch):
         return True
 
     monkeypatch.setattr(oauth, "_backend_alive", _up)
-    view = oauth.AuthorizationServerMetadataView(
-        _provider(oauth, oauth.MODE_LEGACY)
-    )
+    view = oauth.AuthorizationServerMetadataView(_provider(oauth, oauth.MODE_LEGACY))
 
     await view.get(MagicMock())
 

--- a/tests/src/unit/test_webhook_proxy_liveness.py
+++ b/tests/src/unit/test_webhook_proxy_liveness.py
@@ -1,0 +1,108 @@
+"""A stopped add-on backend must take the dev proxy's OAuth surface dark."""
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+COMPONENT_DIR = (
+    REPO_ROOT / "homeassistant-addon-webhook-proxy-dev" / "mcp_proxy_dev"
+)
+
+
+@pytest.fixture
+def oauth(monkeypatch):
+    """Load the dev proxy OAuth module with its Home Assistant imports stubbed."""
+    aiohttp = types.ModuleType("aiohttp")
+    web = types.ModuleType("aiohttp.web")
+    web.Request = MagicMock
+    web.Response = MagicMock
+    web.json_response = MagicMock(name="json_response")
+    aiohttp.web = web
+
+    homeassistant = types.ModuleType("homeassistant")
+    components = types.ModuleType("homeassistant.components")
+    http = types.ModuleType("homeassistant.components.http")
+    http.HomeAssistantView = type("HomeAssistantView", (), {})
+    core = types.ModuleType("homeassistant.core")
+    core.HomeAssistant = MagicMock
+
+    package = types.ModuleType("mcp_proxy_dev")
+    package.__path__ = [str(COMPONENT_DIR)]
+    for name, module in {
+        "aiohttp": aiohttp,
+        "aiohttp.web": web,
+        "homeassistant": homeassistant,
+        "homeassistant.components": components,
+        "homeassistant.components.http": http,
+        "homeassistant.core": core,
+        "mcp_proxy_dev": package,
+    }.items():
+        monkeypatch.setitem(sys.modules, name, module)
+
+    spec = importlib.util.spec_from_file_location(
+        "mcp_proxy_dev.oauth", COMPONENT_DIR / "oauth.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, spec.name, module)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _provider(oauth, mode: str):
+    hass = MagicMock()
+    hass.data = {
+        oauth.DOMAIN: {
+            "oauth_mode": mode,
+            "target_url": "http://127.0.0.1:9583/private_x",
+        }
+    }
+    return type(
+        "Provider",
+        (),
+        {
+            "_hass": hass,
+            "base_url_for": lambda self, request: "https://ha.example",
+            "authorization_server_url": lambda self, base: (
+                f"{base}{oauth.OAUTH_BASE}"
+            ),
+        },
+    )()
+
+
+async def test_mode_none_when_backend_down(oauth, monkeypatch):
+    """A bound discovery view behaves like an unregistered route when stopped."""
+
+    async def _down(_hass):
+        return False
+
+    monkeypatch.setattr(oauth, "_backend_alive", _down)
+    view = oauth.AuthorizationServerMetadataView(
+        _provider(oauth, oauth.MODE_HA_AUTH)
+    )
+
+    await view.get(MagicMock())
+
+    assert oauth.web.json_response.call_args.kwargs["status"] == 404
+
+
+async def test_mode_served_when_backend_up(oauth, monkeypatch):
+    """The existing mode dispatch still serves while the backend is reachable."""
+
+    async def _up(_hass):
+        return True
+
+    monkeypatch.setattr(oauth, "_backend_alive", _up)
+    view = oauth.AuthorizationServerMetadataView(
+        _provider(oauth, oauth.MODE_LEGACY)
+    )
+
+    await view.get(MagicMock())
+
+    body = oauth.web.json_response.call_args.args[0]
+    assert body["issuer"] == "https://ha.example/api/mcp_proxy_dev/oauth"
+    assert oauth.web.json_response.call_args.kwargs.get("status") in (None, 200)

--- a/tests/src/unit/test_webhook_proxy_liveness.py
+++ b/tests/src/unit/test_webhook_proxy_liveness.py
@@ -1,4 +1,4 @@
-"""A stopped add-on backend must take the dev proxy's OAuth surface dark."""
+"""A stopped proxy add-on must take the dev proxy's OAuth surface dark."""
 
 import importlib.util
 import sys
@@ -70,13 +70,13 @@ def _provider(oauth, mode: str):
     )()
 
 
-async def test_mode_none_when_backend_down(oauth, monkeypatch):
+async def test_mode_none_when_addon_down(oauth, monkeypatch):
     """A bound discovery view behaves like an unregistered route when stopped."""
 
     async def _down(_hass):
         return False
 
-    monkeypatch.setattr(oauth, "_backend_alive", _down)
+    monkeypatch.setattr(oauth, "_addon_alive", _down)
     view = oauth.AuthorizationServerMetadataView(_provider(oauth, oauth.MODE_HA_AUTH))
 
     await view.get(MagicMock())
@@ -84,13 +84,13 @@ async def test_mode_none_when_backend_down(oauth, monkeypatch):
     assert oauth.web.json_response.call_args.kwargs["status"] == 404
 
 
-async def test_mode_served_when_backend_up(oauth, monkeypatch):
-    """The existing mode dispatch still serves while the backend is reachable."""
+async def test_mode_served_when_addon_up(oauth, monkeypatch):
+    """The existing mode dispatch still serves while the heartbeat is fresh."""
 
     async def _up(_hass):
         return True
 
-    monkeypatch.setattr(oauth, "_backend_alive", _up)
+    monkeypatch.setattr(oauth, "_addon_alive", _up)
     view = oauth.AuthorizationServerMetadataView(_provider(oauth, oauth.MODE_LEGACY))
 
     await view.get(MagicMock())
@@ -98,3 +98,43 @@ async def test_mode_served_when_backend_up(oauth, monkeypatch):
     body = oauth.web.json_response.call_args.args[0]
     assert body["issuer"] == "https://ha.example/api/mcp_proxy_dev/oauth"
     assert oauth.web.json_response.call_args.kwargs.get("status") in (None, 200)
+
+
+def test_heartbeat_fresh_only_for_recent_mtime(oauth, monkeypatch, tmp_path):
+    """The liveness signal is the heartbeat file's mtime, not TCP reachability
+    of target_url — that URL is the INDEPENDENT ha-mcp server add-on, which
+    keeps accepting connections after this proxy add-on stops (#2218 review)."""
+    import os
+
+    heartbeat = tmp_path / ".mcp_proxy_dev_heartbeat"
+    monkeypatch.setattr(oauth, "HEARTBEAT_FILE", heartbeat)
+
+    # Missing file (clean shutdown deleted it, or the add-on never ran).
+    assert oauth._heartbeat_fresh() is False
+
+    # Fresh touch — the add-on's keep-alive loop is running.
+    heartbeat.touch()
+    assert oauth._heartbeat_fresh() is True
+
+    # Stale mtime — the add-on crashed without cleanup.
+    stale = heartbeat.stat().st_mtime - (oauth._HEARTBEAT_MAX_AGE + 60)
+    os.utime(heartbeat, (stale, stale))
+    assert oauth._heartbeat_fresh() is False
+
+
+async def test_addon_alive_runs_check_in_executor_and_caches(oauth, monkeypatch):
+    """The mtime stat runs off the event loop and the verdict caches briefly."""
+    calls = []
+
+    async def _executor_job(func):
+        calls.append(func)
+        return func()
+
+    hass = MagicMock()
+    hass.async_add_executor_job = _executor_job
+    monkeypatch.setattr(oauth, "_heartbeat_fresh", lambda: True)
+    monkeypatch.setattr(oauth, "_addon_alive_cache", None)
+
+    assert await oauth._addon_alive(hass) is True
+    assert await oauth._addon_alive(hass) is True  # second hit served cached
+    assert len(calls) == 1

--- a/tests/src/unit/test_webhook_proxy_liveness.py
+++ b/tests/src/unit/test_webhook_proxy_liveness.py
@@ -137,7 +137,7 @@ async def test_addon_alive_caches_only_the_negative_verdict(oauth, monkeypatch):
     hass = MagicMock()
     hass.async_add_executor_job = _executor_job
     monkeypatch.setattr(oauth, "_heartbeat_fresh", lambda: fresh["value"])
-    monkeypatch.setattr(oauth, "_addon_down_until", 0.0)
+    monkeypatch.setitem(oauth._addon_down_state, "until", 0.0)
 
     assert await oauth._addon_alive(hass) is True
     assert await oauth._addon_alive(hass) is True

--- a/tests/src/unit/test_webhook_proxy_oauth_unified.py
+++ b/tests/src/unit/test_webhook_proxy_oauth_unified.py
@@ -468,6 +468,40 @@ async def test_cimd_unreachable_result_is_negative_cached(oauth_stack, monkeypat
     indirect._cimd_cache.clear()
 
 
+async def test_invalid_cimd_document_is_not_negative_cached(oauth_stack, monkeypatch):
+    """Draft -00 §4.4.3: an INVALID document is deliberately not cached, so a
+    client that fixes its metadata recovers on the very next request.
+
+    Mirrors the component's test_invalid_cimd_is_not_negative_cached. Without
+    this pin the policy is only a comment on this side: adding a _cache_cimd()
+    call to the invalid branch would keep every other proxy test green, and
+    both review bots have already re-raised the non-caching as a defect
+    (#2218 review by Patch76)."""
+    indirect = oauth_stack.indirect
+    monkeypatch.setattr(
+        indirect,
+        "_resolve_public_addresses",
+        AsyncMock(return_value=["93.184.216.34"]),
+    )
+    outcomes = [(True, None), (True, ["https://client.example/cb"])]
+    calls: list[str] = []
+
+    async def fetch(_session, fetched_id, _parsed, _address):
+        calls.append(fetched_id)
+        return outcomes[len(calls) - 1]
+
+    monkeypatch.setattr(indirect, "_fetch_pinned_cimd", fetch)
+    indirect._cimd_cache.clear()
+    client_id = "https://client.example/client.json"
+
+    assert await indirect.fetch_cimd_redirects(object(), client_id) is None
+    assert await indirect.fetch_cimd_redirects(object(), client_id) == [
+        "https://client.example/cb"
+    ]
+    assert len(calls) == 2  # re-fetched rather than served from a cache
+    indirect._cimd_cache.clear()
+
+
 async def test_as_documents_pin_the_claude_cimd_selection_contract(oauth_stack):
     """Every advertised URL is proxy-owned and both public modes keep CIMD."""
     oauth = oauth_stack.oauth

--- a/tests/src/unit/test_webhook_proxy_oauth_unified.py
+++ b/tests/src/unit/test_webhook_proxy_oauth_unified.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import importlib.util
+import json
 import sys
 import types
 from pathlib import Path
@@ -46,10 +47,10 @@ def oauth_stack(monkeypatch):
 
     oauth = _load_submodule(monkeypatch, package_name, "oauth")
 
-    async def _backend_alive(_hass):
+    async def _addon_alive(_hass):
         return True
 
-    monkeypatch.setattr(oauth, "_backend_alive", _backend_alive)
+    monkeypatch.setattr(oauth, "_addon_alive", _addon_alive)
     dcr = _load_submodule(monkeypatch, package_name, "oauth_dcr")
     indirect = _load_submodule(monkeypatch, package_name, "oauth_indirect")
     autoapprove = _load_submodule(monkeypatch, package_name, "oauth_autoapprove")
@@ -221,21 +222,52 @@ async def test_multi_origin_dcr_uses_presented_redirect_translation(
     assert translated == expected
 
 
-async def test_same_origin_comparison_is_canonical(oauth_stack, monkeypatch):
-    """An explicit default port remains on the no-fetch same-origin path."""
+async def test_explicit_default_port_translates_on_both_legs(oauth_stack, monkeypatch):
+    """#2218 review: a client_id with an explicit scheme-default port misses
+    the raw-netloc fast path, so authorize mints the token under the
+    TRANSLATED origin — and the redirect-less refresh must re-derive that
+    same origin, not pass the raw client_id through. The two legs agree."""
     indirect = oauth_stack.indirect
-    fetch = AsyncMock()
-    monkeypatch.setattr(indirect, "fetch_cimd_redirects", fetch)
+    redirects = AsyncMock(return_value=["https://claude.ai/api/mcp/auth_callback"])
+    monkeypatch.setattr(indirect, "fetch_cimd_redirects", redirects)
+    client_id = "https://claude.ai:443/oauth/client.json"
 
-    translated = await indirect.resolve_forward_client_id(
+    authorize_id = await indirect.resolve_forward_client_id(
         session=object(),
         dcr_key=None,
-        client_id="https://claude.ai:443/oauth/client.json",
+        client_id=client_id,
         redirect_uri="https://claude.ai/api/mcp/auth_callback",
     )
+    refresh_id = await indirect.translated_client_id_for_refresh(
+        object(), None, client_id
+    )
 
-    assert translated == "https://claude.ai:443/oauth/client.json"
-    fetch.assert_not_awaited()
+    assert authorize_id == "https://claude.ai"
+    assert refresh_id == "https://claude.ai"
+
+
+async def test_portless_same_origin_client_passes_through_on_both_legs(
+    oauth_stack, monkeypatch
+):
+    """claude.ai's real shape: raw netlocs match, so authorize forwards the
+    full client_id untranslated and refresh passes through to match."""
+    indirect = oauth_stack.indirect
+    redirects = AsyncMock(return_value=["https://claude.ai/api/mcp/auth_callback"])
+    monkeypatch.setattr(indirect, "fetch_cimd_redirects", redirects)
+    client_id = "https://claude.ai/oauth/client.json"
+
+    authorize_id = await indirect.resolve_forward_client_id(
+        session=object(),
+        dcr_key=None,
+        client_id=client_id,
+        redirect_uri="https://claude.ai/api/mcp/auth_callback",
+    )
+    refresh_id = await indirect.translated_client_id_for_refresh(
+        object(), None, client_id
+    )
+
+    assert authorize_id == client_id
+    assert refresh_id is indirect.RefreshDisposition.PASSTHROUGH
 
 
 async def test_refresh_identity_has_three_variants(oauth_stack, monkeypatch):
@@ -497,3 +529,32 @@ async def test_ha_auth_refresh_with_redirect_translates_presented_origin(
     assert response.status == 200
     forwarded = relay_session.post.call_args.kwargs["data"]
     assert forwarded["client_id"] == ("https://oauth-redirect.googleusercontent.com")
+
+
+async def test_fast_path_passes_through_malformed_port_client_id(oauth_stack):
+    """#2218 review: a client_id with an invalid port must pass through for
+    core to reject — normalized_origin() reads parsed.port, which raises
+    ValueError, so the fast path compares raw netlocs like the component."""
+    resolved = await oauth_stack.indirect.resolve_forward_client_id(
+        None,
+        None,
+        "https://client.example:99999/metadata.json",
+        "https://client.example/cb",
+    )
+
+    assert resolved == "https://client.example:99999/metadata.json"
+
+
+async def test_dcr_register_rejects_deeply_nested_json(oauth_stack):
+    """#2218 review: json.loads raises RecursionError on a deeply nested
+    body — malformed metadata answers 400, never a 500."""
+    oauth, dcr = oauth_stack.oauth, oauth_stack.dcr
+
+    async def _nested_body():
+        return json.loads("[" * 100000 + "]" * 100000)
+
+    request = SimpleNamespace(json=_nested_body)
+    response = await dcr.DcrRegisterView(_hass(oauth, oauth.MODE_HA_AUTH)).post(request)
+
+    assert response.status == 400
+    assert response.json_body["error"] == "invalid_client_metadata"

--- a/tests/src/unit/test_webhook_proxy_oauth_unified.py
+++ b/tests/src/unit/test_webhook_proxy_oauth_unified.py
@@ -8,6 +8,7 @@ import types
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
+from urllib.parse import parse_qs, urlparse
 
 import pytest
 
@@ -53,10 +54,12 @@ def oauth_stack(monkeypatch):
     monkeypatch.setattr(oauth, "_backend_alive", _backend_alive)
     dcr = _load_submodule(monkeypatch, package_name, "oauth_dcr")
     indirect = _load_submodule(monkeypatch, package_name, "oauth_indirect")
+    autoapprove = _load_submodule(monkeypatch, package_name, "oauth_autoapprove")
     return SimpleNamespace(
         oauth=oauth,
         dcr=dcr,
         indirect=indirect,
+        autoapprove=autoapprove,
         package_name=package_name,
     )
 
@@ -73,6 +76,17 @@ def _hass(oauth, mode: str, *, dcr_key: bytes | None = KEY):
 
 def _json_request(body):
     return SimpleNamespace(json=AsyncMock(return_value=body))
+
+
+def _oauth_request(*, query=None, form=None, host="ha.example"):
+    """Build the request surface shared by the unified view tests."""
+    return SimpleNamespace(
+        query=dict(query or {}),
+        headers={"Host": host},
+        scheme="https",
+        path="/api/mcp_proxy_dev/oauth/authorize",
+        post=AsyncMock(return_value=dict(form or {})),
+    )
 
 
 def test_dcr_client_id_round_trips_multiple_redirects(oauth_stack):
@@ -277,3 +291,135 @@ async def test_cimd_unreachable_result_is_negative_cached(oauth_stack, monkeypat
 
     resolve.assert_awaited_once_with("dead.example", 443)
     indirect._cimd_cache.clear()
+
+
+async def test_unified_authorize_dispatches_legacy_handler(
+    oauth_stack, monkeypatch
+):
+    """The scoped authorize route reuses the extracted legacy implementation."""
+    oauth, autoapprove = oauth_stack.oauth, oauth_stack.autoapprove
+    provider = object()
+    hass = _hass(oauth, oauth.MODE_LEGACY)
+    hass.data[oauth.DOMAIN]["oauth"] = provider
+    sentinel = object()
+    handler = AsyncMock(return_value=sentinel)
+    monkeypatch.setattr(autoapprove, "handle_legacy_authorize_get", handler)
+
+    response = await autoapprove.AutoApproveAuthorizeView(hass).get(
+        _oauth_request()
+    )
+
+    assert response is sentinel
+    handler.assert_awaited_once()
+    assert handler.await_args.args[0] is provider
+
+
+async def test_none_mode_autoapproves_any_valid_redirect(oauth_stack):
+    """None mode has no client allowlist after the maintainer decision."""
+    oauth, autoapprove = oauth_stack.oauth, oauth_stack.autoapprove
+    hass = _hass(oauth, oauth.MODE_NONE_AUTOAPPROVE)
+    provider = autoapprove.AutoApproveProvider(hass, "mcp_test", None)
+    hass.data[oauth.DOMAIN][oauth.AUTOAPPROVE_PROVIDER_KEY] = provider
+    redirect_uri = "https://connector.example/oauth/callback"
+
+    response = await autoapprove.AutoApproveAuthorizeView(hass).get(
+        _oauth_request(
+            query={
+                "response_type": "code",
+                "client_id": "https://metadata.example/client.json",
+                "redirect_uri": redirect_uri,
+                "code_challenge": "A" * 43,
+                "code_challenge_method": "S256",
+                "state": "state-1",
+            }
+        )
+    )
+
+    assert response.status == 302
+    location = response.headers["Location"]
+    assert f"{urlparse(location).scheme}://{urlparse(location).netloc}" == (
+        "https://connector.example"
+    )
+    assert parse_qs(urlparse(location).query)["state"] == ["state-1"]
+
+
+async def test_ha_auth_authorize_uses_dedicated_cimd_session(
+    oauth_stack, monkeypatch
+):
+    """Public metadata lookup never borrows the authenticated relay session."""
+    oauth = oauth_stack.oauth
+    autoapprove = oauth_stack.autoapprove
+    indirect = oauth_stack.indirect
+    hass = _hass(oauth, oauth.MODE_HA_AUTH)
+    cimd_session = object()
+    relay_session = object()
+    data = hass.data[oauth.DOMAIN]
+    data[autoapprove.CFG_CIMD_SESSION] = cimd_session
+    data["session"] = relay_session
+    resolver = AsyncMock(return_value="https://callback.example")
+    monkeypatch.setattr(indirect, "resolve_forward_client_id", resolver)
+
+    response = await autoapprove.AutoApproveAuthorizeView(hass).get(
+        _oauth_request(
+            query={
+                "client_id": "https://metadata.example/client.json",
+                "redirect_uri": "https://callback.example/cb",
+            }
+        )
+    )
+
+    assert response.status == 302
+    resolver.assert_awaited_once_with(
+        cimd_session,
+        KEY,
+        "https://metadata.example/client.json",
+        "https://callback.example/cb",
+    )
+    forwarded = parse_qs(urlparse(response.headers["Location"]).query)
+    assert forwarded["client_id"] == ["https://callback.example"]
+
+
+async def test_ha_auth_token_307s_passthrough_identity(oauth_stack):
+    """An unchanged token body stays client-side so core sees the real IP."""
+    oauth, autoapprove = oauth_stack.oauth, oauth_stack.autoapprove
+    hass = _hass(oauth, oauth.MODE_HA_AUTH, dcr_key=None)
+
+    response = await autoapprove.AutoApproveTokenView(hass).post(
+        _oauth_request(
+            form={
+                "grant_type": "authorization_code",
+                "client_id": "https://client.example/metadata.json",
+                "redirect_uri": "https://client.example/callback",
+            }
+        )
+    )
+
+    assert response.status == 307
+    assert response.headers == {
+        "Location": "/auth/token",
+        "Cache-Control": "no-store",
+    }
+
+
+async def test_ha_auth_refresh_rejects_unreproducible_identity_locally(oauth_stack):
+    """A multi-origin refresh never enters core's failed-login accounting."""
+    oauth, dcr, autoapprove = (
+        oauth_stack.oauth,
+        oauth_stack.dcr,
+        oauth_stack.autoapprove,
+    )
+    hass = _hass(oauth, oauth.MODE_HA_AUTH)
+    client_id = dcr.mint_client_id(KEY, GOOGLE_REDIRECT_URIS)
+
+    response = await autoapprove.AutoApproveTokenView(hass).post(
+        _oauth_request(
+            form={
+                "grant_type": "refresh_token",
+                "client_id": client_id,
+                "refresh_token": "opaque",
+            }
+        )
+    )
+
+    assert response.status == 400
+    assert response.json_body["error"] == "invalid_grant"

--- a/tests/src/unit/test_webhook_proxy_oauth_unified.py
+++ b/tests/src/unit/test_webhook_proxy_oauth_unified.py
@@ -17,9 +17,7 @@ from ._embedded_stubs import install
 install()
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
-COMPONENT_DIR = (
-    REPO_ROOT / "homeassistant-addon-webhook-proxy-dev" / "mcp_proxy_dev"
-)
+COMPONENT_DIR = REPO_ROOT / "homeassistant-addon-webhook-proxy-dev" / "mcp_proxy_dev"
 KEY = b"k" * 32
 GOOGLE_REDIRECT_URIS = [
     "https://oauth-redirect.googleusercontent.com/r/ha-mcp",
@@ -315,27 +313,19 @@ async def test_as_documents_pin_the_claude_cimd_selection_contract(oauth_stack):
     for doc in (ha_auth_doc, none_doc):
         assert doc["client_id_metadata_document_supported"] is True
         assert "none" in doc["token_endpoint_auth_methods_supported"]
-        assert doc["registration_endpoint"] == (
-            f"{base}{oauth.OAUTH_BASE}/register"
-        )
+        assert doc["registration_endpoint"] == (f"{base}{oauth.OAUTH_BASE}/register")
 
     for doc in (ha_auth_doc, none_doc, legacy_doc):
-        assert doc["authorization_endpoint"] == (
-            f"{base}{oauth.OAUTH_BASE}/authorize"
-        )
+        assert doc["authorization_endpoint"] == (f"{base}{oauth.OAUTH_BASE}/authorize")
         assert doc["token_endpoint"] == f"{base}{oauth.OAUTH_BASE}/token"
         assert doc["code_challenge_methods_supported"] == ["S256"]
         assert doc["issuer"] == f"{base}{oauth.OAUTH_BASE}"
 
     assert "registration_endpoint" not in legacy_doc
-    assert "client_secret_basic" in legacy_doc[
-        "token_endpoint_auth_methods_supported"
-    ]
+    assert "client_secret_basic" in legacy_doc["token_endpoint_auth_methods_supported"]
 
 
-async def test_unified_authorize_dispatches_legacy_handler(
-    oauth_stack, monkeypatch
-):
+async def test_unified_authorize_dispatches_legacy_handler(oauth_stack, monkeypatch):
     """The scoped authorize route reuses the extracted legacy implementation."""
     oauth, autoapprove = oauth_stack.oauth, oauth_stack.autoapprove
     provider = object()
@@ -345,9 +335,7 @@ async def test_unified_authorize_dispatches_legacy_handler(
     handler = AsyncMock(return_value=sentinel)
     monkeypatch.setattr(autoapprove, "handle_legacy_authorize_get", handler)
 
-    response = await autoapprove.AutoApproveAuthorizeView(hass).get(
-        _oauth_request()
-    )
+    response = await autoapprove.AutoApproveAuthorizeView(hass).get(_oauth_request())
 
     assert response is sentinel
     handler.assert_awaited_once()
@@ -383,9 +371,7 @@ async def test_none_mode_autoapproves_any_valid_redirect(oauth_stack):
     assert parse_qs(urlparse(location).query)["state"] == ["state-1"]
 
 
-async def test_ha_auth_authorize_uses_dedicated_cimd_session(
-    oauth_stack, monkeypatch
-):
+async def test_ha_auth_authorize_uses_dedicated_cimd_session(oauth_stack, monkeypatch):
     """Public metadata lookup never borrows the authenticated relay session."""
     oauth = oauth_stack.oauth
     autoapprove = oauth_stack.autoapprove
@@ -510,6 +496,4 @@ async def test_ha_auth_refresh_with_redirect_translates_presented_origin(
 
     assert response.status == 200
     forwarded = relay_session.post.call_args.kwargs["data"]
-    assert forwarded["client_id"] == (
-        "https://oauth-redirect.googleusercontent.com"
-    )
+    assert forwarded["client_id"] == ("https://oauth-redirect.googleusercontent.com")

--- a/tests/src/unit/test_webhook_proxy_oauth_unified.py
+++ b/tests/src/unit/test_webhook_proxy_oauth_unified.py
@@ -246,10 +246,13 @@ async def test_explicit_default_port_translates_on_both_legs(oauth_stack, monkey
     assert refresh_id == "https://claude.ai"
 
 
-async def test_uppercase_host_passes_through_on_both_legs(oauth_stack, monkeypatch):
-    """#2219 review: hostnames are case-insensitive (RFC 4343) — an
-    uppercase-host same-origin pair takes the fast path on authorize AND
-    passes through on refresh."""
+async def test_same_case_uppercase_pair_passes_through_on_both_legs(
+    oauth_stack, monkeypatch
+):
+    """#2219 review: an all-uppercase pair is equal under core's raw netloc
+    rule, so authorize passes it through — and refresh matches the client_id
+    against the REGISTERED redirects raw, not the lowercased canonical
+    origin, so it passes through too."""
     indirect = oauth_stack.indirect
     redirects = AsyncMock(return_value=["https://CLAUDE.AI/api/mcp/auth_callback"])
     monkeypatch.setattr(indirect, "fetch_cimd_redirects", redirects)
@@ -267,6 +270,29 @@ async def test_uppercase_host_passes_through_on_both_legs(oauth_stack, monkeypat
 
     assert authorize_id == client_id
     assert refresh_id is indirect.RefreshDisposition.PASSTHROUGH
+
+
+async def test_case_mismatched_pair_translates_on_both_legs(oauth_stack, monkeypatch):
+    """#2219 review, second round: a pair differing only in host casing must
+    miss the fast path — core's raw comparison would reject it untranslated —
+    and take the validated translation on both legs."""
+    indirect = oauth_stack.indirect
+    redirects = AsyncMock(return_value=["https://claude.ai/api/mcp/auth_callback"])
+    monkeypatch.setattr(indirect, "fetch_cimd_redirects", redirects)
+    client_id = "https://CLAUDE.AI/oauth/client.json"
+
+    authorize_id = await indirect.resolve_forward_client_id(
+        session=object(),
+        dcr_key=None,
+        client_id=client_id,
+        redirect_uri="https://claude.ai/api/mcp/auth_callback",
+    )
+    refresh_id = await indirect.translated_client_id_for_refresh(
+        object(), None, client_id
+    )
+
+    assert authorize_id == "https://claude.ai"
+    assert refresh_id == "https://claude.ai"
 
 
 async def test_symmetric_explicit_port_passes_through_on_both_legs(

--- a/tests/src/unit/test_webhook_proxy_oauth_unified.py
+++ b/tests/src/unit/test_webhook_proxy_oauth_unified.py
@@ -246,6 +246,64 @@ async def test_explicit_default_port_translates_on_both_legs(oauth_stack, monkey
     assert refresh_id == "https://claude.ai"
 
 
+async def test_uppercase_host_passes_through_on_both_legs(oauth_stack, monkeypatch):
+    """#2219 review: hostnames are case-insensitive (RFC 4343) — an
+    uppercase-host same-origin pair takes the fast path on authorize AND
+    passes through on refresh."""
+    indirect = oauth_stack.indirect
+    redirects = AsyncMock(return_value=["https://CLAUDE.AI/api/mcp/auth_callback"])
+    monkeypatch.setattr(indirect, "fetch_cimd_redirects", redirects)
+    client_id = "https://CLAUDE.AI/oauth/client.json"
+
+    authorize_id = await indirect.resolve_forward_client_id(
+        session=object(),
+        dcr_key=None,
+        client_id=client_id,
+        redirect_uri="https://CLAUDE.AI/api/mcp/auth_callback",
+    )
+    refresh_id = await indirect.translated_client_id_for_refresh(
+        object(), None, client_id
+    )
+
+    assert authorize_id == client_id
+    assert refresh_id is indirect.RefreshDisposition.PASSTHROUGH
+
+
+async def test_symmetric_explicit_port_passes_through_on_both_legs(
+    oauth_stack, monkeypatch
+):
+    """#2219 review: when the client_id AND the registered redirect both
+    carry the same explicit default port, the authorize fast path fires (raw
+    netlocs equal) and the token is bound to the full client_id — so refresh
+    must pass through, not translate to the canonicalized origin."""
+    indirect = oauth_stack.indirect
+    redirects = AsyncMock(return_value=["https://claude.ai:443/api/mcp/auth_callback"])
+    monkeypatch.setattr(indirect, "fetch_cimd_redirects", redirects)
+    client_id = "https://claude.ai:443/oauth/client.json"
+
+    authorize_id = await indirect.resolve_forward_client_id(
+        session=object(),
+        dcr_key=None,
+        client_id=client_id,
+        redirect_uri="https://claude.ai:443/api/mcp/auth_callback",
+    )
+    refresh_id = await indirect.translated_client_id_for_refresh(
+        object(), None, client_id
+    )
+
+    assert authorize_id == client_id
+    assert refresh_id is indirect.RefreshDisposition.PASSTHROUGH
+
+
+def test_redirect_validator_rejects_yarl_unserializable_authority(oauth_stack):
+    """#2218 review: urlparse accepts a backslash-before-@ authority that
+    yarl later rejects in _redirect_with — the validator must 400 it up
+    front, never let it 500 on an unauthenticated view."""
+    assert not oauth_stack.oauth._is_valid_redirect_uri(
+        "https://client.example\\@evil.example/cb"
+    )
+
+
 async def test_portless_same_origin_client_passes_through_on_both_legs(
     oauth_stack, monkeypatch
 ):

--- a/tests/src/unit/test_webhook_proxy_oauth_unified.py
+++ b/tests/src/unit/test_webhook_proxy_oauth_unified.py
@@ -52,7 +52,13 @@ def oauth_stack(monkeypatch):
 
     monkeypatch.setattr(oauth, "_backend_alive", _backend_alive)
     dcr = _load_submodule(monkeypatch, package_name, "oauth_dcr")
-    return SimpleNamespace(oauth=oauth, dcr=dcr, package_name=package_name)
+    indirect = _load_submodule(monkeypatch, package_name, "oauth_indirect")
+    return SimpleNamespace(
+        oauth=oauth,
+        dcr=dcr,
+        indirect=indirect,
+        package_name=package_name,
+    )
 
 
 def _hass(oauth, mode: str, *, dcr_key: bytes | None = KEY):
@@ -145,3 +151,129 @@ async def test_dcr_rejects_non_loopback_http_redirect(oauth_stack):
 
     assert response.status == 400
     assert response.json_body["error"] == "invalid_redirect_uri"
+
+
+def test_cimd_timing_and_negative_cache_contract(oauth_stack):
+    """Pin the anonymous lookup's resolver, total deadline, and cache bounds."""
+    indirect = oauth_stack.indirect
+
+    assert indirect.CIMD_RESOLVE_TIMEOUT == 5.0
+    assert indirect.CIMD_TOTAL_LOOKUP_TIMEOUT == 12.0
+    assert indirect.CIMD_NEGATIVE_TTL == 60.0
+    assert indirect.CIMD_NEGATIVE_TTL < indirect.CIMD_CACHE_TTL
+
+
+def test_cimd_redirect_matching_includes_loopback_port_variance(oauth_stack):
+    """Non-loopback matches are exact; loopback runtime ports may vary."""
+    indirect = oauth_stack.indirect
+    assert indirect.redirect_matches(
+        ["https://spark.example/cb"], "https://spark.example/cb"
+    )
+    assert not indirect.redirect_matches(
+        ["https://spark.example/cb"], "https://spark.example/other"
+    )
+    assert indirect.redirect_matches(
+        ["http://localhost/callback"], "http://localhost:61264/callback"
+    )
+    assert not indirect.redirect_matches(
+        ["http://localhost/callback"], "http://localhost:61264/other"
+    )
+
+
+@pytest.mark.parametrize(
+    ("redirect_uri", "expected"),
+    [
+        (GOOGLE_REDIRECT_URIS[0], "https://oauth-redirect.googleusercontent.com"),
+        (
+            GOOGLE_REDIRECT_URIS[1],
+            "https://oauth-redirect-sandbox.googleusercontent.com",
+        ),
+    ],
+)
+async def test_multi_origin_dcr_uses_presented_redirect_translation(
+    oauth_stack, redirect_uri, expected
+):
+    """Each authorization leg translates to its matched presented origin."""
+    dcr, indirect = oauth_stack.dcr, oauth_stack.indirect
+    client_id = dcr.mint_client_id(KEY, GOOGLE_REDIRECT_URIS)
+
+    translated = await indirect.resolve_forward_client_id(
+        session=None,
+        dcr_key=KEY,
+        client_id=client_id,
+        redirect_uri=redirect_uri,
+    )
+
+    assert translated == expected
+
+
+async def test_same_origin_comparison_is_canonical(oauth_stack, monkeypatch):
+    """An explicit default port remains on the no-fetch same-origin path."""
+    indirect = oauth_stack.indirect
+    fetch = AsyncMock()
+    monkeypatch.setattr(indirect, "fetch_cimd_redirects", fetch)
+
+    translated = await indirect.resolve_forward_client_id(
+        session=object(),
+        dcr_key=None,
+        client_id="https://claude.ai:443/oauth/client.json",
+        redirect_uri="https://claude.ai/api/mcp/auth_callback",
+    )
+
+    assert translated == "https://claude.ai:443/oauth/client.json"
+    fetch.assert_not_awaited()
+
+
+async def test_refresh_identity_has_three_variants(oauth_stack, monkeypatch):
+    """Refresh derives an origin, passes through, or rejects unreproducible IDs."""
+    dcr, indirect = oauth_stack.dcr, oauth_stack.indirect
+    reproducible = dcr.mint_client_id(KEY, ["https://a.example/cb"])
+    multi_origin = dcr.mint_client_id(KEY, GOOGLE_REDIRECT_URIS)
+
+    assert (
+        await indirect.translated_client_id_for_refresh(None, KEY, reproducible)
+        == "https://a.example"
+    )
+    assert (
+        await indirect.translated_client_id_for_refresh(None, KEY, multi_origin)
+        is indirect.RefreshDisposition.UNREPRODUCIBLE
+    )
+
+    monkeypatch.setattr(indirect, "fetch_cimd_redirects", AsyncMock(return_value=None))
+    assert (
+        await indirect.translated_client_id_for_refresh(
+            object(), None, "https://unknown.example/client.json"
+        )
+        is indirect.RefreshDisposition.PASSTHROUGH
+    )
+
+
+async def test_unreproducible_cimd_refresh_is_explicit(oauth_stack, monkeypatch):
+    """Verified CIMD multi-origin identities use UNREPRODUCIBLE too."""
+    indirect = oauth_stack.indirect
+    monkeypatch.setattr(
+        indirect,
+        "fetch_cimd_redirects",
+        AsyncMock(return_value=GOOGLE_REDIRECT_URIS),
+    )
+
+    translated = await indirect.translated_client_id_for_refresh(
+        object(), None, "https://spark.example/client.json"
+    )
+
+    assert translated is indirect.RefreshDisposition.UNREPRODUCIBLE
+
+
+async def test_cimd_unreachable_result_is_negative_cached(oauth_stack, monkeypatch):
+    """Repeated requests for a dead identity do not repeat DNS resolution."""
+    indirect = oauth_stack.indirect
+    resolve = AsyncMock(return_value=[])
+    monkeypatch.setattr(indirect, "_resolve_public_addresses", resolve)
+    indirect._cimd_cache.clear()
+    client_id = "https://dead.example/client.json"
+
+    assert await indirect.fetch_cimd_redirects(object(), client_id) is None
+    assert await indirect.fetch_cimd_redirects(object(), client_id) is None
+
+    resolve.assert_awaited_once_with("dead.example", 443)
+    indirect._cimd_cache.clear()

--- a/tests/src/unit/test_webhook_proxy_oauth_unified.py
+++ b/tests/src/unit/test_webhook_proxy_oauth_unified.py
@@ -7,7 +7,7 @@ import sys
 import types
 from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 from urllib.parse import parse_qs, urlparse
 
 import pytest
@@ -55,11 +55,13 @@ def oauth_stack(monkeypatch):
     dcr = _load_submodule(monkeypatch, package_name, "oauth_dcr")
     indirect = _load_submodule(monkeypatch, package_name, "oauth_indirect")
     autoapprove = _load_submodule(monkeypatch, package_name, "oauth_autoapprove")
+    auth_native = _load_submodule(monkeypatch, package_name, "auth_native")
     return SimpleNamespace(
         oauth=oauth,
         dcr=dcr,
         indirect=indirect,
         autoapprove=autoapprove,
+        auth_native=auth_native,
         package_name=package_name,
     )
 
@@ -293,6 +295,44 @@ async def test_cimd_unreachable_result_is_negative_cached(oauth_stack, monkeypat
     indirect._cimd_cache.clear()
 
 
+async def test_as_documents_pin_the_claude_cimd_selection_contract(oauth_stack):
+    """Every advertised URL is proxy-owned and both public modes keep CIMD."""
+    oauth = oauth_stack.oauth
+    base = "https://ha.example"
+    hass = _hass(oauth, oauth.MODE_LEGACY)
+    provider = SimpleNamespace(
+        _hass=hass,
+        base_url_for=lambda _request: base,
+        authorization_server_url=lambda value: f"{value}{oauth.OAUTH_BASE}",
+    )
+    hass.data[oauth.DOMAIN]["oauth"] = provider
+    legacy_doc = (
+        await oauth.AuthorizationServerMetadataView(provider).get(_oauth_request())
+    ).json_body
+    ha_auth_doc = oauth_stack.auth_native.authorization_server_document(base)
+    none_doc = oauth_stack.autoapprove.authorization_server_document(base)
+
+    for doc in (ha_auth_doc, none_doc):
+        assert doc["client_id_metadata_document_supported"] is True
+        assert "none" in doc["token_endpoint_auth_methods_supported"]
+        assert doc["registration_endpoint"] == (
+            f"{base}{oauth.OAUTH_BASE}/register"
+        )
+
+    for doc in (ha_auth_doc, none_doc, legacy_doc):
+        assert doc["authorization_endpoint"] == (
+            f"{base}{oauth.OAUTH_BASE}/authorize"
+        )
+        assert doc["token_endpoint"] == f"{base}{oauth.OAUTH_BASE}/token"
+        assert doc["code_challenge_methods_supported"] == ["S256"]
+        assert doc["issuer"] == f"{base}{oauth.OAUTH_BASE}"
+
+    assert "registration_endpoint" not in legacy_doc
+    assert "client_secret_basic" in legacy_doc[
+        "token_endpoint_auth_methods_supported"
+    ]
+
+
 async def test_unified_authorize_dispatches_legacy_handler(
     oauth_stack, monkeypatch
 ):
@@ -423,3 +463,53 @@ async def test_ha_auth_refresh_rejects_unreproducible_identity_locally(oauth_sta
 
     assert response.status == 400
     assert response.json_body["error"] == "invalid_grant"
+
+
+async def test_ha_auth_refresh_with_redirect_translates_presented_origin(
+    oauth_stack, monkeypatch
+):
+    """A redirect-carrying refresh remains usable for multi-origin clients."""
+    oauth, dcr, indirect, autoapprove = (
+        oauth_stack.oauth,
+        oauth_stack.dcr,
+        oauth_stack.indirect,
+        oauth_stack.autoapprove,
+    )
+    redirect_uri = GOOGLE_REDIRECT_URIS[0]
+    client_id = dcr.mint_client_id(KEY, GOOGLE_REDIRECT_URIS)
+    core_response = SimpleNamespace(
+        status=200,
+        content_type="application/json",
+        read=AsyncMock(return_value=b'{"access_token":"core"}'),
+    )
+
+    class _CoreRequest:
+        async def __aenter__(self):
+            return core_response
+
+        async def __aexit__(self, *_args):
+            return False
+
+    relay_session = SimpleNamespace(post=MagicMock(return_value=_CoreRequest()))
+    hass = _hass(oauth, oauth.MODE_HA_AUTH)
+    hass.data[oauth.DOMAIN]["session"] = relay_session
+    monkeypatch.setattr(
+        indirect, "core_token_base_url", lambda _hass: "https://core.example"
+    )
+
+    response = await autoapprove.AutoApproveTokenView(hass).post(
+        _oauth_request(
+            form={
+                "grant_type": "refresh_token",
+                "refresh_token": "opaque",
+                "client_id": client_id,
+                "redirect_uri": redirect_uri,
+            }
+        )
+    )
+
+    assert response.status == 200
+    forwarded = relay_session.post.call_args.kwargs["data"]
+    assert forwarded["client_id"] == (
+        "https://oauth-redirect.googleusercontent.com"
+    )

--- a/tests/src/unit/test_webhook_proxy_oauth_unified.py
+++ b/tests/src/unit/test_webhook_proxy_oauth_unified.py
@@ -75,8 +75,26 @@ def _hass(oauth, mode: str, *, dcr_key: bytes | None = KEY):
     return SimpleNamespace(data={oauth.DOMAIN: data}, http=SimpleNamespace())
 
 
+def _reader(raw: bytes):
+    """An async .read(limit) returning at most ``limit`` bytes of ``raw``."""
+
+    async def read(limit):
+        return raw[:limit]
+
+    return read
+
+
+def _raw_request(raw: bytes):
+    """A request whose bounded .content.read() yields ``raw``."""
+
+    async def read(limit):
+        return raw[:limit]
+
+    return SimpleNamespace(content=SimpleNamespace(read=read))
+
+
 def _json_request(body):
-    return SimpleNamespace(json=AsyncMock(return_value=body))
+    return _raw_request(json.dumps(body).encode())
 
 
 def _oauth_request(*, query=None, form=None, host="ha.example"):
@@ -278,27 +296,59 @@ async def test_same_case_uppercase_pair_passes_through_on_both_legs(
     redirects.assert_awaited_once_with(session, client_id)
 
 
-async def test_case_mismatched_pair_translates_on_both_legs(oauth_stack, monkeypatch):
-    """#2219 review, second round: a pair differing only in host casing must
-    miss the fast path — core's raw comparison would reject it untranslated —
-    and take the validated translation on both legs."""
+@pytest.mark.parametrize(
+    "presented_case, registered_case",
+    [("upper", "lower"), ("lower", "lower"), ("lower", "upper")],
+)
+async def test_case_only_differences_pass_through_on_both_legs(
+    oauth_stack, monkeypatch, presented_case, registered_case
+):
+    """#2219 review round 3: core's authorize leg lowercases BOTH sides
+    (indieauth._parse_url) while its refresh leg compares byte-exact, so a
+    case-only difference is same-origin to core and the raw client_id is what
+    both legs must forward — the document's casing is author-written and the
+    presented redirect is client-runtime, so they need not agree."""
     indirect = oauth_stack.indirect
-    redirects = AsyncMock(return_value=["https://claude.ai/api/mcp/auth_callback"])
-    monkeypatch.setattr(indirect, "fetch_cimd_redirects", redirects)
+    upper = "https://CLAUDE.AI/api/mcp/auth_callback"
+    lower = "https://claude.ai/api/mcp/auth_callback"
+    presented = upper if presented_case == "upper" else lower
+    registered = [upper if registered_case == "upper" else lower]
+    monkeypatch.setattr(
+        indirect, "fetch_cimd_redirects", AsyncMock(return_value=registered)
+    )
     client_id = "https://CLAUDE.AI/oauth/client.json"
 
     authorize_id = await indirect.resolve_forward_client_id(
         session=object(),
         dcr_key=None,
         client_id=client_id,
-        redirect_uri="https://claude.ai/api/mcp/auth_callback",
+        redirect_uri=presented,
     )
     refresh_id = await indirect.translated_client_id_for_refresh(
         object(), None, client_id
     )
 
-    assert authorize_id == "https://claude.ai"
-    assert refresh_id == "https://claude.ai"
+    assert authorize_id == client_id
+    assert refresh_id is indirect.RefreshDisposition.PASSTHROUGH
+
+
+async def test_mixed_port_shapes_are_unreproducible(oauth_stack, monkeypatch):
+    """#2219 review round 3: port normalization makes these ONE canonical
+    origin, but authorize passes through for the port-less redirect and
+    translates the explicit-port one — which was presented is unrecorded, so
+    the honest answer is a local invalid_grant."""
+    indirect = oauth_stack.indirect
+    monkeypatch.setattr(
+        indirect,
+        "fetch_cimd_redirects",
+        AsyncMock(return_value=["https://h.example/a", "https://h.example:443/b"]),
+    )
+
+    refresh_id = await indirect.translated_client_id_for_refresh(
+        object(), None, "https://h.example/client.json"
+    )
+
+    assert refresh_id is indirect.RefreshDisposition.UNREPRODUCIBLE
 
 
 async def test_symmetric_explicit_port_passes_through_on_both_legs(
@@ -640,10 +690,20 @@ async def test_dcr_register_rejects_deeply_nested_json(oauth_stack):
     body — malformed metadata answers 400, never a 500."""
     oauth, dcr = oauth_stack.oauth, oauth_stack.dcr
 
-    async def _nested_body():
-        return json.loads("[" * 100000 + "]" * 100000)
+    request = _raw_request(b"[" * 30000 + b"]" * 30000)
+    response = await dcr.DcrRegisterView(_hass(oauth, oauth.MODE_HA_AUTH)).post(request)
 
-    request = SimpleNamespace(json=_nested_body)
+    assert response.status == 400
+    assert response.json_body["error"] == "invalid_client_metadata"
+
+
+async def test_dcr_register_rejects_oversized_body(oauth_stack):
+    """#2219 review round 3: a conforming registration is a few KB, so the
+    read is capped rather than riding HA's 16 MiB client_max_size."""
+    oauth, dcr = oauth_stack.oauth, oauth_stack.dcr
+    oversized = b"x" * (dcr.MAX_DCR_BODY_BYTES + 1)
+
+    request = SimpleNamespace(content=SimpleNamespace(read=_reader(oversized)))
     response = await dcr.DcrRegisterView(_hass(oauth, oauth.MODE_HA_AUTH)).post(request)
 
     assert response.status == 400

--- a/tests/src/unit/test_webhook_proxy_oauth_unified.py
+++ b/tests/src/unit/test_webhook_proxy_oauth_unified.py
@@ -693,11 +693,16 @@ async def test_dcr_register_rejects_deeply_nested_json(oauth_stack):
     body — malformed metadata answers 400, never a 500."""
     oauth, dcr = oauth_stack.oauth, oauth_stack.dcr
 
-    request = _raw_request(b"[" * 30000 + b"]" * 30000)
+    payload = b"[" * 30000 + b"]" * 30000
+    assert len(payload) < dcr.MAX_DCR_BODY_BYTES
+    request = _raw_request(payload)
     response = await dcr.DcrRegisterView(_hass(oauth, oauth.MODE_HA_AUTH)).post(request)
 
     assert response.status == 400
     assert response.json_body["error"] == "invalid_client_metadata"
+    # The description distinguishes the arms: both guards answer the same
+    # error code, so only this pins that the PARSER rejected it.
+    assert response.json_body["error_description"] == "body must be JSON"
 
 
 async def test_dcr_register_reassembles_a_chunked_body(oauth_stack):
@@ -723,3 +728,4 @@ async def test_dcr_register_rejects_oversized_body(oauth_stack):
 
     assert response.status == 400
     assert response.json_body["error"] == "invalid_client_metadata"
+    assert response.json_body["error_description"] == "body is too large"

--- a/tests/src/unit/test_webhook_proxy_oauth_unified.py
+++ b/tests/src/unit/test_webhook_proxy_oauth_unified.py
@@ -1,0 +1,147 @@
+"""Proxy ports of the unified OAuth, DCR, and CIMD regression tests."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from ._embedded_stubs import install
+
+install()
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+COMPONENT_DIR = (
+    REPO_ROOT / "homeassistant-addon-webhook-proxy-dev" / "mcp_proxy_dev"
+)
+KEY = b"k" * 32
+GOOGLE_REDIRECT_URIS = [
+    "https://oauth-redirect.googleusercontent.com/r/ha-mcp",
+    "https://oauth-redirect-sandbox.googleusercontent.com/r/ha-mcp",
+]
+
+
+def _load_submodule(monkeypatch, package_name: str, name: str):
+    module_name = f"{package_name}.{name}"
+    spec = importlib.util.spec_from_file_location(
+        module_name, COMPONENT_DIR / f"{name}.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, module_name, module)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def oauth_stack(monkeypatch):
+    """Load the dev proxy OAuth modules as one package with a live backend."""
+    package_name = "webhook_proxy_dev_oauth_test"
+    package = types.ModuleType(package_name)
+    package.__path__ = [str(COMPONENT_DIR)]
+    monkeypatch.setitem(sys.modules, package_name, package)
+
+    oauth = _load_submodule(monkeypatch, package_name, "oauth")
+
+    async def _backend_alive(_hass):
+        return True
+
+    monkeypatch.setattr(oauth, "_backend_alive", _backend_alive)
+    dcr = _load_submodule(monkeypatch, package_name, "oauth_dcr")
+    return SimpleNamespace(oauth=oauth, dcr=dcr, package_name=package_name)
+
+
+def _hass(oauth, mode: str, *, dcr_key: bytes | None = KEY):
+    data = {
+        "oauth_mode": mode,
+        "target_url": "http://127.0.0.1:9583/private_x",
+    }
+    if dcr_key is not None:
+        data["dcr_signing_key"] = dcr_key
+    return SimpleNamespace(data={oauth.DOMAIN: data}, http=SimpleNamespace())
+
+
+def _json_request(body):
+    return SimpleNamespace(json=AsyncMock(return_value=body))
+
+
+def test_dcr_client_id_round_trips_multiple_redirects(oauth_stack):
+    """A signed registration preserves every presented redirect URI."""
+    dcr = oauth_stack.dcr
+    client_id = dcr.mint_client_id(KEY, GOOGLE_REDIRECT_URIS)
+
+    assert client_id.startswith("hamcp-dcr-")
+    assert dcr.client_redirect_uris(KEY, client_id) == GOOGLE_REDIRECT_URIS
+    assert dcr.client_redirect_uris(b"x" * 32, client_id) is None
+
+
+async def test_dcr_none_mode_advertises_authorization_code_only(oauth_stack):
+    """None-mode registrations do not promise an unsupported refresh grant."""
+    oauth, dcr = oauth_stack.oauth, oauth_stack.dcr
+    response = await dcr.DcrRegisterView(
+        _hass(oauth, oauth.MODE_NONE_AUTOAPPROVE)
+    ).post(_json_request({"redirect_uris": ["https://a.example/cb"]}))
+
+    assert response.status == 201
+    assert response.json_body["grant_types"] == ["authorization_code"]
+
+
+async def test_dcr_ha_auth_narrows_multi_origin_registration(oauth_stack):
+    """Spark's two web origins register, without an unreproducible refresh."""
+    oauth, dcr = oauth_stack.oauth, oauth_stack.dcr
+    response = await dcr.DcrRegisterView(_hass(oauth, oauth.MODE_HA_AUTH)).post(
+        _json_request({"redirect_uris": GOOGLE_REDIRECT_URIS})
+    )
+
+    assert response.status == 201
+    assert response.json_body["grant_types"] == ["authorization_code"]
+    assert dcr.client_redirect_uris(KEY, response.json_body["client_id"]) == (
+        GOOGLE_REDIRECT_URIS
+    )
+
+
+async def test_dcr_ha_auth_keeps_reproducible_refresh(oauth_stack):
+    """A single stable web origin can be reconstructed on refresh."""
+    oauth, dcr = oauth_stack.oauth, oauth_stack.dcr
+    response = await dcr.DcrRegisterView(_hass(oauth, oauth.MODE_HA_AUTH)).post(
+        _json_request({"redirect_uris": ["https://a.example/cb"]})
+    )
+
+    assert response.status == 201
+    assert response.json_body["grant_types"] == [
+        "authorization_code",
+        "refresh_token",
+    ]
+
+
+async def test_dcr_preserves_explicit_zero_port_origin(oauth_stack):
+    """An explicit port zero remains distinct from the HTTPS default port."""
+    oauth, dcr = oauth_stack.oauth, oauth_stack.dcr
+    response = await dcr.DcrRegisterView(_hass(oauth, oauth.MODE_HA_AUTH)).post(
+        _json_request(
+            {
+                "redirect_uris": [
+                    "https://a.example/cb",
+                    "https://a.example:0/cb",
+                ]
+            }
+        )
+    )
+
+    assert response.status == 201
+    assert response.json_body["grant_types"] == ["authorization_code"]
+
+
+async def test_dcr_rejects_non_loopback_http_redirect(oauth_stack):
+    """Only HTTPS and RFC 8252 loopback HTTP callbacks are accepted."""
+    oauth, dcr = oauth_stack.oauth, oauth_stack.dcr
+    response = await dcr.DcrRegisterView(
+        _hass(oauth, oauth.MODE_NONE_AUTOAPPROVE)
+    ).post(_json_request({"redirect_uris": ["http://evil.example/cb"]}))
+
+    assert response.status == 400
+    assert response.json_body["error"] == "invalid_redirect_uri"

--- a/tests/src/unit/test_webhook_proxy_oauth_unified.py
+++ b/tests/src/unit/test_webhook_proxy_oauth_unified.py
@@ -468,37 +468,78 @@ async def test_cimd_unreachable_result_is_negative_cached(oauth_stack, monkeypat
     indirect._cimd_cache.clear()
 
 
+class _CimdContent:
+    """Response body stream over fixed chunks."""
+
+    def __init__(self, chunks):
+        self._chunks = chunks
+
+    async def iter_chunked(self, _size):
+        for chunk in self._chunks:
+            yield chunk
+
+
+class _CimdResponse:
+    status = 200
+
+    def __init__(self, body: bytes):
+        self.content = _CimdContent([body])
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_args):
+        return None
+
+
+class _CimdSession:
+    """Serves queued bodies over the real fetch/parse path."""
+
+    def __init__(self, bodies):
+        self._bodies = list(bodies)
+        self.calls: list[str] = []
+
+    def get(self, url, **_kwargs):
+        self.calls.append(url)
+        return _CimdResponse(self._bodies.pop(0))
+
+
 async def test_invalid_cimd_document_is_not_negative_cached(oauth_stack, monkeypatch):
     """Draft -00 §4.4.3: an INVALID document is deliberately not cached, so a
     client that fixes its metadata recovers on the very next request.
 
-    Mirrors the component's test_invalid_cimd_is_not_negative_cached. Without
-    this pin the policy is only a comment on this side: adding a _cache_cimd()
-    call to the invalid branch would keep every other proxy test green, and
-    both review bots have already re-raised the non-caching as a defect
-    (#2218 review by Patch76)."""
+    Mirrors the component's test_invalid_cimd_is_not_negative_cached, and like
+    it drives REAL bodies through _fetch_pinned_cimd and _parse_cimd rather
+    than stubbing the fetch — otherwise a _cache_cimd() introduced inside the
+    fetch path would stay green here while failing on the component side
+    (#2218 review by Patch76). Without this pin the policy is only a comment
+    on this side, and both review bots have already re-raised the
+    non-caching as a defect."""
     indirect = oauth_stack.indirect
+    client_id = "https://client.example/client.json"
+    invalid = json.dumps(  # no client_name -> rejected by _parse_cimd
+        {"client_id": client_id, "redirect_uris": ["https://client.example/cb"]}
+    ).encode()
+    valid = json.dumps(
+        {
+            "client_id": client_id,
+            "client_name": "Client",
+            "redirect_uris": ["https://client.example/cb"],
+        }
+    ).encode()
     monkeypatch.setattr(
         indirect,
         "_resolve_public_addresses",
         AsyncMock(return_value=["93.184.216.34"]),
     )
-    outcomes = [(True, None), (True, ["https://client.example/cb"])]
-    calls: list[str] = []
-
-    async def fetch(_session, fetched_id, _parsed, _address):
-        calls.append(fetched_id)
-        return outcomes[len(calls) - 1]
-
-    monkeypatch.setattr(indirect, "_fetch_pinned_cimd", fetch)
+    session = _CimdSession([invalid, valid])
     indirect._cimd_cache.clear()
-    client_id = "https://client.example/client.json"
 
-    assert await indirect.fetch_cimd_redirects(object(), client_id) is None
-    assert await indirect.fetch_cimd_redirects(object(), client_id) == [
+    assert await indirect.fetch_cimd_redirects(session, client_id) is None
+    assert await indirect.fetch_cimd_redirects(session, client_id) == [
         "https://client.example/cb"
     ]
-    assert len(calls) == 2  # re-fetched rather than served from a cache
+    assert len(session.calls) == 2  # re-fetched rather than served from a cache
     indirect._cimd_cache.clear()
 
 

--- a/tests/src/unit/test_webhook_proxy_oauth_unified.py
+++ b/tests/src/unit/test_webhook_proxy_oauth_unified.py
@@ -254,22 +254,28 @@ async def test_same_case_uppercase_pair_passes_through_on_both_legs(
     against the REGISTERED redirects raw, not the lowercased canonical
     origin, so it passes through too."""
     indirect = oauth_stack.indirect
+    session = object()
     redirects = AsyncMock(return_value=["https://CLAUDE.AI/api/mcp/auth_callback"])
     monkeypatch.setattr(indirect, "fetch_cimd_redirects", redirects)
     client_id = "https://CLAUDE.AI/oauth/client.json"
 
     authorize_id = await indirect.resolve_forward_client_id(
-        session=object(),
+        session=session,
         dcr_key=None,
         client_id=client_id,
         redirect_uri="https://CLAUDE.AI/api/mcp/auth_callback",
     )
+    # The fast path decided authorize — no lookup.
+    redirects.assert_not_awaited()
     refresh_id = await indirect.translated_client_id_for_refresh(
-        object(), None, client_id
+        session, None, client_id
     )
 
     assert authorize_id == client_id
     assert refresh_id is indirect.RefreshDisposition.PASSTHROUGH
+    # Refresh DID fetch and matched the registered redirect — the passthrough
+    # is the comparison's verdict, not a skipped lookup.
+    redirects.assert_awaited_once_with(session, client_id)
 
 
 async def test_case_mismatched_pair_translates_on_both_legs(oauth_stack, monkeypatch):

--- a/tests/src/unit/test_webhook_proxy_oauth_unified.py
+++ b/tests/src/unit/test_webhook_proxy_oauth_unified.py
@@ -75,11 +75,17 @@ def _hass(oauth, mode: str, *, dcr_key: bytes | None = KEY):
     return SimpleNamespace(data={oauth.DOMAIN: data}, http=SimpleNamespace())
 
 
-def _reader(raw: bytes):
-    """An async .read(limit) returning at most ``limit`` bytes of ``raw``."""
+def _reader(raw: bytes, *, chunk: int | None = None):
+    """An async .read(limit) over ``raw``; ``chunk`` fragments it like a real
+    StreamReader, which may return early before EOF."""
+    pos = 0
 
     async def read(limit):
-        return raw[:limit]
+        nonlocal pos
+        take = min(limit, chunk) if chunk else limit
+        out = raw[pos : pos + take]
+        pos += len(out)
+        return out
 
     return read
 
@@ -87,10 +93,7 @@ def _reader(raw: bytes):
 def _raw_request(raw: bytes):
     """A request whose bounded .content.read() yields ``raw``."""
 
-    async def read(limit):
-        return raw[:limit]
-
-    return SimpleNamespace(content=SimpleNamespace(read=read))
+    return SimpleNamespace(content=SimpleNamespace(read=_reader(raw)))
 
 
 def _json_request(body):
@@ -695,6 +698,18 @@ async def test_dcr_register_rejects_deeply_nested_json(oauth_stack):
 
     assert response.status == 400
     assert response.json_body["error"] == "invalid_client_metadata"
+
+
+async def test_dcr_register_reassembles_a_chunked_body(oauth_stack):
+    """#2219 review round 3: a fragmented body must be read to EOF — a single
+    StreamReader.read() can return early and truncate the document."""
+    oauth, dcr = oauth_stack.oauth, oauth_stack.dcr
+    body = json.dumps({"redirect_uris": ["https://a.example/cb"]}).encode()
+
+    request = SimpleNamespace(content=SimpleNamespace(read=_reader(body, chunk=7)))
+    response = await dcr.DcrRegisterView(_hass(oauth, oauth.MODE_HA_AUTH)).post(request)
+
+    assert response.status == 201
 
 
 async def test_dcr_register_rejects_oversized_body(oauth_stack):


### PR DESCRIPTION
## What does this PR do?

Mirrors the component's OAuth surface overhaul (#2213 + #2217) onto the Webhook Proxy add-on's bundled integration (dev flavor, per the dev-first promote-only flow), and fixes the ghost-surface bug where a stopped add-on kept advertising a live OAuth surface.

- Unified mode-dispatched endpoints: `/api/mcp_proxy_dev/oauth/{authorize,token}` dispatch per request on the live `oauth_mode` (legacy / ha_auth / none auto-approve), so a mode switch never strands a client on cached endpoints. Root `/authorize` + `/token` stay bound as legacy compatibility aliases.
- In-proxy CIMD validation for ha_auth: fetches and validates Client ID Metadata Documents (DNS pinned to public addresses, size-capped, strict parse, negative caching, 12-second total lookup deadline) and hands core a translated client_id its same-origin rule accepts — cross-origin connectors sign in without waiting on the core-side CIMD fix.
- Stateless DCR: `/api/mcp_proxy_dev/oauth/register` (ha_auth + none modes) mints HMAC-signed client_ids embedding the registered redirect set; multi-origin web registrations are accepted with presented-redirect translation.
- Refresh contract: registrations with exactly one reproducible web origin re-derive it on redirect-less refreshes; verified identities without one (multi-origin, loopback-only, hybrid) answer `invalid_grant` locally instead of relaying a guaranteed failure into core's failed-login accounting; a refresh that carries a `redirect_uri` translates from it like any other leg.
- Ghost-surface fix: `start.py` touches a heartbeat file every keep-alive iteration and unlinks it on shutdown, before signal handling is restored and before the slow HA calls; every OAuth view serves only while that file is fresh (90-second staleness window; only the "down" verdict is cached, for 1 second, kept under `_probe_oauth_active`'s 2-second retry delay so a restart's probes can never all land inside one lease). A stopped add-on's views return 404 instead of advertising a live authorization server indefinitely. Probing the forwarding target instead does not work: that URL is the independent ha-mcp server add-on, which keeps accepting connections after this add-on stops.
- Inbound-request debug logging additionally raises `homeassistant.components.webhook` while it is on, so an arriving request for an unregistered webhook id is visible instead of looking like silence (#2220). Only raises a less-verbose logger and undoes only its own raise.
- The AS documents advertise only proxy-owned endpoints plus the CIMD selection flags (`client_id_metadata_document_supported: true`, `"none"` in `token_endpoint_auth_methods_supported`).
- Dev add-on version `2.1.1.dev3` → `2.1.1.dev5` (the dev line's next-stable-patch rule; the promote workflow assigns the stable number later).

Deliberately not mirrored: the component's admin-only ha_auth bearer gate (the proxy's accept-any-valid-HA-login is a confirmed deliberate asymmetry), and entry-data key storage (the proxy's idiom is files under `/config/`; the DCR signing key lives at `/config/.mcp_proxy_dev_dcr_secret`, atomic 0600).

Migration: additive. Existing connections keep working; the one behavior change is that a stopped add-on no longer serves OAuth metadata — clients probing a stopped install get 404s, which is what a never-installed proxy already returns.

The stable flavor is untouched; it receives all of this through the promote workflow after live validation on the dev channel.

## Type of change
- [x] 🐛 Bug fix
- [x] ✨ New feature

## Testing
- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

## Checklist
- [x] I have updated documentation if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added unified OAuth support for legacy, Home Assistant authentication, and no-auth modes.
  - Added Dynamic Client Registration, improved client identity handling, PKCE support, and mode-aware OAuth discovery.
  - Added automatic OAuth endpoint availability monitoring.

- **Bug Fixes**
  - Improved redirect validation, token privacy, timeout handling, and fail-closed behavior.
  - OAuth endpoints now deactivate when the proxy is unavailable.

- **Documentation**
  - Expanded OAuth configuration, behavior, security, and troubleshooting guidance.

- **Chores**
  - Updated the development add-on version to 2.1.1.dev5.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
