### PR TITLE
fix: explain how to disable startup notification

### DIFF
--- a/custom_components/ha_mcp_tools/embedded_setup.py
+++ b/custom_components/ha_mcp_tools/embedded_setup.py
@@ -507,7 +507,9 @@ def _surface_connect_urls(
         "(Settings - Devices & Services - HA-MCP Custom Component - "
         "HA-MCP Server - Configure) and in the Home Assistant log - both "
         "administrator-only, because the URL is the credential.\n\n"
-        f"{auth_note}\n"
+        f"{auth_note}\n\n"
+        "To disable this notification, uncheck the startup notification box "
+        "on that same configuration screen.\n"
     )
     persistent_notification.async_create(
         hass,

--- a/tests/src/unit/test_embedded_setup.py
+++ b/tests/src/unit/test_embedded_setup.py
@@ -757,6 +757,7 @@ class TestSurfaceConnectUrls:
         esetup._surface_connect_urls(hass, entry, "none")
 
         assert self._message().endswith(
+            "\n\n"
             "To disable this notification, uncheck the startup notification box "
             "on that same configuration screen.\n"
         )

--- a/tests/src/unit/test_embedded_setup.py
+++ b/tests/src/unit/test_embedded_setup.py
@@ -749,6 +749,18 @@ class TestSurfaceConnectUrls:
         assert "[HA-MCP settings panel](/ha-mcp)" in self._message()
         dismiss.assert_not_called()
 
+    def test_startup_notification_ends_with_disable_instructions(self):
+        _install_network_cloud(cloud_url=None, local_url="http://192.168.1.5:8123")
+        hass = _make_hass()
+        entry = _make_entry(data={DATA_WEBHOOK_ID: "mcp_id", DATA_SECRET_PATH: "/priv"})
+
+        esetup._surface_connect_urls(hass, entry, "none")
+
+        assert self._message().endswith(
+            "To disable this notification, uncheck the startup notification box "
+            "on that same configuration screen.\n"
+        )
+
     def test_startup_notification_off_dismisses_and_skips_create(
         self, monkeypatch, caplog
     ):


### PR DESCRIPTION
## What does this PR do?

Adds a final paragraph to the embedded HA-MCP Server startup notification explaining how to disable future startup notifications from the same configuration screen already named in the message.

It also adds focused unit coverage that keeps the disable instruction as the notification's final paragraph.

## Type of change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

LLM-agent testing is not applicable to this notification-text-only change.

## Checklist
- [x] I have updated documentation if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Improved the startup notification layout by separating authentication details from configuration guidance.
  * Added clear instructions for disabling the notification through the configuration screen.

* **Tests**
  * Added coverage to verify the notification includes the disabling instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->