### PR TITLE
fix: reuse shared locale translations and update Gemini model

### DIFF
--- a/.github/workflows/locale-sync.yml
+++ b/.github/workflows/locale-sync.yml
@@ -44,11 +44,11 @@ name: Locale Sync
 #
 # Two jobs on purpose, as blast-radius reduction: the translate job executes
 # everything `uv sync` resolves (a supply chain of hundreds of packages) and
-# holds no credential beyond the free-tier Gemini key; the push job runs on
-# a fresh runner, executes only git against a fresh clone (no hooks, no
-# project code), and refuses any patch that touches files outside the locale
-# allowlist — data-only catalog files; settings.js is deliberately not
-# exportable (see the export step). A compromised dependency in the
+# holds no credential beyond the rotatable API key for its free-tier Gemini
+# project; the push job runs on a fresh runner against a fresh clone, executes
+# only git (no hooks or project code), and refuses any patch touching files
+# outside the locale allowlist — data-only catalogs; settings.js is deliberately
+# not exportable (see the export step). A compromised dependency in the
 # translate job can therefore corrupt at most the locale catalogs the
 # pipeline legitimately writes — never reach the ruleset-bypassing push
 # credential and never land executable code.
@@ -118,8 +118,8 @@ jobs:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       with:
         # This job executes the resolved dependency tree, so it gets no
-        # credential except GEMINI_API_KEY (free-tier, rotatable) — never
-        # the push token.
+        # credential except the free-tier project's rotatable GEMINI_API_KEY
+        # — never the push token.
         persist-credentials: false
 
     - name: Install uv

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -804,8 +804,8 @@ Component catalogs need every `strings.json` key with identical
 tool docstring, or `strings.json` + component `en.json`), and the machine
 translates the rest: `scripts/translate_locales.py` reads the English-source
 baseline diff (`tests/src/unit/locale_source_baseline.json`), retranslates
