### PR TITLE
fix(search): floor-area and bulk-control hardening follow-ups

### DIFF
--- a/src/ha_mcp/tools/device_control.py
+++ b/src/ha_mcp/tools/device_control.py
@@ -625,19 +625,21 @@ class DeviceControlTools:
         return value, None
 
     @staticmethod
-    def _normalize_bulk_timeout(value: Any) -> tuple[float | None, bool]:
-        """Normalize an optional non-negative finite timeout."""
-        if value is None:
-            return None, True
+    def _normalize_bulk_timeout(value: Any) -> float | None:
+        """Normalize a non-negative finite timeout, or ``None`` when invalid.
+
+        Bools are rejected before ``float()`` sees them: ``float(True)`` is 1.0,
+        which would silently accept ``timeout_seconds: true`` as a one-second
+        wait. ``None`` is invalid here too — the caller only calls this when the
+        key is present, and a present-but-null timeout is a malformed row.
+        """
+        if isinstance(value, bool) or value is None:
+            return None
         try:
             timeout = float(value)
         except (TypeError, ValueError):
-            return None, False
-        return (
-            (timeout, True)
-            if math.isfinite(timeout) and timeout >= 0
-            else (None, False)
-        )
+            return None
+        return timeout if math.isfinite(timeout) and timeout >= 0 else None
 
     @staticmethod
     def _normalized_bulk_operation(
@@ -749,23 +751,19 @@ class DeviceControlTools:
                 )
                 continue
 
-            timeout = None
-            timeout_valid = "timeout_seconds" not in op
-            if not timeout_valid:
-                timeout, timeout_valid = cls._normalize_bulk_timeout(
-                    op["timeout_seconds"]
-                )
-                timeout_valid = timeout_valid and timeout is not None
-            if not timeout_valid:
-                cls._skip_bulk_operation(
-                    skipped_operations,
-                    op,
-                    ErrorCode.VALIDATION_INVALID_PARAMETER,
-                    f"Operation at index {i} timeout_seconds must be a "
-                    "non-negative number",
-                    {"index": i},
-                )
-                continue
+            timeout: float | None = None
+            if "timeout_seconds" in op:
+                timeout = cls._normalize_bulk_timeout(op["timeout_seconds"])
+                if timeout is None:
+                    cls._skip_bulk_operation(
+                        skipped_operations,
+                        op,
+                        ErrorCode.VALIDATION_INVALID_PARAMETER,
+                        f"Operation at index {i} timeout_seconds must be a "
+                        "non-negative number",
+                        {"index": i},
+                    )
+                    continue
 
             if "validate_first" in op and not isinstance(op["validate_first"], bool):
                 cls._skip_bulk_operation(

--- a/src/ha_mcp/tools/device_control.py
+++ b/src/ha_mcp/tools/device_control.py
@@ -52,6 +52,13 @@ logger = logging.getLogger(__name__)
 # out of sync with what models are told they may send.
 _BULK_OPERATION_KEYS: frozenset[str] = frozenset(BulkControlOperation.__annotations__)
 
+# The row shape models get wrong most often is a service-style row, so this
+# leads every suggestion list a rejected bulk batch produces.
+_BULK_ROW_SHAPE_SUGGESTION = (
+    "Use entity_id and action (e.g. action='off', not service='turn_off'); "
+    "send no domain or service keys and put action data in parameters"
+)
+
 # The ha_mcp_tools/bulk_call_service WS command (Phase 3, D5a): the BATCH write
 # capability. When the component advertises ``bulk_call_service`` the consumer
 # resolves every op's domain/service server-side (D6), sends one register-before-fire
@@ -822,8 +829,24 @@ class DeviceControlTools:
                 f"mode={'parallel' if parallel else 'sequential'}",
             )
             if not valid_operations:
