### PR TITLE
docs(internal): correct the reference-graph ranking comment

### DIFF
--- a/src/ha_mcp/tools/smart_search/_fetch.py
+++ b/src/ha_mcp/tools/smart_search/_fetch.py
@@ -201,7 +201,7 @@ class ConfigFetchMixin(ScoringMixin):
 
         ``deprioritize`` moves the named ids to the BACK of the queue while
         keeping every id in it (relative order preserved within each group).
-        The automation and script callers pass the ids Home Assistant's
+        The automation, script and scene callers pass the ids Home Assistant's
         reference graph already confirmed reference the queried entity: their
         match status is settled without reading the body, so under budget
         pressure the budget belongs to the ids that are NOT in the set, which

--- a/src/ha_mcp/tools/smart_search/_graph.py
+++ b/src/ha_mcp/tools/smart_search/_graph.py
@@ -357,10 +357,16 @@ async def fetch_related_buckets(client: Any, entity_id: str) -> GraphResult | No
 # Score assigned to a reference-graph hit. In the default exact mode every
 # surviving match scores exactly 100 (``_score_deep_match`` takes the max of
 # two 0-or-100 signals against a threshold of 100), so a graph hit sorts
-# indistinguishably from a body hit. Fuzzy scores are capped at 100 too, so
-# there a confirmed reference ranks at or above every fuzzy name match, which
-# is the intent: HA naming the reference is exact evidence, not an
-# approximate one.
+# indistinguishably from a body hit.
+#
+# Fuzzy mode is not symmetric, and no value here makes it so: the 100 cap
+# belongs to the config-body score (``_search_in_dict``), while the NAME score
+# from ``_calculate_entity_score`` accumulates without a ceiling — a name
+# echoing the queried entity's words can pass 100 on its own. So with
+# ``exact_match=False`` a graph-ONLY hit (``_merge_graph_hits`` leaves an
+# already-scored record's score alone) can sort below a match that merely
+# resembles the query, and land on a later page under a small ``limit``. It is
+# still counted in ``total_matches`` unless visibility enforcement scrubs it.
 _GRAPH_HIT_SCORE = 100
 
 

--- a/src/ha_mcp/tools/smart_search/_graph.py
+++ b/src/ha_mcp/tools/smart_search/_graph.py
@@ -359,14 +359,15 @@ async def fetch_related_buckets(client: Any, entity_id: str) -> GraphResult | No
 # two 0-or-100 signals against a threshold of 100), so a graph hit sorts
 # indistinguishably from a body hit.
 #
-# Fuzzy mode is not symmetric, and no value here makes it so: the 100 cap
-# belongs to the config-body score (``_search_in_dict``), while the NAME score
-# from ``_calculate_entity_score`` accumulates without a ceiling — a name
-# echoing the queried entity's words can pass 100 on its own. So with
-# ``exact_match=False`` a graph-ONLY hit (``_merge_graph_hits`` leaves an
-# already-scored record's score alone) can sort below a match that merely
-# resembles the query, and land on a later page under a small ``limit``. It is
-# still counted in ``total_matches`` unless visibility enforcement scrubs it.
+# Fuzzy mode is not symmetric, and no value here makes it so without breaking
+# the tie above: the 100 cap belongs to the config-body score
+# (``_search_in_dict``), while the NAME score from ``_calculate_entity_score``
+# accumulates without a ceiling — a name echoing the queried entity's words can
+# pass 100 on its own. So with ``exact_match=False`` a graph-ONLY hit
+# (``_merge_graph_hits`` leaves an already-scored record's score alone) can sort
+# below a match that merely resembles the query, and land on a later page under
+# a small ``limit``. It is still counted in ``total_matches`` unless visibility
+# enforcement scrubs it.
 _GRAPH_HIT_SCORE = 100
 
 

