### PR TITLE
fix(settings-ui): repaint all flag switches after an ambiguous save; close out the #2153 review deferrals

### DIFF
--- a/src/ha_mcp/settings_ui/settings.js
+++ b/src/ha_mcp/settings_ui/settings.js
@@ -3627,14 +3627,28 @@ async function policyDecide(token, action) {
 // have landed with only its response lost — so re-read first and revert only
 // when the readback actually shows the old value.
 //
-// `spec` is {readState, repaint, revertKey, revertText}: readState() returns
-// {value, known} for this toggle's slice of policyState/readOnlyState, and
-// repaint() is the toggle's own painter.
+// `spec` is {readState, revertKey, revertText}: readState() returns
+// {value, known} for this toggle's slice of policyState/readOnlyState.
+//
+// Repaints are NOT per-toggle. The re-read below is loadPolicyState(),
+// which refreshes — or, through _clearFlagSwitchState(), clears — the
+// state slices of ALL THREE switches. Repainting only the toggle being
+// saved left the other two painted from state that no longer existed:
+// a failed re-read after a Read Only Mode save cleared both policy
+// slices while their switches stayed editable at the stale value with
+// #policyUnknownNotice hidden, and vice versa for #roUnknownNotice.
+function _repaintFlagSwitches() {
+  paintPolicyGlobalToggles();
+  syncReadOnlyToggle();
+  render();
+}
+
 async function handleFailedFlagSave(checkbox, previous, saved, spec) {
   if (saved === false) {
+    // No re-read happened, so the other switches' state is untouched and
+    // repainting them is a no-op — one shape for both branches.
     checkbox.checked = previous;
-    spec.repaint();
-    render();
+    _repaintFlagSwitches();
     updateStatus(t(spec.revertKey, {}, spec.revertText), false, true);
     return;
   }
@@ -3661,8 +3675,7 @@ async function handleFailedFlagSave(checkbox, previous, saved, spec) {
       'reload to see what the server has.');
   }
   // Paint before the status line so the repaint can't clobber it.
-  spec.repaint();
-  render();
+  _repaintFlagSwitches();
   updateStatus(msg, ok, !ok);
 }
 