-                return self._build_bulk_response(
-                    operations, results, operation_ids, skipped_operations, parallel
+                # Nothing dispatched, so nothing to fail soft for: the batch
+                # carve-out from "all tool-level failures raise" exists to
+                # protect successful siblings, and there are none. Raising
+                # before the component probe keeps the no-dispatch guarantee.
+                raise_tool_error(
+                    create_error_response(
+                        ErrorCode.VALIDATION_INVALID_PARAMETER,
+                        f"All {len(operations)} operation(s) failed validation; "
+                        "nothing was dispatched",
+                        suggestions=[
+                            _BULK_ROW_SHAPE_SUGGESTION,
+                            "Each operation requires 'entity_id' and 'action'",
+                            "Check skipped_details for the per-operation reason",
+                            "Example: {'entity_id': 'light.living_room', "
+                            "'action': 'on'}",
+                        ],
+                        context={"skipped_details": skipped_operations},
+                    )
                 )
 
             # Route through the component's bulk_call_service capability when
@@ -1437,6 +1460,7 @@ class DeviceControlTools:
         if skipped_operations:
             response["skipped_details"] = skipped_operations
             response["suggestions"] = [
+                _BULK_ROW_SHAPE_SUGGESTION,
                 "Some operations were skipped due to validation errors",
                 "Each operation requires 'entity_id' and 'action' fields",
                 "Check skipped_details for specific errors",

--- a/src/ha_mcp/tools/device_control.py
+++ b/src/ha_mcp/tools/device_control.py
@@ -42,9 +42,15 @@ from .helpers import (
     safe_info,
     safe_progress,
 )
+from .tools_service import BulkControlOperation
 from .util_helpers import _SERVICE_TO_STATE
 
 logger = logging.getLogger(__name__)
+
+# The bulk row contract is declared once, on the advertised transport schema.
+# Reading its keys back here keeps the runtime batch validator from drifting
+# out of sync with what models are told they may send.
+_BULK_OPERATION_KEYS: frozenset[str] = frozenset(BulkControlOperation.__annotations__)
 
 # The ha_mcp_tools/bulk_call_service WS command (Phase 3, D5a): the BATCH write
 # capability. When the component advertises ``bulk_call_service`` the consumer
@@ -647,6 +653,28 @@ class DeviceControlTools:
             normalized["timeout_seconds"] = timeout
         return normalized
 
+    @staticmethod
+    def _skip_bulk_operation(
+        skipped_operations: list[dict[str, Any]],
+        op: Any,
+        code: ErrorCode,
+        error: str,
+        context: dict[str, Any],
+        suggestions: list[str] | None = None,
+    ) -> None:
+        """Log one rejected bulk row and record its structured skip entry.
+
+        ``create_error_response`` lifts every ``context`` key to the top level,
+        so ``index`` needs no separate write; ``operation`` is not a context
+        key and is attached here so callers can see the row they sent.
+        """
+        logger.warning(f"Bulk control: {error}")
+        err_response = create_error_response(
+            code, error, suggestions=suggestions, context=context
+        )
+        err_response["operation"] = op
+        skipped_operations.append(err_response)
+
     @classmethod
     def _validate_bulk_operations(
         cls,
@@ -656,41 +684,28 @@ class DeviceControlTools:
         valid: list[tuple[int, dict[str, Any], str, str]] = []
         for i, op in enumerate(operations):
             if not isinstance(op, dict):
-                error = f"Operation at index {i} is not a dict: {type(op).__name__}"
-                logger.warning(f"Bulk control: {error}")
-                err_response = create_error_response(
-                    ErrorCode.VALIDATION_MISSING_PARAMETER, error, context={"index": i}
+                cls._skip_bulk_operation(
+                    skipped_operations,
+                    op,
+                    ErrorCode.VALIDATION_MISSING_PARAMETER,
+                    f"Operation at index {i} is not a dict: {type(op).__name__}",
+                    {"index": i},
                 )
-                err_response["index"] = i
-                err_response["operation"] = op
-                skipped_operations.append(err_response)
                 continue
 
-            allowed_keys = {
-                "entity_id",
-                "action",
-                "parameters",
-                "timeout_seconds",
-                "validate_first",
-            }
-            obsolete_keys = sorted(set(op) - allowed_keys)
+            obsolete_keys = sorted(set(op) - _BULK_OPERATION_KEYS)
             if obsolete_keys:
                 key_list = ", ".join(obsolete_keys)
-                error = (
-                    f"Operation at index {i} contains unsupported key(s): {key_list}"
-                )
-                logger.warning(f"Bulk control: {error}")
-                err_response = create_error_response(
+                cls._skip_bulk_operation(
+                    skipped_operations,
+                    op,
                     ErrorCode.VALIDATION_INVALID_PARAMETER,
-                    error,
+                    f"Operation at index {i} contains unsupported key(s): {key_list}",
+                    {"index": i, "unsupported_keys": obsolete_keys},
                     suggestions=[
                         "Use entity_id and action; put action data inside parameters"
                     ],
-                    context={"index": i, "unsupported_keys": obsolete_keys},
                 )
-                err_response["index"] = i
-                err_response["operation"] = op
-                skipped_operations.append(err_response)
                 continue
 
             entity_id = op.get("entity_id")
@@ -698,47 +713,40 @@ class DeviceControlTools:
             missing = [f for f in ("entity_id", "action") if not op.get(f)]
 
             if missing:
-                error = f"Operation at index {i} missing required fields: {', '.join(missing)}"
-                logger.warning(f"Bulk control: {error}")
-                err_response = create_error_response(
-                    ErrorCode.VALIDATION_MISSING_PARAMETER, error, context={"index": i}
+                cls._skip_bulk_operation(
+                    skipped_operations,
+                    op,
+                    ErrorCode.VALIDATION_MISSING_PARAMETER,
+                    f"Operation at index {i} missing required fields: "
+                    f"{', '.join(missing)}",
+                    {"index": i},
                 )
-                err_response["index"] = i
-                err_response["operation"] = op
-                skipped_operations.append(err_response)
                 continue
 
             if not isinstance(entity_id, str) or not isinstance(action, str):
-                error = f"Operation at index {i} requires string entity_id and action fields"
-                logger.warning(f"Bulk control: {error}")
-                err_response = create_error_response(
+                cls._skip_bulk_operation(
+                    skipped_operations,
+                    op,
                     ErrorCode.VALIDATION_INVALID_PARAMETER,
-                    error,
-                    context={"index": i},
+                    f"Operation at index {i} requires string entity_id and "
+                    "action fields",
+                    {"index": i},
                 )
-                err_response["index"] = i
-                err_response["operation"] = op
-                skipped_operations.append(err_response)
                 continue
 
             parameters, parameter_error = cls._normalize_bulk_parameters(
                 op.get("parameters")
             )
             if parameter_error is not None:
-                error = (
+                cls._skip_bulk_operation(
+                    skipped_operations,
+                    op,
+                    parameter_error,
                     f"Operation at index {i} has invalid JSON parameters"
                     if parameter_error == ErrorCode.VALIDATION_INVALID_JSON
-                    else f"Operation at index {i} parameters must be a JSON object"
+                    else f"Operation at index {i} parameters must be a JSON object",
+                    {"index": i},
                 )
-                logger.warning(f"Bulk control: {error}")
-                err_response = create_error_response(
-                    parameter_error,
-                    error,
-                    context={"index": i},
-                )
-                err_response["index"] = i
-                err_response["operation"] = op
-                skipped_operations.append(err_response)
                 continue
 
             timeout = None
@@ -749,32 +757,24 @@ class DeviceControlTools:
                 )
                 timeout_valid = timeout_valid and timeout is not None
             if not timeout_valid:
-                error = (
-                    f"Operation at index {i} timeout_seconds must be a "
-                    "non-negative number"
-                )
-                logger.warning(f"Bulk control: {error}")
-                err_response = create_error_response(
+                cls._skip_bulk_operation(
+                    skipped_operations,
+                    op,
                     ErrorCode.VALIDATION_INVALID_PARAMETER,
-                    error,
-                    context={"index": i},
+                    f"Operation at index {i} timeout_seconds must be a "
+                    "non-negative number",
+                    {"index": i},
                 )
-                err_response["index"] = i
-                err_response["operation"] = op
-                skipped_operations.append(err_response)
                 continue
 
-            if "validate_first" in op and type(op["validate_first"]) is not bool:
-                error = f"Operation at index {i} validate_first must be a boolean"
-                logger.warning(f"Bulk control: {error}")
-                err_response = create_error_response(
+            if "validate_first" in op and not isinstance(op["validate_first"], bool):
+                cls._skip_bulk_operation(
+                    skipped_operations,
+                    op,
                     ErrorCode.VALIDATION_INVALID_PARAMETER,
-                    error,
-                    context={"index": i},
+                    f"Operation at index {i} validate_first must be a boolean",
+                    {"index": i},
                 )
-                err_response["index"] = i
-                err_response["operation"] = op
-                skipped_operations.append(err_response)
                 continue
 
             normalized_op = cls._normalized_bulk_operation(op, parameters, timeout)

--- a/src/ha_mcp/tools/device_control.py
+++ b/src/ha_mcp/tools/device_control.py
@@ -620,16 +620,26 @@ class DeviceControlTools:
     @staticmethod
     def _normalize_bulk_parameters(
         value: Any,
-    ) -> tuple[dict[str, Any] | None, ErrorCode | None]:
-        """Normalize optional bulk parameters and identify invalid values."""
+    ) -> tuple[dict[str, Any] | None, ErrorCode | None, str]:
+        """Normalize optional bulk parameters and identify invalid values.
+
+        Returns ``(parameters, error_code, detail)``. ``detail`` carries the
+        decoder's own reason and offset for a JSON failure — without it the
+        caller can only say "invalid JSON", which does not tell the sender
+        where its string went wrong. It is empty for every other outcome.
+        """
         if isinstance(value, str):
             try:
                 value = json.loads(value)
-            except json.JSONDecodeError:
-                return None, ErrorCode.VALIDATION_INVALID_JSON
+            except json.JSONDecodeError as exc:
+                return (
+                    None,
+                    ErrorCode.VALIDATION_INVALID_JSON,
+                    f"{exc.msg} at position {exc.pos}",
+                )
         if value is not None and not isinstance(value, dict):
-            return None, ErrorCode.VALIDATION_INVALID_PARAMETER
-        return value, None
+            return None, ErrorCode.VALIDATION_INVALID_PARAMETER, ""
+        return value, None, ""
 
     @staticmethod
     def _normalize_bulk_timeout(value: Any) -> float | None:
@@ -711,9 +721,7 @@ class DeviceControlTools:
                     ErrorCode.VALIDATION_INVALID_PARAMETER,
                     f"Operation at index {i} contains unsupported key(s): {key_list}",
                     {"index": i, "unsupported_keys": obsolete_keys},
-                    suggestions=[
-                        "Use entity_id and action; put action data inside parameters"
-                    ],
+                    suggestions=[_BULK_ROW_SHAPE_SUGGESTION],
                 )
                 continue
 
@@ -743,17 +751,21 @@ class DeviceControlTools:
                 )
                 continue
 
-            parameters, parameter_error = cls._normalize_bulk_parameters(
-                op.get("parameters")
+            parameters, parameter_error, parameter_detail = (
+                cls._normalize_bulk_parameters(op.get("parameters"))
             )
             if parameter_error is not None:
+                parameter_message = (
+                    f"Operation at index {i} has invalid JSON parameters: "
+                    f"{parameter_detail}"
+                    if parameter_error == ErrorCode.VALIDATION_INVALID_JSON
+                    else f"Operation at index {i} parameters must be a JSON object"
+                )
                 cls._skip_bulk_operation(
                     skipped_operations,
                     op,
                     parameter_error,
-                    f"Operation at index {i} has invalid JSON parameters"
-                    if parameter_error == ErrorCode.VALIDATION_INVALID_JSON
-                    else f"Operation at index {i} parameters must be a JSON object",
+                    parameter_message,
                     {"index": i},
                 )
                 continue

--- a/src/ha_mcp/tools/device_control.py
+++ b/src/ha_mcp/tools/device_control.py
@@ -360,6 +360,10 @@ class DeviceControlTools:
         "set": "set_temperature",
     }
 
+    # Silent allowlist: _add_domain_params copies only these keys into the
+    # service call and drops everything else without an error, and a domain
+    # absent from this table loses every parameter. Extend it when adding
+    # support for a new parameter, or the parameter vanishes at dispatch.
     _DOMAIN_PARAMS: ClassVar[dict[str, list[str]]] = {
         "light": [
             "brightness",
@@ -487,10 +491,10 @@ class DeviceControlTools:
         """Check status of a device operation, waiting up to ``timeout_seconds`` for completion.
 
         Polls the in-memory operation registry (mutated by the WebSocket
-        listener as state changes arrive) every 0.2s while the operation is
-        pending, up to ``timeout_seconds``. Returns the final structured status
-        — completed/failed/timeout/pending — produced by
-        ``control_device_smart``.
+        listener as state changes arrive) while the operation is pending, at
+        0.2s intervals except for a final shorter poll that lands exactly on
+        the deadline. Returns the final structured status —
+        completed/failed/timeout/pending — produced by ``control_device_smart``.
         """
         operation = get_operation_from_memory(operation_id)
 

--- a/src/ha_mcp/tools/device_control.py
+++ b/src/ha_mcp/tools/device_control.py
@@ -651,10 +651,13 @@ class DeviceControlTools:
 
         Bools are rejected before ``float()`` sees them: ``float(True)`` is 1.0,
         which would silently accept ``timeout_seconds: true`` as a one-second
-        wait. ``None`` is invalid here too — the caller only calls this when the
-        key is present, and a present-but-null timeout is a malformed row.
+        wait. Strings are rejected for the same reason — the advertised schema
+        is ``strict``, so coercing ``"10"`` here would silently accept what the
+        schema tells the model is invalid. ``None`` is invalid here too — the
+        caller only calls this when the key is present, and a present-but-null
+        timeout is a malformed row.
         """
-        if isinstance(value, bool) or value is None:
+        if isinstance(value, (bool, str)) or value is None:
             return None
         try:
             timeout = float(value)

--- a/src/ha_mcp/tools/device_control.py
+++ b/src/ha_mcp/tools/device_control.py
@@ -641,6 +641,14 @@ class DeviceControlTools:
                     ErrorCode.VALIDATION_INVALID_JSON,
                     f"{exc.msg} at position {exc.pos}",
                 )
+            except RecursionError:
+                # json.loads recurses per nesting level; a pathologically
+                # nested string must skip the row, not abort the batch.
+                return (
+                    None,
+                    ErrorCode.VALIDATION_INVALID_JSON,
+                    "JSON nested too deeply",
+                )
         if not isinstance(value, dict):
             # A present-but-null value is malformed, same as timeout_seconds
             # and validate_first; an absent key never reaches this helper.

--- a/src/ha_mcp/tools/device_control.py
+++ b/src/ha_mcp/tools/device_control.py
@@ -859,7 +859,7 @@ class DeviceControlTools:
                             "Each operation requires 'entity_id' and 'action'",
                             "Check skipped_details for the per-operation reason",
                             "Example: {'entity_id': 'light.living_room', "
-                            "'action': 'on'}",
+                            + "'action': 'on'}",
                         ],
                         context={"skipped_details": skipped_operations},
                     )

--- a/src/ha_mcp/tools/device_control.py
+++ b/src/ha_mcp/tools/device_control.py
@@ -731,7 +731,9 @@ class DeviceControlTools:
                 )
                 continue
 
-            obsolete_keys = sorted(set(op) - _BULK_OPERATION_KEYS)
+            # str() before sorting: a direct Python caller can pass non-string
+            # keys, and mixed key types make sorted()/join() raise mid-batch.
+            obsolete_keys = sorted(str(key) for key in set(op) - _BULK_OPERATION_KEYS)
             if obsolete_keys:
                 key_list = ", ".join(obsolete_keys)
                 cls._skip_bulk_operation(

--- a/src/ha_mcp/tools/device_control.py
+++ b/src/ha_mcp/tools/device_control.py
@@ -625,7 +625,7 @@ class DeviceControlTools:
     def _normalize_bulk_parameters(
         value: Any,
     ) -> tuple[dict[str, Any] | None, ErrorCode | None, str]:
-        """Normalize optional bulk parameters and identify invalid values.
+        """Normalize a present ``parameters`` value and identify invalid ones.
 
         Returns ``(parameters, error_code, detail)``. ``detail`` carries the
         decoder's own reason and offset for a JSON failure — without it the
@@ -641,7 +641,9 @@ class DeviceControlTools:
                     ErrorCode.VALIDATION_INVALID_JSON,
                     f"{exc.msg} at position {exc.pos}",
                 )
-        if value is not None and not isinstance(value, dict):
+        if not isinstance(value, dict):
+            # A present-but-null value is malformed, same as timeout_seconds
+            # and validate_first; an absent key never reaches this helper.
             return None, ErrorCode.VALIDATION_INVALID_PARAMETER, ""
         return value, None, ""
 
@@ -715,7 +717,7 @@ class DeviceControlTools:
                 cls._skip_bulk_operation(
                     skipped_operations,
                     op,
-                    ErrorCode.VALIDATION_MISSING_PARAMETER,
+                    ErrorCode.VALIDATION_INVALID_PARAMETER,
                     f"Operation at index {i} is not a dict: {type(op).__name__}",
                     {"index": i},
                 )
@@ -761,7 +763,9 @@ class DeviceControlTools:
                 continue
 
             parameters, parameter_error, parameter_detail = (
-                cls._normalize_bulk_parameters(op.get("parameters"))
+                cls._normalize_bulk_parameters(op["parameters"])
+                if "parameters" in op
+                else (None, None, "")
             )
             if parameter_error is not None:
                 parameter_message = (

--- a/src/ha_mcp/tools/device_control.py
+++ b/src/ha_mcp/tools/device_control.py
@@ -661,7 +661,9 @@ class DeviceControlTools:
             return None
         try:
             timeout = float(value)
-        except (TypeError, ValueError):
+        except (TypeError, ValueError, OverflowError):
+            # OverflowError: an int too large for float must skip the row,
+            # not abort the batch through the generic exception handler.
             return None
         return timeout if math.isfinite(timeout) and timeout >= 0 else None
 

--- a/src/ha_mcp/tools/smart_search/_base.py
+++ b/src/ha_mcp/tools/smart_search/_base.py
@@ -40,9 +40,14 @@ class _SearchBase:
             logger.debug(f"Could not fetch {label}: {result}")
             cause = str(result) or type(result).__name__
         elif isinstance(result, dict) and result.get("success"):
-            payload = result.get("result", [])
+            # No default for a missing key: a legitimate empty registry is
+            # "result": [], so an absent result is a malformed envelope and
+            # must degrade loudly, not read as available-and-empty.
+            payload = result.get("result")
             if isinstance(payload, list):
                 registry = payload
+            elif payload is None and "result" not in result:
+                cause = "malformed result payload: result key missing"
             else:
                 cause = (
                     "malformed result payload: expected list, "

--- a/src/ha_mcp/tools/smart_search/_entities.py
+++ b/src/ha_mcp/tools/smart_search/_entities.py
@@ -777,7 +777,10 @@ class EntitySearchMixin(_SearchBase):
         """Resolve the query to area IDs: exact id/name/alias, then fuzzy.
 
         Exact matches delegate to the shared registry matcher so area and floor
-        precedence use identical case-insensitive semantics.
+        precedence use identical case-insensitive semantics. Exact must win
+        outright: a query like "bedroom_kids" partial-matches its parent
+        "bedroom" at ratio 100, so falling through to the fuzzy pass would
+        aggregate every sibling area's entities under an exact hit.
         """
         exact_area_ids = cls._match_exact_registry_ids(
             area_registry, "area_id", area_query_lower

--- a/src/ha_mcp/tools/smart_search/_entities.py
+++ b/src/ha_mcp/tools/smart_search/_entities.py
@@ -473,13 +473,15 @@ class EntitySearchMixin(_SearchBase):
             area_registry = self._parse_area_registry(results[1], registry_warnings)
             entity_reg_map = self._parse_entity_reg_map(results[2], registry_warnings)
             device_area_map = self._parse_device_area_map(results[3], registry_warnings)
-            floor_result = results[4]
-            floor_registry_available = (
-                isinstance(floor_result, dict)
-                and floor_result.get("success") is True
-                and isinstance(floor_result.get("result"), list)
-            )
-            floor_registry = self._parse_floor_registry(floor_result, registry_warnings)
+            # Availability is read back OUT of the parse rather than re-derived
+            # from the raw payload: the parser already decides what counts as
+            # usable floor data, and a second predicate here drifted from it
+            # once. An empty warnings list means the parser accepted the
+            # payload; anything else disables the fuzzy floor/area fallback.
+            floor_warnings: list[str] = []
+            floor_registry = self._parse_floor_registry(results[4], floor_warnings)
+            floor_registry_available = not floor_warnings
+            registry_warnings.extend(floor_warnings)
             degraded_warnings = registry_warnings + visibility_warnings
 
             matched_area_ids, resolution_warnings = self._resolve_area_query(
@@ -657,8 +659,15 @@ class EntitySearchMixin(_SearchBase):
 
         if not floor_registry_available:
             # Without the floor registry, fuzzy area matching could silently
-            # recreate the original floor->partial-area misresolution.
-            return set(), []
+            # recreate the original floor->partial-area misresolution. The
+            # fetch warning names the outage; this one names what the outage
+            # cost the caller, so "no match" is not read as "no such area".
+            return set(), [
+                f"Floor data is unavailable, so '{area_query}' was matched only "
+                "against exact area IDs, names, and aliases; close-spelling "
+                "matching was skipped. Retry, or pass an exact area_id from "
+                "ha_list_floors_areas."
+            ]
 
         fuzzy_floor_ids, floor_score = cls._match_fuzzy_registry_ids(
             floor_registry, "floor_id", query_lower

--- a/src/ha_mcp/tools/tools_search.py
+++ b/src/ha_mcp/tools/tools_search.py
@@ -321,12 +321,11 @@ def _finalize_partial_state(
     if partial_local:
         response["partial"] = True
         response["errors"].extend(errors_local)
-        local_reason = "; ".join(
-            f"{error['surface']}: {error['error']}" for error in errors_local
-        )
-        existing_reason = response.get("partial_reason")
-        response["partial_reason"] = (
-            f"{existing_reason}; {local_reason}" if existing_reason else local_reason
+        _merge_partial_reason(
+            response,
+            "; ".join(
+                f"{error['surface']}: {error['error']}" for error in errors_local
+            ),
         )
 
 
@@ -2217,7 +2216,11 @@ class SearchTools:
                 raise outcome
             if isinstance(outcome, Exception):
                 partial = True
-                errors.append({"surface": label, "error": str(outcome)})
+                # ``str(asyncio.TimeoutError())`` is "" — fall back to the type
+                # name so partial_reason never reads "entities: ".
+                errors.append(
+                    {"surface": label, "error": str(outcome) or type(outcome).__name__}
+                )
                 logger.warning("ha_search %s branch failed: %r", label, outcome)
                 continue
             _apply_search_outcome(response, label, outcome)

--- a/src/ha_mcp/tools/tools_service.py
+++ b/src/ha_mcp/tools/tools_service.py
@@ -83,7 +83,10 @@ class BulkControlOperation(TypedDict):
             Field(
                 description=(
                     "Optional action parameters, e.g. {'brightness_pct': 30} "
-                    "when action='on'."
+                    "when action='on'. Each domain has a fixed allowlist of "
+                    "supported keys; keys outside it are ignored rather than "
+                    "rejected. Use ha_call_service for parameters this tool "
+                    "does not carry."
                 )
             ),
         ]
@@ -112,8 +115,10 @@ class BulkControlOperation(TypedDict):
             Field(
                 strict=True,
                 description=(
-                    "Validate that the entity exists before dispatch; default true. "
-                    "The action is always validated."
+                    "Report an ENTITY_NOT_FOUND failure when the target entity "
+                    "does not exist; default true. On the component batch path "
+                    "this is detected from the captured pre-state rather than by "
+                    "preventing dispatch. The action is always validated."
                 ),
             ),
         ]

--- a/src/ha_mcp/tools/tools_service.py
+++ b/src/ha_mcp/tools/tools_service.py
@@ -1535,7 +1535,8 @@ class ServiceTools:
 
         Caveats: put every target in ``operations`` and call the tool once. Parallel
         execution is the default, and invalid items are reported without aborting
-        valid operations in the same batch.
+        valid operations in the same batch. A batch in which every item fails
+        validation dispatches nothing and fails the call.
         """
         parallel_bool = parallel
 

--- a/src/ha_mcp/tools/tools_service.py
+++ b/src/ha_mcp/tools/tools_service.py
@@ -1579,10 +1579,13 @@ class ServiceTools:
                 # reports them in skipped_details instead of rejecting the call.
                 # The schema's reason is richer than the runtime validator's and
                 # is the only place it survives, so log it here.
+                # include_input=False: a malformed row can carry sensitive
+                # values (lock or alarm codes in a mistyped field), and
+                # str(exc) would write them to persistent server logs.
                 logger.warning(
                     "ha_bulk_control operation %d failed schema validation: %s",
                     index,
-                    exc,
+                    exc.errors(include_url=False, include_input=False),
                 )
                 operations_list.append(operation)
 

--- a/src/ha_mcp/tools/tools_service.py
+++ b/src/ha_mcp/tools/tools_service.py
@@ -94,6 +94,10 @@ class BulkControlOperation(TypedDict):
             Field(
                 ge=0,
                 allow_inf_nan=False,
+                # ``strict`` for the same reason validate_first carries it:
+                # lax mode coerces ``true`` to 1.0, so a bool would land
+                # downstream as a silent one-second timeout.
+                strict=True,
                 description=(
                     "Optional confirmation timeout. On the component path, all "
                     "operations share the maximum requested wait (default 10s, "
@@ -1559,14 +1563,21 @@ class ServiceTools:
             )
 
         operations_list: list[Any] = []
-        for operation in parsed_operations:
+        for index, operation in enumerate(parsed_operations):
             try:
                 operations_list.append(
                     _BULK_CONTROL_OPERATION_ADAPTER.validate_python(operation)
                 )
-            except ValidationError:
+            except ValidationError as exc:
                 # Preserve malformed rows for the runtime batch validator, which
                 # reports them in skipped_details instead of rejecting the call.
+                # The schema's reason is richer than the runtime validator's and
+                # is the only place it survives, so log it here.
+                logger.warning(
+                    "ha_bulk_control operation %d failed schema validation: %s",
+                    index,
+                    exc,
+                )
                 operations_list.append(operation)
 
         result = await self._device_tools.bulk_device_control(

--- a/tests/src/unit/test_area_filter_search.py
+++ b/tests/src/unit/test_area_filter_search.py
@@ -360,6 +360,16 @@ class TestAreaMatchingLogic:
             ],
         )
 
+    @staticmethod
+    def _entity_ids(result: dict) -> set[str]:
+        """Collect every entity id across a domain-grouped area result."""
+        return {
+            record["entity_id"]
+            for area in result["areas"].values()
+            for records in area["entities"].values()
+            for record in records
+        }
+
     @pytest.mark.asyncio
     async def test_floor_name_expands_to_all_areas_on_floor(self):
         """An exact floor name expands instead of fuzzy-matching one area."""
@@ -370,13 +380,45 @@ class TestAreaMatchingLogic:
                 {"area_id": "garage", "name": "Garage", "floor_id": "ground"},
             ]
         )
+        # A second area on the floor needs its own entity, or the expansion
+        # could aggregate zero entities from it and still look correct.
+        client.entities.append(
+            {
+                "entity_id": "light.cave_lamp",
+                "attributes": {"friendly_name": "Cave Lamp"},
+                "state": "off",
+            }
+        )
+        client.entity_registry.append(
+            {"entity_id": "light.cave_lamp", "area_id": "cave", "device_id": None}
+        )
         tools = SmartSearchTools(client=client, fuzzy_threshold=60)
 
         result = await tools.get_entities_by_area("sous-sol")
 
         assert result["total_areas_found"] == 2
         assert set(result["areas"]) == {"couloir_sous_sol", "cave"}
+        assert self._entity_ids(result) == {"light.basement_hall", "light.cave_lamp"}
+        assert result["total_entities"] == 2
         assert any("expanded to 2 area(s)" in warning for warning in result["warnings"])
+
+    @pytest.mark.asyncio
+    async def test_bare_floor_id_expands_to_all_areas_on_floor(self):
+        """A literal floor_id expands the same way the floor's name does.
+
+        The collision test below renames an AREA to ``sous_sol``; nothing else
+        covered passing the floor's own identifier while it stays unique.
+        """
+        client = self._basement_client()
+        client.areas.append({"area_id": "cave", "name": "Cave", "floor_id": "sous_sol"})
+        tools = SmartSearchTools(client=client, fuzzy_threshold=60)
+
+        result = await tools.get_entities_by_area("sous_sol")
+
+        assert set(result["areas"]) == {"couloir_sous_sol", "cave"}
+        assert any(
+            "is a floor, not an area" in warning for warning in result["warnings"]
+        )
 
     @pytest.mark.asyncio
     async def test_floor_alias_expands_to_areas_on_floor(self):

--- a/tests/src/unit/test_bulk_device_control.py
+++ b/tests/src/unit/test_bulk_device_control.py
@@ -316,7 +316,10 @@ class TestRegisteredBulkToolCompatibility:
         ]
         messages = [detail["error"]["message"] for detail in data["skipped_details"]]
         assert any("required fields" in message for message in messages)
-        assert any("invalid JSON parameters" in message for message in messages)
+        # The decoder's own reason and offset ride along, so the sender can see
+        # where its string went wrong rather than just that it did.
+        json_message = next(m for m in messages if "invalid JSON parameters" in m)
+        assert "at position 1" in json_message
         assert sum("validate_first" in message for message in messages) == 3
         assert sum("timeout_seconds" in message for message in messages) == 3
         tools.control_device_smart.assert_awaited_once()

--- a/tests/src/unit/test_bulk_device_control.py
+++ b/tests/src/unit/test_bulk_device_control.py
@@ -325,6 +325,47 @@ class TestRegisteredBulkToolCompatibility:
         tools.control_device_smart.assert_awaited_once()
 
     @pytest.mark.asyncio
+    async def test_non_string_identifiers_and_non_object_parameters_are_skipped(self):
+        """Two branches the mixed-row test never reached.
+
+        A numeric ``entity_id`` is truthy, so it clears the missing-fields
+        check and lands on the string-type check; a ``parameters`` string that
+        parses to a list clears the JSON decode and lands on the object check.
+        Both differ from the malformed-JSON case already covered.
+        """
+        tools = DeviceControlTools(client=MagicMock())
+        tools._bulk_via_component = AsyncMock(return_value=None)
+        tools.control_device_smart = AsyncMock(
+            return_value={
+                "entity_id": "light.valid",
+                "command_sent": True,
+                "operation_id": "op-valid",
+            }
+        )
+        tool = await self._registered_tool(tools)
+
+        result = await tool.run(
+            {
+                "operations": [
+                    {"entity_id": 123, "action": "off"},
+                    {
+                        "entity_id": "light.list_parameters",
+                        "action": "on",
+                        "parameters": "[1, 2]",
+                    },
+                    {"entity_id": "light.valid", "action": "off"},
+                ]
+            }
+        )
+
+        data = result.structured_content
+        assert data["successful_commands"] == 1
+        assert [detail["index"] for detail in data["skipped_details"]] == [0, 1]
+        messages = [detail["error"]["message"] for detail in data["skipped_details"]]
+        assert "requires string entity_id and action" in messages[0]
+        assert "parameters must be a JSON object" in messages[1]
+
+    @pytest.mark.asyncio
     async def test_nested_json_parameters_round_trip_through_registered_tool(self):
         tools = DeviceControlTools(client=MagicMock())
         tools._bulk_via_component = AsyncMock(return_value=None)

--- a/tests/src/unit/test_bulk_device_control.py
+++ b/tests/src/unit/test_bulk_device_control.py
@@ -1,6 +1,7 @@
 """Unit tests for bulk_device_control validation in device_control module."""
 
 import json
+import logging
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -240,6 +241,37 @@ class TestRegisteredBulkToolCompatibility:
         assert data["successful_commands"] == 1
         assert data["skipped_operations"] == 1
         assert "service" in data["skipped_details"][0]["error"]["message"]
+
+    @pytest.mark.asyncio
+    async def test_schema_validation_log_redacts_input_values(self, caplog):
+        """The validation warning never writes a malformed row's values to logs."""
+        tools = DeviceControlTools(client=MagicMock())
+        tools._bulk_via_component = AsyncMock(return_value=None)
+        tools.control_device_smart = AsyncMock(
+            return_value={
+                "entity_id": "light.valid",
+                "command_sent": True,
+                "operation_id": "op-valid",
+            }
+        )
+        tool = await self._registered_tool(tools)
+
+        with caplog.at_level(logging.WARNING):
+            await tool.run(
+                {
+                    "operations": [
+                        {"entity_id": "light.valid", "action": "off"},
+                        {
+                            "entity_id": "light.alarm",
+                            "action": "off",
+                            "service_data": {"code": "SENTINEL-SECRET-1234"},
+                        },
+                    ]
+                }
+            )
+
+        assert "failed schema validation" in caplog.text
+        assert "SENTINEL-SECRET-1234" not in caplog.text
 
     @pytest.mark.asyncio
     async def test_mixed_schema_invalid_rows_are_reported_without_aborting(self):

--- a/tests/src/unit/test_bulk_device_control.py
+++ b/tests/src/unit/test_bulk_device_control.py
@@ -304,6 +304,18 @@ class TestRegisteredBulkToolCompatibility:
                         "action": "off",
                         "timeout_seconds": "10",
                     },
+                    # Present-but-null parameters are malformed rows, matching
+                    # timeout_seconds and validate_first — in both spellings.
+                    {
+                        "entity_id": "light.null_parameters",
+                        "action": "off",
+                        "parameters": None,
+                    },
+                    {
+                        "entity_id": "light.json_null_parameters",
+                        "action": "off",
+                        "parameters": "null",
+                    },
                     # float() of an int this size raises OverflowError, which
                     # must skip the row rather than abort the whole batch.
                     {
@@ -317,7 +329,7 @@ class TestRegisteredBulkToolCompatibility:
 
         data = result.structured_content
         assert data["successful_commands"] == 1
-        assert data["skipped_operations"] == 10
+        assert data["skipped_operations"] == 12
         assert [detail["index"] for detail in data["skipped_details"]] == [
             0,
             1,
@@ -329,6 +341,8 @@ class TestRegisteredBulkToolCompatibility:
             8,
             9,
             10,
+            11,
+            12,
         ]
         messages = [detail["error"]["message"] for detail in data["skipped_details"]]
         assert any("required fields" in message for message in messages)
@@ -338,6 +352,7 @@ class TestRegisteredBulkToolCompatibility:
         assert "at position 1" in json_message
         assert sum("validate_first" in message for message in messages) == 3
         assert sum("timeout_seconds" in message for message in messages) == 5
+        assert sum("must be a JSON object" in message for message in messages) == 2
         tools.control_device_smart.assert_awaited_once()
 
     @pytest.mark.asyncio

--- a/tests/src/unit/test_bulk_device_control.py
+++ b/tests/src/unit/test_bulk_device_control.py
@@ -272,13 +272,20 @@ class TestRegisteredBulkToolCompatibility:
                         "action": "off",
                         "validate_first": "false",
                     },
+                    # float(True) is 1.0, so a bool must be rejected outright
+                    # rather than silently becoming a one-second timeout.
+                    {
+                        "entity_id": "light.bool_timeout",
+                        "action": "off",
+                        "timeout_seconds": True,
+                    },
                 ]
             }
         )
 
         data = result.structured_content
         assert data["successful_commands"] == 1
-        assert data["skipped_operations"] == 7
+        assert data["skipped_operations"] == 8
         assert [detail["index"] for detail in data["skipped_details"]] == [
             0,
             1,
@@ -287,13 +294,13 @@ class TestRegisteredBulkToolCompatibility:
             4,
             6,
             7,
+            8,
         ]
         messages = [detail["error"]["message"] for detail in data["skipped_details"]]
         assert any("required fields" in message for message in messages)
-        assert any("timeout_seconds" in message for message in messages)
         assert any("invalid JSON parameters" in message for message in messages)
         assert sum("validate_first" in message for message in messages) == 3
-        assert sum("timeout_seconds" in message for message in messages) == 2
+        assert sum("timeout_seconds" in message for message in messages) == 3
         tools.control_device_smart.assert_awaited_once()
 
     @pytest.mark.asyncio

--- a/tests/src/unit/test_bulk_device_control.py
+++ b/tests/src/unit/test_bulk_device_control.py
@@ -323,13 +323,20 @@ class TestRegisteredBulkToolCompatibility:
                         "action": "off",
                         "timeout_seconds": 10**400,
                     },
