### PR TITLE
fix: coordinate shared FastMCP mutations

### DIFF
--- a/custom_components/ha_mcp_tools/embedded_server.py
+++ b/custom_components/ha_mcp_tools/embedded_server.py
@@ -945,7 +945,7 @@ class EmbeddedServerManager:
                 "not installed; refusing the first install because it could "
                 "replace loaded FastMCP files. Restart Home Assistant so HA-MCP "
                 "can establish runtime ownership before other MCP integrations.",
-                kind="restart",
+                kind="package",
             )
 
     def _replaced_dist_name(self) -> str | None:

--- a/custom_components/ha_mcp_tools/embedded_server.py
+++ b/custom_components/ha_mcp_tools/embedded_server.py
@@ -363,7 +363,10 @@ class EmbeddedServerManager:
         # exactly like the sys.modules purge does (review finding), so a
         # mutating install is deferred while any registered worker is alive.
         ready_version = await self._async_ensure_package(
-            defer_mutations=_prune_and_check_importing_workers()
+            defer_mutations=(
+                _prune_and_check_importing_workers()
+                or _unowned_fastmcp_runtime_loaded()
+            )
         )
         await self._async_warn_on_dependency_conflicts()
         access_token = await self._async_provision_token()
@@ -639,6 +642,39 @@ class EmbeddedServerManager:
                     _PENDING_INSTALL_DONE = None
             raise
 
+    async def _async_process_requirements_fast_tracked(self) -> None:
+        """Run HA's async requirements path with cancellation-safe tracking."""
+        global _PENDING_INSTALL_DONE
+        done = threading.Event()
+        with _PENDING_INSTALL_LOCK:
+            _PENDING_INSTALL_DONE = done
+
+        try:
+            task = asyncio.create_task(self._async_process_requirements_fast())
+        except BaseException:
+            done.set()
+            with _PENDING_INSTALL_LOCK:
+                if _PENDING_INSTALL_DONE is done:
+                    _PENDING_INSTALL_DONE = None
+            raise
+
+        def _finished(finished_task: asyncio.Task[None]) -> None:
+            global _PENDING_INSTALL_DONE
+            # Retrieve a detached task's exception to avoid an unhandled-task
+            # warning. A still-attached await below receives the same result.
+            with suppress(asyncio.CancelledError):
+                finished_task.exception()
+            done.set()
+            with _PENDING_INSTALL_LOCK:
+                if _PENDING_INSTALL_DONE is done:
+                    _PENDING_INSTALL_DONE = None
+
+        task.add_done_callback(_finished)
+        # Cancelling this bring-up must detach only its awaiter. The requirements
+        # manager may already have dispatched pip, so its task and reservation
+        # live until actual completion and the next bring-up waits them out.
+        await asyncio.shield(task)
+
     async def _async_wait_for_pending_install(self) -> None:
         """Wait out an install job orphaned by a cancelled previous bring-up.
 
@@ -802,11 +838,11 @@ class EmbeddedServerManager:
             and _is_compatible_embedded_version(installed_version)
         )
         deferred = False
-        if fast_path_ok:
-            await self._async_process_requirements_fast()
-        elif defer_mutations:
+        if defer_mutations:
             deferred = True
             await self._async_defer_package_mutations(installed_version)
+        elif fast_path_ok:
+            await self._async_process_requirements_fast_tracked()
         else:
             await self._async_remove_conflicting_dist()
             await self._async_remove_legacy_target(target_dist, installed_version)
@@ -890,25 +926,27 @@ class EmbeddedServerManager:
     ) -> None:
         """Handle the defer-mutations branch of :meth:`_async_ensure_package`.
 
