### PR TITLE
fix(screenshot): re-arm the theme guard for themed captures only

### DIFF
--- a/docs/beta.md
+++ b/docs/beta.md
@@ -178,17 +178,21 @@ page and (by its design) restarts; ha-mcp surfaces this as a clear "set the
 engine's access token" error rather than a silent failure.
 
 Puppet's theme and dark-mode renderer controls dispatch Home Assistant's
-`settheme` event on render, which Home Assistant persists on the frontend
-profile of the user whose token the engine runs with — and syncs to that
-user's real web and mobile sessions, flipping that user's whole UI on every
-screenshot (#1909). ha-mcp brackets each capture batch with a snapshot/restore
-of that user's saved theme, so the flip is undone automatically. The upstream
-Puppet fix for the dispatch (balloob/home-assistant-addons#89) is merged but
-unreleased as of Puppet 2.6.0, and is scoped to renders that request no
-`theme`/`dark` — an explicit theme or dark-mode capture still writes even once
-it ships, so the bracket stays on regardless of engine version. A dedicated
-Puppet account remains a sound belt-and-suspenders setup. Language selection
-is local to Puppet's browser session.
+`settheme` event, which Home Assistant persists on the frontend profile of the
+user whose token the engine runs with — and syncs to that user's real web and
+mobile sessions, flipping that user's whole UI (#1909). Upstream stopped the
+dispatch for renders that request nothing
+(balloob/home-assistant-addons#89), but only for that case: passing `theme` or
+`dark_mode` still writes, on every engine version.
+
+ha-mcp therefore brackets **only themed captures** with a snapshot/restore of
+that user's saved theme, so the flip is undone automatically. Captures that
+request no theme are not bracketed and issue no writes at all, which is what
+keeps `readOnlyHint: True` accurate on the screenshot tools (#1991). Concurrent
+themed captures against the same engine user are serialized so their brackets
+cannot interleave. A dedicated Puppet account remains a sound
+belt-and-suspenders setup. Language selection is local to Puppet's browser
+session.
 
 To change the Puppet engine app's own options (such as `keep_browser_open`)
 or to restart it, use `ha_manage_app`; the screenshot tools only render and

--- a/docs/beta.md
+++ b/docs/beta.md
@@ -177,18 +177,18 @@ token grants. If the token is missing or invalid, Puppet lands on the login
 page and (by its design) restarts; ha-mcp surfaces this as a clear "set the
 engine's access token" error rather than a silent failure.
 
-Puppet's theme and dark-mode renderer controls used to dispatch Home
-Assistant's `settheme` event on every cold render, which Home Assistant
-persisted on the frontend profile of the user whose token the engine runs with
-— and synced to that user's real web and mobile sessions, flipping a dark-mode
-user's whole UI to light on every screenshot (#1909). Recent Puppet versions
-fixed that cold-render dispatch, so ha-mcp's snapshot/restore bracket around
-each capture is now disabled (#1991); the guard code is retained so it can be
-switched back on if a future engine regression reintroduces the write. If you
-run an older Puppet build, update the app (or your self-hosted sidecar
-image) — older engines still persist the theme selection and will keep
-flipping it. A dedicated Puppet account remains a sound belt-and-suspenders
-setup. Language selection is local to Puppet's browser session.
+Puppet's theme and dark-mode renderer controls dispatch Home Assistant's
+`settheme` event on render, which Home Assistant persists on the frontend
+profile of the user whose token the engine runs with — and syncs to that
+user's real web and mobile sessions, flipping that user's whole UI on every
+screenshot (#1909). ha-mcp brackets each capture batch with a snapshot/restore
+of that user's saved theme, so the flip is undone automatically. The upstream
+Puppet fix for the dispatch (balloob/home-assistant-addons#89) is merged but
+unreleased as of Puppet 2.6.0, and is scoped to renders that request no
+`theme`/`dark` — an explicit theme or dark-mode capture still writes even once
+it ships, so the bracket stays on regardless of engine version. A dedicated
+Puppet account remains a sound belt-and-suspenders setup. Language selection
+is local to Puppet's browser session.
 
 To change the Puppet engine app's own options (such as `keep_browser_open`)
 or to restart it, use `ha_manage_app`; the screenshot tools only render and

--- a/src/ha_mcp/dashboard_screenshot/capture.py
+++ b/src/ha_mcp/dashboard_screenshot/capture.py
@@ -858,8 +858,9 @@ async def capture_dashboard_images(
     A batch that requests a theme (``theme`` or ``dark_mode``) is bracketed by
     a :class:`ThemeGuard` that restores the engine user's saved frontend theme
     afterwards, because such renders make Puppet write it (issue #1909).
-    Unthemed batches issue no writes at all. Guard failures are non-fatal and
-    surface through ``capture_warnings``.
+    Unthemed batches issue no writes at all. Snapshot and restore failures
+    surface through ``capture_warnings``. A theme-lock timeout rejects the
+    themed capture to prevent an unserialized render.
     """
     path = _validate_dashboard_path(dashboard_path)
     options = validate_capture_parameters(

--- a/src/ha_mcp/dashboard_screenshot/capture.py
+++ b/src/ha_mcp/dashboard_screenshot/capture.py
@@ -901,7 +901,31 @@ async def capture_dashboard_images(
     guard = ThemeGuard.for_capture(
         engine_target.addon_credential, client, armed=theme_requested
     )
-    await guard.take_snapshot()
+    # Bound the wait by the caller's own render budget: they are already
+    # willing to wait that long, and a themed render can easily hold the
+    # bracket longer than a short fixed timeout.
+    await guard.take_snapshot(lock_timeout=options.render_timeout_seconds)
+    if guard.lock_timed_out:
+        # Rendering unserialized here would reintroduce exactly the interleave
+        # the lock exists to prevent (this batch would snapshot the other
+        # batch's transient theme and restore it afterwards), so fail instead.
+        raise_tool_error(
+            create_error_response(
+                ErrorCode.INTERNAL_ERROR,
+                "Another themed dashboard screenshot is still in progress for "
+                "this screenshot-engine account.",
+                details=(
+                    "Themed captures are serialized so their theme "
+                    "snapshot/restore brackets cannot interleave and strand "
+                    "the account on the wrong theme."
+                ),
+                suggestions=[
+                    "Retry once the in-flight capture finishes.",
+                    "Omit theme/dark_mode to capture without the bracket.",
+                ],
+                context={"path": path},
+            )
+        )
     batch_error: ToolError | None = None
     try:
         async with httpx.AsyncClient(
@@ -984,8 +1008,20 @@ async def capture_dashboard_images(
         # A non-ToolError failure (e.g. raised while entering the HTTP client
         # context) would otherwise bypass _reraise_with_guard_warnings and
         # reach the caller's generic handler with the guard's warnings
-        # dropped. Wrap it so a failed restore stays visible either way.
-        batch_error = ToolError(str(exc) or exc.__class__.__name__)
+        # dropped. It must become a *structured* ToolError: the merge helper
+        # parses the message as JSON and re-raises unchanged when that is not
+        # a dict, so wrapping the bare text would still lose the warnings.
+        logger.exception("Dashboard capture batch failed unexpectedly")
+        batch_error = ToolError(
+            json.dumps(
+                create_error_response(
+                    ErrorCode.INTERNAL_ERROR,
+                    "Dashboard screenshot capture failed unexpectedly.",
+                    details=f"{exc.__class__.__name__}: {exc}",
+                    context={"path": path},
+                )
+            )
+        )
     finally:
         await guard.restore()
         if capture_warnings is not None:

--- a/src/ha_mcp/dashboard_screenshot/capture.py
+++ b/src/ha_mcp/dashboard_screenshot/capture.py
@@ -855,15 +855,9 @@ async def capture_dashboard_images(
     preset's native orientation. ``full_page`` is a compatibility alias for
     requesting the engine's native ``WIDTHxauto`` viewport.
 
-    The batch used to be bracketed by a :class:`ThemeGuard` that restored the
-    engine user's saved frontend theme when a cold render changed it (issue
-    #1909). That bracket is currently disabled (#1991): upstream Puppet no
-    longer dispatches ``settheme`` on cold renders, so there is nothing to undo.
-    The guard construction and the ``client`` / ``capture_warnings`` plumbing
-    are retained so the bracket can be re-enabled by uncommenting the
-    snapshot/restore calls if a future engine regression reintroduces the write;
-    while disabled ``capture_warnings`` simply stays empty and never affects the
-    captures themselves.
+    The batch is bracketed by a :class:`ThemeGuard` that restores the engine
+    user's saved frontend theme when a render changes it (issue #1909). Guard
+    failures are non-fatal and surface through ``capture_warnings``.
     """
     path = _validate_dashboard_path(dashboard_path)
     options = validate_capture_parameters(
@@ -888,16 +882,20 @@ async def capture_dashboard_images(
     mime_type = _MIME_TYPES[options.image_format]
     captures: list[DashboardImageCapture] = []
 
-    # ThemeGuard bracket — currently DISABLED (#1991). Stock Puppet used to
-    # dispatch a theme write into the authenticated frontend on cold renders,
-    # which Home Assistant persisted to the engine user's real profile (#1909);
-    # ha-mcp snapshotted before and restored after to undo it. Upstream Puppet
-    # has since fixed the cold-render settheme dispatch, so the bracket is no
-    # longer needed. The guard is still constructed (and the snapshot/restore
-    # calls kept below, commented out) so it can be re-enabled by uncommenting
-    # if a future engine regression reintroduces the write.
+    # ThemeGuard bracket. Puppet dispatches a ``settheme`` event into the
+    # authenticated frontend, which Home Assistant persists to the engine
+    # user's real profile and syncs to that user's live sessions (#1909).
+    # ha-mcp snapshots the saved theme before the batch and restores it after.
+    #
+    # The bracket was previously disabled on the premise that upstream Puppet
+    # had fixed the dispatch. It had not shipped: the fix
+    # (balloob/home-assistant-addons#89) is merged to that repo's master but
+    # unreleased — the newest Puppet release, 2.6.0, predates it. It is also
+    # scoped to the no-parameter case ("don't dispatch settheme when no
+    # theme/dark was requested"), so an explicit ``theme=``/``dark`` capture
+    # still writes even once it does ship.
     guard = ThemeGuard.for_capture(engine_target.addon_credential, client)
-    # await guard.take_snapshot()
+    await guard.take_snapshot()
     batch_error: ToolError | None = None
     try:
         async with httpx.AsyncClient(
@@ -977,7 +975,7 @@ async def capture_dashboard_images(
         # and its outcome can be attached to the error payload below.
         batch_error = exc
     finally:
-        # await guard.restore()  # ThemeGuard bracket disabled (#1991) — see above.
+        await guard.restore()
         if capture_warnings is not None:
             capture_warnings.extend(guard.warnings)
 

--- a/src/ha_mcp/dashboard_screenshot/capture.py
+++ b/src/ha_mcp/dashboard_screenshot/capture.py
@@ -855,9 +855,11 @@ async def capture_dashboard_images(
     preset's native orientation. ``full_page`` is a compatibility alias for
     requesting the engine's native ``WIDTHxauto`` viewport.
 
-    The batch is bracketed by a :class:`ThemeGuard` that restores the engine
-    user's saved frontend theme when a render changes it (issue #1909). Guard
-    failures are non-fatal and surface through ``capture_warnings``.
+    A batch that requests a theme (``theme`` or ``dark_mode``) is bracketed by
+    a :class:`ThemeGuard` that restores the engine user's saved frontend theme
+    afterwards, because such renders make Puppet write it (issue #1909).
+    Unthemed batches issue no writes at all. Guard failures are non-fatal and
+    surface through ``capture_warnings``.
     """
     path = _validate_dashboard_path(dashboard_path)
     options = validate_capture_parameters(
@@ -882,19 +884,23 @@ async def capture_dashboard_images(
     mime_type = _MIME_TYPES[options.image_format]
     captures: list[DashboardImageCapture] = []
 
-    # ThemeGuard bracket. Puppet dispatches a ``settheme`` event into the
-    # authenticated frontend, which Home Assistant persists to the engine
-    # user's real profile and syncs to that user's live sessions (#1909).
-    # ha-mcp snapshots the saved theme before the batch and restores it after.
+    # ThemeGuard bracket, armed only for renders that request a theme.
     #
-    # The bracket was previously disabled on the premise that upstream Puppet
-    # had fixed the dispatch. It had not shipped: the fix
-    # (balloob/home-assistant-addons#89) is merged to that repo's master but
-    # unreleased — the newest Puppet release, 2.6.0, predates it. It is also
-    # scoped to the no-parameter case ("don't dispatch settheme when no
-    # theme/dark was requested"), so an explicit ``theme=``/``dark`` capture
-    # still writes even once it does ship.
-    guard = ThemeGuard.for_capture(engine_target.addon_credential, client)
+    # Puppet dispatches a ``settheme`` event into the authenticated frontend,
+    # which Home Assistant persists to the engine user's real profile and
+    # syncs to that user's live sessions (#1909). Upstream stopped the
+    # no-parameter dispatch (balloob/home-assistant-addons#89), but that fix
+    # is scoped by its own title — "don't dispatch settheme when no
+    # theme/dark was requested" — so an explicit ``theme=``/``dark`` render
+    # still writes, on every engine version.
+    #
+    # Arming only that path keeps unthemed captures free of any write, which
+    # is what makes ``readOnlyHint: True`` honest for the overwhelmingly
+    # common case (#1991, PR #2014).
+    theme_requested = options.theme is not None or options.dark_mode
+    guard = ThemeGuard.for_capture(
+        engine_target.addon_credential, client, armed=theme_requested
+    )
     await guard.take_snapshot()
     batch_error: ToolError | None = None
     try:
@@ -974,6 +980,12 @@ async def capture_dashboard_images(
         # Held (not re-raised here) so the restore in ``finally`` runs first
         # and its outcome can be attached to the error payload below.
         batch_error = exc
+    except Exception as exc:
+        # A non-ToolError failure (e.g. raised while entering the HTTP client
+        # context) would otherwise bypass _reraise_with_guard_warnings and
+        # reach the caller's generic handler with the guard's warnings
+        # dropped. Wrap it so a failed restore stays visible either way.
+        batch_error = ToolError(str(exc) or exc.__class__.__name__)
     finally:
         await guard.restore()
         if capture_warnings is not None:

--- a/src/ha_mcp/dashboard_screenshot/theme_guard.py
+++ b/src/ha_mcp/dashboard_screenshot/theme_guard.py
@@ -78,10 +78,11 @@ RESTORE_SETTLE_SECONDS = 1.0
 # returning an image.
 COMMAND_TIMEOUT_SECONDS = 5.0
 
-# Longest a batch waits for another batch's bracket to finish. The guard is
-# best-effort, so a wedged holder must degrade to an unguarded render rather
-# than block the capture indefinitely.
-LOCK_WAIT_SECONDS = 5.0
+# Fallback bound on waiting for another batch's bracket, used when the caller
+# supplies no render budget of its own. Callers should pass their render
+# timeout: a themed render routinely holds the bracket for its whole duration,
+# and giving up early would strand the capture.
+LOCK_WAIT_SECONDS = 60.0
 
 # Snapshot-through-restore must be serialized per engine user. Two concurrent
 # batches would otherwise interleave as: A renders and clobbers dark->light,
@@ -176,6 +177,7 @@ class ThemeGuard:
     _snapshot: Any = None
     _snapshot_taken: bool = False
     _lock: Any = None
+    lock_timed_out: bool = False
 
     @classmethod
     def for_capture(
@@ -234,27 +236,34 @@ class ThemeGuard:
         payload = response.get("result") if isinstance(response, dict) else None
         return payload.get("value") if isinstance(payload, dict) else None
 
-    async def take_snapshot(self) -> None:
+    async def take_snapshot(self, *, lock_timeout: float | None = None) -> None:
         """Record the saved theme before the engine renders. Never raises.
 
         Holds the per-engine-user lock until :meth:`restore` releases it, so
-        two overlapping batches cannot interleave snapshot and restore.
+        two overlapping batches cannot interleave snapshot and restore. When
+        the lock cannot be acquired within ``lock_timeout`` this sets
+        :attr:`lock_timed_out` and takes no snapshot; the caller must then
+        abandon the render rather than proceed unserialized, since an
+        unserialized themed batch is precisely the interleave the lock exists
+        to prevent.
         """
         if self.credential is None:
             return
         # Acquired before the read so the whole snapshot->render->restore
         # window is exclusive for this engine user.
         lock = _engine_lock(self.credential)
+        timeout = LOCK_WAIT_SECONDS if lock_timeout is None else lock_timeout
         try:
-            await asyncio.wait_for(lock.acquire(), timeout=LOCK_WAIT_SECONDS)
+            await asyncio.wait_for(lock.acquire(), timeout=timeout)
             self._lock = lock
         except TimeoutError:
-            # Proceed unguarded rather than stall the render; the concurrent
-            # batch holding the lock is doing its own restore.
             logger.warning(
-                "Timed out waiting for another screenshot batch's theme "
-                "bracket; rendering without serialization"
+                "Timed out after %ss waiting for another screenshot batch's "
+                "theme bracket for this engine user",
+                timeout,
             )
+            self.lock_timed_out = True
+            return
         try:
             async with self._session() as ws:
                 self._snapshot = await self._fetch_theme(ws)

--- a/src/ha_mcp/dashboard_screenshot/theme_guard.py
+++ b/src/ha_mcp/dashboard_screenshot/theme_guard.py
@@ -1,17 +1,20 @@
 """Snapshot and restore the engine user's saved frontend theme (issue #1909).
 
-Puppet dispatches Home Assistant's ``settheme`` event on every
-cold-browser render — its ``dark`` query flag is presence-based, so "not
-requested" reaches the frontend as an explicit "light". Home Assistant
-persists that selection server-side per user (``frontend/set_user_data``,
-key ``"theme"``) and syncs it to every session of the user whose long-lived
-token the engine runs with. A plain screenshot call therefore flips a
-dark-mode user's real web and mobile UI to light.
+Puppet dispatches Home Assistant's ``settheme`` event for renders that ask
+for a theme. Home Assistant persists that selection server-side per user
+(``frontend/set_user_data``, key ``"theme"``) and syncs it to every session
+of the user whose long-lived token the engine runs with, so such a
+screenshot flips that user's real web and mobile UI.
 
-ha-mcp cannot suppress the engine's write, so every capture batch is
+Upstream stopped the dispatch for renders that request nothing
+(balloob/home-assistant-addons#89), but by its own title only for that case —
+an explicit ``theme=``/``dark`` render still writes on every engine version.
+
+ha-mcp cannot suppress the engine's write, so themed capture batches are
 bracketed instead: read the engine user's saved theme before rendering and
 write it back afterwards when the render changed it (an unchanged value is
-never rewritten).
+never rewritten). Unthemed batches are not bracketed and issue no writes,
+keeping the screenshot tools honestly read-only (#1991).
 
 Credential resolution mirrors engine discovery:
 
@@ -69,6 +72,39 @@ _RESTORE_HINT = (
 # restore, and let the late write survive).
 RESTORE_SETTLE_SECONDS = 1.0
 
+# The guard is best-effort and runs *before* the engine is contacted, so it
+# must never eat the caller's MCP timeout window. send_command defaults to a
+# 30s wait; a guard that hangs that long would stop a healthy engine ever
+# returning an image.
+COMMAND_TIMEOUT_SECONDS = 5.0
+
+# Longest a batch waits for another batch's bracket to finish. The guard is
+# best-effort, so a wedged holder must degrade to an unguarded render rather
+# than block the capture indefinitely.
+LOCK_WAIT_SECONDS = 5.0
+
+# Snapshot-through-restore must be serialized per engine user. Two concurrent
+# batches would otherwise interleave as: A renders and clobbers dark->light,
+# B snapshots that transient light, A restores dark, B restores light —
+# leaving the user permanently on the clobbered value.
+#
+# Keyed by running event loop as well as engine user: an asyncio.Lock binds
+# to the loop that first awaits it and raises if reused from another, so a
+# process-global-by-credential dict would break any second loop (and leaks
+# into unit tests, which get a fresh loop each). The server runs one loop, so
+# in production this holds exactly one entry per engine user.
+_ENGINE_LOCKS: dict[tuple[int, str, str], asyncio.Lock] = {}
+
+
+def _engine_lock(credential: EngineCredential) -> asyncio.Lock:
+    """Return this loop's lock for one engine user."""
+    key = (id(asyncio.get_running_loop()), credential.url, credential.token)
+    lock = _ENGINE_LOCKS.get(key)
+    if lock is None:
+        lock = asyncio.Lock()
+        _ENGINE_LOCKS[key] = lock
+    return lock
+
 
 @dataclass(frozen=True, slots=True)
 class EngineCredential:
@@ -82,6 +118,7 @@ class EngineCredential:
 
     url: str
     token: str
+    verify_ssl: bool | None = None
 
 
 def addon_credential_from_options(
@@ -113,7 +150,16 @@ def _client_credential(client: Any) -> EngineCredential | None:
     token = str(getattr(client, "token", "") or "").strip()
     if not base_url.startswith(("http://", "https://")) or not token:
         return None
-    return EngineCredential(url=base_url, token=token)
+    # Carry the client's own TLS setting: a direct client built with
+    # verify_ssl=False (self-signed HA) must not fall back to the global
+    # default here, or every guard session fails and the theme stays
+    # clobbered while the render itself succeeds.
+    verify_ssl = getattr(client, "verify_ssl", None)
+    return EngineCredential(
+        url=base_url,
+        token=token,
+        verify_ssl=verify_ssl if isinstance(verify_ssl, bool) else None,
+    )
 
 
 @dataclass
@@ -129,14 +175,24 @@ class ThemeGuard:
     warnings: list[str] = field(default_factory=list)
     _snapshot: Any = None
     _snapshot_taken: bool = False
+    _lock: Any = None
 
     @classmethod
     def for_capture(
         cls,
         addon_credential: EngineCredential | None,
         client: Any,
+        *,
+        armed: bool = True,
     ) -> ThemeGuard:
-        """Resolve the engine user's credential for one capture batch."""
+        """Resolve the engine user's credential for one capture batch.
+
+        ``armed=False`` yields an inert guard: Puppet only writes the theme
+        for renders that request one, so unthemed captures need no bracket
+        and stay free of any write (#1991).
+        """
+        if not armed:
+            return cls(credential=None)
         credential = addon_credential or _client_credential(client)
         if credential is None:
             logger.debug(
@@ -151,7 +207,11 @@ class ThemeGuard:
         from ..client.websocket_client import HomeAssistantWebSocketClient
 
         assert self.credential is not None
-        ws = HomeAssistantWebSocketClient(self.credential.url, self.credential.token)
+        ws = HomeAssistantWebSocketClient(
+            self.credential.url,
+            self.credential.token,
+            verify_ssl=self.credential.verify_ssl,
+        )
         if not await ws.connect():
             reason = ws.last_connect_error
             detail = f": {reason}" if isinstance(reason, str) else ""
@@ -167,15 +227,34 @@ class ThemeGuard:
     async def _fetch_theme(ws: HomeAssistantWebSocketClient) -> Any:
         """Read the persisted ``theme`` frontend user-data value (may be None)."""
         response = await ws.send_command(
-            "frontend/get_user_data", key=THEME_USER_DATA_KEY
+            "frontend/get_user_data",
+            key=THEME_USER_DATA_KEY,
+            _wait_timeout=COMMAND_TIMEOUT_SECONDS,
         )
         payload = response.get("result") if isinstance(response, dict) else None
         return payload.get("value") if isinstance(payload, dict) else None
 
     async def take_snapshot(self) -> None:
-        """Record the saved theme before the engine renders. Never raises."""
+        """Record the saved theme before the engine renders. Never raises.
+
+        Holds the per-engine-user lock until :meth:`restore` releases it, so
+        two overlapping batches cannot interleave snapshot and restore.
+        """
         if self.credential is None:
             return
+        # Acquired before the read so the whole snapshot->render->restore
+        # window is exclusive for this engine user.
+        lock = _engine_lock(self.credential)
+        try:
+            await asyncio.wait_for(lock.acquire(), timeout=LOCK_WAIT_SECONDS)
+            self._lock = lock
+        except TimeoutError:
+            # Proceed unguarded rather than stall the render; the concurrent
+            # batch holding the lock is doing its own restore.
+            logger.warning(
+                "Timed out waiting for another screenshot batch's theme "
+                "bracket; rendering without serialization"
+            )
         try:
             async with self._session() as ws:
                 self._snapshot = await self._fetch_theme(ws)
@@ -190,10 +269,20 @@ class ThemeGuard:
                 "Could not read the screenshot engine user's saved frontend "
                 f"theme before rendering; if the render changed it, {_RESTORE_HINT}."
             )
+            # Nothing to restore, so do not hold the lock across the render.
+            self._release_lock()
+
+    def _release_lock(self) -> None:
+        """Drop the per-engine lock if this guard holds it."""
+        lock = self._lock
+        self._lock = None
+        if lock is not None and lock.locked():
+            lock.release()
 
     async def restore(self) -> None:
         """Write the snapshot back if the render changed it. Never raises."""
         if not self._snapshot_taken or self.credential is None:
+            self._release_lock()
             return
         try:
             # Puppet's settheme dispatch happens during page navigation, but
@@ -214,6 +303,7 @@ class ThemeGuard:
                         "frontend/set_user_data",
                         key=THEME_USER_DATA_KEY,
                         value=restore_value,
+                        _wait_timeout=COMMAND_TIMEOUT_SECONDS,
                     )
         except Exception as exc:
             logger.warning(
@@ -226,3 +316,5 @@ class ThemeGuard:
                 "theme of the engine token's user and restoring it failed; "
                 f"{_RESTORE_HINT}."
             )
+        finally:
+            self._release_lock()

--- a/src/ha_mcp/dashboard_screenshot/theme_guard.py
+++ b/src/ha_mcp/dashboard_screenshot/theme_guard.py
@@ -1,12 +1,6 @@
 """Snapshot and restore the engine user's saved frontend theme (issue #1909).
 
-NOTE: This guard is currently disabled at its call site (``capture.py``)
-because upstream Puppet fixed the cold-render ``settheme`` dispatch that made
-the bracket necessary (#1991). The code here is retained unchanged so the
-bracket can be re-enabled by uncommenting the snapshot/restore calls in
-``capture.py`` if a future engine regression reintroduces the write.
-
-Stock Puppet dispatches Home Assistant's ``settheme`` event on every
+Puppet dispatches Home Assistant's ``settheme`` event on every
 cold-browser render — its ``dark`` query flag is presence-based, so "not
 requested" reaches the frontend as an explicit "light". Home Assistant
 persists that selection server-side per user (``frontend/set_user_data``,

--- a/src/ha_mcp/dashboard_screenshot/theme_guard.py
+++ b/src/ha_mcp/dashboard_screenshot/theme_guard.py
@@ -278,8 +278,14 @@ class ThemeGuard:
                 "Could not read the screenshot engine user's saved frontend "
                 f"theme before rendering; if the render changed it, {_RESTORE_HINT}."
             )
-            # Nothing to restore, so do not hold the lock across the render.
-            self._release_lock()
+        finally:
+            if not self._snapshot_taken:
+                # Nothing to restore, so never hold the lock across the
+                # render. This lives in ``finally`` rather than the ``except``
+                # because asyncio.CancelledError is a BaseException: a
+                # cancellation mid-session would otherwise strand the lock and
+                # time out every later themed capture.
+                self._release_lock()
 
     def _release_lock(self) -> None:
         """Drop the per-engine lock if this guard holds it."""

--- a/tests/src/unit/test_dashboard_screenshot_theme_guard.py
+++ b/tests/src/unit/test_dashboard_screenshot_theme_guard.py
@@ -5,13 +5,10 @@ Assistant persisted it server-side on the engine token user's profile —
 flipping that user's real sessions to light mode. The guard snapshots the
 saved theme before a capture batch and restores it afterwards.
 
-The capture-time bracket is currently DISABLED (#1991): upstream Puppet fixed
-the cold-render dispatch, so ``capture.py`` no longer calls the guard's
-snapshot/restore. The guard code itself is retained (and unchanged), so the
-unit tests below still cover its credential resolution and snapshot/restore
-semantics against a fake WebSocket client. ``TestCaptureBracketDisabled``
-asserts the bracket stays off — capture opens no guard sessions and adds no
-warnings — guarding against a silent re-enable.
+These cover the guard's credential resolution and snapshot/restore semantics
+against a fake WebSocket client, plus ``TestCaptureBracket``, which asserts
+``capture.py`` actually brackets each batch — guarding against the bracket
+being silently disabled again.
 """
 
 from __future__ import annotations
@@ -366,13 +363,18 @@ def _patch_engine(monkeypatch: Any, addon_credential: EngineCredential | None) -
     _ClobberingEngineClient.status_code = 200
 
 
-class TestCaptureBracketDisabled:
-    """The ThemeGuard bracket around capture_dashboard_images is DISABLED
-    (#1991). Upstream Puppet no longer clobbers the theme on cold renders, so
-    ha-mcp opens no snapshot/restore sessions and adds no guard warnings. These
-    guard against the bracket being silently re-enabled."""
+class TestCaptureBracket:
+    """The ThemeGuard bracket around ``capture_dashboard_images`` is ENABLED.
 
-    async def test_capture_opens_no_guard_sessions_and_leaves_theme(
+    Puppet dispatches a ``settheme`` event on render, which Home Assistant
+    persists onto the engine token user's profile (#1909), so every capture
+    batch snapshots the saved theme before and restores it after. The bracket
+    was once disabled on the premise that upstream Puppet had fixed the
+    dispatch; that fix (balloob/home-assistant-addons#89) is unreleased and is
+    scoped to the no-parameter case, so the bracket stays on.
+    """
+
+    async def test_capture_restores_theme_clobbered_by_the_render(
         self, monkeypatch: Any
     ) -> None:
         from ha_mcp.dashboard_screenshot import capture
@@ -386,19 +388,19 @@ class TestCaptureBracketDisabled:
         )
 
         assert captures[0].data == _PNG
-        # No snapshot/restore WebSocket sessions were opened.
-        assert _FakeWsClient.instances == []
-        # The bracket did not run: the fake engine still simulates the old
-        # clobber, and ha-mcp no longer undoes it (real Puppet no longer
-        # causes it).
-        assert _FakeWsClient.user_data[THEME_USER_DATA_KEY] == _CLOBBERED_THEME
+        # Snapshot and restore each opened a session as the engine user.
+        assert [(ws.url, ws.token) for ws in _FakeWsClient.instances] == [
+            ("http://homeassistant:8123", "puppet-token"),
+            ("http://homeassistant:8123", "puppet-token"),
+        ]
+        # The fake engine clobbered the stored theme; the bracket undid it.
+        assert _FakeWsClient.user_data[THEME_USER_DATA_KEY] == _DARK_THEME
         assert capture_warnings == []
 
-    async def test_client_credential_fallback_opens_no_guard_sessions(
+    async def test_client_credential_fallback_restores_theme(
         self, monkeypatch: Any
     ) -> None:
-        """Sidecar/standalone mode: even with a usable client credential the
-        disabled bracket opens no guard sessions."""
+        """Sidecar/standalone mode: the client credential drives the bracket."""
         from ha_mcp.dashboard_screenshot import capture
 
         _patch_engine(monkeypatch, None)
@@ -409,11 +411,14 @@ class TestCaptureBracketDisabled:
         )
 
         assert captures[0].data == _PNG
-        assert _FakeWsClient.instances == []
+        assert [(ws.url, ws.token) for ws in _FakeWsClient.instances] == [
+            ("http://ha.local:8123", "own-token"),
+            ("http://ha.local:8123", "own-token"),
+        ]
+        assert _FakeWsClient.user_data[THEME_USER_DATA_KEY] == _DARK_THEME
 
-    async def test_capture_failure_raises_without_guard_warnings(
-        self, monkeypatch: Any
-    ) -> None:
+    async def test_capture_failure_still_restores_theme(self, monkeypatch: Any) -> None:
+        """A failed render must not leave the engine user's theme clobbered."""
         import json
 
         from ha_mcp.dashboard_screenshot import capture
@@ -425,8 +430,8 @@ class TestCaptureBracketDisabled:
         with pytest.raises(ToolError) as exc_info:
             await capture.capture_dashboard_images("lovelace/0")
 
-        # No guard sessions opened, and no guard warning on the error payload.
-        assert _FakeWsClient.instances == []
+        # The restore in the ``finally`` ran before the error surfaced.
+        assert _FakeWsClient.user_data[THEME_USER_DATA_KEY] == _DARK_THEME
         payload = json.loads(str(exc_info.value))
         assert not any(
             "restoring it failed" in warning for warning in payload.get("warnings", [])

--- a/tests/src/unit/test_dashboard_screenshot_theme_guard.py
+++ b/tests/src/unit/test_dashboard_screenshot_theme_guard.py
@@ -543,6 +543,46 @@ class TestGuardHardening:
 
         assert _FakeWsClient.user_data[THEME_USER_DATA_KEY] == _DARK_THEME
 
+    async def test_lock_timeout_takes_no_snapshot(self) -> None:
+        """A contended bracket must not silently render unserialized."""
+        _FakeWsClient.user_data[THEME_USER_DATA_KEY] = dict(_DARK_THEME)
+        holder = ThemeGuard.for_capture(_PUPPET_CREDENTIAL, None)
+        await holder.take_snapshot()
+
+        blocked = ThemeGuard.for_capture(_PUPPET_CREDENTIAL, None)
+        await blocked.take_snapshot(lock_timeout=0.01)
+
+        assert blocked.lock_timed_out is True
+        assert blocked._snapshot_taken is False
+        # It never opened a session, so it cannot restore a transient value.
+        assert len(_FakeWsClient.instances) == 1
+        await holder.restore()
+
+    async def test_timed_out_batch_is_refused_rather_than_rendered(
+        self, monkeypatch: Any
+    ) -> None:
+        """Regression: the saved theme survives a contended themed capture."""
+        from ha_mcp.dashboard_screenshot import capture
+
+        _patch_engine(monkeypatch, _PUPPET_CREDENTIAL)
+        _FakeWsClient.user_data[THEME_USER_DATA_KEY] = dict(_DARK_THEME)
+        holder = ThemeGuard.for_capture(_PUPPET_CREDENTIAL, None)
+        await holder.take_snapshot()
+
+        # MIN_RENDER_TIMEOUT_SECONDS is 1.0, so this is the shortest budget
+        # the validator accepts; anything lower would fail validation instead
+        # and make this test pass for the wrong reason.
+        with pytest.raises(ToolError) as exc_info:
+            await capture.capture_dashboard_images(
+                "lovelace/0", dark_mode=True, render_timeout_seconds=1.0
+            )
+        assert "still in progress" in str(exc_info.value)
+
+        # The refused batch never rendered, so nothing clobbered the theme.
+        assert _FakeWsClient.user_data[THEME_USER_DATA_KEY] == _DARK_THEME
+        await holder.restore()
+        assert _FakeWsClient.user_data[THEME_USER_DATA_KEY] == _DARK_THEME
+
     async def test_failed_snapshot_does_not_hold_the_lock(self) -> None:
         _FakeWsClient.fail_get = True
         guard = ThemeGuard.for_capture(_PUPPET_CREDENTIAL, None)

--- a/tests/src/unit/test_dashboard_screenshot_theme_guard.py
+++ b/tests/src/unit/test_dashboard_screenshot_theme_guard.py
@@ -583,6 +583,29 @@ class TestGuardHardening:
         await holder.restore()
         assert _FakeWsClient.user_data[THEME_USER_DATA_KEY] == _DARK_THEME
 
+    async def test_cancelled_snapshot_releases_the_lock(self, monkeypatch: Any) -> None:
+        """CancelledError is a BaseException and must not strand the lock."""
+        started = asyncio.Event()
+
+        async def hang(_ws: Any) -> Any:
+            started.set()
+            await asyncio.sleep(3600)
+
+        monkeypatch.setattr(ThemeGuard, "_fetch_theme", staticmethod(hang))
+        guard = ThemeGuard.for_capture(_PUPPET_CREDENTIAL, None)
+        task = asyncio.ensure_future(guard.take_snapshot())
+        await asyncio.wait_for(started.wait(), timeout=1)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        monkeypatch.undo()
+        _FakeWsClient.user_data[THEME_USER_DATA_KEY] = dict(_DARK_THEME)
+        other = ThemeGuard.for_capture(_PUPPET_CREDENTIAL, None)
+        await asyncio.wait_for(other.take_snapshot(lock_timeout=1), timeout=2)
+        assert other.lock_timed_out is False
+        await other.restore()
+
     async def test_failed_snapshot_does_not_hold_the_lock(self) -> None:
         _FakeWsClient.fail_get = True
         guard = ThemeGuard.for_capture(_PUPPET_CREDENTIAL, None)

--- a/tests/src/unit/test_dashboard_screenshot_theme_guard.py
+++ b/tests/src/unit/test_dashboard_screenshot_theme_guard.py
@@ -591,19 +591,27 @@ class TestGuardHardening:
             started.set()
             await asyncio.sleep(3600)
 
-        monkeypatch.setattr(ThemeGuard, "_fetch_theme", staticmethod(hang))
-        guard = ThemeGuard.for_capture(_PUPPET_CREDENTIAL, None)
-        task = asyncio.ensure_future(guard.take_snapshot())
-        await asyncio.wait_for(started.wait(), timeout=1)
-        task.cancel()
-        with pytest.raises(asyncio.CancelledError):
-            await task
+        # Scoped so undoing the hang leaves the autouse fixture's
+        # HomeAssistantWebSocketClient patch in place; a blanket
+        # monkeypatch.undo() would drop it and let the second snapshot reach
+        # a real client, turning this into a connection-warning test.
+        with monkeypatch.context() as patched:
+            patched.setattr(ThemeGuard, "_fetch_theme", staticmethod(hang))
+            guard = ThemeGuard.for_capture(_PUPPET_CREDENTIAL, None)
+            task = asyncio.ensure_future(guard.take_snapshot())
+            await asyncio.wait_for(started.wait(), timeout=1)
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
 
-        monkeypatch.undo()
         _FakeWsClient.user_data[THEME_USER_DATA_KEY] = dict(_DARK_THEME)
         other = ThemeGuard.for_capture(_PUPPET_CREDENTIAL, None)
         await asyncio.wait_for(other.take_snapshot(lock_timeout=1), timeout=2)
         assert other.lock_timed_out is False
+        # Proves it really snapshotted through the fake client rather than
+        # degrading to a connection warning.
+        assert other.warnings == []
+        assert other._snapshot == _DARK_THEME
         await other.restore()
 
     async def test_failed_snapshot_does_not_hold_the_lock(self) -> None:

--- a/tests/src/unit/test_dashboard_screenshot_theme_guard.py
+++ b/tests/src/unit/test_dashboard_screenshot_theme_guard.py
@@ -538,7 +538,9 @@ class TestGuardHardening:
 
         _FakeWsClient.user_data[THEME_USER_DATA_KEY] = dict(_CLOBBERED_THEME)
         await first.restore()
-        await pending
+        # Bound to a name: a bare `await <name>` statement is what CodeQL's
+        # py/ineffectual-statement flags.
+        assert await pending is None
         await second.restore()
 
         assert _FakeWsClient.user_data[THEME_USER_DATA_KEY] == _DARK_THEME
@@ -602,7 +604,7 @@ class TestGuardHardening:
             await asyncio.wait_for(started.wait(), timeout=1)
             task.cancel()
             with pytest.raises(asyncio.CancelledError):
-                await task
+                _ = await task
 
         _FakeWsClient.user_data[THEME_USER_DATA_KEY] = dict(_DARK_THEME)
         other = ThemeGuard.for_capture(_PUPPET_CREDENTIAL, None)

--- a/tests/src/unit/test_dashboard_screenshot_theme_guard.py
+++ b/tests/src/unit/test_dashboard_screenshot_theme_guard.py
@@ -13,6 +13,7 @@ being silently disabled again.
 
 from __future__ import annotations
 
+import asyncio
 from collections.abc import AsyncIterator
 from types import SimpleNamespace
 from typing import Any, ClassVar
@@ -50,6 +51,7 @@ class _FakeWsClient:
     def __init__(self, url: str, token: str, verify_ssl: Any = None) -> None:
         self.url = url
         self.token = token
+        self.verify_ssl = verify_ssl
         self.commands: list[dict[str, Any]] = []
         self.disconnected = False
         self.last_connect_error: str | None = None
@@ -195,6 +197,7 @@ class TestSnapshotRestore:
         assert [(ws.url, ws.token) for ws in _FakeWsClient.instances] == [
             ("http://homeassistant:8123", "puppet-token")
         ]
+        await guard.restore()
 
     async def test_restore_skips_write_when_unchanged(self) -> None:
         _FakeWsClient.user_data[THEME_USER_DATA_KEY] = dict(_DARK_THEME)
@@ -364,19 +367,20 @@ def _patch_engine(monkeypatch: Any, addon_credential: EngineCredential | None) -
 
 
 class TestCaptureBracket:
-    """The ThemeGuard bracket around ``capture_dashboard_images`` is ENABLED.
+    """The ThemeGuard bracket is armed only for renders that request a theme.
 
-    Puppet dispatches a ``settheme`` event on render, which Home Assistant
-    persists onto the engine token user's profile (#1909), so every capture
-    batch snapshots the saved theme before and restores it after. The bracket
-    was once disabled on the premise that upstream Puppet had fixed the
-    dispatch; that fix (balloob/home-assistant-addons#89) is unreleased and is
-    scoped to the no-parameter case, so the bracket stays on.
+    Puppet writes the engine token user's saved theme when a render asks for
+    one (#1909); upstream stopped only the no-parameter dispatch
+    (balloob/home-assistant-addons#89), so themed renders still write on every
+    engine version. Unthemed captures are therefore left unbracketed and issue
+    no writes at all, which is what keeps ``readOnlyHint: True`` honest on the
+    screenshot tools (#1991, PR #2014).
     """
 
-    async def test_capture_restores_theme_clobbered_by_the_render(
+    async def test_unthemed_capture_opens_no_guard_sessions(
         self, monkeypatch: Any
     ) -> None:
+        """The read-only guarantee: no theme requested means no writes."""
         from ha_mcp.dashboard_screenshot import capture
 
         _patch_engine(monkeypatch, _PUPPET_CREDENTIAL)
@@ -388,14 +392,44 @@ class TestCaptureBracket:
         )
 
         assert captures[0].data == _PNG
+        assert _FakeWsClient.instances == []
+        assert _set_calls() == []
+        assert capture_warnings == []
+
+    async def test_dark_mode_capture_restores_the_clobbered_theme(
+        self, monkeypatch: Any
+    ) -> None:
+        from ha_mcp.dashboard_screenshot import capture
+
+        _patch_engine(monkeypatch, _PUPPET_CREDENTIAL)
+        _FakeWsClient.user_data[THEME_USER_DATA_KEY] = dict(_DARK_THEME)
+        capture_warnings: list[str] = []
+
+        captures = await capture.capture_dashboard_images(
+            "lovelace/0", dark_mode=True, capture_warnings=capture_warnings
+        )
+
+        assert captures[0].data == _PNG
         # Snapshot and restore each opened a session as the engine user.
         assert [(ws.url, ws.token) for ws in _FakeWsClient.instances] == [
             ("http://homeassistant:8123", "puppet-token"),
             ("http://homeassistant:8123", "puppet-token"),
         ]
-        # The fake engine clobbered the stored theme; the bracket undid it.
         assert _FakeWsClient.user_data[THEME_USER_DATA_KEY] == _DARK_THEME
         assert capture_warnings == []
+
+    async def test_explicit_theme_capture_restores_the_clobbered_theme(
+        self, monkeypatch: Any
+    ) -> None:
+        from ha_mcp.dashboard_screenshot import capture
+
+        _patch_engine(monkeypatch, _PUPPET_CREDENTIAL)
+        _FakeWsClient.user_data[THEME_USER_DATA_KEY] = dict(_DARK_THEME)
+
+        captures = await capture.capture_dashboard_images("lovelace/0", theme="shadow")
+
+        assert captures[0].data == _PNG
+        assert _FakeWsClient.user_data[THEME_USER_DATA_KEY] == _DARK_THEME
 
     async def test_client_credential_fallback_restores_theme(
         self, monkeypatch: Any
@@ -407,7 +441,7 @@ class TestCaptureBracket:
         _FakeWsClient.user_data[THEME_USER_DATA_KEY] = dict(_DARK_THEME)
 
         captures = await capture.capture_dashboard_images(
-            "lovelace/0", client=_client()
+            "lovelace/0", dark_mode=True, client=_client()
         )
 
         assert captures[0].data == _PNG
@@ -428,7 +462,7 @@ class TestCaptureBracket:
         _ClobberingEngineClient.status_code = 500
 
         with pytest.raises(ToolError) as exc_info:
-            await capture.capture_dashboard_images("lovelace/0")
+            await capture.capture_dashboard_images("lovelace/0", dark_mode=True)
 
         # The restore in the ``finally`` ran before the error surfaced.
         assert _FakeWsClient.user_data[THEME_USER_DATA_KEY] == _DARK_THEME
@@ -436,3 +470,86 @@ class TestCaptureBracket:
         assert not any(
             "restoring it failed" in warning for warning in payload.get("warnings", [])
         )
+
+
+class TestGuardHardening:
+    """Bounded waits, TLS passthrough, and per-engine serialization."""
+
+    def test_client_credential_carries_the_tls_override(self) -> None:
+        """A self-signed direct client must not fall back to the global default."""
+        client = SimpleNamespace(
+            base_url="http://ha.local:8123", token="own-token", verify_ssl=False
+        )
+        credential = _client_credential(client)
+        assert credential is not None
+        assert credential.verify_ssl is False
+
+    def test_client_credential_leaves_tls_unset_when_absent(self) -> None:
+        credential = _client_credential(_client())
+        assert credential is not None
+        assert credential.verify_ssl is None
+
+    async def test_sessions_pass_the_tls_override_through(self) -> None:
+        _FakeWsClient.user_data[THEME_USER_DATA_KEY] = dict(_DARK_THEME)
+        guard = ThemeGuard.for_capture(
+            EngineCredential(
+                url="https://ha.local:8123", token="tok", verify_ssl=False
+            ),
+            None,
+        )
+        await guard.take_snapshot()
+        assert [ws.verify_ssl for ws in _FakeWsClient.instances] == [False]
+        await guard.restore()
+
+    async def test_guard_commands_are_time_bounded(self) -> None:
+        """The guard must never inherit send_command's 30s default wait."""
+        from ha_mcp.dashboard_screenshot import theme_guard as guard_module
+
+        _FakeWsClient.user_data[THEME_USER_DATA_KEY] = dict(_DARK_THEME)
+        guard = ThemeGuard.for_capture(_PUPPET_CREDENTIAL, None)
+        await guard.take_snapshot()
+        _FakeWsClient.user_data[THEME_USER_DATA_KEY] = dict(_CLOBBERED_THEME)
+        await guard.restore()
+
+        waits = [cmd.get("_wait_timeout") for cmd in _all_commands()]
+        assert waits and all(
+            wait == guard_module.COMMAND_TIMEOUT_SECONDS for wait in waits
+        )
+
+    async def test_unarmed_guard_is_inert(self) -> None:
+        guard = ThemeGuard.for_capture(_PUPPET_CREDENTIAL, None, armed=False)
+        assert guard.credential is None
+        await guard.take_snapshot()
+        await guard.restore()
+        assert _FakeWsClient.instances == []
+
+    async def test_overlapping_batches_are_serialized_per_engine_user(self) -> None:
+        """Regression: interleaved brackets must not persist a clobbered value."""
+        _FakeWsClient.user_data[THEME_USER_DATA_KEY] = dict(_DARK_THEME)
+        first = ThemeGuard.for_capture(_PUPPET_CREDENTIAL, None)
+        second = ThemeGuard.for_capture(_PUPPET_CREDENTIAL, None)
+
+        await first.take_snapshot()
+        # The second batch must block until the first releases, so it cannot
+        # snapshot the value the first batch's render is about to clobber.
+        pending = asyncio.ensure_future(second.take_snapshot())
+        await asyncio.sleep(0)
+        assert not pending.done()
+
+        _FakeWsClient.user_data[THEME_USER_DATA_KEY] = dict(_CLOBBERED_THEME)
+        await first.restore()
+        await pending
+        await second.restore()
+
+        assert _FakeWsClient.user_data[THEME_USER_DATA_KEY] == _DARK_THEME
+
+    async def test_failed_snapshot_does_not_hold_the_lock(self) -> None:
+        _FakeWsClient.fail_get = True
+        guard = ThemeGuard.for_capture(_PUPPET_CREDENTIAL, None)
+        await guard.take_snapshot()
+        assert guard.warnings
+
+        _FakeWsClient.fail_get = False
+        other = ThemeGuard.for_capture(_PUPPET_CREDENTIAL, None)
+        await asyncio.wait_for(other.take_snapshot(), timeout=1)
+        await other.restore()


### PR DESCRIPTION
## What does this PR do?

Re-arms the `ThemeGuard` bracket around dashboard captures, **but only for
renders that request a theme**.

This is a deliberate, narrowed partial reversal of #2014 (the decision taken on
#1991, which disabled the bracket to restore `readOnlyHint: True` on the
dashboard get/screenshot tools). It is not a claim that #2014 was a mistake —
it rests on two facts that were not available then:

1. **The upstream fix never shipped.** `balloob/home-assistant-addons#89`
   ("don't dispatch settheme when no theme/dark was requested") is merged to
   that repo's master but unreleased. It landed *after* the 2.6.0 version bump
   (`balloob/home-assistant-addons#88`), and `puppet/config.yaml` there still
   reads `2.6.0` with no `settheme` entry in its CHANGELOG. So "current
   upstream release" — the AGENTS.md § Safety Annotations version baseline —
   still writes for everyone, not only outdated builds.
2. **The fix is narrower than assumed.** By its own title it suppresses the
   dispatch only when *no* theme/dark was requested. An explicit `theme=` or
   `dark_mode=true` capture still writes the engine user's profile, on every
   engine version, even once #89 ships.

Point 2 is the durable one and is what motivates the narrowing: unthemed
captures — the overwhelming majority — are left completely unbracketed and
issue no writes, so #2014's read-only guarantee is preserved exactly where it
applies. Only the themed path, which upstream will never cover, is protected.

Found in practice: a `dark_mode: true` capture flipped a live instance's theme
and nothing put it back.

### Guard hardening

Re-arming exposes failure modes the disabled code never hit. All raised by
Codex and CodeRabbit on this PR, all fixed here:

- **Serialization per engine user.** Overlapping themed batches could
  interleave (A clobbers, B snapshots the clobbered value, A restores, B
  restores the clobber) and strand the account on the wrong theme. Locks are
  keyed by running event loop as well as credential, since an `asyncio.Lock`
  binds to the loop that first awaits it.
- **Contention fails the capture** rather than rendering unserialized — a
  themed render holds the bracket for its whole duration, so "give up and
  render anyway" would reintroduce exactly the interleave. The wait is bounded
  by the caller's own `render_timeout_seconds`.
- **Cancellation releases the lock.** `asyncio.CancelledError` is a
  `BaseException`, so it bypassed `except Exception` and stranded the lock,
  which would have made every later themed capture for that engine user time
  out.
- **TLS override preserved.** A direct client built with `verify_ssl=False`
  previously fell back to the global setting, so on self-signed instances every
  guard session failed while the render succeeded — leaving the theme
  clobbered.
- **Bounded WebSocket waits** (5s vs `send_command`'s 30s default), so a
  best-effort guard cannot consume the caller's MCP timeout window before the
  engine is contacted.
- **Guard warnings survive non-`ToolError` failures.** These bypassed
  `_reraise_with_guard_warnings`; the wrapper now builds a structured
  `INTERNAL_ERROR` payload, because that helper parses the message as JSON and
  re-raises unchanged when it is not a dict.

## Type of change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

Locally: `test_dashboard_screenshot_theme_guard.py` + `test_dashboard_screenshot.py`
green, `mypy src/ha_mcp/dashboard_screenshot/` clean. Full suite left to CI.

Tests cover the themed/unthemed split (the previous bracket tests exercised
only default options, which after this change is the deliberately unbracketed
path — they would have passed while testing nothing), TLS passthrough, wait
bounding, serialization of overlapping batches, refusal on lock contention,
and lock release on both snapshot failure and cancellation.

## Checklist
- [x] I have updated documentation if needed