+                    # json.loads raises RecursionError past the interpreter
+                    # depth limit; that too must skip the row, not the batch.
+                    {
+                        "entity_id": "light.deep_parameters",
+                        "action": "off",
+                        "parameters": "[" * 50_000 + "]" * 50_000,
+                    },
                 ]
             }
         )
 
         data = result.structured_content
         assert data["successful_commands"] == 1
-        assert data["skipped_operations"] == 12
+        assert data["skipped_operations"] == 13
         assert [detail["index"] for detail in data["skipped_details"]] == [
             0,
             1,
@@ -343,6 +350,7 @@ class TestRegisteredBulkToolCompatibility:
             10,
             11,
             12,
+            13,
         ]
         messages = [detail["error"]["message"] for detail in data["skipped_details"]]
         assert any("required fields" in message for message in messages)
@@ -353,6 +361,7 @@ class TestRegisteredBulkToolCompatibility:
         assert sum("validate_first" in message for message in messages) == 3
         assert sum("timeout_seconds" in message for message in messages) == 5
         assert sum("must be a JSON object" in message for message in messages) == 2
+        assert any("nested too deeply" in message for message in messages)
         tools.control_device_smart.assert_awaited_once()
 
     @pytest.mark.asyncio

--- a/tests/src/unit/test_bulk_device_control.py
+++ b/tests/src/unit/test_bulk_device_control.py
@@ -304,13 +304,20 @@ class TestRegisteredBulkToolCompatibility:
                         "action": "off",
                         "timeout_seconds": "10",
                     },
