### PR TITLE
fix: support refresh for fixed-port loopback OAuth clients

### DIFF
--- a/custom_components/ha_mcp_tools/oauth_autoapprove.py
+++ b/custom_components/ha_mcp_tools/oauth_autoapprove.py
@@ -43,6 +43,7 @@ provider.
 
 from __future__ import annotations
 
+import json
 import secrets
 from typing import TYPE_CHECKING, Any
 
@@ -97,6 +98,133 @@ def _json_error(
     if description is not None:
         body["error_description"] = description
     return web.json_response(body, status=status, headers=_TOKEN_RESPONSE_HEADERS)
+
+
+def _wrap_refresh_token(
+    body: bytes,
+    signing_key: bytes,
+    client_id: str,
+    origin: str,
+) -> bytes:
+    """Wrap a core refresh token with its signed loopback identity."""
+    try:
+        payload = json.loads(body)
+    except (UnicodeDecodeError, ValueError):
+        return body
+    if not isinstance(payload, dict) or not isinstance(
+        payload.get("refresh_token"), str
+    ):
+        return body
+    from .oauth_dcr import mint_refresh_token_envelope
+
+    payload["refresh_token"] = mint_refresh_token_envelope(
+        signing_key,
+        client_id,
+        payload["refresh_token"],
+        origin,
+    )
+    return json.dumps(payload, separators=(",", ":")).encode()
+
+
+def _maybe_wrap_refresh_token(
+    body: bytes,
+    status: int,
+    dcr_key: object,
+    client_id: str,
+    origin: str | None,
+) -> bytes:
+    """Wrap a successful fixed-loopback refresh token when context is valid."""
+    if status != 200 or not isinstance(dcr_key, bytes) or origin is None:
+        return body
+    return _wrap_refresh_token(body, dcr_key, client_id, origin)
+
+
+def _refresh_envelope_origin(
+    grant_type: str,
+    dcr_key: object,
+    client_id: str,
+    redirect_uri: str,
+) -> str | None:
+    """Return the runtime origin to bind for a fixed-loopback code exchange."""
+    if (
+        grant_type != "authorization_code"
+        or not isinstance(dcr_key, bytes)
+        or not client_id
+        or not redirect_uri
+    ):
+        return None
+    from .oauth_dcr import client_redirect_uris, stable_refresh_origin
+    from .oauth_ha_auth import origin_client_id, redirect_matches
+
+    registered = client_redirect_uris(dcr_key, client_id)
+    if registered is None:
+        return None
+    stable = stable_refresh_origin(registered)
+    if not stable or not stable.startswith("http://"):
+        return None
+    if not redirect_matches(registered, redirect_uri):
+        return None
+    return origin_client_id(redirect_uri)
+
+
+async def _refresh_translation(
+    cimd_session: Any,
+    dcr_key: object,
+    client_id: str,
+    refresh_token: str,
+    redirect_uri: str,
+) -> tuple[object, str | None, str | None, str | None]:
+    """Resolve a refresh identity and unwrap a bound loopback token."""
+    if isinstance(dcr_key, bytes):
+        from .oauth_dcr import unwrap_refresh_token_envelope
+
+        wrapped = unwrap_refresh_token_envelope(dcr_key, client_id, refresh_token)
+        if wrapped is not None:
+            core_refresh_token, origin = wrapped
+            if redirect_uri:
+                from .oauth_ha_auth import RefreshDisposition, origin_client_id
+
+                if (
+                    not _is_valid_redirect_uri(redirect_uri)
+                    or origin_client_id(redirect_uri) != origin
+                ):
+                    return (
+                        RefreshDisposition.UNREPRODUCIBLE,
+                        None,
+                        None,
+                        "re-authorize: redirect_uri does not match this refresh "
+                        "token's signed loopback origin",
+                    )
+            return origin, core_refresh_token, origin, None
+    from .oauth_ha_auth import (
+        RefreshDisposition,
+        resolve_forward_client_id,
+        translated_client_id_for_refresh,
+    )
+
+    if redirect_uri:
+        translated = await resolve_forward_client_id(
+            cimd_session, dcr_key, client_id, redirect_uri
+        )
+        return translated, None, None, None
+
+    translated = await translated_client_id_for_refresh(
+        cimd_session,
+        dcr_key,
+        client_id,
+    )
+    refresh_origin = (
+        translated
+        if isinstance(translated, str) and translated.startswith("http://")
+        else None
+    )
+    error_description = (
+        "re-authorize: this client's registration has no single reproducible "
+        "origin, so a refresh without redirect_uri is unavailable"
+        if translated is RefreshDisposition.UNREPRODUCIBLE
+        else None
+    )
+    return translated, None, refresh_origin, error_description
 
 
 def _redirect_with(redirect_uri: str, **params: str) -> web.Response:
@@ -388,7 +516,6 @@ class AutoApproveTokenView(HomeAssistantView):
             RefreshDisposition,
             core_token_base_url,
             resolve_forward_client_id,
-            translated_client_id_for_refresh,
         )
 
         raw_form = await read_form(request)
@@ -405,20 +532,30 @@ class AutoApproveTokenView(HomeAssistantView):
         client_id = str(form.get("client_id", ""))
         redirect_uri = str(form.get("redirect_uri", ""))
         forward_id = client_id
+        refresh_origin: str | None = None
+        dcr_key = cfg.get(CFG_DCR_SIGNING_KEY)
         if client_id:
-            if grant_type == "refresh_token" and not redirect_uri:
-                # refresh_token grant without a redirect_uri on the wire —
-                # re-derive the translation from the registered list alone.
-                translated = await translated_client_id_for_refresh(
+            if grant_type == "refresh_token":
+                (
+                    translated,
+                    core_refresh_token,
+                    refresh_origin,
+                    refresh_error,
+                ) = await _refresh_translation(
                     cfg.get(CFG_CIMD_SESSION),
-                    cfg.get(CFG_DCR_SIGNING_KEY),
+                    dcr_key,
                     client_id,
+                    str(form.get("refresh_token", "")),
+                    redirect_uri,
                 )
+                if core_refresh_token is not None:
+                    form.popall("refresh_token", None)
+                    form["refresh_token"] = core_refresh_token
                 if translated is RefreshDisposition.UNREPRODUCIBLE:
                     # Coupled to oauth_dcr registration semantics: a VERIFIED
                     # identity (DCR blob or fetched CIMD document — #2217
                     # review closed the CIMD half of this guard) whose
-                    # registration has no single reproducible web origin must
+                    # registration has no single reproducible origin must
                     # not advertise refresh_token, because this guard rejects
                     # its redirect-less refresh locally. The token was bound
                     # to an origin we cannot re-derive; answering here avoids
@@ -426,23 +563,22 @@ class AutoApproveTokenView(HomeAssistantView):
                     return _json_error(
                         "invalid_grant",
                         400,
-                        "re-authorize: this client's registration has no "
-                        "single reproducible web origin, so a refresh "
-                        "without redirect_uri is unavailable",
+                        refresh_error,
                     )
                 if translated is not RefreshDisposition.PASSTHROUGH:
                     forward_id = translated
             else:
-                # Authorization-code exchanges — and refreshes that DO carry a
-                # redirect_uri — use the presented redirect, exactly like the
-                # authorize leg (this is what keeps multi-origin identities
-                # refreshable). With no redirect_uri, validation leaves the
-                # client_id untouched for core to reject authoritatively.
+                # Authorization-code exchanges use the presented redirect,
+                # exactly like the authorize leg. With no redirect_uri,
+                # validation leaves the client_id untouched for core to reject.
                 forward_id = await resolve_forward_client_id(
                     cfg.get(CFG_CIMD_SESSION),
-                    cfg.get(CFG_DCR_SIGNING_KEY),
+                    dcr_key,
                     client_id,
                     redirect_uri,
+                )
+                refresh_origin = _refresh_envelope_origin(
+                    grant_type, dcr_key, client_id, redirect_uri
                 )
         if forward_id == client_id:
             # No body rewrite needed, so don't proxy: 307 the client into
@@ -485,6 +621,9 @@ class AutoApproveTokenView(HomeAssistantView):
                 timeout=aiohttp.ClientTimeout(total=25),
             ) as resp:
                 body = await resp.read()
