### PR TITLE
docs: clarify exact filesystem allowlist paths

### DIFF
--- a/src/ha_mcp/settings_ui/locales/en.json
+++ b/src/ha_mcp/settings_ui/locales/en.json
@@ -285,7 +285,7 @@
     "backup.bulk.confirm": "Delete all backups matching: {filters}?",
     "backup.bulk.deleted": "Deleted {count} backup(s)",
     "filesystem.custom.title": "Custom filesystem directories (advanced)",
-    "filesystem.custom.help": "Extra directories (one per line) that file tools may <strong>read and write</strong>. Relative config paths and allowed HAOS sibling volumes are supported. Applies immediately.",
+    "filesystem.custom.help": "Extra directories (one per line) that file tools may <strong>read and write</strong>. Relative config paths and allowed HAOS sibling volumes are supported. Exact config-relative file paths, such as <code>sensor.yaml</code>, are also supported. Applies immediately.",
     "filesystem.custom.blocked": "Always blocked: {paths}, path traversal (<code>..</code>), and absolute paths outside allowed HAOS volumes.",
     "filesystem.custom.enable_first": "Enable beta features and filesystem tools above to edit.",
     "filesystem.custom.unavailable": "Custom directories are currently unavailable.",

--- a/src/ha_mcp/settings_ui/locales/en.json
+++ b/src/ha_mcp/settings_ui/locales/en.json
@@ -285,7 +285,7 @@
     "backup.bulk.confirm": "Delete all backups matching: {filters}?",
     "backup.bulk.deleted": "Deleted {count} backup(s)",
     "filesystem.custom.title": "Custom filesystem directories (advanced)",
-    "filesystem.custom.help": "Extra directories (one per line) that file tools may <strong>read and write</strong>. Relative config paths and allowed HAOS sibling volumes are supported. Exact config-relative file paths, such as <code>sensor.yaml</code>, are also supported. Applies immediately.",
+    "filesystem.custom.help": "Extra paths (one per line) that file tools may <strong>read and write</strong>. Relative config paths and allowed HAOS sibling volumes are supported. Each entry allows that path and anything below it; config-relative filenames, such as <code>sensor.yaml</code>, can be entered directly. Applies immediately.",
     "filesystem.custom.blocked": "Always blocked: {paths}, path traversal (<code>..</code>), and absolute paths outside allowed HAOS volumes.",
     "filesystem.custom.enable_first": "Enable beta features and filesystem tools above to edit.",
     "filesystem.custom.unavailable": "Custom directories are currently unavailable.",

--- a/tests/src/e2e/workflows/filesystem/test_custom_paths.py
+++ b/tests/src/e2e/workflows/filesystem/test_custom_paths.py
@@ -127,6 +127,35 @@ class TestCustomFilesystemPaths:
             )
             await _set_allowed_paths(base_url, token, [])
 
+    async def test_exact_file_grants_root_read_write_live(
+        self, mcp_client_fs, ha_container_with_fresh_config
+    ):
+        base_url = ha_container_with_fresh_config["base_url"]
+        token = await _bootstrap_token(base_url)
+        fname = "sensor.yaml"
+        try:
+            sr = await _set_allowed_paths(base_url, token, [fname])
+            assert sr.get("success") is True, sr
+            assert sr.get("paths") == [fname], sr
+
+            async with MCPAssertions(mcp_client_fs) as mcp:
+                written = await mcp.call_tool_success(
+                    "ha_write_file",
+                    {
+                        "path": fname,
+                        "content": "# 2268 exact-file test\n",
+                        "overwrite": True,
+                    },
+                )
+                assert written.get("success") is True, written
+                read = await mcp.call_tool_success("ha_read_file", {"path": fname})
+                assert "# 2268 exact-file test" in read.get("content", ""), read
+        finally:
+            await safe_call_tool(
+                mcp_client_fs, "ha_delete_file", {"path": fname, "confirm": True}
+            )
+            await _set_allowed_paths(base_url, token, [])
+
     async def test_deny_floor_blocks_storage_even_with_custom_dir(
         self, mcp_client_fs, ha_container_with_fresh_config
     ):


### PR DESCRIPTION
## What does this PR do?

Clarifies that custom filesystem allowlist entries grant the configured path and anything below it, and that config-relative filenames such as sensor.yaml can be entered directly.

Adds E2E coverage that configures sensor.yaml and verifies root-level write/read access.

Closes #2268

## Type of change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [x] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [ ] All automated tests pass (`uv run pytest`)
- [ ] Code follows style guidelines (`uv run ruff check`)

Not run locally; CI will validate the changes.

## Checklist
- [x] I have updated documentation if needed