+                    # float() of an int this size raises OverflowError, which
+                    # must skip the row rather than abort the whole batch.
+                    {
+                        "entity_id": "light.oversized_timeout",
+                        "action": "off",
+                        "timeout_seconds": 10**400,
+                    },
                 ]
             }
         )
 
         data = result.structured_content
         assert data["successful_commands"] == 1
-        assert data["skipped_operations"] == 9
+        assert data["skipped_operations"] == 10
         assert [detail["index"] for detail in data["skipped_details"]] == [
             0,
             1,
@@ -321,6 +328,7 @@ class TestRegisteredBulkToolCompatibility:
             7,
             8,
             9,
+            10,
         ]
         messages = [detail["error"]["message"] for detail in data["skipped_details"]]
         assert any("required fields" in message for message in messages)
@@ -329,7 +337,7 @@ class TestRegisteredBulkToolCompatibility:
         json_message = next(m for m in messages if "invalid JSON parameters" in m)
         assert "at position 1" in json_message
         assert sum("validate_first" in message for message in messages) == 3
-        assert sum("timeout_seconds" in message for message in messages) == 4
+        assert sum("timeout_seconds" in message for message in messages) == 5
         tools.control_device_smart.assert_awaited_once()
 
     @pytest.mark.asyncio

--- a/tests/src/unit/test_bulk_device_control.py
+++ b/tests/src/unit/test_bulk_device_control.py
@@ -297,13 +297,20 @@ class TestRegisteredBulkToolCompatibility:
                         "action": "off",
                         "timeout_seconds": True,
                     },