+                body = _maybe_wrap_refresh_token(
+                    body, resp.status, dcr_key, client_id, refresh_origin
+                )
                 return web.Response(
                     status=resp.status,
                     body=body,

--- a/custom_components/ha_mcp_tools/oauth_dcr.py
+++ b/custom_components/ha_mcp_tools/oauth_dcr.py
@@ -51,6 +51,7 @@ CFG_DCR_SIGNING_KEY = "dcr_signing_key"
 _DCR_VIEW_REGISTERED_KEY = "ha_mcp_tools_oauth_dcr_view_registered"
 
 _CLIENT_ID_PREFIX = "hamcp-dcr-"
+_REFRESH_TOKEN_PREFIX = "hamcp-refresh-"
 
 # Registration floor: enough for any real client (claude.ai registers one
 # callback; CLI clients a couple of loopback variants), small enough that the
@@ -92,6 +93,67 @@ def client_redirect_uris(signing_key: bytes, client_id: str) -> list[str] | None
     if not isinstance(uris, list) or not all(isinstance(u, str) for u in uris):
         return None
     return uris
+
+
+def mint_refresh_token_envelope(
+    signing_key: bytes,
+    client_id: str,
+    refresh_token: str,
+    origin: str,
+) -> str:
+    """Bind a core refresh token to its authorization-time loopback origin."""
+    client_hash = _b64url_encode(hashlib.sha256(client_id.encode()).digest())
+    payload = {"v": 1, "c": client_hash, "t": refresh_token, "o": origin}
+    body = _b64url_encode(json.dumps(payload, separators=(",", ":")).encode())
+    signature = hmac.new(signing_key, body.encode("ascii"), hashlib.sha256).digest()
+    return f"{_REFRESH_TOKEN_PREFIX}{body}.{_b64url_encode(signature)}"
+
+
+def unwrap_refresh_token_envelope(
+    signing_key: bytes,
+    client_id: str,
+    envelope: str,
+) -> tuple[str, str] | None:
+    """Return the core token and loopback origin from a valid bound envelope."""
+    if not envelope.startswith(_REFRESH_TOKEN_PREFIX):
+        return None
+    blob = envelope[len(_REFRESH_TOKEN_PREFIX) :]
+    body, separator, signature = blob.rpartition(".")
+    if not separator or not body:
+        return None
+    try:
+        expected = hmac.new(signing_key, body.encode("ascii"), hashlib.sha256).digest()
+        if not hmac.compare_digest(_b64url_decode(signature), expected):
+            return None
+        payload = json.loads(_b64url_decode(body))
+    except (ValueError, binascii.Error, UnicodeEncodeError):
+        return None
+    client_hash = _b64url_encode(hashlib.sha256(client_id.encode()).digest())
+    if (
+        not isinstance(payload, dict)
+        or payload.get("v") != 1
+        or payload.get("c") != client_hash
+        or not isinstance(payload.get("t"), str)
+        or not payload["t"]
+        or not isinstance(payload.get("o"), str)
+    ):
+        return None
+    origin = payload["o"]
+    parsed = urlparse(origin)
+    normalized = normalized_origin(origin)
+    if (
+        parsed.scheme != "http"
+        or parsed.hostname is None
+        or not _is_loopback_host(parsed.hostname)
+        or parsed.path not in ("", "/")
+        or parsed.params
+        or parsed.query
+        or parsed.fragment
+        or normalized is None
+        or canonical_origin_url(normalized) != origin.rstrip("/")
+    ):
+        return None
+    return payload["t"], origin.rstrip("/")
 
 
 def _active_dcr_key(hass: HomeAssistant) -> bytes | None:
@@ -142,27 +204,41 @@ def canonical_origin_url(origin: tuple[str, str, int]) -> str:
     return f"{scheme}://{url_host}:{port}"
 
 
-def _non_loopback_origins(redirect_uris: list[str]) -> set[tuple[str, str, int]]:
-    """Return normalized web origins represented by validated redirects."""
+def stable_refresh_origin(redirect_uris: list[str]) -> str | None:
+    """Return the one origin that a redirect-less refresh can reproduce.
+
+    Web redirects are stable by origin. Loopback redirects are stable only
+    when every callback uses the same explicit, nonzero port; omitted and zero
+    ports represent runtime-selected listeners and cannot be reconstructed.
+    """
     origins: set[tuple[str, str, int]] = set()
+    loopback: bool | None = None
     for uri in redirect_uris:
-        parsed = urlparse(uri)
-        if parsed.hostname is None or _is_loopback_host(parsed.hostname):
-            continue
+        try:
+            parsed = urlparse(uri)
+            port = parsed.port
+        except ValueError:
+            return None
+        if parsed.hostname is None:
+            return None
+        is_loopback = _is_loopback_host(parsed.hostname)
+        if loopback is not None and loopback != is_loopback:
+            return None
+        loopback = is_loopback
+        if is_loopback and port in (None, 0):
+            return None
         origin = normalized_origin(uri)
-        if origin is not None:
-            origins.add(origin)
-    return origins
+        if origin is None:
+            return None
+        origins.add(origin)
+    if len(origins) != 1:
+        return None
+    return canonical_origin_url(origins.pop())
 
 
 def _refresh_identity_is_reproducible(redirect_uris: list[str]) -> bool:
-    """Return whether every callback maps to exactly one stable web origin."""
-    if len(_non_loopback_origins(redirect_uris)) != 1:
-        return False
-    return not any(
-        (hostname := urlparse(uri).hostname) is None or _is_loopback_host(hostname)
-        for uri in redirect_uris
-    )
+    """Return whether the callback set has one stable refresh origin."""
+    return stable_refresh_origin(redirect_uris) is not None
 
 
 def _redirect_uris_error(value: Any) -> tuple[str, str] | None:
@@ -194,9 +270,9 @@ def _active_grant_types(hass: HomeAssistant, redirect_uris: list[str]) -> list[s
     none mode's auto-approve token endpoint rejects refresh grants and its AS
     document advertises only ``authorization_code`` — the registration response
     must not promise more. ha_auth forwards to core, but refresh is advertised
-    only when every callback maps to exactly one reproducible non-loopback
-    origin. Multiple web origins and ephemeral loopback origins cannot be
-    reconstructed for a redirect_uri-less refresh grant without server state.
+    only when every callback maps to one reproducible origin. Multiple web
+    origins and omitted/ephemeral loopback ports cannot be reconstructed for a
+    redirect_uri-less refresh grant without server state.
     """
     domain_data = hass.data.get(DOMAIN)
     cfg = domain_data.get(DATA_WEBHOOK) if isinstance(domain_data, dict) else None

--- a/custom_components/ha_mcp_tools/oauth_ha_auth.py
+++ b/custom_components/ha_mcp_tools/oauth_ha_auth.py
@@ -54,6 +54,7 @@ from .oauth_dcr import (
     canonical_origin_url,
     client_redirect_uris,
     normalized_origin,
+    stable_refresh_origin,
 )
 from .oauth_legacy import _is_loopback_host, _is_valid_redirect_uri
 
@@ -236,14 +237,7 @@ def redirect_matches(registered: list[str], redirect_uri: str) -> bool:
 
 
 def stable_translation_origin(registered: list[str]) -> str | None:
-    """The single origin shared by every non-loopback registered redirect.
-
-    None when there is no such origin (no web redirects, or several distinct
-    ones). Loopback redirects are excluded because their runtime origin embeds
-    an ephemeral port (RFC 8252) — they are translated from the presented
-    redirect on the authorize/code legs, but cannot be re-derived here for the
-    redirect_uri-less refresh leg.
-    """
+    """Return the single web origin shared by non-loopback redirects."""
     origins: set[str] = set()
     for uri in registered:
         parsed = urlparse(uri)
@@ -490,11 +484,13 @@ async def translated_client_id_for_refresh(
       keys off the PRESENTED redirect, and the server keeps no record →
       ``UNREPRODUCIBLE`` (a local invalid_grant and a clean re-authorize beat
       forwarding a coin-flip identity into core's failed-login accounting).
-    * Cross-origin identities with exactly one web origin and no loopback
-      entries were translated to that origin on every leg → return it.
+    * Cross-origin identities with one stable origin were translated to that
+      origin on every leg → return it. This includes loopback-only registrations
+      whose callbacks all use the same explicit, nonzero port.
     * Everything else that is VERIFIED — multiple web origins (Gemini
-      Spark-class), loopback-only (Claude Code-class), or hybrid — cannot be
-      re-derived without the redirect: ``UNREPRODUCIBLE``.
+      Spark-class), omitted/ephemeral loopback ports (Claude Code-class), or
+      hybrid registrations — cannot be re-derived without the redirect:
+      ``UNREPRODUCIBLE``.
     """
     registered: list[str] | None = None
     if dcr_key is not None:
@@ -512,9 +508,8 @@ async def translated_client_id_for_refresh(
         return RefreshDisposition.PASSTHROUGH
     if not _refresh_identity_is_reproducible(registered):
         return RefreshDisposition.UNREPRODUCIBLE
-    # Reproducible ⇒ exactly one web origin ⇒ stable_translation_origin cannot
-    # return None (canonical_origin_url is one-to-one over normalized origins).
-    stable = stable_translation_origin(registered)
+    # Reproducible implies exactly one stable origin.
+    stable = stable_refresh_origin(registered)
     assert stable is not None
     # Reproduce what the authorize leg forwarded, or admit we cannot. That
     # leg's fast path keys off the PRESENTED redirect, which the redirect-less

--- a/homeassistant-addon-webhook-proxy-dev/config.yaml
+++ b/homeassistant-addon-webhook-proxy-dev/config.yaml
@@ -1,6 +1,6 @@
 name: "Nabu Casa - Webhook Proxy for HA MCP (Dev)"
 description: "DEV CHANNEL (unstable) — remote access proxy via Nabu Casa or any reverse proxy. Cannot run alongside the stable Webhook Proxy add-on."
-version: "3.0.2.dev1"
+version: "3.0.2.dev2"
 slug: "ha_mcp_webhook_proxy_dev"
 url: "https://github.com/homeassistant-ai/ha-mcp"
 stage: experimental

--- a/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/manifest.json
+++ b/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/manifest.json
@@ -7,5 +7,5 @@
   "dependencies": ["webhook"],
   "documentation": "https://github.com/homeassistant-ai/ha-mcp",
   "iot_class": "local_push",
-  "version": "3.0.2.dev1"
+  "version": "3.0.2.dev2"
 }

--- a/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/oauth_autoapprove.py
+++ b/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/oauth_autoapprove.py
@@ -33,6 +33,7 @@ secret-URL trust model.
 
 from __future__ import annotations
 
+import json
 import secrets
 from typing import Any
 
@@ -129,6 +130,133 @@ def _json_error(
     if description is not None:
         body["error_description"] = description
     return web.json_response(body, status=status, headers=_TOKEN_RESPONSE_HEADERS)
+
+
+def _wrap_refresh_token(
+    body: bytes,
+    signing_key: bytes,
+    client_id: str,
+    origin: str,
+) -> bytes:
+    """Wrap a core refresh token with its signed loopback identity."""
+    try:
+        payload = json.loads(body)
+    except (UnicodeDecodeError, ValueError):
+        return body
+    if not isinstance(payload, dict) or not isinstance(
+        payload.get("refresh_token"), str
+    ):
+        return body
+    from .oauth_dcr import mint_refresh_token_envelope
+
+    payload["refresh_token"] = mint_refresh_token_envelope(
+        signing_key,
+        client_id,
+        payload["refresh_token"],
+        origin,
+    )
+    return json.dumps(payload, separators=(",", ":")).encode()
+
+
+def _maybe_wrap_refresh_token(
+    body: bytes,
+    status: int,
+    dcr_key: object,
+    client_id: str,
+    origin: str | None,
+) -> bytes:
+    """Wrap a successful fixed-loopback refresh token when context is valid."""
+    if status != 200 or not isinstance(dcr_key, bytes) or origin is None:
+        return body
+    return _wrap_refresh_token(body, dcr_key, client_id, origin)
+
+
+def _refresh_envelope_origin(
+    grant_type: str,
+    dcr_key: object,
+    client_id: str,
+    redirect_uri: str,
+) -> str | None:
+    """Return the runtime origin to bind for a fixed-loopback code exchange."""
+    if (
+        grant_type != "authorization_code"
+        or not isinstance(dcr_key, bytes)
+        or not client_id
+        or not redirect_uri
+    ):
+        return None
+    from .oauth_dcr import client_redirect_uris, stable_refresh_origin
+    from .oauth_indirect import origin_client_id, redirect_matches
+
+    registered = client_redirect_uris(dcr_key, client_id)
+    if registered is None:
+        return None
+    stable = stable_refresh_origin(registered)
+    if not stable or not stable.startswith("http://"):
+        return None
+    if not redirect_matches(registered, redirect_uri):
+        return None
+    return origin_client_id(redirect_uri)
+
+
+async def _refresh_translation(
+    cimd_session: Any,
+    dcr_key: object,
+    client_id: str,
+    refresh_token: str,
+    redirect_uri: str,
+) -> tuple[object, str | None, str | None, str | None]:
+    """Resolve a refresh identity and unwrap a bound loopback token."""
+    if isinstance(dcr_key, bytes):
+        from .oauth_dcr import unwrap_refresh_token_envelope
+
+        wrapped = unwrap_refresh_token_envelope(dcr_key, client_id, refresh_token)
+        if wrapped is not None:
+            core_refresh_token, origin = wrapped
+            if redirect_uri:
+                from .oauth_indirect import RefreshDisposition, origin_client_id
+
+                if (
+                    not _is_valid_redirect_uri(redirect_uri)
+                    or origin_client_id(redirect_uri) != origin
+                ):
+                    return (
+                        RefreshDisposition.UNREPRODUCIBLE,
+                        None,
+                        None,
+                        "re-authorize: redirect_uri does not match this refresh "
+                        "token's signed loopback origin",
+                    )
+            return origin, core_refresh_token, origin, None
+    from .oauth_indirect import (
+        RefreshDisposition,
+        resolve_forward_client_id,
+        translated_client_id_for_refresh,
+    )
+
+    if redirect_uri:
+        translated = await resolve_forward_client_id(
+            cimd_session, dcr_key, client_id, redirect_uri
+        )
+        return translated, None, None, None
+
+    translated = await translated_client_id_for_refresh(
+        cimd_session,
+        dcr_key,
+        client_id,
+    )
+    refresh_origin = (
+        translated
+        if isinstance(translated, str) and translated.startswith("http://")
+        else None
+    )
+    error_description = (
+        "re-authorize: this client's registration has no single reproducible "
+        "origin, so a refresh without redirect_uri is unavailable"
+        if translated is RefreshDisposition.UNREPRODUCIBLE
+        else None
+    )
+    return translated, None, refresh_origin, error_description
 
 
 def _validate_autoapprove_authorize(params: Any) -> web.Response | None:
@@ -433,7 +561,6 @@ class AutoApproveTokenView(HomeAssistantView):
             RefreshDisposition,
             core_token_base_url,
             resolve_forward_client_id,
-            translated_client_id_for_refresh,
         )
 
         raw_form = await read_form(request)
@@ -444,29 +571,42 @@ class AutoApproveTokenView(HomeAssistantView):
         client_id = str(form.get("client_id", ""))
         redirect_uri = str(form.get("redirect_uri", ""))
         forward_id = client_id
+        refresh_origin: str | None = None
+        dcr_key = data.get(CFG_DCR_SIGNING_KEY)
         if client_id:
-            if grant_type == "refresh_token" and not redirect_uri:
-                translated = await translated_client_id_for_refresh(
+            if grant_type == "refresh_token":
+                (
+                    translated,
+                    core_refresh_token,
+                    refresh_origin,
+                    refresh_error,
+                ) = await _refresh_translation(
                     data.get(CFG_CIMD_SESSION),
-                    data.get(CFG_DCR_SIGNING_KEY),
+                    dcr_key,
                     client_id,
+                    str(form.get("refresh_token", "")),
+                    redirect_uri,
                 )
+                if core_refresh_token is not None:
+                    form.popall("refresh_token", None)
+                    form["refresh_token"] = core_refresh_token
                 if translated is RefreshDisposition.UNREPRODUCIBLE:
                     return _json_error(
                         "invalid_grant",
                         400,
-                        "re-authorize: this client's registration has no "
-                        "single reproducible web origin, so a refresh "
-                        "without redirect_uri is unavailable",
+                        refresh_error,
                     )
                 if translated is not RefreshDisposition.PASSTHROUGH:
                     forward_id = translated
             else:
                 forward_id = await resolve_forward_client_id(
                     data.get(CFG_CIMD_SESSION),
-                    data.get(CFG_DCR_SIGNING_KEY),
+                    dcr_key,
                     client_id,
                     redirect_uri,
+                )
+                refresh_origin = _refresh_envelope_origin(
+                    grant_type, dcr_key, client_id, redirect_uri
                 )
 
         if forward_id == client_id:
@@ -488,6 +628,9 @@ class AutoApproveTokenView(HomeAssistantView):
                 timeout=aiohttp.ClientTimeout(total=25),
             ) as response:
                 body = await response.read()
+                body = _maybe_wrap_refresh_token(
+                    body, response.status, dcr_key, client_id, refresh_origin
+                )
                 return web.Response(
                     status=response.status,
                     body=body,

--- a/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/oauth_dcr.py
+++ b/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/oauth_dcr.py
@@ -42,6 +42,7 @@ from .oauth import (
 CFG_DCR_SIGNING_KEY = "dcr_signing_key"
 _DCR_VIEW_REGISTERED_KEY = "mcp_proxy_dev_oauth_dcr_view_registered"
 _CLIENT_ID_PREFIX = "hamcp-dcr-"
+_REFRESH_TOKEN_PREFIX = "hamcp-refresh-"
 
 # A conforming registration is a few KB; HA's own 16 MiB client_max_size is
 # no bound for an anonymous endpoint, so cap the read like the sibling CIMD
@@ -82,6 +83,67 @@ def client_redirect_uris(signing_key: bytes, client_id: str) -> list[str] | None
     return uris
 
 
+def mint_refresh_token_envelope(
+    signing_key: bytes,
+    client_id: str,
+    refresh_token: str,
+    origin: str,
+) -> str:
+    """Bind a core refresh token to its authorization-time loopback origin."""
+    client_hash = _b64url_encode(hashlib.sha256(client_id.encode()).digest())
+    payload = {"v": 1, "c": client_hash, "t": refresh_token, "o": origin}
+    body = _b64url_encode(json.dumps(payload, separators=(",", ":")).encode())
+    signature = hmac.new(signing_key, body.encode("ascii"), hashlib.sha256).digest()
+    return f"{_REFRESH_TOKEN_PREFIX}{body}.{_b64url_encode(signature)}"
+
+
+def unwrap_refresh_token_envelope(
+    signing_key: bytes,
+    client_id: str,
+    envelope: str,
+) -> tuple[str, str] | None:
+    """Return the core token and loopback origin from a valid bound envelope."""
+    if not envelope.startswith(_REFRESH_TOKEN_PREFIX):
+        return None
+    blob = envelope[len(_REFRESH_TOKEN_PREFIX) :]
+    body, separator, signature = blob.rpartition(".")
+    if not separator or not body:
+        return None
+    try:
+        expected = hmac.new(signing_key, body.encode("ascii"), hashlib.sha256).digest()
+        if not hmac.compare_digest(_b64url_decode(signature), expected):
+            return None
+        payload = json.loads(_b64url_decode(body))
+    except (ValueError, binascii.Error, UnicodeEncodeError):
+        return None
+    client_hash = _b64url_encode(hashlib.sha256(client_id.encode()).digest())
+    if (
+        not isinstance(payload, dict)
+        or payload.get("v") != 1
+        or payload.get("c") != client_hash
+        or not isinstance(payload.get("t"), str)
+        or not payload["t"]
+        or not isinstance(payload.get("o"), str)
+    ):
+        return None
+    origin = payload["o"]
+    parsed = urlparse(origin)
+    normalized = normalized_origin(origin)
+    if (
+        parsed.scheme != "http"
+        or parsed.hostname is None
+        or not _is_loopback_host(parsed.hostname)
+        or parsed.path not in ("", "/")
+        or parsed.params
+        or parsed.query
+        or parsed.fragment
+        or normalized is None
+        or canonical_origin_url(normalized) != origin.rstrip("/")
+    ):
+        return None
+    return payload["t"], origin.rstrip("/")
+
+
 def _active_dcr_key(hass: HomeAssistant) -> bytes | None:
     """Return the live signing key, or None when registration is unavailable."""
     domain_data = hass.data.get(DOMAIN)
@@ -120,27 +182,36 @@ def canonical_origin_url(origin: tuple[str, str, int]) -> str:
     return f"{scheme}://{url_host}:{port}"
 
 
-def _non_loopback_origins(redirect_uris: list[str]) -> set[tuple[str, str, int]]:
-    """Return the normalized web origins represented by redirects."""
+def stable_refresh_origin(redirect_uris: list[str]) -> str | None:
+    """Return the one origin that a redirect-less refresh can reproduce."""
     origins: set[tuple[str, str, int]] = set()
+    loopback: bool | None = None
     for uri in redirect_uris:
-        parsed = urlparse(uri)
-        if parsed.hostname is None or _is_loopback_host(parsed.hostname):
-            continue
+        try:
+            parsed = urlparse(uri)
+            port = parsed.port
+        except ValueError:
+            return None
+        if parsed.hostname is None:
+            return None
+        is_loopback = _is_loopback_host(parsed.hostname)
+        if loopback is not None and loopback != is_loopback:
+            return None
+        loopback = is_loopback
+        if is_loopback and port in (None, 0):
+            return None
         origin = normalized_origin(uri)
-        if origin is not None:
-            origins.add(origin)
-    return origins
+        if origin is None:
+            return None
+        origins.add(origin)
+    if len(origins) != 1:
+        return None
+    return canonical_origin_url(origins.pop())
 
 
 def _refresh_identity_is_reproducible(redirect_uris: list[str]) -> bool:
-    """Return whether every callback maps to one stable non-loopback origin."""
-    if len(_non_loopback_origins(redirect_uris)) != 1:
-        return False
-    return not any(
-        (hostname := urlparse(uri).hostname) is None or _is_loopback_host(hostname)
-        for uri in redirect_uris
-    )
+    """Return whether the callback set has one stable refresh origin."""
+    return stable_refresh_origin(redirect_uris) is not None
 
 
 def _redirect_uris_error(value: Any) -> tuple[str, str] | None:

--- a/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/oauth_indirect.py
+++ b/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/oauth_indirect.py
@@ -42,6 +42,7 @@ from .oauth_dcr import (
     canonical_origin_url,
     client_redirect_uris,
     normalized_origin,
+    stable_refresh_origin,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -380,7 +381,7 @@ async def translated_client_id_for_refresh(
         return RefreshDisposition.PASSTHROUGH
     if not _refresh_identity_is_reproducible(registered):
         return RefreshDisposition.UNREPRODUCIBLE
-    stable = stable_translation_origin(registered)
+    stable = stable_refresh_origin(registered)
     assert stable is not None
     # Reproduce what the authorize leg forwarded, or admit we cannot. That
     # leg's fast path keys off the PRESENTED redirect, which the redirect-less

--- a/tests/src/unit/test_oauth_autoapprove.py
+++ b/tests/src/unit/test_oauth_autoapprove.py
@@ -55,6 +55,9 @@ class _CoreTokenResponse:
     status = 200
     content_type = "application/json"
 
+    def __init__(self, body: bytes = b'{"access_token":"x"}') -> None:
+        self.body = body
+
     async def __aenter__(self):
         return self
 
@@ -62,21 +65,27 @@ class _CoreTokenResponse:
         return None
 
     async def read(self):
-        return b'{"access_token":"x"}'
+        return self.body
 
 
 class _CoreTokenSession:
     """Capture token-forward POSTs and optionally raise a transport error."""
 
-    def __init__(self, *, error: Exception | None = None) -> None:
+    def __init__(
+        self,
+        *,
+        error: Exception | None = None,
+        body: bytes = b'{"access_token":"x"}',
+    ) -> None:
         self.error = error
+        self.body = body
         self.calls = []
 
     def post(self, url, *, data, timeout):
         self.calls.append({"url": url, "data": data, "timeout": timeout})
         if self.error is not None:
             raise self.error
-        return _CoreTokenResponse()
+        return _CoreTokenResponse(self.body)
 
 
 if "yarl" not in sys.modules:
@@ -1058,6 +1067,150 @@ async def test_ha_auth_refresh_loopback_only_dcr_client_gets_invalid_grant(
     assert session.calls == []  # never reached core
 
 
+async def test_ha_auth_refresh_fixed_loopback_dcr_client_forwards_to_core(
+    unified_view_client_factory,
+    monkeypatch,
+):
+    """A fixed loopback registration can reproduce its refresh identity."""
+    session = _CoreTokenSession(
+        body=b'{"access_token":"x","refresh_token":"rotated-refresh"}'
+    )
+    dcr_key = b"d" * 32
+    client_id = oauth_dcr.mint_client_id(
+        dcr_key, ["http://127.0.0.1:19876/mcp/oauth/callback"]
+    )
+    monkeypatch.setattr(
+        oauth_ha_auth,
+        "core_token_base_url",
+        lambda _hass: "https://core.example",
+    )
+    client = await unified_view_client_factory(
+        mode="ha_auth", session=session, dcr_key=dcr_key
+    )
+
+    resp = await client.post(
+        "/api/ha_mcp_tools/oauth/token",
+        data={
+            "grant_type": "refresh_token",
+            "refresh_token": "refresh-1",
+            "client_id": client_id,
+        },
+        allow_redirects=False,
+    )
+
+    assert resp.status == 200
+    assert len(session.calls) == 1
+    assert session.calls[0]["data"]["client_id"] == "http://127.0.0.1:19876"
+    response_body = await resp.json()
+    assert oauth_dcr.unwrap_refresh_token_envelope(
+        dcr_key, client_id, response_body["refresh_token"]
+    ) == ("rotated-refresh", "http://127.0.0.1:19876")
+
+
+@pytest.mark.parametrize(
+    "redirect_uri",
+    [
+        "http://127.0.0.1:19876/mcp/oauth/callback",
+        "http://127.0.0.1:3118/mcp/oauth/callback",
+    ],
+)
+async def test_ha_auth_fixed_loopback_refresh_tracks_authorization_origin(
+    unified_view_client_factory,
+    monkeypatch,
+    redirect_uri,
+):
+    """A signed envelope reproduces the authorization-time loopback origin."""
+    session = _CoreTokenSession(
+        body=b'{"access_token":"x","refresh_token":"refresh-1"}'
+    )
+    dcr_key = b"d" * 32
+    client_id = oauth_dcr.mint_client_id(
+        dcr_key, ["http://127.0.0.1:19876/mcp/oauth/callback"]
+    )
+    monkeypatch.setattr(
+        oauth_ha_auth,
+        "core_token_base_url",
+        lambda _hass: "https://core.example",
+    )
+    client = await unified_view_client_factory(
+        mode="ha_auth", session=session, dcr_key=dcr_key
+    )
+
+    resp = await client.post(
+        "/api/ha_mcp_tools/oauth/token",
+        data={
+            "grant_type": "authorization_code",
+            "code": "code-1",
+            "code_verifier": "verifier-1",
+            "redirect_uri": redirect_uri,
+            "client_id": client_id,
+        },
+        allow_redirects=False,
+    )
+
+    assert resp.status == 200
+    body = await resp.json()
+    envelope = body["refresh_token"]
+    assert envelope != "refresh-1"
+    assert session.calls[0]["data"]["client_id"] == redirect_uri.rsplit("/", 3)[0]
+
+    refresh_data = {
+        "grant_type": "refresh_token",
+        "refresh_token": envelope,
+        "client_id": client_id,
+    }
+    if ":3118/" in redirect_uri:
+        refresh_data["redirect_uri"] = redirect_uri
+    resp = await client.post(
+        "/api/ha_mcp_tools/oauth/token",
+        data=refresh_data,
+        allow_redirects=False,
+    )
+
+    assert resp.status == 200
+    assert session.calls[1]["data"]["refresh_token"] == "refresh-1"
+    assert session.calls[1]["data"]["client_id"] == redirect_uri.rsplit("/", 3)[0]
+    rotated = (await resp.json())["refresh_token"]
+    assert oauth_dcr.unwrap_refresh_token_envelope(dcr_key, client_id, rotated) == (
+        "refresh-1",
+        redirect_uri.rsplit("/", 3)[0],
+    )
+
+
+@pytest.mark.parametrize(
+    "redirect_uri",
+    [
+        "http://127.0.0.1:19876/mcp/oauth/callback",
+        "http://127.0.0.1:99999/mcp/oauth/callback",
+    ],
+)
+async def test_ha_auth_enveloped_refresh_rejects_invalid_redirect(redirect_uri):
+    """A supplied redirect cannot override the envelope's signed origin."""
+    dcr_key = b"d" * 32
+    client_id = oauth_dcr.mint_client_id(
+        dcr_key, ["http://127.0.0.1:19876/mcp/oauth/callback"]
+    )
+    envelope = oauth_dcr.mint_refresh_token_envelope(
+        dcr_key, client_id, "refresh-1", "http://127.0.0.1:3118"
+    )
+
+    translated, core_token, origin, error_description = await aa._refresh_translation(
+        None,
+        dcr_key,
+        client_id,
+        envelope,
+        redirect_uri,
+    )
+
+    assert translated is oauth_ha_auth.RefreshDisposition.UNREPRODUCIBLE
+    assert core_token is None
+    assert origin is None
+    assert error_description == (
+        "re-authorize: redirect_uri does not match this refresh token's signed "
+        "loopback origin"
+    )
+
+
 async def test_ha_auth_refresh_multi_origin_dcr_client_gets_invalid_grant(
     unified_view_client_factory,
 ):
@@ -1089,7 +1242,7 @@ async def test_ha_auth_refresh_multi_origin_dcr_client_gets_invalid_grant(
     assert await resp.json() == {
         "error": "invalid_grant",
         "error_description": "re-authorize: this client's registration has no "
-        "single reproducible web origin, so a refresh without redirect_uri "
+        "single reproducible origin, so a refresh without redirect_uri "
         "is unavailable",
     }
     assert session.calls == []  # never reached core

--- a/tests/src/unit/test_oauth_dcr.py
+++ b/tests/src/unit/test_oauth_dcr.py
@@ -60,6 +60,31 @@ def test_non_dcr_client_id_rejects():
     assert client_redirect_uris(KEY, "hamcp-dcr-notablob") is None
 
 
+def test_refresh_token_envelope_round_trip_and_binding():
+    """Protect the core token and runtime origin with the DCR signing key."""
+    client_id = mint_client_id(KEY, ["http://127.0.0.1:19876/callback"])
+    envelope = oauth_dcr.mint_refresh_token_envelope(
+        KEY,
+        client_id,
+        "core-refresh-token",
+        "http://127.0.0.1:3118",
+    )
+
+    assert oauth_dcr.unwrap_refresh_token_envelope(KEY, client_id, envelope) == (
+        "core-refresh-token",
+        "http://127.0.0.1:3118",
+    )
+    assert (
+        oauth_dcr.unwrap_refresh_token_envelope(OTHER_KEY, client_id, envelope) is None
+    )
+    assert (
+        oauth_dcr.unwrap_refresh_token_envelope(KEY, f"{client_id}x", envelope) is None
+    )
+    assert (
+        oauth_dcr.unwrap_refresh_token_envelope(KEY, client_id, f"{envelope}x") is None
+    )
+
+
 def _module_is(name: str, root: str) -> bool:
     """Return whether a module name is ``root`` or one of its children."""
     return name == root or name.startswith(f"{root}.")
@@ -346,10 +371,32 @@ async def test_register_ha_auth_advertises_refresh_token(dcr_view_client_factory
     ]
 
 
+async def test_register_ha_auth_advertises_refresh_for_fixed_loopback(
+    dcr_view_client_factory,
+):
+    """A loopback callback with an explicit port has a stable refresh origin."""
+    client = await dcr_view_client_factory(
+        dcr_key=KEY,
+        resource_server=object(),
+    )
+
+    resp = await client.post(
+        "/api/ha_mcp_tools/oauth/register",
+        json={"redirect_uris": ["http://127.0.0.1:19876/callback"]},
+    )
+
+    assert resp.status == 201
+    assert (await resp.json())["grant_types"] == [
+        "authorization_code",
+        "refresh_token",
+    ]
+
+
 @pytest.mark.parametrize(
     "redirect_uris",
     [
         ["http://127.0.0.1/callback"],
+        ["http://127.0.0.1:19876/callback", "http://127.0.0.1/callback"],
         ["https://a.example/cb", "http://localhost/callback"],
     ],
 )

--- a/tests/src/unit/test_oauth_ha_auth.py
+++ b/tests/src/unit/test_oauth_ha_auth.py
@@ -53,6 +53,10 @@ def test_redirect_matches_loopback_port_agnostic():
     registered = ["http://localhost/callback", "http://127.0.0.1/callback"]
     assert redirect_matches(registered, "http://localhost:61264/callback")
     assert redirect_matches(registered, "http://127.0.0.1:3118/callback")
+    assert redirect_matches(
+        ["http://127.0.0.1:19876/callback"],
+        "http://127.0.0.1:3118/callback",
+    )
     assert not redirect_matches(registered, "http://localhost:61264/other")
     assert not redirect_matches(registered, "http://localhost:61264/callback?next=1")
     assert not redirect_matches(registered, "http://evil.example:80/callback")
@@ -182,6 +186,20 @@ async def test_refresh_translates_single_origin_dcr_client():
     )
 
     assert translated == "https://a.example"
+
+
+@pytest.mark.asyncio
+async def test_refresh_translates_fixed_loopback_dcr_client():
+    """Re-derive an explicitly ported loopback origin on the refresh leg."""
+    client_id = mint_client_id(KEY, ["http://127.0.0.1:19876/callback"])
+
+    translated = await oauth_ha_auth.translated_client_id_for_refresh(
+        session=None,
+        dcr_key=KEY,
+        client_id=client_id,
+    )
+
+    assert translated == "http://127.0.0.1:19876"
 
 
 @pytest.mark.parametrize(

--- a/tests/src/unit/test_webhook_proxy_oauth_unified.py
+++ b/tests/src/unit/test_webhook_proxy_oauth_unified.py
@@ -160,6 +160,20 @@ async def test_dcr_ha_auth_keeps_reproducible_refresh(oauth_stack):
     ]
 
 
+async def test_dcr_ha_auth_keeps_fixed_loopback_refresh(oauth_stack):
+    """An explicitly ported loopback callback has a stable refresh origin."""
+    oauth, dcr = oauth_stack.oauth, oauth_stack.dcr
+    response = await dcr.DcrRegisterView(_hass(oauth, oauth.MODE_HA_AUTH)).post(
+        _json_request({"redirect_uris": ["http://127.0.0.1:19876/mcp/oauth/callback"]})
+    )
+
+    assert response.status == 201
+    assert response.json_body["grant_types"] == [
+        "authorization_code",
+        "refresh_token",
+    ]
+
+
 async def test_dcr_preserves_explicit_zero_port_origin(oauth_stack):
     """An explicit port zero remains distinct from the HTTPS default port."""
     oauth, dcr = oauth_stack.oauth, oauth_stack.dcr
@@ -210,6 +224,9 @@ def test_cimd_redirect_matching_includes_loopback_port_variance(oauth_stack):
     )
     assert indirect.redirect_matches(
         ["http://localhost/callback"], "http://localhost:61264/callback"
+    )
+    assert indirect.redirect_matches(
+        ["http://localhost:19876/callback"], "http://localhost:61264/callback"
     )
     assert not indirect.redirect_matches(
         ["http://localhost/callback"], "http://localhost:61264/other"
@@ -352,6 +369,16 @@ async def test_mixed_port_shapes_are_unreproducible(oauth_stack, monkeypatch):
     )
 
     assert refresh_id is indirect.RefreshDisposition.UNREPRODUCIBLE
+
+
+async def test_fixed_loopback_refresh_derives_registered_origin(oauth_stack):
+    """A single explicitly ported loopback callback is reproducible."""
+    dcr, indirect = oauth_stack.dcr, oauth_stack.indirect
+    client_id = dcr.mint_client_id(KEY, ["http://127.0.0.1:19876/mcp/oauth/callback"])
+
+    refresh_id = await indirect.translated_client_id_for_refresh(None, KEY, client_id)
+
+    assert refresh_id == "http://127.0.0.1:19876"
 
 
 async def test_symmetric_explicit_port_passes_through_on_both_legs(
@@ -699,6 +726,180 @@ async def test_ha_auth_refresh_rejects_unreproducible_identity_locally(oauth_sta
 
     assert response.status == 400
     assert response.json_body["error"] == "invalid_grant"
+
+
+async def test_ha_auth_refresh_forwards_fixed_loopback_identity(
+    oauth_stack, monkeypatch
+):
+    """A fixed loopback refresh is forwarded with its registered origin."""
+    oauth, dcr, indirect, autoapprove = (
+        oauth_stack.oauth,
+        oauth_stack.dcr,
+        oauth_stack.indirect,
+        oauth_stack.autoapprove,
+    )
+    client_id = dcr.mint_client_id(KEY, ["http://127.0.0.1:19876/mcp/oauth/callback"])
+    core_response = SimpleNamespace(
+        status=200,
+        content_type="application/json",
+        read=AsyncMock(
+            return_value=b'{"access_token":"core","refresh_token":"rotated-refresh"}'
+        ),
+    )
+
+    class _CoreRequest:
+        async def __aenter__(self):
+            return core_response
+
+        async def __aexit__(self, *_args):
+            return False
+
+    relay_session = SimpleNamespace(post=MagicMock(return_value=_CoreRequest()))
+    hass = _hass(oauth, oauth.MODE_HA_AUTH)
+    hass.data[oauth.DOMAIN]["session"] = relay_session
+    monkeypatch.setattr(
+        indirect, "core_token_base_url", lambda _hass: "https://core.example"
+    )
+
+    response = await autoapprove.AutoApproveTokenView(hass).post(
+        _oauth_request(
+            form={
+                "grant_type": "refresh_token",
+                "refresh_token": "opaque",
+                "client_id": client_id,
+            }
+        )
+    )
+
+    assert response.status == 200
+    forwarded = relay_session.post.call_args.kwargs["data"]
+    assert forwarded["client_id"] == "http://127.0.0.1:19876"
+    response_body = json.loads(response.body)
+    assert dcr.unwrap_refresh_token_envelope(
+        KEY, client_id, response_body["refresh_token"]
+    ) == ("rotated-refresh", "http://127.0.0.1:19876")
+
+
+@pytest.mark.parametrize(
+    "redirect_uri",
+    [
+        "http://127.0.0.1:19876/mcp/oauth/callback",
+        "http://127.0.0.1:3118/mcp/oauth/callback",
+    ],
+)
+async def test_fixed_loopback_refresh_tracks_authorization_origin(
+    oauth_stack, monkeypatch, redirect_uri
+):
+    """A signed envelope reproduces the authorization-time loopback origin."""
+    oauth, dcr, indirect, autoapprove = (
+        oauth_stack.oauth,
+        oauth_stack.dcr,
+        oauth_stack.indirect,
+        oauth_stack.autoapprove,
+    )
+    client_id = dcr.mint_client_id(KEY, ["http://127.0.0.1:19876/mcp/oauth/callback"])
+    core_response = SimpleNamespace(
+        status=200,
+        content_type="application/json",
+        read=AsyncMock(
+            return_value=b'{"access_token":"core","refresh_token":"refresh-1"}'
+        ),
+    )
+
+    class _CoreRequest:
+        async def __aenter__(self):
+            return core_response
+
+        async def __aexit__(self, *_args):
+            return False
+
+    relay_session = SimpleNamespace(post=MagicMock(return_value=_CoreRequest()))
+    hass = _hass(oauth, oauth.MODE_HA_AUTH)
+    hass.data[oauth.DOMAIN]["session"] = relay_session
+    monkeypatch.setattr(
+        indirect, "core_token_base_url", lambda _hass: "https://core.example"
+    )
+
+    response = await autoapprove.AutoApproveTokenView(hass).post(
+        _oauth_request(
+            form={
+                "grant_type": "authorization_code",
+                "code": "code-1",
+                "code_verifier": "verifier-1",
+                "redirect_uri": redirect_uri,
+                "client_id": client_id,
+            }
+        )
+    )
+
+    assert response.status == 200
+    body = json.loads(response.body)
+    envelope = body["refresh_token"]
+    assert envelope != "refresh-1"
+    forwarded = relay_session.post.call_args.kwargs["data"]
+    assert forwarded["client_id"] == redirect_uri.rsplit("/", 3)[0]
+
+    refresh_form = {
+        "grant_type": "refresh_token",
+        "refresh_token": envelope,
+        "client_id": client_id,
+    }
+    if ":3118/" in redirect_uri:
+        refresh_form["redirect_uri"] = redirect_uri
+    response = await autoapprove.AutoApproveTokenView(hass).post(
+        _oauth_request(form=refresh_form)
+    )
+
+    assert response.status == 200
+    forwarded = relay_session.post.call_args.kwargs["data"]
+    assert forwarded["refresh_token"] == "refresh-1"
+    assert forwarded["client_id"] == redirect_uri.rsplit("/", 3)[0]
+    rotated = json.loads(response.body)["refresh_token"]
+    assert dcr.unwrap_refresh_token_envelope(KEY, client_id, rotated) == (
+        "refresh-1",
+        redirect_uri.rsplit("/", 3)[0],
+    )
+
+
+@pytest.mark.parametrize(
+    "redirect_uri",
+    [
+        "http://127.0.0.1:19876/mcp/oauth/callback",
+        "http://127.0.0.1:99999/mcp/oauth/callback",
+    ],
+)
+async def test_enveloped_refresh_rejects_invalid_redirect(oauth_stack, redirect_uri):
+    """A supplied redirect cannot override the envelope's signed origin."""
+    dcr, indirect, autoapprove = (
+        oauth_stack.dcr,
+        oauth_stack.indirect,
+        oauth_stack.autoapprove,
+    )
+    client_id = dcr.mint_client_id(KEY, ["http://127.0.0.1:19876/mcp/oauth/callback"])
+    envelope = dcr.mint_refresh_token_envelope(
+        KEY, client_id, "refresh-1", "http://127.0.0.1:3118"
+    )
+
+    (
+        translated,
+        core_token,
+        origin,
+        error_description,
+    ) = await autoapprove._refresh_translation(
+        None,
+        KEY,
+        client_id,
+        envelope,
+        redirect_uri,
+    )
+
+    assert translated is indirect.RefreshDisposition.UNREPRODUCIBLE
+    assert core_token is None
+    assert origin is None
+    assert error_description == (
+        "re-authorize: redirect_uri does not match this refresh token's signed "
+        "loopback origin"
+    )
 
 
 async def test_ha_auth_refresh_with_redirect_translates_presented_origin(


### PR DESCRIPTION
## What does this PR do?

Fixes #2248.

Fixed-port loopback DCR registrations in `ha_auth` mode now advertise and complete refresh-token grants in both the in-process component and the mirrored development Webhook Proxy app.

The narrow design is:

- Explicitly ported loopback registrations become refresh-capable; portless, port-zero, mixed, hybrid, and multi-origin registrations retain their prior behavior.
- Authorization-time loopback redirect matching remains port-agnostic as required by RFC 8252.
- The actual authorization-time loopback origin and the Home Assistant Core refresh token are carried in an HMAC-signed envelope bound to the DCR client ID.
- Refresh unwraps the envelope and forwards the raw Core token using the signed origin.
- Rotated Core refresh tokens are re-enveloped with the same origin.
- Existing raw refresh tokens for exact fixed-port registrations remain compatible and are upgraded if Core rotates them.

Implementation references:

- Component DCR [signed envelope](https://github.com/nikduvall/ha-mcp/blob/befddca54d2d785afac590cb64ee74a260da2b5c/custom_components/ha_mcp_tools/oauth_dcr.py#L98-L156) and [stable-origin/grant advertisement](https://github.com/nikduvall/ha-mcp/blob/befddca54d2d785afac590cb64ee74a260da2b5c/custom_components/ha_mcp_tools/oauth_dcr.py#L207-L285).
- Component token [wrapping, unwrapping, and redirect validation](https://github.com/nikduvall/ha-mcp/blob/befddca54d2d785afac590cb64ee74a260da2b5c/custom_components/ha_mcp_tools/oauth_autoapprove.py#L103-L227) plus [forwarding and rotation](https://github.com/nikduvall/ha-mcp/blob/befddca54d2d785afac590cb64ee74a260da2b5c/custom_components/ha_mcp_tools/oauth_autoapprove.py#L531-L632).
- Component [refresh identity derivation](https://github.com/nikduvall/ha-mcp/blob/befddca54d2d785afac590cb64ee74a260da2b5c/custom_components/ha_mcp_tools/oauth_ha_auth.py#L463-L524).
- Mirrored development proxy [signed envelope and stable origin](https://github.com/nikduvall/ha-mcp/blob/befddca54d2d785afac590cb64ee74a260da2b5c/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/oauth_dcr.py#L86-L214), [token translation and wrapping](https://github.com/nikduvall/ha-mcp/blob/befddca54d2d785afac590cb64ee74a260da2b5c/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/oauth_autoapprove.py#L135-L259), [forwarding and rotation](https://github.com/nikduvall/ha-mcp/blob/befddca54d2d785afac590cb64ee74a260da2b5c/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/oauth_autoapprove.py#L570-L639), and [refresh identity derivation](https://github.com/nikduvall/ha-mcp/blob/befddca54d2d785afac590cb64ee74a260da2b5c/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/oauth_indirect.py#L362-L396).
- Regression coverage for [envelope integrity/client binding and grant advertisement](https://github.com/nikduvall/ha-mcp/blob/befddca54d2d785afac590cb64ee74a260da2b5c/tests/src/unit/test_oauth_dcr.py#L63-L85), [fixed/variable ports, raw-token migration, rotation, and malformed redirects](https://github.com/nikduvall/ha-mcp/blob/befddca54d2d785afac590cb64ee74a260da2b5c/tests/src/unit/test_oauth_autoapprove.py#L1070-L1211), and [mirrored proxy behavior](https://github.com/nikduvall/ha-mcp/blob/befddca54d2d785afac590cb64ee74a260da2b5c/tests/src/unit/test_webhook_proxy_oauth_unified.py#L731-L902).

Issue #2248 was opened before implementation. At the reporter's request, implementation and validation proceeded before maintainer direction was available. A maintainer subsequently noted that they were also working on a fix. This PR remains a draft and is offered for review or comparison; it can be reshaped or closed based on maintainer guidance. This does not claim prior maintainer approval of the design.

A sanitized deployment check against the in-process component passed after a valid configuration check and full Home Assistant restart:

- DCR: HTTP 201 with `authorization_code` and `refresh_token`.
- Initial token exchange: HTTP 200 with access and refresh tokens present.
- Immediate refresh: HTTP 200 with an access token and no OAuth error.
- Core refresh-token revocation: HTTP 200.
- A read-only HA-MCP call succeeded after refresh.

No hostname, credential, OAuth artifact, internal address, or Home Assistant identifier is included. The deployment was a local HACS-managed hotfix and may be overwritten by a future HACS update.

## Type of change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [x] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

Validation completed before deployment:

- Focused OAuth suite: 174 passed.
- Full unit suite: 10,937 passed, 112 expected skips.
- Webhook Proxy app suite: 633 passed, 1 expected skip.
- Remote Docker E2E suite: 1,136 passed, 80 expected skips.
- Ruff, mypy across 214 source files, AST lint, and `git diff --check` passed.

The full unit/app/E2E battery was not repeated after deployment; deployment validation was intentionally limited to configuration/startup health and the single positive authorization, immediate-refresh, and revocation flow above.

Full validation artifacts are retained outside this minimal PR diff:

- [Validation report](https://github.com/nikduvall/ha-mcp/blob/db93dd5eab8aa01e156b3e490d0b71b8ad3fb279/docs/fixed-loopback-oauth-refresh-test-report.md)
- [Suite manifest](https://github.com/nikduvall/ha-mcp/blob/db93dd5eab8aa01e156b3e490d0b71b8ad3fb279/tests/fixed_loopback_oauth_refresh_suite.json)
- [Suite runner](https://github.com/nikduvall/ha-mcp/blob/db93dd5eab8aa01e156b3e490d0b71b8ad3fb279/scripts/run_fixed_loopback_oauth_refresh_tests.py)
- [Sanitized live-flow reproducer](https://github.com/nikduvall/ha-mcp/blob/db93dd5eab8aa01e156b3e490d0b71b8ad3fb279/scripts/reproduce_fixed_loopback_oauth_refresh.py)

## Checklist
- [x] I have updated documentation if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added refresh-token support for OAuth clients using fixed loopback callback ports.
  - Refresh tokens now preserve and validate their authorization origin across token rotation.
  - Added secure handling for refresh tokens, including detection of altered, mismatched, or invalid redirect origins.
  - Runtime loopback ports continue to work when matching registered callbacks.

- **Bug Fixes**
  - Improved refresh-grant handling for clients with stable callback origins.
  - Prevented refresh operations when callback origins are ambiguous or inconsistent.

- **Chores**
  - Updated the development add-on version to 3.0.2.dev2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->