### PR TITLE
fix: complete the File & YAML Tools entry's unload and document the two-entry contract

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -783,6 +783,36 @@ fully validate a component change before merge.
 - **Live-test on the dev server immediately after merge**, before the next
   stable cut. The component path cannot be fully exercised by CI pre-merge.
 
+### Two entry types, one shared command surface
+
+One domain, two config-entry types with different jobs: **HA-MCP Server** runs
+the ha-mcp server in-process and exposes it through a HA webhook, and **File &
+YAML Tools** registers the privileged filesystem/YAML HA services. Since
+component 2.1.0 (#2289/#2291) **both** entries register the shared
+`ha_mcp_tools/*` WebSocket command surface, so an external server (app, Docker,
+uvx/PyPI) reaches those in-process capabilities through the tools entry alone.
+The surface is entry-agnostic (every handler reads live HA-core state, never the
+tools entry's `hass.data`), `async_register_command` is idempotent, and HA
+offers **no unregister** — the commands survive an entry unload and stay
+registered until HA restarts. Don't try to tear them down on unload; do pop that
+entry's `hass.data` caches so the next setup re-reads storage.
+
+**The privileged filesystem/YAML HA services stay tools-entry-ONLY** — never
+reachable from a server-entry-only install. Because `ha_mcp_tools/info` now
+answers on both entries, the server gates those services on the additive
+`tools_services` field in that handshake (#2292), not on the general capability
+list.
+
+When you add or change component-backed functionality:
+- update the server consumer, its capability gate, and its legacy fallback under
+  `src/ha_mcp/` in the same PR as the producer in `custom_components/ha_mcp_tools/`;
+- make the shared command serve identically from both entries — a handler that
+  reads tools-entry state breaks the server-entry-only install silently;
+- keep anything privileged or beta behind an explicit tools-entry signal (the
+  `tools_services` caps field), never behind the general capability handshake;
+- exercise both topologies with the no-tools lanes (`E2E_NO_TOOLS_ENTRY=1`, see
+  `tests/AGENTS.md` § *No-tools lanes*).
+
 ## Translations
 
 **One canonical store, generated projections, automated retranslation**

--- a/custom_components/ha_mcp_tools/__init__.py
+++ b/custom_components/ha_mcp_tools/__init__.py
@@ -3620,13 +3620,19 @@ async def _async_unload_tools_entry(hass: HomeAssistant, entry: ConfigEntry) -> 
     hass.services.async_remove(DOMAIN, SERVICE_GET_CALLER_TOKEN)
     hass.services.async_remove(DOMAIN, SERVICE_GET_ALLOWED_PATHS)
     hass.services.async_remove(DOMAIN, SERVICE_SET_ALLOWED_PATHS)
+    hass.services.async_remove(DOMAIN, SERVICE_GET_EXTRA_YAML_KEYS)
+    hass.services.async_remove(DOMAIN, SERVICE_SET_EXTRA_YAML_KEYS)
     hass.services.async_remove(DOMAIN, SERVICE_LIST_LEGACY_BACKUPS)
     hass.services.async_remove(DOMAIN, SERVICE_READ_LEGACY_BACKUP)
 
-    # Drop the cached token + allowlist from hass.data so a subsequent
-    # setup_entry re-reads from storage (covers the reload-after-rotate path).
+    # Drop the cached token + allowlist + extra YAML keys from hass.data so a
+    # subsequent setup_entry re-reads from storage (covers the
+    # reload-after-rotate path). The WS command surface is deliberately NOT
+    # unregistered here — it is shared with the server entry and HA offers no
+    # unregister (#2292); see ``websocket_api.async_register_commands``.
     domain_data = hass.data.get(DOMAIN)
     if isinstance(domain_data, dict):
         domain_data.pop(_HASS_DATA_TOKEN_KEY, None)
         domain_data.pop(_HASS_DATA_ALLOWED_PATHS_KEY, None)
+        domain_data.pop(_HASS_DATA_EXTRA_YAML_KEYS_KEY, None)
     return True

--- a/custom_components/ha_mcp_tools/strings.json
+++ b/custom_components/ha_mcp_tools/strings.json
@@ -3,7 +3,7 @@
         "step": {
             "user": {
                 "title": "HA-MCP Custom Component",
-                "description": "Choose what to add. **HA-MCP Server** runs the full ha-mcp server inside Home Assistant and exposes it through a Home Assistant webhook - this is the install most people want. It is a standalone server and a complete replacement for every other install method: App (add-on), Docker, uvx/PyPI, stdio; if you run it, do not also run one of those. **HA-MCP File & YAML Tools** adds the privileged file and YAML editing services, needed only if you turn on ha-mcp's opt-in file/YAML tools. If your ha-mcp server already runs elsewhere - App (add-on), Docker, uvx - you do not need the server entry - add only this File & YAML entry, and only if you use those tools. It works with every server type and can be added later at any time.",
+                "description": "Choose what to add. **HA-MCP Server** runs the full ha-mcp server inside Home Assistant and exposes it through a Home Assistant webhook - this is the install most people want. It is a standalone server and a complete replacement for every other install method: App (add-on), Docker, uvx/PyPI, stdio; if you run it, do not also run one of those. **HA-MCP File & YAML Tools** has two roles. If your ha-mcp server runs outside Home Assistant - app, Docker, uvx/PyPI - this entry also gives that server the in-process component capabilities it cannot reach from outside (fast in-process search, config entry metadata, registry-backed reads), so it is worth adding to every external install, and it gates the privileged file and YAML editing services used by ha-mcp's opt-in file/YAML tools. If you add the HA-MCP Server entry instead, that entry already provides those shared capabilities, so this second entry is then needed only as the gate for the opt-in file/YAML tools. It works with every server type and can be added later at any time.",
                 "menu_options": {
                     "server": "HA-MCP Server (recommended)",
                     "tools": "HA-MCP File & YAML Tools (optional)"
@@ -11,7 +11,7 @@
             },
             "tools": {
                 "title": "HA-MCP File & YAML Tools",
-                "description": "Sets up the privileged file and YAML configuration services. Only needed if you enable ha-mcp's opt-in file/YAML editing tools (feature flags, off by default) - this applies to every server type, including the in-process HA-MCP Server. You can add or remove this entry at any time."
+                "description": "Sets up the privileged file and YAML configuration services, which stay gated behind ha-mcp's opt-in file/YAML editing tools (feature flags, off by default) - this applies to every server type, including the in-process HA-MCP Server. If your ha-mcp server runs outside Home Assistant, this entry also gives it the in-process component capabilities it cannot reach from outside (fast in-process search, config entry metadata, registry-backed reads), which are worth having even with the file/YAML tools off. You can add or remove this entry at any time."
             },
             "server": {
                 "title": "HA-MCP Server",

--- a/custom_components/ha_mcp_tools/translations/en.json
+++ b/custom_components/ha_mcp_tools/translations/en.json
@@ -3,7 +3,7 @@
         "step": {
             "user": {
                 "title": "HA-MCP Custom Component",
-                "description": "Choose what to add. **HA-MCP Server** runs the full ha-mcp server inside Home Assistant and exposes it through a Home Assistant webhook - this is the install most people want. It is a standalone server and a complete replacement for every other install method: App (add-on), Docker, uvx/PyPI, stdio; if you run it, do not also run one of those. **HA-MCP File & YAML Tools** adds the privileged file and YAML editing services, needed only if you turn on ha-mcp's opt-in file/YAML tools. If your ha-mcp server already runs elsewhere - App (add-on), Docker, uvx - you do not need the server entry - add only this File & YAML entry, and only if you use those tools. It works with every server type and can be added later at any time.",
+                "description": "Choose what to add. **HA-MCP Server** runs the full ha-mcp server inside Home Assistant and exposes it through a Home Assistant webhook - this is the install most people want. It is a standalone server and a complete replacement for every other install method: App (add-on), Docker, uvx/PyPI, stdio; if you run it, do not also run one of those. **HA-MCP File & YAML Tools** has two roles. If your ha-mcp server runs outside Home Assistant - app, Docker, uvx/PyPI - this entry also gives that server the in-process component capabilities it cannot reach from outside (fast in-process search, config entry metadata, registry-backed reads), so it is worth adding to every external install, and it gates the privileged file and YAML editing services used by ha-mcp's opt-in file/YAML tools. If you add the HA-MCP Server entry instead, that entry already provides those shared capabilities, so this second entry is then needed only as the gate for the opt-in file/YAML tools. It works with every server type and can be added later at any time.",
                 "menu_options": {
                     "server": "HA-MCP Server (recommended)",
                     "tools": "HA-MCP File & YAML Tools (optional)"
@@ -11,7 +11,7 @@
             },
             "tools": {
                 "title": "HA-MCP File & YAML Tools",
-                "description": "Sets up the privileged file and YAML configuration services. Only needed if you enable ha-mcp's opt-in file/YAML editing tools (feature flags, off by default) - this applies to every server type, including the in-process HA-MCP Server. You can add or remove this entry at any time."
+                "description": "Sets up the privileged file and YAML configuration services, which stay gated behind ha-mcp's opt-in file/YAML editing tools (feature flags, off by default) - this applies to every server type, including the in-process HA-MCP Server. If your ha-mcp server runs outside Home Assistant, this entry also gives it the in-process component capabilities it cannot reach from outside (fast in-process search, config entry metadata, registry-backed reads), which are worth having even with the file/YAML tools off. You can add or remove this entry at any time."
             },
             "server": {
                 "title": "HA-MCP Server",

--- a/custom_components/ha_mcp_tools/websocket_api.py
+++ b/custom_components/ha_mcp_tools/websocket_api.py
@@ -531,15 +531,31 @@ _SPLIT_RE = re.compile(r"[._\-\s]+")
 def async_register_commands(hass: HomeAssistant) -> None:
     """Register the ``ha_mcp_tools/*`` WebSocket commands.
 
-    Called from BOTH config-entry setups: the tools entry (alongside its service
-    registrations) and the server entry (#2289). The surface is entry-agnostic —
-    every handler reads HA-core state, none of it the tools entry's
-    ``hass.data`` — so a server-entry-only install gets it too; only the
-    filesystem/YAML HA *services* remain tools-entry-only.
+    Called from BOTH config-entry setups since component 2.1.0: the tools entry
+    (alongside its service registrations) and the server entry (#2289/#2291).
+    The surface is entry-agnostic — every handler reads HA-core state, none of
+    it the tools entry's ``hass.data`` — so a server-entry-only install gets it
+    too; only the filesystem/YAML HA *services* remain tools-entry-only.
 
     Idempotent: HA's ``async_register_command`` overwrites an existing handler,
     so re-running on a config-entry reload, or from both entries on a dual-entry
     install, is harmless.
+
+    There is NO unregister. HA's ``websocket_api`` exposes no counterpart to
+    ``async_register_command``, so the commands outlive an entry unload and stay
+    on the connection surface until Home Assistant restarts. That is deliberate
+    and accepted (#2292). Unloading one entry must not strip the surface the
+    other entry still serves from, and a surface left behind by a FULLY unloaded
+    component holds no privilege of its own: every handler works off live
+    HA-core state rather than anything the unloaded entry cached, HA core
+    authenticates the connection, and ``@require_admin`` gates each command — so
+    a caller reaching it can already do the same through HA's own WS API. The
+    write commands are no exception: their D1 domain block refuses
+    ``domain == "ha_mcp_tools"`` unconditionally, so the leftover surface can
+    never reach the privileged filesystem/YAML services, which
+    :func:`~custom_components.ha_mcp_tools._async_unload_tools_entry` does remove
+    on unload. Admin-gated commands answering from live core state until the
+    next restart is the trade this makes.
     """
     for schema, do_fn, prep in _command_specs():
         websocket_api.async_register_command(hass, _build_handler(schema, do_fn, prep))

--- a/tests/src/unit/test_tools_entry_lifecycle.py
+++ b/tests/src/unit/test_tools_entry_lifecycle.py
@@ -1,0 +1,378 @@
+"""Unit tests for the tools-entry lifecycle and the entry-type dispatch (#2292).
+
+Three things this pins, all of which the two-entry split (#2289/#2291/#2292)
+made easy to get wrong:
+
+1. **Registration/unload parity** — every service ``_async_setup_tools_entry``
+   registers is removed by ``_async_unload_tools_entry``. Asserted as SET
+   EQUALITY on the service names, so the next service added to setup without a
+   matching removal fails this test *by name*, not by an opaque count. The
+   extra-YAML-keys pair (#1887) was exactly that leak.
+2. **hass.data cleanup** — unload drops the caller token, the extra directories
+   AND the extra YAML write keys, so a still-loaded component stops granting a
+   removed entry's widened access. Asserted through the live readers
+   (``_caller_token_ok`` / ``_current_extra_dirs`` / ``_current_extra_yaml_keys``)
+   rather than the raw dict keys, since those readers are what enforcement uses.
+3. **Entry-type dispatch** — ``entry_type == "server"`` routes to the embedded
+   server entry; anything else (including a *missing* ``entry_type``, the
+   pre-2.1.0 shape) routes to the tools setup.
+
+Plus the shared WebSocket surface: the tools setup registers the
+``ha_mcp_tools/*`` commands, and unload deliberately does NOT unregister them
+(HA exposes no counterpart to ``async_register_command``, and the server entry
+may still be serving from that surface). The server entry's own half of that
+contract is covered by
+``test_embedded_entry.py::TestWebSocketCommandRegistration``.
+
+Home Assistant is stubbed via ``_embedded_stubs`` (imported first so the fakes
+are installed before the component module binds them); the collaborators the
+tools setup reaches for at call time — the ``.storage`` ``Store``, the device
+registry, the manifest read, the WS command registration — are replaced per
+test, so the whole lifecycle runs with no HA install and no I/O.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import sys
+import textwrap
+from types import ModuleType, SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from ._embedded_stubs import install
+
+install()
+
+import custom_components.ha_mcp_tools as comp  # noqa: E402
+
+# Imported eagerly so ``async_setup_entry``'s lazy
+# ``from .install_source_check import ...`` resolves from sys.modules whatever a
+# peer test module has since done to the ``homeassistant.*`` stubs.
+import custom_components.ha_mcp_tools.install_source_check  # noqa: E402, F401
+from custom_components.ha_mcp_tools.const import (  # noqa: E402
+    CONF_ENTRY_TYPE,
+    DOMAIN,
+    ENTRY_TYPE_SERVER,
+    ENTRY_TYPE_TOOLS,
+    TOOLS_ENTRY_TITLE,
+)
+
+_EMBEDDED_ENTRY_MODULE = "custom_components.ha_mcp_tools.embedded_entry"
+
+
+def _make_hass(tmp_path) -> MagicMock:
+    hass = MagicMock(name="hass")
+    hass.data = {}
+    hass.config.config_dir = str(tmp_path)
+    # The only executor offload the tools setup makes is the legacy-backup
+    # migration; (0, 0) means "nothing to migrate", so the notification branch
+    # stays out of the lifecycle under test.
+    hass.async_add_executor_job = AsyncMock(return_value=(0, 0))
+    hass.services.async_register = MagicMock(name="async_register")
+    hass.services.async_remove = MagicMock(name="async_remove")
+    return hass
+
+
+def _make_entry(entry_type: str | None = None) -> MagicMock:
+    entry = MagicMock(name="entry")
+    entry.entry_id = "tools-entry-1"
+    # Not the pre-#1853 default, so the retitle branch stays out of the way.
+    entry.title = TOOLS_ENTRY_TITLE
+    entry.data = {} if entry_type is None else {CONF_ENTRY_TYPE: entry_type}
+    return entry
+
+
+def _make_call(token: str | None) -> MagicMock:
+    call = MagicMock(name="ServiceCall")
+    call.data = {} if token is None else {comp.CALLER_TOKEN_FIELD: token}
+    return call
+
+
+def _service_names(mock: MagicMock) -> set[str]:
+    """Service names the mock was called with as ``(DOMAIN, <service>, ...)``."""
+    return {
+        call.args[1]
+        for call in mock.call_args_list
+        if len(call.args) >= 2 and call.args[0] == DOMAIN
+    }
+
+
+def _called_names(func: Any) -> set[str]:
+    """Every callee expression in ``func``, as source text.
+
+    AST-based rather than a substring scan of the source: comments and
+    docstrings routinely mention names the code must NOT call.
+    """
+    tree = ast.parse(textwrap.dedent(inspect.getsource(func)))
+    return {
+        ast.unparse(node.func) for node in ast.walk(tree) if isinstance(node, ast.Call)
+    }
+
+
+@pytest.fixture
+def store_backing() -> dict[str, Any]:
+    """In-memory stand-in for the component's three ``.storage`` blobs."""
+    return {}
+
+
+@pytest.fixture
+def tools_env(monkeypatch, store_backing):
+    """Replace the collaborators the tools setup reaches for at call time.
+
+    ``Store`` (three separate stores: token, allowed paths, extra YAML keys),
+    the device registry, the manifest version read and the WebSocket command
+    registration are all module-level names in the component, so patching them
+    here keeps ``_async_setup_tools_entry`` runnable without Home Assistant.
+    """
+
+    class _FakeStore:
+        def __init__(self, hass: Any, version: int, key: str) -> None:
+            self._key = key
+
+        async def async_load(self) -> Any:
+            return store_backing.get(self._key)
+
+        async def async_save(self, data: Any) -> None:
+            store_backing[self._key] = data
+
+    register_commands = MagicMock(name="async_register_commands")
+    monkeypatch.setattr(comp, "Store", _FakeStore)
+    monkeypatch.setattr(comp, "async_register_commands", register_commands)
+    monkeypatch.setattr(comp, "dr", MagicMock(name="device_registry"))
+    monkeypatch.setattr(
+        comp,
+        "async_get_integration",
+        AsyncMock(return_value=SimpleNamespace(version="2.1.0")),
+    )
+    return SimpleNamespace(
+        register_commands=register_commands,
+        storage=store_backing,
+    )
+
+
+class TestServiceRegistrationParity:
+    """Setup and unload must cover exactly the same set of services.
+
+    The load-bearing test of this module: ``_async_unload_tools_entry`` is a
+    hand-maintained list, so a service added to setup alone survives the unload
+    and keeps answering after the entry is gone.
+    """
+
+    async def test_unload_removes_every_service_setup_registers(
+        self, tools_env, tmp_path
+    ):
+        hass = _make_hass(tmp_path)
+        entry = _make_entry()
+
+        assert await comp._async_setup_tools_entry(hass, entry) is True
+        registered = _service_names(hass.services.async_register)
+        assert registered, "the tools setup registered no services at all"
+
+        assert await comp._async_unload_tools_entry(hass, entry) is True
+        removed = _service_names(hass.services.async_remove)
+
+        assert registered == removed, (
+            "every service the tools setup registers must be removed on "
+            "unload; registered but never removed: "
+            f"{sorted(registered - removed)}; removed but never registered: "
+            f"{sorted(removed - registered)}"
+        )
+
+    async def test_extra_yaml_keys_services_are_on_both_sides(
+        self, tools_env, tmp_path
+    ):
+        """The #2292 pair specifically — set equality alone would also be
+        satisfied by registering neither."""
+        hass = _make_hass(tmp_path)
+        entry = _make_entry()
+
+        await comp._async_setup_tools_entry(hass, entry)
+        await comp._async_unload_tools_entry(hass, entry)
+
+        pair = {comp.SERVICE_GET_EXTRA_YAML_KEYS, comp.SERVICE_SET_EXTRA_YAML_KEYS}
+        assert pair <= _service_names(hass.services.async_register)
+        assert pair <= _service_names(hass.services.async_remove)
+
+
+class TestHassDataCleanup:
+    """Unload drops the token, the extra dirs and the extra YAML keys.
+
+    Asserted through the live readers rather than the raw ``hass.data`` keys:
+    those readers are what the handlers and the enforcement path consult, so a
+    value left behind is a permission the unloaded entry still grants.
+    """
+
+    async def test_unload_revokes_the_cached_caller_token(
+        self, tools_env, tmp_path, store_backing
+    ):
+        store_backing[comp._TOKEN_STORAGE_KEY] = {"token": "tok-abc"}
+        hass = _make_hass(tmp_path)
+        entry = _make_entry()
+
+        await comp._async_setup_tools_entry(hass, entry)
+        assert comp._caller_token_ok(hass, _make_call("tok-abc")) is True
+
+        await comp._async_unload_tools_entry(hass, entry)
+
+        assert comp._caller_token_ok(hass, _make_call("tok-abc")) is False
+
+    async def test_unload_reverts_the_extra_directories(
+        self, tools_env, tmp_path, store_backing
+    ):
+        store_backing[comp._ALLOWED_PATHS_STORAGE_KEY] = {"paths": ["my_scripts"]}
+        hass = _make_hass(tmp_path)
+        entry = _make_entry()
+
+        await comp._async_setup_tools_entry(hass, entry)
+        assert comp._current_extra_dirs(hass) == ["my_scripts"]
+
+        await comp._async_unload_tools_entry(hass, entry)
+
+        assert comp._current_extra_dirs(hass) == []
+
+    async def test_unload_reverts_the_extra_yaml_write_keys(
+        self, tools_env, tmp_path, store_backing
+    ):
+        """The #2292 fix: a leftover list would keep widening the YAML write
+        allowlist after the entry that configured it is gone."""
+        store_backing[comp._EXTRA_YAML_KEYS_STORAGE_KEY] = {"keys": ["rest_command"]}
+        hass = _make_hass(tmp_path)
+        entry = _make_entry()
+
+        await comp._async_setup_tools_entry(hass, entry)
+        assert comp._current_extra_yaml_keys(hass) == ["rest_command"]
+
+        await comp._async_unload_tools_entry(hass, entry)
+
+        assert comp._current_extra_yaml_keys(hass) == []
+
+
+class TestEntryTypeDispatch:
+    """``async_setup_entry`` / ``async_unload_entry`` route on ``entry_type``.
+
+    A missing ``entry_type`` means the tools entry: pre-2.1.0 entries carry no
+    such field and must keep working across the component update with no
+    migration.
+    """
+
+    @pytest.fixture
+    def routes(self, monkeypatch):
+        """Fake both destinations so only the routing decision is exercised.
+
+        The server side is faked as a whole ``sys.modules`` entry because the
+        entry points import it lazily, at call time — the real module would drag
+        in the entire embedded chain for a test that only cares about which of
+        the two functions was reached.
+        """
+        server_setup = AsyncMock(name="async_setup_server_entry", return_value=True)
+        server_unload = AsyncMock(name="async_unload_server_entry", return_value=True)
+        fake_embedded = ModuleType(_EMBEDDED_ENTRY_MODULE)
+        fake_embedded.async_setup_server_entry = server_setup
+        fake_embedded.async_unload_server_entry = server_unload
+        monkeypatch.setitem(sys.modules, _EMBEDDED_ENTRY_MODULE, fake_embedded)
+
+        tools_setup = AsyncMock(name="_async_setup_tools_entry", return_value=True)
+        tools_unload = AsyncMock(name="_async_unload_tools_entry", return_value=True)
+        monkeypatch.setattr(comp, "_async_setup_tools_entry", tools_setup)
+        monkeypatch.setattr(comp, "_async_unload_tools_entry", tools_unload)
+        return SimpleNamespace(
+            server_setup=server_setup,
+            server_unload=server_unload,
+            tools_setup=tools_setup,
+            tools_unload=tools_unload,
+        )
+
+    async def test_server_entry_type_sets_up_the_server_entry(self, routes, tmp_path):
+        hass = _make_hass(tmp_path)
+        entry = _make_entry(ENTRY_TYPE_SERVER)
+
+        assert await comp.async_setup_entry(hass, entry) is True
+
+        routes.server_setup.assert_awaited_once_with(hass, entry)
+        routes.tools_setup.assert_not_awaited()
+
+    @pytest.mark.parametrize(
+        "entry_type", [None, ENTRY_TYPE_TOOLS], ids=["missing", "explicit_tools"]
+    )
+    async def test_non_server_entry_type_sets_up_the_tools_entry(
+        self, routes, tmp_path, entry_type
+    ):
+        hass = _make_hass(tmp_path)
+        entry = _make_entry(entry_type)
+
+        assert await comp.async_setup_entry(hass, entry) is True
+
+        routes.tools_setup.assert_awaited_once_with(hass, entry)
+        routes.server_setup.assert_not_awaited()
+
+    async def test_server_entry_type_unloads_the_server_entry(self, routes, tmp_path):
+        hass = _make_hass(tmp_path)
+        entry = _make_entry(ENTRY_TYPE_SERVER)
+
+        assert await comp.async_unload_entry(hass, entry) is True
+
+        routes.server_unload.assert_awaited_once_with(hass, entry)
+        routes.tools_unload.assert_not_awaited()
+
+    @pytest.mark.parametrize(
+        "entry_type", [None, ENTRY_TYPE_TOOLS], ids=["missing", "explicit_tools"]
+    )
+    async def test_non_server_entry_type_unloads_the_tools_entry(
+        self, routes, tmp_path, entry_type
+    ):
+        hass = _make_hass(tmp_path)
+        entry = _make_entry(entry_type)
+
+        assert await comp.async_unload_entry(hass, entry) is True
+
+        routes.tools_unload.assert_awaited_once_with(hass, entry)
+        routes.server_unload.assert_not_awaited()
+
+
+class TestWebSocketCommandSurface:
+    """Both entry setups register the shared ``ha_mcp_tools/*`` commands, and
+    unload leaves them alone.
+
+    The server-entry half is pinned by
+    ``test_embedded_entry.py::TestWebSocketCommandRegistration``; this covers
+    the tools half and the unload side. HA offers no counterpart to
+    ``async_register_command``, and the surface is shared with the server entry,
+    so unloading the tools entry must not attempt to tear it down (#2292).
+    """
+
+    async def test_tools_setup_registers_the_ws_commands(self, tools_env, tmp_path):
+        hass = _make_hass(tmp_path)
+
+        await comp._async_setup_tools_entry(hass, _make_entry())
+
+        tools_env.register_commands.assert_called_once_with(hass)
+
+    async def test_unload_does_not_touch_the_ws_commands(self, tools_env, tmp_path):
+        hass = _make_hass(tmp_path)
+        entry = _make_entry()
+        await comp._async_setup_tools_entry(hass, entry)
+        tools_env.register_commands.reset_mock()
+
+        await comp._async_unload_tools_entry(hass, entry)
+
+        tools_env.register_commands.assert_not_called()
+
+    def test_unload_calls_nothing_that_registers_or_unregisters_commands(self):
+        """Source-level companion to the mock above: an unregister attempt would
+        be a NEW call to something this test cannot pre-stub, so no mock can
+        observe it. Reads the calls out of the AST, so the design note in the
+        function body — which does name the WS surface — is not a false hit."""
+        called = _called_names(comp._async_unload_tools_entry)
+        offenders = sorted(
+            name
+            for name in called
+            if "register" in name.lower() or "websocket" in name.lower()
+        )
+        assert not offenders, (
+            "the shared ha_mcp_tools/* WS command surface must survive a "
+            f"tools-entry unload, but it calls: {offenders}"
+        )

--- a/tests/src/unit/test_tools_entry_lifecycle.py
+++ b/tests/src/unit/test_tools_entry_lifecycle.py
@@ -296,7 +296,9 @@ class TestEntryTypeDispatch:
         routes.tools_setup.assert_not_awaited()
 
     @pytest.mark.parametrize(
-        "entry_type", [None, ENTRY_TYPE_TOOLS], ids=["missing", "explicit_tools"]
+        "entry_type",
+        [None, ENTRY_TYPE_TOOLS, "future_entry_type"],
+        ids=["missing", "explicit_tools", "other_nonserver"],
     )
     async def test_non_server_entry_type_sets_up_the_tools_entry(
         self, routes, tmp_path, entry_type
@@ -319,7 +321,9 @@ class TestEntryTypeDispatch:
         routes.tools_unload.assert_not_awaited()
 
     @pytest.mark.parametrize(
-        "entry_type", [None, ENTRY_TYPE_TOOLS], ids=["missing", "explicit_tools"]
+        "entry_type",
+        [None, ENTRY_TYPE_TOOLS, "future_entry_type"],
+        ids=["missing", "explicit_tools", "other_nonserver"],
     )
     async def test_non_server_entry_type_unloads_the_tools_entry(
         self, routes, tmp_path, entry_type


### PR DESCRIPTION
## What does this PR do?

Closes out the remaining #2292 acceptance criteria on top of #2302 (stacked;
base is #2302's branch, so this diff is only the separation work).

- **Tools-entry unload is now complete**: the extra-YAML-keys service pair
  (`get_extra_yaml_keys`/`set_extra_yaml_keys`) is removed on unload and the
  cached extra-keys list is dropped from `hass.data` — previously a leftover
  list kept widening the YAML write allowlist after the entry was gone.
- **The WS command lifecycle is documented as a contract**
  (`async_register_commands`): registered by both entry types since 2.1.0,
  idempotent, no unregister exists, the surface survives unload until
  restart — and why that is accepted (live-core-state handlers behind HA
  auth + `require_admin`; the service-call path's D1 block refuses the
  `ha_mcp_tools` domain unconditionally; stripping the surface would break
  the other entry).
- **The config-flow description states the File & YAML Tools entry's two
  roles**: for a server running outside Home Assistant it also provides the
  shared in-process component capabilities (fast search, config-entry
  metadata, registry-backed reads) — worth adding to every external install
  — and everywhere it gates the privileged file/YAML services. The
  tools-step description is aligned the same way (it contradicted the new
  menu text otherwise). Mirrored into the component `en.json`; the
  post-merge locale sync retranslates the other languages.
- **Root `AGENTS.md` records the two-entry/shared-surface invariant** and
  the contributor checklist (update consumer + gate + fallback under
  `src/ha_mcp` AND the producer under `custom_components`; shared commands
  serve from both entries; privileged capabilities stay behind the explicit
  tools-entry signal; test topologies via the `E2E_NO_TOOLS_ENTRY=1` lanes).
- **Lifecycle unit tests** pin it: runtime registration/unload parity by
  service NAME (set equality — the next service added without a matching
  removal fails by name), `hass.data` cleanup asserted through the live
  readers, entry-type dispatch including the missing-`entry_type`
  back-compat default, and the WS-surface contract on both setup paths.

No component version bump: the changes add no server-depended service, so
they ride the pending 2.1.0 opened by #2291 (released stable is v2.0.0).

Of the issue's checklist, this leaves only the #2247/#2273 rechecks, which
are verification tasks rather than code: the four no-tools lanes from #2302
now run the full suite on the exact reported topologies.

## Type of change
- [x] 🐛 Bug fix (unload cleanup)
- [x] 📚 Documentation
- [x] 🧪 Tests only (lifecycle pinning)

## Testing
- [x] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

## Checklist
- [x] I have updated documentation if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified setup options for the HA-MCP Server and File & YAML Tools entries.
  * Documented shared WebSocket command availability and opt-in requirements for privileged file and YAML tools.

* **Bug Fixes**
  * Improved cleanup when the File & YAML Tools entry is unloaded by removing cached permissions and services.

* **Tests**
  * Added coverage for entry lifecycle handling, cleanup, command registration, and server/tools entry routing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->