--- a/src/ha_mcp/tools/smart_search/_graph.py
+++ b/src/ha_mcp/tools/smart_search/_graph.py
@@ -362,8 +362,8 @@ async def fetch_related_buckets(client: Any, entity_id: str) -> GraphResult | No
 # Fuzzy mode is not symmetric, and no value here makes it so without breaking
 # the tie above: the 100 cap belongs to the config-body score
 # (``_search_in_dict``), while the NAME score from ``_calculate_entity_score``
-# accumulates without a ceiling — a name echoing the queried entity's words can
-# pass 100 on its own. So with ``exact_match=False`` a graph-ONLY hit
+# is not capped at 100 — a name echoing the queried entity's words can pass
+# 100 on its own. So with ``exact_match=False`` a graph-ONLY hit
 # (``_merge_graph_hits`` leaves an already-scored record's score alone) can sort
 # below a match that merely resembles the query, and land on a later page under
 # a small ``limit``. It is still counted in ``total_matches`` unless visibility


### PR DESCRIPTION
## What does this PR do?

Corrects two pieces of prose in `smart_search` that state something the code does not do — one `#` comment and one docstring. No behaviour change; the AST is identical with docstrings stripped.

**`_GRAPH_HIT_SCORE`'s ranking claim.** It says fuzzy scores are capped at 100, so a confirmed reference ranks at or above every fuzzy name match. The cap it describes is in `_search_in_dict` and bounds the config-body score. The fuzzy *name* score comes from `_calculate_entity_score`, which has a single return and is not capped at 100.

This is not the common case — most unrelated names score well under 100 — and it does not need to be. One name echoing the queried entity's words is enough, and you can check this one yourself: `_calculate_entity_score("automation.kitchen_lights_evening", "Kitchen Lights Evening", "automation", "light.kitchen_ceiling")` returns 118, against a graph hit's fixed 100. That is sufficient to push the confirmed reference below a config that merely resembles the query. The exact-mode half of the original claim holds and stays.

The replacement comment is scoped to what I could verify: it speaks about graph-**only** hits, because `_merge_graph_hits` leaves an already-scored record's score alone, and it hedges the "still counted" clause, because `_scrub_results_for_enforce` runs after the merge and can drop a graph hit outright under visibility enforcement.

**`_individual_fetch_budgeted`'s deprioritize docstring** names the automation and script callers; the scene branch passes the set too.

This documents the fuzzy ordering rather than changing it. If you meant the stronger guarantee the comment originally claimed, that needs `match_in_references` in the sort key in `_paginate_and_build_response`. Note that also touches exact mode, where graph hits tie with body hits at 100 and follow them **within a bucket** — across buckets the flattening order in `_paginate_and_build_response` dominates, not the append order. That is a behaviour change, so it stayed out of this comment correction.

One negative result worth recording, since it is about the code this comment describes. I built and then dropped a change that skipped the deprioritization when `include_config=True`, on the theory that a caller asking for bodies wants the confirmed reference's body most. Measuring it killed the idea. In the case I ran — two automations, a budget affording one fetch — the current ordering returned two matches (a templated reference with its body, plus the graph hit) and the change returned one, because the unfetched config scores 0 and falls below threshold. Which id wins the budget is incidental to the change rather than caused by it, and the caller is told the scan was partial either way, so the reference goes unnamed rather than undisclosed. What the change does remove is the guarantee that non-graph ids get the budget first. Losing a reference is worse than returning one without its body, so the ordering as it stands is right. That experiment is not in this branch — treat it as an anecdote, not evidence.

## Type of change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [x] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing

Nothing to test — prose only. `tests/src/unit/test_search_related_graph.py` collects 41 and passes 41 with `--maxfail=0`. CI covers the rest.

- [ ] I have tested these changes with a LLM agent
- [ ] All automated tests pass (`uv run pytest`)
- [ ] Code follows style guidelines (`uv run ruff check`)

## Checklist
- [x] I have updated documentation if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified budget-ordering guidance to include scene callers alongside automations and scripts.
  * Expanded fuzzy-search ranking documentation, including graph-only match scoring and visibility behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

