### PR TITLE
chore(deps): update python:3.13-slim docker digest to 7e3a6ac

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --locked --no-dev
 
 # --- Runtime stage: clean image without uv ---
-FROM python:3.13-slim@sha256:3de9a8d7aedbb7984dc18f2dff178a7850f16c1ae7c34ba9d7ecc23d0755e35f
+FROM python:3.13-slim@sha256:7e3a6aca9d74f93cca21a91d86a8dad8c34749afd5b4a98ee481c9c47b9f5ed4
 
 LABEL org.opencontainers.image.title="Home Assistant MCP Server" \
       org.opencontainers.image.description="AI assistant integration for Home Assistant via Model Context Protocol" \

--- a/homeassistant-addon-dev/Dockerfile
+++ b/homeassistant-addon-dev/Dockerfile
@@ -22,7 +22,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --locked --no-dev --no-editable
 
 # --- Runtime stage: clean image without uv ---
-FROM python:3.13-slim@sha256:3de9a8d7aedbb7984dc18f2dff178a7850f16c1ae7c34ba9d7ecc23d0755e35f
+FROM python:3.13-slim@sha256:7e3a6aca9d74f93cca21a91d86a8dad8c34749afd5b4a98ee481c9c47b9f5ed4
 
 WORKDIR /app
 

--- a/homeassistant-addon/Dockerfile
+++ b/homeassistant-addon/Dockerfile
@@ -23,7 +23,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --locked --no-dev --no-editable
 
 # --- Runtime stage: clean image without uv ---
-FROM python:3.13-slim@sha256:3de9a8d7aedbb7984dc18f2dff178a7850f16c1ae7c34ba9d7ecc23d0755e35f
+FROM python:3.13-slim@sha256:7e3a6aca9d74f93cca21a91d86a8dad8c34749afd5b4a98ee481c9c47b9f5ed4
 
 WORKDIR /app
 

--- a/tests/haos_image_build/screenshot_engine_mock/Dockerfile
+++ b/tests/haos_image_build/screenshot_engine_mock/Dockerfile
@@ -5,9 +5,13 @@
 # (a bad token fails, exactly like the real engine reaching only the login
 # screen). python:3.13-slim is the same fast, reliable base the dev +
 # webhook-proxy add-ons build from in this bake. No apt, no npm, no Chromium.
-# Digest-pinned (matches the webhook-proxy addon) so the in-Supervisor build is
-# reproducible and Renovate-bumpable — an unpinned tag would reintroduce the
-# floating-base bake failure this change exists to eliminate.
+# Digest-pinned (tracks the coordinated Python base every managed Dockerfile
+# shares -- see the "python" packageRule in renovate.json) so the
+# in-Supervisor build is reproducible and Renovate-bumpable. The
+# webhook-proxy add-ons are excluded from that automation and update only
+# through their own dev-first promotion workflow, so their pin can lag this
+# one. An unpinned tag here would reintroduce the floating-base bake failure
+# this change exists to eliminate.
 FROM python:3.13-slim@sha256:7e3a6aca9d74f93cca21a91d86a8dad8c34749afd5b4a98ee481c9c47b9f5ed4
 COPY server.py /server.py
 CMD ["python", "/server.py"]

--- a/tests/haos_image_build/screenshot_engine_mock/Dockerfile
+++ b/tests/haos_image_build/screenshot_engine_mock/Dockerfile
@@ -8,6 +8,6 @@
 # Digest-pinned (matches the webhook-proxy addon) so the in-Supervisor build is
 # reproducible and Renovate-bumpable — an unpinned tag would reintroduce the
 # floating-base bake failure this change exists to eliminate.
-FROM python:3.13-slim@sha256:3de9a8d7aedbb7984dc18f2dff178a7850f16c1ae7c34ba9d7ecc23d0755e35f
+FROM python:3.13-slim@sha256:7e3a6aca9d74f93cca21a91d86a8dad8c34749afd5b4a98ee481c9c47b9f5ed4
 COPY server.py /server.py
 CMD ["python", "/server.py"]


### PR DESCRIPTION
## What does this PR do?

Refreshes the `python:3.13-slim` runtime digest from `3de9a8d7` to `7e3a6aca`
across the four Dockerfiles that share the coordinated pin.

The commit was authored by Renovate on 2026-08-25 and has been sitting on
`renovate/python-3.13-slim` ever since without a PR. Renovate wrote the branch
and then aborted before the PR-creation step:

```
15:31:22.068  INFO: Branch updated (branch=renovate/python-3.13-slim)
15:31:22.529  INFO: Repository has changed during renovation - aborting
```

The 2026-08-18 run aborted the same way; both are the only scheduled runs
since #2202 (2026-08-12) that had a real update to act on. Root cause is now
identified and fixed in #2283: the Renovate App installation lacked
commit-status write, so its stability-check call 404'd, which Renovate reads
as the repository having changed and aborts the whole run. That PR also
promotes the abort to error level so a recurrence fails the workflow instead
of reporting green.

This PR only delivers the update that was already computed on the stuck
branch; it does not itself fix the abort. The runtime digest not moving since
2026-02-17 (#628) is a separate fact: Docker Hub shows the current upstream
digest was pushed 2026-08-25, so there was likely nothing new to update to for
most of that window regardless of this bug.

The two webhook-proxy Dockerfiles are deliberately untouched, per the
`packageRules` entry that disables them in favour of the dev-first promotion
workflow.

## Type of change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [x] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

CI on this branch is the real check: the digest change is only exercised by
actually building the images.

## Checklist
- [x] I have updated documentation if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the pinned Python runtime images used by the application, development environment, add-on, and screenshot testing tools.
  * Improved consistency across runtime environments while preserving existing build instructions and application behavior.
  * Documented coordinated image update tracking for supported testing and add-on workflows.
  * No user-facing features or configuration changes were introduced.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