-        A previous bring-up's worker is still importing, so the package files
-        must not be replaced under it. With an importable build on disk
-        (``installed_version`` non-None — importability only, compatibility is
-        checked by the caller afterwards) nothing is touched at all — not even
-        the requirements manager, which installs any unsatisfied spec and
-        would mutate exactly like the deferred force install. When nothing
-        imports there are no distribution files to replace under the live
-        importer, and without an install this bring-up cannot produce a
-        server at all, so the requirements manager still runs.
+        A previous or external worker has process-global dependency code loaded,
+        so no package path may run — including Home Assistant's requirements
+        manager, which installs an unsatisfied stable spec. The external worker
+        can exist even when ``ha-mcp`` itself is not installed, so a first install
+        also fails closed instead of resolving FastMCP beneath that worker.
         """
         _LOGGER.warning(
             "Deferring the ha-mcp install/upgrade: a previous bring-up's "
-            "worker thread is still importing, and replacing the package "
-            "files under it could corrupt that import. The currently "
+            "worker or an external FastMCP consumer is active, and replacing "
+            "package files under it could corrupt the shared runtime. The currently "
             "installed build will be used; reload the integration (or "
             "restart Home Assistant) to apply the update."
         )
         if installed_version is None:
-            await self._async_process_requirements_fast()
+            raise EmbeddedServerError(
+                "A process-global dependency consumer is active while ha-mcp is "
+                "not installed; refusing the first install because it could "
+                "replace loaded FastMCP files. Restart Home Assistant so HA-MCP "
+                "can establish runtime ownership before other MCP integrations.",
+                kind="restart",
+            )
 
     def _replaced_dist_name(self) -> str | None:
         """Return the distribution whose presence could no-op the new spec.
@@ -1932,6 +1970,13 @@ def _prune_and_check_importing_workers() -> bool:
         return bool(_IMPORTING_WORKERS)
 
 
+def _unowned_fastmcp_runtime_loaded() -> bool:
+    """Return whether FastMCP was loaded before HA-MCP established ownership."""
+    return _CACHED_IMPORT_VERSION is None and any(
+        name == "fastmcp" or name.startswith("fastmcp.") for name in sys.modules
+    )
+
+
 # Completion event of the package-mutating install/uninstall job currently on
 # the executor, if any. asyncio cancellation of a bring-up detaches the
 # awaiter, but the executor job keeps running to completion — untracked, an
@@ -1955,6 +2000,12 @@ def _prune_and_check_importing_workers() -> bool:
 # co-occur with a live orphaned job worth waiting on.
 _PENDING_INSTALL_LOCK = threading.Lock()
 _PENDING_INSTALL_DONE: threading.Event | None = None
+
+# Inter-integration contract for process-global FastMCP consumers. Version 1
+# guarantees that every package path honors _IMPORTING_WORKERS before mutation,
+# async requirements work remains registered across cancellation, and a loaded
+# unowned FastMCP runtime blocks HA-MCP's first install.
+FASTMCP_MUTATION_PROTOCOL = 1
 
 
 # Version of the ha_mcp generation currently cached in sys.modules — set by

--- a/tests/src/unit/test_embedded_server.py
+++ b/tests/src/unit/test_embedded_server.py
@@ -3276,6 +3276,55 @@ class TestPendingInstallTracking:
         with es._PENDING_INSTALL_LOCK:
             assert es._PENDING_INSTALL_DONE is None
 
+    async def test_requirements_manager_fast_path_is_tracked(
+        self, tmp_path, monkeypatch
+    ):
+        mgr, _hass, _entry = _manager(tmp_path)
+        monkeypatch.setattr(es, "_PENDING_INSTALL_DONE", None)
+        observed: list[bool] = []
+
+        async def _fast_path() -> None:
+            with es._PENDING_INSTALL_LOCK:
+                observed.append(es._PENDING_INSTALL_DONE is not None)
+
+        monkeypatch.setattr(mgr, "_async_process_requirements_fast", _fast_path)
+
+        await mgr._async_process_requirements_fast_tracked()
+
+        assert observed == [True]
+        with es._PENDING_INSTALL_LOCK:
+            assert es._PENDING_INSTALL_DONE is None
+
+    async def test_cancelled_fast_path_remains_tracked_until_inner_task_finishes(
+        self, tmp_path, monkeypatch
+    ):
+        mgr, _hass, _entry = _manager(tmp_path)
+        monkeypatch.setattr(es, "_PENDING_INSTALL_DONE", None)
+        started = asyncio.Event()
+        release = asyncio.Event()
+
+        async def _fast_path() -> None:
+            started.set()
+            await release.wait()
+
+        monkeypatch.setattr(mgr, "_async_process_requirements_fast", _fast_path)
+        outer = asyncio.create_task(mgr._async_process_requirements_fast_tracked())
+        await started.wait()
+
+        outer.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await outer
+        with es._PENDING_INSTALL_LOCK:
+            pending = es._PENDING_INSTALL_DONE
+        assert pending is not None and not pending.is_set()
+
+        release.set()
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        assert pending.is_set()
+        with es._PENDING_INSTALL_LOCK:
+            assert es._PENDING_INSTALL_DONE is None
+
     async def test_wait_returns_once_orphan_finishes(
         self, tmp_path, monkeypatch, caplog
     ):
