### PR TITLE
ci: SMOKE TEST - Fast Checks failure attribution (#2311) - DO NOT MERGE

### DIFF
--- a/scripts/smoke_ci_2311.py
+++ b/scripts/smoke_ci_2311.py
@@ -1,12 +1,6 @@
-"""Intentional Fast Checks smoke-test violations for #2311. Never merge."""
-
-import os
-import sys
+"""Fast Checks smoke-test file for #2311 (PR is never merged)."""
 
 
 def smoke() -> int:
-    value: int = "not an int"
-    return value
-
-
-BAD_FORMAT = {  'spacing' : 1,   'quotes'  :2 }
+    """Return a constant; exists so the diff is non-empty and clean."""
+    return 1

--- a/scripts/smoke_ci_2311.py
+++ b/scripts/smoke_ci_2311.py
@@ -1,0 +1,12 @@
+"""Intentional Fast Checks smoke-test violations for #2311. Never merge."""
+
+import os
+import sys
+
+
+def smoke() -> int:
+    value: int = "not an int"
+    return value
+
+
+BAD_FORMAT = {  'spacing' : 1,   'quotes'  :2 }


### PR DESCRIPTION
Deliberate ruff (unused imports), ruff-format (spacing/quotes), and mypy (int = str) violations to verify the folded Fast Checks lane reports every failing step while HACS/Hassfest and the remaining checks still run. Will be closed, never merged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated the smoke-test fixture to use valid, clean code.
  * Removed intentionally invalid type assignments and formatting violations from the test scenario.
  * Simplified the fixture by removing unused imports and obsolete test data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->