+                    # The advertised schema is strict, so a numeric string must
+                    # not be quietly coerced at runtime either.
+                    {
+                        "entity_id": "light.string_timeout",
+                        "action": "off",
+                        "timeout_seconds": "10",
+                    },
                 ]
             }
         )
 
         data = result.structured_content
         assert data["successful_commands"] == 1
-        assert data["skipped_operations"] == 8
+        assert data["skipped_operations"] == 9
         assert [detail["index"] for detail in data["skipped_details"]] == [
             0,
             1,
@@ -313,6 +320,7 @@ class TestRegisteredBulkToolCompatibility:
             6,
             7,
             8,
+            9,
         ]
         messages = [detail["error"]["message"] for detail in data["skipped_details"]]
         assert any("required fields" in message for message in messages)
@@ -321,7 +329,7 @@ class TestRegisteredBulkToolCompatibility:
         json_message = next(m for m in messages if "invalid JSON parameters" in m)
         assert "at position 1" in json_message
         assert sum("validate_first" in message for message in messages) == 3
-        assert sum("timeout_seconds" in message for message in messages) == 3
+        assert sum("timeout_seconds" in message for message in messages) == 4
         tools.control_device_smart.assert_awaited_once()
 
     @pytest.mark.asyncio

--- a/tests/src/unit/test_bulk_device_control.py
+++ b/tests/src/unit/test_bulk_device_control.py
@@ -10,6 +10,13 @@ from ha_mcp.errors import ErrorCode, create_error_response
 from ha_mcp.tools.device_control import DeviceControlTools
 
 
