### PR TITLE
fix: honor TLS settings in app proxy

### DIFF
--- a/src/ha_mcp/tools/tools_addons.py
+++ b/src/ha_mcp/tools/tools_addons.py
@@ -1033,6 +1033,24 @@ def _build_ws_result(
     return result
 
 
+def _ws_auth_error_suggestions(
+    addon: dict[str, Any], slug: str, port: int | None, status: int
+) -> list[str]:
+    """Return route-appropriate guidance for a rejected WS handshake."""
+    options = addon.get("options") or {}
+    if port and options.get("leave_front_door_open") is False:
+        primary = _direct_port_auth_suggestion(slug)
+    else:
+        primary = (
+            "The ingress session may have expired or your HA token may lack the "
+            "required scope. Verify the token has admin rights and try again."
+        )
+    return [
+        primary,
+        f"Status {status} from the WebSocket handshake.",
+    ]
+
+
 async def _call_addon_ws(
     client: HomeAssistantClient,
     slug: str,
@@ -1144,19 +1162,7 @@ async def _call_addon_ws(
         if isinstance(e, websockets.exceptions.InvalidStatus):
             status = e.response.status_code
             if status in (401, 403):
-                options = addon.get("options") or {}
-                if port and "leave_front_door_open" in options:
-                    suggestions = [
-                        _direct_port_auth_suggestion(slug),
-                        f"Status {status} from the WebSocket handshake.",
-                    ]
-                else:
-                    suggestions = [
-                        "The ingress session may have expired or your HA token "
-                        "may lack the required scope. Verify the token has admin "
-                        "rights and try again.",
-                        f"Status {status} from the WebSocket handshake.",
-                    ]
+                suggestions = _ws_auth_error_suggestions(addon, slug, port, status)
         raise_tool_error(
             create_error_response(
                 ErrorCode.SERVICE_CALL_FAILED,
@@ -1606,7 +1612,7 @@ def _add_http_error_hints(
         result["error"] = f"Add-on API returned HTTP {response.status_code}"
         if response.status_code == 401:
             options = addon.get("options") or {}
-            if direct_port and "leave_front_door_open" in options:
+            if direct_port and options.get("leave_front_door_open") is False:
                 result["addon_config"] = _addon_config_for_http_hint(addon)
                 result["suggestion"] = _direct_port_auth_suggestion(slug)
             else:
@@ -1631,7 +1637,7 @@ def _add_http_error_hints(
             options = addon.get("options") or {}
             example_proto = unmapped[0] if unmapped else ""
             example_port = example_proto.split("/", 1)[0] if example_proto else ""
-            if direct_port and "leave_front_door_open" in options:
+            if direct_port and options.get("leave_front_door_open") is False:
                 result["suggestion"] = _direct_port_auth_suggestion(slug_val)
             elif unmapped and example_port.isdigit():
                 addon_label = addon.get("name") or slug_val

--- a/src/ha_mcp/tools/tools_addons.py
+++ b/src/ha_mcp/tools/tools_addons.py
@@ -1038,8 +1038,11 @@ def _ws_auth_error_suggestions(
 ) -> list[str]:
     """Return route-appropriate guidance for a rejected WS handshake."""
     options = addon.get("options") or {}
-    if port and options.get("leave_front_door_open") is False:
-        primary = _direct_port_auth_suggestion(slug)
+    if port:
+        if options.get("leave_front_door_open") is False:
+            primary = _direct_port_auth_suggestion(slug)
+        else:
+            primary = _direct_port_rejection_suggestion()
     else:
         primary = (
             "The ingress session may have expired or your HA token may lack the "
@@ -1600,6 +1603,14 @@ def _direct_port_auth_suggestion(slug: str) -> str:
     )
 
 
+def _direct_port_rejection_suggestion() -> str:
+    """Explain authentication that remains after direct access is enabled."""
+    return (
+        "The app rejected this direct-port request. Check the app's own "
+        "authentication and access-control settings, IP allowlist, and logs."
+    )
+
+
 def _add_http_error_hints(
     result: dict[str, Any],
     response: httpx.Response,
@@ -1612,9 +1623,12 @@ def _add_http_error_hints(
         result["error"] = f"Add-on API returned HTTP {response.status_code}"
         if response.status_code == 401:
             options = addon.get("options") or {}
-            if direct_port and options.get("leave_front_door_open") is False:
+            if direct_port:
                 result["addon_config"] = _addon_config_for_http_hint(addon)
-                result["suggestion"] = _direct_port_auth_suggestion(slug)
+                if options.get("leave_front_door_open") is False:
+                    result["suggestion"] = _direct_port_auth_suggestion(slug)
+                else:
+                    result["suggestion"] = _direct_port_rejection_suggestion()
             else:
                 # An ingress 401 is a credential/session problem. Keep network
                 # configuration out of that result so the caller fixes the HA
@@ -1637,8 +1651,11 @@ def _add_http_error_hints(
             options = addon.get("options") or {}
             example_proto = unmapped[0] if unmapped else ""
             example_port = example_proto.split("/", 1)[0] if example_proto else ""
-            if direct_port and options.get("leave_front_door_open") is False:
-                result["suggestion"] = _direct_port_auth_suggestion(slug_val)
+            if direct_port:
+                if options.get("leave_front_door_open") is False:
+                    result["suggestion"] = _direct_port_auth_suggestion(slug_val)
+                else:
+                    result["suggestion"] = _direct_port_rejection_suggestion()
             elif unmapped and example_port.isdigit():
                 addon_label = addon.get("name") or slug_val
                 result["suggestion"] = (

--- a/src/ha_mcp/tools/tools_addons.py
+++ b/src/ha_mcp/tools/tools_addons.py
@@ -11,6 +11,7 @@ import asyncio
 import json
 import logging
 import re
+import ssl
 import time
 from typing import Annotated, Any, ClassVar, Literal, NoReturn
 from urllib.parse import unquote, urlsplit
@@ -900,6 +901,7 @@ async def _run_ws_session(
     timeout: int,
     wait_for_close: bool,
     caller_capped: bool,
+    verify_ssl: bool,
 ) -> tuple[list[str], int, str, float]:
     """Connect to a WebSocket URL, optionally send body, collect messages.
 
@@ -908,6 +910,12 @@ async def _run_ws_session(
     the caller, which maps them to structured ToolErrors.
     """
     start_time = time.monotonic()
+    ssl_context: ssl.SSLContext | None = None
+    if ws_url.startswith("wss://"):
+        ssl_context = ssl.create_default_context()
+        if not verify_ssl:
+            ssl_context.check_hostname = False
+            ssl_context.verify_mode = ssl.CERT_NONE
     async with websockets.connect(
         ws_url,
         additional_headers=headers,
@@ -916,6 +924,7 @@ async def _run_ws_session(
         max_size=5 * 1024 * 1024,  # 5MB max per message
         open_timeout=10,
         close_timeout=5,
+        ssl=ssl_context,
     ) as ws:
         if body is not None:
             await ws.send(json.dumps(body) if isinstance(body, dict) else str(body))
@@ -1124,6 +1133,7 @@ async def _call_addon_ws(
             timeout,
             wait_for_close,
             caller_capped=message_limit is not None,
+            verify_ssl=client.verify_ssl,
         )
     except websockets.exceptions.InvalidHandshake as e:
         suggestions = [
@@ -1134,12 +1144,19 @@ async def _call_addon_ws(
         if isinstance(e, websockets.exceptions.InvalidStatus):
             status = e.response.status_code
             if status in (401, 403):
-                suggestions = [
-                    "The ingress session may have expired or your HA token "
-                    "may lack the required scope. Verify the token has admin "
-                    "rights and try again.",
-                    f"Status {status} from the WebSocket handshake.",
-                ]
+                options = addon.get("options") or {}
+                if port and "leave_front_door_open" in options:
+                    suggestions = [
+                        _direct_port_auth_suggestion(slug),
+                        f"Status {status} from the WebSocket handshake.",
+                    ]
+                else:
+                    suggestions = [
+                        "The ingress session may have expired or your HA token "
+                        "may lack the required scope. Verify the token has admin "
+                        "rights and try again.",
+                        f"Status {status} from the WebSocket handshake.",
+                    ]
         raise_tool_error(
             create_error_response(
                 ErrorCode.SERVICE_CALL_FAILED,
@@ -1553,42 +1570,70 @@ def _build_http_result(
     return result
 
 
+def _addon_config_for_http_hint(addon: dict[str, Any]) -> dict[str, Any]:
+    """Return the app settings that can explain direct-access failures."""
+    return {
+        "options": addon.get("options"),
+        "ports": addon.get("network") or addon.get("ports") or None,
+        "host_network": addon.get("host_network"),
+        "ingress_port": addon.get("ingress_port"),
+    }
+
+
+def _direct_port_auth_suggestion(slug: str) -> str:
+    """Explain the configurable direct-access auth trade-off."""
+    return (
+        "The app rejected this direct-port request. Its "
+        "'leave_front_door_open' option controls direct-access authentication. "
+        "If the user accepts the security trade-off, use "
+        f"ha_manage_app(slug='{slug}', "
+        "options={'leave_front_door_open': True}), then "
+        f"ha_manage_app(slug='{slug}', action='restart'), and retry. Prefer "
+        "Ingress when possible; enabling this option removes authentication from "
+        "the app's direct-access surface for hosts that can reach the mapped port."
+    )
+
+
 def _add_http_error_hints(
     result: dict[str, Any],
     response: httpx.Response,
     addon: dict[str, Any],
     slug: str,
+    direct_port: bool,
 ) -> None:
     """Mutate result to add an error key for 4xx/5xx responses, with tailored suggestions for 401 and 403."""
     if response.status_code >= 400:
         result["error"] = f"Add-on API returned HTTP {response.status_code}"
         if response.status_code == 401:
-            # 401 is a credential/session problem — addon_config is not attached
-            # because the network layout is irrelevant; the caller needs to fix
-            # their token or re-establish the ingress session, not reconfigure ports.
-            result["suggestion"] = (
-                "Authentication failed. The ingress session may have expired, "
-                "or your HA token may lack the required scope. Verify the "
-                "token has admin rights and try again."
-            )
+            options = addon.get("options") or {}
+            if direct_port and "leave_front_door_open" in options:
+                result["addon_config"] = _addon_config_for_http_hint(addon)
+                result["suggestion"] = _direct_port_auth_suggestion(slug)
+            else:
+                # An ingress 401 is a credential/session problem. Keep network
+                # configuration out of that result so the caller fixes the HA
+                # token or ingress session instead of weakening app authentication.
+                result["suggestion"] = (
+                    "Authentication failed. The ingress session may have expired, "
+                    "or your HA token may lack the required scope. Verify the "
+                    "token has admin rights and try again."
+                )
         elif response.status_code == 403:
             # 403 is typically an Nginx IP ACL blocking direct access — a
             # network configuration problem. Attach addon_config so the LLM
             # can see the port mapping and suggest the correct port override.
             ports_dict = addon.get("network") or addon.get("ports") or {}
             unmapped = sorted(k for k, v in ports_dict.items() if v is None)
-            result["addon_config"] = {
-                "options": addon.get("options"),
-                "ports": ports_dict or None,
-                "host_network": addon.get("host_network"),
-                "ingress_port": addon.get("ingress_port"),
-            }
+            result["addon_config"] = _addon_config_for_http_hint(addon)
             # Prefer the caller-resolved slug (authoritative); fall back to the
             # addon dict, then a placeholder only if neither is populated.
             slug_val = slug or addon.get("slug") or "<slug>"
+            options = addon.get("options") or {}
             example_proto = unmapped[0] if unmapped else ""
             example_port = example_proto.split("/", 1)[0] if example_proto else ""
-            if unmapped and example_port.isdigit():
+            if direct_port and "leave_front_door_open" in options:
+                result["suggestion"] = _direct_port_auth_suggestion(slug_val)
+            elif unmapped and example_port.isdigit():
                 addon_label = addon.get("name") or slug_val
                 result["suggestion"] = (
                     f"Map {example_proto} to a host port in the HA UI "
@@ -1714,7 +1759,10 @@ async def _call_addon_api(
         request_content = None
 
     try:
-        async with httpx.AsyncClient(timeout=httpx.Timeout(timeout)) as http_client:
+        async with httpx.AsyncClient(
+            timeout=httpx.Timeout(timeout),
+            verify=client.verify_ssl,
+        ) as http_client:
             response = await http_client.request(
                 method=method.upper(),
                 url=url,
@@ -1786,7 +1834,7 @@ async def _call_addon_api(
         transformed,
         truncated,
     )
-    _add_http_error_hints(result, response, addon, slug)
+    _add_http_error_hints(result, response, addon, slug, direct_port=bool(port))
     return result
 
 
@@ -2884,7 +2932,10 @@ def register_addon_tools(mcp: Any, client: HomeAssistantClient, **kwargs: Any) -
             int | None,
             Field(
                 description="Proxy mode only. Connect to this port instead of the Ingress port. "
-                "Use ha_get_app(slug='...') to find available ports.",
+                "Use ha_get_app(slug='...') to find available ports. Some apps, including "
+                "Node-RED, reject direct access unless their leave_front_door_open option is "
+                "enabled and the app is restarted; related errors include an actionable, "
+                "security-qualified ha_manage_app options command.",
                 default=None,
             ),
         ] = None,
@@ -3086,7 +3137,11 @@ def register_addon_tools(mcp: Any, client: HomeAssistantClient, **kwargs: Any) -
         proxy by default (works on HAOS, Supervised, and off-host PyPI/uvx
         installs). Pass `port=...` to bypass Ingress and connect directly to
         an add-on's container port — that mode requires the MCP host to
-        share Home Assistant's container network (i.e. only the HAOS addon).
+        share Home Assistant's container network. Apps such as Node-RED may
+        reject direct requests unless `leave_front_door_open` is enabled in
+        their options and the app is restarted. Authentication errors name
+        the exact `ha_manage_app(options=...)` remedy and its security tradeoff;
+        prefer Ingress when it works.
 
         **ESPHome Device Builder dashboard (current rewrite):** config and log
         access is a WebSocket JSON-command API, NOT REST. The legacy endpoints
@@ -3148,7 +3203,7 @@ def register_addon_tools(mcp: Any, client: HomeAssistantClient, **kwargs: Any) -
         - Change host port: ha_manage_app(slug="...", network={"5800/tcp": 8082})
         - Set boot mode: ha_manage_app(slug="...", boot="manual")
         - Call HTTP API: ha_manage_app(slug="...", path="/api/events")
-        - Direct port: ha_manage_app(slug="...", path="/flows", port=1880)
+        - Direct Node-RED port after an auth rejection: ha_manage_app(slug="...", options={"leave_front_door_open": True}), then ha_manage_app(slug="...", action="restart"), then ha_manage_app(slug="...", path="/flows", port=1880). This disables authentication on the reachable direct port; prefer Ingress.
         - ESPHome list devices (HTTP): ha_manage_app(slug="<prefix>_esphome", path="/devices")
         - ESPHome read a device's YAML (WS one-shot): ha_manage_app(slug="<prefix>_esphome", path="/ws", websocket=True, wait_for_close=False, message_limit=2, body={"command": "devices/get_config", "message_id": "1", "args": {"configuration": "device.yaml"}})
         - ESPHome live logs (WS, bounded): ha_manage_app(slug="<prefix>_esphome", path="/ws", websocket=True, wait_for_close=False, message_limit=60, body={"command": "devices/logs", "message_id": "1", "args": {"configuration": "device.yaml", "port": "OTA"}})

--- a/src/ha_mcp/tools/tools_addons.py
+++ b/src/ha_mcp/tools/tools_addons.py
@@ -24,7 +24,11 @@ from ha_mcp._vendor import websockets
 from ha_mcp._vendor.websockets.asyncio.client import ClientConnection
 
 from .._version import is_running_in_addon
-from ..client.rest_client import HomeAssistantClient, HomeAssistantCommandError
+from ..client.rest_client import (
+    HomeAssistantClient,
+    HomeAssistantCommandError,
+    _is_ssl_error,
+)
 from ..errors import (
     ErrorCode,
     create_error_response,
@@ -893,6 +897,110 @@ async def _collect_ws_messages_loop(
         total_size += len(clean)
 
 
+def _tls_setup_error(e: Exception, slug: str) -> NoReturn:
+    """Report a CA-store/TLS-context build failure distinctly from network errors."""
+    raise_tool_error(
+        create_error_response(
+            ErrorCode.CONNECTION_FAILED,
+            f"Could not build a TLS context for the app (add-on) request: {e!s}",
+            context={"slug": slug},
+            suggestions=[
+                "The MCP host's CA store failed to load. Check SSL_CERT_FILE "
+                "and SSL_CERT_DIR, or the system certificate bundle.",
+            ],
+        )
+    )
+
+
+def _build_ws_ssl_context(
+    ws_url: str, verify_ssl: bool, slug: str
+) -> ssl.SSLContext | None:
+    """Build the proxy's client TLS context, honoring the HA verify setting."""
+    if not ws_url.startswith("wss://"):
+        return None
+    try:
+        ssl_context = ssl.create_default_context()
+    except OSError as e:
+        _tls_setup_error(e, slug)
+    if not verify_ssl:
+        logger.warning(
+            "TLS verification disabled for add-on WebSocket proxy "
+            "(HA_VERIFY_SSL=false). Connecting to %s with hostname/cert "
+            "checks off.",
+            ws_url,
+        )
+        ssl_context.check_hostname = False
+        ssl_context.verify_mode = ssl.CERT_NONE
+    return ssl_context
+
+
+def _tls_verification_failure_suggestions() -> list[str]:
+    """Name the TLS remedy instead of pointing the caller at the network."""
+    return [
+        "Home Assistant's certificate did not validate. If it is self-signed "
+        "or issued for a different hostname than the configured HA URL, set "
+        "HA_VERIFY_SSL=false to skip verification, or reach HA at the "
+        "hostname the certificate was issued for.",
+    ]
+
+
+def _build_addon_http_client(
+    client: HomeAssistantClient, timeout: int, slug: str
+) -> httpx.AsyncClient:
+    """Build the proxy's HTTP client, honoring the HA verify setting.
+
+    httpx builds its TLS context at construction; doing it before the request
+    try reports a CA-store failure as such rather than letting it escape
+    unstructured.
+    """
+    try:
+        return httpx.AsyncClient(
+            timeout=httpx.Timeout(timeout),
+            verify=client.verify_ssl,
+        )
+    except OSError as e:
+        _tls_setup_error(e, slug)
+
+
+def _raise_connect_failure(
+    client: HomeAssistantClient,
+    e: Exception,
+    *,
+    label: str,
+    url: str,
+    slug: str,
+    port: int | None,
+) -> NoReturn:
+    """Raise the structured connect-phase error, classifying TLS failures.
+
+    A certificate-verification failure with verification enabled gets the TLS
+    remedy; everything else keeps the route-appropriate network guidance.
+    """
+    if _is_ssl_error(e) and client.verify_ssl:
+        raise_tool_error(
+            create_error_response(
+                ErrorCode.CONNECTION_FAILED,
+                f"TLS verification failed connecting to {label}: {e!s}",
+                details=f"url={url}",
+                context={
+                    "slug": slug,
+                    "direct_port": bool(port),
+                    "verify_ssl": True,
+                },
+                suggestions=_tls_verification_failure_suggestions(),
+            )
+        )
+    raise_tool_error(
+        create_error_response(
+            ErrorCode.CONNECTION_FAILED,
+            f"Failed to connect to {label}: {e!s}",
+            details=f"url={url}",
+            context={"slug": slug, "direct_port": bool(port)},
+            suggestions=_addon_connection_failure_suggestions(client, port),
+        )
+    )
+
+
 async def _run_ws_session(
     ws_url: str,
     headers: dict[str, str],
@@ -901,7 +1009,7 @@ async def _run_ws_session(
     timeout: int,
     wait_for_close: bool,
     caller_capped: bool,
-    verify_ssl: bool,
+    ssl_context: ssl.SSLContext | None,
 ) -> tuple[list[str], int, str, float]:
     """Connect to a WebSocket URL, optionally send body, collect messages.
 
@@ -910,12 +1018,6 @@ async def _run_ws_session(
     the caller, which maps them to structured ToolErrors.
     """
     start_time = time.monotonic()
-    ssl_context: ssl.SSLContext | None = None
-    if ws_url.startswith("wss://"):
-        ssl_context = ssl.create_default_context()
-        if not verify_ssl:
-            ssl_context.check_hostname = False
-            ssl_context.verify_mode = ssl.CERT_NONE
     async with websockets.connect(
         ws_url,
         additional_headers=headers,
@@ -1033,16 +1135,47 @@ def _build_ws_result(
     return result
 
 
+def _front_door_state(addon: dict[str, Any]) -> bool | None:
+    """Return the app's ``leave_front_door_open`` state, or None when unexposed.
+
+    Supervisor's ``options`` dict omits an option the user never saved even
+    when the app's schema exposes it, and the app treats that absence as
+    disabled — so the schema, not key presence, decides whether the option
+    applies (stock installs ship the key in the schema only).
+    """
+    options = addon.get("options")
+    if isinstance(options, dict) and "leave_front_door_open" in options:
+        return bool(options["leave_front_door_open"])
+    schema = addon.get("schema")
+    if isinstance(schema, list) and any(
+        isinstance(item, dict) and item.get("name") == "leave_front_door_open"
+        for item in schema
+    ):
+        return False
+    return None
+
+
 def _ws_auth_error_suggestions(
     addon: dict[str, Any], slug: str, port: int | None, status: int
 ) -> list[str]:
     """Return route-appropriate guidance for a rejected WS handshake."""
-    options = addon.get("options") or {}
     if port:
-        if options.get("leave_front_door_open") is False:
-            primary = _direct_port_auth_suggestion(slug)
+        # Prefer the caller-resolved slug; fall back to the addon dict, then a
+        # placeholder, so the suggestion never renders slug=''.
+        slug_val = slug or addon.get("slug") or "<slug>"
+        if _front_door_state(addon) is False:
+            primary = _direct_port_auth_suggestion(slug_val)
         else:
             primary = _direct_port_rejection_suggestion()
+    elif is_running_in_addon():
+        # The addon-variant route authenticates with Supervisor ingress
+        # headers, not an ingress session or HA token — do not send the
+        # caller to inspect credentials this request never carried.
+        primary = (
+            "The app (add-on) rejected the ingress-port handshake. This route "
+            "authenticates with Supervisor ingress headers; check that the "
+            "target app is running and its ingress is healthy."
+        )
     else:
         primary = (
             "The ingress session may have expired or your HA token may lack the "
@@ -1145,6 +1278,9 @@ async def _call_addon_ws(
         requested = max(0, message_offset) + max(0, message_limit)
         collection_cap = min(_MAX_WS_MESSAGES, requested)
 
+    # Built before the try so a CA-store failure is reported as such rather
+    # than as the add-on being unreachable.
+    ssl_context = _build_ws_ssl_context(ws_url, client.verify_ssl, slug)
     try:
         collected, total_size, close_reason, elapsed = await _run_ws_session(
             ws_url,
@@ -1154,7 +1290,7 @@ async def _call_addon_ws(
             timeout,
             wait_for_close,
             caller_capped=message_limit is not None,
-            verify_ssl=client.verify_ssl,
+            ssl_context=ssl_context,
         )
     except websockets.exceptions.InvalidHandshake as e:
         suggestions = [
@@ -1203,14 +1339,13 @@ async def _call_addon_ws(
             )
         )
     except OSError as e:
-        raise_tool_error(
-            create_error_response(
-                ErrorCode.CONNECTION_FAILED,
-                f"Failed to connect to add-on '{addon_name}' WebSocket: {e!s}",
-                details=f"url={ws_url}",
-                context={"slug": slug, "direct_port": bool(port)},
-                suggestions=_addon_connection_failure_suggestions(client, port),
-            )
+        _raise_connect_failure(
+            client,
+            e,
+            label=f"app (add-on) '{addon_name}' WebSocket",
+            url=ws_url,
+            slug=slug,
+            port=port,
         )
 
     return _build_ws_result(
@@ -1590,23 +1725,30 @@ def _addon_config_for_http_hint(addon: dict[str, Any]) -> dict[str, Any]:
 
 
 def _direct_port_auth_suggestion(slug: str) -> str:
-    """Explain the configurable direct-access auth trade-off."""
+    """Explain the configurable direct-access auth trade-off, Ingress first."""
     return (
-        "The app rejected this direct-port request. Its "
-        "'leave_front_door_open' option controls direct-access authentication. "
-        "If the user accepts the security trade-off, use "
+        "The app (add-on) rejected this direct-port request. Prefer Ingress: retry "
+        f"without the 'port' parameter (ha_manage_app(slug='{slug}', "
+        "path='...')). The app's 'leave_front_door_open' option controls "
+        "direct-access authentication; only if the user explicitly accepts "
+        "the security trade-off, use "
         f"ha_manage_app(slug='{slug}', "
         "options={'leave_front_door_open': True}), then "
-        f"ha_manage_app(slug='{slug}', action='restart'), and retry. Prefer "
-        "Ingress when possible; enabling this option removes authentication from "
-        "the app's direct-access surface for hosts that can reach the mapped port."
+        f"ha_manage_app(slug='{slug}', action='restart'), and retry. Enabling "
+        "it removes authentication from the app's direct-access surface for "
+        "hosts that can reach the mapped port."
     )
 
 
 def _direct_port_rejection_suggestion() -> str:
-    """Explain authentication that remains after direct access is enabled."""
+    """Explain a direct-port rejection the front-door option cannot fix.
+
+    Fires when the app exposes no ``leave_front_door_open`` option, or when it
+    is already enabled — either way the remedy lives in the app's own auth
+    configuration, not in that option.
+    """
     return (
-        "The app rejected this direct-port request. Check the app's own "
+        "The app (add-on) rejected this direct-port request. Check the app's own "
         "authentication and access-control settings, IP allowlist, and logs."
     )
 
@@ -1621,12 +1763,14 @@ def _add_http_error_hints(
     """Mutate result to add an error key for 4xx/5xx responses, with tailored suggestions for 401 and 403."""
     if response.status_code >= 400:
         result["error"] = f"Add-on API returned HTTP {response.status_code}"
+        # Prefer the caller-resolved slug (authoritative); fall back to the
+        # addon dict, then a placeholder only if neither is populated.
+        slug_val = slug or addon.get("slug") or "<slug>"
         if response.status_code == 401:
-            options = addon.get("options") or {}
             if direct_port:
                 result["addon_config"] = _addon_config_for_http_hint(addon)
-                if options.get("leave_front_door_open") is False:
-                    result["suggestion"] = _direct_port_auth_suggestion(slug)
+                if _front_door_state(addon) is False:
+                    result["suggestion"] = _direct_port_auth_suggestion(slug_val)
                 else:
                     result["suggestion"] = _direct_port_rejection_suggestion()
             else:
@@ -1639,39 +1783,37 @@ def _add_http_error_hints(
                     "token has admin rights and try again."
                 )
         elif response.status_code == 403:
-            # 403 is typically an Nginx IP ACL blocking direct access — a
-            # network configuration problem. Attach addon_config so the LLM
-            # can see the port mapping and suggest the correct port override.
-            ports_dict = addon.get("network") or addon.get("ports") or {}
-            unmapped = sorted(k for k, v in ports_dict.items() if v is None)
+            # A direct-port 403 is app-level access control; an ingress 403 is
+            # typically an Nginx IP ACL blocking direct access — a network
+            # configuration problem. Attach addon_config either way so the LLM
+            # can see the port mapping.
             result["addon_config"] = _addon_config_for_http_hint(addon)
-            # Prefer the caller-resolved slug (authoritative); fall back to the
-            # addon dict, then a placeholder only if neither is populated.
-            slug_val = slug or addon.get("slug") or "<slug>"
-            options = addon.get("options") or {}
-            example_proto = unmapped[0] if unmapped else ""
-            example_port = example_proto.split("/", 1)[0] if example_proto else ""
             if direct_port:
-                if options.get("leave_front_door_open") is False:
+                if _front_door_state(addon) is False:
                     result["suggestion"] = _direct_port_auth_suggestion(slug_val)
                 else:
                     result["suggestion"] = _direct_port_rejection_suggestion()
-            elif unmapped and example_port.isdigit():
-                addon_label = addon.get("name") or slug_val
-                result["suggestion"] = (
-                    f"Map {example_proto} to a host port in the HA UI "
-                    f"('{addon_label}' → Configuration → Network), restart the "
-                    f"add-on, then retry with ha_manage_app(slug='{slug_val}', "
-                    f"path='...', port={example_port})."
-                )
             else:
-                result["suggestion"] = (
-                    "This add-on is blocking direct connections (likely Nginx IP restriction). "
-                    "Try using the 'port' parameter to connect to the add-on's direct access port "
-                    "(see addon_config.ports above) with 'leave_front_door_open' enabled. "
-                    "Example: ha_manage_app(slug='...', path='...', port=<direct_port>). "
-                    "The user may need to change add-on settings in the HA UI and restart the add-on."
-                )
+                ports_dict = addon.get("network") or addon.get("ports") or {}
+                unmapped = sorted(k for k, v in ports_dict.items() if v is None)
+                example_proto = unmapped[0] if unmapped else ""
+                example_port = example_proto.split("/", 1)[0] if example_proto else ""
+                if unmapped and example_port.isdigit():
+                    addon_label = addon.get("name") or slug_val
+                    result["suggestion"] = (
+                        f"Map {example_proto} to a host port in the HA UI "
+                        f"('{addon_label}' → Configuration → Network), restart the "
+                        f"add-on, then retry with ha_manage_app(slug='{slug_val}', "
+                        f"path='...', port={example_port})."
+                    )
+                else:
+                    result["suggestion"] = (
+                        "This add-on is blocking direct connections (likely Nginx IP restriction). "
+                        "Try using the 'port' parameter to connect to the add-on's direct access port "
+                        "(see addon_config.ports above) with 'leave_front_door_open' enabled. "
+                        "Example: ha_manage_app(slug='...', path='...', port=<direct_port>). "
+                        "The user may need to change add-on settings in the HA UI and restart the add-on."
+                    )
 
 
 async def _call_addon_api(
@@ -1781,11 +1923,9 @@ async def _call_addon_api(
     else:
         request_content = None
 
+    addon_http_client = _build_addon_http_client(client, timeout, slug)
     try:
-        async with httpx.AsyncClient(
-            timeout=httpx.Timeout(timeout),
-            verify=client.verify_ssl,
-        ) as http_client:
+        async with addon_http_client as http_client:
             response = await http_client.request(
                 method=method.upper(),
                 url=url,
@@ -1809,14 +1949,13 @@ async def _call_addon_api(
             )
         )
     except httpx.ConnectError as e:
-        raise_tool_error(
-            create_error_response(
-                ErrorCode.CONNECTION_FAILED,
-                f"Failed to connect to add-on '{addon_name}': {e!s}",
-                details=f"url={url}",
-                context={"slug": slug, "direct_port": bool(port)},
-                suggestions=_addon_connection_failure_suggestions(client, port),
-            )
+        _raise_connect_failure(
+            client,
+            e,
+            label=f"app (add-on) '{addon_name}'",
+            url=url,
+            slug=slug,
+            port=port,
         )
 
     # 6. Parse response body
@@ -3160,11 +3299,12 @@ def register_addon_tools(mcp: Any, client: HomeAssistantClient, **kwargs: Any) -
         proxy by default (works on HAOS, Supervised, and off-host PyPI/uvx
         installs). Pass `port=...` to bypass Ingress and connect directly to
         an add-on's container port — that mode requires the MCP host to
-        share Home Assistant's container network. Apps such as Node-RED may
-        reject direct requests unless `leave_front_door_open` is enabled in
-        their options and the app is restarted. Authentication errors name
-        the exact `ha_manage_app(options=...)` remedy and its security tradeoff;
-        prefer Ingress when it works.
+        share Home Assistant's container network (in practice: the HAOS app
+        (add-on) deployment). Apps such as Node-RED may reject direct requests
+        unless `leave_front_door_open` is enabled in their options and the app
+        is restarted. Authentication errors name the exact
+        `ha_manage_app(options=...)` remedy and its security tradeoff; prefer
+        Ingress when it works.
 
         **ESPHome Device Builder dashboard (current rewrite):** config and log
         access is a WebSocket JSON-command API, NOT REST. The legacy endpoints
@@ -3226,7 +3366,7 @@ def register_addon_tools(mcp: Any, client: HomeAssistantClient, **kwargs: Any) -
         - Change host port: ha_manage_app(slug="...", network={"5800/tcp": 8082})
         - Set boot mode: ha_manage_app(slug="...", boot="manual")
         - Call HTTP API: ha_manage_app(slug="...", path="/api/events")
-        - Direct Node-RED port after an auth rejection: ha_manage_app(slug="...", options={"leave_front_door_open": True}), then ha_manage_app(slug="...", action="restart"), then ha_manage_app(slug="...", path="/flows", port=1880). This disables authentication on the reachable direct port; prefer Ingress.
+        - Direct port: ha_manage_app(slug="...", path="/flows", port=1880) — if the app rejects it, the error names the 'leave_front_door_open' remedy and its security trade-off; prefer Ingress.
         - ESPHome list devices (HTTP): ha_manage_app(slug="<prefix>_esphome", path="/devices")
         - ESPHome read a device's YAML (WS one-shot): ha_manage_app(slug="<prefix>_esphome", path="/ws", websocket=True, wait_for_close=False, message_limit=2, body={"command": "devices/get_config", "message_id": "1", "args": {"configuration": "device.yaml"}})
         - ESPHome live logs (WS, bounded): ha_manage_app(slug="<prefix>_esphome", path="/ws", websocket=True, wait_for_close=False, message_limit=60, body={"command": "devices/logs", "message_id": "1", "args": {"configuration": "device.yaml", "port": "OTA"}})

--- a/src/ha_mcp/tools/tools_addons.py
+++ b/src/ha_mcp/tools/tools_addons.py
@@ -960,6 +960,7 @@ def _build_addon_http_client(
         )
     except OSError as e:
         _tls_setup_error(e, slug)
+        return None  # py/mixed-returns: unreachable, _tls_setup_error raises
 
 
 def _raise_connect_failure(

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -64,6 +64,7 @@ markers =
     external_only: in-process-server tiers only — skip for inaddon, stdio, container-embedded, and HAOS-embedded servers; #1349, #1527, #2233
     inaddon_only: HAOS inaddon mode only — exercises is_running_in_addon()=True paths; #1349
     haos_stdio_only: HAOS stdio mode only — exercises the installed ha-mcp command over a real stdio subprocess transport; #2233
+    haos_tls: final HAOS embedded scenario that restarts Core with HTTPS in the existing worker VM, then restores HTTP; #2241
     not_on_embedded: skip on the embedded backend (E2E_BACKEND=embedded) — provably redundant with the lane's own in-process ha_mcp_server session backend; #1527
     not_on_haos_embedded: skip on the haos_embedded backend (HAOS_TEST_MODE=embedded) — provably redundant with the lane's own session backend, which enables the entry once and drives the in-process server for the whole suite; #1527
 

--- a/tests/src/e2e/basic/test_backend_dispatch_smoke.py
+++ b/tests/src/e2e/basic/test_backend_dispatch_smoke.py
@@ -87,14 +87,17 @@ _SKIP_CEILING_PER_LANE = {
     # intentional marker-gated additions rather than runtime skips. A new lane
     # starts at its observed count plus the five-item buffer described above;
     # subsequent additions consume that buffer explicitly.
-    "container": 74,  # was 73; +1 HAOS stdio visibility e2e (haos_stdio_only)
-    "haos": 49,  # was 48; +1 HAOS stdio visibility e2e (haos_stdio_only)
+    # #2241's final same-VM Core-TLS scenario runs only on haos_embedded. Its
+    # haos_tls marker deliberately adds one collection-time skip everywhere
+    # else, consuming one ceiling slot on each of those lanes.
+    "container": 75,
+    "haos": 50,
     # HAOS stdio is the external HAOS set plus ``external_only`` tests, whose
     # test-process monkeypatches cannot reach the subprocess server. The first
     # full lane run on 2026-08-18 observed 103 collection-time marker skips
     # (plus 9 runtime skips); keep the same five-item buffer as established lanes.
-    "haos_stdio": 108,
-    "haos_inaddon": 77,  # was 76; +1 visibility e2e (haos_stdio_only)
+    "haos_stdio": 109,
+    "haos_inaddon": 78,
     # Embedded backend (#1527, E2E_BACKEND=embedded). Skips exactly the container
     # lane's marker-skips PLUS two embedded-specific additions:
     #   - haos_only + inaddon_only tests skip on embedded just like on container
@@ -103,12 +106,12 @@ _SKIP_CEILING_PER_LANE = {
     #     by test-process env/monkeypatch — same reason as inaddon), plus the
     #     workflows/embedded smoke test (not_on_embedded).
     # Static def-level derivation (Docker-less, so parametrize item-inflation isn't
-    # visible locally): haos_only 52 + inaddon_only-outside-haos 11 + external_only
+    # visible locally): haos_only 53 + inaddon_only-outside-haos 11 + external_only
     # 36 (auto_backup 19, supervisor_mock 15, self_update_notice 1, file_operations
-    # 1) + not_on_embedded 2 = 101. Parametrize inflates that to the CI-observed
+    # 1) + not_on_embedded 2 = 102. Parametrize inflates that to the CI-observed
     # count of 133 in the 2026-08-18 CI run (132 before the self-restart e2e).
     # Read future changes from CI instead of deriving them.
-    "embedded": 134,  # was 133; +1 visibility e2e (haos_stdio_only)
+    "embedded": 135,
     # HAOS embedded backend (#1527, HAOS_TEST_MODE=embedded). A HAOS lane, so it
     # skips the SAME set as the external HAOS lane (container_only + inaddon_only)
     # PLUS two haos_embedded-specific additions:

--- a/tests/src/e2e/basic/test_backend_dispatch_smoke.py
+++ b/tests/src/e2e/basic/test_backend_dispatch_smoke.py
@@ -87,15 +87,17 @@ _SKIP_CEILING_PER_LANE = {
     # intentional marker-gated additions rather than runtime skips. A new lane
     # starts at its observed count plus the five-item buffer described above;
     # subsequent additions consume that buffer explicitly.
-    # #2241's final same-VM Core-TLS scenario runs only on haos_embedded. Its
-    # haos_tls marker deliberately adds one collection-time skip everywhere
-    # else, consuming one ceiling slot on each of those lanes.
+    # #2241's final same-VM Core-TLS scenario runs only on haos_embedded and
+    # deliberately adds one collection-time skip on every other lane — via
+    # haos_tls on the HAOS lanes, and via haos_only on container/embedded,
+    # which already skip its directory.
     "container": 75,
     "haos": 50,
     # HAOS stdio is the external HAOS set plus ``external_only`` tests, whose
     # test-process monkeypatches cannot reach the subprocess server. The first
     # full lane run on 2026-08-18 observed 103 collection-time marker skips
-    # (plus 9 runtime skips); keep the same five-item buffer as established lanes.
+    # (plus 9 runtime skips); keep the same five-item buffer as established
+    # lanes (108), +1 #2241 haos_tls scenario.
     "haos_stdio": 109,
     "haos_inaddon": 78,
     # Embedded backend (#1527, E2E_BACKEND=embedded). Skips exactly the container
@@ -109,7 +111,9 @@ _SKIP_CEILING_PER_LANE = {
     # visible locally): haos_only 53 + inaddon_only-outside-haos 11 + external_only
     # 36 (auto_backup 19, supervisor_mock 15, self_update_notice 1, file_operations
     # 1) + not_on_embedded 2 = 102. Parametrize inflates that to the CI-observed
-    # count of 133 in the 2026-08-18 CI run (132 before the self-restart e2e).
+    # count of 133 in the 2026-08-18 CI run (132 before the self-restart e2e);
+    # +1 visibility e2e (haos_stdio_only) and +1 #2241 haos_tls scenario
+    # (haos_only) bridge 133 -> 135.
     # Read future changes from CI instead of deriving them.
     "embedded": 135,
     # HAOS embedded backend (#1527, HAOS_TEST_MODE=embedded). A HAOS lane, so it

--- a/tests/src/e2e/conftest.py
+++ b/tests/src/e2e/conftest.py
@@ -31,6 +31,7 @@ import threading
 import time
 import urllib.error
 import urllib.request
+import warnings
 from collections.abc import AsyncGenerator
 from functools import partial
 from pathlib import Path
@@ -39,6 +40,7 @@ from typing import Any
 import pytest
 import requests
 from testcontainers.core.container import DockerContainer
+from urllib3.exceptions import InsecureRequestWarning
 
 # Add src to path for imports
 sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
@@ -243,6 +245,12 @@ def _move_haos_tls_items_last(items: list[Any]) -> None:
     items[:] = [*ordinary, *tls]
 
 
+def _apply_haos_tls_skip(item: Any, enabled: bool, skip_marker: Any) -> None:
+    """Keep the main collection hook below its complexity ceiling."""
+    if "haos_tls" in item.keywords and not enabled:
+        item.add_marker(skip_marker)
+
+
 def pytest_collection_modifyitems(config, items):
     """Enforce backend markers and auto-apply ``haos_only`` to its dir.
 
@@ -326,8 +334,7 @@ def pytest_collection_modifyitems(config, items):
             item.add_marker(skip_inaddon_only)
         if "haos_stdio_only" in keywords and not haos_stdio:
             item.add_marker(skip_haos_stdio_only)
-        if "haos_tls" in keywords and not haos_embedded:
-            item.add_marker(skip_haos_tls)
+        _apply_haos_tls_skip(item, haos_embedded, skip_haos_tls)
         # ``external_only`` skips on any tier where the server is NOT in the
         # pytest process: the inaddon HAOS addon AND the embedded backend's
         # in-process MCP server (both #1527). The name is historical (from
@@ -349,7 +356,7 @@ def pytest_collection_modifyitems(config, items):
         # cannot observe pytest-process env changes, monkeypatches, or in-process
         # mocks. The same tests retain coverage on container/external HAOS lanes.
         #
-        elif "external_only" in keywords and (
+        if "external_only" in keywords and (
             inaddon or embedded or haos_embedded or haos_stdio
         ):
             item.add_marker(skip_external_only)
@@ -1022,13 +1029,19 @@ def _wait_for_embedded_webhook_ready(
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
         try:
-            resp = requests.post(
-                webhook_url,
-                headers=headers,
-                data=json.dumps(payload),
-                timeout=30,
-                verify=verify,
-            )
+            with warnings.catch_warnings():
+                if not verify:
+                    # This test deliberately uses Core's hostname-mismatched
+                    # loopback certificate. Keep the suite's warnings-as-errors
+                    # policy for every warning except this expected one.
+                    warnings.simplefilter("ignore", InsecureRequestWarning)
+                resp = requests.post(
+                    webhook_url,
+                    headers=headers,
+                    data=json.dumps(payload),
+                    timeout=30,
+                    verify=verify,
+                )
             if resp.status_code == 200:
                 parsed = _embedded_mcp_result(resp)
                 if parsed is not None and "result" in parsed:

--- a/tests/src/e2e/conftest.py
+++ b/tests/src/e2e/conftest.py
@@ -67,6 +67,7 @@ from haos_runtime import (
     set_default_backup_password,
     stage_embedded_server_feature_flags_in_qcow2,
     stage_embedded_server_wheel_in_qcow2,
+    stage_home_assistant_tls_in_qcow2,
     trigger_dev_addon_update,
     wait_for_addon_ha_link_ready,
     wait_for_addon_mcp_ready,
@@ -228,6 +229,20 @@ def _log_readiness_timing(gate: str, elapsed_s: float, **extras: Any) -> None:
     _READINESS_TIMINGS.append({"gate": gate, "elapsed_s": elapsed_s, **extras})
 
 
+def _move_haos_tls_items_last(items: list[Any]) -> None:
+    """Make the one destructive Core-restart scope the final xdist work unit.
+
+    ``loadscope`` groups tests by module, sorts scopes by descending size, and
+    preserves collection order for equal-sized scopes. The TLS module contains
+    exactly one test; moving its item to the end makes it the final one-test
+    scope. Whichever existing worker receives it has therefore drained its
+    ordinary work before Core is restarted in that worker's already-running VM.
+    """
+    ordinary = [item for item in items if "haos_tls" not in item.keywords]
+    tls = [item for item in items if "haos_tls" in item.keywords]
+    items[:] = [*ordinary, *tls]
+
+
 def pytest_collection_modifyitems(config, items):
     """Enforce backend markers and auto-apply ``haos_only`` to its dir.
 
@@ -249,6 +264,8 @@ def pytest_collection_modifyitems(config, items):
       exercised). Skipped on external mode and on testcontainer.
     - ``haos_stdio_only``: HAOS stdio mode only (``mcp_client`` launches the
       installed ``ha-mcp`` command and uses real stdio JSON-RPC framing).
+    - ``haos_tls``: final HAOS-embedded scenario. It restarts Core with HTTPS,
+      exercises the same VM, and restores HTTP before session teardown.
     """
     del config
     haos = is_haos_backend_selected()
@@ -281,6 +298,9 @@ def pytest_collection_modifyitems(config, items):
     skip_haos_stdio_only = pytest.mark.skip(
         reason="HAOS stdio mode required (set HAOS_TEST_MODE=stdio)"
     )
+    skip_haos_tls = pytest.mark.skip(
+        reason="final Core TLS scenario runs only in the existing HAOS embedded worker"
+    )
     skip_external_only = pytest.mark.skip(
         reason="out-of-process server (stdio/inaddon/embedded); test needs an "
         "in-process server it can reconfigure via env/monkeypatch or reach an "
@@ -306,6 +326,8 @@ def pytest_collection_modifyitems(config, items):
             item.add_marker(skip_inaddon_only)
         if "haos_stdio_only" in keywords and not haos_stdio:
             item.add_marker(skip_haos_stdio_only)
+        if "haos_tls" in keywords and not haos_embedded:
+            item.add_marker(skip_haos_tls)
         # ``external_only`` skips on any tier where the server is NOT in the
         # pytest process: the inaddon HAOS addon AND the embedded backend's
         # in-process MCP server (both #1527). The name is historical (from
@@ -347,6 +369,7 @@ def pytest_collection_modifyitems(config, items):
         # the sole thing exercising the in-process server).
         if "not_on_haos_embedded" in keywords and haos_embedded:
             item.add_marker(skip_not_on_haos_embedded)
+    _move_haos_tls_items_last(items)
 
 
 # Fail fast on a doomed run, on EVERY e2e lane (this conftest is shared by the
@@ -973,7 +996,9 @@ def _embedded_mcp_result(resp: requests.Response) -> dict[str, Any] | None:
     return parse_mcp_response(resp.headers.get("Content-Type", ""), resp.content)
 
 
-def _wait_for_embedded_webhook_ready(webhook_url: str, timeout: int) -> bool:
+def _wait_for_embedded_webhook_ready(
+    webhook_url: str, timeout: int, *, verify: bool = True
+) -> bool:
     """Poll the embedded server's ingress webhook until MCP ``initialize`` works.
 
     A valid JSON-RPC ``result`` means the in-process MCP server has installed
@@ -998,7 +1023,11 @@ def _wait_for_embedded_webhook_ready(webhook_url: str, timeout: int) -> bool:
     while time.monotonic() < deadline:
         try:
             resp = requests.post(
-                webhook_url, headers=headers, data=json.dumps(payload), timeout=30
+                webhook_url,
+                headers=headers,
+                data=json.dumps(payload),
+                timeout=30,
+                verify=verify,
             )
             if resp.status_code == 200:
                 parsed = _embedded_mcp_result(resp)
@@ -1842,6 +1871,11 @@ def _prepare_haos_image(
     # below applies it via Docker layer cache (#1349 item 7).
     if inaddon:
         refresh_dev_addon_source_in_qcow2(image_path)
+    if haos_embedded:
+        certificate = stage_home_assistant_tls_in_qcow2(image_path)
+        # Do not alter process-wide trust during ordinary tests. The final TLS
+        # scenario trusts this cert only while reproducing the legacy mismatch.
+        os.environ["HAOS_TEST_TLS_CA_PATH"] = str(certificate)
     return image_path
 
 

--- a/tests/src/e2e/conftest.py
+++ b/tests/src/e2e/conftest.py
@@ -234,11 +234,15 @@ def _log_readiness_timing(gate: str, elapsed_s: float, **extras: Any) -> None:
 def _move_haos_tls_items_last(items: list[Any]) -> None:
     """Make the one destructive Core-restart scope the final xdist work unit.
 
-    ``loadscope`` groups tests by module, sorts scopes by descending size, and
-    preserves collection order for equal-sized scopes. The TLS module contains
-    exactly one test; moving its item to the end makes it the final one-test
-    scope. Whichever existing worker receives it has therefore drained its
-    ordinary work before Core is restarted in that worker's already-running VM.
+    ``loadscope`` groups tests into scopes by module (or module::class). With
+    xdist's default ``--loadscope-reorder`` the scopes are sorted by
+    descending size with a stable sort, so the one-test TLS module moved to
+    the end stays last among the one-test scopes; with ``--no-loadscope-reorder``
+    plain collection order keeps it last outright. The FIFO workqueue then
+    dispatches it as the final unit. The worker that receives it may still
+    hold up to two queued ordinary tests (xdist tops nodes up at <=2 pending)
+    but executes units in dispatch order, so Core is restarted in that
+    worker's already-running VM only after its ordinary work has run.
     """
     ordinary = [item for item in items if "haos_tls" not in item.keywords]
     tls = [item for item in items if "haos_tls" in item.keywords]
@@ -246,7 +250,11 @@ def _move_haos_tls_items_last(items: list[Any]) -> None:
 
 
 def _apply_haos_tls_skip(item: Any, enabled: bool, skip_marker: Any) -> None:
-    """Keep the main collection hook below its complexity ceiling."""
+    """Skip a ``haos_tls`` item on every lane where the scenario is disabled.
+
+    Kept out-of-line so ``pytest_collection_modifyitems`` stays under the
+    repo-wide C901 ceiling — inlining this branch trips it.
+    """
     if "haos_tls" in item.keywords and not enabled:
         item.add_marker(skip_marker)
 
@@ -335,6 +343,11 @@ def pytest_collection_modifyitems(config, items):
         if "haos_stdio_only" in keywords and not haos_stdio:
             item.add_marker(skip_haos_stdio_only)
         _apply_haos_tls_skip(item, haos_embedded, skip_haos_tls)
+        # Deliberate: inserting the haos_tls dispatch above broke the old
+        # ``elif`` chain into this ``if``. An item carrying several gate
+        # markers now collects one skip marker per gate instead of the first
+        # only — still one skipped item, same counts; only the reported
+        # reason (first marker added) could differ.
         # ``external_only`` skips on any tier where the server is NOT in the
         # pytest process: the inaddon HAOS addon AND the embedded backend's
         # in-process MCP server (both #1527). The name is historical (from
@@ -1011,6 +1024,8 @@ def _wait_for_embedded_webhook_ready(
     A valid JSON-RPC ``result`` means the in-process MCP server has installed
     itself, started its worker thread, and registered the webhook. Returns False
     on timeout so the caller can dump diagnostics and fail with context.
+    ``verify=False`` lets the TLS scenario poll the ``https://`` webhook while
+    Core runs its trial certificate.
     """
     payload = {
         "jsonrpc": "2.0",
@@ -1885,10 +1900,21 @@ def _prepare_haos_image(
     if inaddon:
         refresh_dev_addon_source_in_qcow2(image_path)
     if haos_embedded:
-        certificate = stage_home_assistant_tls_in_qcow2(image_path)
-        # Do not alter process-wide trust during ordinary tests. The final TLS
-        # scenario trusts this cert only while reproducing the legacy mismatch.
-        os.environ["HAOS_TEST_TLS_CA_PATH"] = str(certificate)
+        # Best-effort like the wheel staging above: only the final TLS scenario
+        # consumes this certificate, and it asserts on HAOS_TEST_TLS_CA_PATH —
+        # a staging failure should fail that one test, not abort the lane.
+        try:
+            certificate = stage_home_assistant_tls_in_qcow2(image_path)
+        except RuntimeError:
+            logger.warning(
+                "HAOS Core TLS staging failed; the TLS scenario will report it",
+                exc_info=True,
+            )
+        else:
+            # Do not alter process-wide trust during ordinary tests. The final
+            # TLS scenario trusts this cert only while reproducing the legacy
+            # mismatch.
+            os.environ["HAOS_TEST_TLS_CA_PATH"] = str(certificate)
     return image_path
 
 

--- a/tests/src/e2e/haos_only/test_zz_manage_app_tls.py
+++ b/tests/src/e2e/haos_only/test_zz_manage_app_tls.py
@@ -4,11 +4,15 @@ This module intentionally contains exactly one test. The collection hook moves
 its ``haos_tls`` item to the end, and xdist ``loadscope`` therefore schedules
 this one-test module only after an existing embedded worker drains its ordinary
 modules. Core is restarted in that worker's current VM, never a second lane.
+The ``zz`` filename prefix is belt-and-braces: it puts the module last in
+collection order even if the hook is ever bypassed.
 """
 
 from __future__ import annotations
 
+import asyncio
 import os
+import time
 from typing import Any
 
 import httpx
@@ -38,16 +42,46 @@ from .test_manage_addon_modes import (
     _wait_addon_running,
 )
 
-pytestmark = [pytest.mark.haos_only]
-
 
 def _require_tls_ca_path() -> str:
-    """Return the staged host CA path before entering async test work."""
+    """Return the staged host CA path, failing fast before Core is touched."""
     ca_path = os.environ.get("HAOS_TEST_TLS_CA_PATH")
     assert ca_path and os.path.isfile(ca_path), (
         "HAOS embedded setup did not stage the issue #2241 TLS certificate"
     )
     return ca_path
+
+
+_DIRECT_PORT_READY_TIMEOUT_S = 240.0
+
+
+async def _direct_flows_request(mcp: Client, slug: str) -> dict[str, Any]:
+    """Call Node-RED's direct port, retrying while its HTTP server binds.
+
+    Supervisor reports ``started`` before the app's nginx binds the mapped
+    direct port (CONNECTION_FAILED), and nginx binds before Node-RED itself
+    listens on its upstream socket (502/503/504 with the front door open).
+    Retry only those transient shapes until the app answers with a settled
+    status; every other outcome goes back to the caller's assertions
+    unchanged.
+    """
+    deadline = time.monotonic() + _DIRECT_PORT_READY_TIMEOUT_S
+    while True:
+        payload = await safe_call_tool(
+            mcp,
+            "ha_manage_app",
+            {"slug": slug, "path": "/flows", "method": "GET", "port": 1880},
+        )
+        error = payload.get("error")
+        code = error.get("code") if isinstance(error, dict) else None
+        transient = code == "CONNECTION_FAILED" or payload.get("status_code") in (
+            502,
+            503,
+            504,
+        )
+        if not transient or time.monotonic() >= deadline:
+            return payload
+        await asyncio.sleep(3)
 
 
 async def _set_front_door(
@@ -129,8 +163,10 @@ async def test_manage_app_reproduces_legacy_tls_failure_then_uses_fix(
             ).get("addon") or {}
             options = detail.get("options") or {}
             assert isinstance(options, dict), detail
-            assert "leave_front_door_open" in options, detail
-            original_front_door = bool(options["leave_front_door_open"])
+            # Stock installs carry leave_front_door_open in the schema only
+            # (the bake sets it True); absent means disabled, exactly as the
+            # app treats it.
+            original_front_door = bool(options.get("leave_front_door_open", False))
             front_door_touched = False
 
             # Resolve the real Ingress route with the same production helper.
@@ -145,6 +181,12 @@ async def test_manage_app_reproduces_legacy_tls_failure_then_uses_fix(
                 ingress_url, ingress_headers = await _resolve_http_route(
                     legacy_ha_client, detail, "flows", None
                 )
+                # The legacy reproduction runs in the pytest host process:
+                # SSL_CERT_FILE makes it trust the staged DNS-only CA (it
+                # stays set for the rest of the test — later calls are
+                # http:// or verify=False, so only this request cares), and
+                # NO_PROXY keeps an ambient HTTPS_PROXY from intercepting the
+                # request and masking the certificate/IP mismatch.
                 monkeypatch.setenv("SSL_CERT_FILE", ca_path)
                 monkeypatch.setenv("NO_PROXY", "127.0.0.1,localhost")
                 with pytest.raises(httpx.ConnectError) as legacy_error:
@@ -173,19 +215,17 @@ async def test_manage_app_reproduces_legacy_tls_failure_then_uses_fix(
             assert fixed_ingress.get("status_code") == 200, fixed_ingress
             assert isinstance(fixed_ingress.get("response"), list), fixed_ingress
 
+            if original_front_door:
+                # Direct-port baseline: prove port 1880 answers at all on this
+                # lane before any flip, so a later refusal reads as a restart
+                # readiness race rather than an unreachable port.
+                baseline = await _direct_flows_request(mcp, slug)
+                assert baseline.get("status_code") == 200, baseline
+
             try:
                 front_door_touched = True
                 await _set_front_door(mcp, assertions, slug, False)
-                locked = await safe_call_tool(
-                    mcp,
-                    "ha_manage_app",
-                    {
-                        "slug": slug,
-                        "path": "/flows",
-                        "method": "GET",
-                        "port": 1880,
-                    },
-                )
+                locked = await _direct_flows_request(mcp, slug)
                 assert locked.get("success") is False, locked
                 assert locked.get("status_code") == 401, locked
                 locked_options = (locked.get("addon_config") or {}).get("options") or {}
@@ -200,15 +240,7 @@ async def test_manage_app_reproduces_legacy_tls_failure_then_uses_fix(
                 # Follow the hint with the same management tool, then prove the
                 # formerly rejected direct request works on the real add-on.
                 await _set_front_door(mcp, assertions, slug, True)
-                opened = await assertions.call_tool_success(
-                    "ha_manage_app",
-                    {
-                        "slug": slug,
-                        "path": "/flows",
-                        "method": "GET",
-                        "port": 1880,
-                    },
-                )
+                opened = await _direct_flows_request(mcp, slug)
                 assert opened.get("success") is True, opened
                 assert opened.get("status_code") == 200, opened
                 assert isinstance(opened.get("response"), list), opened

--- a/tests/src/e2e/haos_only/test_zz_manage_app_tls.py
+++ b/tests/src/e2e/haos_only/test_zz_manage_app_tls.py
@@ -41,6 +41,15 @@ from .test_manage_addon_modes import (
 pytestmark = [pytest.mark.haos_only]
 
 
+def _require_tls_ca_path() -> str:
+    """Return the staged host CA path before entering async test work."""
+    ca_path = os.environ.get("HAOS_TEST_TLS_CA_PATH")
+    assert ca_path and os.path.isfile(ca_path), (
+        "HAOS embedded setup did not stage the issue #2241 TLS certificate"
+    )
+    return ca_path
+
+
 def _assert_manage_success(payload: dict[str, Any], operation: str) -> None:
     """Accept the two successful Supervisor config/action result shapes."""
     assert (
@@ -86,10 +95,7 @@ async def test_manage_app_reproduces_legacy_tls_failure_then_uses_fix(
     assert http_base_url.startswith("http://"), container
     token = str(container.get("token", ""))
     assert token, container
-    ca_path = os.environ.get("HAOS_TEST_TLS_CA_PATH")
-    assert ca_path and os.path.isfile(ca_path), (
-        "HAOS embedded setup did not stage the issue #2241 TLS certificate"
-    )
+    ca_path = _require_tls_ca_path()
 
     http_state = get_home_assistant_http_config(http_base_url, token)
     stable = http_state.get("stable")
@@ -111,10 +117,10 @@ async def test_manage_app_reproduces_legacy_tls_failure_then_uses_fix(
             "Core did not schedule the HTTP-to-HTTPS restart"
         )
         _wait_http_ok(f"{https_base_url}/manifest.json", timeout=300, verify_ssl=False)
-        https_ready = True
         assert _wait_for_embedded_webhook_ready(
             https_webhook_url, timeout=180, verify=False
         ), "Embedded MCP webhook did not return after the Core TLS restart"
+        https_ready = True
         # Cancel Core's five-minute pending-config auto-revert before the
         # deliberately thorough Node-RED sequence. The final block stages and
         # promotes the original HTTP config again.
@@ -232,7 +238,11 @@ async def test_manage_app_reproduces_legacy_tls_failure_then_uses_fix(
                 _wait_http_ok(
                     f"{https_base_url}/manifest.json", timeout=30, verify_ssl=False
                 )
-                https_ready = True
+                https_ready = _wait_for_embedded_webhook_ready(
+                    https_webhook_url, timeout=180, verify=False
+                )
+                if not https_ready:
+                    _wait_http_ok(f"{http_base_url}/manifest.json", timeout=330)
             except TimeoutError:
                 _wait_http_ok(f"{http_base_url}/manifest.json", timeout=330)
         if tls_requested and https_ready:

--- a/tests/src/e2e/haos_only/test_zz_manage_app_tls.py
+++ b/tests/src/e2e/haos_only/test_zz_manage_app_tls.py
@@ -31,7 +31,7 @@ from tests.src.haos_runtime import (
 )
 
 from ..conftest import _wait_for_embedded_webhook_ready
-from ..utilities.assertions import parse_mcp_result, safe_call_tool
+from ..utilities.assertions import MCPAssertions, safe_call_tool
 from .test_manage_addon_modes import (
     NODERED_NAME,
     _resolve_slug,
@@ -50,26 +50,17 @@ def _require_tls_ca_path() -> str:
     return ca_path
 
 
-def _assert_manage_success(payload: dict[str, Any], operation: str) -> None:
-    """Accept the two successful Supervisor config/action result shapes."""
-    assert (
-        payload.get("success") is True or payload.get("status") == "pending_restart"
-    ), f"{operation} failed: {payload}"
-
-
-async def _set_front_door(mcp: Client, slug: str, enabled: bool) -> None:
+async def _set_front_door(
+    mcp: Client, assertions: MCPAssertions, slug: str, enabled: bool
+) -> None:
     """Set Node-RED direct auth, restart it, and wait for the live state."""
-    configured = parse_mcp_result(
-        await mcp.call_tool(
-            "ha_manage_app",
-            {"slug": slug, "options": {"leave_front_door_open": enabled}},
-        )
+    await assertions.call_tool_success(
+        "ha_manage_app",
+        {"slug": slug, "options": {"leave_front_door_open": enabled}},
     )
-    _assert_manage_success(configured, f"set leave_front_door_open={enabled}")
-    restarted = parse_mcp_result(
-        await mcp.call_tool("ha_manage_app", {"slug": slug, "action": "restart"})
+    await assertions.call_tool_success(
+        "ha_manage_app", {"slug": slug, "action": "restart"}
     )
-    _assert_manage_success(restarted, "restart Node-RED")
     await _wait_addon_running(mcp, slug)
 
 
@@ -127,15 +118,15 @@ async def test_manage_app_reproduces_legacy_tls_failure_then_uses_fix(
         promote_home_assistant_http_config(https_base_url, token, verify_ssl=False)
 
         transport = StreamableHttpTransport(url=https_webhook_url, verify=False)
-        async with Client(transport) as mcp:
+        async with (
+            Client(transport) as mcp,
+            MCPAssertions(mcp) as assertions,
+        ):
             slug = await _resolve_slug(mcp, NODERED_NAME)
             await _wait_addon_running(mcp, slug)
             detail = (
-                parse_mcp_result(await mcp.call_tool("ha_get_app", {"slug": slug})).get(
-                    "addon"
-                )
-                or {}
-            )
+                await assertions.call_tool_success("ha_get_app", {"slug": slug})
+            ).get("addon") or {}
             options = detail.get("options") or {}
             assert isinstance(options, dict), detail
             assert "leave_front_door_open" in options, detail
@@ -174,11 +165,9 @@ async def test_manage_app_reproduces_legacy_tls_failure_then_uses_fix(
             assert "IP address mismatch" in mismatch, mismatch
             assert "127.0.0.1" in mismatch, mismatch
 
-            fixed_ingress = parse_mcp_result(
-                await mcp.call_tool(
-                    "ha_manage_app",
-                    {"slug": slug, "path": "/flows", "method": "GET"},
-                )
+            fixed_ingress = await assertions.call_tool_success(
+                "ha_manage_app",
+                {"slug": slug, "path": "/flows", "method": "GET"},
             )
             assert fixed_ingress.get("success") is True, fixed_ingress
             assert fixed_ingress.get("status_code") == 200, fixed_ingress
@@ -186,7 +175,7 @@ async def test_manage_app_reproduces_legacy_tls_failure_then_uses_fix(
 
             try:
                 front_door_touched = True
-                await _set_front_door(mcp, slug, False)
+                await _set_front_door(mcp, assertions, slug, False)
                 locked = await safe_call_tool(
                     mcp,
                     "ha_manage_app",
@@ -210,24 +199,22 @@ async def test_manage_app_reproduces_legacy_tls_failure_then_uses_fix(
 
                 # Follow the hint with the same management tool, then prove the
                 # formerly rejected direct request works on the real add-on.
-                await _set_front_door(mcp, slug, True)
-                opened = parse_mcp_result(
-                    await mcp.call_tool(
-                        "ha_manage_app",
-                        {
-                            "slug": slug,
-                            "path": "/flows",
-                            "method": "GET",
-                            "port": 1880,
-                        },
-                    )
+                await _set_front_door(mcp, assertions, slug, True)
+                opened = await assertions.call_tool_success(
+                    "ha_manage_app",
+                    {
+                        "slug": slug,
+                        "path": "/flows",
+                        "method": "GET",
+                        "port": 1880,
+                    },
                 )
                 assert opened.get("success") is True, opened
                 assert opened.get("status_code") == 200, opened
                 assert isinstance(opened.get("response"), list), opened
             finally:
                 if front_door_touched:
-                    await _set_front_door(mcp, slug, original_front_door)
+                    await _set_front_door(mcp, assertions, slug, original_front_door)
     finally:
         # If the configure socket closed while Core accepted the command, the
         # assignment above may not have observed readiness. Probe briefly; if

--- a/tests/src/e2e/haos_only/test_zz_manage_app_tls.py
+++ b/tests/src/e2e/haos_only/test_zz_manage_app_tls.py
@@ -1,0 +1,253 @@
+"""Final same-VM HAOS TLS regression for issue #2241.
+
+This module intentionally contains exactly one test. The collection hook moves
+its ``haos_tls`` item to the end, and xdist ``loadscope`` therefore schedules
+this one-test module only after an existing embedded worker drains its ordinary
+modules. Core is restarted in that worker's current VM, never a second lane.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import httpx
+import pytest
+from fastmcp import Client
+from fastmcp.client.transports import StreamableHttpTransport
+
+from ha_mcp.client import HomeAssistantClient
+from ha_mcp.tools.tools_addons import _resolve_http_route
+from tests.src.haos_runtime import (
+    HA_MCP_SERVER_WEBHOOK_ID,
+    HAOS_TLS_CERTIFICATE_PATH,
+    HAOS_TLS_KEY_PATH,
+    _wait_http_ok,
+    build_home_assistant_tls_config,
+    clean_home_assistant_http_config,
+    configure_home_assistant_http,
+    get_home_assistant_http_config,
+    promote_home_assistant_http_config,
+)
+
+from ..conftest import _wait_for_embedded_webhook_ready
+from ..utilities.assertions import parse_mcp_result, safe_call_tool
+from .test_manage_addon_modes import (
+    NODERED_NAME,
+    _resolve_slug,
+    _wait_addon_running,
+)
+
+pytestmark = [pytest.mark.haos_only]
+
+
+def _assert_manage_success(payload: dict[str, Any], operation: str) -> None:
+    """Accept the two successful Supervisor config/action result shapes."""
+    assert (
+        payload.get("success") is True or payload.get("status") == "pending_restart"
+    ), f"{operation} failed: {payload}"
+
+
+async def _set_front_door(mcp: Client, slug: str, enabled: bool) -> None:
+    """Set Node-RED direct auth, restart it, and wait for the live state."""
+    configured = parse_mcp_result(
+        await mcp.call_tool(
+            "ha_manage_app",
+            {"slug": slug, "options": {"leave_front_door_open": enabled}},
+        )
+    )
+    _assert_manage_success(configured, f"set leave_front_door_open={enabled}")
+    restarted = parse_mcp_result(
+        await mcp.call_tool("ha_manage_app", {"slug": slug, "action": "restart"})
+    )
+    _assert_manage_success(restarted, "restart Node-RED")
+    await _wait_addon_running(mcp, slug)
+
+
+@pytest.mark.haos_tls
+@pytest.mark.timeout(2400)
+async def test_manage_app_reproduces_legacy_tls_failure_then_uses_fix(
+    ha_container_with_fresh_config: dict[str, Any], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Reproduce #2241's old mismatch, then prove both fixes on real HAOS.
+
+    The legacy request below uses the old implementation's exact HTTPX shape:
+    an ``AsyncClient`` with a timeout and no ``verify`` argument. With the test
+    certificate trusted but issued only for ``haos-e2e.local``, its request to
+    the real ``https://127.0.0.1/.../flows`` Ingress route must fail with the
+    reporter's certificate/IP mismatch. The real MCP tool then makes the same
+    call successfully because ``client.verify_ssl=False`` reaches its proxy
+    transport. Finally, a real Node-RED 401 proves the front-door hint and the
+    hinted config/restart sequence are both actionable.
+    """
+    container = ha_container_with_fresh_config
+    assert container.get("backend") == "haos_embedded", container
+    http_base_url = str(container.get("base_url", ""))
+    assert http_base_url.startswith("http://"), container
+    token = str(container.get("token", ""))
+    assert token, container
+    ca_path = os.environ.get("HAOS_TEST_TLS_CA_PATH")
+    assert ca_path and os.path.isfile(ca_path), (
+        "HAOS embedded setup did not stage the issue #2241 TLS certificate"
+    )
+
+    http_state = get_home_assistant_http_config(http_base_url, token)
+    stable = http_state.get("stable")
+    assert isinstance(stable, dict), http_state
+    original_http_config = clean_home_assistant_http_config(stable)
+    tls_config = build_home_assistant_tls_config(
+        stable,
+        certificate_path=HAOS_TLS_CERTIFICATE_PATH,
+        key_path=HAOS_TLS_KEY_PATH,
+    )
+    https_base_url = http_base_url.replace("http://", "https://", 1)
+    https_webhook_url = f"{https_base_url}/api/webhook/{HA_MCP_SERVER_WEBHOOK_ID}"
+    tls_requested = False
+    https_ready = False
+
+    try:
+        tls_requested = True
+        assert configure_home_assistant_http(http_base_url, token, tls_config), (
+            "Core did not schedule the HTTP-to-HTTPS restart"
+        )
+        _wait_http_ok(f"{https_base_url}/manifest.json", timeout=300, verify_ssl=False)
+        https_ready = True
+        assert _wait_for_embedded_webhook_ready(
+            https_webhook_url, timeout=180, verify=False
+        ), "Embedded MCP webhook did not return after the Core TLS restart"
+        # Cancel Core's five-minute pending-config auto-revert before the
+        # deliberately thorough Node-RED sequence. The final block stages and
+        # promotes the original HTTP config again.
+        promote_home_assistant_http_config(https_base_url, token, verify_ssl=False)
+
+        transport = StreamableHttpTransport(url=https_webhook_url, verify=False)
+        async with Client(transport) as mcp:
+            slug = await _resolve_slug(mcp, NODERED_NAME)
+            await _wait_addon_running(mcp, slug)
+            detail = (
+                parse_mcp_result(await mcp.call_tool("ha_get_app", {"slug": slug})).get(
+                    "addon"
+                )
+                or {}
+            )
+            options = detail.get("options") or {}
+            assert isinstance(options, dict), detail
+            assert "leave_front_door_open" in options, detail
+            original_front_door = bool(options["leave_front_door_open"])
+            front_door_touched = False
+
+            # Resolve the real Ingress route with the same production helper.
+            # The only legacy behavior being reproduced is the missing
+            # verify=client.verify_ssl argument on the final HTTPX client.
+            legacy_ha_client = HomeAssistantClient(
+                base_url=https_base_url,
+                token=token,
+                verify_ssl=False,
+            )
+            try:
+                ingress_url, ingress_headers = await _resolve_http_route(
+                    legacy_ha_client, detail, "flows", None
+                )
+                monkeypatch.setenv("SSL_CERT_FILE", ca_path)
+                monkeypatch.setenv("NO_PROXY", "127.0.0.1,localhost")
+                with pytest.raises(httpx.ConnectError) as legacy_error:
+                    async with httpx.AsyncClient(
+                        timeout=httpx.Timeout(30)
+                    ) as legacy_http:
+                        await legacy_http.request(
+                            method="GET",
+                            url=ingress_url,
+                            headers=ingress_headers,
+                            content=None,
+                        )
+            finally:
+                await legacy_ha_client.close()
+
+            mismatch = str(legacy_error.value)
+            assert "CERTIFICATE_VERIFY_FAILED" in mismatch, mismatch
+            assert "IP address mismatch" in mismatch, mismatch
+            assert "127.0.0.1" in mismatch, mismatch
+
+            fixed_ingress = parse_mcp_result(
+                await mcp.call_tool(
+                    "ha_manage_app",
+                    {"slug": slug, "path": "/flows", "method": "GET"},
+                )
+            )
+            assert fixed_ingress.get("success") is True, fixed_ingress
+            assert fixed_ingress.get("status_code") == 200, fixed_ingress
+            assert isinstance(fixed_ingress.get("response"), list), fixed_ingress
+
+            try:
+                front_door_touched = True
+                await _set_front_door(mcp, slug, False)
+                locked = await safe_call_tool(
+                    mcp,
+                    "ha_manage_app",
+                    {
+                        "slug": slug,
+                        "path": "/flows",
+                        "method": "GET",
+                        "port": 1880,
+                    },
+                )
+                assert locked.get("success") is False, locked
+                assert locked.get("status_code") == 401, locked
+                locked_options = (locked.get("addon_config") or {}).get("options") or {}
+                assert locked_options.get("leave_front_door_open") is False, locked
+                suggestion = str(locked.get("suggestion", ""))
+                assert "leave_front_door_open" in suggestion, locked
+                assert "ha_manage_app" in suggestion, locked
+                assert "restart" in suggestion.lower(), locked
+                assert "security" in suggestion.lower(), locked
+                assert "ingress" in suggestion.lower(), locked
+
+                # Follow the hint with the same management tool, then prove the
+                # formerly rejected direct request works on the real add-on.
+                await _set_front_door(mcp, slug, True)
+                opened = parse_mcp_result(
+                    await mcp.call_tool(
+                        "ha_manage_app",
+                        {
+                            "slug": slug,
+                            "path": "/flows",
+                            "method": "GET",
+                            "port": 1880,
+                        },
+                    )
+                )
+                assert opened.get("success") is True, opened
+                assert opened.get("status_code") == 200, opened
+                assert isinstance(opened.get("response"), list), opened
+            finally:
+                if front_door_touched:
+                    await _set_front_door(mcp, slug, original_front_door)
+    finally:
+        # If the configure socket closed while Core accepted the command, the
+        # assignment above may not have observed readiness. Probe briefly; if
+        # HTTPS never came up, wait for Core's five-minute trial auto-revert so
+        # the shared fixture never tears down while its expected HTTP URL is dark.
+        if tls_requested and not https_ready:
+            try:
+                _wait_http_ok(
+                    f"{https_base_url}/manifest.json", timeout=30, verify_ssl=False
+                )
+                https_ready = True
+            except TimeoutError:
+                _wait_http_ok(f"{http_base_url}/manifest.json", timeout=330)
+        if tls_requested and https_ready:
+            assert configure_home_assistant_http(
+                https_base_url,
+                token,
+                original_http_config,
+                verify_ssl=False,
+            ), "Core did not schedule the HTTPS-to-HTTP restoration restart"
+            _wait_http_ok(f"{http_base_url}/manifest.json", timeout=300)
+            restored = get_home_assistant_http_config(http_base_url, token)
+            # A failure before TLS promotion restores the already-stable HTTP
+            # config by clearing pending, so promote only when one remains.
+            if restored.get("pending") is not None:
+                promote_home_assistant_http_config(http_base_url, token)
+                restored = get_home_assistant_http_config(http_base_url, token)
+            assert restored.get("pending") is None, restored
+            assert restored.get("active_config_type") == "stable", restored

--- a/tests/src/e2e/utilities/assertions.py
+++ b/tests/src/e2e/utilities/assertions.py
@@ -144,7 +144,16 @@ def assert_mcp_success(result, operation_name: str = "operation"):
     # Handle different success indicators
     success_indicators = [
         data.get("success") is True,
-        data.get("status") == "pending_restart",
+        # ha_manage_app's options/network write returns
+        # {"status": "pending_restart"} with no success key — the write was
+        # accepted, the app just needs a restart (tools_addons.py). The extra
+        # guards keep an explicit failure from riding in on the status string,
+        # hence "is not False" rather than "is True".
+        (
+            data.get("status") == "pending_restart"
+            and data.get("success") is not False
+            and data.get("error") is None
+        ),
         # If no explicit success field but has data and no error, consider success
         ("data" in data and data.get("error") is None and data.get("success") is None),
         # Bulk operations success: has operational data without explicit success field

--- a/tests/src/e2e/utilities/assertions.py
+++ b/tests/src/e2e/utilities/assertions.py
@@ -144,6 +144,7 @@ def assert_mcp_success(result, operation_name: str = "operation"):
     # Handle different success indicators
     success_indicators = [
         data.get("success") is True,
+        data.get("status") == "pending_restart",
         # If no explicit success field but has data and no error, consider success
         ("data" in data and data.get("error") is None and data.get("success") is None),
         # Bulk operations success: has operational data without explicit success field

--- a/tests/src/haos_runtime.py
+++ b/tests/src/haos_runtime.py
@@ -19,6 +19,7 @@ import json
 import logging
 import os
 import socket
+import ssl
 import subprocess
 import time
 import urllib.error
@@ -1014,6 +1015,116 @@ def stage_embedded_server_wheel_in_qcow2(image_path: Path) -> None:
 # runtime); kept in step with the container backend's ``_EMBEDDED_SERVER_CONFIG_SUBDIR``.
 _HAOS_CONFIG_DIR = "/supervisor/homeassistant"
 _HAOS_EMBEDDED_SERVER_DATA_DIR = f"{_HAOS_CONFIG_DIR}/.ha_mcp"
+_HAOS_TLS_DIR = f"{_HAOS_CONFIG_DIR}/ssl"
+_HAOS_TLS_CERT_NAME = "haos-e2e-cert.pem"
+_HAOS_TLS_KEY_NAME = "haos-e2e-key.pem"
+HAOS_TLS_CERTIFICATE_PATH = f"/config/ssl/{_HAOS_TLS_CERT_NAME}"
+HAOS_TLS_KEY_PATH = f"/config/ssl/{_HAOS_TLS_KEY_NAME}"
+_HA_HTTP_CONFIG_META_KEYS = frozenset({"created_at", "error", "error_message"})
+
+
+def clean_home_assistant_http_config(config: dict[str, Any]) -> dict[str, Any]:
+    """Strip read-only metadata from an HTTP config returned by Core."""
+    return {
+        key: value
+        for key, value in config.items()
+        if key not in _HA_HTTP_CONFIG_META_KEYS
+    }
+
+
+def build_home_assistant_tls_config(
+    stable: dict[str, Any], *, certificate_path: str, key_path: str
+) -> dict[str, Any]:
+    """Build a pending TLS trial while preserving the active HTTP settings."""
+    return {
+        **clean_home_assistant_http_config(stable),
+        "ssl_certificate": certificate_path,
+        "ssl_key": key_path,
+    }
+
+
+def stage_home_assistant_tls_in_qcow2(image_path: Path) -> Path:
+    """Stage a hostname-only Core certificate without enabling TLS yet.
+
+    The certificate is deliberately valid for ``haos-e2e.local`` but not
+    ``127.0.0.1``. Trusting it from the host therefore reproduces issue #2241's
+    exact IP-address-mismatch failure when the legacy app proxy uses HTTPX's
+    default verification. The final E2E enables it at runtime through Core's
+    supported HTTP configuration API, in the worker's already-running VM.
+    """
+    import shutil
+    import tempfile
+
+    workdir = Path(tempfile.mkdtemp(prefix="haos-core-tls-"))
+    certificate = workdir / _HAOS_TLS_CERT_NAME
+    key = workdir / _HAOS_TLS_KEY_NAME
+    try:
+        subprocess.run(
+            [
+                "openssl",
+                "req",
+                "-x509",
+                "-newkey",
+                "rsa:2048",
+                "-sha256",
+                "-nodes",
+                "-days",
+                "1",
+                "-subj",
+                "/CN=haos-e2e.local",
+                "-addext",
+                "subjectAltName=DNS:haos-e2e.local",
+                "-addext",
+                "basicConstraints=critical,CA:TRUE",
+                "-addext",
+                "keyUsage=critical,digitalSignature,keyEncipherment,keyCertSign",
+                "-addext",
+                "extendedKeyUsage=serverAuth",
+                "-keyout",
+                str(key),
+                "-out",
+                str(certificate),
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        subprocess.run(
+            [
+                "guestfish",
+                "--rw",
+                "-a",
+                str(image_path),
+                "run",
+                ":",
+                "mount",
+                "/dev/sda8",
+                "/",
+                ":",
+                "mkdir-p",
+                _HAOS_TLS_DIR,
+                ":",
+                "copy-in",
+                str(certificate),
+                _HAOS_TLS_DIR,
+                ":",
+                "copy-in",
+                str(key),
+                _HAOS_TLS_DIR,
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=180,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        shutil.rmtree(workdir, ignore_errors=True)
+        raise RuntimeError(
+            f"Failed to stage Home Assistant TLS files into {image_path}: {exc}"
+        ) from exc
+    LOG.info("Staged HA Core TLS files into %s (host CA: %s)", image_path, certificate)
+    return certificate
 
 
 def stage_embedded_server_feature_flags_in_qcow2(
@@ -1106,6 +1217,131 @@ def stage_embedded_server_feature_flags_in_qcow2(
         )
     finally:
         _shutil.rmtree(workdir, ignore_errors=True)
+
+
+def _home_assistant_ws_command(
+    base_url: str,
+    token: str,
+    command: dict[str, Any],
+    *,
+    timeout: float = 60.0,
+    verify_ssl: bool = True,
+) -> Any:
+    """Run one authenticated Home Assistant WebSocket command."""
+    import websockets.sync.client
+
+    ws_url = (
+        base_url.replace("http://", "ws://").replace("https://", "wss://")
+        + "/api/websocket"
+    )
+    ssl_context: ssl.SSLContext | None = None
+    if ws_url.startswith("wss://"):
+        ssl_context = ssl.create_default_context()
+        if not verify_ssl:
+            ssl_context.check_hostname = False
+            ssl_context.verify_mode = ssl.CERT_NONE
+
+    with websockets.sync.client.connect(
+        ws_url,
+        max_size=None,
+        open_timeout=min(timeout, 30.0),
+        ssl=ssl_context,
+    ) as ws:
+        first = json.loads(ws.recv())
+        if first.get("type") != "auth_required":
+            raise RuntimeError(f"WS handshake: expected auth_required, got {first!r}")
+        ws.send(json.dumps({"type": "auth", "access_token": token}))
+        auth_resp = json.loads(ws.recv())
+        if auth_resp.get("type") != "auth_ok":
+            raise RuntimeError(f"WS auth rejected: {auth_resp}")
+
+        msg_id = 1
+        ws.send(json.dumps({"id": msg_id, **command}))
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            try:
+                raw = ws.recv(timeout=max(deadline - time.monotonic(), 1.0))
+            except TimeoutError:
+                continue
+            if not isinstance(raw, str):
+                raw = raw.decode()
+            response = json.loads(raw)
+            if response.get("id") != msg_id:
+                continue
+            if not response.get("success", False):
+                raise RuntimeError(
+                    f"Home Assistant WS command {command.get('type')!r} failed: "
+                    f"{response.get('error') or response!r}"
+                )
+            return response.get("result")
+    raise TimeoutError(
+        f"Home Assistant WS command {command.get('type')!r} got no response "
+        f"within {timeout}s"
+    )
+
+
+def get_home_assistant_http_config(
+    base_url: str,
+    token: str,
+    *,
+    timeout: float = 60.0,
+    verify_ssl: bool = True,
+) -> dict[str, Any]:
+    """Read Core's stable, pending, default, and active HTTP config slots."""
+    result = _home_assistant_ws_command(
+        base_url,
+        token,
+        {"type": "http/config"},
+        timeout=timeout,
+        verify_ssl=verify_ssl,
+    )
+    if not isinstance(result, dict):
+        raise RuntimeError(f"http/config returned a non-object result: {result!r}")
+    return result
+
+
+def configure_home_assistant_http(
+    base_url: str,
+    token: str,
+    config: dict[str, Any],
+    *,
+    timeout: float = 60.0,
+    verify_ssl: bool = True,
+) -> bool:
+    """Stage an HTTP config and return whether Core scheduled its restart."""
+    result = _home_assistant_ws_command(
+        base_url,
+        token,
+        {"type": "http/config/configure", "config": config},
+        timeout=timeout,
+        verify_ssl=verify_ssl,
+    )
+    if not isinstance(result, dict) or not isinstance(result.get("restart"), bool):
+        raise RuntimeError(
+            f"http/config/configure returned an invalid result: {result!r}"
+        )
+    return result["restart"]
+
+
+def promote_home_assistant_http_config(
+    base_url: str,
+    token: str,
+    *,
+    timeout: float = 60.0,
+    verify_ssl: bool = True,
+) -> None:
+    """Promote Core's live pending HTTP config to the stable slot."""
+    result = _home_assistant_ws_command(
+        base_url,
+        token,
+        {"type": "http/config/promote"},
+        timeout=timeout,
+        verify_ssl=verify_ssl,
+    )
+    if result is not None:
+        raise RuntimeError(
+            f"http/config/promote returned an unexpected result: {result!r}"
+        )
 
 
 def enable_config_entry(
@@ -1730,12 +1966,17 @@ def _wait_port(port: int, host: str = "127.0.0.1", timeout: float = 180.0) -> No
     raise TimeoutError(f"{host}:{port} did not open within {timeout}s")
 
 
-def _wait_http_ok(url: str, timeout: float = 300.0) -> None:
+def _wait_http_ok(url: str, timeout: float = 300.0, *, verify_ssl: bool = True) -> None:
     deadline = time.monotonic() + timeout
     last_err: Exception | None = None
+    context: ssl.SSLContext | None = None
+    if url.startswith("https://") and not verify_ssl:
+        context = ssl.create_default_context()
+        context.check_hostname = False
+        context.verify_mode = ssl.CERT_NONE
     while time.monotonic() < deadline:
         try:
-            with urllib.request.urlopen(url, timeout=5.0) as resp:
+            with urllib.request.urlopen(url, timeout=5.0, context=context) as resp:
                 if resp.status == 200:
                     return
         except (urllib.error.URLError, urllib.error.HTTPError, OSError) as e:

--- a/tests/src/haos_runtime.py
+++ b/tests/src/haos_runtime.py
@@ -1051,7 +1051,13 @@ def stage_home_assistant_tls_in_qcow2(image_path: Path) -> Path:
     exact IP-address-mismatch failure when the legacy app proxy uses HTTPX's
     default verification. The final E2E enables it at runtime through Core's
     supported HTTP configuration API, in the worker's already-running VM.
+
+    Returns the host-side certificate path — the caller exports it as
+    ``HAOS_TEST_TLS_CA_PATH`` so the test can trust it via ``SSL_CERT_FILE``.
+    That trust path is also why the self-signed cert carries
+    ``basicConstraints=CA:TRUE``: the host uses the same file as its CA.
     """
+    import atexit
     import shutil
     import tempfile
 
@@ -1068,8 +1074,11 @@ def stage_home_assistant_tls_in_qcow2(image_path: Path) -> Path:
                 "rsa:2048",
                 "-sha256",
                 "-nodes",
+                # Staging reruns per image prep, but VM clock drift or an
+                # image reused across a day boundary would turn a 1-day cert
+                # into a confusing "certificate has expired" failure.
                 "-days",
-                "1",
+                "30",
                 "-subj",
                 "/CN=haos-e2e.local",
                 "-addext",
@@ -1124,6 +1133,9 @@ def stage_home_assistant_tls_in_qcow2(image_path: Path) -> Path:
             f"Failed to stage Home Assistant TLS files into {image_path}: {exc}"
         ) from exc
     LOG.info("Staged HA Core TLS files into %s (host CA: %s)", image_path, certificate)
+    # The caller reads the certificate as a trust anchor for the rest of the
+    # session, so remove the workdir (and its private key) only at exit.
+    atexit.register(shutil.rmtree, workdir, ignore_errors=True)
     return certificate
 
 
@@ -1308,7 +1320,12 @@ def configure_home_assistant_http(
     timeout: float = 60.0,
     verify_ssl: bool = True,
 ) -> bool:
-    """Stage an HTTP config and return whether Core scheduled its restart."""
+    """Stage an HTTP config and return whether Core scheduled its restart.
+
+    The underlying ``http/config/configure`` WS command requires an admin
+    token and a Core in ``CoreState.running`` — mid-restart Core rejects it
+    with ``not_running``, which surfaces here as ``RuntimeError``.
+    """
     result = _home_assistant_ws_command(
         base_url,
         token,

--- a/tests/src/unit/test_e2e_assertions.py
+++ b/tests/src/unit/test_e2e_assertions.py
@@ -27,7 +27,13 @@ from __future__ import annotations
 import json
 
 from tests.src.e2e.error_handling.test_network_errors import _hard_failures
-from tests.src.e2e.utilities.assertions import parse_mcp_result
+from tests.src.e2e.utilities.assertions import assert_mcp_success, parse_mcp_result
+
+
+def test_pending_restart_is_a_successful_mcp_result() -> None:
+    assert assert_mcp_success({"status": "pending_restart"}) == {
+        "status": "pending_restart"
+    }
 
 
 class _TextBlock:

--- a/tests/src/unit/test_e2e_assertions.py
+++ b/tests/src/unit/test_e2e_assertions.py
@@ -26,6 +26,8 @@ from __future__ import annotations
 
 import json
 
+import pytest
+
 from tests.src.e2e.error_handling.test_network_errors import _hard_failures
 from tests.src.e2e.utilities.assertions import assert_mcp_success, parse_mcp_result
 
@@ -34,6 +36,16 @@ def test_pending_restart_is_a_successful_mcp_result() -> None:
     assert assert_mcp_success({"status": "pending_restart"}) == {
         "status": "pending_restart"
     }
+
+
+def test_pending_restart_does_not_override_an_explicit_failure() -> None:
+    with pytest.raises(AssertionError):
+        assert_mcp_success({"status": "pending_restart", "success": False})
+
+
+def test_pending_restart_does_not_override_an_error_field() -> None:
+    with pytest.raises(AssertionError):
+        assert_mcp_success({"status": "pending_restart", "error": "config rejected"})
 
 
 class _TextBlock:

--- a/tests/src/unit/test_haos_tls_staging.py
+++ b/tests/src/unit/test_haos_tls_staging.py
@@ -132,13 +132,14 @@ def test_promote_home_assistant_http_config_commits_pending_slot(
         lambda *args, **kwargs: websocket,
     )
 
-    result = haos_runtime.promote_home_assistant_http_config(
+    # No result binding: the wrapper is a procedure (it raises on any
+    # non-None promote result — see the negative test below).
+    haos_runtime.promote_home_assistant_http_config(
         "https://127.0.0.1:18123",
         "token",
         verify_ssl=False,
     )
 
-    assert result is None
     assert websocket.sent == [
         {"type": "auth", "access_token": "token"},
         {"id": 1, "type": "http/config/promote"},

--- a/tests/src/unit/test_haos_tls_staging.py
+++ b/tests/src/unit/test_haos_tls_staging.py
@@ -5,12 +5,13 @@ from __future__ import annotations
 import json
 from typing import Any
 
+import pytest
+
 from tests.src import haos_runtime
 
 
 def test_build_home_assistant_tls_config_preserves_runtime_settings() -> None:
     """A pending TLS trial keeps proxy/port settings and drops storage metadata."""
-    assert hasattr(haos_runtime, "build_home_assistant_tls_config")
     stable = {
         "server_port": 8123,
         "use_x_forwarded_for": True,
@@ -38,10 +39,14 @@ def test_build_home_assistant_tls_config_preserves_runtime_settings() -> None:
 
 
 class _FakeWebSocket:
-    def __init__(self, result: Any) -> None:
+    def __init__(
+        self, result: Any, *, frames: list[dict[str, Any]] | None = None
+    ) -> None:
         self.sent: list[dict[str, Any]] = []
         self._frames = iter(
-            [
+            frames
+            if frames is not None
+            else [
                 {"type": "auth_required"},
                 {"type": "auth_ok"},
                 {
@@ -71,7 +76,6 @@ def test_configure_home_assistant_http_requests_in_place_core_restart(
     monkeypatch: Any,
 ) -> None:
     """The runtime switch uses Core's supported pending-config restart API."""
-    assert hasattr(haos_runtime, "configure_home_assistant_http")
     websocket = _FakeWebSocket({"restart": True})
     monkeypatch.setattr(
         "websockets.sync.client.connect",
@@ -96,7 +100,6 @@ def test_configure_home_assistant_http_requests_in_place_core_restart(
 
 def test_get_home_assistant_http_config_reads_stable_slot(monkeypatch: Any) -> None:
     """The runtime switch derives its TLS trial from Core's active store."""
-    assert hasattr(haos_runtime, "get_home_assistant_http_config")
     expected = {
         "stable": {"server_port": 8123, "use_x_forwarded_for": True},
         "pending": None,
@@ -123,7 +126,6 @@ def test_promote_home_assistant_http_config_commits_pending_slot(
     monkeypatch: Any,
 ) -> None:
     """The live TLS/HTTP trial is promoted before its auto-revert deadline."""
-    assert hasattr(haos_runtime, "promote_home_assistant_http_config")
     websocket = _FakeWebSocket(None)
     monkeypatch.setattr(
         "websockets.sync.client.connect",
@@ -143,11 +145,98 @@ def test_promote_home_assistant_http_config_commits_pending_slot(
     ]
 
 
-def test_move_haos_tls_item_last() -> None:
-    """The destructive TLS/Core-restart scenario runs after ordinary work."""
-    from tests.src.e2e import conftest as e2e_conftest
+def _patch_ws_connect(monkeypatch: Any, websocket: _FakeWebSocket) -> None:
+    monkeypatch.setattr(
+        "websockets.sync.client.connect",
+        lambda *args, **kwargs: websocket,
+    )
 
-    assert hasattr(e2e_conftest, "_move_haos_tls_items_last")
+
+def test_ws_command_requires_the_auth_required_handshake(monkeypatch: Any) -> None:
+    """A socket that skips auth_required fails loudly instead of proceeding."""
+    _patch_ws_connect(monkeypatch, _FakeWebSocket(None, frames=[{"type": "auth_ok"}]))
+
+    with pytest.raises(RuntimeError, match="expected auth_required"):
+        haos_runtime.get_home_assistant_http_config("http://127.0.0.1:18123", "token")
+
+
+def test_ws_command_rejected_auth_fails_loudly(monkeypatch: Any) -> None:
+    """An auth_invalid reply never falls through to the command send."""
+    _patch_ws_connect(
+        monkeypatch,
+        _FakeWebSocket(
+            None, frames=[{"type": "auth_required"}, {"type": "auth_invalid"}]
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match="auth rejected"):
+        haos_runtime.get_home_assistant_http_config("http://127.0.0.1:18123", "token")
+
+
+def test_ws_command_unsuccessful_result_fails_loudly(monkeypatch: Any) -> None:
+    """A success=False result frame raises with Core's error payload."""
+    _patch_ws_connect(
+        monkeypatch,
+        _FakeWebSocket(
+            None,
+            frames=[
+                {"type": "auth_required"},
+                {"type": "auth_ok"},
+                {
+                    "id": 1,
+                    "type": "result",
+                    "success": False,
+                    "error": {"code": "unknown_command"},
+                },
+            ],
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match="unknown_command"):
+        haos_runtime.get_home_assistant_http_config("http://127.0.0.1:18123", "token")
+
+
+def test_get_home_assistant_http_config_rejects_non_object_result(
+    monkeypatch: Any,
+) -> None:
+    """A non-dict http/config result is a contract break, not data."""
+    _patch_ws_connect(monkeypatch, _FakeWebSocket("not-a-config"))
+
+    with pytest.raises(RuntimeError, match="non-object result"):
+        haos_runtime.get_home_assistant_http_config("http://127.0.0.1:18123", "token")
+
+
+def test_configure_home_assistant_http_rejects_invalid_result(
+    monkeypatch: Any,
+) -> None:
+    """A configure result without a boolean restart flag fails loudly."""
+    _patch_ws_connect(monkeypatch, _FakeWebSocket({"restart": "yes"}))
+
+    with pytest.raises(RuntimeError, match="invalid result"):
+        haos_runtime.configure_home_assistant_http(
+            "http://127.0.0.1:18123", "token", {"server_port": 8123}
+        )
+
+
+def test_promote_home_assistant_http_config_rejects_unexpected_result(
+    monkeypatch: Any,
+) -> None:
+    """A non-None promote result means the API shape changed underneath us."""
+    _patch_ws_connect(monkeypatch, _FakeWebSocket({"promoted": True}))
+
+    with pytest.raises(RuntimeError, match="unexpected result"):
+        haos_runtime.promote_home_assistant_http_config(
+            "http://127.0.0.1:18123", "token"
+        )
+
+
+def test_move_haos_tls_item_last() -> None:
+    """The hook reorders collection so the haos_tls item is last.
+
+    The scheduling consequence (Core restarts only after a worker's ordinary
+    work) is documented on ``_move_haos_tls_items_last`` itself.
+    """
+    from tests.src.e2e import conftest as e2e_conftest
 
     class Item:
         def __init__(self, name: str, *, tls: bool = False) -> None:
@@ -159,3 +248,57 @@ def test_move_haos_tls_item_last() -> None:
     e2e_conftest._move_haos_tls_items_last(items)
 
     assert [item.name for item in items] == ["first", "last", "tls"]
+
+
+def test_apply_haos_tls_skip_gates_on_the_embedded_lane() -> None:
+    """The TLS scenario is skipped exactly where it is disabled.
+
+    An inverted condition would silently stop the #2241 regression proof from
+    running anywhere, under the skip ceilings' radar.
+    """
+    from tests.src.e2e import conftest as e2e_conftest
+
+    class Item:
+        def __init__(self, *, tls: bool) -> None:
+            self.keywords = {"haos_tls": True} if tls else {}
+            self.markers: list[Any] = []
+
+        def add_marker(self, marker: Any) -> None:
+            self.markers.append(marker)
+
+    marker = object()
+
+    disabled = Item(tls=True)
+    e2e_conftest._apply_haos_tls_skip(disabled, False, marker)
+    assert disabled.markers == [marker]
+
+    enabled = Item(tls=True)
+    e2e_conftest._apply_haos_tls_skip(enabled, True, marker)
+    assert enabled.markers == []
+
+    ordinary = Item(tls=False)
+    e2e_conftest._apply_haos_tls_skip(ordinary, False, marker)
+    assert ordinary.markers == []
+
+
+def test_tls_module_contains_exactly_one_test() -> None:
+    """The end-of-queue scheduling guarantee needs a one-test module.
+
+    ``loadscope`` schedules whole modules; a second test here would make the
+    TLS scope larger than the other one-test scopes and let the reorder sort
+    schedule the destructive Core restart mid-suite.
+    """
+    import ast
+    from pathlib import Path
+
+    module = (
+        Path(__file__).parents[1] / "e2e" / "haos_only" / "test_zz_manage_app_tls.py"
+    )
+    tree = ast.parse(module.read_text())
+    test_defs = [
+        node.name
+        for node in ast.walk(tree)
+        if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef)
+        and node.name.startswith("test_")
+    ]
+    assert test_defs == ["test_manage_app_reproduces_legacy_tls_failure_then_uses_fix"]

--- a/tests/src/unit/test_haos_tls_staging.py
+++ b/tests/src/unit/test_haos_tls_staging.py
@@ -1,0 +1,161 @@
+"""Unit coverage for the final same-VM HAOS Core TLS scenario."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import tests.src.haos_runtime as haos_runtime
+
+
+def test_build_home_assistant_tls_config_preserves_runtime_settings() -> None:
+    """A pending TLS trial keeps proxy/port settings and drops storage metadata."""
+    assert hasattr(haos_runtime, "build_home_assistant_tls_config")
+    stable = {
+        "server_port": 8123,
+        "use_x_forwarded_for": True,
+        "trusted_proxies": ["172.30.32.0/23"],
+        "ip_ban_enabled": True,
+        "created_at": "2026-08-20T00:00:00+00:00",
+        "error": None,
+        "error_message": None,
+    }
+
+    result = haos_runtime.build_home_assistant_tls_config(
+        stable,
+        certificate_path="/config/ssl/haos-e2e-cert.pem",
+        key_path="/config/ssl/haos-e2e-key.pem",
+    )
+
+    assert result == {
+        "server_port": 8123,
+        "use_x_forwarded_for": True,
+        "trusted_proxies": ["172.30.32.0/23"],
+        "ip_ban_enabled": True,
+        "ssl_certificate": "/config/ssl/haos-e2e-cert.pem",
+        "ssl_key": "/config/ssl/haos-e2e-key.pem",
+    }
+
+
+class _FakeWebSocket:
+    def __init__(self, result: Any) -> None:
+        self.sent: list[dict[str, Any]] = []
+        self._frames = iter(
+            [
+                {"type": "auth_required"},
+                {"type": "auth_ok"},
+                {
+                    "id": 1,
+                    "type": "result",
+                    "success": True,
+                    "result": result,
+                },
+            ]
+        )
+
+    def __enter__(self) -> _FakeWebSocket:
+        return self
+
+    def __exit__(self, *args: Any) -> None:
+        return None
+
+    def send(self, payload: str) -> None:
+        self.sent.append(json.loads(payload))
+
+    def recv(self, timeout: float | None = None) -> str:
+        del timeout
+        return json.dumps(next(self._frames))
+
+
+def test_configure_home_assistant_http_requests_in_place_core_restart(
+    monkeypatch: Any,
+) -> None:
+    """The runtime switch uses Core's supported pending-config restart API."""
+    assert hasattr(haos_runtime, "configure_home_assistant_http")
+    websocket = _FakeWebSocket({"restart": True})
+    monkeypatch.setattr(
+        "websockets.sync.client.connect",
+        lambda *args, **kwargs: websocket,
+    )
+    config = {"server_port": 8123, "ssl_certificate": "/config/ssl/cert.pem"}
+
+    restarted = haos_runtime.configure_home_assistant_http(
+        "http://127.0.0.1:18123", "token", config
+    )
+
+    assert restarted is True
+    assert websocket.sent == [
+        {"type": "auth", "access_token": "token"},
+        {
+            "id": 1,
+            "type": "http/config/configure",
+            "config": config,
+        },
+    ]
+
+
+def test_get_home_assistant_http_config_reads_stable_slot(monkeypatch: Any) -> None:
+    """The runtime switch derives its TLS trial from Core's active store."""
+    assert hasattr(haos_runtime, "get_home_assistant_http_config")
+    expected = {
+        "stable": {"server_port": 8123, "use_x_forwarded_for": True},
+        "pending": None,
+        "active_config_type": "stable",
+    }
+    websocket = _FakeWebSocket(expected)
+    monkeypatch.setattr(
+        "websockets.sync.client.connect",
+        lambda *args, **kwargs: websocket,
+    )
+
+    result = haos_runtime.get_home_assistant_http_config(
+        "http://127.0.0.1:18123", "token"
+    )
+
+    assert result == expected
+    assert websocket.sent == [
+        {"type": "auth", "access_token": "token"},
+        {"id": 1, "type": "http/config"},
+    ]
+
+
+def test_promote_home_assistant_http_config_commits_pending_slot(
+    monkeypatch: Any,
+) -> None:
+    """The live TLS/HTTP trial is promoted before its auto-revert deadline."""
+    assert hasattr(haos_runtime, "promote_home_assistant_http_config")
+    websocket = _FakeWebSocket(None)
+    monkeypatch.setattr(
+        "websockets.sync.client.connect",
+        lambda *args, **kwargs: websocket,
+    )
+
+    result = haos_runtime.promote_home_assistant_http_config(
+        "https://127.0.0.1:18123",
+        "token",
+        verify_ssl=False,
+    )
+
+    assert result is None
+    assert websocket.sent == [
+        {"type": "auth", "access_token": "token"},
+        {"id": 1, "type": "http/config/promote"},
+    ]
+
+
+def test_move_haos_tls_item_last() -> None:
+    """The destructive TLS/Core-restart scenario runs after ordinary work."""
+    from tests.src.e2e import conftest as e2e_conftest
+
+    assert hasattr(e2e_conftest, "_move_haos_tls_items_last")
+
+    class Item:
+        def __init__(self, name: str, *, tls: bool = False) -> None:
+            self.name = name
+            self.keywords = {"haos_tls": True} if tls else {}
+
+    items = [Item("first"), Item("tls", tls=True), Item("last")]
+
+    e2e_conftest._move_haos_tls_items_last(items)
+
+    assert [item.name for item in items] == ["first", "last", "tls"]

--- a/tests/src/unit/test_haos_tls_staging.py
+++ b/tests/src/unit/test_haos_tls_staging.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 from typing import Any
 
-import tests.src.haos_runtime as haos_runtime
+from tests.src import haos_runtime
 
 
 def test_build_home_assistant_tls_config_preserves_runtime_settings() -> None:

--- a/tests/src/unit/test_tools_addons.py
+++ b/tests/src/unit/test_tools_addons.py
@@ -44,6 +44,23 @@ _RUNNING_ADDON_INFO = {
 
 _INGRESS_SESSION_TOKEN = "test-ingress-session"
 
+_FRONT_DOOR_SCHEMA = [
+    {"name": "leave_front_door_open", "type": "boolean", "optional": True}
+]
+
+
+def _front_door_fixture(front_door) -> tuple[dict, list]:
+    """Return (options, schema) for one leave_front_door_open state.
+
+    False/True: option saved with that value. "absent": exposed in the schema
+    but never saved (stock install). "unexposed": app without the option.
+    """
+    if front_door == "unexposed":
+        return {}, []
+    if front_door == "absent":
+        return {}, list(_FRONT_DOOR_SCHEMA)
+    return {"leave_front_door_open": front_door}, list(_FRONT_DOOR_SCHEMA)
+
 
 def _make_mock_client() -> MagicMock:
     """Create a mock HomeAssistantClient."""
@@ -803,15 +820,22 @@ class TestCallAddonApiErrors:
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("status", [401, 403])
-    @pytest.mark.parametrize("front_door", [False, True])
+    @pytest.mark.parametrize("front_door", [False, True, "absent", "unexposed"])
     async def test_http_direct_port_auth_hints_at_app_option(self, status, front_door):
-        """Direct auth errors suggest changing the option only when disabled."""
+        """Direct auth errors suggest the option only when it is off.
+
+        "absent" mirrors a stock install: the option lives in the schema but
+        was never saved, so Supervisor omits it from options — the app treats
+        that as disabled. "unexposed" is an app without the option at all.
+        """
+        options, schema = _front_door_fixture(front_door)
         client = _make_mock_client()
         addon_info = {
             "success": True,
             "addon": {
                 **_RUNNING_ADDON_INFO["addon"],
-                "options": {"leave_front_door_open": front_door},
+                "options": options,
+                "schema": schema,
                 "ports": {"1880/tcp": 1880},
             },
         }
@@ -845,14 +869,14 @@ class TestCallAddonApiErrors:
 
         assert result["status_code"] == status
         suggestion = result["suggestion"]
-        if front_door:
+        if front_door in (True, "unexposed"):
             assert "options={'leave_front_door_open': True}" not in suggestion
             assert "app's own authentication" in suggestion
             assert "access-control" in suggestion
             assert "ingress session" not in suggestion.lower()
             assert "HA token" not in suggestion
         else:
-            assert result["addon_config"]["options"]["leave_front_door_open"] is False
+            assert result["addon_config"]["options"] == options
             assert "leave_front_door_open" in suggestion
             assert "ha_manage_app" in suggestion
             assert "restart" in suggestion.lower()
@@ -893,6 +917,90 @@ class TestCallAddonApiErrors:
 
         assert result["success"] is True
         assert mock_httpx.call_args.kwargs["verify"] is False
+
+    @pytest.mark.asyncio
+    async def test_http_proxy_keeps_tls_verification_by_default(
+        self, mock_ingress_session
+    ):
+        """verify_ssl=True must reach httpx unchanged — the secure default."""
+        client = _make_mock_client()
+        client.base_url = "https://ha.local:8123"
+        client.verify_ssl = True
+
+        response = MagicMock()
+        response.headers = {"content-type": "application/json"}
+        response.status_code = 200
+        response.json.return_value = {}
+        response.text = "{}"
+
+        with (
+            patch(
+                "ha_mcp.tools.tools_addons.get_addon_info",
+                new_callable=AsyncMock,
+                return_value=_RUNNING_ADDON_INFO,
+            ),
+            patch(
+                "ha_mcp.tools.tools_addons.httpx.AsyncClient",
+            ) as mock_httpx,
+        ):
+            mock_http_client = AsyncMock()
+            mock_http_client.request.return_value = response
+            mock_httpx.return_value.__aenter__ = AsyncMock(
+                return_value=mock_http_client
+            )
+            mock_httpx.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            result = await _call_addon_api(client, "test_addon", "/flows")
+
+        assert result["success"] is True
+        assert mock_httpx.call_args.kwargs["verify"] is True
+
+    @pytest.mark.asyncio
+    async def test_http_proxy_classifies_tls_verification_failure(
+        self, mock_ingress_session
+    ):
+        """A cert failure with verification on names the TLS remedy."""
+        client = _make_mock_client()
+        client.base_url = "https://ha.local:8123"
+        client.verify_ssl = True
+
+        connect_error = httpx.ConnectError("All connection attempts failed")
+        connect_error.__cause__ = ssl.SSLCertVerificationError(
+            "certificate verify failed: IP address mismatch"
+        )
+
+        with (
+            patch(
+                "ha_mcp.tools.tools_addons.get_addon_info",
+                new_callable=AsyncMock,
+                return_value=_RUNNING_ADDON_INFO,
+            ),
+            patch(
+                "ha_mcp.tools.tools_addons.httpx.AsyncClient",
+            ) as mock_httpx,
+        ):
+            mock_http_client = AsyncMock()
+            mock_http_client.request.side_effect = connect_error
+            mock_httpx.return_value.__aenter__ = AsyncMock(
+                return_value=mock_http_client
+            )
+            mock_httpx.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            with pytest.raises(ToolError) as exc_info:
+                await _call_addon_api(client, "test_addon", "/flows")
+
+        result = _parse_tool_error(exc_info)
+        assert "TLS verification failed" in result["error"]["message"]
+        # A single suggestion lands under the singular key.
+        joined = " ".join(
+            [
+                result["error"].get("suggestion", ""),
+                *result["error"].get("suggestions", []),
+            ]
+        )
+        assert "HA_VERIFY_SSL" in joined
+        # The generic network suggestions would misdirect here.
+        assert "network connectivity" not in joined.lower()
 
     @pytest.mark.asyncio
     async def test_http_403_response_hints_at_ip_restriction(
@@ -1402,6 +1510,78 @@ class TestCallAddonWsErrors:
         assert ssl_context.verify_mode == ssl.CERT_NONE
 
     @pytest.mark.asyncio
+    async def test_ws_proxy_keeps_tls_verification_by_default(
+        self, mock_ingress_session
+    ):
+        """verify_ssl=True keeps the default secure WSS context."""
+        client = _make_mock_client()
+        client.base_url = "https://ha.local:8123"
+        client.verify_ssl = True
+
+        with (
+            patch(
+                "ha_mcp.tools.tools_addons.get_addon_info",
+                new_callable=AsyncMock,
+                return_value=_RUNNING_ADDON_INFO,
+            ),
+            patch(
+                "ha_mcp.tools.tools_addons.websockets.connect",
+            ) as mock_ws_connect,
+        ):
+            mock_ws = AsyncMock()
+            mock_ws.recv.side_effect = ConnectionClosed(None, None)
+            mock_ws_connect.return_value.__aenter__ = AsyncMock(return_value=mock_ws)
+            mock_ws_connect.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            result = await _call_addon_ws(client, "test_addon", "/ws")
+
+        assert result["success"] is True
+        ssl_context = mock_ws_connect.call_args.kwargs["ssl"]
+        assert isinstance(ssl_context, ssl.SSLContext)
+        assert ssl_context.check_hostname is True
+        assert ssl_context.verify_mode == ssl.CERT_REQUIRED
+
+    @pytest.mark.asyncio
+    async def test_ws_proxy_classifies_tls_verification_failure(
+        self, mock_ingress_session
+    ):
+        """A WSS cert failure with verification on names the TLS remedy."""
+        client = _make_mock_client()
+        client.base_url = "https://ha.local:8123"
+        client.verify_ssl = True
+
+        with (
+            patch(
+                "ha_mcp.tools.tools_addons.get_addon_info",
+                new_callable=AsyncMock,
+                return_value=_RUNNING_ADDON_INFO,
+            ),
+            patch(
+                "ha_mcp.tools.tools_addons.websockets.connect",
+            ) as mock_ws_connect,
+        ):
+            mock_ws_connect.return_value.__aenter__ = AsyncMock(
+                side_effect=ssl.SSLCertVerificationError(
+                    "certificate verify failed: IP address mismatch"
+                )
+            )
+            mock_ws_connect.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            with pytest.raises(ToolError) as exc_info:
+                await _call_addon_ws(client, "test_addon", "/ws")
+
+        result = _parse_tool_error(exc_info)
+        assert "TLS verification failed" in result["error"]["message"]
+        joined = " ".join(
+            [
+                result["error"].get("suggestion", ""),
+                *result["error"].get("suggestions", []),
+            ]
+        )
+        assert "HA_VERIFY_SSL" in joined
+        assert "network connectivity" not in joined.lower()
+
+    @pytest.mark.asyncio
     async def test_ws_addon_not_running(self):
         """Should raise ToolError when add-on is not running."""
         client = _make_mock_client()
@@ -1476,18 +1656,25 @@ class TestCallAddonWsErrors:
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("status", [401, 403])
-    @pytest.mark.parametrize("front_door", [False, True])
+    @pytest.mark.parametrize("front_door", [False, True, "absent", "unexposed"])
     async def test_ws_direct_port_auth_hints_at_app_option(self, status, front_door):
-        """Direct WS errors suggest changing the option only when disabled."""
+        """Direct WS errors suggest the option only when it is off.
+
+        Same four option states as the HTTP variant: saved False/True,
+        exposed-but-unsaved ("absent", the stock install), and an app without
+        the option ("unexposed").
+        """
         from ha_mcp._vendor.websockets.datastructures import Headers
         from ha_mcp._vendor.websockets.http11 import Response
 
+        options, schema = _front_door_fixture(front_door)
         client = _make_mock_client()
         addon_info = {
             "success": True,
             "addon": {
                 **_RUNNING_ADDON_INFO_WS["addon"],
-                "options": {"leave_front_door_open": front_door},
+                "options": options,
+                "schema": schema,
                 "ports": {"1880/tcp": 1880},
             },
         }
@@ -1514,7 +1701,7 @@ class TestCallAddonWsErrors:
         result = _parse_tool_error(exc_info)
         suggestions = result["error"].get("suggestions", [])
         joined = " ".join(suggestions).lower()
-        if front_door:
+        if front_door in (True, "unexposed"):
             assert "options={'leave_front_door_open': true}" not in joined
             assert "app's own authentication" in joined
             assert "access-control" in joined

--- a/tests/src/unit/test_tools_addons.py
+++ b/tests/src/unit/test_tools_addons.py
@@ -803,14 +803,15 @@ class TestCallAddonApiErrors:
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("status", [401, 403])
-    async def test_http_direct_port_auth_hints_at_app_option(self, status):
-        """A direct-port 401 surfaces the app option the tool can change."""
+    @pytest.mark.parametrize("front_door", [False, True])
+    async def test_http_direct_port_auth_hints_at_app_option(self, status, front_door):
+        """Direct auth errors suggest changing the option only when disabled."""
         client = _make_mock_client()
         addon_info = {
             "success": True,
             "addon": {
                 **_RUNNING_ADDON_INFO["addon"],
-                "options": {"leave_front_door_open": False},
+                "options": {"leave_front_door_open": front_door},
                 "ports": {"1880/tcp": 1880},
             },
         }
@@ -843,13 +844,16 @@ class TestCallAddonApiErrors:
             result = await _call_addon_api(client, "test_addon", "/flows", port=1880)
 
         assert result["status_code"] == status
-        assert result["addon_config"]["options"]["leave_front_door_open"] is False
         suggestion = result["suggestion"]
-        assert "leave_front_door_open" in suggestion
-        assert "ha_manage_app" in suggestion
-        assert "restart" in suggestion.lower()
-        assert "action='restart'" in suggestion
-        assert "security" in suggestion.lower()
+        if front_door:
+            assert "options={'leave_front_door_open': True}" not in suggestion
+        else:
+            assert result["addon_config"]["options"]["leave_front_door_open"] is False
+            assert "leave_front_door_open" in suggestion
+            assert "ha_manage_app" in suggestion
+            assert "restart" in suggestion.lower()
+            assert "action='restart'" in suggestion
+            assert "security" in suggestion.lower()
 
     @pytest.mark.asyncio
     async def test_http_proxy_propagates_tls_verification(self, mock_ingress_session):
@@ -1468,8 +1472,9 @@ class TestCallAddonWsErrors:
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("status", [401, 403])
-    async def test_ws_direct_port_auth_hints_at_app_option(self, status):
-        """Direct-port WS auth failures surface the configurable app option."""
+    @pytest.mark.parametrize("front_door", [False, True])
+    async def test_ws_direct_port_auth_hints_at_app_option(self, status, front_door):
+        """Direct WS errors suggest changing the option only when disabled."""
         from ha_mcp._vendor.websockets.datastructures import Headers
         from ha_mcp._vendor.websockets.http11 import Response
 
@@ -1478,7 +1483,7 @@ class TestCallAddonWsErrors:
             "success": True,
             "addon": {
                 **_RUNNING_ADDON_INFO_WS["addon"],
-                "options": {"leave_front_door_open": False},
+                "options": {"leave_front_door_open": front_door},
                 "ports": {"1880/tcp": 1880},
             },
         }
@@ -1505,11 +1510,14 @@ class TestCallAddonWsErrors:
         result = _parse_tool_error(exc_info)
         suggestions = result["error"].get("suggestions", [])
         joined = " ".join(suggestions).lower()
-        assert "leave_front_door_open" in joined, suggestions
-        assert "ha_manage_app" in joined, suggestions
-        assert "restart" in joined, suggestions
-        assert "action='restart'" in joined, suggestions
-        assert "security" in joined, suggestions
+        if front_door:
+            assert "options={'leave_front_door_open': true}" not in joined
+        else:
+            assert "leave_front_door_open" in joined, suggestions
+            assert "ha_manage_app" in joined, suggestions
+            assert "restart" in joined, suggestions
+            assert "action='restart'" in joined, suggestions
+            assert "security" in joined, suggestions
 
     @pytest.mark.asyncio
     async def test_ws_handshake_404_keeps_path_hint(self, mock_ingress_session):

--- a/tests/src/unit/test_tools_addons.py
+++ b/tests/src/unit/test_tools_addons.py
@@ -1542,6 +1542,37 @@ class TestCallAddonWsErrors:
         assert ssl_context.verify_mode == ssl.CERT_REQUIRED
 
     @pytest.mark.asyncio
+    async def test_ws_direct_port_uses_no_ssl_context(self):
+        """A plaintext ws:// direct-port route must pass ssl=None.
+
+        websockets.connect rejects any SSL context on a ws:// URI, so always
+        building one would break every direct-port call.
+        """
+        client = _make_mock_client()
+        client.base_url = "https://ha.local:8123"
+        client.verify_ssl = True
+
+        with (
+            patch(
+                "ha_mcp.tools.tools_addons.get_addon_info",
+                new_callable=AsyncMock,
+                return_value=_RUNNING_ADDON_INFO_WS,
+            ),
+            patch(
+                "ha_mcp.tools.tools_addons.websockets.connect",
+            ) as mock_ws_connect,
+        ):
+            mock_ws = AsyncMock()
+            mock_ws.recv.side_effect = ConnectionClosed(None, None)
+            mock_ws_connect.return_value.__aenter__ = AsyncMock(return_value=mock_ws)
+            mock_ws_connect.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            result = await _call_addon_ws(client, "test_addon", "/ws", port=1880)
+
+        assert result["success"] is True
+        assert mock_ws_connect.call_args.kwargs["ssl"] is None
+
+    @pytest.mark.asyncio
     async def test_ws_proxy_classifies_tls_verification_failure(
         self, mock_ingress_session
     ):

--- a/tests/src/unit/test_tools_addons.py
+++ b/tests/src/unit/test_tools_addons.py
@@ -847,6 +847,10 @@ class TestCallAddonApiErrors:
         suggestion = result["suggestion"]
         if front_door:
             assert "options={'leave_front_door_open': True}" not in suggestion
+            assert "app's own authentication" in suggestion
+            assert "access-control" in suggestion
+            assert "ingress session" not in suggestion.lower()
+            assert "HA token" not in suggestion
         else:
             assert result["addon_config"]["options"]["leave_front_door_open"] is False
             assert "leave_front_door_open" in suggestion
@@ -1512,6 +1516,10 @@ class TestCallAddonWsErrors:
         joined = " ".join(suggestions).lower()
         if front_door:
             assert "options={'leave_front_door_open': true}" not in joined
+            assert "app's own authentication" in joined
+            assert "access-control" in joined
+            assert "ingress session" not in joined
+            assert "ha token" not in joined
         else:
             assert "leave_front_door_open" in joined, suggestions
             assert "ha_manage_app" in joined, suggestions

--- a/tests/src/unit/test_tools_addons.py
+++ b/tests/src/unit/test_tools_addons.py
@@ -1,6 +1,7 @@
 """Unit tests for add-on tools (AddOnTools, manage_addon, _validate_addon_access, _call_addon_api, _call_addon_ws, list_addons)."""
 
 import json
+import ssl
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
@@ -49,6 +50,7 @@ def _make_mock_client() -> MagicMock:
     client = MagicMock()
     client.base_url = "http://localhost:8123"
     client.token = "test-token"
+    client.verify_ssl = True
     return client
 
 
@@ -800,6 +802,91 @@ class TestCallAddonApiErrors:
         assert "addon_config" not in result, result
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("status", [401, 403])
+    async def test_http_direct_port_auth_hints_at_app_option(self, status):
+        """A direct-port 401 surfaces the app option the tool can change."""
+        client = _make_mock_client()
+        addon_info = {
+            "success": True,
+            "addon": {
+                **_RUNNING_ADDON_INFO["addon"],
+                "options": {"leave_front_door_open": False},
+                "ports": {"1880/tcp": 1880},
+            },
+        }
+
+        async def fake_request(*, method, url, headers, content):
+            response = MagicMock()
+            response.headers = {"content-type": "application/json"}
+            response.status_code = status
+            response.json.return_value = {}
+            response.text = "{}"
+            return response
+
+        with (
+            patch(
+                "ha_mcp.tools.tools_addons.get_addon_info",
+                new_callable=AsyncMock,
+                return_value=addon_info,
+            ),
+            patch(
+                "ha_mcp.tools.tools_addons.httpx.AsyncClient",
+            ) as mock_httpx,
+        ):
+            mock_http_client = AsyncMock()
+            mock_http_client.request.side_effect = fake_request
+            mock_httpx.return_value.__aenter__ = AsyncMock(
+                return_value=mock_http_client
+            )
+            mock_httpx.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            result = await _call_addon_api(client, "test_addon", "/flows", port=1880)
+
+        assert result["status_code"] == status
+        assert result["addon_config"]["options"]["leave_front_door_open"] is False
+        suggestion = result["suggestion"]
+        assert "leave_front_door_open" in suggestion
+        assert "ha_manage_app" in suggestion
+        assert "restart" in suggestion.lower()
+        assert "action='restart'" in suggestion
+        assert "security" in suggestion.lower()
+
+    @pytest.mark.asyncio
+    async def test_http_proxy_propagates_tls_verification(self, mock_ingress_session):
+        """The add-on proxy must honor the HA client's TLS verification setting."""
+        client = _make_mock_client()
+        client.base_url = "https://ha.local:8123"
+        client.verify_ssl = False
+
+        response = MagicMock()
+        response.headers = {"content-type": "application/json"}
+        response.status_code = 200
+        response.json.return_value = {}
+        response.text = "{}"
+
+        with (
+            patch(
+                "ha_mcp.tools.tools_addons.get_addon_info",
+                new_callable=AsyncMock,
+                return_value=_RUNNING_ADDON_INFO,
+            ),
+            patch(
+                "ha_mcp.tools.tools_addons.httpx.AsyncClient",
+            ) as mock_httpx,
+        ):
+            mock_http_client = AsyncMock()
+            mock_http_client.request.return_value = response
+            mock_httpx.return_value.__aenter__ = AsyncMock(
+                return_value=mock_http_client
+            )
+            mock_httpx.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            result = await _call_addon_api(client, "test_addon", "/flows")
+
+        assert result["success"] is True
+        assert mock_httpx.call_args.kwargs["verify"] is False
+
+    @pytest.mark.asyncio
     async def test_http_403_response_hints_at_ip_restriction(
         self, mock_ingress_session
     ):
@@ -1275,6 +1362,38 @@ class TestCallAddonWsErrors:
         assert result["closed_by"] == "server_closed"
 
     @pytest.mark.asyncio
+    async def test_ws_proxy_propagates_disabled_tls_verification(
+        self, mock_ingress_session
+    ):
+        """WSS proxy calls honor HA_VERIFY_SSL=false via an SSL context."""
+        client = _make_mock_client()
+        client.base_url = "https://ha.local:8123"
+        client.verify_ssl = False
+
+        with (
+            patch(
+                "ha_mcp.tools.tools_addons.get_addon_info",
+                new_callable=AsyncMock,
+                return_value=_RUNNING_ADDON_INFO,
+            ),
+            patch(
+                "ha_mcp.tools.tools_addons.websockets.connect",
+            ) as mock_ws_connect,
+        ):
+            mock_ws = AsyncMock()
+            mock_ws.recv.side_effect = ConnectionClosed(None, None)
+            mock_ws_connect.return_value.__aenter__ = AsyncMock(return_value=mock_ws)
+            mock_ws_connect.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            result = await _call_addon_ws(client, "test_addon", "/ws")
+
+        assert result["success"] is True
+        ssl_context = mock_ws_connect.call_args.kwargs["ssl"]
+        assert isinstance(ssl_context, ssl.SSLContext)
+        assert ssl_context.check_hostname is False
+        assert ssl_context.verify_mode == ssl.CERT_NONE
+
+    @pytest.mark.asyncio
     async def test_ws_addon_not_running(self):
         """Should raise ToolError when add-on is not running."""
         client = _make_mock_client()
@@ -1346,6 +1465,51 @@ class TestCallAddonWsErrors:
         assert not any("supports WebSocket on this path" in s for s in suggestions), (
             suggestions
         )
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("status", [401, 403])
+    async def test_ws_direct_port_auth_hints_at_app_option(self, status):
+        """Direct-port WS auth failures surface the configurable app option."""
+        from ha_mcp._vendor.websockets.datastructures import Headers
+        from ha_mcp._vendor.websockets.http11 import Response
+
+        client = _make_mock_client()
+        addon_info = {
+            "success": True,
+            "addon": {
+                **_RUNNING_ADDON_INFO_WS["addon"],
+                "options": {"leave_front_door_open": False},
+                "ports": {"1880/tcp": 1880},
+            },
+        }
+
+        with (
+            patch(
+                "ha_mcp.tools.tools_addons.get_addon_info",
+                new_callable=AsyncMock,
+                return_value=addon_info,
+            ),
+            patch(
+                "ha_mcp.tools.tools_addons.websockets.connect",
+            ) as mock_ws_connect,
+        ):
+            response = Response(status, "Unauthorized", Headers())
+            mock_ws_connect.return_value.__aenter__ = AsyncMock(
+                side_effect=InvalidStatus(response),
+            )
+            mock_ws_connect.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            with pytest.raises(ToolError) as exc_info:
+                await _call_addon_ws(client, "test_addon", "/compile", port=1880)
+
+        result = _parse_tool_error(exc_info)
+        suggestions = result["error"].get("suggestions", [])
+        joined = " ".join(suggestions).lower()
+        assert "leave_front_door_open" in joined, suggestions
+        assert "ha_manage_app" in joined, suggestions
+        assert "restart" in joined, suggestions
+        assert "action='restart'" in joined, suggestions
+        assert "security" in joined, suggestions
 
     @pytest.mark.asyncio
     async def test_ws_handshake_404_keeps_path_hint(self, mock_ingress_session):


### PR DESCRIPTION
## What does this PR do?

Fixes #2241 by propagating the configured Home Assistant TLS verification setting to `ha_manage_app` HTTP and WebSocket proxy transports.

It also adds an actionable, security-qualified hint when a direct-port 401/403 comes from an app exposing `leave_front_door_open`: the response gives the exact `ha_manage_app` option update and restart calls while recommending Ingress when available.

The HAOS embedded E2E keeps the existing lane and worker VM. After that worker's ordinary tests, it temporarily restarts Core with a trusted DNS-only TLS certificate, proves the legacy HTTPX request fails with the reporter's exact certificate/IP mismatch, proves the fixed Ingress request succeeds, follows the Node-RED front-door hint through a real config/restart/direct request, and restores both Node-RED and Core HTTP state.

## Type of change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [x] I have tested these changes with a LLM agent
- [ ] All automated tests pass (`uv run pytest`)
- [ ] Code follows style guidelines (`uv run ruff check`)

Focused local verification:

- `uv run pytest -q tests/src/unit/test_haos_tls_staging.py tests/src/unit/test_tools_addons.py` (192 passed)
- `uv run ruff format --check` on all changed Python files
- `uv run mypy src/ custom_components/ homeassistant-addon/ scripts/` (252 source files)
- HAOS embedded collect-only order check confirms the one-test TLS module is the final `loadscope` work unit

The HAOS VM scenario is intentionally left to its existing CI lane; no local HAOS/QEMU run was performed.

## Checklist
- [x] I have updated documentation if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added SSL verification controls for HTTP and WebSocket add-on connections.
  * Improved authentication guidance for direct-port, add-on ingress, and off-host ingress access.
  * Added route-specific troubleshooting for TLS certificates, network failures, and configuration requirements.

* **Bug Fixes**
  * Improved handling of HTTPS and secure WebSocket certificate validation failures.
  * Corrected detection of direct-port access settings across supported configurations.
  * Prevented pending-restart operations with explicit errors from being reported as successful.

* **Documentation**
  * Clarified direct-port requirements and related security considerations.

* **Tests**
  * Expanded coverage for TLS connections and HAOS HTTPS workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->