-the changed or missing keys in every language via the Gemini API
-(`GEMINI_API_KEY`; free tier), validates placeholders and markup, regenerates
+the changed or missing keys in every language via the Gemini API free tier
+using `GEMINI_API_KEY`, validates placeholders and markup, regenerates
 the derived catalogs, and repins the baseline. The `locale-sync.yml` workflow
 runs it AFTER merge, on a daily schedule, and pushes the result straight to
 master with the release App credential (the same pattern as the version-bump
@@ -857,8 +857,11 @@ stub-review work, not translation work — the pipeline holds that baseline key
 stale, and the locale-sync run stays red until a human confirms the stub
 still describes the tool and runs `python scripts/update_locale_baseline.py`.
 
-**Rate limits and outages degrade loudly, never silently.** Engine calls are
-paced under the free-tier request rate and retry transient errors (429/5xx,
+**Rate limits and outages degrade loudly, never silently.** The sync is intended
+to remain on Gemini's free tier. Active RPM and RPD limits are project- and
+tier-specific and are shown in Google AI Studio. Engine calls use a
+conservative fixed interval rather than claiming one universal free-tier
+ceiling, and retry transient errors (429/5xx,
 timeouts) with backoff; a request that keeps failing marks its strings failed
 and the run continues, and two consecutive dead batches stop the run early
 instead of burning the remaining quota. A partial run — a daily-quota hit,

--- a/scripts/translate_locales.py
+++ b/scripts/translate_locales.py
@@ -1016,7 +1016,7 @@ def _reuse_existing_authored_shared(
     locale: str, items: list[WorkItem], module: Any
 ) -> tuple[dict[tuple[str, str], str], list[WorkItem]]:
     """Copy current shared wording before sending the remaining work out."""
-    planned = {(item.section, item.key) for item in items}
+    planned = {(item.section, item.key): item for item in items}
     settings = _load_json(LOCALES_DIR / f"{locale}.json")
     existing: dict[tuple[str, str], str] = {
         ("messages", key): value
@@ -1034,22 +1034,26 @@ def _reuse_existing_authored_shared(
         )
 
     reused: dict[tuple[str, str], str] = {}
-    for _english, where in module._authored_shared_groups():
-        refs: list[tuple[str, str]] = []
+    for english, where in module._authored_shared_groups():
+        refs: list[tuple[Section, str]] = []
         for surface, key in where:
             if surface == SETTINGS_SURFACE and key.startswith("messages."):
                 refs.append(("messages", key.removeprefix("messages.")))
             elif surface == COMPONENT_SURFACE:
                 refs.append(("component", key))
+        planned_refs = set(refs) & planned.keys()
         current_values = {
-            existing[ref] for ref in refs if ref not in planned and ref in existing
+            existing[ref]
+            for ref in refs
+            if ref not in planned and ref in existing and existing[ref] != english
         }
         if len(current_values) != 1:
             continue
         value = next(iter(current_values))
-        for ref in refs:
-            if ref in planned:
-                reused[ref] = value
+        if any(_validate(planned[ref], value) is not None for ref in planned_refs):
+            continue
+        for ref in planned_refs:
+            reused[ref] = value
 
     if reused:
         print(f"  {locale}: reused existing wording for {len(reused)} shared string(s)")

--- a/scripts/translate_locales.py
+++ b/scripts/translate_locales.py
@@ -1097,7 +1097,7 @@ def _reuse_existing_authored_shared(
 
 
 def _align_authored_shared(
-    _locale: str, results: dict[tuple[str, str], str], module: Any
+    locale: str, results: dict[tuple[str, str], str], module: Any
 ) -> None:
     """Byte-align the wording shared across the two authored surfaces.
 
@@ -1105,11 +1105,12 @@ def _align_authored_shared(
     of one shared English string differently, while
     ``test_authored_shared_strings_read_the_same`` requires them identical. An
     eligible existing sibling was already copied into ``results`` by
-    ``_reuse_existing_authored_shared``; otherwise a newly validated engine
-    result becomes the reference. The settings result wins when both surfaces
-    were translated, preserving the historical rule.
+    ``_reuse_existing_authored_shared``; otherwise an engine result becomes the
+    reference only after it passes every destination's validation. The settings
+    result wins when both surfaces were translated, preserving the historical
+    rule.
     """
-    for _english, where in module._authored_shared_groups():
+    for english, where in module._authored_shared_groups():
         refs = _authored_shared_refs(where)
         settings_refs = [ref for ref in refs if ref[0] == "messages"]
         affected = [ref for ref in refs if ref in results]
@@ -1119,6 +1120,15 @@ def _align_authored_shared(
             (results[ref] for ref in settings_refs if ref in results),
             results[affected[0]],
         )
+        if any(
+            _validate(WorkItem(locale, section, key, english), value) is not None
+            for section, key in refs
+        ):
+            # Do not let a looser component-only partial result bypass the
+            # settings gate or mark the rest of the shared group complete.
+            for ref in affected:
+                results.pop(ref, None)
+            continue
         for ref in refs:
             results[ref] = value
 

--- a/scripts/translate_locales.py
+++ b/scripts/translate_locales.py
@@ -31,8 +31,8 @@ Python hardcodes staying untranslated) before it is written; a failure
 leaves that string unwritten and the run red rather than shipping a broken
 translation.
 
-Rate limits and outages: requests are paced under the free-tier rate and
-retry transient errors with backoff; a persistently failing batch marks its
+Rate limits and outages: requests use conservative free-tier pacing and retry
+transient errors with backoff; a persistently failing batch marks its
 strings failed and the run continues, and two consecutive dead batches stop
 the run early. Partial runs are resumable — completed work is recorded in
 ``tests/src/unit/locale_sync_progress.json`` and skipped on the rerun; only a
@@ -91,8 +91,9 @@ SETTINGS_SURFACE = "src/ha_mcp/settings_ui/locales"
 COMPONENT_SURFACE = "custom_components/ha_mcp_tools/translations"
 TOOLS_SURFACE = "settings UI tool titles and descriptions"
 
-DEFAULT_MODEL = "gemini-2.5-flash"
-# Free-tier pacing: stay comfortably under the strictest published RPM.
+DEFAULT_MODEL = "gemini-3.5-flash-lite"
+# Free-tier pacing goal. Active RPM/RPD limits are project- and tier-specific
+# and are shown in Google AI Studio.
 _SECONDS_BETWEEN_REQUESTS = 7.0
 # Self-imposed wall-clock bound, kept below the workflow's job timeout: when
 # it trips, the run degrades exactly like a quota hit — remaining strings
@@ -682,10 +683,7 @@ def _call_gemini(prompt: str) -> dict[str, Any]:
     )
     body = {
         "contents": [{"role": "user", "parts": [{"text": prompt}]}],
-        "generationConfig": {
-            "temperature": 0.2,
-            "response_mime_type": "application/json",
-        },
+        "generationConfig": {"response_mime_type": "application/json"},
     }
     last_error = ""
     for attempt in range(1, 6):
@@ -886,8 +884,8 @@ def _translate_locale(
     identifiers rather than deduplicated by English text — the same English
     may legitimately need different wording per key (Spanish genders
     "enabled" as ``activado``/``activada`` depending on the noun), and the
-    key gives the model that context. The one pair *required* to share
-    wording across the authored surfaces is aligned afterwards by
+    key gives the model that context. Authored copies required to share
+    wording across surfaces are aligned afterwards by
     ``_align_authored_shared``. A chunk-level engine failure marks that
     chunk's strings failed and moves on, so one blocked or truncated batch
     cannot take down the whole run.

--- a/scripts/translate_locales.py
+++ b/scripts/translate_locales.py
@@ -1014,6 +1014,51 @@ def _apply_component(
         print(f"updated {path.relative_to(REPO_ROOT)}")
 
 
+def _reuse_existing_authored_shared(
+    locale: str, items: list[WorkItem], module: Any
+) -> tuple[dict[tuple[str, str], str], list[WorkItem]]:
+    """Copy current shared wording before sending the remaining work out."""
+    planned = {(item.section, item.key) for item in items}
+    settings = _load_json(LOCALES_DIR / f"{locale}.json")
+    existing: dict[tuple[str, str], str] = {
+        ("messages", key): value
+        for key, value in settings.get("messages", {}).items()
+        if isinstance(value, str) and value
+    }
+    component_path = COMPONENT_DIR / f"{locale}.json"
+    if component_path.exists():
+        existing.update(
+            {
+                ("component", key): value
+                for key, value in _flatten(_load_json(component_path)).items()
+                if value
+            }
+        )
+
+    reused: dict[tuple[str, str], str] = {}
+    for _english, where in module._authored_shared_groups():
+        refs: list[tuple[str, str]] = []
+        for surface, key in where:
+            if surface == SETTINGS_SURFACE and key.startswith("messages."):
+                refs.append(("messages", key.removeprefix("messages.")))
+            elif surface == COMPONENT_SURFACE:
+                refs.append(("component", key))
+        current_values = {
+            existing[ref] for ref in refs if ref not in planned and ref in existing
+        }
+        if len(current_values) != 1:
+            continue
+        value = next(iter(current_values))
+        for ref in refs:
+            if ref in planned:
+                reused[ref] = value
+
+    if reused:
+        print(f"  {locale}: reused existing wording for {len(reused)} shared string(s)")
+    remaining = [item for item in items if (item.section, item.key) not in reused]
+    return reused, remaining
+
+
 def _align_authored_shared(
     locale: str, results: dict[tuple[str, str], str], module: Any
 ) -> None:
@@ -1063,19 +1108,24 @@ def _translate_and_apply(
     engine_dead = False
     try:
         for locale in _target_locales():
-            results: dict[tuple[str, str], str] = {}
-            if locale in by_locale and engine_dead:
+            locale_items = by_locale.get(locale, [])
+            results, remaining = _reuse_existing_authored_shared(
+                locale, locale_items, module
+            )
+            if remaining and engine_dead:
                 failures.append(
-                    f"{locale}: {len(by_locale[locale])} string(s) skipped — "
+                    f"{locale}: {len(remaining)} string(s) skipped — "
                     "the engine was declared unavailable earlier in this run"
                 )
-            elif locale in by_locale:
-                results, locale_failures, _failed, engine_dead = _translate_locale(
-                    locale, by_locale[locale]
+            elif remaining:
+                translated, locale_failures, _failed, engine_dead = _translate_locale(
+                    locale, remaining
                 )
+                results.update(translated)
                 failures += locale_failures
+            if locale_items:
                 _align_authored_shared(locale, results, module)
-                for item in by_locale[locale]:
+                for item in locale_items:
                     if item.changed and (item.section, item.key) in results:
                         completed.setdefault((item.section, item.key), set()).add(
                             locale

--- a/scripts/translate_locales.py
+++ b/scripts/translate_locales.py
@@ -1012,6 +1012,19 @@ def _apply_component(
         print(f"updated {path.relative_to(REPO_ROOT)}")
 
 
+def _authored_shared_refs(
+    where: tuple[tuple[str, str], ...],
+) -> list[tuple[Section, str]]:
+    """Convert authored catalog locations to translation-result references."""
+    refs: list[tuple[Section, str]] = []
+    for surface, key in where:
+        if surface == SETTINGS_SURFACE and key.startswith("messages."):
+            refs.append(("messages", key.removeprefix("messages.")))
+        elif surface == COMPONENT_SURFACE:
+            refs.append(("component", key))
+    return refs
+
+
 def _reuse_existing_authored_shared(
     locale: str, items: list[WorkItem], module: Any
 ) -> tuple[dict[tuple[str, str], str], list[WorkItem]]:
@@ -1034,66 +1047,80 @@ def _reuse_existing_authored_shared(
         )
 
     reused: dict[tuple[str, str], str] = {}
+    replaced: set[tuple[Section, str]] = set()
+    fallback_items: list[WorkItem] = []
     for english, where in module._authored_shared_groups():
-        refs: list[tuple[Section, str]] = []
-        for surface, key in where:
-            if surface == SETTINGS_SURFACE and key.startswith("messages."):
-                refs.append(("messages", key.removeprefix("messages.")))
-            elif surface == COMPONENT_SURFACE:
-                refs.append(("component", key))
+        refs = _authored_shared_refs(where)
         planned_refs = set(refs) & planned.keys()
+        if not planned_refs:
+            continue
         current_values = {
             existing[ref]
             for ref in refs
             if ref not in planned and ref in existing and existing[ref] != english
         }
-        if len(current_values) != 1:
+        if len(current_values) == 1:
+            value = next(iter(current_values))
+            if all(_validate(planned[ref], value) is None for ref in planned_refs):
+                for ref in planned_refs:
+                    reused[ref] = value
+                continue
+
+        # Component answers are validated under looser markup rules. When no
+        # sibling is reusable, queue one settings reference so the value later
+        # aligned across the group passes the strictest destination gate.
+        settings_refs = {ref for ref in refs if ref[0] == "messages"}
+        if not settings_refs or settings_refs & planned_refs:
             continue
-        value = next(iter(current_values))
-        if any(_validate(planned[ref], value) is not None for ref in planned_refs):
-            continue
-        for ref in planned_refs:
-            reused[ref] = value
+        canonical_ref = next(ref for ref in refs if ref in settings_refs)
+        replaced.update(planned_refs)
+        fallback_items.append(
+            WorkItem(
+                locale,
+                canonical_ref[0],
+                canonical_ref[1],
+                english,
+                changed=any(planned[ref].changed for ref in planned_refs),
+            )
+        )
 
     if reused:
         print(f"  {locale}: reused existing wording for {len(reused)} shared string(s)")
-    remaining = [item for item in items if (item.section, item.key) not in reused]
+    remaining = [
+        item
+        for item in items
+        if (item.section, item.key) not in reused
+        and (item.section, item.key) not in replaced
+    ]
+    remaining.extend(fallback_items)
     return reused, remaining
 
 
 def _align_authored_shared(
-    locale: str, results: dict[tuple[str, str], str], module: Any
+    _locale: str, results: dict[tuple[str, str], str], module: Any
 ) -> None:
     """Byte-align the wording shared across the two authored surfaces.
 
     Per-key contextual translation may word the settings and component copies
-    of one shared English string differently;
-    ``test_authored_shared_strings_read_the_same`` requires them identical.
-    The settings side wins (the historical rule); when only the component
-    side was retranslated this run, the locale's existing settings
-    translation is the reference.
+    of one shared English string differently, while
+    ``test_authored_shared_strings_read_the_same`` requires them identical. An
+    eligible existing sibling was already copied into ``results`` by
+    ``_reuse_existing_authored_shared``; otherwise a newly validated engine
+    result becomes the reference. The settings result wins when both surfaces
+    were translated, preserving the historical rule.
     """
     for _english, where in module._authored_shared_groups():
-        settings_keys = [
-            key.removeprefix("messages.")
-            for surface, key in where
-            if surface == SETTINGS_SURFACE and key.startswith("messages.")
-        ]
-        component_keys = [key for surface, key in where if surface == COMPONENT_SURFACE]
-        if not settings_keys:
+        refs = _authored_shared_refs(where)
+        settings_refs = [ref for ref in refs if ref[0] == "messages"]
+        affected = [ref for ref in refs if ref in results]
+        if not settings_refs or not affected:
             continue
-        value = results.get(("messages", settings_keys[0]))
-        if value is None:
-            catalog = _load_json(LOCALES_DIR / f"{locale}.json")
-            value = catalog.get("messages", {}).get(settings_keys[0])
-        if value is None:
-            continue
-        for key in settings_keys[1:]:
-            if ("messages", key) in results:
-                results[("messages", key)] = value
-        for key in component_keys:
-            if ("component", key) in results:
-                results[("component", key)] = value
+        value = next(
+            (results[ref] for ref in settings_refs if ref in results),
+            results[affected[0]],
+        )
+        for ref in refs:
+            results[ref] = value
 
 
 def _translate_and_apply(

--- a/tests/src/unit/test_translate_locales.py
+++ b/tests/src/unit/test_translate_locales.py
@@ -1244,6 +1244,49 @@ class TestSharedTranslationReuse:
         assert "messages:shared" in prompts[0]
         written = json.loads((locales / "de.json").read_text(encoding="utf-8"))
         assert written["messages"]["shared"] == "unbekannt"
+        component_written = json.loads(
+            (component / "de.json").read_text(encoding="utf-8")
+        )
+        assert component_written["common"]["version_unknown"] == "unbekannt"
+
+    def test_english_settings_sibling_is_translated_instead_of_reused(
+        self,
+        catalogs: tuple[Path, Path, Any],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        locales, component, module = catalogs
+        settings = json.loads((locales / "de.json").read_text(encoding="utf-8"))
+        settings["messages"]["shared"] = "Unknown"
+        (locales / "de.json").write_text(json.dumps(settings), encoding="utf-8")
+        (component / "de.json").write_text(json.dumps({"common": {}}), encoding="utf-8")
+        prompts: list[str] = []
+
+        def fake_engine(prompt: str) -> dict[str, str]:
+            prompts.append(prompt)
+            return {"messages:shared": "unbekannt"}
+
+        monkeypatch.setattr(translate_locales, "_call_gemini", fake_engine)
+        items = [
+            WorkItem(
+                "de",
+                "component",
+                "common.version_unknown",
+                "Unknown",
+            )
+        ]
+        failures, _completed = translate_locales._translate_and_apply(
+            Plan(items=items), {"de": items}, module
+        )
+
+        assert failures == []
+        assert len(prompts) == 1
+        assert "messages:shared" in prompts[0]
+        settings_written = json.loads((locales / "de.json").read_text(encoding="utf-8"))
+        component_written = json.loads(
+            (component / "de.json").read_text(encoding="utf-8")
+        )
+        assert settings_written["messages"]["shared"] == "unbekannt"
+        assert component_written["common"]["version_unknown"] == "unbekannt"
 
     def test_disagreeing_siblings_are_translated_instead_of_reused(
         self,
@@ -1292,6 +1335,13 @@ class TestSharedTranslationReuse:
         assert "messages:shared" in prompts[0]
         written = json.loads((locales / "de.json").read_text(encoding="utf-8"))
         assert written["messages"]["shared"] == "unbekannt"
+        component_written = json.loads(
+            (component / "de.json").read_text(encoding="utf-8")
+        )
+        assert component_written["common"] == {
+            "version_unknown": "unbekannt",
+            "other_unknown": "unbekannt",
+        }
 
     def test_sibling_invalid_for_destination_is_translated_instead_of_reused(
         self,
@@ -1320,6 +1370,10 @@ class TestSharedTranslationReuse:
         assert "messages:shared" in prompts[0]
         written = json.loads((locales / "de.json").read_text(encoding="utf-8"))
         assert written["messages"]["shared"] == "unbekannt"
+        component_written = json.loads(
+            (component / "de.json").read_text(encoding="utf-8")
+        )
+        assert component_written["common"]["version_unknown"] == "unbekannt"
 
     def test_fully_stale_shared_group_is_translated_instead_of_reused(
         self,

--- a/tests/src/unit/test_translate_locales.py
+++ b/tests/src/unit/test_translate_locales.py
@@ -1375,6 +1375,45 @@ class TestSharedTranslationReuse:
         )
         assert component_written["common"]["version_unknown"] == "unbekannt"
 
+    def test_component_partial_result_invalid_for_settings_is_not_aligned(
+        self,
+        catalogs: tuple[Path, Path, Any],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        locales, component, module = catalogs
+        settings = json.loads((locales / "de.json").read_text(encoding="utf-8"))
+        settings["messages"]["shared"] = "alt"
+        (locales / "de.json").write_text(json.dumps(settings), encoding="utf-8")
+
+        def fake_engine(prompt: str) -> dict[str, str]:
+            if "messages:shared" in prompt:
+                return {"messages:shared": "<script>neu</script>"}
+            return {"component:common.version_unknown": "<script>neu</script>"}
+
+        monkeypatch.setattr(translate_locales, "_call_gemini", fake_engine)
+        items = [
+            WorkItem("de", "messages", "shared", "Unknown", changed=True),
+            WorkItem(
+                "de",
+                "component",
+                "common.version_unknown",
+                "Unknown",
+                changed=True,
+            ),
+        ]
+        failures, completed = translate_locales._translate_and_apply(
+            Plan(items=items), {"de": items}, module
+        )
+
+        assert failures
+        assert completed == {}
+        settings_written = json.loads((locales / "de.json").read_text(encoding="utf-8"))
+        component_written = json.loads(
+            (component / "de.json").read_text(encoding="utf-8")
+        )
+        assert settings_written["messages"]["shared"] == "alt"
+        assert component_written["common"]["version_unknown"] == "unbekannt"
+
     def test_fully_stale_shared_group_is_translated_instead_of_reused(
         self,
         catalogs: tuple[Path, Path, Any],

--- a/tests/src/unit/test_translate_locales.py
+++ b/tests/src/unit/test_translate_locales.py
@@ -793,6 +793,28 @@ class TestCallGeminiRetry:
             ),
         )
 
+    def test_uses_current_model_without_deprecated_sampling_parameters(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("GEMINI_MODEL", raising=False)
+        monkeypatch.delenv("GEMINI_API_URL", raising=False)
+        request: dict[str, Any] = {}
+
+        def fake_post(url: str, **kwargs: Any) -> Any:
+            request["url"] = url
+            request["body"] = kwargs["json"]
+            return self._response(200)
+
+        monkeypatch.setattr(translate_locales.httpx, "post", fake_post)
+        assert translate_locales._call_gemini("prompt") == {"s0": "Hallo"}
+        assert request["url"] == (
+            "https://generativelanguage.googleapis.com/v1beta/models/"
+            "gemini-3.5-flash-lite:generateContent"
+        )
+        generation_config = request["body"]["generationConfig"]
+        assert generation_config["response_mime_type"] == "application/json"
+        assert {"temperature", "topP", "topK"}.isdisjoint(generation_config)
+
     def test_retries_transient_statuses_then_succeeds(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/src/unit/test_translate_locales.py
+++ b/tests/src/unit/test_translate_locales.py
@@ -1217,6 +1217,110 @@ class TestSharedTranslationReuse:
             "other": "Andere",
         }
 
+    def test_english_sibling_is_translated_instead_of_reused(
+        self,
+        catalogs: tuple[Path, Path, Any],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        locales, component, module = catalogs
+        (component / "de.json").write_text(
+            json.dumps({"common": {"version_unknown": "Unknown"}}),
+            encoding="utf-8",
+        )
+        prompts: list[str] = []
+
+        def fake_engine(prompt: str) -> dict[str, str]:
+            prompts.append(prompt)
+            return {"messages:shared": "unbekannt"}
+
+        monkeypatch.setattr(translate_locales, "_call_gemini", fake_engine)
+        items = [WorkItem("de", "messages", "shared", "Unknown")]
+        failures, _completed = translate_locales._translate_and_apply(
+            Plan(items=items), {"de": items}, module
+        )
+
+        assert failures == []
+        assert len(prompts) == 1
+        assert "messages:shared" in prompts[0]
+        written = json.loads((locales / "de.json").read_text(encoding="utf-8"))
+        assert written["messages"]["shared"] == "unbekannt"
+
+    def test_disagreeing_siblings_are_translated_instead_of_reused(
+        self,
+        catalogs: tuple[Path, Path, Any],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        locales, component, _module = catalogs
+        component_en = json.loads((component / "en.json").read_text(encoding="utf-8"))
+        component_en["common"]["other_unknown"] = "Unknown"
+        (component / "en.json").write_text(json.dumps(component_en), encoding="utf-8")
+        component_de = json.loads((component / "de.json").read_text(encoding="utf-8"))
+        component_de["common"]["other_unknown"] = "nicht bekannt"
+        (component / "de.json").write_text(json.dumps(component_de), encoding="utf-8")
+        module = SimpleNamespace(
+            _authored_shared_groups=lambda: (
+                (
+                    "Unknown",
+                    (
+                        (translate_locales.SETTINGS_SURFACE, "messages.shared"),
+                        (
+                            translate_locales.COMPONENT_SURFACE,
+                            "common.version_unknown",
+                        ),
+                        (
+                            translate_locales.COMPONENT_SURFACE,
+                            "common.other_unknown",
+                        ),
+                    ),
+                ),
+            )
+        )
+        prompts: list[str] = []
+
+        def fake_engine(prompt: str) -> dict[str, str]:
+            prompts.append(prompt)
+            return {"messages:shared": "unbekannt"}
+
+        monkeypatch.setattr(translate_locales, "_call_gemini", fake_engine)
+        items = [WorkItem("de", "messages", "shared", "Unknown")]
+        failures, _completed = translate_locales._translate_and_apply(
+            Plan(items=items), {"de": items}, module
+        )
+
+        assert failures == []
+        assert len(prompts) == 1
+        assert "messages:shared" in prompts[0]
+        written = json.loads((locales / "de.json").read_text(encoding="utf-8"))
+        assert written["messages"]["shared"] == "unbekannt"
+
+    def test_sibling_invalid_for_destination_is_translated_instead_of_reused(
+        self,
+        catalogs: tuple[Path, Path, Any],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        locales, component, module = catalogs
+        (component / "de.json").write_text(
+            json.dumps({"common": {"version_unknown": "<script>unbekannt</script>"}}),
+            encoding="utf-8",
+        )
+        prompts: list[str] = []
+
+        def fake_engine(prompt: str) -> dict[str, str]:
+            prompts.append(prompt)
+            return {"messages:shared": "unbekannt"}
+
+        monkeypatch.setattr(translate_locales, "_call_gemini", fake_engine)
+        items = [WorkItem("de", "messages", "shared", "Unknown")]
+        failures, _completed = translate_locales._translate_and_apply(
+            Plan(items=items), {"de": items}, module
+        )
+
+        assert failures == []
+        assert len(prompts) == 1
+        assert "messages:shared" in prompts[0]
+        written = json.loads((locales / "de.json").read_text(encoding="utf-8"))
+        assert written["messages"]["shared"] == "unbekannt"
+
     def test_fully_stale_shared_group_is_translated_instead_of_reused(
         self,
         catalogs: tuple[Path, Path, Any],

--- a/tests/src/unit/test_translate_locales.py
+++ b/tests/src/unit/test_translate_locales.py
@@ -1104,6 +1104,145 @@ class TestMetaOnlyStub:
         assert written["messages"] == {"greeting": "Hallo-xx"}
 
 
+class TestSharedTranslationReuse:
+    @pytest.fixture()
+    def catalogs(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> tuple[Path, Path, Any]:
+        locales = tmp_path / "locales"
+        component = tmp_path / "component"
+        locales.mkdir()
+        component.mkdir()
+        (locales / "en.json").write_text(
+            json.dumps(
+                {
+                    "meta": {"native_name": "English", "dir": "ltr"},
+                    "messages": {"shared": "Unknown", "other": "Other"},
+                    "tool_groups": {},
+                    "tools": {},
+                }
+            ),
+            encoding="utf-8",
+        )
+        (locales / "de.json").write_text(
+            json.dumps(
+                {
+                    "meta": {"native_name": "Deutsch", "dir": "ltr"},
+                    "messages": {},
+                    "tool_groups": {},
+                    "tools": {},
+                }
+            ),
+            encoding="utf-8",
+        )
+        (component / "en.json").write_text(
+            json.dumps({"common": {"version_unknown": "Unknown"}}),
+            encoding="utf-8",
+        )
+        (component / "de.json").write_text(
+            json.dumps({"common": {"version_unknown": "unbekannt"}}),
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(translate_locales, "LOCALES_DIR", locales)
+        monkeypatch.setattr(translate_locales, "COMPONENT_DIR", component)
+        monkeypatch.setattr(translate_locales, "REPO_ROOT", tmp_path)
+        monkeypatch.setattr(translate_locales.generate_locales, "write", lambda: None)
+        monkeypatch.setattr(translate_locales.time, "sleep", lambda _s: None)
+        module = SimpleNamespace(
+            _authored_shared_groups=lambda: (
+                (
+                    "Unknown",
+                    (
+                        (translate_locales.SETTINGS_SURFACE, "messages.shared"),
+                        (
+                            translate_locales.COMPONENT_SURFACE,
+                            "common.version_unknown",
+                        ),
+                    ),
+                ),
+            )
+        )
+        return locales, component, module
+
+    def test_missing_shared_key_reuses_existing_sibling_before_engine_call(
+        self,
+        catalogs: tuple[Path, Path, Any],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        locales, _component, module = catalogs
+        prompts: list[str] = []
+
+        def fake_engine(prompt: str) -> dict[str, str]:
+            prompts.append(prompt)
+            return {"messages:other": "Andere"}
+
+        monkeypatch.setattr(translate_locales, "_call_gemini", fake_engine)
+        items = [
+            WorkItem("de", "messages", "shared", "Unknown"),
+            WorkItem("de", "messages", "other", "Other"),
+        ]
+        failures, _completed = translate_locales._translate_and_apply(
+            Plan(items=items), {"de": items}, module
+        )
+
+        assert failures == []
+        assert len(prompts) == 1
+        assert "messages:other" in prompts[0]
+        assert "messages:shared" not in prompts[0]
+        written = json.loads((locales / "de.json").read_text(encoding="utf-8"))
+        assert written["messages"] == {
+            "shared": "unbekannt",
+            "other": "Andere",
+        }
+
+    def test_fully_stale_shared_group_is_translated_instead_of_reused(
+        self,
+        catalogs: tuple[Path, Path, Any],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        locales, component, module = catalogs
+        settings = json.loads((locales / "de.json").read_text(encoding="utf-8"))
+        settings["messages"]["shared"] = "alt"
+        (locales / "de.json").write_text(json.dumps(settings), encoding="utf-8")
+        prompts: list[str] = []
+
+        def fake_engine(prompt: str) -> dict[str, str]:
+            prompts.append(prompt)
+            if "messages:shared" in prompt:
+                return {"messages:shared": "neu"}
+            return {"component:common.version_unknown": "anders"}
+
+        monkeypatch.setattr(translate_locales, "_call_gemini", fake_engine)
+        items = [
+            WorkItem("de", "messages", "shared", "Unknown", changed=True),
+            WorkItem(
+                "de",
+                "component",
+                "common.version_unknown",
+                "Unknown",
+                changed=True,
+            ),
+        ]
+        failures, completed = translate_locales._translate_and_apply(
+            Plan(items=items), {"de": items}, module
+        )
+
+        assert failures == []
+        assert len(prompts) == 2
+        assert any("messages:shared" in prompt for prompt in prompts)
+        assert any("component:common.version_unknown" in prompt for prompt in prompts)
+        settings_written = json.loads((locales / "de.json").read_text(encoding="utf-8"))
+        component_written = json.loads(
+            (component / "de.json").read_text(encoding="utf-8")
+        )
+        assert settings_written["messages"]["shared"] == "neu"
+        assert component_written["common"]["version_unknown"] == "neu"
+        assert completed == {
+            ("messages", "shared"): {"de"},
+            ("component", "common.version_unknown"): {"de"},
+        }
+
+
 class TestApplyWrites:
     @pytest.fixture()
     def catalog_dirs(


### PR DESCRIPTION
## What does this PR do?

- Reuses an existing translated sibling for a planned authored-shared string before building the Gemini request queue. Reuse requires one unanimous, non-English sibling value that passes validation for every destination it will populate. If no sibling is reusable, the job queues one canonical Settings item under the stricter validation rules and aligns the accepted result across every authored copy. Any engine result selected for alignment is revalidated for every destination; a rejected partial-group result is discarded instead of bypassing the stricter Settings gate. If every shared copy is planned because its English changed, the group is still translated and aligned normally.
- Updates Locale Sync to Gemini 3.5 Flash-Lite, which Google lists on the free tier and documents as supporting structured output.
- Removes the deprecated explicit `temperature: 0.2` setting for Gemini 3.5 Flash-Lite, so requests use the model default of `1.0` as recommended by the migration guidance.
- Keeps the conservative 7-second request interval and documents that active RPM/RPD limits are project- and tier-specific in Google AI Studio instead of claiming one universal published ceiling.

This PR is intended to supersede #2205.

Google references:
- [Gemini 3.5 Flash-Lite model](https://ai.google.dev/gemini-api/docs/models/gemini-3.5-flash-lite)
- [Gemini API pricing](https://ai.google.dev/gemini-api/docs/pricing)
- [Latest-model migration guidance](https://ai.google.dev/gemini-api/docs/latest-model)
- [Gemini API rate limits](https://ai.google.dev/gemini-api/docs/rate-limits)

## Type of change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [x] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [ ] All automated tests pass (uv run pytest)
- [x] Code follows style guidelines (uv run ruff check)

Local verification:
- The complete touched Locale Sync unit-test file passed: 112 passed, 1 expected post-merge completeness skip
- 19 focused Locale Sync, parity, and workflow-wiring tests passed
- Ruff format and lint passed repository-wide; the touched files were rechecked after review fixes
- mypy passed for src and scripts/translate_locales.py; the touched script was rechecked after review fixes
- ast-grep scan passed

PR #2222 translation-flow audit:
- The dry-run queued all six changed settings strings and five changed component strings for every one of the 11 locales despite their existing translated values (121 retranslations), plus the renamed tool/group entries and corresponding orphan deletions.
- The component English-source mirror and generated-catalog guards passed. Settings is the canonical source for both stable and dev add-on translation YAMLs, so the audit covers all four localized shipping surfaces: settings UI, component, stable add-on, and dev add-on.
- Focused planner, baseline, component-mirror, and derived-catalog regression tests passed.
- Hand-edited translations remain authoritative after the completed manual pass repins the baseline; without that explicit repin, changed English intentionally remains queued.

CI remains responsible for the heavier lanes. After merge, manually dispatch Locale Sync against the pending translation work to validate the live free-tier Gemini path.

## Checklist
- [x] I have updated documentation if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Improved locale translation processing by reusing validated translations for shared settings and component text.
  - Preserved translation progress when automated translation is temporarily unavailable.
  - Updated translation engine configuration for more consistent results.

- **Documentation**
  - Clarified translation pacing, retry behavior, API key usage, and credential isolation.

- **Tests**
  - Expanded coverage for shared translations, catalog updates, and fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