+def _all_invalid_payload(exc_info) -> dict:
+    """Parse the structured payload of an all-invalid batch ToolError."""
+    payload = json.loads(str(exc_info.value))
+    assert payload["success"] is False
+    return payload
+
+
 class TestBulkDeviceControlValidation:
     """Test bulk_device_control validation logic."""
 
@@ -30,32 +37,35 @@ class TestBulkDeviceControlValidation:
 
     @pytest.mark.asyncio
     async def test_missing_entity_id_reports_error(self, device_control_tools):
-        """Operations missing entity_id are reported in skipped_operations."""
+        """A batch where every row is invalid fails the call, not just the rows."""
         device_control_tools._bulk_via_component = AsyncMock()
         operations = [
             {"action": "on"},  # Missing entity_id
         ]
-        result = await device_control_tools.bulk_device_control(operations)
 
-        assert result["total_operations"] == 1
-        assert result["skipped_operations"] == 1
-        assert len(result["skipped_details"]) == 1
-        assert "entity_id" in result["skipped_details"][0]["error"]["message"]
-        assert result["skipped_details"][0]["index"] == 0
+        with pytest.raises(ToolError) as exc_info:
+            await device_control_tools.bulk_device_control(operations)
+
+        payload = _all_invalid_payload(exc_info)
+        assert "All 1 operation(s) failed validation" in payload["error"]["message"]
+        assert len(payload["skipped_details"]) == 1
+        assert "entity_id" in payload["skipped_details"][0]["error"]["message"]
+        assert payload["skipped_details"][0]["index"] == 0
         device_control_tools._bulk_via_component.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_missing_action_reports_error(self, device_control_tools):
-        """Operations missing action are reported in skipped_operations."""
+        """The missing field is named in the raised payload's skipped_details."""
         operations = [
             {"entity_id": "light.test"},  # Missing action
         ]
-        result = await device_control_tools.bulk_device_control(operations)
 
-        assert result["total_operations"] == 1
-        assert result["skipped_operations"] == 1
-        assert len(result["skipped_details"]) == 1
-        assert "action" in result["skipped_details"][0]["error"]["message"]
+        with pytest.raises(ToolError) as exc_info:
+            await device_control_tools.bulk_device_control(operations)
+
+        payload = _all_invalid_payload(exc_info)
+        assert len(payload["skipped_details"]) == 1
+        assert "action" in payload["skipped_details"][0]["error"]["message"]
 
     @pytest.mark.asyncio
     async def test_missing_both_fields_reports_both(self, device_control_tools):
@@ -63,10 +73,12 @@ class TestBulkDeviceControlValidation:
         operations = [
             {},  # Missing both entity_id and action
         ]
-        result = await device_control_tools.bulk_device_control(operations)
 
-        assert result["skipped_operations"] == 1
-        error_msg = result["skipped_details"][0]["error"]["message"]
+        with pytest.raises(ToolError) as exc_info:
+            await device_control_tools.bulk_device_control(operations)
+
+        payload = _all_invalid_payload(exc_info)
+        error_msg = payload["skipped_details"][0]["error"]["message"]
         assert "entity_id" in error_msg
         assert "action" in error_msg
 
@@ -78,12 +90,14 @@ class TestBulkDeviceControlValidation:
             123,
             None,
         ]
-        result = await device_control_tools.bulk_device_control(operations)
 