@@ -3453,6 +3502,7 @@ class TestImporterAwareBringUp:
 
     def _stub_bring_up(self, mgr, monkeypatch, ensure: AsyncMock) -> None:
         monkeypatch.setattr(mgr, "_async_ensure_package", ensure)
+        monkeypatch.setattr(es, "_unowned_fastmcp_runtime_loaded", lambda: False)
         monkeypatch.setattr(
             mgr, "_async_provision_token", AsyncMock(return_value="tok")
         )
@@ -3514,6 +3564,49 @@ class TestImporterAwareBringUp:
             mgr._thread.join(timeout=2)
 
         assert ensure.await_args.kwargs == {"defer_mutations": False}
+
+    async def test_async_start_defers_when_an_external_fastmcp_runtime_is_loaded(
+        self, tmp_path, monkeypatch
+    ):
+        mgr, _hass, _entry = _manager(tmp_path)
+        monkeypatch.setattr(es, "_IMPORTING_WORKERS", set())
+        ensure = AsyncMock(return_value="1.2.3")
+        self._stub_bring_up(mgr, monkeypatch, ensure)
+        monkeypatch.setattr(es, "_unowned_fastmcp_runtime_loaded", lambda: True)
+        monkeypatch.setattr(mgr, "_thread_main", lambda token: None)
+
+        await mgr.async_start()
+        if mgr._thread is not None:
+            mgr._thread.join(timeout=2)
+
+        assert ensure.await_args.kwargs == {"defer_mutations": True}
+
+    def test_unowned_fastmcp_runtime_detection(self, monkeypatch):
+        monkeypatch.setattr(es, "_CACHED_IMPORT_VERSION", None)
+        monkeypatch.setitem(sys.modules, "fastmcp.external_consumer", ModuleType("x"))
+
+        assert es._unowned_fastmcp_runtime_loaded() is True
+
+        monkeypatch.setattr(es, "_CACHED_IMPORT_VERSION", "3.4.7")
+        assert es._unowned_fastmcp_runtime_loaded() is False
+
+    async def test_ensure_package_defers_unchanged_fast_path(
+        self, tmp_path, monkeypatch
+    ):
+        """A stable pin cannot bypass a live external-consumer lease."""
+        mgr, _hass, _entry = _manager(
+            tmp_path,
+            options={OPT_PIP_SPEC: "ha-mcp==7.12.1"},
+            data={DATA_SECRET_PATH: "/p", DATA_LAST_PIP_SPEC: "ha-mcp==7.12.1"},
+        )
+        monkeypatch.setattr(es, "_installed_ha_mcp_version", lambda: "7.12.1")
+        fast = AsyncMock()
+        monkeypatch.setattr(mgr, "_async_process_requirements_fast_tracked", fast)
+
+        ready = await mgr._async_ensure_package(defer_mutations=True)
+
+        assert ready == "7.12.1"
+        fast.assert_not_awaited()
 
     async def test_ensure_package_defers_force_install(
         self, tmp_path, monkeypatch, caplog
@@ -3608,31 +3701,26 @@ class TestImporterAwareBringUp:
         force.assert_not_awaited()
         assert DATA_LAST_PIP_SPEC not in entry.data
 
-    async def test_deferred_with_nothing_installed_still_installs(
+    async def test_deferred_with_nothing_installed_fails_without_installing(
         self, tmp_path, monkeypatch
     ):
-        # defer_mutations with NO build on disk: there are no distribution
-        # files to replace under the live importer, and without an install this
-        # bring-up cannot produce a server at all — the requirements manager
-        # must still run.
+        # A foreign consumer may have FastMCP loaded even when ha-mcp itself is
+        # absent. Installing the first ha-mcp build could replace that shared
+        # dependency, so a live lease must make the transition fail closed.
         mgr, _hass, entry = _manager(tmp_path)
-        monkeypatch.setattr(
-            es,
-            "_installed_ha_mcp_version",
-            MagicMock(side_effect=[None, "7.13.0"]),
-        )
+        monkeypatch.setattr(es, "_installed_ha_mcp_version", lambda: None)
         fast = AsyncMock()
         force = AsyncMock()
-        monkeypatch.setattr(mgr, "_async_process_requirements_fast", fast)
+        monkeypatch.setattr(mgr, "_async_process_requirements_fast_tracked", fast)
         monkeypatch.setattr(mgr, "_async_force_install", force)
 
-        ready = await mgr._async_ensure_package(defer_mutations=True)
+        with pytest.raises(es.EmbeddedServerError) as exc:
+            await mgr._async_ensure_package(defer_mutations=True)
 
-        assert ready == "7.13.0"
-        fast.assert_awaited_once()
+        assert exc.value.kind == "restart"
+        assert "refusing the first install" in str(exc.value)
+        fast.assert_not_awaited()
         force.assert_not_awaited()
-        # Still a deferred bring-up: nothing is recorded as installed, so the
-        # next (undeferred) reload applies the configured spec for real.
         assert DATA_LAST_PIP_SPEC not in entry.data
 
 

--- a/tests/src/unit/test_embedded_server.py
+++ b/tests/src/unit/test_embedded_server.py
@@ -3717,7 +3717,7 @@ class TestImporterAwareBringUp:
         with pytest.raises(es.EmbeddedServerError) as exc:
             await mgr._async_ensure_package(defer_mutations=True)
 
-        assert exc.value.kind == "restart"
+        assert exc.value.kind == "package"
         assert "refusing the first install" in str(exc.value)
         fast.assert_not_awaited()
         force.assert_not_awaited()


### PR DESCRIPTION
## Summary

- give `defer_mutations` priority over every package path, including stable-spec requirements processing
- track the async Home Assistant requirements path across bring-up cancellation so later starts can wait for the real pip completion
- reject a first HA-MCP install when an unowned process-global FastMCP runtime is already loaded
- publish `FASTMCP_MUTATION_PROTOCOL = 1` as the runtime contract for cooperating custom integrations

## Why

FastMCP modules and their installed files are process-global inside Home Assistant. A live consumer lease already deferred the direct install/uninstall path, but the stable-spec fast path could still reach pip, and a first HA-MCP install could replace FastMCP beneath a previously started external consumer. Both cases can mix cached modules with a different on-disk generation.

This patch makes every mutation-capable route honor the gate and keeps requirements-manager work visible after cancellation. It is the upstream half of a linked ESPHome MCP compatibility change.

## Verification

- `ruff format custom_components/ha_mcp_tools/embedded_server.py tests/src/unit/test_embedded_server.py`
- `ruff check custom_components/ha_mcp_tools/embedded_server.py tests/src/unit/test_embedded_server.py`
- focused regression selection: 5 passed
- full `test_embedded_server.py`: 192 passed; 2 existing metadata-warning assertions fail only in the direct Termux environment because the project distribution is not installed there (CI's managed environment remains authoritative)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when starting the embedded server while package installation is in progress.
  * Prevented cancelled startup operations from leaving installations in an inconsistent state.
  * Added safer handling when another FastMCP runtime is already active.
  * Startup now fails safely when a compatible package is unavailable during deferred installation.

* **Compatibility**
  * Improved coordination with other integrations using the same FastMCP runtime.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->