### PR TITLE
docs: SMOKE TEST - docs-only skip path (#2311) - DO NOT MERGE

### DIFF
--- a/docs/beta.md
+++ b/docs/beta.md
@@ -304,3 +304,5 @@ validates legacy `dashboard_path` values (rejects URLs, query strings,
 fragments, `..`, and backslashes) and checks the first route segment against
 Home Assistant's registered Lovelace dashboards. A raw path therefore cannot
 use Puppet's independent credential to render another frontend panel.
+
+<!-- smoke test #2311: docs-only skip path; never merged -->


### PR DESCRIPTION
One markdown comment line. Verifies that after the Fast Checks fold + ruleset swap, a docs-only PR skips the heavy lanes and still satisfies all 12 required contexts. Will be closed, never merged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added an internal note to the dashboard screenshot documentation.
  * No user-facing content or functionality was changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->