-        assert result["total_operations"] == 3
-        assert result["skipped_operations"] == 3
-        assert len(result["skipped_details"]) == 3
-        for detail in result["skipped_details"]:
+        with pytest.raises(ToolError) as exc_info:
+            await device_control_tools.bulk_device_control(operations)
+
+        payload = _all_invalid_payload(exc_info)
+        assert "All 3 operation(s) failed validation" in payload["error"]["message"]
+        assert len(payload["skipped_details"]) == 3
+        for detail in payload["skipped_details"]:
             assert "not a dict" in detail["error"]["message"]
 
     @pytest.mark.slow
@@ -142,15 +156,18 @@ class TestBulkDeviceControlValidation:
 
     @pytest.mark.asyncio
     async def test_all_invalid_operations_has_suggestions(self, device_control_tools):
-        """When operations are skipped, response includes suggestions."""
+        """The raised payload carries the actionable row-shape guidance."""
         operations = [
             {"action": "on"},  # Invalid
         ]
-        result = await device_control_tools.bulk_device_control(operations)
 
-        assert "suggestions" in result
-        assert any("entity_id" in s for s in result["suggestions"])
-        assert any("action" in s for s in result["suggestions"])
+        with pytest.raises(ToolError) as exc_info:
+            await device_control_tools.bulk_device_control(operations)
+
+        suggestions = _all_invalid_payload(exc_info)["error"]["suggestions"]
+        assert any("entity_id" in s for s in suggestions)
+        assert any("action" in s for s in suggestions)
+        assert any("service='turn_off'" in s for s in suggestions)
 
     @pytest.mark.asyncio
     async def test_skipped_details_includes_original_operation(
@@ -158,25 +175,26 @@ class TestBulkDeviceControlValidation:
     ):
         """Skipped details include the original operation for debugging."""
         original_op = {"action": "on", "parameters": {"brightness": 100}}
-        operations = [original_op]
-        result = await device_control_tools.bulk_device_control(operations)
 
-        assert result["skipped_details"][0]["operation"] == original_op
+        with pytest.raises(ToolError) as exc_info:
+            await device_control_tools.bulk_device_control([original_op])
+
+        payload = _all_invalid_payload(exc_info)
+        assert payload["skipped_details"][0]["operation"] == original_op
 
     @pytest.mark.asyncio
     async def test_sequential_execution_validates_operations(
         self, device_control_tools
     ):
-        """Sequential execution mode also validates operations."""
+        """Sequential execution mode validates before it reaches the mode split."""
         operations = [
             {"action": "on"},  # Missing entity_id
         ]
-        result = await device_control_tools.bulk_device_control(
-            operations, parallel=False
-        )
 
-        assert result["skipped_operations"] == 1
-        assert result["execution_mode"] == "sequential"
+        with pytest.raises(ToolError) as exc_info:
+            await device_control_tools.bulk_device_control(operations, parallel=False)
+
+        assert len(_all_invalid_payload(exc_info)["skipped_details"]) == 1
 
 
 class TestRegisteredBulkToolCompatibility:

--- a/tests/src/unit/test_bulk_device_control.py
+++ b/tests/src/unit/test_bulk_device_control.py
@@ -330,13 +330,20 @@ class TestRegisteredBulkToolCompatibility:
                         "action": "off",
                         "parameters": "[" * 50_000 + "]" * 50_000,
                     },
+                    # A direct Python caller can pass a non-string key; mixed
+                    # key types must not make sorted()/join() abort the batch.
+                    {
+                        "entity_id": "light.int_key",
+                        "action": "off",
+                        1: "x",
+                    },
                 ]
             }
         )
 
         data = result.structured_content
         assert data["successful_commands"] == 1
-        assert data["skipped_operations"] == 13
+        assert data["skipped_operations"] == 14
         assert [detail["index"] for detail in data["skipped_details"]] == [
             0,
             1,
@@ -351,6 +358,7 @@ class TestRegisteredBulkToolCompatibility:
             11,
             12,
             13,
+            14,
         ]
         messages = [detail["error"]["message"] for detail in data["skipped_details"]]
         assert any("required fields" in message for message in messages)
@@ -362,6 +370,7 @@ class TestRegisteredBulkToolCompatibility:
         assert sum("timeout_seconds" in message for message in messages) == 5
         assert sum("must be a JSON object" in message for message in messages) == 2
         assert any("nested too deeply" in message for message in messages)
+        assert any("unsupported key(s): 1" in message for message in messages)
         tools.control_device_smart.assert_awaited_once()
 
     @pytest.mark.asyncio

--- a/tests/src/unit/test_config_param_no_string_schema.py
+++ b/tests/src/unit/test_config_param_no_string_schema.py
@@ -281,7 +281,9 @@ def test_bulk_operation_timeout_rejects_negative_and_accepts_zero():
     with pytest.raises(ValidationError):
         adapter.validate_python({**operation, "timeout_seconds": -1})
 
-    for invalid_value in (float("inf"), "inf", float("nan")):
+    # ``True`` is the trap: ``float(True)`` is 1.0, so a bool that slips past
+    # the schema reads downstream as a one-second timeout.
+    for invalid_value in (float("inf"), "inf", float("nan"), True, False):
         with pytest.raises(ValidationError):
             adapter.validate_python({**operation, "timeout_seconds": invalid_value})
 

--- a/tests/src/unit/test_ha_search_merge.py
+++ b/tests/src/unit/test_ha_search_merge.py
@@ -8,9 +8,12 @@ on ``has_more``/``next_offset``, and the budget-exhaustion ``partial`` flag.
 
 from __future__ import annotations
 
+from unittest.mock import MagicMock
+
 import pytest
 from fastmcp.exceptions import ToolError
 
+from ha_mcp.tools import tools_search
 from ha_mcp.tools.smart_search._deep import DeepSearchMixin
 from ha_mcp.tools.smart_search._scenes import SceneSearchMixin
 from ha_mcp.tools.tools_search import (
@@ -502,9 +505,28 @@ def test_finalize_partial_state_appends_existing_reason() -> None:
         errors_local=[{"surface": "entities", "error": "ws closed"}],
     )
 
+    # Routed through _merge_partial_reason like every other writer, so the
+    # separator and the de-duplication are the module's, not this call site's.
     assert response["partial_reason"] == (
-        "config: budget exhausted; entities: ws closed"
+        "config: budget exhausted ; entities: ws closed"
     )
+
+
+def test_finalize_partial_state_does_not_repeat_an_identical_reason() -> None:
+    """The shared merger de-dups; the inline concat it replaced did not."""
+    response = {
+        "partial": True,
+        "partial_reason": "entities: ws closed",
+        "errors": [],
+    }
+
+    _finalize_partial_state(
+        response,
+        partial_local=True,
+        errors_local=[{"surface": "entities", "error": "ws closed"}],
+    )
+
+    assert response["partial_reason"] == "entities: ws closed"
 
 
 def test_finalize_partial_state_noop_when_no_branch_raised() -> None:
@@ -518,6 +540,48 @@ def test_finalize_partial_state_noop_when_no_branch_raised() -> None:
     _finalize_partial_state(response, partial_local=False, errors_local=[])
     assert response["partial"] is True
     assert response["errors"] == [{"surface": "config-internal", "code": "BUDGET"}]
+
+
+def _entities_only_request() -> tools_search._ResolvedSearch:
+    """A resolved request that fans out to the entity branch only."""
+    return tools_search._ResolvedSearch(
+        query="lamp",
+        query_text="lamp",
+        domain_filter=None,
+        area_filter=None,
+        state_filter=None,
+        parsed_search_types=None,
+        parsed_fields=None,
+        result_fields=None,
+        limit=10,
+        offset=0,
+        exact_match=False,
+        include_hidden=False,
+        include_config=False,
+        group_by_domain=False,
+        per_domain_limit=None,
+        config_time_budget=None,
+        registry_eligible=True,
+        body_eligible=False,
+        body_skipped_by_intent_gate=False,
+    )
+
+
+@pytest.mark.asyncio
+async def test_branch_exception_without_a_message_reports_its_type() -> None:
+    """``str(TimeoutError())`` is "", which used to yield ``"entities: "``."""
+    tools = tools_search.SearchTools(MagicMock(), MagicMock())
+
+    async def _time_out(**kwargs: object) -> dict:
+        raise TimeoutError
+
+    tools._ha_search_entities = _time_out  # type: ignore[method-assign]
+
+    response = await tools._legacy_ha_search(_entities_only_request(), None)
+
+    assert response["partial"] is True
+    assert response["errors"] == [{"surface": "entities", "error": "TimeoutError"}]
+    assert response["partial_reason"] == "entities: TimeoutError"
 
 
 # Entity-intent skip warning emission ------------------------------------

