### PR TITLE
fix: allow custom dashboard screenshot dimensions

### DIFF
--- a/src/ha_mcp/tools/tools_dashboard_screenshot.py
+++ b/src/ha_mcp/tools/tools_dashboard_screenshot.py
@@ -152,17 +152,20 @@ class DashboardScreenshotTools:
                 "'auto'."
             ),
         ] = DEFAULT_HEIGHT,
-        viewport_presets: Annotated[
-            list[ViewportPreset] | None,
-            JSON_STRING_COERCION,
-            Field(
-                description="Render one or more named responsive viewports in "
-                "this order: mobile (390x844), tablet (768x1024), desktop "
-                "(1280x800). Overrides width/height.",
-                min_length=1,
-                max_length=3,
-            ),
-        ] = None,
+        viewport_presets: (
+            Annotated[
+                list[ViewportPreset],
+                JSON_STRING_COERCION,
+                Field(
+                    description="Render one or more named responsive viewports in "
+                    "this order: mobile (390x844), tablet (768x1024), desktop "
+                    "(1280x800). Overrides width/height.",
+                    min_length=1,
+                    max_length=3,
+                ),
+            ]
+            | None
+        ) = None,
         orientation: Annotated[
             Orientation | None,
             Field(

--- a/src/ha_mcp/tools/tools_dashboard_screenshot.py
+++ b/src/ha_mcp/tools/tools_dashboard_screenshot.py
@@ -152,20 +152,17 @@ class DashboardScreenshotTools:
                 "'auto'."
             ),
         ] = DEFAULT_HEIGHT,
