### PR TITLE
fix(addon): bound Supervisor error payloads reaching the model

### DIFF
--- a/src/ha_mcp/tools/tools_addons.py
+++ b/src/ha_mcp/tools/tools_addons.py
@@ -284,9 +284,7 @@ def _supervisor_rest_failure(
     response_data: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Normalize direct REST failure and retain 4xx/5xx status metadata."""
-    # ``error`` is built from the Supervisor payload, so it is only as bounded
-    # as whatever Supervisor sent; it reaches the model as the tool error.
-    error_text = _bounded_supervisor_text(str(error))
+    error_text = str(error)
     result: dict[str, Any] = {"success": False, "error": error_text}
     if response.is_error:
         result["_status_code"] = response.status_code
@@ -564,7 +562,12 @@ def _raise_supervisor_api_failure(
     endpoint: str,
 ) -> NoReturn:
     """Raise the structured exception represented by a non-retryable result."""
-    error_text = str(result.get("error", f"Supervisor API call failed: {endpoint}"))
+    # Both transports land here, and both carry Supervisor's own text: the
+    # direct REST payload and the message Core relays over the WebSocket
+    # bridge. Bind the size once, where every failure passes.
+    error_text = _bounded_supervisor_text(
+        str(result.get("error", f"Supervisor API call failed: {endpoint}"))
+    )
     status_code = result.get("_status_code")
     response_data = result.get("_response_data")
     if status_code == 401:

--- a/src/ha_mcp/tools/tools_addons.py
+++ b/src/ha_mcp/tools/tools_addons.py
@@ -284,7 +284,9 @@ def _supervisor_rest_failure(
     response_data: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Normalize direct REST failure and retain 4xx/5xx status metadata."""
-    error_text = str(error)
+    # ``error`` is built from the Supervisor payload, so it is only as bounded
+    # as whatever Supervisor sent; it reaches the model as the tool error.
+    error_text = _bounded_supervisor_text(str(error))
     result: dict[str, Any] = {"success": False, "error": error_text}
     if response.is_error:
         result["_status_code"] = response.status_code
@@ -316,13 +318,17 @@ def _supervisor_invalid_response(
     return _supervisor_rest_failure(response, error)
 
 
+def _bounded_supervisor_text(value: str) -> str:
+    """Return model-safe Supervisor text, marking any truncation visibly."""
+    if len(value) <= _MAX_RESPONSE_SIZE:
+        return value
+    prefix_size = _MAX_RESPONSE_SIZE - len(_SUPERVISOR_RESPONSE_TRUNCATION_SUFFIX)
+    return value[:prefix_size] + _SUPERVISOR_RESPONSE_TRUNCATION_SUFFIX
+
+
 def _bounded_supervisor_response_text(response: httpx.Response) -> str:
     """Return a model-safe Supervisor response body with visible truncation."""
-    body = response.text.strip()
-    if len(body) <= _MAX_RESPONSE_SIZE:
-        return body
-    prefix_size = _MAX_RESPONSE_SIZE - len(_SUPERVISOR_RESPONSE_TRUNCATION_SUFFIX)
-    return body[:prefix_size] + _SUPERVISOR_RESPONSE_TRUNCATION_SUFFIX
+    return _bounded_supervisor_text(response.text.strip())
 
 
 def _normalize_supervisor_rest_response(
@@ -613,7 +619,7 @@ def _supervisor_result_mapping(
         return payload
 
     verb = method.upper()
-    message = (
+    message = _bounded_supervisor_text(
         f"Supervisor API {verb} {endpoint} returned an invalid result payload: "
         f"{payload!r}"
     )

--- a/src/ha_mcp/tools/tools_addons.py
+++ b/src/ha_mcp/tools/tools_addons.py
@@ -726,6 +726,10 @@ async def _supervisor_api_call(
             if _JOB_COLLISION_MARKER not in error_text.lower():
                 _raise_supervisor_api_failure(result, endpoint)
 
+            # The marker test runs on the raw text; everything below reports
+            # it, so bind the size once the classification is settled.
+            error_text = _bounded_supervisor_text(error_text)
+
             remaining = deadline - time.monotonic()
             if remaining <= 0:
                 # The retry budget is exhausted; the group may be stuck or

--- a/tests/src/unit/test_tools_addons.py
+++ b/tests/src/unit/test_tools_addons.py
@@ -4624,6 +4624,30 @@ class TestSupervisorApiCall:
         )
 
     @pytest.mark.asyncio
+    async def test_core_routed_failure_message_is_capped(self, monkeypatch):
+        """A Core-relayed Supervisor failure cannot produce an unbounded error."""
+        from ha_mcp.tools.tools_addons import _supervisor_api_call
+
+        monkeypatch.delenv("SUPERVISOR_TOKEN", raising=False)
+        client = _make_mock_client()
+        client.send_websocket_message = AsyncMock(
+            return_value={
+                "success": False,
+                "error": "Command failed: " + "w" * (50 * 1024 + 1),
+            }
+        )
+
+        with pytest.raises(ToolError) as exc_info:
+            await _supervisor_api_call(client, "/addons")
+
+        payload = _parse_tool_error(exc_info)
+        suffix = "\n[Supervisor response truncated to 50 KiB]"
+        message = payload["error"]["message"]
+        assert message.startswith("Command failed: w")
+        assert message.endswith(suffix)
+        assert len(message) == 50 * 1024
+
+    @pytest.mark.asyncio
     async def test_addon_mode_non_object_json_caps_error_message(self, monkeypatch):
         """A valid-JSON non-object body cannot produce an unbounded tool error."""
         from ha_mcp.tools.tools_addons import _supervisor_api_call
@@ -4656,7 +4680,7 @@ class TestSupervisorApiCall:
         suffix = "\n[Supervisor response truncated to 50 KiB]"
         assert message.startswith(prefix)
         assert message.endswith(suffix)
-        assert len(message) == len("Command failed: ") + 50 * 1024
+        assert len(message) == 50 * 1024
 
     @pytest.mark.asyncio
     async def test_addon_mode_error_payload_message_is_capped(self, monkeypatch):
@@ -4687,9 +4711,13 @@ class TestSupervisorApiCall:
 
         payload = _parse_tool_error(exc_info)
         suffix = "\n[Supervisor response truncated to 50 KiB]"
-        assert payload["error"]["message"] == (
-            "Command failed: " + "y" * (50 * 1024 - len(suffix)) + suffix
-        )
+        message = payload["error"]["message"]
+        # The status-code path prefixes the bounded Supervisor text, so the
+        # constant framing sits outside the bound.
+        prefix = "Command failed: "
+        assert message.startswith(prefix + "y")
+        assert message.endswith(suffix)
+        assert len(message.removeprefix(prefix)) == 50 * 1024
 
     @pytest.mark.asyncio
     async def test_addon_mode_non_mapping_result_payload_is_capped(self, monkeypatch):

--- a/tests/src/unit/test_tools_addons.py
+++ b/tests/src/unit/test_tools_addons.py
@@ -4624,6 +4624,109 @@ class TestSupervisorApiCall:
         )
 
     @pytest.mark.asyncio
+    async def test_addon_mode_non_object_json_caps_error_message(self, monkeypatch):
+        """A valid-JSON non-object body cannot produce an unbounded tool error."""
+        from ha_mcp.tools.tools_addons import _supervisor_api_call
+
+        monkeypatch.setenv("SUPERVISOR_TOKEN", "test-supervisor-token")
+        client = _make_mock_client()
+        client.send_websocket_message = AsyncMock()
+        direct_client = AsyncMock()
+        direct_client.request.return_value = httpx.Response(
+            200,
+            json=["x" * 1000] * 200,
+        )
+        context = MagicMock()
+        context.__aenter__ = AsyncMock(return_value=direct_client)
+        context.__aexit__ = AsyncMock(return_value=False)
+
+        with (
+            patch(
+                "ha_mcp.tools.tools_addons.make_supervisor_httpx_client",
+                return_value=context,
+                create=True,
+            ),
+            pytest.raises(ToolError) as exc_info,
+        ):
+            await _supervisor_api_call(client, "/addons")
+
+        payload = _parse_tool_error(exc_info)
+        message = payload["error"]["message"]
+        prefix = "Command failed: Supervisor returned an invalid response: "
+        suffix = "\n[Supervisor response truncated to 50 KiB]"
+        assert message.startswith(prefix)
+        assert message.endswith(suffix)
+        assert len(message) == len("Command failed: ") + 50 * 1024
+
+    @pytest.mark.asyncio
+    async def test_addon_mode_error_payload_message_is_capped(self, monkeypatch):
+        """An oversized Supervisor error message is bounded before it is raised."""
+        from ha_mcp.tools.tools_addons import _supervisor_api_call
+
+        monkeypatch.setenv("SUPERVISOR_TOKEN", "test-supervisor-token")
+        client = _make_mock_client()
+        client.send_websocket_message = AsyncMock()
+        direct_client = AsyncMock()
+        direct_client.request.return_value = httpx.Response(
+            502,
+            json={"result": "error", "message": "y" * (50 * 1024 + 1)},
+        )
+        context = MagicMock()
+        context.__aenter__ = AsyncMock(return_value=direct_client)
+        context.__aexit__ = AsyncMock(return_value=False)
+
+        with (
+            patch(
+                "ha_mcp.tools.tools_addons.make_supervisor_httpx_client",
+                return_value=context,
+                create=True,
+            ),
+            pytest.raises(ToolError) as exc_info,
+        ):
+            await _supervisor_api_call(client, "/addons")
+
+        payload = _parse_tool_error(exc_info)
+        suffix = "\n[Supervisor response truncated to 50 KiB]"
+        assert payload["error"]["message"] == (
+            "Command failed: " + "y" * (50 * 1024 - len(suffix)) + suffix
+        )
+
+    @pytest.mark.asyncio
+    async def test_addon_mode_non_mapping_result_payload_is_capped(self, monkeypatch):
+        """An oversized non-mapping result payload is bounded before it is raised."""
+        from ha_mcp.tools.tools_addons import _supervisor_api_call
+
+        monkeypatch.setenv("SUPERVISOR_TOKEN", "test-supervisor-token")
+        client = _make_mock_client()
+        client.send_websocket_message = AsyncMock()
+        direct_client = AsyncMock()
+        direct_client.request.return_value = httpx.Response(
+            200,
+            json={"result": "ok", "data": "z" * (50 * 1024 + 1)},
+        )
+        context = MagicMock()
+        context.__aenter__ = AsyncMock(return_value=direct_client)
+        context.__aexit__ = AsyncMock(return_value=False)
+
+        with (
+            patch(
+                "ha_mcp.tools.tools_addons.make_supervisor_httpx_client",
+                return_value=context,
+                create=True,
+            ),
+            pytest.raises(ToolError) as exc_info,
+        ):
+            await _supervisor_api_call(client, "/addons")
+
+        payload = _parse_tool_error(exc_info)
+        message = payload["error"]["message"]
+        prefix = "Supervisor API GET /addons returned an invalid result payload: "
+        suffix = "\n[Supervisor response truncated to 50 KiB]"
+        assert message.startswith(prefix)
+        assert message.endswith(suffix)
+        assert len(message) == 50 * 1024
+
+    @pytest.mark.asyncio
     async def test_addon_mode_write_redirect_reports_unknown_outcome(self, monkeypatch):
         """A redirect cannot prove whether Supervisor applied the received write."""
         from ha_mcp.tools.tools_addons import _supervisor_api_call

--- a/tests/src/unit/test_tools_addons.py
+++ b/tests/src/unit/test_tools_addons.py
@@ -4624,6 +4624,34 @@ class TestSupervisorApiCall:
         )
 
     @pytest.mark.asyncio
+    async def test_job_collision_giveup_message_is_capped(self, monkeypatch):
+        """An exhausted job-collision retry cannot report an unbounded error."""
+        from ha_mcp.tools import tools_addons
+        from ha_mcp.tools.tools_addons import _supervisor_api_call
+
+        monkeypatch.delenv("SUPERVISOR_TOKEN", raising=False)
+        monkeypatch.setattr(tools_addons, "_JOB_COLLISION_RETRY_WINDOW", 0.0)
+        client = _make_mock_client()
+        client.send_websocket_message = AsyncMock(
+            return_value={
+                "success": False,
+                "error": (
+                    "Command failed: another job is running for job group "
+                    + "v" * (50 * 1024 + 1)
+                ),
+            }
+        )
+
+        with pytest.raises(ToolError) as exc_info:
+            await _supervisor_api_call(client, "/addons/x/restart", method="POST")
+
+        payload = _parse_tool_error(exc_info)
+        suffix = "\n[Supervisor response truncated to 50 KiB]"
+        message = payload["error"]["message"]
+        assert message.endswith(suffix)
+        assert len(message) == 50 * 1024
+
+    @pytest.mark.asyncio
     async def test_core_routed_failure_message_is_capped(self, monkeypatch):
         """A Core-relayed Supervisor failure cannot produce an unbounded error."""
         from ha_mcp.tools.tools_addons import _supervisor_api_call


### PR DESCRIPTION
## What does this PR do?

Bounds the Supervisor error text that reaches the model, on both transports.

Supervisor failure text is built from parsed payloads: the two invalid-payload branches embed the payload repr, the failure branch forwards Supervisor's own `message`/`error` field, the result mapping embeds a non-mapping result payload, and the Core WebSocket bridge relays Supervisor's message unchanged. #2274 bounded the two Supervisor response-body call sites in the same file at 50 KiB, but these payload-derived paths stayed unbounded, so a single oversized Supervisor response can still produce a tool error several times that size.

The bound sits at the three payload-derived reporting points this path still had: `_raise_supervisor_api_failure`, which every non-retryable failure result carrying Supervisor text is raised through on either transport; `_supervisor_result_mapping`, which raises on its own payload; and the job-collision give-up branch in `_supervisor_api_call`, which builds its error from the raw text it computed for the marker test. The bound helper takes a string, so the response-body path and the payload-derived messages share one implementation and one truncation marker.

## Type of change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [ ] All automated tests pass (`uv run pytest`)
- [ ] Code follows style guidelines (`uv run ruff check`)

Locally I ran the unit suite only, not the full `pytest`: 11203 passed, 370 skipped, 9 failed, and that failure set is identical to the one the base commit produces without this change. Five regression tests are new — a non-object JSON body, an oversized Supervisor `message` field, a non-mapping result payload, a Core-relayed failure over the WebSocket bridge, and an exhausted job-collision retry. Each bound is pinned separately: reverting the one in `_raise_supervisor_api_failure` fails three of the five, reverting the one in `_supervisor_result_mapping` fails the result-payload test, and reverting the one in the collision branch fails the collision test.

## Checklist
- [x] I have updated documentation if needed