--- a/tests/src/unit/test_ws_degraders_warn.py
+++ b/tests/src/unit/test_ws_degraders_warn.py
@@ -202,6 +202,39 @@ class TestAreaSearchReportsSkippedEnrichment:
         ), response["warnings"]
 
     @pytest.mark.asyncio
+    async def test_missing_result_key_floor_registry_is_unavailable(self) -> None:
+        """A success envelope with no result key is an outage, not an empty registry.
+
+        A legitimate zero-floor instance sends ``"result": []``; an absent key
+        must not mark the floor registry available-and-empty, which would
+        re-enable the fuzzy floor-to-partial-area misresolution.
+        """
+        client = _make_client(failing=set())
+
+        async def _ws(message: dict[str, Any]) -> dict[str, Any]:
+            if message.get("type") == _FLOOR_LIST:
+                return {"success": True}
+            if message.get("type") == _AREA_LIST:
+                return {
+                    "success": True,
+                    "result": [
+                        {"area_id": "couloir_sous_sol", "name": "Couloir Sous-Sol"}
+                    ],
+                }
+            return {"success": True, "result": []}
+
+        client.send_websocket_message = AsyncMock(side_effect=_ws)
+        tools = SmartSearchTools(client=client)
+
+        response = await tools.get_entities_by_area("sous-sol")
+
+        assert response["total_areas_found"] == 0
+        assert any("result key missing" in w for w in response["warnings"])
+        assert any(
+            "close-spelling matching was skipped" in w for w in response["warnings"]
+        ), response["warnings"]
+
+    @pytest.mark.asyncio
     async def test_bare_list_floor_registry_is_unavailable(self) -> None:
         """A bare list must not enable fuzzy area fallback after parser rejection."""
         client = _make_client(failing=set())

--- a/tests/src/unit/test_ws_degraders_warn.py
+++ b/tests/src/unit/test_ws_degraders_warn.py
@@ -164,6 +164,12 @@ class TestAreaSearchReportsSkippedEnrichment:
 
         assert response["total_areas_found"] == 0
         assert any("floor registry unavailable" in w for w in response["warnings"])
+        # The fetch warning says what broke; the resolution warning must say
+        # what that cost this query, or "no match" reads as "no such area".
+        assert any(
+            "close-spelling matching was skipped" in w and "'sous-sol'" in w
+            for w in response["warnings"]
+        ), response["warnings"]
 
     @pytest.mark.asyncio
     async def test_malformed_floor_registry_does_not_fuzzy_match_partial_area(
@@ -191,6 +197,9 @@ class TestAreaSearchReportsSkippedEnrichment:
 
         assert response["total_areas_found"] == 0
         assert any("floor registry unavailable" in w for w in response["warnings"])
+        assert any(
+            "close-spelling matching was skipped" in w for w in response["warnings"]
+        ), response["warnings"]
 
     @pytest.mark.asyncio
     async def test_bare_list_floor_registry_is_unavailable(self) -> None:
@@ -216,6 +225,9 @@ class TestAreaSearchReportsSkippedEnrichment:
 
         assert response["total_areas_found"] == 0
         assert any("floor registry unavailable" in w for w in response["warnings"])
+        assert any(
+            "close-spelling matching was skipped" in w for w in response["warnings"]
+        ), response["warnings"]
 
     @pytest.mark.asyncio
     async def test_healthy_registries_produce_no_registry_warning(self) -> None:


### PR DESCRIPTION
## What does this PR do?

Follow-up fixes on top of #2235, from a review of the floor/area resolution and
bulk-control paths it touched.

- **A floor-registry outage now says what it cost.** With the floor registry
  unreachable, all fuzzy area matching is suppressed — correctly, so the
  floor-to-partial-area misresolution cannot come back — but the caller only saw
  the generic fetch warning and read "no areas found" as "this area does not
  exist". The suppression branch now returns a resolution warning naming the
  consequence and the recovery. The availability flag is also derived from the
  parse outcome instead of a second, subtly different predicate over the raw
  payload.
- **`ha_search` partial_reason.** `_finalize_partial_state` concatenated with its
  own separator and no de-duplication while the module's three other writers used
  `_merge_partial_reason`; it now uses the shared helper. A branch exception whose
  message is empty (`asyncio.TimeoutError`) produced `partial_reason:
  "entities: "` — it now falls back to the exception type name.
- **Boolean bulk timeouts.** Pydantic's lax mode coerces `true` to `1.0` and
  `float(True)` is `1.0`, so `timeout_seconds: true` was silently accepted as a
  one-second wait at both the transport schema and the runtime batch validator.
  The field now carries `strict=True` (matching `validate_first`) and the runtime
  helper rejects bools before `float()` sees them.
- **An all-invalid batch now fails the call.** An empty operations list already
  raised, but a batch where every row failed validation returned the
  success-shaped response with `successful_commands: 0`. Per AGENTS.md the
  batch-item carve-out exists to protect successful siblings, and there are none.
  It raises with the skipped rows in the payload, still ahead of the component
  probe so nothing dispatches. Mixed batches keep failing soft.
- **Diagnostics that were being dropped.** The `ValidationError` swallowed in
  `ha_bulk_control` is logged with its row index (the schema's reason is richer
  than the runtime validator's and survives nowhere else), and a `JSONDecodeError`
  in bulk `parameters` now reports the decoder's reason and offset instead of just
  "invalid JSON".
- **Model-facing descriptions corrected.** `validate_first` claimed to prevent
  dispatch, but on the component batch path the missing entity is detected
  afterwards from the captured pre-state. The `parameters` description never said
  the per-domain key list is a silent allowlist that drops unsupported keys.
- **Cleanup in the touched code.** Seven copies of log/build/append in
  `_validate_bulk_operations` collapse into one `_skip_bulk_operation` helper, and
  the dead `err_response["index"]` writes go with them — `create_error_response`
  already lifts every context key to the top level. The allowed-key literal is
  read back from `BulkControlOperation` so the runtime validator cannot drift from
  the advertised schema. Also `_DOMAIN_PARAMS` gains a note that it is a silent
  allowlist, `get_device_operation_status` reflects its shortened final poll, and
  `_match_area_ids` regains the exact-first rationale.

## Type of change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [ ] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

Test files touched:
- `tests/src/unit/test_ws_degraders_warn.py` — all three floor-registry degrader
  tests assert the consequence warning alongside the fetch warning.
- `tests/src/unit/test_ha_search_merge.py` — `partial_reason` separator and
  de-duplication, plus an orchestrator test for an exception with no message.
- `tests/src/unit/test_bulk_device_control.py` — all-invalid batches now expect
  `ToolError` with the structured payload; a boolean timeout, a non-string
  `entity_id`, and a `parameters` string that parses to a list are added to the
  mixed-row coverage; the JSON parse error asserts its reported position.
- `tests/src/unit/test_config_param_no_string_schema.py` — booleans rejected by
  the advertised `timeout_seconds` contract.
- `tests/src/unit/test_area_filter_search.py` — entity aggregation across a floor
  expansion (a second area on the floor with its own entity), and a bare
  `floor_id` as the area filter.

## Checklist
- [x] I have updated documentation if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Bulk device controls now provide clearer per-item validation errors, decoder details, and actionable suggestions.
  - Invalid, empty, malformed, unsupported, null, deeply nested, or excessively large inputs are rejected consistently.
  - All-invalid bulk requests now fail without dispatching operations.
  - Floor searches warn when floor data is unavailable or malformed and fuzzy matching is skipped.
  - Floor searches correctly include entities across all areas on the selected floor.
  - Partial search failures report meaningful, deduplicated reasons, including unnamed errors.

- **Documentation**
  - Clarified supported bulk-control parameters, validation behavior, and polling deadlines.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->