### PR TITLE
fix(ci): stop Renovate silently aborting its whole run on every branch

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -48,13 +48,21 @@ jobs:
           # dead: an installation token that lists any permission-* input drops
           # every permission it does not name, including vulnerability_alerts.
           permission-vulnerability-alerts: read
+          # Renovate publishes a stability status check on every branch it
+          # writes (minimumReleaseAge). Without commit-status access GitHub
+          # answers 404 rather than 403, Renovate reads that as the repository
+          # having changed, and aborts the WHOLE run right after writing its
+          # first branch: no PR, no dependency dashboard, nothing else
+          # processed. The app installation must grant this too; the token can
+          # only ever narrow what the installation already has.
+          permission-statuses: write
           permission-workflows: write
 
       - name: Self-hosted Renovate
         uses: renovatebot/github-action@e09d604f8f803bb527bd8321ed5be06c460b8682 # v46.2.2
         with:
           configurationFile: renovate.json
-          renovate-version: 44.26.0
+          renovate-version: 44.46.2
           token: ${{ steps.app-token.outputs.token }}
         env:
           LOG_LEVEL: ${{ inputs.logLevel || 'info' }}

--- a/renovate.json
+++ b/renovate.json
@@ -19,6 +19,10 @@
       "newLogLevel": "error"
     },
     {
+      "matchMessage": "Repository has changed during renovation - aborting",
+      "newLogLevel": "error"
+    },
+    {
       "matchMessage": "/^Some release\\(s\\) did not have a releaseTimestamp, but as we're running with minimumReleaseAgeBehaviour=timestamp-optional, proceeding\\. See debug logs for more information$/",
       "newLogLevel": "info"
     }
@@ -50,7 +54,7 @@
       "datasourceTemplate": "{{{datasource}}}"
     },
     {
-      "description": "Vendored library pins. src/ha_mcp/_vendor/ holds third-party code copied verbatim from the pinned sdist, so no package manager sees it: enabledManagers excludes pip_requirements and dependabot's uv ecosystem reads only pyproject.toml/uv.lock. Without this manager a CVE fix would never open a PR. A bump alone does not regenerate the tree — tests/src/unit/test_vendored_websockets.py fails the renovate PR until scripts/vendor_websockets.py is re-run and the result committed, which is the intended handoff.",
+      "description": "Vendored library pins. src/ha_mcp/_vendor/ holds third-party code copied verbatim from the pinned sdist, so no package manager sees it: enabledManagers excludes pip_requirements and dependabot's uv ecosystem reads only pyproject.toml/uv.lock. Without this manager a CVE fix would never open a PR. A bump alone does not regenerate the tree \u2014 tests/src/unit/test_vendored_websockets.py fails the renovate PR until scripts/vendor_websockets.py is re-run and the result committed, which is the intended handoff.",
       "customType": "regex",
       "managerFilePatterns": [
         "/^src/ha_mcp/_vendor/requirements\\.txt$/"

--- a/tests/src/unit/test_supply_chain_workflow_shape.py
+++ b/tests/src/unit/test_supply_chain_workflow_shape.py
@@ -320,3 +320,46 @@ def test_dev_release_tag_cleanup_uses_authenticated_github_api() -> None:
         in cleanup_run
     )
     assert "git push origin --delete" not in create_run + cleanup_run
+
+
+def test_renovate_can_write_the_status_check_it_publishes() -> None:
+    """Renovate must not abort its whole run right after writing a branch.
+
+    ``minimumReleaseAge`` makes Renovate publish a stability status check on
+    every branch it writes. GitHub answers a commit-status call from a token
+    without that permission with 404, not 403, and Renovate reads 404 there as
+    the repository having changed underneath it and aborts the ENTIRE run,
+    before opening the PR, before updating the dependency dashboard, and
+    before processing any other dependency. That is silent: the abort logs
+    below error level, so the workflow still reports success.
+
+    This pins the workflow half only. The app installation must grant
+    ``statuses`` as well, which no test here can see: an installation token
+    can only narrow the permissions the installation already holds.
+    """
+    steps = _workflow(_WORKFLOW_DIR / "renovate.yml")["jobs"]["renovate"]["steps"]
+    token_step = next(
+        step for step in steps if "create-github-app-token" in str(step.get("uses", ""))
+    )
+    assert token_step["with"].get("permission-statuses") == "write", (
+        "Renovate needs commit-status write, and a token listing any "
+        "permission-* input drops every permission it does not name"
+    )
+
+
+def test_a_renovate_abort_fails_the_workflow() -> None:
+    """A run that dies mid-way must not report success.
+
+    Renovate exits non-zero only when some record is logged at error level or
+    above, so a fatal abort logged at info leaves the workflow green. This one
+    hid two weeks of dead runs.
+    """
+    config = json.loads((_REPO_ROOT / "renovate.json").read_text(encoding="utf-8"))
+    promoted = {
+        remap["matchMessage"]
+        for remap in config["logLevelRemap"]
+        if remap["newLogLevel"] == "error"
+    }
+    assert "Repository has changed during renovation - aborting" in promoted, (
+        "this abort ends the whole repository run, so it cannot stay at info"
+    )


### PR DESCRIPTION
## What does this PR do?

Fixes Renovate silently aborting its entire repository run on every branch it
writes. Since #2202 merged (2026-08-12), the two scheduled runs that had real
work to do (2026-08-18, 2026-08-25) both wrote a branch for the
`python:3.13-slim` digest and then aborted before opening a PR, updating the
dependency dashboard, or processing anything else that run.

**Root cause.** `minimumReleaseAge` makes Renovate publish a stability status
check on every branch it writes. The `ha-mcp-renovate` App installation never
had commit-status access. GitHub answers a status-check call from a token
without that permission with 404, not 403, and Renovate reads that 404 as the
repository having changed underneath it, aborting the whole run immediately
after the first branch: before the PR opens, before the dependency dashboard
updates, before any other dependency is processed. The abort logs below error
level, so Renovate exits 0 and the workflow reports green through it.

**Fix.**
- Request `permission-statuses: write` on the App token.
- Promote the abort message to `error` in `logLevelRemap`, so a recurrence
  fails the workflow.
- Bump the pinned engine to `44.46.2`.

The org-side installation grant for the new permission was accepted
separately and is confirmed live.

## Type of change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

Two new tests pin both halves of the fix, and both were verified against the
actual defect by reverting each half and confirming its test fails:
`test_renovate_can_write_the_status_check_it_publishes` (token requests the
permission) and `test_a_renovate_abort_fails_the_workflow` (abort promoted to
error). The permission grant itself can't be pinned by a test: an installation
token can only narrow what the installation already holds.

## Checklist
- [x] I have updated documentation if needed
