### PR TITLE
fix: keep ha_search on the component fast path with dashboard search_types and on server-entry-only installs

### DIFF
--- a/custom_components/ha_mcp_tools/__init__.py
+++ b/custom_components/ha_mcp_tools/__init__.py
@@ -3557,7 +3557,10 @@ async def _async_setup_tools_entry(hass: HomeAssistant, entry: ConfigEntry) -> b
     # Register the in-process ha_mcp_tools/* WebSocket commands (info + search)
     # the server calls behind a capability gate. Idempotent, and independent of
     # the caller-token gate above — HA core authenticates the WS connection and
-    # @require_admin gates each command (see websocket_api.py).
+    # @require_admin gates each command (see websocket_api.py). The server
+    # (embedded) entry registers the same surface (#2289), so a server-only
+    # install has it as well; on a dual-entry install both entries register it
+    # and the second registration simply overwrites the first.
     async_register_commands(hass)
 
     # Entry-level finalization: pick up the #1853 rename on existing installs and

--- a/custom_components/ha_mcp_tools/const.py
+++ b/custom_components/ha_mcp_tools/const.py
@@ -25,7 +25,7 @@ DOMAIN = "ha_mcp_tools"
 # in CI. The
 # capability negotiation — not this version — gates each WS command (see
 # ``websocket_api.CAPABILITIES``).
-COMPONENT_VERSION = "2.0.1"
+COMPONENT_VERSION = "2.1.0"
 
 # Config-entry discriminator (``entry.data[CONF_ENTRY_TYPE]``). A missing value
 # means "tools" so the pre-existing services entry keeps working across the

--- a/custom_components/ha_mcp_tools/embedded_entry.py
+++ b/custom_components/ha_mcp_tools/embedded_entry.py
@@ -48,12 +48,13 @@ from .const import (
 )
 
 # NOTE: embedded_setup / coordinator (and their embedded_server / mcp_webhook
-# chain) are imported lazily inside the entry lifecycle functions below, not at
-# module top level. They pull in aiohttp and several homeassistant.* submodules
-# (auth, requirements, util.package, components.http/webhook) that the
-# entry-point wiring here never touches directly, so a top-level import would
-# make importing this package require that whole stack — breaking hermetic unit
-# tests that stub only the modules they use.
+# chain), plus websocket_api, are imported lazily inside the entry lifecycle
+# functions below, not at module top level. They pull in aiohttp, yaml and
+# several homeassistant.* submodules (auth, requirements, util.package,
+# components.http/webhook, components.websocket_api, half a dozen helpers) that
+# the entry-point wiring here never touches directly, so a top-level import
+# would make importing this package require that whole stack — breaking
+# hermetic unit tests that stub only the modules they use.
 
 if TYPE_CHECKING:
     from homeassistant.config_entries import ConfigEntry
@@ -67,13 +68,28 @@ async def async_setup_server_entry(hass: HomeAssistant, entry: ConfigEntry) -> b
     startup. It runs as a config-entry background task — automatically cancelled
     on unload. The secret webhook id and secret path are generated first, before
     the update listener is registered, so those ``entry.data`` writes never