@@ -3677,7 +3690,6 @@ document.getElementById('policy-master-toggle').addEventListener('change', async
   if (!saved) {
     await handleFailedFlagSave(e.target, previous, saved, {
       readState: () => ({value: policyState.enabled, known: policyState.enabledKnown}),
-      repaint: paintPolicyGlobalToggles,
       revertKey: 'policies.errors.master_save',
       revertText:
         'Tool Security Policies change did not save. The server still has the previous value',
@@ -3713,7 +3725,6 @@ document.getElementById('policy-manage-tool-toggle').addEventListener('change', 
   if (!saved) {
     await handleFailedFlagSave(e.target, previous, saved, {
       readState: () => ({value: policyState.manageToolEnabled, known: policyState.manageToolKnown}),
-      repaint: paintPolicyGlobalToggles,
       revertKey: 'policies.errors.manage_tool_save',
       revertText:
         'Policy-editing tool change did not save. The server still has the previous value',
@@ -3744,7 +3755,6 @@ document.getElementById('read-only-mode-toggle').addEventListener('change', asyn
   if (!saved) {
     await handleFailedFlagSave(e.target, previous, saved, {
       readState: () => ({value: readOnlyState.enabled, known: readOnlyState.enabledKnown}),
-      repaint: syncReadOnlyToggle,
       revertKey: 'tools.read_only.save_failed',
       revertText:
         'Read Only Mode change did not save. The server still has the previous value',

--- a/src/ha_mcp/settings_ui/settings.js
+++ b/src/ha_mcp/settings_ui/settings.js
@@ -489,7 +489,11 @@ async function loadTools() {
   updateStatus(t('status.loaded', {}, 'Loaded'));
 }
 
-async function applyInfoChrome() {
+// Restart-chrome half of applyInfoChrome: which restart control is shown
+// and what the restart notice tells the user to do. Split out (with the
+// footer below) so applyInfoChrome stays orchestration — the branch ladder
+// here alone sits near the complexity limit.
+function _applyRestartChrome(info) {
   // Show restart button if running as add-on; show Stop Sidecar
   // button only when this page is served by the stdio sidecar
   // (HTTP modes serve the same HTML but is_sidecar=false there, so
@@ -499,84 +503,91 @@ async function applyInfoChrome() {
   // reopen Claude Desktop" vs "click Restart Add-on" vs "restart
   // your Docker container") instead of a generic "restart the add-on"
   // that only matches one of three real deployment surfaces.
+  const noticeEl = document.getElementById('restartNoticeText');
+  if (info.is_addon) {
+    document.getElementById('restartBtn').style.display = '';
+    if (noticeEl) {
+      noticeEl.textContent = t(
+        'notice.restart.addon',
+        {},
+        '⚠ Changes saved. Click "Restart App (add-on)" for them to take effect. Then refresh the MCP tool list in your AI client.'
+      );
+    }
+  } else if (info.deployment_mode === 'embedded') {
+    // In-process (custom component) server: the restart endpoint reloads
+    // the server config entry, which reinstalls-if-newer and swaps the
+    // worker onto the freshly installed code.
+    const rbtn = document.getElementById('restartBtn');
+    rbtn.style.display = '';
+    restartTargetEmbedded = true;
+    rbtn.textContent = t('actions.restart_server', {}, 'Restart HA-MCP Server');
+    if (noticeEl) {
+      noticeEl.textContent = t(
+        'notice.restart.embedded',
+        {},
+        '⚠ Changes saved. Click "Restart HA-MCP Server" for them to take effect. Then refresh the MCP tool list in your AI client.'
+      );
+    }
+  } else if (info.is_sidecar) {
+    if (noticeEl) {
+      noticeEl.textContent = t(
+        'notice.restart.sidecar',
+        {},
+        '⚠ Changes saved. Fully quit and reopen your MCP client for them to take effect.'
+      );
+    }
+    document.getElementById('sidecarStopRow').style.display = '';
+  } else if (noticeEl) {
+    // HTTP / Docker / standalone — no button we can wire to a restart,
+    // so describe the action in process terms, then the client-refresh
+    // step (remote connectors cache the tool list, same as add-on mode).
+    noticeEl.textContent = t(
+      'notice.restart.standalone',
+      {},
+      '⚠ Changes saved. Restart the ha-mcp process, then refresh the MCP tool list in your AI client.'
+    );
+  }
+}
+
+// Footer — show the running build and the same deployment classification
+// used by ha_report_issue. The backend keeps embedded and sidecar distinct
+// because they need different restart behavior; preserve those concise
+// names here and clarify the less obvious packaging-oriented values.
+function _applyVersionFooter(info) {
+  if (!info.version) return;
+  const fEl = document.getElementById('versionFooterText');
+  const deploymentMode = typeof info.deployment_mode === 'string'
+    ? info.deployment_mode
+    : '';
+  const deploymentLabels = {
+    embedded: 'embedded',
+    sidecar: 'sidecar',
+    addon: t('footer.deployment.addon', {}, 'app/add-on'),
+    docker: t('footer.deployment.docker', {}, 'container/docker'),
+    pyinstaller: t('footer.deployment.pyinstaller', {}, 'standalone binary'),
+    git: t('footer.deployment.git', {}, 'source checkout'),
+    pypi: t('footer.deployment.pypi', {}, 'python package'),
+    unknown: t('footer.deployment.unknown', {}, 'unknown'),
+  };
+  const deploymentLabel = Object.prototype.hasOwnProperty.call(
+    deploymentLabels, deploymentMode
+  ) ? deploymentLabels[deploymentMode] : deploymentMode;
+  const installation = deploymentLabel
+    ? ' · ' + t(
+      'footer.installation',
+      {method: deploymentLabel},
+      'installation: {method}'
+    )
+    : '';
+  if (fEl) fEl.textContent = 'ha-mcp ' + info.version + installation;
+}
+
+async function applyInfoChrome() {
   try {
     const infoResp = await fetch('./api/settings/info');
     const info = await infoResp.json();
-    const noticeEl = document.getElementById('restartNoticeText');
-    if (info.is_addon) {
-      document.getElementById('restartBtn').style.display = '';
-      if (noticeEl) {
-        noticeEl.textContent = t(
-          'notice.restart.addon',
-          {},
-          '⚠ Changes saved. Click "Restart App (add-on)" for them to take effect. Then refresh the MCP tool list in your AI client.'
-        );
-      }
-    } else if (info.deployment_mode === 'embedded') {
-      // In-process (custom component) server: the restart endpoint reloads
-      // the server config entry, which reinstalls-if-newer and swaps the
-      // worker onto the freshly installed code.
-      const rbtn = document.getElementById('restartBtn');
-      rbtn.style.display = '';
-      restartTargetEmbedded = true;
-      rbtn.textContent = t('actions.restart_server', {}, 'Restart HA-MCP Server');
-      if (noticeEl) {
-        noticeEl.textContent = t(
-          'notice.restart.embedded',
-          {},
-          '⚠ Changes saved. Click "Restart HA-MCP Server" for them to take effect. Then refresh the MCP tool list in your AI client.'
-        );
-      }
-    } else if (info.is_sidecar) {
-      if (noticeEl) {
-        noticeEl.textContent = t(
-          'notice.restart.sidecar',
-          {},
-          '⚠ Changes saved. Fully quit and reopen your MCP client for them to take effect.'
-        );
-      }
-      document.getElementById('sidecarStopRow').style.display = '';
-    } else if (noticeEl) {
-      // HTTP / Docker / standalone — no button we can wire to a restart,
-      // so describe the action in process terms, then the client-refresh
-      // step (remote connectors cache the tool list, same as add-on mode).
-      noticeEl.textContent = t(
-        'notice.restart.standalone',
-        {},
-        '⚠ Changes saved. Restart the ha-mcp process, then refresh the MCP tool list in your AI client.'
-      );
-    }
-    // Footer — show the running build and the same deployment classification
-    // used by ha_report_issue. The backend keeps embedded and sidecar distinct
-    // because they need different restart behavior; preserve those concise
-    // names here and clarify the less obvious packaging-oriented values.
-    if (info.version) {
-      const fEl = document.getElementById('versionFooterText');
-      const deploymentMode = typeof info.deployment_mode === 'string'
-        ? info.deployment_mode
-        : '';
-      const deploymentLabels = {
-        embedded: 'embedded',
-        sidecar: 'sidecar',
-        addon: t('footer.deployment.addon', {}, 'app/add-on'),
-        docker: t('footer.deployment.docker', {}, 'container/docker'),
-        pyinstaller: t('footer.deployment.pyinstaller', {}, 'standalone binary'),
-        git: t('footer.deployment.git', {}, 'source checkout'),
-        pypi: t('footer.deployment.pypi', {}, 'python package'),
-        unknown: t('footer.deployment.unknown', {}, 'unknown'),
-      };
-      const deploymentLabel = Object.prototype.hasOwnProperty.call(
-        deploymentLabels, deploymentMode
-      ) ? deploymentLabels[deploymentMode] : deploymentMode;
-      const installation = deploymentLabel
-        ? ' · ' + t(
-          'footer.installation',
-          {method: deploymentLabel},
-          'installation: {method}'
-        )
-        : '';
-      if (fEl) fEl.textContent = 'ha-mcp ' + info.version + installation;
-    }
+    _applyRestartChrome(info);
+    _applyVersionFooter(info);
   } catch (e) {
     // A transient /api/settings/info failure must not leave the restart
     // button hidden / the restart notice unset silently — log it so the

--- a/tests/src/e2e/workflows/auto_backup/test_capture_and_restore.py
+++ b/tests/src/e2e/workflows/auto_backup/test_capture_and_restore.py
@@ -1049,6 +1049,21 @@ class TestToggleOffSkipsCapture:
         from ha_mcp.config import _reset_global_settings
 
         _reset_global_settings()
+        # The reset above rebuilds the process-global settings singleton
+        # with auto-backup DISABLED, and monkeypatch teardown restores only
+        # the env var — the singleton would stay disabled for the rest of
+        # this worker's life. Whichever test xdist schedules next on this
+        # worker then fails its auto-backup gate unless it happens to call
+        # _enable_auto_backup itself (CI hit this: ha_config_set_yaml
+        # refused in test_yaml_read immediately after this test). Undo the
+        # env FIRST, then rebuild the singleton from the restored values.
+        try:
+            await self._run_disabled_capture_check(mcp_client)
+        finally:
+            monkeypatch.undo()
+            _reset_global_settings()
+
+    async def _run_disabled_capture_check(self, mcp_client) -> None:
 
         # Count before
         before = await safe_call_tool(

--- a/tests/src/unit/test_lite_docstrings.py
+++ b/tests/src/unit/test_lite_docstrings.py
@@ -22,6 +22,7 @@ Covers three layers:
 
 from __future__ import annotations
 
+import ast
 import json
 import re
 import sys
@@ -733,10 +734,20 @@ class TestDocumentedToolLists:
 
 
 def _tool_response_has_field(tool_name: str, field: str) -> bool:
-    """True when ``tool_name``'s source returns ``field`` in its response.
+    """True when ``tool_name``'s own function builds a dict carrying ``field``.
 
-    Static check against the module ``extract_tools`` attributes the tool
-    to — enough to catch a renamed response key, without a live HA.
+    AST check, scoped to the function whose name matches the tool inside the
+    module ``extract_tools`` attributes it to. The previous version substring-
+    matched ``'"<field>":'`` over the WHOLE source file, so any dict literal
+    anywhere in the module satisfied it — including one never returned, which
+    is the checked-the-pointer-never-the-destination pattern this test file
+    exists to replace. Scoping to the function is still static (no live HA)
+    and still an approximation — it accepts a dict built but not returned —
+    but the dict must at least live in the tool's own body.
+
+    Assumes the tool's function shares its registered name (true for every
+    tool today); a mismatch returns False, which fails the destination test
+    loudly rather than passing it silently.
     """
     sources = {
         t["source_file"]
@@ -744,7 +755,17 @@ def _tool_response_has_field(tool_name: str, field: str) -> bool:
         if t["name"] == tool_name
     }
     tools_dir = REPO_ROOT / "src" / "ha_mcp" / "tools"
-    return any(
-        f'"{field}":' in (tools_dir / source).read_text(encoding="utf-8")
-        for source in sources
-    )
+    for source in sources:
+        tree = ast.parse((tools_dir / source).read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if (
+                isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef)
+                and node.name == tool_name
+            ):
+                for sub in ast.walk(node):
+                    if isinstance(sub, ast.Dict) and any(
+                        isinstance(key, ast.Constant) and key.value == field
+                        for key in sub.keys
+                    ):
+                        return True
+    return False

--- a/tests/src/unit/test_lite_docstrings.py
+++ b/tests/src/unit/test_lite_docstrings.py
@@ -755,17 +755,40 @@ def _tool_response_has_field(tool_name: str, field: str) -> bool:
         if t["name"] == tool_name
     }
     tools_dir = REPO_ROOT / "src" / "ha_mcp" / "tools"
+
+    def _dict_with_field_in_scope(node: ast.AST) -> bool:
+        """Scan one function's own scope, not code nested inside it.
+
+        A helper or lambda defined inside the tool has its own return
+        value, so a dict it builds is not the tool's response — descending
+        into it would re-open the any-dict-anywhere hole one level down.
+        """
+        for child in ast.iter_child_nodes(node):
+            if isinstance(
+                child,
+                ast.FunctionDef | ast.AsyncFunctionDef | ast.Lambda | ast.ClassDef,
+            ):
+                continue
+            if isinstance(child, ast.Dict) and any(
+                isinstance(key, ast.Constant) and key.value == field
+                for key in child.keys
+            ):
+                return True
+            if _dict_with_field_in_scope(child):
+                return True
+        return False
+
     for source in sources:
         tree = ast.parse((tools_dir / source).read_text(encoding="utf-8"))
         for node in ast.walk(tree):
+            # ast.walk, not module-level lookup: registered tools are
+            # methods on registrar classes (ha_report_issue lives inside
+            # one), so the function has to be findable at any depth — only
+            # the scan of its BODY stops at nested scope boundaries.
             if (
                 isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef)
                 and node.name == tool_name
             ):
-                for sub in ast.walk(node):
-                    if isinstance(sub, ast.Dict) and any(
-                        isinstance(key, ast.Constant) and key.value == field
-                        for key in sub.keys
-                    ):
-                        return True
+                if _dict_with_field_in_scope(node):
+                    return True
     return False

--- a/tests/src/unit/test_settings_ui_js_behavior.py
+++ b/tests/src/unit/test_settings_ui_js_behavior.py
@@ -2387,6 +2387,14 @@ def _toggle_probe(toggle_id: str, probe_id: str) -> str:
         ? (toast.querySelector('.ha-toast-msg')?.textContent || '') : '';
       probe.dataset.restart = String(
         document.getElementById('restartNotice').classList.contains('show'));
+      // One digit per switch, declaration order of _TOGGLES. The failure
+      // path re-reads via loadPolicyState(), which refreshes or clears the
+      // state of ALL THREE switches — so the repaint has to cover all three,
+      // not just the toggle under test (the repaint-one-of-three bug).
+      probe.dataset.allIndet = ['policy-master-toggle',
+        'policy-manage-tool-toggle', 'read-only-mode-toggle']
+        .map(i => document.getElementById(i).indeterminate ? '1' : '0')
+        .join('');
       document.body.appendChild(probe);
     """
 
@@ -2446,6 +2454,11 @@ class TestAmbiguousSaveAcrossToggles:
         assert 'data-restart="true"' in tag, (
             f"[{case}/{flag}] a landed write needs the restart banner — the "
             f"toast alone auto-dismisses in 4s: {tag}"
+        )
+        # Positive, not just the absence of the wrong message: this branch
+        # exists to say the save landed, and nothing else pins that it does.
+        assert "Saved. Restart required." in tag, (
+            f"[{case}/{flag}] a landed write must say so: {tag}"
         )
 
     @pytest.mark.parametrize("toggle_id,flag,label", _TOGGLES)
@@ -2522,6 +2535,21 @@ class TestAmbiguousSaveAcrossToggles:
             f"[{flag}] must not claim the previous value survived when that "
             f"is unknown: {tag}"
         )
+        # The dedicated copy, positively. Swapping errors.save_outcome_unknown
+        # for the saved toast would otherwise leave the suite green.
+        assert "Could not confirm the change" in tag, (
+            f"[{flag}] the unknown outcome has its own message and this is "
+            f"the only case that shows it: {tag}"
+        )
+        # The failed re-read cleared ALL THREE switch slices
+        # (_clearFlagSwitchState), so all three must repaint as unknown —
+        # repainting only the toggle under test leaves the other two painted
+        # editable at a value that no longer exists, with their unknown
+        # notices hidden.
+        assert 'data-all-indet="111"' in tag, (
+            f"[{flag}] every flag switch must repaint as unknown after the "
+            f"re-read cleared all three state slices: {tag}"
+        )
 
     @pytest.mark.parametrize("toggle_id,flag,label", _TOGGLES)
     def test_server_refusal_reverts_immediately(
@@ -2556,6 +2584,9 @@ class TestAmbiguousSaveAcrossToggles:
         assert 'data-indeterminate="false"' in tag, (
             f"[{flag}] a refusal leaves the server's value KNOWN, so the "
             f"switch stays editable rather than going unknown: {tag}"
+        )
+        assert "did not save" in tag, (
+            f"[{flag}] the revert must say the server kept the previous value: {tag}"
         )
 
 

--- a/tests/src/unit/test_skill_loader.py
+++ b/tests/src/unit/test_skill_loader.py
@@ -302,7 +302,13 @@ def test_extract_section_matches_ampersand_double_hyphen_anchor() -> None:
     )
 
 
-_ANCHOR_CITATION_RE = re.compile(r"[\w./-]+\.md#[A-Za-z0-9_-]+")
+# Group 1 is the citation; the prefix class keeps URL fragments out. Every
+# character inside "https://host/path.md#a" is \w, ".", "/" or ":", so no
+# substring of an external link can follow line-start, whitespace, "(", "["
+# or a backtick — while prose, backticked and markdown-link citations all do.
+_ANCHOR_CITATION_RE = re.compile(
+    r"(?:^|[\s(\[`])([\w./-]+\.md#[A-Za-z0-9_-]+)", re.MULTILINE
+)
 
 
 def _vendored_anchor_citations() -> list[str]:
@@ -318,7 +324,7 @@ def _vendored_anchor_citations() -> list[str]:
     citations: set[tuple[str, str]] = set()
     for md in sorted(skill.rglob("*.md")):
         for match in _ANCHOR_CITATION_RE.finditer(md.read_text(encoding="utf-8")):
-            citations.add((str(md.relative_to(skill)), match.group(0)))
+            citations.add((str(md.relative_to(skill)), match.group(1)))
     return [f"{citing} -> {cite}" for citing, cite in sorted(citations)]
 
 

--- a/tests/src/unit/test_skill_loader.py
+++ b/tests/src/unit/test_skill_loader.py
@@ -351,11 +351,24 @@ def test_every_vendored_anchor_citation_resolves(citation: str | None) -> None:
     citing, cite = citation.split(" -> ")
     path_part, anchor = cite.rsplit("#", 1)
 
-    target = skill / path_part
-    if not target.is_file():
-        target = (skill / citing).parent / path_part
-    assert target.is_file(), (
-        f"{citing} cites {cite!r} but no such file exists in the pack"
+    # Containment mirrors resolve_skill_files: a citation that escapes the
+    # skill directory (e.g. "../README.md#intro") is one production would
+    # reject as traversal, so the test must not bless it just because the
+    # file happens to exist outside the pack.
+    skill_root = skill.resolve()
+    candidates = [skill / path_part, (skill / citing).parent / path_part]
+    target = next(
+        (
+            c
+            for c in candidates
+            if c.resolve().is_relative_to(skill_root) and c.is_file()
+        ),
+        None,
+    )
+    assert target is not None, (
+        f"{citing} cites {cite!r} but no such file exists inside the pack "
+        "(a file outside the skill directory does not count — "
+        "resolve_skill_files rejects traversal)"
     )
     section = skill_loader.extract_section(target.read_text(encoding="utf-8"), anchor)
     assert section, (

--- a/tests/src/unit/test_skill_loader.py
+++ b/tests/src/unit/test_skill_loader.py
@@ -9,6 +9,7 @@ never fail the write operation that's embedding the response.
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 from unittest.mock import patch
 
@@ -267,14 +268,17 @@ def test_extract_section_handles_ifthen_style_anchor() -> None:
 def test_extract_section_matches_githubs_double_hyphen_anchor() -> None:
     """Stripped punctuation leaves BOTH flanking spaces → a double hyphen.
 
-    GitHub removes the em dash and turns each surrounding space into its own
+    The rule is any punctuation flanked by spaces — the em dash here and the
+    ampersand in the test below behave identically. GitHub drops the
+    punctuation in place and turns each surrounding space into its own
     hyphen, so its own heading link is
     ``#config-entry-data--blind-spots-for-entity-registry-renames``. A
     skill author copies that anchor out of the rendered page, so it is the
     form that has to resolve. Collapsing whitespace runs produced a single
-    hyphen and matched nothing — and ``resolve_skill_files`` skips misses
-    silently, so the agent got no content and no error. Two anchors cited in
-    the bundled ``SKILL.md`` were dead this way.
+    hyphen and matched nothing. Two anchors cited in the bundled
+    ``SKILL.md`` were dead this way — as prose citations only: a miss is
+    logged at WARNING by ``resolve_skill_files``, but nothing requested
+    either anchor at runtime, so no warning ever fired.
     """
     body = (
         "## Config-Entry Data — Blind Spots for entity registry renames\n"
@@ -295,6 +299,62 @@ def test_extract_section_matches_ampersand_double_hyphen_anchor() -> None:
             body, "purpose-specific-triggers--conditions-default-since-20267"
         )
         is not None
+    )
+
+
+_ANCHOR_CITATION_RE = re.compile(r"[\w./-]+\.md#[A-Za-z0-9_-]+")
+
+
+def _vendored_anchor_citations() -> list[str]:
+    """Every ``file.md#anchor`` citation in the bundled skill pack.
+
+    Encoded as ``citing-file.md -> cited-file.md#anchor`` param ids so a
+    failure names where the dead citation lives.
+    """
+    skills_dir = skill_loader.get_skills_dir()
+    if skills_dir is None:
+        return []
+    skill = skills_dir / "home-assistant-best-practices"
+    citations: set[tuple[str, str]] = set()
+    for md in sorted(skill.rglob("*.md")):
+        for match in _ANCHOR_CITATION_RE.finditer(md.read_text(encoding="utf-8")):
+            citations.add((str(md.relative_to(skill)), match.group(0)))
+    return [f"{citing} -> {cite}" for citing, cite in sorted(citations)]
+
+
+@pytest.mark.parametrize("citation", _vendored_anchor_citations() or [None])
+def test_every_vendored_anchor_citation_resolves(citation: str | None) -> None:
+    """Each ``*.md#anchor`` the bundled pack cites must actually resolve.
+
+    The two synthetic-heading tests above prove ``_slugify`` emits a double
+    hyphen; they cannot prove the anchors the pack actually cites are live —
+    if a real heading used a different dash or spacing, both would pass while
+    the citation stayed dead. This is the assertion that matters, and it is
+    what the #2153 slug fix was for: under the old slugifier two of these
+    parameters fail.
+
+    Cited paths are resolved against the skill root first (the form
+    ``resolve_skill_files`` takes), then against the citing file's own
+    directory for sibling-relative prose citations.
+    """
+    if citation is None:
+        pytest.skip("skills-vendor submodule not initialised in this checkout")
+    skills_dir = skill_loader.get_skills_dir()
+    assert skills_dir is not None
+    skill = skills_dir / "home-assistant-best-practices"
+    citing, cite = citation.split(" -> ")
+    path_part, anchor = cite.rsplit("#", 1)
+
+    target = skill / path_part
+    if not target.is_file():
+        target = (skill / citing).parent / path_part
+    assert target.is_file(), (
+        f"{citing} cites {cite!r} but no such file exists in the pack"
+    )
+    section = skill_loader.extract_section(target.read_text(encoding="utf-8"), anchor)
+    assert section, (
+        f"{citing} cites {cite!r} but the anchor matches no heading in "
+        f"{target.name} — the citation is dead if followed"
     )
 
 


### PR DESCRIPTION
## What does this PR do?

Four items from the #2153 review round, verified against merged master before touching anything.

**The fix: `handleFailedFlagSave` re-read all three flags and repainted one.** The re-read is `loadPolicyState()`, which refreshes — or, through `_clearFlagSwitchState()`, clears — the state slices of ALL THREE flag switches; `spec.repaint` covered only the toggle being saved. A failed re-read after a Read Only Mode save cleared both policy slices while their switches stayed painted editable at the stale value with `#policyUnknownNotice` hidden, and vice versa for `#roUnknownNotice`. New in #2153 — before it, the failure paths never called `loadPolicyState()`. One `_repaintFlagSwitches()` now covers all three in both branches, and the per-toggle `repaint` leaves the spec. The ambiguous-save table records all three switches' indeterminate state and pins the unknown case to `"111"` — verified by mutation: all three parametrizations fail against the previous `handleFailedFlagSave`.

**Positive message assertions.** Three of the four table cases asserted only that the wrong message is absent, so the branch producing `errors.save_outcome_unknown` was unguarded — swapping it for the saved toast left the suite green. Each case now asserts its own message.

**The vendored anchors, resolved for real.** The two double-hyphen tests build their headings inside the test body, so they prove `_slugify` emits a double hyphen — not that the anchors the pack actually cites are live. `test_every_vendored_anchor_citation_resolves` parametrizes over every `file.md#anchor` citation in the bundled pack (33 today), resolving against the skill root first, then the citing file's directory for sibling-relative citations. Their docstrings also stop claiming misses are silent (they log at WARNING — the same stale claim #2153 fixed in `skill_loader` itself) and name the real mechanism: any punctuation flanked by spaces, not the em dash specifically.

**`_tool_response_has_field`, deferred on #2153, now scoped.** It substring-matched `'"<field>":'` over the whole source file, so any dict literal anywhere in the module satisfied `test_every_lite_destination_resolves` — the checked-the-pointer-never-the-destination pattern the file exists to replace. It now AST-walks the function whose name matches the tool and requires the key inside that function's body. Still static, no live HA needed.

**`applyInfoChrome` split (CodeRabbit, #2153).** The cited guideline is ruff's C901, which does not run on this file — no JS linter covers `settings_ui`, and the AGENTS.md line it quotes is about `pyproject.toml` per-file-ignores — but the function was carrying two unrelated jobs and sat around 14 either way. `_applyRestartChrome` and `_applyVersionFooter` are now helpers; branch bodies and strings moved verbatim.

**Review-round additions.** CodeRabbit's three findings are in: the citation regex now requires line-start/whitespace/`(`/`[`/backtick before a match so no substring of an external URL qualifies, the AST scan stops at nested function/lambda/class boundaries (while still locating the tool function at any depth — registered tools are methods on registrar classes), and citation targets must resolve inside the skill directory, mirroring `resolve_skill_files`' traversal rejection.

**One pre-existing e2e flake, root-caused and fixed.** `TestToggleOffSkipsCapture` sets `ENABLE_AUTO_BACKUP=false` and rebuilds the settings singleton; monkeypatch teardown restores only the env var, so the singleton stayed disabled for the rest of that xdist worker's life and whichever test scheduled next failed its auto-backup gate. CI hit exactly this here: `[gw1]` passed the toggle-off test at 16:42:08.38, and the very next test on gw1 (`test_read_content_is_accepted_by_set_yaml`) refused with "requires auto-backup, which is currently disabled" at 16:42:08.54. The body now runs in a try/finally that undoes the env patches first and then rebuilds the singleton from the restored values.

## Type of change
- [x] 🐛 Bug fix
- [x] 🧪 Tests only <!-- three of five items -->
- [x] 🔧 Maintenance/refactor

## Testing
- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

Targeted runs: `test_skill_loader.py` + `test_lite_docstrings.py` (97 passed, includes the 33 new citation params), `TestAmbiguousSaveAcrossToggles` with jsdom (18 passed; 3 fail by mutation against the pre-fix `handleFailedFlagSave`). `ruff check` clean. Full suite left to CI.

## Checklist
- [x] I have updated documentation if needed
