### PR TITLE
test: pin the probe memo's concurrency contract and close the lane-table drift gap

### DIFF
--- a/tests/src/unit/test_e2e_lane_env_shape.py
+++ b/tests/src/unit/test_e2e_lane_env_shape.py
@@ -133,6 +133,7 @@ def test_no_tools_haos_inaddon_has_no_component_surface(
 _PR = "pr.yml"
 _E2E = "e2e-tests.yml"
 _HAOS = "haos-e2e-tests.yml"
+_BETA = "haos-e2e-beta-tests.yml"
 
 # (workflow, job) -> the backend selectors that step's env must carry, exactly.
 # An absent selector is as load-bearing as a present one: the two no-component
@@ -147,8 +148,11 @@ _NO_TOOLS_LANES: dict[tuple[str, str], dict[str, str]] = {
     (_HAOS, "haos-e2e-inaddon-no-tools"): {"HAOS_TEST_MODE": "inaddon"},
 }
 
-# The component-present siblings each no-tools lane is paired against. If one of
-# these ever grows E2E_NO_TOOLS_ENTRY, the pair stops being a comparison.
+# Every component-present lane: the siblings each no-tools lane is paired
+# against, plus the beta lanes, which have no no-tools counterpart but are
+# component-present all the same. If one of these ever grows
+# E2E_NO_TOOLS_ENTRY, a pair stops being a comparison and a beta lane stops
+# covering the topology it was built to run on beta images.
 _ORDINARY_LANES: tuple[tuple[str, str], ...] = (
     (_PR, "e2e-validation"),
     (_PR, "e2e-validation-embedded"),
@@ -160,6 +164,8 @@ _ORDINARY_LANES: tuple[tuple[str, str], ...] = (
     (_HAOS, "haos-e2e-embedded"),
     (_HAOS, "haos-e2e-inaddon"),
     (_HAOS, "haos-e2e-stdio"),
+    (_BETA, "haos-e2e-inaddon-beta"),
+    (_BETA, "haos-e2e-embedded-beta"),
 )
 
 # The container no-tools lanes are whole-topology audits: pytest.ini's
@@ -174,6 +180,23 @@ _AUDIT_LANES: tuple[tuple[str, str], ...] = (
 )
 
 _SELECTOR_NAMES = ("E2E_BACKEND", "HAOS_TEST_MODE")
+
+# The workflows whose e2e jobs the two tables above are expected to classify.
+# `performance-tests.yml` also runs `uv run pytest tests/src/e2e/...`, but its
+# single job is a benchmark over `src/e2e/performance/` rather than a topology
+# lane paired against anything, so it is deliberately left unclassified.
+_LANE_WORKFLOWS: tuple[str, ...] = (_PR, _E2E, _HAOS, _BETA)
+
+# A pytest step is an e2e lane when it targets the e2e suite: the path
+# literally, or `$PYTEST_PATHS`, the HAOS workflows' dispatch-overridable input
+# that defaults to `src/e2e/`. Matching `uv run pytest` alone would also sweep
+# in pr.yml's unit-tests and docker-validation jobs.
+_E2E_TARGET = re.compile(r"src/e2e/|\$\{?PYTEST_PATHS")
+
+# Floor on the discovered count, so a predicate that quietly stops matching (a
+# workflow restructure, a renamed input) fails here rather than reporting an
+# empty sweep as full coverage.
+_MIN_DISCOVERED_LANES = 18
 
 
 def _job(workflow: str, job_id: str) -> dict[str, Any]:
@@ -270,6 +293,71 @@ def test_container_audit_lane_reports_the_full_failure_surface(
     assert "--maxfail=0" in run, (
         f"{workflow}::{job_id} stops after pytest.ini's --maxfail=3, so a "
         "topology audit reports three failures instead of the full surface"
+    )
+
+
+def _discover_e2e_lanes() -> set[tuple[str, str]]:
+    """Every ``(workflow, job)`` in ``_LANE_WORKFLOWS`` that runs the e2e suite."""
+    discovered: set[tuple[str, str]] = set()
+    for workflow in _LANE_WORKFLOWS:
+        data = yaml.safe_load((_WORKFLOW_DIR / workflow).read_text(encoding="utf-8"))
+        for job_id, job in (data.get("jobs") or {}).items():
+            if not isinstance(job, dict):
+                continue
+            for step in job.get("steps", []):
+                if not isinstance(step, dict):
+                    continue
+                run = str(step.get("run", ""))
+                if "uv run pytest" in run and _E2E_TARGET.search(run):
+                    discovered.add((workflow, job_id))
+                    break
+    return discovered
+
+
+def test_every_e2e_lane_is_claimed_by_exactly_one_table() -> None:
+    """Both lane tables are hand-maintained, so a lane added later belongs to
+    neither and is exempt from every env-contract check above: it is
+    parametrized nowhere, and nothing goes red for it (#2302 review).
+
+    Completeness is all this test claims, and classification stays the tables'
+    job deliberately. Deriving it from the presence of E2E_NO_TOOLS_ENTRY would
+    make the contract vacuous in exactly the case #2292 is about: a no-tools
+    lane that LOST the variable would re-classify itself as ordinary, and
+    ``test_ordinary_lane_does_not_carry_the_no_tools_env`` would then cheerfully
+    confirm the variable it just dropped is absent. So the author says which
+    table a new lane belongs to; this test only insists that they say.
+    """
+    discovered = _discover_e2e_lanes()
+    tables = {
+        "_NO_TOOLS_LANES": set(_NO_TOOLS_LANES),
+        "_ORDINARY_LANES": set(_ORDINARY_LANES),
+    }
+
+    for lane in sorted(discovered):
+        claimants = [name for name, table in tables.items() if lane in table]
+        workflow, job_id = lane
+        assert len(claimants) == 1, (
+            f"{workflow}::{job_id} runs the e2e suite but is claimed by "
+            f"{claimants or 'no table'}, not by exactly one. Add it to "
+            "_NO_TOOLS_LANES (with the backend selectors its pytest step must "
+            "carry) if it sets E2E_NO_TOOLS_ENTRY=1, otherwise to "
+            "_ORDINARY_LANES — a lane in neither table is checked by nothing "
+            "in this module, and a lane in both is contradicting itself"
+        )
+
+    for name, table in tables.items():
+        stale = sorted(lane for lane in table if lane not in discovered)
+        assert not stale, (
+            f"{name} names {stale}, which no longer runs the e2e suite — a "
+            "renamed or deleted job. Fix the entry rather than dropping it: "
+            "the lane it stood for may still exist under its new name"
+        )
+
+    assert len(discovered) >= _MIN_DISCOVERED_LANES, (
+        f"discovered only {len(discovered)} e2e lanes across {_LANE_WORKFLOWS}, "
+        f"below the {_MIN_DISCOVERED_LANES} that exist today — the discovery "
+        "predicate stopped matching, and an empty sweep passes the checks "
+        "above vacuously"
     )
 
 

--- a/tests/src/unit/test_e2e_lane_env_shape.py
+++ b/tests/src/unit/test_e2e_lane_env_shape.py
@@ -181,11 +181,18 @@ _AUDIT_LANES: tuple[tuple[str, str], ...] = (
 
 _SELECTOR_NAMES = ("E2E_BACKEND", "HAOS_TEST_MODE")
 
-# The workflows whose e2e jobs the two tables above are expected to classify.
-# `performance-tests.yml` also runs `uv run pytest tests/src/e2e/...`, but its
-# single job is a benchmark over `src/e2e/performance/` rather than a topology
-# lane paired against anything, so it is deliberately left unclassified.
-_LANE_WORKFLOWS: tuple[str, ...] = (_PR, _E2E, _HAOS, _BETA)
+# Workflows whose e2e-pytest jobs are deliberately NOT topology lanes and so
+# stay outside the two tables. Every OTHER workflow in the directory is
+# discovered by glob, so a topology lane introduced in a brand-new workflow
+# file fails the completeness check until it is classified — hand-listing the
+# lane files here would exempt the next file the same way the tables used to
+# exempt the next lane (Codex review on the #2302 follow-up).
+_NON_TOPOLOGY_WORKFLOWS: dict[str, str] = {
+    "performance-tests.yml": (
+        "benchmark over src/e2e/performance/, not a topology lane paired "
+        "against anything"
+    ),
+}
 
 # A pytest step is an e2e lane when it targets the e2e suite: the path
 # literally, or `$PYTEST_PATHS`, the HAOS workflows' dispatch-overridable input
@@ -297,10 +304,15 @@ def test_container_audit_lane_reports_the_full_failure_surface(
 
 
 def _discover_e2e_lanes() -> set[tuple[str, str]]:
-    """Every ``(workflow, job)`` in ``_LANE_WORKFLOWS`` that runs the e2e suite."""
+    """Every ``(workflow, job)`` in the workflow dir that runs the e2e suite."""
     discovered: set[tuple[str, str]] = set()
-    for workflow in _LANE_WORKFLOWS:
-        data = yaml.safe_load((_WORKFLOW_DIR / workflow).read_text(encoding="utf-8"))
+    for path in sorted(_WORKFLOW_DIR.glob("*.yml")):
+        workflow = path.name
+        if workflow in _NON_TOPOLOGY_WORKFLOWS:
+            continue
+        data = yaml.safe_load(path.read_text(encoding="utf-8"))
+        if not isinstance(data, dict):
+            continue
         for job_id, job in (data.get("jobs") or {}).items():
             if not isinstance(job, dict):
                 continue
@@ -354,7 +366,7 @@ def test_every_e2e_lane_is_claimed_by_exactly_one_table() -> None:
         )
 
     assert len(discovered) >= _MIN_DISCOVERED_LANES, (
-        f"discovered only {len(discovered)} e2e lanes across {_LANE_WORKFLOWS}, "
+        f"discovered only {len(discovered)} e2e lanes across the workflow dir, "
         f"below the {_MIN_DISCOVERED_LANES} that exist today — the discovery "
         "predicate stopped matching, and an empty sweep passes the checks "
         "above vacuously"

--- a/tests/src/unit/test_e2e_lane_env_shape.py
+++ b/tests/src/unit/test_e2e_lane_env_shape.py
@@ -306,7 +306,7 @@ def test_container_audit_lane_reports_the_full_failure_surface(
 def _discover_e2e_lanes() -> set[tuple[str, str]]:
     """Every ``(workflow, job)`` in the workflow dir that runs the e2e suite."""
     discovered: set[tuple[str, str]] = set()
-    for path in sorted(_WORKFLOW_DIR.glob("*.yml")):
+    for path in sorted((*_WORKFLOW_DIR.glob("*.yml"), *_WORKFLOW_DIR.glob("*.yaml"))):
         workflow = path.name
         if workflow in _NON_TOPOLOGY_WORKFLOWS:
             continue

--- a/tests/src/unit/test_tools_filesystem.py
+++ b/tests/src/unit/test_tools_filesystem.py
@@ -3,6 +3,7 @@
 import asyncio
 import json
 import os
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -410,7 +411,7 @@ class TestAssertMcpToolsAvailableCapsFirst:
         entered_probe = asyncio.Event()
         release_probe = asyncio.Event()
 
-        async def _suspending_get_services():
+        async def _suspending_get_services() -> list[dict[str, Any]]:
             entered_probe.set()
             await release_probe.wait()
             return [{"domain": MCP_TOOLS_DOMAIN, "services": {"get_caller_token": {}}}]
@@ -435,6 +436,60 @@ class TestAssertMcpToolsAvailableCapsFirst:
             await asyncio.gather(first, second)  # neither may raise
 
         client.get_services.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_concurrent_refresh_after_expiry_probes_once(self, monkeypatch):
+        """The lock must also serialize the EXPIRED-entry refresh, not just the
+        cold cache. Steady state is a memo that expires every TTL with the
+        gated tools still being called; an implementation that serialized only
+        the initial insert would pass the cold-cache test above while issuing
+        one full service-registry fetch per concurrent caller every window
+        (Codex review on the #2302 follow-up)."""
+        from ha_mcp.tools import tools_filesystem
+        from ha_mcp.tools.tools_filesystem import _assert_mcp_tools_available
+
+        clock = {"now": 1000.0}
+        monkeypatch.setattr(tools_filesystem, "_monotonic", lambda: clock["now"])
+
+        services_present = [
+            {"domain": MCP_TOOLS_DOMAIN, "services": {"get_caller_token": {}}}
+        ]
+        entered_probe = asyncio.Event()
+        release_probe = asyncio.Event()
+        primed = {"done": False}
+
+        async def _get_services() -> list[dict[str, Any]]:
+            if not primed["done"]:
+                # The priming call resolves immediately; only the refresh
+                # after expiry parks, so the race lands on the expired path.
+                return services_present
+            entered_probe.set()
+            await release_probe.wait()
+            return services_present
+
+        client = AsyncMock()
+        client.get_services = AsyncMock(side_effect=_get_services)
+
+        with patch(
+            "ha_mcp.tools.tools_filesystem.get_component_caps",
+            AsyncMock(return_value=self._caps("2.1.0", tools_services=True)),
+        ):
+            await _assert_mcp_tools_available(client)  # prime the memo
+            primed["done"] = True
+            clock["now"] += tools_filesystem._LIVE_TOOLS_PROBE_TTL_S + 1.0
+
+            first = asyncio.create_task(_assert_mcp_tools_available(client))
+            await asyncio.wait_for(entered_probe.wait(), timeout=5)
+            second = asyncio.create_task(_assert_mcp_tools_available(client))
+            for _ in range(10):
+                await asyncio.sleep(0)
+            release_probe.set()
+            await asyncio.gather(first, second)
+
+        assert client.get_services.await_count == 2, (
+            "expiry refresh must cost ONE probe regardless of concurrent "
+            f"callers; got {client.get_services.await_count}"
+        )
 
     @pytest.mark.asyncio
     async def test_false_verdict_is_memoized_for_the_ttl_too(self, monkeypatch):

--- a/tests/src/unit/test_tools_filesystem.py
+++ b/tests/src/unit/test_tools_filesystem.py
@@ -1,5 +1,6 @@
 """Unit tests for tools_filesystem module."""
 
+import asyncio
 import json
 import os
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -385,6 +386,98 @@ class TestAssertMcpToolsAvailableCapsFirst:
             "ha_mcp.tools.tools_filesystem.get_component_caps",
             AsyncMock(return_value=self._caps("2.1.0", tools_services=True)),
         ):
+            await _assert_mcp_tools_available(client)  # must not raise
+
+        assert client.get_services.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_concurrent_probes_on_one_client_fetch_the_registry_once(self):
+        """Two gated calls racing on an empty memo serialize on the per-client
+        lock and pay for ONE ``get_services()``.
+
+        The suspension is the whole test. With a plain
+        ``AsyncMock(return_value=...)`` nothing inside the probe ever yields to
+        the event loop, so the first caller runs miss → lock → probe → store to
+        completion before the second is scheduled at all: the memo is already
+        warm by the time the second arrives, and the assertion below would hold
+        with no lock and no second cache check in the code. Parking the first
+        caller *inside* ``get_services`` is what puts the second one at the lock
+        while the memo is still unwritten, which is the only arrangement that
+        distinguishes the serialized refresh (#2302) from a per-caller probe.
+        """
+        from ha_mcp.tools.tools_filesystem import _assert_mcp_tools_available
+
+        entered_probe = asyncio.Event()
+        release_probe = asyncio.Event()
+
+        async def _suspending_get_services():
+            entered_probe.set()
+            await release_probe.wait()
+            return [{"domain": MCP_TOOLS_DOMAIN, "services": {"get_caller_token": {}}}]
+
+        client = AsyncMock()
+        client.get_services = AsyncMock(side_effect=_suspending_get_services)
+
+        with patch(
+            "ha_mcp.tools.tools_filesystem.get_component_caps",
+            AsyncMock(return_value=self._caps("2.1.0", tools_services=True)),
+        ):
+            first = asyncio.create_task(_assert_mcp_tools_available(client))
+            # Resumes only once the first caller is parked mid-probe. Bounded so
+            # a gate that stops probing at all fails here instead of hanging.
+            await asyncio.wait_for(entered_probe.wait(), timeout=5)
+            second = asyncio.create_task(_assert_mcp_tools_available(client))
+            # Let the second caller reach the per-client lock and block on it
+            # while the memo is still empty.
+            for _ in range(10):
+                await asyncio.sleep(0)
+            release_probe.set()
+            await asyncio.gather(first, second)  # neither may raise
+
+        client.get_services.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_false_verdict_is_memoized_for_the_ttl_too(self, monkeypatch):
+        """A ``False`` verdict is memoized deliberately, and that costs the user
+        who adds the tools entry mid-window at most one TTL of staleness.
+
+        Memoizing only the ``True`` side would look kinder and be worse: the
+        install that is already broken — no tools entry — would put a full
+        uncached ``get_services()`` in front of every gated call until it is
+        fixed. The bound is what makes the trade acceptable, so pin both halves:
+        the error repeats without re-probing inside the window, and the entry
+        added mid-session starts working once the window passes, with no server
+        restart (#2302).
+        """
+        from ha_mcp.tools import tools_filesystem
+        from ha_mcp.tools.tools_filesystem import _assert_mcp_tools_available
+
+        clock = {"now": 1000.0}
+        monkeypatch.setattr(tools_filesystem, "_monotonic", lambda: clock["now"])
+
+        client = AsyncMock()
+        client.get_services = AsyncMock(return_value=[])
+        with patch(
+            "ha_mcp.tools.tools_filesystem.get_component_caps",
+            AsyncMock(return_value=self._caps("2.1.0", tools_services=True)),
+        ):
+            with pytest.raises(ToolError):
+                await _assert_mcp_tools_available(client)
+            client.get_services.assert_awaited_once()
+
+            # The user adds the "File & YAML Tools" entry mid-window.
+            client.get_services.return_value = [
+                {"domain": MCP_TOOLS_DOMAIN, "services": {"get_caller_token": {}}}
+            ]
+            clock["now"] += tools_filesystem._LIVE_TOOLS_PROBE_TTL_S / 2
+            with pytest.raises(ToolError) as exc:
+                await _assert_mcp_tools_available(client)
+            data = json.loads(str(exc.value))
+            assert "file & yaml tools" in data["error"]["message"].lower()
+            # Still the memoized False — no second registry fetch.
+            client.get_services.assert_awaited_once()
+
+            clock["now"] += tools_filesystem._LIVE_TOOLS_PROBE_TTL_S
             await _assert_mcp_tools_available(client)  # must not raise
 
         assert client.get_services.await_count == 2


### PR DESCRIPTION
## What does this PR do?

Addresses the two non-blocking notes from the maintainer review on #2302:

- **Probe-memo pins**: the serialized refresh in `_probe_tools_services` (per-client lock + second cache check) and the deliberate False-verdict retention now have discriminating tests. The concurrency test parks the first caller mid-probe with a suspending `side_effect` — a plain resolved mock costs one fetch with or without the lock, so only this shape can catch a removed lock or double-check. The retention test pins False-for-the-TTL and the re-probe after expiry.
- **Lane-table completeness**: the hand-maintained no-tools/ordinary tables in `test_e2e_lane_env_shape.py` are now backed by discovery over every e2e pytest lane in the four lane workflows (18 today, floored), each required to appear in exactly one table. Classification deliberately stays with the tables: auto-classifying on `E2E_NO_TOOLS_ENTRY` would let a no-tools lane that dropped the variable re-classify itself as ordinary and pass vacuously. The two beta lanes join the ordinary table (they were in neither); `performance-tests.yml` is excluded as a benchmark lane with the reason recorded in a comment.

## Type of change
- [x] 🧪 Tests only

## Testing
- [x] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

## Checklist
- [x] I have updated documentation if needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded end-to-end workflow coverage for beta and no-tools lane configurations.
  * Added checks to ensure all available workflow lanes are recognized exactly once and meet the expected minimum coverage.
  * Added coverage for concurrent filesystem availability checks, including cold-cache and cache-refresh scenarios.
  * Verified that negative availability results are consistently reused during the probe period.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->