-        viewport_presets: (
-            Annotated[
-                list[ViewportPreset],
-                JSON_STRING_COERCION,
-                Field(
-                    description="Render one or more named responsive viewports in "
-                    "this order: mobile (390x844), tablet (768x1024), desktop "
-                    "(1280x800). Overrides width/height.",
-                    min_length=1,
-                    max_length=3,
-                ),
-            ]
-            | None
-        ) = None,
+        viewport_presets: Annotated[
+            list[ViewportPreset] | None,
+            Field(
+                description="Render one or more named responsive viewports in "
+                "this order: mobile (390x844), tablet (768x1024), desktop "
+                "(1280x800). Overrides width/height.",
+                min_length=1,
+                max_length=3,
+            ),
+            JSON_STRING_COERCION,
+        ] = None,
         orientation: Annotated[
             Orientation | None,
             Field(

--- a/tests/src/unit/test_dashboard_screenshot.py
+++ b/tests/src/unit/test_dashboard_screenshot.py
@@ -18,12 +18,12 @@ from __future__ import annotations
 import json
 from collections.abc import AsyncIterator
 from types import SimpleNamespace
-from typing import Any, ClassVar, Literal
+from typing import Any, ClassVar, Literal, get_type_hints
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from fastmcp.exceptions import ToolError
-from pydantic import ValidationError
+from pydantic import TypeAdapter, ValidationError
 
 from ha_mcp import config
 from ha_mcp.dashboard_screenshot.provision import EngineTarget
@@ -169,6 +169,20 @@ class TestRegistrationGate:
 
 
 class TestStandaloneScreenshotTool:
+    def test_viewport_presets_allow_none_without_weakening_list_bounds(self) -> None:
+        from ha_mcp.tools import tools_dashboard_screenshot as mod
+
+        annotation = get_type_hints(
+            mod.DashboardScreenshotTools.ha_get_dashboard_screenshot,
+            include_extras=True,
+        )["viewport_presets"]
+        adapter = TypeAdapter(annotation)
+
+        assert adapter.validate_python(None) is None
+        assert adapter.validate_python('["mobile"]') == ["mobile"]
+        with pytest.raises(ValidationError):
+            adapter.validate_python([])
+
     async def test_structured_target_returns_ordered_images_and_metadata(
         self, monkeypatch: Any
     ) -> None:

--- a/tests/src/unit/test_dashboard_screenshot.py
+++ b/tests/src/unit/test_dashboard_screenshot.py
@@ -18,12 +18,13 @@ from __future__ import annotations
 import json
 from collections.abc import AsyncIterator
 from types import SimpleNamespace
-from typing import Any, ClassVar, Literal, get_type_hints
+from typing import Any, ClassVar, Literal
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from fastmcp.exceptions import ToolError
-from pydantic import TypeAdapter, ValidationError
+from fastmcp.exceptions import ValidationError as FastMCPValidationError
+from pydantic import ValidationError
 
 from ha_mcp import config
 from ha_mcp.dashboard_screenshot.provision import EngineTarget
@@ -169,19 +170,67 @@ class TestRegistrationGate:
 
 
 class TestStandaloneScreenshotTool:
-    def test_viewport_presets_allow_none_without_weakening_list_bounds(self) -> None:
+    async def test_viewport_presets_registered_validation_and_schema(
+        self, monkeypatch: Any
+    ) -> None:
+        from fastmcp import FastMCP
+
+        from ha_mcp.dashboard_screenshot.paths import DashboardRenderTarget
         from ha_mcp.tools import tools_dashboard_screenshot as mod
 
-        annotation = get_type_hints(
-            mod.DashboardScreenshotTools.ha_get_dashboard_screenshot,
-            include_extras=True,
-        )["viewport_presets"]
-        adapter = TypeAdapter(annotation)
+        async def resolve(*_a: Any, **_kw: Any) -> DashboardRenderTarget:
+            return DashboardRenderTarget(
+                dashboard_url_path="wall-panel",
+                view_path=None,
+                render_path="wall-panel",
+                view_index=None,
+                stable=True,
+            )
 
-        assert adapter.validate_python(None) is None
-        assert adapter.validate_python('["mobile"]') == ["mobile"]
-        with pytest.raises(ValidationError):
-            adapter.validate_python([])
+        captures: list[dict[str, Any]] = []
+
+        async def capture(*_a: Any, **kwargs: Any) -> list[Any]:
+            captures.append(kwargs)
+            return [_fake_dashboard_capture()]
+
+        monkeypatch.setattr(
+            config,
+            "get_global_settings",
+            lambda: SimpleNamespace(enable_dashboard_screenshot=True),
+        )
+        monkeypatch.setattr(mod, "resolve_dashboard_render_target", resolve)
+        monkeypatch.setattr(mod, "capture_dashboard_images", capture)
+
+        mcp = FastMCP("test")
+        mod.register_dashboard_screenshot_tools(mcp, MagicMock())
+        tool = await mcp.get_tool("ha_get_dashboard_screenshot")
+
+        await tool.run(
+            {
+                "dashboard_url_path": "wall-panel",
+                "width": 2560,
+                "viewport_presets": None,
+            }
+        )
+        assert captures[-1]["viewport_presets"] is None
+        assert captures[-1]["width"] == 2560
+
+        await tool.run(
+            {
+                "dashboard_url_path": "wall-panel",
+                "viewport_presets": '["mobile"]',
+            }
+        )
+        assert captures[-1]["viewport_presets"] == ["mobile"]
+
+        for invalid in ([], ["mobile"] * 4):
+            with pytest.raises(FastMCPValidationError):
+                await tool.run({"viewport_presets": invalid})
+
+        schema = tool.parameters["properties"]["viewport_presets"]
+        assert schema["description"].startswith("Render one or more named")
+        assert schema["anyOf"][0]["minItems"] == 1
+        assert schema["anyOf"][0]["maxItems"] == 3
 
     async def test_structured_target_returns_ordered_images_and_metadata(
         self, monkeypatch: Any


### PR DESCRIPTION
Fixes [#2303 — `ha_get_dashboard_screenshot` rejects an explicit null viewport preset](https://github.com/homeassistant-ai/ha-mcp/issues/2303).

## Problem

An explicit `null` for `viewport_presets` failed validation before `ha_get_dashboard_screenshot` could use custom `width` and `height`. `JSON_STRING_COERCION` is a `BeforeValidator`; placing it before the `Field` metadata made Pydantic attach the length constraints through a function-before schema and apply its generic constraint path to `None`.

The same metadata order also advertised string `minLength`/`maxLength` keywords for an array parameter.

## Fix

Place `Field` before `JSON_STRING_COERCION` while keeping the optional union intact. This accepts `null`, preserves JSON-string coercion and the property-level model guidance, enforces one to three presets, and emits the correct array `minItems`/`maxItems` schema keywords.

The regression runs through the registered FastMCP tool and checks explicit `null` with custom dimensions, JSON-string coercion, both list bounds, and the published property schema.

## User impact

Clients can pass `viewport_presets: null` and use custom screenshot dimensions. Models continue to see the valid preset names, dimensions, and override behavior in the tool schema.

## Verification

- `uv run pytest -o timeout=0 src/unit/test_dashboard_screenshot.py src/unit/test_json_string_param_coercion.py src/unit/test_config_param_no_string_schema.py -q` — 206 passed
- `uv run ruff format --check src/ha_mcp/tools/tools_dashboard_screenshot.py tests/src/unit/test_dashboard_screenshot.py` — passed
- `uv run ruff check src/ha_mcp/tools/tools_dashboard_screenshot.py tests/src/unit/test_dashboard_screenshot.py` — passed
- `uv run ast-grep scan` — passed
- PR CI — 37 checks passed, including the full unit suite, mypy, Ruff, AST, CodeQL, all platform builds, x64 and embedded ARM E2E, and every HAOS lane
- `E2E Validation (ubuntu-24.04-arm)` — two unrelated HACS startup-nudge tests timed out after 165 seconds; this lane passed on the previous PR commit, and rerunning upstream Actions requires repository admin access

## Type of change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing

- [ ] I have tested these changes with a LLM agent
- [ ] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

## Checklist

- [x] I have updated documentation if needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for dashboard screenshot viewport presets.
  * Preserved support for optional presets and JSON-formatted preset lists.
  * Added clear limits requiring between one and three presets when provided.

* **Tests**
  * Added coverage for valid, optional, JSON-formatted, empty, and oversized preset lists.
  * Verified the published input schema accurately communicates preset limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->