### PR TITLE
docs: clarify HACS pre-release selection

### DIFF
--- a/.github/integration-mirror-readme-prefix.md
+++ b/.github/integration-mirror-readme-prefix.md
@@ -9,7 +9,13 @@ which syncs this repository automatically.
 - **Development**: enable this repository's **Pre-release** switch in HACS
   (an entity HACS creates per downloaded repository, disabled by default)
   to receive `-dev.N` pre-release builds. Their new features may require a
-  newer server and only become fully usable with the next stable release.
+  newer server and only become fully usable with the next stable release. Then
+  within the HA-MCP custom component page on HACS open the menu, click "update
+  information." Open the menu again, select "redownload", then "Need a
+  different version?" and then you will be able to pick the
+  pre-release/development version of your choosing. When the next stable update
+  releases you should still automatically get the update notification from
+  HACS.
 
 Please open issues and pull requests on the
 [main repository](https://github.com/homeassistant-ai/ha-mcp/issues) -

--- a/.github/integration-mirror-readme-prefix.md
+++ b/.github/integration-mirror-readme-prefix.md
@@ -9,13 +9,15 @@ which syncs this repository automatically.
 - **Development**: enable this repository's **Pre-release** switch in HACS
   (an entity HACS creates per downloaded repository, disabled by default)
   to receive `-dev.N` pre-release builds. Their new features may require a
-  newer server and only become fully usable with the next stable release. Then
-  within the HA-MCP custom component page on HACS open the menu, click "update
-  information." Open the menu again, select "redownload", then "Need a
-  different version?" and then you will be able to pick the
-  pre-release/development version of your choosing. When the next stable update
-  releases you should still automatically get the update notification from
-  HACS.
+  newer server and only become fully usable with the next stable release.
+  To install a specific development build, open the repository menu in HACS
+  and select **Update information**. Open the menu again, select
+  **Redownload**, expand **Need a different version?**, choose the desired
+  pre-release, and select **Download**. After the download completes, restart
+  Home Assistant so the selected integration version becomes active. If you
+  do not want notifications for later development releases, turn the
+  repository's **Pre-release** switch off again; HACS will continue checking
+  stable releases and notify you when the next stable version is available.
 
 Please open issues and pull requests on the
 [main repository](https://github.com/homeassistant-ai/ha-mcp/issues) -

--- a/.github/integration-mirror-readme-prefix.md
+++ b/.github/integration-mirror-readme-prefix.md
@@ -13,8 +13,9 @@ which syncs this repository automatically.
   To install a specific development build, open the repository menu in HACS
   and select **Update information**. Open the menu again, select
   **Redownload**, expand **Need a different version?**, choose the desired
-  pre-release, and select **Download**. After the download completes, restart
-  Home Assistant so the selected integration version becomes active. If you
+  pre-release, and select **Download**. Home Assistant will then show a
+  notification that a restart is required; restart from that notification to
+  finish installing the selected integration version. If you
   do not want notifications for later development releases, turn the
   repository's **Pre-release** switch off again; HACS will continue checking
   stable releases and notify you when the next stable version is available.


### PR DESCRIPTION
## What does this PR do?

Updates the HACS mirror README prefix with the steps for refreshing repository
information, selecting a development pre-release, restarting Home Assistant,
and returning to stable-only update notifications.

The mirror workflow regenerates its README from this parent-repository source,
so keeping these instructions here prevents future syncs from overwriting them.

## Type of change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [x] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [ ] All automated tests pass (`uv run pytest`)
- [ ] Code follows style guidelines (`uv run ruff check`)

Generated the mirror README with `scripts/build_mirror_readme.py` and verified
that the updated prefix appears in the composed output. No automated tests were
run because this changes only the Markdown prefix.

## Checklist
- [x] I have updated documentation if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated development installation instructions with steps to refresh HACS information and redownload the integration.
  * Added guidance for selecting a specific pre-release build and restarting Home Assistant.
  * Clarified how to disable future development-release notifications while continuing to receive stable-release notifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->