### PR TITLE
docs(internal): drop hardcoded home path from bat-story-eval skill

### DIFF
--- a/.claude/skills/bat-story-eval/SKILL.md
+++ b/.claude/skills/bat-story-eval/SKILL.md
@@ -33,7 +33,7 @@ If `$ARGUMENTS` is `--help` or missing `--baseline`, show usage and stop:
 ### 0a. Compute Diff
 
 ```bash
-cd "$(git rev-parse --show-toplevel)/worktree/uat-stories"
+cd "$(dirname "$(git rev-parse --path-format=absolute --git-common-dir)")/worktree/uat-stories"
 git diff <baseline>..HEAD -- src/ha_mcp/ --stat
 git diff <baseline>..HEAD -- src/ha_mcp/ --name-only
 ```
@@ -112,7 +112,7 @@ For EACH agent, run all stories against the **baseline** version. One container 
 ### 1a. Start container with first story
 
 ```bash
-cd "$(git rev-parse --show-toplevel)/worktree/uat-stories"
+cd "$(dirname "$(git rev-parse --path-format=absolute --git-common-dir)")/worktree/uat-stories"
 uv run python tests/uat/stories/run_story.py \
   catalog/<first_story>.yaml \
   --agents <agent> --keep-container \

--- a/.claude/skills/bat-story-eval/SKILL.md
+++ b/.claude/skills/bat-story-eval/SKILL.md
@@ -33,7 +33,7 @@ If `$ARGUMENTS` is `--help` or missing `--baseline`, show usage and stop:
 ### 0a. Compute Diff
 
 ```bash
-cd /home/julien/github/ha-mcp/worktree/uat-stories
+cd "$(git rev-parse --show-toplevel)/worktree/uat-stories"
 git diff <baseline>..HEAD -- src/ha_mcp/ --stat
 git diff <baseline>..HEAD -- src/ha_mcp/ --name-only
 ```
@@ -112,7 +112,7 @@ For EACH agent, run all stories against the **baseline** version. One container 
 ### 1a. Start container with first story
 
 ```bash
-cd /home/julien/github/ha-mcp/worktree/uat-stories
+cd "$(git rev-parse --show-toplevel)/worktree/uat-stories"
 uv run python tests/uat/stories/run_story.py \
   catalog/<first_story>.yaml \
   --agents <agent> --keep-container \
@@ -370,4 +370,4 @@ Flag >5% total size increase (directly impacts token cost per turn).
 - Reuse containers: first story starts it (`--keep-container`), rest use `--ha-url`
 - Custom story YAMLs go to `/tmp/` (ephemeral); full details reported in Step 6
 - See "Metrics" section in Step 4 for primary vs secondary metric classification
-- The working directory MUST be `/home/julien/github/ha-mcp/worktree/uat-stories` for `uv run`
+- The working directory MUST be the `worktree/uat-stories` worktree root (where `pyproject.toml` lives) for `uv run`

--- a/.claude/skills/bat-story-eval/references/evaluation-protocol.md
+++ b/.claude/skills/bat-story-eval/references/evaluation-protocol.md
@@ -32,7 +32,7 @@ uv run python tests/uat/stories/scripts/ha_query.py \
 Check the exit code first. `ha_query.py` exits non-zero when the agent CLI
 itself failed, and prints `[exit N]` (plus stderr, when there is any) after
 whatever text the CLI managed to produce — `[exit 124]` for a query that hung
-past its timeout. The one non-zero exit without a marker is `Error: <agent>
+past its timeout. The one non-zero exit without a marker is `Error: {agent}
 CLI not found`, which means the agent is not installed: fix the environment
 rather than re-running. A failed query is **not a measurement**: do not score
 it as any of the three outcomes below — re-run it, and if it keeps failing,


### PR DESCRIPTION
## What does this PR do?

Removes a contributor's hardcoded home directory from the `bat-story-eval` skill, and fixes a placeholder that reads as an unclosed XML tag.

- `SKILL.md` (3 sites): `/home/julien/github/ha-mcp/worktree/uat-stories` is gone. The two `cd` commands now resolve the UAT worktree from the repository's common Git directory:

  ```bash
  cd "$(dirname "$(git rev-parse --path-format=absolute --git-common-dir)")/worktree/uat-stories"
  ```

  The Step 7 rule now names the required directory (`worktree/uat-stories`, where `pyproject.toml` lives) instead of one person's absolute path.
- `references/evaluation-protocol.md`: `Error: <agent>` becomes `Error: {agent}`, which also matches the f-string it documents at `tests/uat/stories/scripts/ha_query.py:250`.

The first commit used `git rev-parse --show-toplevel`, which Codex and CodeRabbit both flagged. It returns the *current* worktree's root, so invoking the skill from any worktree (this repo's normal flow) built the nested, nonexistent `<worktree>/worktree/uat-stories`; and because Step 0 leaves the shell in `worktree/uat-stories`, Step 1a doubled the path even from the main checkout. Commit 36983e32 switched to `--git-common-dir`, verified from four positions: main checkout root, a subdirectory of it, a linked worktree root, and a subdirectory of that. `--path-format=absolute` is used so the result is canonical rather than relative to the invoking directory.

Both findings came from running [agnix](https://github.com/agent-sh/agnix) over the repo's agent configs. That evaluation concluded agnix is not worth adding as a CI gate here (4 errors / 110 warnings, with 2 of the errors being false positives against skills that demonstrably load, plus ~40 phantom "missing file" warnings from backticked identifiers), so this PR carries only the two real findings.

## Type of change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [x] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [ ] All automated tests pass (`uv run pytest`)
- [ ] Code follows style guidelines (`uv run ruff check`)

Markdown-only, no Python touched, so the lefthook `ruff` / `unit-tests` / `mypy` steps all reported "no matching staged files". Verified instead by:

- re-running `npx agnix .claude/skills/bat-story-eval`, which now reports 0 errors (the single remaining warning is the intentional unrestricted-`Bash` `allowed-tools` line);
- resolving the `cd` target from all four checkout positions listed above, confirming each lands on the main checkout's `worktree/uat-stories`.

## Checklist
- [x] I have updated documentation if needed
