### PR TITLE
ci: fold the seven fast checks into one Fast Checks lane

### DIFF
--- a/.github/workflows/_build-and-release.yml
+++ b/.github/workflows/_build-and-release.yml
@@ -53,7 +53,8 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
-          version: "latest"
+          # renovate: datasource=github-releases depName=astral-sh/uv
+          version: "0.12.7"
 
       - name: Create virtual environment and install dependencies
         run: |

--- a/.github/workflows/build-binary.yml
+++ b/.github/workflows/build-binary.yml
@@ -65,7 +65,8 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
-          version: "latest"
+          # renovate: datasource=github-releases depName=astral-sh/uv
+          version: "0.12.7"
 
       - name: Create virtual environment and install dependencies
         run: |

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -51,7 +51,8 @@ jobs:
     - name: Install uv
       uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
       with:
-        version: "latest"
+        # renovate: datasource=github-releases depName=astral-sh/uv
+        version: "0.12.7"
 
     - name: Set up Python
       run: uv python install ${{ env.PYTHON_VERSION }}
@@ -133,7 +134,8 @@ jobs:
     - name: Install uv
       uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
       with:
-        version: "latest"
+        # renovate: datasource=github-releases depName=astral-sh/uv
+        version: "0.12.7"
 
     - name: Set up Python
       run: uv python install ${{ env.PYTHON_VERSION }}
@@ -229,7 +231,8 @@ jobs:
     - name: Install uv
       uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
       with:
-        version: "latest"
+        # renovate: datasource=github-releases depName=astral-sh/uv
+        version: "0.12.7"
 
     - name: Set up Python
       run: uv python install ${{ env.PYTHON_VERSION }}
@@ -312,7 +315,8 @@ jobs:
     - name: Install uv
       uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
       with:
-        version: "latest"
+        # renovate: datasource=github-releases depName=astral-sh/uv
+        version: "0.12.7"
 
     - name: Set up Python
       run: uv python install ${{ env.PYTHON_VERSION }}
@@ -414,7 +418,8 @@ jobs:
     - name: Install uv
       uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
       with:
-        version: "latest"
+        # renovate: datasource=github-releases depName=astral-sh/uv
+        version: "0.12.7"
 
     - name: Set up Python
       run: uv python install ${{ env.PYTHON_VERSION }}

--- a/.github/workflows/haos-e2e-beta-tests.yml
+++ b/.github/workflows/haos-e2e-beta-tests.yml
@@ -252,7 +252,8 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
-          version: "latest"
+          # renovate: datasource=github-releases depName=astral-sh/uv
+          version: "0.12.7"
 
       - name: Set up Python
         run: uv python install ${{ env.PYTHON_VERSION }}
@@ -522,7 +523,8 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
-          version: "latest"
+          # renovate: datasource=github-releases depName=astral-sh/uv
+          version: "0.12.7"
 
       - name: Set up Python
         run: uv python install ${{ env.PYTHON_VERSION }}

--- a/.github/workflows/haos-e2e-beta-tests.yml
+++ b/.github/workflows/haos-e2e-beta-tests.yml
@@ -14,17 +14,21 @@ name: HAOS E2E Tests (beta)
 # SCHEDULE GATING: the two lanes deliberately keep different nightly slots, but
 # `schedule` is a property of the workflow, not of a job — a merged file would
 # otherwise start BOTH lanes on BOTH crons. So each lane's `if:` appends a
-# `github.event.schedule` term to the shared classifier predicate: inaddon beta
+# `github.event.schedule` term to its `if:` predicate: inaddon beta
 # answers 06:00 UTC, embedded beta 08:00 UTC. Every non-schedule event
 # (push, workflow_dispatch) leaves `github.event.schedule` empty,
 # which is what the `github.event_name != 'schedule'` disjunct lets through, so
 # both lanes still run on those.
 
 on:
-  # NOT on pull_request (#2311): per-PR beta runs cost ~21 runner-minutes per
-  # push to answer a question that moves nightly (upstream beta) or per-merge
-  # (our code). A beta incompatibility surfaces on the merge commit via the
-  # push trigger, and upstream-side breakage within a day via the crons.
+  # NOT on pull_request (#2311). The load-bearing reason is attribution: a
+  # per-PR beta failure blames every open PR for an upstream change none of
+  # them made (test_haos_image_workflow_shape.py pins this). It also cost ~21
+  # runner-minutes per push to answer a question that moves nightly (upstream
+  # beta) or per-merge (our code): a beta incompatibility surfaces on the
+  # merge commit via the push trigger, upstream breakage within a day via the
+  # crons. No docs-only classifier here any more — every surviving trigger is
+  # a trusted ref where the suite should simply run.
   push:
     branches: [master]
   schedule:
@@ -59,71 +63,14 @@ env:
   LIBGUESTFS_BACKEND: direct
 
 jobs:
-  # Gate the heavy suite: run on code, tests, configuration, app, or bake-input
-  # changes; skip only when every changed file is documentation or website
-  # content. Non-documentation app and bake-input files count as code.
-  changes:
-    name: Detect relevant changes
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    outputs:
-      run: ${{ steps.filter.outputs.run }}
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-        with:
-          persist-credentials: false
-      - name: Classify changed files
-        id: filter
-        env:
-          BASE_REF: ${{ github.base_ref }}
-        run: |
-          # Fail-closed gate: default to RUNNING the suite; skip only when the
-          # PR is proven to contain only docs/website changes. Any classifier failure
-          # (non-PR event, fetch/rev-parse/diff error, or empty diff) leaves
-          # run=true so code cannot be mislabeled as docs-only.
-          run=true
-          if [ "${{ github.event_name }}" = "pull_request" ] \
-            && git fetch --depth=1 origin "$BASE_REF" \
-            && base_sha=$(git rev-parse "origin/$BASE_REF") \
-            && changed=$(git diff --no-renames --name-only --diff-filter=ACMD "$base_sha" HEAD) \
-            && [ -n "$changed" ]; then
-            echo "Changed files:"; printf '%s\n' "$changed" | sed 's/^/  /'
-            run=false
-            while IFS= read -r f; do
-              [ -z "$f" ] && continue
-              case "$f" in
-                # Markdown-only app/component changes are treated as docs-only
-                # because they do not alter runtime behavior.
-                homeassistant-addon/*.md|homeassistant-addon-dev/*.md|homeassistant-addon-webhook-proxy/*.md|custom_components/ha_mcp_tools/*.md)
-                  continue ;;
-                # Bake inputs and app directories are baked into the qcow2 or
-                # shipped, so their non-doc files count as code.
-                homeassistant-addon/*|homeassistant-addon-dev/*|homeassistant-addon-webhook-proxy/*|custom_components/ha_mcp_tools/*|tests/haos_image_build/*|tests/initial_test_state/*)
-                  run=true; break ;;
-                # Pure docs / website do not, on their own, warrant the suite.
-                *.md|*.mdx|docs/*|site/*)
-                  continue ;;
-                # Anything else (code, tests, config, workflows, lockfile, ...) runs.
-                *)
-                  run=true; break ;;
-              esac
-            done <<< "$changed"
-          else
-            echo "Non-PR event or unresolved diff — running suite (fail-closed)."
-          fi
-          echo "run=$run"
-          echo "run=$run" >> "$GITHUB_OUTPUT"
-
   haos-e2e-inaddon-beta:
     name: HAOS E2E Tests (inaddon beta)
-    needs: changes
-    # Run unless the classifier succeeds and explicitly confirms docs-only.
-    # Any missing/failed classifier result runs fail-closed; a real cancellation
-    # remains cancelled.
     # Only this lane's own cron starts it; see SCHEDULE GATING in the file
-    # header. Non-schedule events leave `github.event.schedule` empty and
-    # are admitted by the `github.event_name != 'schedule'` disjunct.
-    if: ${{ !cancelled() && (needs.changes.result != 'success' || needs.changes.outputs.run != 'false') && (github.event_name != 'schedule' || github.event.schedule == '0 6 * * *') }}
+    # header. The master-push and dispatch events leave `github.event.schedule`
+    # empty and are admitted by the `github.event_name != 'schedule'` disjunct
+    # — with pull_request gone (#2311) that disjunct is what lets every
+    # non-cron trigger through.
+    if: ${{ !cancelled() && (github.event_name != 'schedule' || github.event.schedule == '0 6 * * *') }}
     runs-on: ubuntu-22.04
     timeout-minutes: 75
 
@@ -401,14 +348,12 @@ jobs:
 
   haos-e2e-embedded-beta:
     name: HAOS E2E Tests (embedded beta)
-    needs: changes
-    # Run unless the classifier succeeds and explicitly confirms docs-only.
-    # Any missing/failed classifier result runs fail-closed; a real cancellation
-    # remains cancelled.
     # Only this lane's own cron starts it; see SCHEDULE GATING in the file
-    # header. Non-schedule events leave `github.event.schedule` empty and
-    # are admitted by the `github.event_name != 'schedule'` disjunct.
-    if: ${{ !cancelled() && (needs.changes.result != 'success' || needs.changes.outputs.run != 'false') && (github.event_name != 'schedule' || github.event.schedule == '0 8 * * *') }}
+    # header. The master-push and dispatch events leave `github.event.schedule`
+    # empty and are admitted by the `github.event_name != 'schedule'` disjunct
+    # — with pull_request gone (#2311) that disjunct is what lets every
+    # non-cron trigger through.
+    if: ${{ !cancelled() && (github.event_name != 'schedule' || github.event.schedule == '0 8 * * *') }}
     runs-on: ubuntu-22.04
     # The embedded beta lane receives extra headroom for the per-worker runtime
     # package installation inside the resource-constrained QEMU guest.

--- a/.github/workflows/haos-e2e-beta-tests.yml
+++ b/.github/workflows/haos-e2e-beta-tests.yml
@@ -16,14 +16,15 @@ name: HAOS E2E Tests (beta)
 # otherwise start BOTH lanes on BOTH crons. So each lane's `if:` appends a
 # `github.event.schedule` term to the shared classifier predicate: inaddon beta
 # answers 06:00 UTC, embedded beta 08:00 UTC. Every non-schedule event
-# (pull_request, push, workflow_dispatch) leaves `github.event.schedule` empty,
+# (push, workflow_dispatch) leaves `github.event.schedule` empty,
 # which is what the `github.event_name != 'schedule'` disjunct lets through, so
 # both lanes still run on those.
 
 on:
-  # Run on every pull request so beta compatibility stays visible. The
-  # `changes` job skips the QEMU suite only for docs/website-only changes.
-  pull_request:
+  # NOT on pull_request (#2311): per-PR beta runs cost ~21 runner-minutes per
+  # push to answer a question that moves nightly (upstream beta) or per-merge
+  # (our code). A beta incompatibility surfaces on the merge commit via the
+  # push trigger, and upstream-side breakage within a day via the crons.
   push:
     branches: [master]
   schedule:

--- a/.github/workflows/haos-e2e-tests.yml
+++ b/.github/workflows/haos-e2e-tests.yml
@@ -253,7 +253,8 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
-          version: "latest"
+          # renovate: datasource=github-releases depName=astral-sh/uv
+          version: "0.12.7"
 
       - name: Set up Python
         run: uv python install ${{ env.PYTHON_VERSION }}
@@ -476,7 +477,8 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
-          version: "latest"
+          # renovate: datasource=github-releases depName=astral-sh/uv
+          version: "0.12.7"
 
       - name: Set up Python
         run: uv python install ${{ env.PYTHON_VERSION }}
@@ -713,7 +715,8 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
-          version: "latest"
+          # renovate: datasource=github-releases depName=astral-sh/uv
+          version: "0.12.7"
 
       - name: Set up Python
         run: uv python install ${{ env.PYTHON_VERSION }}
@@ -950,7 +953,8 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
-          version: "latest"
+          # renovate: datasource=github-releases depName=astral-sh/uv
+          version: "0.12.7"
 
       - name: Set up Python
         run: uv python install ${{ env.PYTHON_VERSION }}
@@ -1164,7 +1168,8 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
-          version: "latest"
+          # renovate: datasource=github-releases depName=astral-sh/uv
+          version: "0.12.7"
 
       - name: Set up Python
         run: uv python install ${{ env.PYTHON_VERSION }}
@@ -1408,7 +1413,8 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
-          version: "latest"
+          # renovate: datasource=github-releases depName=astral-sh/uv
+          version: "0.12.7"
 
       - name: Set up Python
         run: uv python install ${{ env.PYTHON_VERSION }}

--- a/.github/workflows/locale-sync.yml
+++ b/.github/workflows/locale-sync.yml
@@ -129,6 +129,9 @@ jobs:
 
     - name: Install uv
       uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+      with:
+        # renovate: datasource=github-releases depName=astral-sh/uv
+        version: "0.12.7"
 
     - name: Install dependencies
       run: uv sync --dev

--- a/.github/workflows/performance-tests.yml
+++ b/.github/workflows/performance-tests.yml
@@ -81,7 +81,8 @@ jobs:
     - name: Install uv
       uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
       with:
-        version: "latest"
+        # renovate: datasource=github-releases depName=astral-sh/uv
+        version: "0.12.7"
 
     - name: Set up Python
       run: uv python install ${{ env.PYTHON_VERSION }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -202,30 +202,41 @@ jobs:
   # into one lane they share a single `uv sync --dev`.
   #
   # A PLAIN runner, not the `ghcr.io/astral-sh/uv` container image the folded
-  # jobs used: hacs/action and home-assistant/actions/hassfest are Docker
-  # actions, and a Docker action cannot be assumed to work inside a container
-  # job. uv therefore comes from astral-sh/setup-uv here. (The unit-tests job
-  # below still runs in that container image, so the Renovate datasource pinning
-  # it stays live.)
+  # jobs used: hacs/action is a Docker action and hassfest is a composite
+  # action that shells out to `docker run` — neither can run inside a container
+  # job, which has no docker CLI or socket. uv therefore comes from
+  # astral-sh/setup-uv here.
   #
   # `if: success() || failure()` on every step after the first check is the
   # failure-attribution requirement: one lane must still report EVERY check, so
   # a ruff failure cannot hide a mypy failure the way it would if the steps
   # simply stopped at the first red. It is deliberately not `always()` —
-  # a cancelled run stops here instead of grinding through the rest.
+  # a cancelled run stops here instead of grinding through the rest. The setup
+  # steps (Install uv, Set up Python, Install dependencies) carry the same
+  # condition so a setup failure is reported rather than swallowed, at the cost
+  # of noisy downstream reds: read the FIRST red step, not the last.
   #
   # ORDER IS LOAD-BEARING: HACS and Hassfest validate the checkout as
-  # committed, so they run before ANY step that executes PR-controlled code —
-  # `uv sync` builds this project via its PR-supplied PEP 517 backend, and the
-  # lock/constraint/lint steps run PR-supplied config and scripts. Reordering
-  # a validator after any of those would let a PR rewrite the tree the
-  # validators certify (Codex review on #2314).
+  # committed (minus the vendored fixtures, removed just for Hassfest below),
+  # so they run before ANY step that executes PR-controlled code — `uv sync`
+  # builds this project via its PR-supplied PEP 517 backend, and the
+  # lock/constraint/lint steps run PR-supplied config and scripts. This guards
+  # against accidental or inconspicuous tree mutation ahead of the validators
+  # (a pull_request workflow runs the PR's own copy of this file, so it is not
+  # a defense against a PR that openly edits the workflow — reviewers see that
+  # diff). Only the Docs Size Check precedes them: it reads AGENTS.md and
+  # executes nothing from the tree. Do not add anything else above HACS.
+  # (Origin: Codex review on #2314. Pinned by
+  # tests/src/unit/test_fast_checks_workflow_shape.py.)
   fast-checks:
     name: Fast Checks
     runs-on: ubuntu-latest
-    # 15: under the 18 the five folded pr.yml jobs budgeted between them
-    # (5 + 1 + 5 + 2 + 5), because two of the three dependency installs are
-    # gone, with headroom left for the two Docker actions to pull their images.
+    # 15 covers the serial worst case: two Docker image pulls (~1 min), one
+    # `uv sync --dev`, the HA-constraints fetch budget (3 x 10s + backoff,
+    # sized in tests/src/unit/test_ha_constraint_alignment.py — the fetch must
+    # exit on its own code, never as an opaque runner kill), and the four
+    # linters. Observed full-lane time: ~1.5 min; the headroom is for cold
+    # caches and slow image pulls.
     timeout-minutes: 15
 
     steps:
@@ -249,8 +260,8 @@ jobs:
     # Drop vendored third-party fixtures (e.g. the upstream HACS integration
     # used as an e2e fixture) so hassfest only validates integrations this repo
     # owns. Mirrors scripts/codeql_quality_gate.py's PATHS_IGNORE convention.
-    # Restored right after Hassfest so the later checks see the tree as
-    # committed.
+    # Restored right after Hassfest so the later checks see the tracked tree
+    # again (a fresh CI checkout holds nothing untracked here).
     - name: Remove vendored test fixtures
       if: success() || failure()
       run: rm -rf tests/initial_test_state
@@ -260,14 +271,23 @@ jobs:
       uses: home-assistant/actions/hassfest@a7c616ce81ccda50150bf1595786c71b1883fabb # master
 
     - name: Restore vendored test fixtures
+      # The restore must be verified: the fixture tree holds 59 tracked .py
+      # files that ast-grep and the changed-files format check walk, so a
+      # silently failed restore would stamp green checks on a reduced file set.
       if: success() || failure()
-      run: git checkout -- tests/initial_test_state
+      run: |
+        git checkout HEAD -- tests/initial_test_state
+        if ! git diff --quiet HEAD -- tests/initial_test_state; then
+          echo "::error::tests/initial_test_state was not fully restored; the lint steps below would silently skip its files"
+          exit 1
+        fi
 
     - name: Install uv
       # Pinned, not "latest": the folded jobs got uv from the Renovate-pinned
       # container image, and `uv lock --check` is sensitive to the uv version.
-      # Renovate bumps this pin (github-releases datasource) alongside the
-      # unit-tests job's container image tag.
+      # renovate.json groups this github-releases pin with the unit-tests
+      # job's container image tag (group "uv"), so both move in one Renovate
+      # PR and cannot drift apart.
       if: success() || failure()
       uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
       with:
@@ -333,14 +353,14 @@ jobs:
         # untouched files stays grandfathered. Avoids the disruption of a
         # repo-wide sweep while still preventing fresh debt from landing.
         if [ -z "${GITHUB_BASE_REF}" ]; then
-          echo "No PR base ref (workflow_dispatch); skipping format check."
+          echo "::notice::no PR base ref (workflow_dispatch) - the ruff format check did not run"
           exit 0
         fi
         git fetch --depth=1 origin "${GITHUB_BASE_REF}"
         base_sha=$(git rev-parse "origin/${GITHUB_BASE_REF}")
         changed_py=$(git diff --name-only --diff-filter=ACMR "${base_sha}" -- '*.py')
         if [ -z "$changed_py" ]; then
-          echo "No Python files changed; skipping ruff format check."
+          echo "::notice::no Python files changed - the ruff format check did not run"
           exit 0
         fi
         count=$(echo "$changed_py" | wc -l)
@@ -354,10 +374,15 @@ jobs:
 
     - name: Run mypy
       if: success() || failure()
+      # Accumulate, don't abort: under the default `bash -e` the first failing
+      # invocation would hide the other trees' errors — the same failure mode
+      # the per-step `if:` guards exist to prevent, one level down.
       run: |
-        uv run mypy src/ custom_components/ homeassistant-addon/ scripts/
-        uv run mypy homeassistant-addon-webhook-proxy/
-        uv run mypy homeassistant-addon-webhook-proxy-dev/
+        status=0
+        uv run mypy src/ custom_components/ homeassistant-addon/ scripts/ || status=1
+        uv run mypy homeassistant-addon-webhook-proxy/ || status=1
+        uv run mypy homeassistant-addon-webhook-proxy-dev/ || status=1
+        exit "$status"
 
   # Anchors the docs-site accessibility work (#1574/#1595): astro check (types
   # + a11y diagnostics), eslint-plugin-astro + jsx-a11y, and an axe-core audit

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -208,11 +208,18 @@ jobs:
   # below still runs in that container image, so the Renovate datasource pinning
   # it stays live.)
   #
-  # `if: success() || failure()` on every check step from the docs-size one down
-  # is the failure-attribution requirement: one lane must still report EVERY
-  # check, so a ruff failure cannot hide a mypy failure the way it would if the
-  # steps simply stopped at the first red. It is deliberately not `always()` —
+  # `if: success() || failure()` on every step after the first check is the
+  # failure-attribution requirement: one lane must still report EVERY check, so
+  # a ruff failure cannot hide a mypy failure the way it would if the steps
+  # simply stopped at the first red. It is deliberately not `always()` —
   # a cancelled run stops here instead of grinding through the rest.
+  #
+  # ORDER IS LOAD-BEARING: HACS and Hassfest validate the checkout as
+  # committed, so they run before ANY step that executes PR-controlled code —
+  # `uv sync` builds this project via its PR-supplied PEP 517 backend, and the
+  # lock/constraint/lint steps run PR-supplied config and scripts. Reordering
+  # a validator after any of those would let a PR rewrite the tree the
+  # validators certify (Codex review on #2314).
   fast-checks:
     name: Fast Checks
     runs-on: ubuntu-latest
@@ -226,23 +233,57 @@ jobs:
       with:
         persist-credentials: false
 
+    - name: Docs Size Check
+      run: |
+        size=$(LC_ALL=C.UTF-8 wc -m < AGENTS.md)
+        if [ "$size" -gt 40000 ]; then
+          echo "::warning file=AGENTS.md::AGENTS.md is ${size} chars (>40k). Claude Code will show a startup performance warning."
+        fi
+
+    - name: HACS validation
+      if: success() || failure()
+      uses: hacs/action@1ebf01c408f29afcb6406bd431bc98fd8cbb15aa # main
+      with:
+        category: integration
+
+    # Drop vendored third-party fixtures (e.g. the upstream HACS integration
+    # used as an e2e fixture) so hassfest only validates integrations this repo
+    # owns. Mirrors scripts/codeql_quality_gate.py's PATHS_IGNORE convention.
+    # Restored right after Hassfest so the later checks see the tree as
+    # committed.
+    - name: Remove vendored test fixtures
+      if: success() || failure()
+      run: rm -rf tests/initial_test_state
+
+    - name: Hassfest
+      if: success() || failure()
+      uses: home-assistant/actions/hassfest@a7c616ce81ccda50150bf1595786c71b1883fabb # master
+
+    - name: Restore vendored test fixtures
+      if: success() || failure()
+      run: git checkout -- tests/initial_test_state
+
     - name: Install uv
       # Pinned, not "latest": the folded jobs got uv from the Renovate-pinned
       # container image, and `uv lock --check` is sensitive to the uv version.
       # Renovate bumps this pin (github-releases datasource) alongside the
       # unit-tests job's container image tag.
+      if: success() || failure()
       uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
       with:
         # renovate: datasource=github-releases depName=astral-sh/uv
         version: "0.12.7"
 
     - name: Set up Python
+      if: success() || failure()
       run: uv python install ${{ env.PYTHON_VERSION }}
 
     - name: Verify uv.lock is in sync with pyproject.toml
+      if: success() || failure()
       run: uv lock --check
 
     - name: Check dependency alignment with HA core constraints
+      if: success() || failure()
       # Mechanical link to HA's own package_constraints.txt (#2135/#2146):
       # where HA pins a shared dependency exactly, ha-mcp must admit the pin;
       # where HA is loose, ha-mcp must not pin exactly (an exact pin forces
@@ -273,14 +314,6 @@ jobs:
           exit 0
         fi
         exit "$status"
-
-    - name: Docs Size Check
-      if: success() || failure()
-      run: |
-        size=$(LC_ALL=C.UTF-8 wc -m < AGENTS.md)
-        if [ "$size" -gt 40000 ]; then
-          echo "::warning file=AGENTS.md::AGENTS.md is ${size} chars (>40k). Claude Code will show a startup performance warning."
-        fi
 
     - name: Install dependencies
       # One install for ruff, ast-grep and mypy. The three folded jobs each ran
@@ -325,25 +358,6 @@ jobs:
         uv run mypy src/ custom_components/ homeassistant-addon/ scripts/
         uv run mypy homeassistant-addon-webhook-proxy/
         uv run mypy homeassistant-addon-webhook-proxy-dev/
-
-    - name: HACS validation
-      if: success() || failure()
-      uses: hacs/action@1ebf01c408f29afcb6406bd431bc98fd8cbb15aa # main
-      with:
-        category: integration
-
-    # Drop vendored third-party fixtures (e.g. the upstream HACS integration
-    # used as an e2e fixture) so hassfest only validates integrations this repo
-    # owns. Mirrors scripts/codeql_quality_gate.py's PATHS_IGNORE convention.
-    # LAST of the checks that read the tree, because it mutates the workspace:
-    # every step above still sees the checkout as committed.
-    - name: Remove vendored test fixtures
-      if: success() || failure()
-      run: rm -rf tests/initial_test_state
-
-    - name: Hassfest
-      if: success() || failure()
-      uses: home-assistant/actions/hassfest@a7c616ce81ccda50150bf1595786c71b1883fabb # master
 
   # Anchors the docs-site accessibility work (#1574/#1595): astro check (types
   # + a11y diagnostics), eslint-plugin-astro + jsx-a11y, and an axe-core audit

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -194,23 +194,45 @@ jobs:
             exit 1
           fi
 
-  lockfile:
-    name: Check uv.lock
+  # The seven fast checks that used to be seven separate jobs and seven
+  # required contexts (issue #2311): Check uv.lock, Docs Size Check, Ruff Lint,
+  # AST Lint and Mypy Type Check from this file, plus HACS and Hassfest, which
+  # validate.yml used to run on pull_request. They all finish in a couple of
+  # minutes and three of them each paid for their own dependency install; folded
+  # into one lane they share a single `uv sync --dev`.
+  #
+  # A PLAIN runner, not the `ghcr.io/astral-sh/uv` container image the folded
+  # jobs used: hacs/action and home-assistant/actions/hassfest are Docker
+  # actions, and a Docker action cannot be assumed to work inside a container
+  # job. uv therefore comes from astral-sh/setup-uv here. (The unit-tests job
+  # below still runs in that container image, so the Renovate datasource pinning
+  # it stays live.)
+  #
+  # `if: success() || failure()` on every check step from the docs-size one down
+  # is the failure-attribution requirement: one lane must still report EVERY
+  # check, so a ruff failure cannot hide a mypy failure the way it would if the
+  # steps simply stopped at the first red. It is deliberately not `always()` —
+  # a cancelled run stops here instead of grinding through the rest.
+  fast-checks:
+    name: Fast Checks
     runs-on: ubuntu-latest
-    container:
-      # renovate: datasource=docker depName=ghcr.io/astral-sh/uv
-      image: ghcr.io/astral-sh/uv:0.12.7-python3.13-trixie-slim
-    # 5 (was 2): this job now also fetches HA's constraints file over the
-    # network. The fetch is budgeted to fail fast (3 x 10s + short backoff)
-    # so its own distinct exit code is always reachable, and the headroom
-    # here keeps a slow network from turning that clean failure into an
-    # opaque runner kill.
-    timeout-minutes: 5
+    # 15: under the 18 the five folded pr.yml jobs budgeted between them
+    # (5 + 1 + 5 + 2 + 5), because two of the three dependency installs are
+    # gone, with headroom left for the two Docker actions to pull their images.
+    timeout-minutes: 15
 
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       with:
         persist-credentials: false
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+      with:
+        version: "latest"
+
+    - name: Set up Python
+      run: uv python install ${{ env.PYTHON_VERSION }}
 
     - name: Verify uv.lock is in sync with pyproject.toml
       run: uv lock --check
@@ -247,22 +269,76 @@ jobs:
         fi
         exit "$status"
 
-  docs-size:
-    name: Docs Size Check
-    runs-on: ubuntu-latest
-    timeout-minutes: 1
-
-    steps:
-    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-      with:
-        persist-credentials: false
-
-    - name: Check AGENTS.md size
+    - name: Docs Size Check
+      if: success() || failure()
       run: |
         size=$(LC_ALL=C.UTF-8 wc -m < AGENTS.md)
         if [ "$size" -gt 40000 ]; then
           echo "::warning file=AGENTS.md::AGENTS.md is ${size} chars (>40k). Claude Code will show a startup performance warning."
         fi
+
+    - name: Install dependencies
+      # One install for ruff, ast-grep and mypy. The three folded jobs each ran
+      # their own; this is where most of the fold's wall-clock saving comes from.
+      if: success() || failure()
+      run: uv sync --dev
+
+    - name: Run ruff check
+      if: success() || failure()
+      run: uv run ruff check src/ tests/ custom_components/ homeassistant-addon/ homeassistant-addon-webhook-proxy/ homeassistant-addon-webhook-proxy-dev/ packaging/ scripts/
+
+    - name: Run ruff format check on changed Python files
+      if: success() || failure()
+      run: |
+        # Changed-files-only gate per the maintainer call on issue #1318:
+        # new edits must be formatted; pre-existing format-debt on
+        # untouched files stays grandfathered. Avoids the disruption of a
+        # repo-wide sweep while still preventing fresh debt from landing.
+        if [ -z "${GITHUB_BASE_REF}" ]; then
+          echo "No PR base ref (workflow_dispatch); skipping format check."
+          exit 0
+        fi
+        git fetch --depth=1 origin "${GITHUB_BASE_REF}"
+        base_sha=$(git rev-parse "origin/${GITHUB_BASE_REF}")
+        changed_py=$(git diff --name-only --diff-filter=ACMR "${base_sha}" -- '*.py')
+        if [ -z "$changed_py" ]; then
+          echo "No Python files changed; skipping ruff format check."
+          exit 0
+        fi
+        count=$(echo "$changed_py" | wc -l)
+        echo "Checking ruff format on $count changed Python files:"
+        echo "$changed_py" | sed 's/^/  /'
+        echo "$changed_py" | xargs uv run ruff format --check
+
+    - name: Run ast-grep
+      if: success() || failure()
+      run: uv run ast-grep scan
+
+    - name: Run mypy
+      if: success() || failure()
+      run: |
+        uv run mypy src/ custom_components/ homeassistant-addon/ scripts/
+        uv run mypy homeassistant-addon-webhook-proxy/
+        uv run mypy homeassistant-addon-webhook-proxy-dev/
+
+    - name: HACS validation
+      if: success() || failure()
+      uses: hacs/action@1ebf01c408f29afcb6406bd431bc98fd8cbb15aa # main
+      with:
+        category: integration
+
+    # Drop vendored third-party fixtures (e.g. the upstream HACS integration
+    # used as an e2e fixture) so hassfest only validates integrations this repo
+    # owns. Mirrors scripts/codeql_quality_gate.py's PATHS_IGNORE convention.
+    # LAST of the checks that read the tree, because it mutates the workspace:
+    # every step above still sees the checkout as committed.
+    - name: Remove vendored test fixtures
+      if: success() || failure()
+      run: rm -rf tests/initial_test_state
+
+    - name: Hassfest
+      if: success() || failure()
+      uses: home-assistant/actions/hassfest@a7c616ce81ccda50150bf1595786c71b1883fabb # master
 
   # Anchors the docs-site accessibility work (#1574/#1595): astro check (types
   # + a11y diagnostics), eslint-plugin-astro + jsx-a11y, and an axe-core audit
@@ -304,96 +380,6 @@ jobs:
       # Blocking: the baseline is clean (0 violations across all pages), so a
       # new axe-core violation fails the PR rather than slipping through.
       run: npm run audit:a11y
-
-  lint:
-    name: Ruff Lint
-    runs-on: ubuntu-latest
-    container:
-      # renovate: datasource=docker depName=ghcr.io/astral-sh/uv
-      image: ghcr.io/astral-sh/uv:0.12.7-python3.13-trixie-slim
-    timeout-minutes: 5
-
-    steps:
-    - name: Install git for changed-files diff
-      run: apt-get update -qq && apt-get install -y -qq git >/dev/null 2>&1
-
-    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-      with:
-        persist-credentials: false
-
-    - name: Install dependencies
-      run: uv sync --dev
-
-    - name: Run ruff check
-      run: uv run ruff check src/ tests/ custom_components/ homeassistant-addon/ homeassistant-addon-webhook-proxy/ homeassistant-addon-webhook-proxy-dev/ packaging/ scripts/
-
-    - name: Run ruff format check on changed Python files
-      run: |
-        # actions/checkout sets safe.directory in a temp HOME that this
-        # step doesn't inherit; re-add it here so git operations succeed
-        # when the checkout dir is owned by a different UID than the
-        # container's root.
-        git config --global --add safe.directory "$GITHUB_WORKSPACE"
-        # Changed-files-only gate per the maintainer call on issue #1318:
-        # new edits must be formatted; pre-existing format-debt on
-        # untouched files stays grandfathered. Avoids the disruption of a
-        # repo-wide sweep while still preventing fresh debt from landing.
-        if [ -z "${GITHUB_BASE_REF}" ]; then
-          echo "No PR base ref (workflow_dispatch); skipping format check."
-          exit 0
-        fi
-        git fetch --depth=1 origin "${GITHUB_BASE_REF}"
-        base_sha=$(git rev-parse "origin/${GITHUB_BASE_REF}")
-        changed_py=$(git diff --name-only --diff-filter=ACMR "${base_sha}" -- '*.py')
-        if [ -z "$changed_py" ]; then
-          echo "No Python files changed; skipping ruff format check."
-          exit 0
-        fi
-        count=$(echo "$changed_py" | wc -l)
-        echo "Checking ruff format on $count changed Python files:"
-        echo "$changed_py" | sed 's/^/  /'
-        echo "$changed_py" | xargs uv run ruff format --check
-
-  ast-grep:
-    name: AST Lint
-    runs-on: ubuntu-latest
-    container:
-      # renovate: datasource=docker depName=ghcr.io/astral-sh/uv
-      image: ghcr.io/astral-sh/uv:0.12.7-python3.13-trixie-slim
-    timeout-minutes: 2
-
-    steps:
-    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-      with:
-        persist-credentials: false
-
-    - name: Install dependencies
-      run: uv sync --dev
-
-    - name: Run ast-grep
-      run: uv run ast-grep scan
-
-  mypy:
-    name: Mypy Type Check
-    runs-on: ubuntu-latest
-    container:
-      # renovate: datasource=docker depName=ghcr.io/astral-sh/uv
-      image: ghcr.io/astral-sh/uv:0.12.7-python3.13-trixie-slim
-    timeout-minutes: 5
-
-    steps:
-    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-      with:
-        persist-credentials: false
-
-    - name: Install dependencies
-      run: uv sync --dev
-
-    - name: Run mypy
-      run: |
-        uv run mypy src/ custom_components/ homeassistant-addon/ scripts/
-        uv run mypy homeassistant-addon-webhook-proxy/
-        uv run mypy homeassistant-addon-webhook-proxy-dev/
 
   # Fast unit tests (no Docker, no HA instance needed)
   unit-tests:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -227,9 +227,14 @@ jobs:
         persist-credentials: false
 
     - name: Install uv
+      # Pinned, not "latest": the folded jobs got uv from the Renovate-pinned
+      # container image, and `uv lock --check` is sensitive to the uv version.
+      # Renovate bumps this pin (github-releases datasource) alongside the
+      # unit-tests job's container image tag.
       uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
       with:
-        version: "latest"
+        # renovate: datasource=github-releases depName=astral-sh/uv
+        version: "0.12.7"
 
     - name: Set up Python
       run: uv python install ${{ env.PYTHON_VERSION }}
@@ -488,7 +493,8 @@ jobs:
     - name: Install uv
       uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
       with:
-        version: "latest"
+        # renovate: datasource=github-releases depName=astral-sh/uv
+        version: "0.12.7"
 
     - name: Set up Python
       run: uv python install ${{ env.PYTHON_VERSION }}
@@ -578,7 +584,8 @@ jobs:
     - name: Install uv
       uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
       with:
-        version: "latest"
+        # renovate: datasource=github-releases depName=astral-sh/uv
+        version: "0.12.7"
 
     - name: Set up Python
       run: uv python install ${{ env.PYTHON_VERSION }}
@@ -684,7 +691,8 @@ jobs:
     - name: Install uv
       uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
       with:
-        version: "latest"
+        # renovate: datasource=github-releases depName=astral-sh/uv
+        version: "0.12.7"
 
     - name: Set up Python
       run: uv python install ${{ env.PYTHON_VERSION }}
@@ -775,7 +783,8 @@ jobs:
     - name: Install uv
       uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
       with:
-        version: "latest"
+        # renovate: datasource=github-releases depName=astral-sh/uv
+        version: "0.12.7"
 
     - name: Set up Python
       run: uv python install ${{ env.PYTHON_VERSION }}
@@ -888,7 +897,8 @@ jobs:
     - name: Install uv
       uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
       with:
-        version: "latest"
+        # renovate: datasource=github-releases depName=astral-sh/uv
+        version: "0.12.7"
 
     - name: Set up Python
       run: uv python install ${{ env.PYTHON_VERSION }}
@@ -967,7 +977,8 @@ jobs:
     - name: Install uv
       uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
       with:
-        version: "latest"
+        # renovate: datasource=github-releases depName=astral-sh/uv
+        version: "0.12.7"
 
     - name: Set up Python
       run: uv python install ${{ env.PYTHON_VERSION }}

--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -90,6 +90,9 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          # renovate: datasource=github-releases depName=astral-sh/uv
+          version: "0.12.7"
 
       - name: Temporarily set package name and version for dev build
         run: |

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -143,6 +143,9 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          # renovate: datasource=github-releases depName=astral-sh/uv
+          version: "0.12.7"
 
       - name: Build distribution
         run: uv build
@@ -273,6 +276,9 @@ jobs:
       - name: Install uv
         if: ${{ needs.publish_pypi.result == 'success' && needs.publish_docker.result == 'success' }}
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          # renovate: datasource=github-releases depName=astral-sh/uv
+          version: "0.12.7"
 
       - name: Validate server manifest
         if: ${{ needs.publish_pypi.result == 'success' && needs.publish_docker.result == 'success' }}

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,9 +1,10 @@
 name: Validate
 
+# No pull_request trigger: PR-time HACS and Hassfest run as steps of pr.yml's
+# Fast Checks lane (issue #2311). What stays here is the post-merge and weekly
+# sweep, which catches upstream validator changes that no PR would have run.
 on:
   push:
-    branches: [master]
-  pull_request:
     branches: [master]
   schedule:
     - cron: "0 6 * * 1"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,7 @@ uv run mypy src/                   # Type check
 uv run ast-grep scan               # AST lint (error handling patterns)
 ```
 
-On every commit, hooks run `ruff check --fix` (lint), `ast-grep scan` (AST lint), `mypy` (type check), and unit tests in parallel via [lefthook](https://github.com/evilmartians/lefthook). The **Fast Checks** CI job also enforces these on pull requests, alongside the lockfile, docs-size, HACS and Hassfest checks, and additionally runs `ruff format --check` on changed Python files.
+On every commit, hooks run `ruff check --fix` (lint), `ast-grep scan` (AST lint), `mypy` (type check), and unit tests in parallel via [lefthook](https://github.com/evilmartians/lefthook). On pull requests the **Fast Checks** CI job enforces the lint, AST lint, and type checks (unit tests run in the separate **Unit Tests** job), alongside the lockfile, docs-size, HACS and Hassfest checks, and additionally runs `ruff format --check` on changed Python files.
 
 ## 🔄 Migrating from pre-commit to lefthook
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,7 @@ uv run mypy src/                   # Type check
 uv run ast-grep scan               # AST lint (error handling patterns)
 ```
 
-On every commit, hooks run `ruff check --fix` (lint), `ast-grep scan` (AST lint), `mypy` (type check), and unit tests in parallel via [lefthook](https://github.com/evilmartians/lefthook). On pull requests the **Fast Checks** CI job enforces the lint, AST lint, and type checks (unit tests run in the separate **Unit Tests** job), alongside the lockfile, docs-size, HACS and Hassfest checks, and additionally runs `ruff format --check` on changed Python files.
+On every commit, hooks run `ruff check --fix` (lint), `ast-grep scan` (AST lint), `mypy` (type check), and unit tests in parallel via [lefthook](https://github.com/evilmartians/lefthook). On pull requests the **Fast Checks** CI job re-runs the lint, AST lint and type checks, plus `ruff format --check` on changed Python files, the `uv.lock` sync check, the HA-core constraint-alignment check, the docs-size check, and HACS and Hassfest validation. Unit tests run in the separate **Unit Tests** job.
 
 ## 🔄 Migrating from pre-commit to lefthook
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,7 @@ uv run mypy src/                   # Type check
 uv run ast-grep scan               # AST lint (error handling patterns)
 ```
 
-On every commit, hooks run `ruff check --fix` (lint), `ast-grep scan` (AST lint), `mypy` (type check), and unit tests in parallel via [lefthook](https://github.com/evilmartians/lefthook). The **Ruff Lint** and **AST Lint** CI jobs also enforce these on pull requests; **Ruff Lint** additionally runs `ruff format --check` on changed Python files.
+On every commit, hooks run `ruff check --fix` (lint), `ast-grep scan` (AST lint), `mypy` (type check), and unit tests in parallel via [lefthook](https://github.com/evilmartians/lefthook). The **Fast Checks** CI job also enforces these on pull requests, alongside the lockfile, docs-size, HACS and Hassfest checks, and additionally runs `ruff format --check` on changed Python files.
 
 ## 🔄 Migrating from pre-commit to lefthook
 

--- a/renovate.json
+++ b/renovate.json
@@ -92,6 +92,14 @@
   ],
   "packageRules": [
     {
+      "description": "The setup-uv version pin (github-releases) and the uv container image (docker) must move together: pr.yml's Fast Checks lane and unit-tests job assume the same uv version",
+      "matchDepNames": [
+        "astral-sh/uv",
+        "ghcr.io/astral-sh/uv"
+      ],
+      "groupName": "uv"
+    },
+    {
       "description": "Keep Python interpreter changes coordinated while allowing same-tag digest refreshes",
       "matchManagers": [
         "dockerfile"

--- a/renovate.json
+++ b/renovate.json
@@ -48,7 +48,8 @@
         "/.github/workflows/.*\\.yml$/"
       ],
       "matchStrings": [
-        "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)\\s+.*?\\S+:(?<currentValue>[\\d.]+)"
+        "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)\\s+.*?\\S+:(?<currentValue>[\\d.]+)",
+        "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)\\s+version: \"(?<currentValue>[\\d.]+)\""
       ],
       "depNameTemplate": "{{{depName}}}",
       "datasourceTemplate": "{{{datasource}}}"

--- a/tests/src/unit/test_fast_checks_workflow_shape.py
+++ b/tests/src/unit/test_fast_checks_workflow_shape.py
@@ -136,11 +136,12 @@ def _setup_uv_sites() -> list[tuple[Path, dict[str, Any]]]:
         for job in (data.get("jobs") or {}).values():
             if not isinstance(job, dict):
                 continue
-            for step in job.get("steps", []):
-                if isinstance(step, dict) and str(step.get("uses", "")).startswith(
-                    "astral-sh/setup-uv"
-                ):
-                    sites.append((path, step))
+            sites.extend(
+                (path, step)
+                for step in job.get("steps", [])
+                if isinstance(step, dict)
+                and str(step.get("uses", "")).startswith("astral-sh/setup-uv")
+            )
     return sites
 
 

--- a/tests/src/unit/test_fast_checks_workflow_shape.py
+++ b/tests/src/unit/test_fast_checks_workflow_shape.py
@@ -1,0 +1,199 @@
+"""Shape pins for pr.yml's Fast Checks lane and the repo-wide setup-uv pins.
+
+The lane folds seven required checks into one job (#2311), and its job comment
+declares two invariants load-bearing: the clean-tree validators (HACS,
+Hassfest) run before any step that executes PR-controlled code, and every step
+after the first check carries ``if: success() || failure()`` so one red check
+cannot hide another. A comment is not a gate — these tests read the workflow
+YAML directly, pass on arrival, and fire only when an edit drops a clause.
+
+The setup-uv tests are a ratchet: ``version: "latest"`` is setup-uv's default
+when the key is omitted, so the 27-site pinning sweep (#2311) regresses one
+copy-paste at a time unless the pinned shape is asserted. The Renovate test
+executes renovate.json's matchStrings against the real workflow text because a
+custom regex manager that silently stops matching freezes every pin forever
+with no red check — the exact failure the pins exist to prevent.
+"""
+
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_WORKFLOW_DIR = _REPO_ROOT / ".github" / "workflows"
+_PR_YML = _WORKFLOW_DIR / "pr.yml"
+
+# Steps allowed to precede the validators: the checkout, the docs-size check
+# (reads AGENTS.md, executes nothing from the tree), and the fixture handling
+# Hassfest itself needs. Everything else executes PR-controlled code.
+_PRE_VALIDATOR_ALLOWLIST = {
+    "(checkout)",
+    "Docs Size Check",
+    "HACS validation",
+    "Remove vendored test fixtures",
+    "Hassfest",
+    "Restore vendored test fixtures",
+}
+
+
+def _fast_checks_job() -> dict[str, Any]:
+    data = yaml.safe_load(_PR_YML.read_text(encoding="utf-8"))
+    return data["jobs"]["fast-checks"]
+
+
+def _steps() -> list[dict[str, Any]]:
+    return _fast_checks_job()["steps"]
+
+
+def _step_name(step: dict[str, Any]) -> str:
+    return step.get("name") or "(checkout)"
+
+
+def test_clean_tree_validators_precede_pr_controlled_execution() -> None:
+    """ORDER IS LOAD-BEARING: uv sync runs the PR's own PEP 517 backend."""
+    names = [_step_name(step) for step in _steps()]
+    hassfest = names.index("Hassfest")
+    hacs = names.index("HACS validation")
+    assert hacs < hassfest
+    for index, step in enumerate(_steps()):
+        text = str(step.get("run", "")) + str(step.get("uses", ""))
+        executes_tree = "uv" in text.split("#")[0] or "setup-uv" in text
+        if executes_tree:
+            assert index > hassfest, (
+                f"step {_step_name(step)!r} executes PR-controlled code before "
+                "the clean-tree validators - a PR-supplied build backend or "
+                "script could rewrite the tree HACS/Hassfest certify "
+                "(pr.yml ORDER IS LOAD-BEARING, Codex review on #2314)"
+            )
+    for name in names[: hassfest + 1]:
+        assert name in _PRE_VALIDATOR_ALLOWLIST, (
+            f"step {name!r} was inserted above Hassfest - only steps that "
+            "execute nothing from the tree may precede the validators"
+        )
+
+
+def test_every_step_after_the_first_check_reports_on_a_red_run() -> None:
+    """The failure-attribution requirement: one red cannot hide another."""
+    steps = _steps()
+    for step in steps[2:]:
+        assert step.get("if") == "success() || failure()", (
+            f"step {_step_name(step)!r} would be skipped after an earlier red "
+            "step, hiding its own result - and `always()` is deliberately "
+            "rejected so a cancelled run stops (pr.yml failure-attribution "
+            "comment)"
+        )
+
+
+def test_mypy_step_accumulates_instead_of_aborting() -> None:
+    """Under `bash -e` the first failing tree would hide the other two."""
+    mypy = next(step for step in _steps() if _step_name(step) == "Run mypy")
+    run = str(mypy["run"])
+    for line in run.splitlines():
+        if "uv run mypy" in line:
+            assert "|| status=1" in line, (
+                "a mypy invocation without `|| status=1` aborts the block on "
+                "its first error and hides every later tree's errors"
+            )
+    assert 'exit "$status"' in run
+
+
+def test_fixture_restore_verifies_its_own_postcondition() -> None:
+    """A silently failed restore shrinks ruff/ast-grep/format coverage."""
+    names = [_step_name(step) for step in _steps()]
+    restore = names.index("Restore vendored test fixtures")
+    assert restore == names.index("Hassfest") + 1
+    run = str(_steps()[restore]["run"])
+    assert "git checkout HEAD -- tests/initial_test_state" in run
+    assert "git diff --quiet HEAD -- tests/initial_test_state" in run, (
+        "the restore must assert its postcondition: the fixture tree holds "
+        "tracked .py files the later lint steps walk"
+    )
+
+
+def test_pr_time_hacs_and_hassfest_survive_in_the_lane() -> None:
+    """validate.yml lost its pull_request trigger; this lane is the only
+    PR-time run of both validators now."""
+    uses = [str(step.get("uses", "")) for step in _steps()]
+    assert any(u.startswith("hacs/action@") for u in uses)
+    assert any(u.startswith("home-assistant/actions/hassfest@") for u in uses)
+
+
+def test_lane_timeout_matches_the_fetch_budget_docstring() -> None:
+    """test_ha_constraint_alignment sizes its 60s fetch budget against this
+    number; keep the two in sync."""
+    assert _fast_checks_job()["timeout-minutes"] == 15
+
+
+def _setup_uv_sites() -> list[tuple[Path, dict[str, Any]]]:
+    sites = []
+    for path in sorted(_WORKFLOW_DIR.glob("*.yml")):
+        data = yaml.safe_load(path.read_text(encoding="utf-8"))
+        if not isinstance(data, dict):
+            continue
+        for job in (data.get("jobs") or {}).values():
+            if not isinstance(job, dict):
+                continue
+            for step in job.get("steps", []):
+                if isinstance(step, dict) and str(step.get("uses", "")).startswith(
+                    "astral-sh/setup-uv"
+                ):
+                    sites.append((path, step))
+    return sites
+
+
+def test_every_setup_uv_site_pins_a_full_version() -> None:
+    """`latest` is setup-uv's default when `version:` is omitted - the 28th
+    site reintroduces the floating-tool problem the sweep removed (#2311)."""
+    sites = _setup_uv_sites()
+    assert len(sites) >= 20, "the setup-uv sweep matched almost nothing"
+    for path, step in sites:
+        version = (step.get("with") or {}).get("version")
+        assert isinstance(version, str) and re.fullmatch(r"\d+\.\d+\.\d+", version), (
+            f"{path.name}: setup-uv must pin a full x.y.z version, got "
+            f"{version!r} - an omitted key or 'latest' floats with uv "
+            "releases and can redden CI with zero repo change"
+        )
+
+
+def test_renovate_matchstrings_actually_match_the_setup_uv_pins() -> None:
+    """A custom regex manager that stops matching fails open: no PR, no red
+    check, every pin frozen forever."""
+    config = json.loads((_REPO_ROOT / "renovate.json").read_text())
+    patterns = [
+        re.compile(match.replace("?<", "?P<"), re.DOTALL)
+        for manager in config["customManagers"]
+        for match in manager["matchStrings"]
+    ]
+    for path, step in _setup_uv_sites():
+        version = (step.get("with") or {}).get("version")
+        text = path.read_text(encoding="utf-8")
+        captured = {
+            found.group("currentValue")
+            for pattern in patterns
+            for found in pattern.finditer(text)
+        }
+        assert version in captured, (
+            f"{path.name}: no renovate.json matchString captures the pin "
+            f"{version!r} - Renovate would silently never bump it"
+        )
+
+
+def test_renovate_groups_the_uv_pin_with_the_uv_container_image() -> None:
+    """pr.yml's comment promises the setup-uv pin and the unit-tests container
+    image move in one Renovate PR; only a packageRules group delivers that."""
+    config = json.loads((_REPO_ROOT / "renovate.json").read_text())
+    for rule in config.get("packageRules", []):
+        if set(rule.get("matchDepNames", [])) >= {
+            "astral-sh/uv",
+            "ghcr.io/astral-sh/uv",
+        }:
+            assert rule.get("groupName"), "the uv rule must set a groupName"
+            return
+    raise AssertionError(
+        "renovate.json has no packageRules entry grouping astral-sh/uv "
+        "(github-releases) with ghcr.io/astral-sh/uv (docker) - the two pins "
+        "would drift across separate Renovate PRs"
+    )

--- a/tests/src/unit/test_ha_constraint_alignment.py
+++ b/tests/src/unit/test_ha_constraint_alignment.py
@@ -4,7 +4,7 @@ The script is the mechanical link between ha-mcp's direct dependencies and
 HA core's ``package_constraints.txt``: where HA pins exactly we must admit
 the pin, and where HA is loose we must not pin exactly (the forced in-place
 replacement that tears packages). These tests pin the two rules offline; the
-lockfile CI job runs the script against the live constraints of the HA
+Fast Checks CI lane runs the script against the live constraints of the HA
 version the e2e lanes test.
 """
 
@@ -95,8 +95,8 @@ class TestRepoPyprojectIsAligned:
     Uses a constraints sample frozen from the HA release the suite pins
     (HA_TEST_IMAGE / HA_IMAGE_GHCR), covering the packages ha-mcp actually
     shares with HA — the live check against that same version runs in CI
-    (lockfile job), where drift on either side should fail the PR that
-    introduces it, not this offline test.
+    (the Fast Checks lane), where drift on either side should fail the PR
+    that introduces it, not this offline test.
     """
 
     def test_current_pyproject_has_no_violations(self):
@@ -151,7 +151,7 @@ class TestMarkerAndOperatorHandling:
 
 
 class TestMainExitCodes:
-    """The lockfile CI job invokes main(); its exit codes are the contract."""
+    """The Fast Checks CI lane invokes main(); its exit codes are the contract."""
 
     def test_clean_alignment_exits_zero(self, tmp_path):
         constraints = tmp_path / "cons.txt"
@@ -273,9 +273,9 @@ class TestFetchFailurePath:
             for n in range(checker._FETCH_ATTEMPTS - 1)
         )
         assert budget <= 60, (
-            f"worst-case fetch is {budget}s; the lockfile job also checks the "
-            "lockfile and resolves packages, so keep this well under its "
-            "timeout-minutes or exit 2 becomes an opaque kill"
+            f"worst-case fetch is {budget}s; the Fast Checks lane shares one "
+            "timeout-minutes across every fast check, so keep this well under "
+            "it or exit 2 becomes an opaque kill"
         )
 
     def test_unreadable_local_file_exits_two(self, tmp_path):

--- a/tests/src/unit/test_ha_constraint_alignment.py
+++ b/tests/src/unit/test_ha_constraint_alignment.py
@@ -173,12 +173,13 @@ class TestMainExitCodes:
 class TestFetchFailurePath:
     """The fetch budget the CI job's timeout is sized against.
 
-    pr.yml raised the lockfile job to 5 minutes and treats
+    pr.yml runs this check as a step of the Fast Checks lane and treats
     EXIT_CONSTRAINTS_UNREACHABLE as a fail-open warning on the reasoning
-    that a fetch failure resolves FAST and distinctly. Restoring a long
-    timeout or a trailing sleep would push the worst case past the job
-    budget, turning that clean exit into an opaque runner kill — the exact
-    outcome the comments say must not happen.
+    that a fetch failure resolves FAST and distinctly. That lane's 15-minute
+    budget is shared with every other fast check, so restoring a long timeout
+    or a trailing sleep would push the worst case past it, turning that clean
+    exit into an opaque runner kill — the exact outcome the comments say must
+    not happen.
     """
 
     def _patch_fetch(self, monkeypatch, *, sleeps, attempts):

--- a/tests/src/unit/test_haos_image_workflow_shape.py
+++ b/tests/src/unit/test_haos_image_workflow_shape.py
@@ -220,8 +220,6 @@ def test_beta_lanes_share_a_current_supervisor_and_core_image() -> None:
     workflow = _workflow(beta_path)
 
     triggers = workflow[True]
-    # No pull_request trigger (#2311): the beta lanes run nightly and on the
-    # master push after each merge, never per PR push.
     assert "pull_request" not in triggers, (
         "beta lanes must not run per PR push (#2311) - a per-PR beta failure "
         "blames every open PR for an upstream change none of them made"
@@ -232,18 +230,21 @@ def test_beta_lanes_share_a_current_supervisor_and_core_image() -> None:
     assert {entry["cron"] for entry in triggers["schedule"]} == {
         cron for _job_id, _mode, cron, _stable_job_id in lane_specs
     }, "the shared file must carry exactly the two lanes' nightly slots"
-    classifier = next(
-        step
-        for step in _job_steps(workflow["jobs"]["changes"])
-        if step.get("id") == "filter"
+    # No `changes` classifier job (#2311): with pull_request gone every
+    # surviving trigger is a trusted ref, so a docs-only classifier could only
+    # ever compute run=true while burning a runner per nightly and per merge.
+    assert "changes" not in workflow["jobs"], (
+        "a docs-only classifier is dead weight here - no pull_request trigger "
+        "means it can never authorize a skip (#2311)"
     )
-    assert "git diff --no-renames --name-only --diff-filter=ACMD" in classifier["run"]
 
     for beta_job_id, mode, cron, stable_job_id in lane_specs:
         job = workflow["jobs"][beta_job_id]
 
-        assert job["needs"] == "changes"
-        assert "needs.changes.outputs.run != 'false'" in job["if"]
+        assert "needs" not in job, (
+            f"{beta_job_id} gained a needs: dependency - nothing in this "
+            "workflow should gate the lanes any more (#2311)"
+        )
         assert f"github.event.schedule == '{cron}'" in job["if"], (
             f"{beta_job_id} must claim its own nightly slot, or the shared "
             "schedule trigger starts it on the other lane's cron too"

--- a/tests/src/unit/test_haos_image_workflow_shape.py
+++ b/tests/src/unit/test_haos_image_workflow_shape.py
@@ -220,7 +220,12 @@ def test_beta_lanes_share_a_current_supervisor_and_core_image() -> None:
     workflow = _workflow(beta_path)
 
     triggers = workflow[True]
-    assert triggers["pull_request"] is None
+    # No pull_request trigger (#2311): the beta lanes run nightly and on the
+    # master push after each merge, never per PR push.
+    assert "pull_request" not in triggers, (
+        "beta lanes must not run per PR push (#2311) - a per-PR beta failure "
+        "blames every open PR for an upstream change none of them made"
+    )
     assert triggers["push"]["branches"] == ["master"]
     assert triggers["schedule"]
     assert all(entry.get("cron") for entry in triggers["schedule"])
@@ -244,7 +249,7 @@ def test_beta_lanes_share_a_current_supervisor_and_core_image() -> None:
             "schedule trigger starts it on the other lane's cron too"
         )
         assert "github.event_name != 'schedule'" in job["if"], (
-            f"{beta_job_id} would never run on pull_request / push / dispatch, "
+            f"{beta_job_id} would never run on push / dispatch, "
             "where github.event.schedule is empty"
         )
         for other_cron in (c for _j, _m, c, _s in lane_specs if c != cron):

--- a/tests/src/unit/test_locale_parity.py
+++ b/tests/src/unit/test_locale_parity.py
@@ -161,10 +161,8 @@ def _discover_translation_surfaces() -> set[str]:
         completed = subprocess.run(
             # The unit-test job runs in a container against a checkout owned by
             # another uid, and actions/checkout's safe.directory lands in a temp
-            # HOME that container jobs don't see — the Ruff Lint job's "Run ruff
-            # format check on changed Python files" step re-adds it by hand for
-            # the same reason. Without this, git refuses the repo as dubious
-            # ownership and the check dies with an empty stderr.
+            # HOME that container jobs don't see. Without this, git refuses the
+            # repo as dubious ownership and the check dies with an empty stderr.
             ["git", "-c", "safe.directory=*", "ls-files", "-z"],
             cwd=_REPO_ROOT,
             capture_output=True,

--- a/tests/src/unit/test_ruff_scope_covers_the_tree.py
+++ b/tests/src/unit/test_ruff_scope_covers_the_tree.py
@@ -63,10 +63,10 @@ def _holds_python(directory: Path) -> bool:
     """True if the tree under ``directory`` contains a ``.py`` file.
 
     Walked directly rather than via ``git ls-files`` so the test does not
-    depend on git being installed, or on the checkout passing git's
-    ownership check — CI containers run as a different UID than the checkout
-    owner, which is why ``pr.yml`` re-adds ``safe.directory`` for its own git
-    calls.
+    depend on git being installed, or on the checkout passing git's ownership
+    check — this test's own job (``unit-tests``) runs in a container as a
+    different UID than the checkout owner, which is why the tests that do shell
+    out to git pass ``-c safe.directory=*`` per invocation.
     """
     for path in directory.rglob("*.py"):
         if any(


### PR DESCRIPTION
## What does this PR do?

Folds seven separate CI jobs — and seven required status contexts — into one `Fast Checks` job on `pr.yml`. Part of #2311.

Folded in: **Check uv.lock**, **Docs Size Check**, **Ruff Lint**, **AST Lint** and **Mypy Type Check** (all from `pr.yml`), plus **HACS** and **Hassfest**, which `validate.yml` ran on its `pull_request` trigger.

Each of these finishes in a couple of minutes, and three of them (`lint`, `ast-grep`, `mypy`) each paid for their own `uv sync --dev`. Folded into one lane they share a single install, and the PR's check list gets six rows shorter.

### Baseline

Measured on the head commit of #2302: **39 check runs across 8 workflows**, 18 from `pr.yml` and 2 from `validate.yml`. All 39 report under the `github-actions` app slug — including all three CodeQL runs, which come from the repo's own `codeql-quality.yml`, so nothing beyond that custom workflow feeds the `CodeQL Gate` context. After this PR the same push would report **33**.

### Why a plain runner and not the uv container

The folded `pr.yml` jobs (except `docs-size`) ran in `ghcr.io/astral-sh/uv:...-trixie-slim`. `hacs/action` is a Docker action and `hassfest` a composite action that shells out to `docker run` — neither can work inside a container job, which has no docker CLI or socket — so the combined lane runs on plain `ubuntu-latest` and gets uv from `astral-sh/setup-uv`, version-pinned (see below). Leaving the container also drops the `apt-get install git` step and the `safe.directory` workaround — both existed only for the container's UID mismatch (their own comments said so). The rest of the format script is byte-identical, including the changed-files-only gate from #1318.

### Every setup-uv is now version-pinned

Every `astral-sh/setup-uv` site in the repo (26 across 10 workflows) ran `version: "latest"` or omitted the version, which defaults to it — an unpinned external tool in CI, where a new uv release can redden lanes with zero repo change; `uv lock --check` is the most version-sensitive consumer. All are now pinned to `0.12.7` (the current latest, so no behavior change today) behind a `# renovate: datasource=github-releases depName=astral-sh/uv` comment, with a matching matchString added to `renovate.json`'s existing workflow regex manager, and the setup-uv pin grouped with the uv container image (`groupName: uv`) so both move in one Renovate PR. `tests/src/unit/test_fast_checks_workflow_shape.py` pins the lane's load-bearing invariants — validator ordering, the per-step `if:` guards, the repo-wide version-pin ratchet, and that the renovate matchStrings actually match every pin site.

### Failure attribution

Every step after the first check carries `if: success() || failure()`, so the lane reports **every** check on a red run — a ruff failure can't hide a mypy failure (the mypy step likewise accumulates per-tree status instead of aborting under `bash -e`). Deliberately not `always()`: a cancelled run stops. The fixture removal Hassfest needs runs before it and is restored — with a verified postcondition — immediately after, so every later check sees the tracked tree.

### `validate.yml`

Only the `pull_request` trigger is removed; push, the weekly schedule, and dispatch stay, and both jobs are unchanged.

### Beta HAOS lanes off pull_request

`haos-e2e-beta-tests.yml` no longer runs per PR push (~21 runner-min each). The two nightly crons catch upstream-beta breakage within a day, and the `push: master` trigger runs both lanes on each merge commit, so a merge that breaks beta compatibility is attributed to exactly that merge. Manual dispatch stays for targeted iteration. Not required checks, so no ruleset impact. `test_haos_image_workflow_shape.py` now asserts the trigger's absence.

### Clean-tree validators run first

HACS and Hassfest run immediately after checkout, before any step that executes PR-controlled code (`uv sync`'s PEP 517 project build, the lock/constraint scripts, the linters) — otherwise a PR-supplied build backend could rewrite the tree those validators certify (Codex review finding). The fixture removal Hassfest needs is restored via `git checkout` right after it, so later checks see the tree as committed. The ordering is pinned as load-bearing in the job comment.

### Ruleset changes at merge

Required contexts go 18 → 12 at merge time: **add** `Fast Checks`; **remove** `Check uv.lock`, `Docs Size Check`, `Ruff Lint`, `AST Lint`, `Mypy Type Check`, `HACS`, `Hassfest` — applied via the rulesets API alongside the merge. Merging without the removals wedges every subsequent PR on seven contexts that will never report again.

## Type of change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [x] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

## Checklist
- [x] I have updated documentation if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Reliability**
  * CI workflows now use a consistent, pinned version of the build tool instead of automatically selecting the latest release.
  * Validation reports more issues in a single run and verifies test-fixture restoration.

* **CI Improvements**
  * Pull-request checks provide clearer notices and stronger validation coverage.
  * Beta end-to-end tests no longer run for pull requests.

* **Maintenance**
  * Automated updates now track and group related tool releases.
  * Contributor guidance and test documentation better describe current CI checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->