-    trigger a mid-setup reload.
+    trigger a mid-setup reload. The ``ha_mcp_tools/*`` WebSocket command surface
+    is registered up front, before any of that.
     """
     # Imported lazily (see the import note) so the aiohttp / auth / requirements
     # chain is pulled in only when an entry is actually set up.
     from .coordinator import ServerVersionCoordinator
     from .embedded_setup import async_bring_up_server, async_maybe_auto_update
     from .ui_panel import async_register_ui_panel
+    from .websocket_api import async_register_commands
+
+    # The ha_mcp_tools/* WS commands are entry-agnostic read/search machinery
+    # over HA-core state (entity components, storage collections, lovelace,
+    # registries) — nothing in them reads the tools entry's hass.data, and HA
+    # core authenticates the connection while @require_admin gates each command.
+    # So the server entry registers them too (#2289): a server-entry-only
+    # install used to have no ha_mcp_tools/* commands at all, silently dropping
+    # every ha_search to the legacy path. Only the filesystem/YAML HA *services*
+    # stay tools-entry-only. Registered first, before anything that can fail or
+    # await, so a broken bring-up later never costs the install this surface;
+    # registration is idempotent, so a dual-entry install re-registering is
+    # harmless.
+    async_register_commands(hass)
 
     _ensure_secrets(hass, entry)
     # Bind every applicable OAuth route synchronously here — before the slow

--- a/custom_components/ha_mcp_tools/manifest.json
+++ b/custom_components/ha_mcp_tools/manifest.json
@@ -22,5 +22,5 @@
     "requirements": [
         "ruamel.yaml>=0.18.0"
     ],
-    "version": "2.0.1"
+    "version": "2.1.0"
 }

--- a/custom_components/ha_mcp_tools/websocket_api.py
+++ b/custom_components/ha_mcp_tools/websocket_api.py
@@ -531,9 +531,15 @@ _SPLIT_RE = re.compile(r"[._\-\s]+")
 def async_register_commands(hass: HomeAssistant) -> None:
     """Register the ``ha_mcp_tools/*`` WebSocket commands.
 
+    Called from BOTH config-entry setups: the tools entry (alongside its service
+    registrations) and the server entry (#2289). The surface is entry-agnostic —
+    every handler reads HA-core state, none of it the tools entry's
+    ``hass.data`` — so a server-entry-only install gets it too; only the
+    filesystem/YAML HA *services* remain tools-entry-only.
+
     Idempotent: HA's ``async_register_command`` overwrites an existing handler,
-    so re-running on a config-entry reload is harmless. Called from the tools
-    config-entry setup alongside the service registrations.
+    so re-running on a config-entry reload, or from both entries on a dual-entry
+    install, is harmless.
     """
     for schema, do_fn, prep in _command_specs():
         websocket_api.async_register_command(hass, _build_handler(schema, do_fn, prep))

--- a/custom_components/ha_mcp_tools/websocket_api.py
+++ b/custom_components/ha_mcp_tools/websocket_api.py
@@ -918,11 +918,18 @@ def _bulk_call_service_schema() -> dict[Any, Any]:
 def _do_info(hass: HomeAssistant | None = None) -> dict[str, Any]:
     """Return the handshake payload.
 
-    ``timezone`` is an additive field (``hass.config.time_zone``) consumers detect
-    by presence — it carries NO capability entry and does NOT bump
+    ``timezone`` (``hass.config.time_zone``) and ``tools_services`` (whether
+    the tools entry's HA services are registered) are additive fields consumers
+    detect by presence — they carry NO capability entry and do NOT bump
     ``schema_version``. ``hass`` is optional (defaulting to ``None`` so a direct
     ``_do_info()`` still works for callers that only need the static handshake);
-    when absent, ``timezone`` degrades to ``None``.
+    when absent, both degrade to ``None``.
+
+    ``tools_services`` exists because 2.1.0 registers this command surface from
+    BOTH entry types (#2289): ``info`` answering no longer implies the tools
+    entry — and its filesystem/YAML services — are present (#2292). The server's
+    filesystem/YAML gate reads this field to keep raising its actionable
+    "tools entry not set up" error on server-entry-only installs.
     """
     return {
         "schema_version": SCHEMA_VERSION,
@@ -930,6 +937,7 @@ def _do_info(hass: HomeAssistant | None = None) -> dict[str, Any]:
         "capabilities": list(CAPABILITIES),
         "limits": dict(LIMITS),
         "timezone": _config_time_zone(hass),
+        "tools_services": _tools_services_loaded(hass),
     }
 
 
@@ -938,6 +946,23 @@ def _config_time_zone(hass: HomeAssistant | None) -> str | None:
     config = getattr(hass, "config", None)
     tz = getattr(config, "time_zone", None)
     return tz if isinstance(tz, str) and tz else None
+
+
+def _tools_services_loaded(hass: HomeAssistant | None) -> bool | None:
+    """True when the tools entry's filesystem/YAML HA services are registered.
+
+    Probes the service registry itself (``read_file`` — one of the services
+    ``_async_setup_tools_entry`` registers and its unload removes) rather than
+    the config-entry list, so the answer tracks what a caller can actually
+    invoke. ``None`` when ``hass`` is absent (the direct ``_do_info()`` call);
+    the WS handler always passes ``hass``, so the wire value is a bool.
+    """
+    services = getattr(hass, "services", None)
+    if services is None:
+        return None
+    # Literal matches SERVICE_READ_FILE in __init__.py (importing it here would
+    # be circular).
+    return bool(services.has_service(DOMAIN, "read_file"))
 
 
 # =============================================================================

--- a/scripts/codeql_quality_gate.py
+++ b/scripts/codeql_quality_gate.py
@@ -106,6 +106,17 @@ ALLOWLIST: tuple[tuple[str, str, str, str, str], ...] = (
     ),
     (
         "py/ineffectual-statement",
+        "tests/src/unit/test_websocket_client.py",
+        "This statement has no effect",
+        "await task",
+        "False positive on the bare 'await task' inside pytest.raises in "
+        "test_send_command_cancellation_drops_the_pending_future: awaiting "
+        "the cancelled send_command task IS the effect (it drives the task to "
+        "completion and raises the CancelledError the context manager "
+        "asserts).",
+    ),
+    (
+        "py/ineffectual-statement",
         "tests/src/unit/test_ha_search_dashboard_split.py",
         "This statement has no effect",
         "await call",

--- a/scripts/codeql_quality_gate.py
+++ b/scripts/codeql_quality_gate.py
@@ -106,6 +106,17 @@ ALLOWLIST: tuple[tuple[str, str, str, str, str], ...] = (
     ),
     (
         "py/ineffectual-statement",
+        "tests/src/unit/test_ha_search_dashboard_split.py",
+        "This statement has no effect",
+        "await call",
+        "False positive on the bare 'await call' inside pytest.raises in "
+        "test_parent_cancellation_settles_the_dashboard_leg: awaiting the "
+        "cancelled ha_search task IS the effect (it drives the call to "
+        "completion and raises the CancelledError the context manager "
+        "asserts).",
+    ),
+    (
+        "py/ineffectual-statement",
         "tests/src/e2e/workflows/hacs/test_auto_refresh_startup.py",
         "This statement has no effect",
         "await task",

--- a/src/ha_mcp/client/websocket_client.py
+++ b/src/ha_mcp/client/websocket_client.py
@@ -672,6 +672,11 @@ class HomeAssistantWebSocketClient:
             # never-sent. Still cancel the pending future so it cannot leak.
             self.cancel_pending_response(message_id)
             raise
+        except BaseException:
+            # Cancellation mid-send: same leak potential as the response-wait
+            # clause below — drop the registered future before propagating.
+            self.cancel_pending_response(message_id)
+            raise
 
         # Wait for response outside the lock.
         try:
@@ -705,6 +710,15 @@ class HomeAssistantWebSocketClient:
             self.cancel_pending_response(message_id)
             raise HomeAssistantCommandTimeout("Command timeout") from e
         except Exception:
+            self.cancel_pending_response(message_id)
+            raise
+        except BaseException:
+            # Cancellation (or another BaseException) while awaiting the
+            # response: without this clause the registered future stays in
+            # _pending_requests until a response with this id arrives — which a
+            # hung handler never sends — leaking one entry per cancelled call
+            # (e.g. the ha_search dashboards leg cancelled on a component-leg
+            # failure, #2291).
             self.cancel_pending_response(message_id)
             raise
 

--- a/src/ha_mcp/tools/component_api.py
+++ b/src/ha_mcp/tools/component_api.py
@@ -102,6 +102,13 @@ class ComponentCaps:
     capabilities: frozenset[str]
     limits: dict[str, Any]
     timezone: str | None = None
+    # Whether the tools entry's filesystem/YAML HA services are registered.
+    # Additive ``info`` field (2.1.0, #2292): since the server entry also
+    # registers the WS surface (#2289), caps-present no longer implies those
+    # services exist; ``None`` means a component too old to report it (where
+    # the old implication still holds — only the tools entry registered
+    # ``info`` there).
+    tools_services: bool | None = None
 
 
 # Weak-keyed by client so the negotiated caps self-evict when the client is
@@ -218,6 +225,7 @@ def _parse_caps(response: Any) -> ComponentCaps | None:
     except (TypeError, ValueError):
         schema_version = 0
     raw_timezone = result.get("timezone")
+    raw_tools_services = result.get("tools_services")
     return ComponentCaps(
         schema_version=schema_version,
         component_version=str(result.get("component_version", "")),
@@ -226,6 +234,11 @@ def _parse_caps(response: Any) -> ComponentCaps | None:
         # Additive info field: a component too old to report it (or an unset
         # time_zone) leaves this None; a non-string value is ignored likewise.
         timezone=raw_timezone if isinstance(raw_timezone, str) else None,
+        # Additive info field (#2292): non-bool (including absent, on a
+        # pre-2.1.0 component) stays None.
+        tools_services=raw_tools_services
+        if isinstance(raw_tools_services, bool)
+        else None,
     )
 
 

--- a/src/ha_mcp/tools/tools_filesystem.py
+++ b/src/ha_mcp/tools/tools_filesystem.py
@@ -429,6 +429,12 @@ async def _assert_mcp_tools_available(client: Any) -> None:
     (``get_component_caps`` returns caps) obviously exists — reuse that shared
     cached probe and enforce ``MIN_COMPONENT_VERSION`` from
     ``caps.component_version`` (info shipped in 1.1.0, already past the floor).
+    Caps alone no longer prove the SERVICES exist, though: since 2.1.0 the
+    server entry also registers the WS surface (#2289), so ``info`` answers on
+    a server-entry-only install too. Such a component reports the additive
+    ``tools_services`` field (#2292); ``False`` raises the tools-entry error
+    below. ``None`` (a pre-2.1.0 component) keeps the old implication, which
+    was sound there — only the tools entry registered ``info``.
     Legacy fallback: caps is None for a component in the 0.11.0-1.1.0 band
     (services, no info command) or an absent one, so fall back to the per-call
     ``get_services()`` existence probe. A no-services verdict raises the
@@ -445,6 +451,8 @@ async def _assert_mcp_tools_available(client: Any) -> None:
     caps = await get_component_caps(client)
     if caps is not None:
         _assert_caps_version_ok(caps)
+        if caps.tools_services is False:
+            _raise_tools_entry_not_set_up()
         return
     if not await _is_mcp_tools_available(client):
         _raise_tools_entry_not_set_up()

--- a/src/ha_mcp/tools/tools_filesystem.py
+++ b/src/ha_mcp/tools/tools_filesystem.py
@@ -433,8 +433,10 @@ async def _assert_mcp_tools_available(client: Any) -> None:
     server entry also registers the WS surface (#2289), so ``info`` answers on
     a server-entry-only install too. Such a component reports the additive
     ``tools_services`` field (#2292); ``False`` raises the tools-entry error
-    below. ``None`` (a pre-2.1.0 component) keeps the old implication, which
-    was sound there — only the tools entry registered ``info``.
+    below — after a live service-registry re-check, because the cached caps can
+    predate the user adding the tools entry mid-session. ``None`` (a pre-2.1.0
+    component) keeps the old implication, which was sound there — only the
+    tools entry registered ``info``.
     Legacy fallback: caps is None for a component in the 0.11.0-1.1.0 band
     (services, no info command) or an absent one, so fall back to the per-call
     ``get_services()`` existence probe. A no-services verdict raises the
@@ -451,7 +453,12 @@ async def _assert_mcp_tools_available(client: Any) -> None:
     caps = await get_component_caps(client)
     if caps is not None:
         _assert_caps_version_ok(caps)
-        if caps.tools_services is False:
+        # Caps are cached for the client's lifetime, so a ``False`` snapshot
+        # taken before the user added the tools entry would block these tools
+        # until a server restart. Service registration is dynamic — re-check
+        # the live service registry before raising, and only raise when it
+        # confirms the services are still absent.
+        if caps.tools_services is False and not await _is_mcp_tools_available(client):
             _raise_tools_entry_not_set_up()
         return
     if not await _is_mcp_tools_available(client):

--- a/src/ha_mcp/tools/tools_search.py
+++ b/src/ha_mcp/tools/tools_search.py
@@ -1124,7 +1124,22 @@ def _dashboard_split_requested(req: _ResolvedSearch) -> bool:
     )
 
 
-def _dashboard_split_serviceable(req: _ResolvedSearch) -> bool:
+def _component_max_results(caps: Any) -> int:
+    """The component's advertised ``limits.max_results``, defaulting to 500.
+
+    The advisory ``limits`` ride the cached ``info`` probe, so a component
+    advertising a smaller ceiling gates the window fetch here instead of
+    accepting the split and then rejecting the frame in its schema (an
+    avoidable failed round-trip whose fallback still serves the caller).
+    """
+    limits = getattr(caps, "limits", None)
+    value = limits.get("max_results") if isinstance(limits, dict) else None
+    if isinstance(value, int) and value > 0:
+        return value
+    return _COMPONENT_MAX_RESULTS
+
+
+def _dashboard_split_serviceable(req: _ResolvedSearch, caps: Any) -> bool:
     """True when the split can serve the request; False ⇒ legacy serves it whole.
 
     Two corner cases route away rather than being half-served:
@@ -1135,12 +1150,13 @@ def _dashboard_split_serviceable(req: _ResolvedSearch) -> bool:
       split as a dashboards leg wearing a component envelope — the legacy path
       already produces exactly that, with its own bucket.
     - The window fetch would ask for more records than the component's
-      ``limit`` ceiling, which its schema rejects outright.
+      ``limit`` ceiling (``_component_max_results``), which its schema rejects
+      outright.
     """
     serves_body = req.body_eligible and bool(_component_body_search_types(req))
     if not (req.registry_eligible or serves_body):
         return False
-    return req.offset + req.limit <= _COMPONENT_MAX_RESULTS
+    return req.offset + req.limit <= _component_max_results(caps)
 
 
 @dataclass(frozen=True)
@@ -1186,6 +1202,26 @@ def _apply_entity_window(req: _ResolvedSearch, windowed: dict[str, Any]) -> None
     windowed["entity_has_more"] = (req.offset + len(page)) < total
 
 
+def _merge_sort_key(record: dict[str, Any]) -> str:
+    """Mirror of the component's ``_sort_key`` config tiebreak, dashboards added.
+
+    The component cuts its window with ``(-score, _sort_key)`` where
+    ``_sort_key`` is ``str(entity_id or id or name or "")``
+    (``custom_components/ha_mcp_tools/websocket_api.py``); those fields ride
+    the wire records unchanged, so the merge reproduces the exact order that
+    decided window membership. Dashboard records are outside the component
+    corpus, so any deterministic key places them consistently across pages —
+    ``dashboard_url`` extends the same chain.
+    """
+    return str(
+        record.get("entity_id")
+        or record.get("id")
+        or record.get("name")
+        or record.get("dashboard_url")
+        or ""
+    )
+
+
 def _merge_dashboard_window(
     req: _ResolvedSearch,
     component_result: dict[str, Any],
@@ -1198,9 +1234,14 @@ def _merge_dashboard_window(
     the merged page has to be cut server-side. It is exact: the component
     fetched the whole ``[0, offset + limit)`` window of its own corpus, a
     superset of every component record that can reach the caller's page, and
-    the leg returns its bucket unpaginated. Ties keep component records ahead
-    of dashboards (the sort is stable and dashboards are appended last),
-    matching the legacy insertion order.
+    the leg returns its bucket unpaginated.
+
+    The cut uses the SAME total order that selected the window —
+    ``(-score, _merge_sort_key)``, mirroring the component's
+    ``(-score, _sort_key)`` — because window membership is decided by the
+    component's order: cutting the merge with any other order lets an
+    equal-score record at a window boundary repeat on one page and vanish
+    from the next as ``offset`` grows.
 
     Returns the component result rewritten for the caller's page — buckets
     sliced, entity records re-sliced, totals and ``*_has_more`` recomputed —
@@ -1213,7 +1254,9 @@ def _merge_dashboard_window(
         for record in _as_record_list(component_result.get(bucket))
     ]
     tagged.extend(("dashboards", record) for record in dashboard_records)
-    tagged.sort(key=lambda item: item[1].get("score") or 0, reverse=True)
+    tagged.sort(
+        key=lambda item: (-(item[1].get("score") or 0), _merge_sort_key(item[1]))
+    )
     page = tagged[req.offset : req.offset + req.limit]
 
     total = int(component_result.get("config_total_matches", 0) or 0) + len(
@@ -2377,7 +2420,7 @@ class SearchTools:
                 ) = await self._resolve_component_search_visibility(caps)
                 if route_component:
                     component_response = await self._ha_search_via_component(
-                        req, ctx, visibility=visibility
+                        req, ctx, visibility=visibility, caps=caps
                     )
                     if component_response is not None:
                         return component_response
@@ -2419,6 +2462,7 @@ class SearchTools:
         ctx: Context | None,
         *,
         visibility: dict[str, Any] | None = None,
+        caps: Any = None,
     ) -> dict[str, Any] | None:
         """Serve ha_search from the component; ``None`` ⇒ run the legacy path.
 
@@ -2431,10 +2475,12 @@ class SearchTools:
         A ``search_types`` naming ``dashboard`` splits the work — the command
         serves the surfaces it has, the dashboards leg serves that bucket, and
         the two are merged (issue #2289). ``_dashboard_split_serviceable``
-        names the corner cases that send the whole call to legacy instead.
+        names the corner cases that send the whole call to legacy instead;
+        ``caps`` (the routing block's cached probe) feeds its
+        component-advertised ``limits.max_results`` ceiling.
         """
         if _dashboard_split_requested(req):
-            if not _dashboard_split_serviceable(req):
+            if not _dashboard_split_serviceable(req, caps):
                 return None
             return await self._component_search_with_dashboards(
                 req, ctx, visibility=visibility
@@ -2504,28 +2550,38 @@ class SearchTools:
         serialising them would add its latency to every mixed search.
 
         A failing component leg takes the taxonomy's legacy fallback, which
-        serves the WHOLE call — dashboards bucket included — so the finished
-        leg's records are dropped rather than merged on top of a response that
-        already carries them.
+        serves the WHOLE call — dashboards bucket included — so the dashboards
+        leg is CANCELLED on that failure rather than awaited: the legacy
+        response carries its own dashboards bucket, and on the slow leg shapes
+        (an older component's per-dashboard walk, fuzzy, ``include_config``)
+        waiting would delay the fallback and then re-walk the same dashboards
+        inside it.
         """
-        outcomes = await asyncio.gather(
-            self._send_component_search(req, visibility, dashboard_split=True),
-            self._search_dashboards_leg(req),
-            return_exceptions=True,
+        component_task = asyncio.ensure_future(
+            self._send_component_search(req, visibility, dashboard_split=True)
         )
-        component_outcome, dashboard_outcome = outcomes
-        if isinstance(dashboard_outcome, BaseException):
-            # The leg reports ordinary failures in-band, so anything arriving
-            # here is cancellation / shutdown — propagate it like
-            # ``_legacy_ha_search`` does.
-            raise dashboard_outcome
-        if isinstance(component_outcome, BaseException):
-            if not isinstance(component_outcome, Exception):
-                raise component_outcome
-            return await self._component_search_fallback(req, ctx, component_outcome)
+        dashboard_task = asyncio.ensure_future(self._search_dashboards_leg(req))
+        try:
+            raw = await component_task
+        except Exception as exc:
+            dashboard_task.cancel()
+            try:
+                await dashboard_task
+            except (asyncio.CancelledError, Exception):
+                # The leg reports ordinary failures in-band; anything raising
+                # here is the cancellation itself. Either way its outcome is
+                # unused — the fallback serves the dashboards bucket too.
+                pass
+            return await self._component_search_fallback(req, ctx, exc)
+        except BaseException:
+            # Cancellation / shutdown of THIS coroutine: release the leg and
+            # propagate, like ``_legacy_ha_search`` does.
+            dashboard_task.cancel()
+            raise
+        dashboard_outcome = await dashboard_task
 
         windowed, dashboards_page = _merge_dashboard_window(
-            req, component_outcome.get("result") or {}, dashboard_outcome.records
+            req, raw.get("result") or {}, dashboard_outcome.records
         )
         response = _shape_component_search_response(
             req,

--- a/src/ha_mcp/tools/tools_search.py
+++ b/src/ha_mcp/tools/tools_search.py
@@ -2574,9 +2574,16 @@ class SearchTools:
                 pass
             return await self._component_search_fallback(req, ctx, exc)
         except BaseException:
-            # Cancellation / shutdown of THIS coroutine: release the leg and
-            # propagate, like ``_legacy_ha_search`` does.
+            # Cancellation / shutdown of THIS coroutine: settle the leg before
+            # propagating, so no cancelled task outlives the call or drops an
+            # unretrieved exception, then re-raise like ``_legacy_ha_search``.
             dashboard_task.cancel()
+            try:
+                await dashboard_task
+            except BaseException:
+                # The leg's own CancelledError (or a re-delivered outer
+                # cancellation at this await) — the original is re-raised below.
+                pass
             raise
         dashboard_outcome = await dashboard_task
 

--- a/src/ha_mcp/tools/tools_search.py
+++ b/src/ha_mcp/tools/tools_search.py
@@ -2564,26 +2564,22 @@ class SearchTools:
         try:
             raw = await component_task
         except Exception as exc:
+            # Settle the leg via ``asyncio.wait``, which never raises the
+            # leg's own CancelledError — while a cancellation of THIS
+            # coroutine delivered at that await still propagates instead of
+            # being consumed right before the fallback runs the whole legacy
+            # search uncancellably.
             dashboard_task.cancel()
-            try:
-                await dashboard_task
-            except (asyncio.CancelledError, Exception):
-                # The leg reports ordinary failures in-band; anything raising
-                # here is the cancellation itself. Either way its outcome is
-                # unused — the fallback serves the dashboards bucket too.
-                pass
+            await asyncio.wait([dashboard_task])
             return await self._component_search_fallback(req, ctx, exc)
         except BaseException:
             # Cancellation / shutdown of THIS coroutine: settle the leg before
-            # propagating, so no cancelled task outlives the call or drops an
-            # unretrieved exception, then re-raise like ``_legacy_ha_search``.
+            # propagating, so no cancelled task outlives the call, then
+            # re-raise like ``_legacy_ha_search``. A second cancellation
+            # delivered during the wait propagates on its own, which is the
+            # same outcome.
             dashboard_task.cancel()
-            try:
-                await dashboard_task
-            except BaseException:
-                # The leg's own CancelledError (or a re-delivered outer
-                # cancellation at this await) — the original is re-raised below.
-                pass
+            await asyncio.wait([dashboard_task])
             raise
         dashboard_outcome = await dashboard_task
 

--- a/src/ha_mcp/tools/tools_search.py
+++ b/src/ha_mcp/tools/tools_search.py
@@ -44,6 +44,7 @@ from .helpers import (
     raise_tool_error,
     register_tool_methods,
 )
+from .smart_search import DEFAULT_CONCURRENCY_LIMIT, DeepSearchMixin
 from .util_helpers import (
     JSON_STRING_COERCION,
     add_timezone_metadata,
@@ -1003,53 +1004,97 @@ def _normalize_component_config_record(
 # Body surfaces the ``ha_mcp_tools`` component's ``search`` command accepts
 # (its voluptuous allowlist also has ``entity``, appended separately by
 # ``_build_component_search_request``). ``dashboard`` is deliberately absent:
-# the component has no dashboard scanner, so a request naming it must stay on
-# the legacy path — forwarding it just bounced off the component schema into a
-# warning-laden fallback on every call (issue #2008).
+# the command has no dashboard scanner and its ``vol.In(ALL_SEARCH_TYPES)``
+# rejects the value, which bounced every such call off the component schema
+# into a warning-laden fallback (issue #2008). The value is still ROUTE-
+# eligible: a request naming it keeps the fast path for the surfaces above
+# while the dashboards leg fills that bucket and the server merges the two
+# (issue #2289) — only the wire request drops it.
 _COMPONENT_BODY_SEARCH_TYPES: frozenset[str] = frozenset(
     {"automation", "script", "scene", "helper"}
 )
 
+# The ``search_types`` value the component's ``search`` command cannot serve;
+# the dashboards leg serves it instead (issue #2289).
+_DASHBOARD_SEARCH_TYPE = "dashboard"
+
+# The component's ``limits.max_results``, which its ``search`` schema enforces
+# as a hard ``vol.Range(max=...)`` on ``limit``. The dashboard merge fetches a
+# ``[0, offset + limit)`` window, so a deep enough page exceeds it — see
+# ``_dashboard_split_serviceable``.
+_COMPONENT_MAX_RESULTS = 500
+
+# Config buckets a component ``search`` result can carry. ``dashboards`` is
+# excluded: the command has no dashboard surface, so that bucket always comes
+# from the dashboards leg (issue #2289).
+_COMPONENT_CONFIG_BUCKETS: tuple[str, ...] = tuple(
+    bucket for bucket in _CONFIG_BUCKETS if bucket != "dashboards"
+)
+
 
 def _component_serves_search_types(req: _ResolvedSearch) -> bool:
-    """True when the component's search command accepts every requested surface.
+    """True when the component route can serve every requested surface.
 
-    Only an explicit ``search_types`` list can name an unsupported surface, and
-    only the body-eligible branch forwards it to the component — a
+    Only an explicit ``search_types`` list can name a surface the component's
+    ``search`` command lacks, and only the body-eligible branch forwards it — a
     body-ineligible request sends the entity surface alone, which the component
-    always accepts. Routing is all-or-nothing per command, so one unsupported
-    surface sends the whole request to the legacy path, silently — the same
-    treatment as the other route-ineligible modes, not the warning-emitting
-    failure fallback.
+    always accepts.
+
+    ``dashboard`` is served ALONGSIDE the command rather than by it: the wire
+    request drops the value (``_build_component_search_request``) and the
+    dashboards leg fills the bucket, merged server-side (issue #2289). Any
+    other unsupported surface still sends the whole request to the legacy path,
+    silently — the same treatment as the other route-ineligible modes, not the
+    warning-emitting failure fallback.
     """
     if not req.body_eligible or req.parsed_search_types is None:
         return True
-    return all(t in _COMPONENT_BODY_SEARCH_TYPES for t in req.parsed_search_types)
+    return all(
+        t in _COMPONENT_BODY_SEARCH_TYPES or t == _DASHBOARD_SEARCH_TYPE
+        for t in req.parsed_search_types
+    )
 
 
-def _build_component_search_request(req: _ResolvedSearch) -> dict[str, Any]:
+def _component_body_search_types(req: _ResolvedSearch) -> list[str]:
+    """The body surfaces forwarded to the component, ``dashboard`` stripped.
+
+    The component's ``search`` schema rejects ``dashboard``, so the value never
+    crosses the wire even when the caller asked for it — the dashboards leg
+    serves that bucket instead (issue #2289).
+    """
+    parsed = req.parsed_search_types or ["automation", "script", "scene", "helper"]
+    return [t for t in parsed if t != _DASHBOARD_SEARCH_TYPE]
+
+
+def _build_component_search_request(
+    req: _ResolvedSearch, *, dashboard_split: bool = False
+) -> dict[str, Any]:
     """Translate resolved ha_search inputs into an ``ha_mcp_tools/search`` request.
 
     ``search_types`` on the WS command selects surfaces including the entity
     surface (``"entity"``), so branch eligibility computed server-side maps
-    directly onto which surfaces the component searches — all-or-nothing per
-    command. Optional string filters are omitted when empty to satisfy the
-    component's ``str``-typed voluptuous schema.
+    directly onto which surfaces the component searches. Optional string
+    filters are omitted when empty to satisfy the component's ``str``-typed
+    voluptuous schema.
+
+    ``dashboard_split`` switches to the WINDOW fetch the dashboard merge needs.
+    The component pages its own corpus, so the server can only page the MERGED
+    list if it holds every component record that could reach the caller's page
+    — that is the whole ``[0, offset + limit)`` prefix. With the default
+    ``offset=0`` the window is byte-identical to the plain request.
     """
     search_types: list[str] = []
     if req.registry_eligible:
         search_types.append("entity")
     if req.body_eligible:
-        search_types.extend(
-            req.parsed_search_types or ["automation", "script", "scene", "helper"]
-        )
+        search_types.extend(_component_body_search_types(req))
     request: dict[str, Any] = {
         "search_types": search_types,
         "exact": req.exact_match,
         "include_hidden": req.include_hidden,
         "include_config": req.include_config,
-        "limit": req.limit,
-        "offset": req.offset,
+        "limit": (req.offset + req.limit) if dashboard_split else req.limit,
+        "offset": 0 if dashboard_split else req.offset,
     }
     membership_fields = _requested_membership(
         _parse_component_result_fields(req.result_fields)
@@ -1068,6 +1113,153 @@ def _build_component_search_request(req: _ResolvedSearch) -> dict[str, Any]:
     if state_filter:
         request["state_filter"] = state_filter
     return request
+
+
+def _dashboard_split_requested(req: _ResolvedSearch) -> bool:
+    """True when this request needs the dashboards leg merged in (issue #2289)."""
+    return bool(
+        req.body_eligible
+        and req.parsed_search_types is not None
+        and _DASHBOARD_SEARCH_TYPE in req.parsed_search_types
+    )
+
+
+def _dashboard_split_serviceable(req: _ResolvedSearch) -> bool:
+    """True when the split can serve the request; False ⇒ legacy serves it whole.
+
+    Two corner cases route away rather than being half-served:
+
+    - Nothing is left for the component command once ``dashboard`` is stripped.
+      An explicit ``search_types`` pin also drops the entity surface, so
+      ``search_types=["dashboard"]`` would send an empty request and leave the
+      split as a dashboards leg wearing a component envelope — the legacy path
+      already produces exactly that, with its own bucket.
+    - The window fetch would ask for more records than the component's
+      ``limit`` ceiling, which its schema rejects outright.
+    """
+    serves_body = req.body_eligible and bool(_component_body_search_types(req))
+    if not (req.registry_eligible or serves_body):
+        return False
+    return req.offset + req.limit <= _COMPONENT_MAX_RESULTS
+
+
+@dataclass(frozen=True)
+class _DashboardLeg:
+    """The dashboards surface's contribution to a component-served ha_search.
+
+    ``records`` are legacy-shaped (``dashboard_url`` / ``dashboard_title`` /
+    ``score``), NOT component records — they never pass through
+    ``_normalize_component_config_record``. ``failed`` is the leg's own
+    "not scanned" count, reported with the deep path's wording. ``error`` is
+    set only when the leg raised, in which case the bucket is empty and the
+    response says so rather than reading as a clean zero.
+    """
+
+    records: list[dict[str, Any]]
+    failed: int = 0
+    error: str | None = None
+
+
+def _apply_entity_window(req: _ResolvedSearch, windowed: dict[str, Any]) -> None:
+    """Re-slice the over-fetched entity surface onto the caller's page.
+
+    The window fetch over-fetches every surface the request names. Entity
+    records merge with nothing, so their page is the same slice applied
+    server-side. ``entity_total_matches`` is a corpus total and
+    pagination-independent, so ``entity_has_more`` is recomputed against it
+    (and pinned, so the shaping helper never falls back to the sliced length).
+
+    No CURRENT request gets past the early return: the split needs an explicit
+    ``search_types``, which pins the call config-only
+    (``_compute_eligibility``), so the window carries no entity surface at all.
+    This is the guard that keeps the window honest if that eligibility ever
+    admits one — without it the entity page would silently be the whole
+    ``[0, offset + limit)`` prefix.
+    """
+    if not req.registry_eligible:
+        return
+    entities = _as_record_list(windowed.get("entities"))
+    total = int(windowed.get("entity_total_matches", len(entities)) or 0)
+    page = entities[req.offset : req.offset + req.limit]
+    windowed["entities"] = page
+    windowed["entity_total_matches"] = total
+    windowed["entity_has_more"] = (req.offset + len(page)) < total
+
+
+def _merge_dashboard_window(
+    req: _ResolvedSearch,
+    component_result: dict[str, Any],
+    dashboard_records: list[dict[str, Any]],
+) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+    """Page the window fetch and the dashboards leg as ONE score-sorted list.
+
+    The legacy contract is a global score sort across every config bucket, then
+    ``[offset : offset + limit]`` (``_deep._paginate_and_build_response``), so
+    the merged page has to be cut server-side. It is exact: the component
+    fetched the whole ``[0, offset + limit)`` window of its own corpus, a
+    superset of every component record that can reach the caller's page, and
+    the leg returns its bucket unpaginated. Ties keep component records ahead
+    of dashboards (the sort is stable and dashboards are appended last),
+    matching the legacy insertion order.
+
+    Returns the component result rewritten for the caller's page — buckets
+    sliced, entity records re-sliced, totals and ``*_has_more`` recomputed —
+    plus the dashboards page.
+    """
+    tagged: list[tuple[str, dict[str, Any]]] = [
+        (bucket, record)
+        for bucket in _COMPONENT_CONFIG_BUCKETS
+        if bucket in component_result
+        for record in _as_record_list(component_result.get(bucket))
+    ]
+    tagged.extend(("dashboards", record) for record in dashboard_records)
+    tagged.sort(key=lambda item: item[1].get("score") or 0, reverse=True)
+    page = tagged[req.offset : req.offset + req.limit]
+
+    total = int(component_result.get("config_total_matches", 0) or 0) + len(
+        dashboard_records
+    )
+    windowed: dict[str, Any] = dict(component_result)
+    for bucket in _COMPONENT_CONFIG_BUCKETS:
+        if bucket in component_result:
+            windowed[bucket] = [rec for name, rec in page if name == bucket]
+    windowed["config_total_matches"] = total
+    # The component's own flag still carries information the merged count
+    # cannot: it reports a corpus extending past the window, whose records are
+    # not in the merged list at all.
+    windowed["config_has_more"] = (req.offset + len(page)) < total or bool(
+        component_result.get("config_has_more")
+    )
+    _apply_entity_window(req, windowed)
+
+    dashboards_page = [rec for name, rec in page if name == "dashboards"]
+    if not req.include_config:
+        # Mirrors the legacy pipeline's per-record pop, which also runs on the
+        # paginated slice rather than the corpus.
+        for record in dashboards_page:
+            record.pop("config", None)
+    return windowed, dashboards_page
+
+
+def _apply_dashboard_leg_state(response: dict[str, Any], leg: _DashboardLeg) -> None:
+    """Fold the dashboards leg's incompleteness into the merged response.
+
+    ``failed`` reuses the deep path's own per-type wording verbatim, so a
+    merged response and a legacy one report the same sentence for the same
+    condition. A raised leg is reported like a failed legacy branch — an
+    ``errors[]`` entry naming the surface plus ``partial`` — so an empty
+    dashboards bucket is never mistaken for a clean zero.
+    """
+    if leg.failed:
+        DeepSearchMixin._apply_per_type_partial_flag(
+            response, dashboard_failed=leg.failed
+        )
+    if leg.error is not None:
+        _finalize_partial_state(
+            response,
+            partial_local=True,
+            errors_local=[{"surface": "dashboards", "error": leg.error}],
+        )
 
 
 def _merge_component_visibility_warnings(
@@ -1125,8 +1317,39 @@ async def _scrub_component_config_buckets(
         response["count"] = max(0, response["count"] - dropped)
 
 
+def _component_config_payload(
+    req: _ResolvedSearch,
+    component_result: dict[str, Any],
+    dashboard_leg: _DashboardLeg | None,
+) -> dict[str, Any]:
+    """Build the config-surface payload ``_apply_search_outcome`` consumes.
+
+    Component records are normalized into the legacy vocabulary; the
+    dashboards leg's records are already legacy-shaped, so they are attached
+    as-is (issue #2289).
+    """
+    config_has_more = bool(component_result.get("config_has_more", False))
+    payload: dict[str, Any] = {
+        "total_matches": int(component_result.get("config_total_matches", 0) or 0),
+        "has_more": config_has_more,
+        "next_offset": (req.offset + req.limit) if config_has_more else None,
+    }
+    for bucket in _CONFIG_BUCKETS:
+        if bucket in component_result:
+            payload[bucket] = [
+                _normalize_component_config_record(bucket, rec, req.include_config)
+                for rec in _as_record_list(component_result.get(bucket))
+            ]
+    if dashboard_leg is not None:
+        payload["dashboards"] = dashboard_leg.records
+    return payload
+
+
 def _shape_component_search_response(
-    req: _ResolvedSearch, component_result: dict[str, Any]
+    req: _ResolvedSearch,
+    component_result: dict[str, Any],
+    *,
+    dashboard_leg: _DashboardLeg | None = None,
 ) -> dict[str, Any]:
     """Map an ``ha_mcp_tools/search`` result into the ha_search envelope.
 
@@ -1137,6 +1360,11 @@ def _shape_component_search_response(
     finalisation all stay server-side and reuse the same helpers the legacy
     path uses (``_apply_search_outcome`` and friends), so the shape is
     identical to the legacy response by construction.
+
+    ``dashboard_leg`` carries the separately-served dashboards bucket for a
+    ``dashboard``-including request (issue #2289); it is injected here, before
+    the count / partial-mirror finalisation, so a ``fields=`` projection and
+    the enforce-mode scrub both see the merged envelope.
     """
     response = _new_search_response(req.query, req.parsed_search_types)
     _emit_intent_skip_warning(response, req.body_skipped_by_intent_gate)
@@ -1190,19 +1418,11 @@ def _shape_component_search_response(
         _apply_search_outcome(response, "entities", entity_payload)
 
     if req.body_eligible:
-        config_has_more = bool(component_result.get("config_has_more", False))
-        config_payload: dict[str, Any] = {
-            "total_matches": int(component_result.get("config_total_matches", 0) or 0),
-            "has_more": config_has_more,
-            "next_offset": (req.offset + req.limit) if config_has_more else None,
-        }
-        for bucket in _CONFIG_BUCKETS:
-            if bucket in component_result:
-                config_payload[bucket] = [
-                    _normalize_component_config_record(bucket, rec, req.include_config)
-                    for rec in _as_record_list(component_result.get(bucket))
-                ]
-        _apply_search_outcome(response, "configs", config_payload)
+        _apply_search_outcome(
+            response,
+            "configs",
+            _component_config_payload(req, component_result, dashboard_leg),
+        )
 
     # The component reports a single overall partial flag (design § 1). In-process
     # joins are effectively never partial, but a body too large to serialize can
@@ -1224,6 +1444,9 @@ def _shape_component_search_response(
         if diag_reason:
             response["partial"] = True
             _merge_partial_reason(response, diag_reason)
+
+    if dashboard_leg is not None:
+        _apply_dashboard_leg_state(response, dashboard_leg)
 
     _merge_component_visibility_warnings(response, component_result)
 
@@ -2105,9 +2328,9 @@ class SearchTools:
 
         # Prefer the custom component's in-process unified search when it
         # advertises the capability: one WS round-trip replaces the multi-fetch
-        # legacy pipeline. Route all-or-nothing per command and fall back
-        # cleanly when the component is absent, downlevel, or errors — the
-        # taxonomy lives in ``_ha_search_via_component``.
+        # legacy pipeline. Route per command and fall back cleanly when the
+        # component is absent, downlevel, or errors — the taxonomy lives in
+        # ``_ha_search_via_component``.
         #
         # Only QUERY-DRIVEN searches route through the component. The listing
         # modes — empty/whitespace query with domain_filter (legacy
@@ -2116,9 +2339,14 @@ class SearchTools:
         # response keys) — keep the legacy path: their response contracts
         # differ per mode, and after the request-dedup work they are cheap
         # registry-only calls, so the component round-trip buys nothing worth
-        # the shape risk. A ``search_types`` naming a surface the component
-        # lacks (``dashboard``) also stays legacy — see
-        # ``_component_serves_search_types`` (issue #2008).
+        # the shape risk. A ``search_types`` naming a surface the component's
+        # ``search`` command lacks also stays legacy — see
+        # ``_component_serves_search_types`` (issue #2008). ``dashboard`` is
+        # the exception: naming it keeps the fast path for the surfaces the
+        # command DOES serve, and its own bucket comes from the dashboards leg
+        # merged in ``_ha_search_via_component`` — dropping the whole call to
+        # legacy for it cost every mixed search the per-config REST fetches
+        # (issue #2289).
         #
         # Entity-visibility gate. A plain ``search`` component applies no
         # filtering, so an install with an ACTIVE visibility filter would leak
@@ -2200,7 +2428,32 @@ class SearchTools:
         component surfaces every match, correct only because the caller routes
         here solely when the filter is inactive or the component can apply it).
 
-        Error taxonomy (design § 4):
+        A ``search_types`` naming ``dashboard`` splits the work — the command
+        serves the surfaces it has, the dashboards leg serves that bucket, and
+        the two are merged (issue #2289). ``_dashboard_split_serviceable``
+        names the corner cases that send the whole call to legacy instead.
+        """
+        if _dashboard_split_requested(req):
+            if not _dashboard_split_serviceable(req):
+                return None
+            return await self._component_search_with_dashboards(
+                req, ctx, visibility=visibility
+            )
+        try:
+            raw = await self._send_component_search(req, visibility)
+        except Exception as exc:
+            return await self._component_search_fallback(req, ctx, exc)
+        response = _shape_component_search_response(req, raw.get("result") or {})
+        await _scrub_component_config_buckets(response, self._client)
+        return response
+
+    async def _component_search_fallback(
+        self, req: _ResolvedSearch, ctx: Context | None, exc: Exception
+    ) -> dict[str, Any] | None:
+        """Apply the component-search failure taxonomy (design § 4).
+
+        Returns the legacy-served response, or ``None`` when the caller should
+        run the legacy path itself with no diagnostic:
 
         - ``unknown_command`` (component downgraded mid-session, so the cached
           positive caps are stale): invalidate the caps and return ``None`` so
@@ -2218,46 +2471,121 @@ class SearchTools:
           pooled connection, so a dead transport raises there too (#1947) and
           the registry-unavailable warning names what was skipped.
         """
-        try:
-            raw = await self._send_component_search(req, visibility)
-        except (HomeAssistantCommandError, HomeAssistantCommandTimeout) as exc:
+        if isinstance(exc, (HomeAssistantCommandError, HomeAssistantCommandTimeout)):
             if is_unknown_command(exc):
                 invalidate_caps(self._client)
                 return None
-            legacy = await self._legacy_ha_search(req, ctx)
-            legacy.setdefault("warnings", []).append(
-                f"component search path failed ({exc}); served via legacy path"
-            )
-            logger.warning("ha_mcp_tools/search failed; fell back to legacy: %r", exc)
-            return legacy
-        except Exception as exc:
-            legacy = await self._legacy_ha_search(req, ctx)
-            legacy.setdefault("warnings", []).append(
+            warning = f"component search path failed ({exc}); served via legacy path"
+            log_message = "ha_mcp_tools/search failed; fell back to legacy: %r"
+        else:
+            warning = (
                 f"component search connection error ({exc}); served via legacy path"
             )
-            logger.warning(
-                "ha_mcp_tools/search connection error; fell back to legacy: %r", exc
+            log_message = (
+                "ha_mcp_tools/search connection error; fell back to legacy: %r"
             )
-            return legacy
-        response = _shape_component_search_response(req, raw.get("result") or {})
+        legacy = await self._legacy_ha_search(req, ctx)
+        legacy.setdefault("warnings", []).append(warning)
+        logger.warning(log_message, exc)
+        return legacy
+
+    async def _component_search_with_dashboards(
+        self,
+        req: _ResolvedSearch,
+        ctx: Context | None,
+        *,
+        visibility: dict[str, Any] | None,
+    ) -> dict[str, Any] | None:
+        """Serve a ``dashboard``-including request from both legs (issue #2289).
+
+        The two legs run concurrently: the dashboards leg is a second frame on
+        the same pooled connection (or, on a component without
+        ``dashboards_doc_search``, the legacy per-dashboard walk), so
+        serialising them would add its latency to every mixed search.
+
+        A failing component leg takes the taxonomy's legacy fallback, which
+        serves the WHOLE call — dashboards bucket included — so the finished
+        leg's records are dropped rather than merged on top of a response that
+        already carries them.
+        """
+        outcomes = await asyncio.gather(
+            self._send_component_search(req, visibility, dashboard_split=True),
+            self._search_dashboards_leg(req),
+            return_exceptions=True,
+        )
+        component_outcome, dashboard_outcome = outcomes
+        if isinstance(dashboard_outcome, BaseException):
+            # The leg reports ordinary failures in-band, so anything arriving
+            # here is cancellation / shutdown — propagate it like
+            # ``_legacy_ha_search`` does.
+            raise dashboard_outcome
+        if isinstance(component_outcome, BaseException):
+            if not isinstance(component_outcome, Exception):
+                raise component_outcome
+            return await self._component_search_fallback(req, ctx, component_outcome)
+
+        windowed, dashboards_page = _merge_dashboard_window(
+            req, component_outcome.get("result") or {}, dashboard_outcome.records
+        )
+        response = _shape_component_search_response(
+            req,
+            windowed,
+            dashboard_leg=_DashboardLeg(
+                records=dashboards_page,
+                failed=dashboard_outcome.failed,
+                error=dashboard_outcome.error,
+            ),
+        )
         await _scrub_component_config_buckets(response, self._client)
         return response
 
+    async def _search_dashboards_leg(self, req: _ResolvedSearch) -> _DashboardLeg:
+        """The dashboards bucket for a merged component search.
+
+        Reuses the deep path's own dashboards surface, which is already
+        component-first (the ``dashboards_doc_search`` frame) with the legacy
+        per-dashboard walk as its fallback — so the merged route covers exactly
+        the dashboards the legacy route covers.
+
+        An ordinary failure is reported through ``_DashboardLeg.error`` instead
+        of raising: the other surfaces succeeded, so the call returns them and
+        says the dashboard bucket is incomplete. Cancellation still propagates.
+        """
+        semaphore = asyncio.Semaphore(DEFAULT_CONCURRENCY_LIMIT)
+        try:
+            records, failed = await self._smart_tools._search_dashboards_surface(
+                req.query_text.lower(),
+                req.exact_match,
+                semaphore,
+                include_config=req.include_config,
+            )
+        except Exception as exc:
+            logger.warning("ha_search dashboards leg failed: %r", exc)
+            # ``str(asyncio.TimeoutError())`` is "" — fall back to the type name
+            # so the errors[] entry never reads "dashboards: ".
+            return _DashboardLeg(records=[], error=str(exc) or type(exc).__name__)
+        return _DashboardLeg(records=list(records), failed=failed)
+
     async def _send_component_search(
-        self, req: _ResolvedSearch, visibility: dict[str, Any] | None = None
+        self,
+        req: _ResolvedSearch,
+        visibility: dict[str, Any] | None = None,
+        *,
+        dashboard_split: bool = False,
     ) -> dict[str, Any]:
         """Send one ``ha_mcp_tools/search`` command over the per-client WebSocket.
 
         ``visibility`` (the serialized hide config) is attached only when set, so
         a plain-``search`` component (which lacks the param in its schema) never
-        receives it.
+        receives it. ``dashboard_split`` asks for the window fetch the dashboard
+        merge pages server-side.
         """
         ws = await get_websocket_client(
             url=self._client.base_url,
             token=self._client.token,
             verify_ssl=getattr(self._client, "verify_ssl", None),
         )
-        request = _build_component_search_request(req)
+        request = _build_component_search_request(req, dashboard_split=dashboard_split)
         if visibility is not None:
             request["visibility"] = visibility
         return await ws.send_command("ha_mcp_tools/search", **request)

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -42,8 +42,12 @@ testcontainer run).
   `unique_id`, which Home Assistant's own API never exposes on any endpoint.
   Consequence for `ha_search`: a query-driven call is served by the component's
   in-process scan, not the legacy REST path, so a test written for legacy-only
-  behaviour passes *vacuously*. Naming a `search_types` the component does not
-  serve (`"dashboard"`) sends the whole call down the legacy path.
+  behaviour passes *vacuously*. Naming `"dashboard"` in `search_types` no
+  longer changes that — the component serves the surfaces its search command
+  has while the dashboards leg serves that bucket, merged server-side
+  (#2289). What still routes a whole call to legacy is `offset + limit` past
+  the component's 500-record `limit` ceiling on such a request
+  (`tests/src/e2e/tools/test_search_reference_graph.py` uses exactly that).
 - **The in-process "server" config entry** of that same component (#1527) is
   the embedded backend only, seeded separately. That one IS lane-specific.
 

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -45,9 +45,11 @@ testcontainer run).
   behaviour passes *vacuously*. Naming `"dashboard"` in `search_types` no
   longer changes that — the component serves the surfaces its search command
   has while the dashboards leg serves that bucket, merged server-side
-  (#2289). What still routes a whole call to legacy is `offset + limit` past
-  the component's 500-record `limit` ceiling on such a request
-  (`tests/src/e2e/tools/test_search_reference_graph.py` uses exactly that).
+  (#2289). Two conditions still route such a whole call to legacy:
+  `offset + limit` past the component's advertised `limit` ceiling (500
+  default — `tests/src/e2e/tools/test_search_reference_graph.py` uses exactly
+  that), and a `search_types` that leaves the component search command no
+  surface once `dashboard` is stripped (e.g. `search_types=["dashboard"]`).
 - **The in-process "server" config entry** of that same component (#1527) is
   the embedded backend only, seeded separately. That one IS lane-specific.
 

--- a/tests/src/e2e/tools/test_search_reference_graph.py
+++ b/tests/src/e2e/tools/test_search_reference_graph.py
@@ -16,17 +16,22 @@ command name, its parameters, the envelope parsing, and the item-type-to-bucket
 mapping in a single pass. Everything else about the merge is pure logic already
 covered by ``tests/src/unit/test_search_related_graph.py``.
 
-**Why this test names a dashboard search type.** The reference-graph merge runs
-on the legacy config-body path only. It is deliberately absent from the
-``ha_mcp_tools`` component route, which reads HA's loaded config in-process and
-so has neither of the blind spots above (no per-id budget, and YAML-defined
-configs are visible to it). This suite installs that component into every test
-container, so a plain ``search_types=["automation"]`` call is served by the
-component and never reaches the code under test. Naming ``dashboard`` -- a
-surface the component's search command does not accept -- sends the whole
-request down the legacy path (``_component_serves_search_types`` is
-all-or-nothing per call). Without it this test passes vacuously against a
-feature that never ran.
+**Why this test asks for a dashboard surface and an oversized limit.** The
+reference-graph merge runs on the legacy config-body path only. It is
+deliberately absent from the ``ha_mcp_tools`` component route, which reads HA's
+loaded config in-process and so has neither of the blind spots above (no per-id
+budget, and YAML-defined configs are visible to it). This suite installs that
+component into every test container, so a plain ``search_types=["automation"]``
+call is served by the component and never reaches the code under test.
+
+Naming ``dashboard`` alone no longer sends the call to legacy: the component
+serves the surfaces its search command has while the dashboards leg serves that
+bucket, merged server-side (issue #2289). What still routes the WHOLE call to
+legacy is a page the merge cannot fetch -- ``offset + limit`` past the
+component's 500-record ``limit`` ceiling, which its schema rejects outright --
+so the request pairs the dashboard surface with a limit one past that ceiling.
+Should that lever stop working, this test fails on ``match_in_references``
+rather than passing vacuously against a feature that never ran.
 """
 
 import logging
@@ -45,6 +50,11 @@ _REFERENCED_ENTITY = f"input_boolean.refgraph_{_RUN_ID}"
 _SLUG = f"reference_graph_probe_{_RUN_ID}"
 _ALIAS = f"Reference Graph Probe {_RUN_ID}"
 _PROBE_ENTITY_ID = f"automation.{_SLUG}"
+# One past the component's 500-record ``limit`` ceiling, which is what sends a
+# ``dashboard``-including request to the legacy path whole — see the module
+# docstring. Wide enough that the probe automation is on the page regardless of
+# how many configs the container holds.
+_LEGACY_ROUTE_LIMIT = 501
 
 
 @pytest.mark.asyncio
@@ -79,9 +89,9 @@ async def test_reference_graph_flags_an_automation_that_uses_the_entity(mcp_clie
             tool_name="ha_search",
             arguments={
                 "query": _REFERENCED_ENTITY,
-                # "dashboard" forces the legacy path -- see the module docstring.
+                # This pair forces the legacy path -- see the module docstring.
                 "search_types": ["automation", "dashboard"],
-                "limit": 25,
+                "limit": _LEGACY_ROUTE_LIMIT,
             },
             predicate=lambda d: any(
                 a.get("friendly_name") == _ALIAS for a in d.get("automations", [])

--- a/tests/src/unit/test_component_search_contract.py
+++ b/tests/src/unit/test_component_search_contract.py
@@ -33,6 +33,7 @@ import pytest
 
 from ha_mcp.tools.tools_search import (
     _COMPONENT_BODY_SEARCH_TYPES,
+    _DASHBOARD_SEARCH_TYPE,
     _VALID_SEARCH_TYPES,
     _ResolvedSearch,
     _shape_component_search_response,
@@ -590,9 +591,13 @@ def test_component_body_search_types_lockstep() -> None:
     # The gate's allowlist is exactly the component's search surfaces minus
     # the entity surface (appended separately by the request builder).
     assert set(wsapi.ALL_SEARCH_TYPES) - {"entity"} == _COMPONENT_BODY_SEARCH_TYPES
-    # Every public search_types value is either component-served or on the
-    # deliberate legacy-only list.
-    assert {"dashboard"} == _VALID_SEARCH_TYPES - _COMPONENT_BODY_SEARCH_TYPES
+    # ``dashboard`` is the one public value the search command cannot take. It
+    # is not legacy-only: the dashboards leg serves that bucket alongside the
+    # command and the server merges the two (issue #2289). Any OTHER value
+    # outside the allowlist would still route its whole call to legacy in
+    # silence, which is what this pin exists to prevent.
+    unserved = _VALID_SEARCH_TYPES - _COMPONENT_BODY_SEARCH_TYPES
+    assert unserved == {_DASHBOARD_SEARCH_TYPE}
 
 
 @pytest.mark.parametrize(

--- a/tests/src/unit/test_component_ws_search.py
+++ b/tests/src/unit/test_component_ws_search.py
@@ -766,6 +766,30 @@ class TestInfo:
         assert wsapi._do_info()["timezone"] is None
         assert wsapi._do_info(FakeHass())["timezone"] is None
 
+    def test_tools_services_reflects_service_registry(self):
+        """The additive ``tools_services`` field mirrors the service registry.
+
+        Since 2.1.0 both entry types register the WS surface (#2289), so the
+        server's filesystem/YAML gate reads this field instead of inferring the
+        tools services from ``info`` answering (#2292). Probes the actual
+        registry entry (``read_file``), degrading to None on a hass-less call.
+        """
+
+        class _Services:
+            def __init__(self, present: bool) -> None:
+                self._present = present
+
+            def has_service(self, domain: str, service: str) -> bool:
+                assert domain == wsapi.DOMAIN
+                assert service == "read_file"
+                return self._present
+
+        info_with = wsapi._do_info(FakeHass(services=_Services(True)))
+        assert info_with["tools_services"] is True
+        info_without = wsapi._do_info(FakeHass(services=_Services(False)))
+        assert info_without["tools_services"] is False
+        assert wsapi._do_info()["tools_services"] is None
+
     def test_manifest_version_parity(self):
         """Manifest and COMPONENT_VERSION lockstep, plus the ONE literal pin.
 

--- a/tests/src/unit/test_component_ws_search.py
+++ b/tests/src/unit/test_component_ws_search.py
@@ -783,7 +783,7 @@ class TestInfo:
                 _REPO_ROOT / "custom_components" / "ha_mcp_tools" / "manifest.json"
             ).read_text(encoding="utf-8")
         )
-        assert manifest["version"] == COMPONENT_VERSION == "2.0.1"
+        assert manifest["version"] == COMPONENT_VERSION == "2.1.0"
 
 
 # =============================================================================

--- a/tests/src/unit/test_embedded_entry.py
+++ b/tests/src/unit/test_embedded_entry.py
@@ -5,7 +5,8 @@ wire up around the :class:`~.coordinator.ServerVersionCoordinator`: creating
 it with the right interval, registering its auto-update listener (as a
 background task, never a synchronous reload from inside the listener),
 kicking off an initial (non-blocking) refresh, and forwarding/unloading the
-``update`` platform.
+``update`` platform — plus the ``ha_mcp_tools/*`` WebSocket command surface
+the server entry registers up front (issue #2289).
 
 Home Assistant / aiohttp are stubbed via ``_embedded_stubs`` (imported first so
 the fakes are installed before the component module binds them). The lazily
@@ -134,8 +135,9 @@ def fake_collaborators(monkeypatch):
 
     ``async_setup_server_entry`` imports ``async_bring_up_server`` /
     ``async_maybe_auto_update`` from ``embedded_setup``,
-    ``async_register_ui_panel`` from ``ui_panel``, and ``ServerVersionCoordinator``
-    from ``coordinator`` at call time; the fakes keep the full HA chain out of
+    ``async_register_ui_panel`` from ``ui_panel``, ``ServerVersionCoordinator``
+    from ``coordinator``, and ``async_register_commands`` from
+    ``websocket_api`` at call time; the fakes keep the full HA chain out of
     this test.
     """
     fake_setup = ModuleType("custom_components.ha_mcp_tools.embedded_setup")
@@ -152,6 +154,9 @@ def fake_collaborators(monkeypatch):
     fake_coord_mod = ModuleType("custom_components.ha_mcp_tools.coordinator")
     fake_coord_mod.ServerVersionCoordinator = _FakeCoordinator
 
+    fake_wsapi = ModuleType("custom_components.ha_mcp_tools.websocket_api")
+    fake_wsapi.async_register_commands = MagicMock(name="async_register_commands")
+
     monkeypatch.setitem(
         sys.modules, "custom_components.ha_mcp_tools.embedded_setup", fake_setup
     )
@@ -161,8 +166,14 @@ def fake_collaborators(monkeypatch):
     monkeypatch.setitem(
         sys.modules, "custom_components.ha_mcp_tools.coordinator", fake_coord_mod
     )
+    monkeypatch.setitem(
+        sys.modules, "custom_components.ha_mcp_tools.websocket_api", fake_wsapi
+    )
     return SimpleNamespace(
-        setup=fake_setup, panel=fake_panel, coordinator_cls=_FakeCoordinator
+        setup=fake_setup,
+        panel=fake_panel,
+        coordinator_cls=_FakeCoordinator,
+        websocket_api=fake_wsapi,
     )
 
 
@@ -279,6 +290,43 @@ class TestSetup:
         await _drain_background_tasks(hass, entry)
 
         fake_collaborators.panel.async_register_ui_panel.assert_not_awaited()
+
+
+class TestWebSocketCommandRegistration:
+    """The server entry registers the ``ha_mcp_tools/*`` WS commands (#2289).
+
+    They used to be registered only from the tools entry, so an install with
+    just the server (embedded) entry had no ``ha_mcp_tools/*`` commands at all
+    and every ``ha_search`` silently fell back to the legacy path.
+    """
+
+    async def test_setup_registers_ws_commands(self, fake_collaborators):
+        hass = _make_hass()
+        entry = _make_entry()
+
+        await eentry.async_setup_server_entry(hass, entry)
+        await _drain_background_tasks(hass, entry)
+
+        register = fake_collaborators.websocket_api.async_register_commands
+        register.assert_called_once_with(hass)
+
+    async def test_ws_commands_registered_before_fallible_setup_steps(
+        self, fake_collaborators
+    ):
+        # Placement pin: registration runs first, so a later setup step failing
+        # (the sidebar panel here, the background bring-up in the field) never
+        # costs a server-only install its command surface.
+        hass = _make_hass()
+        entry = _make_entry()
+        fake_collaborators.panel.async_register_ui_panel.side_effect = RuntimeError(
+            "panel registration failed"
+        )
+
+        with pytest.raises(RuntimeError):
+            await eentry.async_setup_server_entry(hass, entry)
+
+        register = fake_collaborators.websocket_api.async_register_commands
+        register.assert_called_once_with(hass)
 
 
 class TestPrebindOAuthViews:

--- a/tests/src/unit/test_ha_search_component_routing.py
+++ b/tests/src/unit/test_ha_search_component_routing.py
@@ -940,20 +940,24 @@ class ConfigNotFoundDashboardClient(DashboardRoutingClient):
 
 
 class TestDashboardSearchTypesGate:
-    """``search_types`` naming a surface the component lacks stays legacy.
+    """``dashboard`` in ``search_types`` never reaches the ``search`` command.
 
     The component's ``search`` command has no dashboard surface — its
-    voluptuous allowlist rejects the value — so routing such a request there
-    bounced off the schema into a warning-laden fallback on every call
-    (issue #2008). The gate keeps the whole request on the legacy path,
-    silently, exactly like the other route-ineligible modes.
+    voluptuous allowlist rejects the value — so forwarding it bounced off the
+    schema into a warning-laden fallback on every call (issue #2008). What the
+    value costs is the split's business (issue #2289): a mixed list keeps the
+    fast path for the surfaces the command DOES serve, while a
+    ``dashboard``-only pin leaves the command nothing to search and takes the
+    legacy path whole, silently, exactly like the other route-ineligible modes.
     """
 
     @pytest.mark.asyncio
     async def test_dashboard_search_types_skip_component(
         self, tmp_path, monkeypatch
     ) -> None:
-        """search_types=["dashboard"] → no component frame, no fallback warning."""
+        """An explicit pin drops the entity surface, so ``["dashboard"]``
+        leaves the component search with no surface at all → legacy for the
+        whole call, with no component frame and no fallback warning."""
         _setup_visibility_disabled(tmp_path, monkeypatch)
         ws = make_ws("ha_mcp_tools/search", info_result=_CAPS_SEARCH)
         client = DashboardRoutingClient()
@@ -976,12 +980,24 @@ class TestDashboardSearchTypesGate:
         assert client.ws_types["lovelace/dashboards/list"] == 1
 
     @pytest.mark.asyncio
-    async def test_mixed_search_types_with_dashboard_skip_component(
+    async def test_mixed_search_types_keep_the_component_fast_path(
         self, tmp_path, monkeypatch
     ) -> None:
-        """A mixed list including 'dashboard' is all-or-nothing → all legacy."""
+        """A mixed list naming 'dashboard' keeps the component search for the
+        surfaces the command serves and reaches the dashboard bucket
+        separately — here through the legacy walk, since this component has no
+        ``dashboards_doc_search``. Sending the whole call to legacy instead is
+        what cost every such search the per-config REST fetches (issue #2289)."""
         _setup_visibility_disabled(tmp_path, monkeypatch)
-        ws = make_ws("ha_mcp_tools/search", info_result=_CAPS_SEARCH)
+        result = {
+            "automations": [],
+            "entity_total_matches": 0,
+            "entity_has_more": False,
+            "config_total_matches": 0,
+            "config_has_more": False,
+            "partial": False,
+        }
+        ws = make_ws("ha_mcp_tools/search", info_result=_CAPS_SEARCH, cmd_result=result)
         client = DashboardRoutingClient()
         ha_search = _build_ha_search(client)
 
@@ -991,13 +1007,22 @@ class TestDashboardSearchTypesGate:
             )
 
         assert resp["success"] is True
-        assert not any(
-            c.args[0] == "ha_mcp_tools/search" for c in ws.send_command.call_args_list
-        ), "a mixed request naming 'dashboard' must not be split across paths"
-        assert not any("served via legacy path" in w for w in resp.get("warnings", []))
-        # The legacy pipeline served both surfaces.
-        assert client.get_states_calls >= 1
+        search_calls = [
+            c
+            for c in ws.send_command.call_args_list
+            if c.args[0] == "ha_mcp_tools/search"
+        ]
+        assert len(search_calls) == 1
+        # ``dashboard`` never crosses the wire: the command's schema rejects it.
+        assert search_calls[0].kwargs["search_types"] == ["automation"]
+        # The config-body surfaces came from the component, so none of the
+        # legacy per-config inventory ran.
+        assert client.get_states_calls == 0
+        # The dashboard bucket still got scanned, and stayed clean.
         assert client.ws_types["lovelace/dashboards/list"] == 1
+        assert resp["dashboards"] == []
+        assert not resp.get("partial")
+        assert not any("served via legacy path" in w for w in resp.get("warnings", []))
 
     @pytest.mark.asyncio
     async def test_dashboard_search_served_by_component_dashboards_frame(

--- a/tests/src/unit/test_ha_search_dashboard_split.py
+++ b/tests/src/unit/test_ha_search_dashboard_split.py
@@ -1,0 +1,716 @@
+"""``ha_search`` split route: component ``search`` + dashboards leg, merged.
+
+Naming ``dashboard`` in ``search_types`` used to send the WHOLE call to the
+legacy path, so the automation/script/scene/helper surfaces lost the
+component's in-process scan and went back to one REST fetch per config —
+~94 seconds and ``partial`` on a 136-automation instance versus 62ms complete
+for the same call without ``dashboard`` (issue #2289).
+
+These tests pin the split: the component's ``search`` command serves the
+surfaces it has, the component's separate ``ha_mcp_tools/dashboards``
+doc-search frame serves the dashboard bucket, and the server merges the two
+into one score-sorted page. The corner cases (a request the component search
+could not serve at all, a page deeper than the component's ``limit`` ceiling,
+either leg failing) are pinned here too, because each of them decides between
+a merged response and the legacy path.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from ha_mcp.client.rest_client import HomeAssistantCommandError
+from ha_mcp.tools import tools_config_dashboards, tools_search
+from ha_mcp.tools.smart_search import SmartSearchTools
+from ha_mcp.tools.tools_search import _merge_dashboard_window, _ResolvedSearch
+
+from ._component_routing_helpers import patch_ws
+from .test_ha_search_component_routing import (
+    DashboardRoutingClient,
+    RoutingClient,
+    _build_ha_search,
+    _setup_visibility_disabled,
+)
+
+# A component that advertises the search command AND the dashboards doc-search
+# frame — the install the split targets.
+_CAPS_SPLIT = {
+    "schema_version": 1,
+    "component_version": "2.0.0",
+    "capabilities": ["search", "dashboards", "dashboards_doc_search"],
+    "limits": {"max_results": 500},
+}
+
+
+class MatchingDashboardClient(RoutingClient):
+    """A legacy dashboard walk whose one (default) dashboard matches."""
+
+    async def send_websocket_message(self, msg: dict[str, Any]) -> dict[str, Any]:
+        """Serve the lovelace list/config reads the legacy walk makes."""
+        msg_type = msg.get("type", "")
+        if msg_type == "lovelace/dashboards/list":
+            self.ws_types[msg_type] += 1
+            return {"success": True, "result": []}
+        if msg_type == "lovelace/config":
+            self.ws_types[msg_type] += 1
+            return {"success": True, "result": {"views": [{"title": "Kitchen"}]}}
+        return await super().send_websocket_message(msg)
+
+
+class FailingDashboardClient(RoutingClient):
+    """A legacy dashboard walk whose per-dashboard config read fails."""
+
+    async def send_websocket_message(self, msg: dict[str, Any]) -> dict[str, Any]:
+        """List cleanly, then fail the config read of the one dashboard."""
+        msg_type = msg.get("type", "")
+        if msg_type == "lovelace/dashboards/list":
+            self.ws_types[msg_type] += 1
+            return {"success": True, "result": []}
+        if msg_type == "lovelace/config":
+            self.ws_types[msg_type] += 1
+            return {"success": False, "error": "Command failed: boom"}
+        return await super().send_websocket_message(msg)
+
+
+def _automation_record(name: str, score: int) -> dict[str, Any]:
+    """One component ``automations`` bucket record."""
+    return {
+        "entity_id": f"automation.{name}",
+        "alias": name.replace("_", " ").title(),
+        "score": score,
+        "match_in_name": False,
+        "match_in_config": True,
+    }
+
+
+def _search_result(
+    automations: list[dict[str, Any]] | None = None,
+    *,
+    config_total_matches: int | None = None,
+    config_has_more: bool = False,
+) -> dict[str, Any]:
+    """A component ``search`` result carrying only config buckets.
+
+    Mirrors the component, which emits all four config bucket keys plus the
+    corpus-wide ``config_total_matches`` regardless of which surfaces the
+    request named.
+    """
+    records = automations if automations is not None else []
+    return {
+        "entities": [],
+        "entity_total_matches": 0,
+        "entity_has_more": False,
+        "automations": records,
+        "scripts": [],
+        "scenes": [],
+        "helpers": [],
+        "config_total_matches": (
+            len(records) if config_total_matches is None else config_total_matches
+        ),
+        "config_has_more": config_has_more,
+        "partial": False,
+    }
+
+
+def _dashboards_result(
+    document_matches: list[dict[str, Any]],
+    *,
+    load_failed: int = 0,
+    yaml_skipped: int = 0,
+) -> dict[str, Any]:
+    """A component ``dashboards`` search-mode result."""
+    return {
+        "mode": "search",
+        "available": True,
+        "matches": [],
+        "truncated": False,
+        "document_matches": document_matches,
+        "yaml_skipped": yaml_skipped,
+        "load_failed": load_failed,
+    }
+
+
+def _split_ws(
+    *,
+    caps: dict[str, Any] | None = None,
+    search_result: dict[str, Any] | None = None,
+    search_exc: Exception | None = None,
+    dashboards_result: dict[str, Any] | None = None,
+) -> AsyncMock:
+    """A WS mock serving the caps probe, the search frame and the dashboards frame.
+
+    ``make_ws`` dispatches one read command; the split issues two, so this
+    suite carries its own dispatcher. The dashboards ``list`` mode (which the
+    legacy walk's registry read funnels through) answers with an empty registry
+    so the walk covers the default dashboard alone. Any other command type is
+    an ``AssertionError`` so a stray frame fails loudly.
+    """
+
+    async def _send(command_type: str, **kwargs: Any) -> dict[str, Any]:
+        if command_type == "ha_mcp_tools/info":
+            return {"success": True, "result": caps or _CAPS_SPLIT}
+        if command_type == "ha_mcp_tools/search":
+            if search_exc is not None:
+                raise search_exc
+            return {"success": True, "result": search_result}
+        if command_type == "ha_mcp_tools/dashboards":
+            if kwargs.get("mode") == "list":
+                return {
+                    "success": True,
+                    "result": {"mode": "list", "available": True, "dashboards": []},
+                }
+            return {"success": True, "result": dashboards_result}
+        raise AssertionError(f"unexpected command {command_type!r}")
+
+    ws = AsyncMock()
+    ws.send_command = AsyncMock(side_effect=_send)
+    return ws
+
+
+def _patch_dashboards_ws(ws: AsyncMock) -> Any:
+    """Resolve the dashboards module's own WS binding to ``ws`` as well."""
+    return patch.object(
+        tools_config_dashboards, "get_websocket_client", AsyncMock(return_value=ws)
+    )
+
+
+def _sent(ws: AsyncMock, command: str) -> list[Any]:
+    """Every call the mock recorded for ``command``."""
+    return [c for c in ws.send_command.call_args_list if c.args[0] == command]
+
+
+def _resolved_split(
+    *,
+    offset: int = 0,
+    limit: int = 10,
+    registry_eligible: bool = False,
+    include_config: bool = False,
+) -> _ResolvedSearch:
+    """A resolved mixed-surface search, for driving the merge helper directly."""
+    return _ResolvedSearch(
+        query="kitchen",
+        query_text="kitchen",
+        domain_filter=None,
+        area_filter=None,
+        state_filter=None,
+        parsed_search_types=["automation", "dashboard"],
+        parsed_fields=None,
+        result_fields=None,
+        limit=limit,
+        offset=offset,
+        exact_match=True,
+        include_hidden=True,
+        include_config=include_config,
+        group_by_domain=False,
+        per_domain_limit=None,
+        config_time_budget=None,
+        registry_eligible=registry_eligible,
+        body_eligible=True,
+        body_skipped_by_intent_gate=False,
+    )
+
+
+class TestMergeWindowHelper:
+    """The window merge, driven directly — including a case the tool cannot reach."""
+
+    def test_entity_records_are_resliced_onto_the_page(self) -> None:
+        """The window fetch asks for ``[0, offset + limit)`` on EVERY surface
+        the request names, so an entity surface would arrive over-fetched.
+
+        No live call reaches this: the split needs an explicit ``search_types``,
+        which pins the call config-only, so the window carries no entities. The
+        re-slice is the guard for an eligibility change that admits one —
+        without it the entity page would be the whole prefix.
+        """
+        req = _resolved_split(offset=2, limit=2, registry_eligible=True)
+        component_result = {
+            "entities": [{"entity_id": f"light.e{i}"} for i in range(4)],
+            "entity_total_matches": 9,
+            "entity_has_more": True,
+            "config_total_matches": 0,
+        }
+
+        windowed, dashboards = _merge_dashboard_window(req, component_result, [])
+
+        assert [e["entity_id"] for e in windowed["entities"]] == [
+            "light.e2",
+            "light.e3",
+        ]
+        assert windowed["entity_total_matches"] == 9
+        assert windowed["entity_has_more"] is True
+        assert dashboards == []
+
+    def test_entity_has_more_false_on_the_last_page(self) -> None:
+        """``entity_has_more`` is recomputed from the corpus total, so the tail
+        page does not inherit the window fetch's own ``has_more``."""
+        req = _resolved_split(offset=2, limit=5, registry_eligible=True)
+        component_result = {
+            "entities": [{"entity_id": f"light.e{i}"} for i in range(3)],
+            "entity_total_matches": 3,
+            "entity_has_more": True,
+            "config_total_matches": 0,
+        }
+
+        windowed, _ = _merge_dashboard_window(req, component_result, [])
+
+        assert [e["entity_id"] for e in windowed["entities"]] == ["light.e2"]
+        assert windowed["entity_has_more"] is False
+
+    def test_buckets_absent_from_the_component_result_stay_absent(self) -> None:
+        """Only the buckets the component actually returned are rewritten — an
+        untouched key must not appear as an empty list it never had."""
+        req = _resolved_split()
+        component_result = {
+            "automations": [{"entity_id": "automation.one", "score": 100}],
+            "config_total_matches": 1,
+        }
+
+        windowed, dashboards = _merge_dashboard_window(
+            req, component_result, [{"dashboard_url": "energy", "score": 90}]
+        )
+
+        assert "scripts" not in windowed
+        assert "scenes" not in windowed
+        assert "helpers" not in windowed
+        # The dashboards bucket is the leg's, never the component's.
+        assert "dashboards" not in windowed
+        assert [d["dashboard_url"] for d in dashboards] == ["energy"]
+        assert windowed["config_total_matches"] == 2
+
+
+class TestDashboardSplitRoute:
+    """A mixed ``search_types`` keeps the component fast path for its surfaces."""
+
+    @pytest.mark.asyncio
+    async def test_mixed_search_types_merge_both_legs(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        """The #2289 regression: one component search frame, one dashboards
+        frame, both buckets filled, and none of the legacy fetches the
+        all-or-nothing route used to force."""
+        _setup_visibility_disabled(tmp_path, monkeypatch)
+        ws = _split_ws(
+            search_result=_search_result([_automation_record("kitchen_lights", 100)]),
+            dashboards_result=_dashboards_result(
+                [{"url_path": "energy", "title": "Energy"}]
+            ),
+        )
+        client = DashboardRoutingClient()
+        ha_search = _build_ha_search(client)
+
+        with patch_ws(ws, tools_search), _patch_dashboards_ws(ws):
+            resp = await ha_search(
+                query="kitchen", search_types=["automation", "dashboard"]
+            )
+
+        assert resp["success"] is True
+        assert [a["entity_id"] for a in resp["automations"]] == [
+            "automation.kitchen_lights"
+        ]
+        assert [d["dashboard_url"] for d in resp["dashboards"]] == ["energy"]
+        assert resp["config_total_matches"] == 2
+        assert resp["count"] == 2
+        assert resp["partial"] is False
+        assert resp["warnings"] == []
+        # Exactly one frame per leg, and the legacy inventory is untouched.
+        assert len(_sent(ws, "ha_mcp_tools/search")) == 1
+        assert len(_sent(ws, "ha_mcp_tools/dashboards")) == 1
+        assert client.get_states_calls == 0
+        assert client.ws_types.get("lovelace/dashboards/list", 0) == 0
+        assert client.ws_types.get("lovelace/config", 0) == 0
+
+    @pytest.mark.asyncio
+    async def test_dashboard_stripped_from_the_component_request(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        """The component's voluptuous allowlist has no ``dashboard`` value, so
+        the surface must never reach it (issue #2008's original failure)."""
+        _setup_visibility_disabled(tmp_path, monkeypatch)
+        ws = _split_ws(
+            search_result=_search_result(),
+            dashboards_result=_dashboards_result([]),
+        )
+        client = DashboardRoutingClient()
+        ha_search = _build_ha_search(client)
+
+        with patch_ws(ws, tools_search), _patch_dashboards_ws(ws):
+            await ha_search(
+                query="kitchen", search_types=["automation", "helper", "dashboard"]
+            )
+
+        request = _sent(ws, "ha_mcp_tools/search")[0].kwargs
+        assert request["search_types"] == ["automation", "helper"]
+
+    @pytest.mark.asyncio
+    async def test_dashboard_only_request_stays_legacy(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        """``search_types=["dashboard"]`` leaves the component search request
+        with no surface of its own (an explicit pin drops the entity surface),
+        so the whole call goes to the legacy path — silently, as before."""
+        _setup_visibility_disabled(tmp_path, monkeypatch)
+        ws = _split_ws(dashboards_result=_dashboards_result([]))
+        client = DashboardRoutingClient()
+        ha_search = _build_ha_search(client)
+
+        with patch_ws(ws, tools_search), _patch_dashboards_ws(ws):
+            resp = await ha_search(query="kitchen", search_types=["dashboard"])
+
+        assert resp["success"] is True
+        assert _sent(ws, "ha_mcp_tools/search") == []
+        assert not any("served via legacy path" in w for w in resp.get("warnings", []))
+
+    @pytest.mark.asyncio
+    async def test_window_beyond_component_limit_ceiling_stays_legacy(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        """The window fetch asks for ``offset + limit`` records; past the
+        component's 500-record ``limit`` ceiling that frame would be rejected
+        outright, so the call takes the legacy path whole instead."""
+        _setup_visibility_disabled(tmp_path, monkeypatch)
+        ws = _split_ws(
+            search_result=_search_result(),
+            dashboards_result=_dashboards_result([]),
+        )
+        client = DashboardRoutingClient()
+        ha_search = _build_ha_search(client)
+
+        with patch_ws(ws, tools_search), _patch_dashboards_ws(ws):
+            resp = await ha_search(
+                query="kitchen",
+                search_types=["automation", "dashboard"],
+                offset=460,
+                limit=50,
+            )
+
+        assert resp["success"] is True
+        assert _sent(ws, "ha_mcp_tools/search") == []
+        assert not any("served via legacy path" in w for w in resp.get("warnings", []))
+        # The legacy pipeline served it.
+        assert client.get_states_calls == 1
+
+    @pytest.mark.asyncio
+    async def test_window_at_the_ceiling_still_merges(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        """500 is the inclusive maximum the component's schema accepts, so the
+        boundary page still splits."""
+        _setup_visibility_disabled(tmp_path, monkeypatch)
+        ws = _split_ws(
+            search_result=_search_result(),
+            dashboards_result=_dashboards_result([]),
+        )
+        client = DashboardRoutingClient()
+        ha_search = _build_ha_search(client)
+
+        with patch_ws(ws, tools_search), _patch_dashboards_ws(ws):
+            await ha_search(
+                query="kitchen",
+                search_types=["automation", "dashboard"],
+                offset=450,
+                limit=50,
+            )
+
+        assert _sent(ws, "ha_mcp_tools/search")[0].kwargs["limit"] == 500
+
+
+class TestDashboardSplitPagination:
+    """The merged page is one global score sort across both legs."""
+
+    @pytest.mark.asyncio
+    async def test_window_fetch_and_merged_slice(self, tmp_path, monkeypatch) -> None:
+        """With ``offset>0`` the component is asked for the whole
+        ``[0, offset+limit)`` prefix, and the server pages the merged list."""
+        _setup_visibility_disabled(tmp_path, monkeypatch)
+        ws = _split_ws(
+            search_result=_search_result(
+                [
+                    _automation_record("first", 100),
+                    _automation_record("second", 80),
+                    _automation_record("third", 60),
+                ]
+            ),
+            dashboards_result=_dashboards_result(
+                [{"url_path": "energy", "title": "Energy"}]
+            ),
+        )
+        client = DashboardRoutingClient()
+        ha_search = _build_ha_search(client)
+
+        with patch_ws(ws, tools_search), _patch_dashboards_ws(ws):
+            resp = await ha_search(
+                query="kitchen",
+                search_types=["automation", "dashboard"],
+                offset=2,
+                limit=2,
+            )
+
+        request = _sent(ws, "ha_mcp_tools/search")[0].kwargs
+        assert request["offset"] == 0
+        assert request["limit"] == 4
+        # Merged order: automation(100), dashboard(100), automation(80),
+        # automation(60) — the score tie keeps the component record first, so
+        # page [2:4] is the 80 then the 60 automation.
+        assert [a["entity_id"] for a in resp["automations"]] == [
+            "automation.second",
+            "automation.third",
+        ]
+        assert resp["dashboards"] == []
+        assert resp["config_total_matches"] == 4
+        assert resp["config_has_more"] is False
+        assert resp["config_next_offset"] is None
+        assert resp["count"] == 2
+
+    @pytest.mark.asyncio
+    async def test_score_tie_keeps_component_record_first(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        """Legacy appends its dashboards bucket last, so a tie must not let a
+        dashboard displace a component record from the page."""
+        _setup_visibility_disabled(tmp_path, monkeypatch)
+        ws = _split_ws(
+            search_result=_search_result([_automation_record("kitchen_lights", 100)]),
+            dashboards_result=_dashboards_result(
+                [{"url_path": "energy", "title": "Energy"}]
+            ),
+        )
+        client = DashboardRoutingClient()
+        ha_search = _build_ha_search(client)
+
+        with patch_ws(ws, tools_search), _patch_dashboards_ws(ws):
+            resp = await ha_search(
+                query="kitchen", search_types=["automation", "dashboard"], limit=1
+            )
+
+        assert [a["entity_id"] for a in resp["automations"]] == [
+            "automation.kitchen_lights"
+        ]
+        assert resp["dashboards"] == []
+        assert resp["config_total_matches"] == 2
+        assert resp["config_has_more"] is True
+        assert resp["config_next_offset"] == 1
+        assert resp["has_more"] is True
+
+    @pytest.mark.asyncio
+    async def test_component_corpus_past_the_window_reports_has_more(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        """The component's own ``config_has_more`` for the window is OR-ed in:
+        its records beyond the window are not in the merged list at all."""
+        _setup_visibility_disabled(tmp_path, monkeypatch)
+        ws = _split_ws(
+            search_result=_search_result(
+                [_automation_record("first", 100)],
+                config_total_matches=1,
+                config_has_more=True,
+            ),
+            dashboards_result=_dashboards_result([]),
+        )
+        client = DashboardRoutingClient()
+        ha_search = _build_ha_search(client)
+
+        with patch_ws(ws, tools_search), _patch_dashboards_ws(ws):
+            resp = await ha_search(
+                query="kitchen", search_types=["automation", "dashboard"], limit=5
+            )
+
+        assert resp["config_total_matches"] == 1
+        assert resp["config_has_more"] is True
+        assert resp["config_next_offset"] == 5
+
+
+class TestDashboardSplitIncludeConfig:
+    """``include_config`` governs the dashboard records' bodies too."""
+
+    @pytest.mark.asyncio
+    async def test_include_config_false_strips_the_body(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        """Mirrors the legacy pipeline's per-record ``config`` pop. A non-zero
+        ``yaml_skipped`` sends the leg to the legacy walk, which is the route
+        that carries bodies at all."""
+        _setup_visibility_disabled(tmp_path, monkeypatch)
+        ws = _split_ws(
+            search_result=_search_result(),
+            dashboards_result=_dashboards_result([], yaml_skipped=1),
+        )
+        client = MatchingDashboardClient()
+        ha_search = _build_ha_search(client)
+
+        with patch_ws(ws, tools_search), _patch_dashboards_ws(ws):
+            resp = await ha_search(
+                query="kitchen",
+                search_types=["automation", "dashboard"],
+                include_config=False,
+            )
+
+        assert [d["dashboard_url"] for d in resp["dashboards"]] == ["default"]
+        assert "config" not in resp["dashboards"][0]
+
+    @pytest.mark.asyncio
+    async def test_include_config_true_keeps_the_body(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        """``include_config=True`` also forces the legacy dashboard walk (the
+        component's doc-search carries no bodies), which is where the body
+        comes from."""
+        _setup_visibility_disabled(tmp_path, monkeypatch)
+        ws = _split_ws(search_result=_search_result())
+        client = MatchingDashboardClient()
+        ha_search = _build_ha_search(client)
+
+        with patch_ws(ws, tools_search), _patch_dashboards_ws(ws):
+            resp = await ha_search(
+                query="kitchen",
+                search_types=["automation", "dashboard"],
+                include_config=True,
+            )
+
+        assert resp["dashboards"][0]["config"] == {"views": [{"title": "Kitchen"}]}
+
+
+class TestDashboardSplitPartialSemantics:
+    """The dashboard bucket is never dropped silently."""
+
+    @pytest.mark.asyncio
+    async def test_dashboard_leg_failure_marks_partial(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        """A raising dashboards leg reports like a failed legacy branch:
+        ``partial``, an ``errors[]`` entry naming the surface, the warning
+        mirror — and the component's buckets survive intact."""
+        _setup_visibility_disabled(tmp_path, monkeypatch)
+        ws = _split_ws(
+            search_result=_search_result([_automation_record("kitchen_lights", 100)]),
+            dashboards_result=_dashboards_result([]),
+        )
+        client = DashboardRoutingClient()
+        ha_search = _build_ha_search(client)
+
+        with (
+            patch_ws(ws, tools_search),
+            _patch_dashboards_ws(ws),
+            patch.object(
+                SmartSearchTools,
+                "_search_dashboards_surface",
+                AsyncMock(side_effect=RuntimeError("dashboards backend exploded")),
+            ),
+        ):
+            resp = await ha_search(
+                query="kitchen", search_types=["automation", "dashboard"]
+            )
+
+        assert resp["success"] is True
+        assert [a["entity_id"] for a in resp["automations"]] == [
+            "automation.kitchen_lights"
+        ]
+        assert resp["dashboards"] == []
+        assert resp["partial"] is True
+        assert {e["surface"] for e in resp["errors"]} == {"dashboards"}
+        assert "dashboards backend exploded" in resp["partial_reason"]
+        assert any("incomplete results" in w for w in resp["warnings"])
+
+    @pytest.mark.asyncio
+    async def test_dashboard_failed_count_marks_partial(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        """A dashboard whose config read failed without raising gets the deep
+        path's own ``not scanned`` wording, not a second phrasing."""
+        _setup_visibility_disabled(tmp_path, monkeypatch)
+        ws = _split_ws(
+            search_result=_search_result(),
+            dashboards_result=_dashboards_result([], load_failed=2),
+        )
+        client = DashboardRoutingClient()
+        ha_search = _build_ha_search(client)
+
+        with patch_ws(ws, tools_search), _patch_dashboards_ws(ws):
+            resp = await ha_search(
+                query="kitchen", search_types=["automation", "dashboard"]
+            )
+
+        assert resp["partial"] is True
+        assert "2 dashboard(s) not scanned" in resp["partial_reason"]
+        assert any("2 dashboard(s) not scanned" in w for w in resp["warnings"])
+
+    @pytest.mark.asyncio
+    async def test_legacy_walk_failure_marks_partial(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        """The same count reaches the envelope from the legacy walk fallback."""
+        _setup_visibility_disabled(tmp_path, monkeypatch)
+        ws = _split_ws(
+            search_result=_search_result(),
+            dashboards_result=_dashboards_result([], yaml_skipped=1),
+        )
+        client = FailingDashboardClient()
+        ha_search = _build_ha_search(client)
+
+        with patch_ws(ws, tools_search), _patch_dashboards_ws(ws):
+            resp = await ha_search(
+                query="kitchen", search_types=["automation", "dashboard"]
+            )
+
+        # yaml_skipped sends the leg to the legacy walk, whose one dashboard
+        # config read fails.
+        assert client.ws_types["lovelace/config"] == 1
+        assert resp["partial"] is True
+        assert "1 dashboard(s) not scanned" in resp["partial_reason"]
+
+
+class TestDashboardSplitComponentLegFailure:
+    """The component leg's failure taxonomy is unchanged by the split."""
+
+    @pytest.mark.asyncio
+    async def test_command_error_falls_back_once(self, tmp_path, monkeypatch) -> None:
+        """A failing component search serves the WHOLE call from legacy — which
+        searches dashboards itself, so the split's own dashboard records must
+        not be merged on top of it."""
+        _setup_visibility_disabled(tmp_path, monkeypatch)
+        ws = _split_ws(
+            search_exc=HomeAssistantCommandError("Command failed: boom", "internal"),
+            dashboards_result=_dashboards_result(
+                [{"url_path": "energy", "title": "Energy"}]
+            ),
+        )
+        client = DashboardRoutingClient()
+        ha_search = _build_ha_search(client)
+
+        with patch_ws(ws, tools_search), _patch_dashboards_ws(ws):
+            resp = await ha_search(
+                query="kitchen", search_types=["automation", "dashboard"]
+            )
+
+        assert resp["success"] is True
+        assert any("served via legacy path" in w for w in resp["warnings"])
+        assert client.get_states_calls == 1
+        # Exactly one "energy" record: the legacy path produced it, and the
+        # split leg's copy was dropped rather than merged on top.
+        assert [d["dashboard_url"] for d in resp["dashboards"]] == ["energy"]
+
+    @pytest.mark.asyncio
+    async def test_unknown_command_falls_back_silently(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        """A component downgraded mid-session is still a silent legacy route."""
+        _setup_visibility_disabled(tmp_path, monkeypatch)
+        ws = _split_ws(
+            search_exc=HomeAssistantCommandError(
+                "Command failed: nope", "unknown_command"
+            ),
+            dashboards_result=_dashboards_result([]),
+        )
+        client = DashboardRoutingClient()
+        ha_search = _build_ha_search(client)
+
+        with patch_ws(ws, tools_search), _patch_dashboards_ws(ws):
+            resp = await ha_search(
+                query="kitchen", search_types=["automation", "dashboard"]
+            )
+
+        assert resp["success"] is True
+        assert client.get_states_calls == 1
+        assert not any("served via legacy path" in w for w in resp["warnings"])

--- a/tests/src/unit/test_ha_search_dashboard_split.py
+++ b/tests/src/unit/test_ha_search_dashboard_split.py
@@ -809,6 +809,63 @@ class TestDashboardSplitComponentLegFailure:
         assert state["cancelled"] is True
 
     @pytest.mark.asyncio
+    async def test_parent_cancellation_settles_the_dashboard_leg(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        """Cancelling ha_search settles the dashboards leg BEFORE the call
+        completes: the leg task must not outlive the parent with an
+        unobserved cancellation."""
+        _setup_visibility_disabled(tmp_path, monkeypatch)
+        search_started = asyncio.Event()
+        state = {"cancelled": False}
+
+        async def hang_forever(
+            self: SmartSearchTools,
+            query_lower: str,
+            exact_match: bool,
+            semaphore: asyncio.Semaphore,
+            *,
+            include_config: bool,
+        ) -> tuple[list[dict[str, Any]], int]:
+            try:
+                await asyncio.Event().wait()
+            except asyncio.CancelledError:
+                state["cancelled"] = True
+                raise
+            return [], 0
+
+        monkeypatch.setattr(
+            SmartSearchTools, "_search_dashboards_surface", hang_forever
+        )
+
+        async def _send(command_type: str, **kwargs: Any) -> dict[str, Any]:
+            if command_type == "ha_mcp_tools/info":
+                return {"success": True, "result": _CAPS_SPLIT}
+            if command_type == "ha_mcp_tools/search":
+                search_started.set()
+                await asyncio.Event().wait()
+            raise AssertionError(f"unexpected command {command_type!r}")
+
+        ws = AsyncMock()
+        ws.send_command = AsyncMock(side_effect=_send)
+        client = DashboardRoutingClient()
+        ha_search = _build_ha_search(client)
+
+        with patch_ws(ws, tools_search), _patch_dashboards_ws(ws):
+            call = asyncio.ensure_future(
+                ha_search(query="kitchen", search_types=["automation", "dashboard"])
+            )
+            await search_started.wait()
+            call.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await call
+
+        # The leg settled before the parent call completed — without the
+        # settle-await, its CancelledError delivery would still be pending
+        # here and the flag unset.
+        assert state["cancelled"] is True
+
+    @pytest.mark.asyncio
     async def test_unknown_command_falls_back_silently(
         self, tmp_path, monkeypatch
     ) -> None:

--- a/tests/src/unit/test_ha_search_dashboard_split.py
+++ b/tests/src/unit/test_ha_search_dashboard_split.py
@@ -17,6 +17,7 @@ a merged response and the legacy path.
 
 from __future__ import annotations
 
+import asyncio
 from typing import Any
 from unittest.mock import AsyncMock, patch
 
@@ -393,6 +394,35 @@ class TestDashboardSplitRoute:
         assert client.get_states_calls == 1
 
     @pytest.mark.asyncio
+    async def test_component_advertised_smaller_ceiling_gates_the_split(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        """The gate reads the component's own ``limits.max_results``: a
+        component advertising a smaller ceiling routes legacy instead of
+        accepting the split and having its schema reject the window frame."""
+        _setup_visibility_disabled(tmp_path, monkeypatch)
+        ws = _split_ws(
+            caps={**_CAPS_SPLIT, "limits": {"max_results": 3}},
+            search_result=_search_result(),
+            dashboards_result=_dashboards_result([]),
+        )
+        client = DashboardRoutingClient()
+        ha_search = _build_ha_search(client)
+
+        with patch_ws(ws, tools_search), _patch_dashboards_ws(ws):
+            resp = await ha_search(
+                query="kitchen",
+                search_types=["automation", "dashboard"],
+                limit=4,
+            )
+
+        assert resp["success"] is True
+        assert _sent(ws, "ha_mcp_tools/search") == []
+        assert not any("served via legacy path" in w for w in resp.get("warnings", []))
+        # The legacy pipeline served it.
+        assert client.get_states_calls == 1
+
+    @pytest.mark.asyncio
     async def test_window_at_the_ceiling_still_merges(
         self, tmp_path, monkeypatch
     ) -> None:
@@ -452,7 +482,8 @@ class TestDashboardSplitPagination:
         assert request["offset"] == 0
         assert request["limit"] == 4
         # Merged order: automation(100), dashboard(100), automation(80),
-        # automation(60) — the score tie keeps the component record first, so
+        # automation(60) — on the score tie the mirrored component tiebreak
+        # sorts "automation.first" before the "energy" dashboard_url, so
         # page [2:4] is the 80 then the 60 automation.
         assert [a["entity_id"] for a in resp["automations"]] == [
             "automation.second",
@@ -468,8 +499,9 @@ class TestDashboardSplitPagination:
     async def test_score_tie_keeps_component_record_first(
         self, tmp_path, monkeypatch
     ) -> None:
-        """Legacy appends its dashboards bucket last, so a tie must not let a
-        dashboard displace a component record from the page."""
+        """On a score tie the mirrored component tiebreak decides the page:
+        "automation.kitchen_lights" sorts before the "energy" dashboard_url,
+        so the dashboard does not displace the component record."""
         _setup_visibility_disabled(tmp_path, monkeypatch)
         ws = _split_ws(
             search_result=_search_result([_automation_record("kitchen_lights", 100)]),
@@ -493,6 +525,45 @@ class TestDashboardSplitPagination:
         assert resp["config_has_more"] is True
         assert resp["config_next_offset"] == 1
         assert resp["has_more"] is True
+
+    def test_equal_score_pages_stay_disjoint_across_offsets(self) -> None:
+        """Pages must be cut with the same total order that picked the window.
+
+        The component orders its corpus by ``(-score, _sort_key)``; on an
+        all-tied score, "scene.aaa" sorts before "script.aaa" even though the
+        scenes bucket is concatenated after scripts. A bucket-order (or
+        score-only stable) cut would show "scene.aaa" on BOTH pages and never
+        show "script.aaa" (the Codex review's boundary-tie finding)."""
+        scene = {"entity_id": "scene.aaa", "score": 100, "match_in_config": True}
+        script = {"entity_id": "script.aaa", "score": 100, "match_in_config": True}
+
+        def window(
+            records_by_bucket: dict[str, list[dict[str, Any]]],
+        ) -> dict[str, Any]:
+            return {
+                "automations": [],
+                "scripts": records_by_bucket.get("scripts", []),
+                "scenes": records_by_bucket.get("scenes", []),
+                "helpers": [],
+                "config_total_matches": 2,
+                "config_has_more": False,
+            }
+
+        page1, _ = _merge_dashboard_window(
+            _resolved_split(offset=0, limit=1),
+            window({"scenes": [scene]}),
+            [],
+        )
+        page2, _ = _merge_dashboard_window(
+            _resolved_split(offset=1, limit=1),
+            window({"scenes": [scene], "scripts": [script]}),
+            [],
+        )
+
+        assert [r["entity_id"] for r in page1["scenes"]] == ["scene.aaa"]
+        assert page1["scripts"] == []
+        assert [r["entity_id"] for r in page2["scripts"]] == ["script.aaa"]
+        assert page2["scenes"] == []
 
     @pytest.mark.asyncio
     async def test_component_corpus_past_the_window_reports_has_more(
@@ -690,6 +761,52 @@ class TestDashboardSplitComponentLegFailure:
         # Exactly one "energy" record: the legacy path produced it, and the
         # split leg's copy was dropped rather than merged on top.
         assert [d["dashboard_url"] for d in resp["dashboards"]] == ["energy"]
+
+    @pytest.mark.asyncio
+    async def test_component_error_cancels_slow_dashboard_leg(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        """A failed component leg cancels the dashboards leg instead of
+        waiting for it: the legacy fallback searches dashboards itself, so a
+        slow leg would only delay the fallback and duplicate its I/O."""
+        _setup_visibility_disabled(tmp_path, monkeypatch)
+        state = {"calls": 0, "cancelled": False}
+
+        async def hang_then_serve(
+            self: SmartSearchTools,
+            query_lower: str,
+            exact_match: bool,
+            semaphore: asyncio.Semaphore,
+            *,
+            include_config: bool,
+        ) -> tuple[list[dict[str, Any]], int]:
+            state["calls"] += 1
+            if state["calls"] == 1:
+                try:
+                    await asyncio.Event().wait()
+                except asyncio.CancelledError:
+                    state["cancelled"] = True
+                    raise
+            return [], 0
+
+        monkeypatch.setattr(
+            SmartSearchTools, "_search_dashboards_surface", hang_then_serve
+        )
+        ws = _split_ws(
+            search_exc=HomeAssistantCommandError("Command failed: boom", "internal"),
+            dashboards_result=_dashboards_result([]),
+        )
+        client = DashboardRoutingClient()
+        ha_search = _build_ha_search(client)
+
+        with patch_ws(ws, tools_search), _patch_dashboards_ws(ws):
+            resp = await ha_search(
+                query="kitchen", search_types=["automation", "dashboard"]
+            )
+
+        assert resp["success"] is True
+        assert any("served via legacy path" in w for w in resp["warnings"])
+        assert state["cancelled"] is True
 
     @pytest.mark.asyncio
     async def test_unknown_command_falls_back_silently(

--- a/tests/src/unit/test_ha_search_dashboard_split.py
+++ b/tests/src/unit/test_ha_search_dashboard_split.py
@@ -496,12 +496,15 @@ class TestDashboardSplitPagination:
         assert resp["count"] == 2
 
     @pytest.mark.asyncio
-    async def test_score_tie_keeps_component_record_first(
+    async def test_score_tie_is_cut_by_the_mirrored_sort_key(
         self, tmp_path, monkeypatch
     ) -> None:
-        """On a score tie the mirrored component tiebreak decides the page:
-        "automation.kitchen_lights" sorts before the "energy" dashboard_url,
-        so the dashboard does not displace the component record."""
+        """On a score tie the mirrored component tiebreak decides the page.
+
+        There is no component-first rule: the lexical key alone decides, and
+        here "automation.kitchen_lights" < "energy" keeps the automation on
+        the page. A dashboard whose url_path sorted lower would win instead —
+        exactly as it would in the component's own corpus order."""
         _setup_visibility_disabled(tmp_path, monkeypatch)
         ws = _split_ws(
             search_result=_search_result([_automation_record("kitchen_lights", 100)]),
@@ -807,6 +810,57 @@ class TestDashboardSplitComponentLegFailure:
         assert resp["success"] is True
         assert any("served via legacy path" in w for w in resp["warnings"])
         assert state["cancelled"] is True
+
+    @pytest.mark.asyncio
+    async def test_parent_cancellation_during_fallback_settle_propagates(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        """A cancellation delivered while the failed-component branch settles
+        the leg must propagate — not be consumed right before the legacy
+        fallback runs uncancellably (human review on #2291)."""
+        _setup_visibility_disabled(tmp_path, monkeypatch)
+        cancel_seen = asyncio.Event()
+        release = asyncio.Event()
+
+        async def stubborn_leg(
+            self: SmartSearchTools,
+            query_lower: str,
+            exact_match: bool,
+            semaphore: asyncio.Semaphore,
+            *,
+            include_config: bool,
+        ) -> tuple[list[dict[str, Any]], int]:
+            try:
+                await asyncio.Event().wait()
+            except asyncio.CancelledError:
+                cancel_seen.set()
+                # Hold through the first cancellation so the caller is
+                # provably parked in its settle wait when the test cancels it.
+                await release.wait()
+                raise
+            return [], 0
+
+        monkeypatch.setattr(
+            SmartSearchTools, "_search_dashboards_surface", stubborn_leg
+        )
+        ws = _split_ws(
+            search_exc=HomeAssistantCommandError("Command failed: boom", "internal"),
+            dashboards_result=_dashboards_result([]),
+        )
+        client = DashboardRoutingClient()
+        ha_search = _build_ha_search(client)
+
+        with patch_ws(ws, tools_search), _patch_dashboards_ws(ws):
+            call = asyncio.ensure_future(
+                ha_search(query="kitchen", search_types=["automation", "dashboard"])
+            )
+            # The component leg fails fast; once the leg has received its
+            # cancel, the call is parked in the settle wait.
+            await cancel_seen.wait()
+            call.cancel()
+            release.set()
+            with pytest.raises(asyncio.CancelledError):
+                await call
 
     @pytest.mark.asyncio
     async def test_parent_cancellation_settles_the_dashboard_leg(

--- a/tests/src/unit/test_tools_filesystem.py
+++ b/tests/src/unit/test_tools_filesystem.py
@@ -236,11 +236,13 @@ class TestAssertMcpToolsAvailableCapsFirst:
     async def test_caps_tools_services_false_raises_tools_entry_error(self):
         """Since 2.1.0 the server entry also answers ``info`` (#2289), so caps
         alone no longer prove the tools SERVICES exist. A component reporting
-        ``tools_services: False`` raises the actionable tools-entry error
-        instead of letting the call hit raw service-not-found (#2292)."""
+        ``tools_services: False`` — confirmed by the live service-registry
+        probe — raises the actionable tools-entry error instead of letting the
+        call hit raw service-not-found (#2292)."""
         from ha_mcp.tools.tools_filesystem import _assert_mcp_tools_available
 
         client = AsyncMock()
+        client.get_services = AsyncMock(return_value=[])
         with (
             patch(
                 "ha_mcp.tools.tools_filesystem.get_component_caps",
@@ -253,7 +255,29 @@ class TestAssertMcpToolsAvailableCapsFirst:
         data = json.loads(str(exc.value))
         assert data["success"] is False
         assert "file & yaml tools" in data["error"]["message"].lower()
-        client.get_services.assert_not_called()
+        client.get_services.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_caps_tools_services_false_but_live_services_present_passes(self):
+        """Caps are cached for the client's lifetime, so a ``False`` snapshot
+        can predate the user adding the tools entry mid-session. The live
+        service-registry re-check keeps the tools usable without a server
+        restart (Codex review on #2291)."""
+        from ha_mcp.tools.tools_filesystem import _assert_mcp_tools_available
+
+        client = AsyncMock()
+        client.get_services = AsyncMock(
+            return_value=[
+                {"domain": "ha_mcp_tools", "services": {"get_caller_token": {}}}
+            ]
+        )
+        with patch(
+            "ha_mcp.tools.tools_filesystem.get_component_caps",
+            AsyncMock(return_value=self._caps("2.1.0", tools_services=False)),
+        ):
+            await _assert_mcp_tools_available(client)  # must not raise
+
+        client.get_services.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_caps_tools_services_true_passes(self):

--- a/tests/src/unit/test_tools_filesystem.py
+++ b/tests/src/unit/test_tools_filesystem.py
@@ -185,7 +185,7 @@ class TestAssertMcpToolsAvailableCapsFirst:
     (issue #1813 P5 item 1c)."""
 
     @staticmethod
-    def _caps(version: str = "1.2.0"):
+    def _caps(version: str = "1.2.0", tools_services: bool | None = None):
         from ha_mcp.tools.component_api import ComponentCaps
 
         return ComponentCaps(
@@ -193,6 +193,7 @@ class TestAssertMcpToolsAvailableCapsFirst:
             component_version=version,
             capabilities=frozenset({"search"}),
             limits={},
+            tools_services=tools_services,
         )
 
     @pytest.mark.asyncio
@@ -230,6 +231,69 @@ class TestAssertMcpToolsAvailableCapsFirst:
         assert data["success"] is False
         assert "too old" in data["error"]["message"].lower()
         client.get_services.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_caps_tools_services_false_raises_tools_entry_error(self):
+        """Since 2.1.0 the server entry also answers ``info`` (#2289), so caps
+        alone no longer prove the tools SERVICES exist. A component reporting
+        ``tools_services: False`` raises the actionable tools-entry error
+        instead of letting the call hit raw service-not-found (#2292)."""
+        from ha_mcp.tools.tools_filesystem import _assert_mcp_tools_available
+
+        client = AsyncMock()
+        with (
+            patch(
+                "ha_mcp.tools.tools_filesystem.get_component_caps",
+                AsyncMock(return_value=self._caps("2.1.0", tools_services=False)),
+            ),
+            pytest.raises(ToolError) as exc,
+        ):
+            await _assert_mcp_tools_available(client)
+
+        data = json.loads(str(exc.value))
+        assert data["success"] is False
+        assert "file & yaml tools" in data["error"]["message"].lower()
+        client.get_services.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_caps_tools_services_true_passes(self):
+        """A dual-entry (or tools-only) 2.1.0 component reports True and the
+        gate passes without the get_services probe."""
+        from ha_mcp.tools.tools_filesystem import _assert_mcp_tools_available
+
+        client = AsyncMock()
+        with patch(
+            "ha_mcp.tools.tools_filesystem.get_component_caps",
+            AsyncMock(return_value=self._caps("2.1.0", tools_services=True)),
+        ):
+            await _assert_mcp_tools_available(client)  # must not raise
+
+        client.get_services.assert_not_called()
+
+    def test_parse_caps_reads_additive_tools_services(self):
+        """``_parse_caps`` maps the additive field: bool passes through, absent
+        or non-bool stays None (pre-2.1.0 components)."""
+        from ha_mcp.tools.component_api import _parse_caps
+
+        base = {
+            "schema_version": 1,
+            "component_version": "2.1.0",
+            "capabilities": ["search"],
+            "limits": {},
+        }
+        assert (
+            _parse_caps({"result": {**base, "tools_services": False}}).tools_services
+            is False
+        )
+        assert (
+            _parse_caps({"result": {**base, "tools_services": True}}).tools_services
+            is True
+        )
+        assert _parse_caps({"result": base}).tools_services is None
+        assert (
+            _parse_caps({"result": {**base, "tools_services": "yes"}}).tools_services
+            is None
+        )
 
     @pytest.mark.asyncio
     async def test_caps_miss_falls_back_to_get_services_present(self):

--- a/tests/src/unit/test_websocket_client.py
+++ b/tests/src/unit/test_websocket_client.py
@@ -194,8 +194,6 @@ class TestSendCommandErrorContract:
         left its future in ``_pending_requests`` until a response with that id
         arrived — which a hung handler never sends — leaking one entry per
         cancelled call."""
-        import asyncio
-
         client = self._prepare_client()
         sent = asyncio.Event()
 

--- a/tests/src/unit/test_websocket_client.py
+++ b/tests/src/unit/test_websocket_client.py
@@ -185,6 +185,38 @@ class TestSendCommandErrorContract:
         assert "entity not available" in str(exc_info.value)
 
     @pytest.mark.asyncio
+    async def test_send_command_cancellation_drops_the_pending_future(self):
+        """Cancelling a caller mid-wait removes its pending-request entry.
+
+        Only ``TimeoutError`` and ``Exception`` cleaned up before the
+        ``BaseException`` clause was added: a cancelled caller (e.g. the
+        ha_search dashboards leg cancelled on a component-leg failure, #2291)
+        left its future in ``_pending_requests`` until a response with that id
+        arrived — which a hung handler never sends — leaking one entry per
+        cancelled call."""
+        import asyncio
+
+        client = self._prepare_client()
+        sent = asyncio.Event()
+
+        async def _never_resolve(message: dict) -> None:
+            sent.set()
+
+        client.send_json_message = _never_resolve  # type: ignore[method-assign]
+
+        task = asyncio.ensure_future(client.send_command("test/ping"))
+        # The future registers before send_json_message runs, so once the send
+        # stub fires the task is parked on the response wait with its entry in
+        # place.
+        await sent.wait()
+        assert client._state._pending_requests
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        assert client._state._pending_requests == {}
+
+    @pytest.mark.asyncio
     async def test_send_command_raises_on_string_error(self):
         """send_command raises HomeAssistantCommandError when error is a string."""
         from ha_mcp.client.rest_client import HomeAssistantCommandError


### PR DESCRIPTION
## What does this PR do?

Fixes #2289. Naming `dashboard` in `search_types` sent the whole `ha_search` call to the legacy path, because routing was all-or-nothing per command and the component's `search` command has no dashboard surface. Every other requested surface then lost the component's in-process scan and fell back to one REST config fetch per automation under the time budget — ~94s and `partial` on the reporter's 136-automation instance, versus 62ms complete without `dashboard`. The model picks `search_types`, so there was no user-side workaround.

This splits the route server-side (option 1 from the issue):

- The component's `search` command serves the surfaces it has; `dashboard` is stripped from the wire request (its voluptuous allowlist rejects it).
- The dashboards bucket is served by the deep path's existing component-first dashboards surface (`dashboards_doc_search` frame, legacy walk fallback), running concurrently.
- The two legs merge into one score-sorted page matching the legacy contract (global sort then `[offset : offset+limit]`): the component leg is fetched as a `[0, offset+limit)` window so the merged list can be sliced exactly, cut with the same `(-score, tiebreak-key)` total order the component itself uses, so ties fall exactly where the component's own corpus order puts them.
- Corner cases route whole to legacy instead of being half-served: a dashboard-only pin (nothing left for the command) and a page past the component's 500-record `limit` ceiling.
- Component-leg failure taxonomy is unchanged; its legacy fallback covers dashboards itself, so leg results are dropped, not double-merged. A dashboards leg failure reports like a failed legacy branch (`partial` + `errors[]`), and its "not scanned" count reuses the deep path's wording.

**Component change (2.0.1 → 2.1.0 pending):** the `ha_mcp_tools/*` WebSocket command surface now registers from the server (embedded) entry as well, not only from the tools entry. A server-entry-only install previously had no component WS commands at all, so every `ha_search` silently ran the legacy path; now the full fast path works there. The surface is entry-agnostic (handlers read HA-core state; HA core authenticates and `@require_admin` gates each command) — only the filesystem/YAML HA services remain tools-entry-only. `MIN_COMPONENT_VERSION` is untouched: the server gates on the capability probe, which degrades cleanly on older components. Installs without any component entry are byte-identical to before.

**Relationship to #2292:** that issue's audit shows the server-entry-only gap is much wider than search. This PR resolves its central defect — the WS command surface registering only from the tools entry — so on server-entry-only (embedded) installs the following #2292 items are fixed as a side effect: `ha_config_list_helpers(helper_type="all")` and flow-helper listing, YAML zones in `ha_get_zone` (including `home`), full blueprint `config` from `ha_get_blueprint`, config-entry `unique_id` / raw options and `expected_unique_id` reconfigure in `ha_get_integration` / `ha_set_integration`, the default dashboard in `ha_config_get_dashboard(mode="search")`, area/floor/label enrichment on `ha_get_entity` and exposure reads, component-version detection in issue diagnostics, and every capability previously forced through legacy fallbacks (overview, bulk states, registries, system snapshots, backup prep, service calls, and the component search routes). It also addresses #2292's coordination point directly: the filesystem/YAML gate no longer treats a successful capability probe as proof the File & YAML services exist — the component's `info` now reports an additive `tools_services` field and the gate raises the actionable tools-entry error when it is `false`. Still open in #2292 and not attempted here: the entry-boundary documentation (config-flow description, root `AGENTS.md` topology guidance), tools-entry unload cleanup, per-topology test coverage, and the #2247 / #2273 rechecks.

The reference-graph e2e relied on `dashboard`-in-`search_types` as its route-to-legacy lever; it now uses a page width past the component ceiling (separate commit), staying green on both the old and new routing.

## Type of change
- [x] 🐛 Bug fix

## Testing
- [x] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

Live-tested on a real HA instance (embedded component server): the combined `automation,script,helper,dashboard` search went from `partial: true` with 85 automations unscanned (~35s) to complete in well under 5s, with results identical to the fast-path baseline; page 2 (`offset=10`) returns the dashboard hits with consistent totals. Locally: ruff + mypy clean, 217 targeted unit tests pass.

## Checklist
- [x] I have updated documentation if needed (`tests/AGENTS.md` routing note)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved searches that include dashboards by combining dashboard and other results into one relevance-sorted list.
  * Preserved pagination, configuration details, and result ordering across combined results.
  * Enabled search commands for server-only installations.
  * Added clearer detection and reporting of available file and YAML tools.

* **Bug Fixes**
  * Prevented unnecessary fallback for mixed dashboard searches.
  * Ensured cancelled searches and requests clean up correctly.

* **Tests**
  * Added coverage for combined search, pagination, errors, cancellation, and fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


