### PR TITLE
fix(oauth): percent-encode the query forwarded to core's /auth/authorize

### DIFF
--- a/custom_components/ha_mcp_tools/oauth_autoapprove.py
+++ b/custom_components/ha_mcp_tools/oauth_autoapprove.py
@@ -303,13 +303,24 @@ class AutoApproveAuthorizeView(HomeAssistantView):
         if forward_id != client_id:
             params.popall("client_id", None)
             params["client_id"] = forward_id
-        import yarl
+        from urllib.parse import urlencode
 
         # Keep the browser hop relative, matching the token leg. Browsers cannot
         # be made to send X-Forwarded-Host, so this is consistency rather than a
         # vulnerability fix.
-        target = yarl.URL("/auth/authorize").with_query(params)
-        return web.Response(status=302, headers={"Location": str(target)})
+        #
+        # Percent-encode the query instead of handing the params to yarl: yarl
+        # legally leaves ":" and "/" literal inside query values (RFC 3986
+        # permits both in the query component), so a loopback client's callback
+        # forwards as ``redirect_uri=http://127.0.0.1:1234/callback``. Reverse
+        # proxies shipping a generic "block common exploits" ruleset -- Nginx
+        # Proxy Manager enables one per host with a checkbox -- match
+        # ``[a-zA-Z0-9_]=http://`` and answer 403 before core ever sees the
+        # request, stranding every native-app client behind such a proxy.
+        # Full encoding is semantically identical and survives those filters.
+        query = urlencode(list(params.items()))
+        target = f"/auth/authorize?{query}" if query else "/auth/authorize"
+        return web.Response(status=302, headers={"Location": target})
 
     async def post(self, request: web.Request) -> web.Response:
         """Handle a legacy-mode consent submission on the scoped route."""

--- a/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/oauth_autoapprove.py
+++ b/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/oauth_autoapprove.py
@@ -353,10 +353,20 @@ class AutoApproveAuthorizeView(HomeAssistantView):
             params.popall("client_id", None)
             params["client_id"] = forward_id
 
-        import yarl
+        from urllib.parse import urlencode
 
-        target = yarl.URL("/auth/authorize").with_query(params)
-        return web.Response(status=302, headers={"Location": str(target)})
+        # Percent-encode the query instead of handing the params to yarl: yarl
+        # legally leaves ":" and "/" literal inside query values (RFC 3986
+        # permits both in the query component), so a loopback client's callback
+        # forwards as ``redirect_uri=http://127.0.0.1:1234/callback``. Reverse
+        # proxies shipping a generic "block common exploits" ruleset -- Nginx
+        # Proxy Manager enables one per host with a checkbox -- match
+        # ``[a-zA-Z0-9_]=http://`` and answer 403 before core ever sees the
+        # request, stranding every native-app client behind such a proxy.
+        # Full encoding is semantically identical and survives those filters.
+        query = urlencode(list(params.items()))
+        target = f"/auth/authorize?{query}" if query else "/auth/authorize"
+        return web.Response(status=302, headers={"Location": target})
 
     async def post(self, request: web.Request) -> web.Response:
         """Handle legacy consent submissions on the scoped authorize route."""

--- a/homeassistant-addon-webhook-proxy/mcp_proxy/oauth_autoapprove.py
+++ b/homeassistant-addon-webhook-proxy/mcp_proxy/oauth_autoapprove.py
@@ -353,10 +353,20 @@ class AutoApproveAuthorizeView(HomeAssistantView):
             params.popall("client_id", None)
             params["client_id"] = forward_id
 
-        import yarl
+        from urllib.parse import urlencode
 
-        target = yarl.URL("/auth/authorize").with_query(params)
-        return web.Response(status=302, headers={"Location": str(target)})
+        # Percent-encode the query instead of handing the params to yarl: yarl
+        # legally leaves ":" and "/" literal inside query values (RFC 3986
+        # permits both in the query component), so a loopback client's callback
+        # forwards as ``redirect_uri=http://127.0.0.1:1234/callback``. Reverse
+        # proxies shipping a generic "block common exploits" ruleset -- Nginx
+        # Proxy Manager enables one per host with a checkbox -- match
+        # ``[a-zA-Z0-9_]=http://`` and answer 403 before core ever sees the
+        # request, stranding every native-app client behind such a proxy.
+        # Full encoding is semantically identical and survives those filters.
+        query = urlencode(list(params.items()))
+        target = f"/auth/authorize?{query}" if query else "/auth/authorize"
+        return web.Response(status=302, headers={"Location": target})
 
     async def post(self, request: web.Request) -> web.Response:
         """Handle legacy consent submissions on the scoped authorize route."""

--- a/tests/src/unit/test_oauth_autoapprove.py
+++ b/tests/src/unit/test_oauth_autoapprove.py
@@ -716,6 +716,40 @@ async def test_ha_auth_authorize_preserves_repeated_resource_parameters(
     ]
 
 
+async def test_ha_auth_authorize_percent_encodes_the_forwarded_query(
+    unified_view_client_factory,
+):
+    """Forward a loopback callback percent-encoded, not as a literal URL.
+
+    yarl legally leaves ":" and "/" unencoded inside a query value, which
+    renders a native-app callback as ``redirect_uri=http://127.0.0.1:1234/cb``.
+    Reverse proxies shipping a generic "block common exploits" ruleset -- Nginx
+    Proxy Manager enables one per host with a checkbox -- match
+    ``[a-zA-Z0-9_]=http://`` and answer 403 before core ever sees the request,
+    stranding every native-app client behind such a proxy.
+    """
+    import re
+    from urllib.parse import parse_qs, urlparse
+
+    client = await unified_view_client_factory(mode="ha_auth")
+    resp = await client.get(
+        "/api/ha_mcp_tools/oauth/authorize"
+        "?response_type=code&client_id=http%3A%2F%2F127.0.0.1%3A19877"
+        "&redirect_uri=http%3A%2F%2F127.0.0.1%3A19877%2Fmcp%2Foauth%2Fcallback"
+        "&code_challenge=" + "a" * 43 + "&code_challenge_method=S256"
+        "&state=xyz",
+        allow_redirects=False,
+    )
+    assert resp.status == 302
+    location = resp.headers["Location"]
+    # The exact pattern those proxy rulesets match must not survive the hop.
+    assert re.search(r"[a-zA-Z0-9_]=http://", location) is None
+    # ...while the parameters themselves are untouched.
+    query = parse_qs(urlparse(location).query)
+    assert query["redirect_uri"] == ["http://127.0.0.1:19877/mcp/oauth/callback"]
+    assert query["state"] == ["xyz"]
+
+
 async def test_ha_auth_token_forwards_translated_client_id(
     unified_view_client_factory, monkeypatch
 ):


### PR DESCRIPTION
## What does this PR do?

Percent-encodes the query string that `_ha_auth_authorize` forwards to core's
`/auth/authorize`, so a native-app client's loopback callback is not forwarded as
a literal URL.

`yarl.URL("/auth/authorize").with_query(params)` legally leaves `:` and `/`
unencoded inside query values (RFC 3986 permits both in the query component), so
the redirect currently reads:

```
Location: /auth/authorize?...&redirect_uri=http://127.0.0.1:1234/callback
```

Reverse proxies that ship a generic "block common exploits" ruleset match
`[a-zA-Z0-9_]=http://` — the classic file-injection rule — and answer **403
before core ever sees the request**. Nginx Proxy Manager, very common in front of
Home Assistant, enables that ruleset per proxy host with a single checkbox. The
effect is that `ha_auth` mode is unreachable for every loopback (native-app)
client behind such a proxy, while browser-based clients on `https://` callbacks
are unaffected — which makes it look like a client bug rather than a proxy one.

Observed with Claude Code against HA 2026.8.3 / ha-mcp 8.3.0 (component 2.0.0)
behind NPM: the initial `GET /api/ha_mcp_tools/oauth/authorize` is accepted, and
the 302 it returns is then rejected at `/auth/authorize`.

`urllib.parse.urlencode` is used instead. Passing `list(params.items())`
preserves the `MultiDict`, so repeated parameters (RFC 8707 `resource`) still
survive the forward, and an empty query yields a bare path rather than a trailing
`?`. This is strictly more conservative encoding — after parsing, core receives
exactly the same parameters.

Applied identically to the two webhook-proxy add-on flavors; the tree drift
guards (`WEBHOOK_PROXY_TREES_SYNCED=1`) confirm the copies stay in sync with what
`webhook_proxy_sync.py` would generate.

## Type of change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [x] I have tested these changes with a LLM agent
- [ ] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

Notes on the above, to be precise about what was and was not run:

- **Unit tests, affected areas: 329 passed.** `test_oauth_autoapprove.py`,
  `test_oauth_ha_auth.py`, `test_oauth_dcr.py`,
  `test_webhook_proxy_oauth_unified.py` and `test_webhook_proxy_sync.py`, the
  last with `WEBHOOK_PROXY_TREES_SYNCED=1` so the drift guards actually ran.
  The **full** `uv run pytest` was not run — the e2e lane needs Docker, which
  the environment this was developed in does not have. Hence that box is left
  unticked.
- **The existing authorize tests pass unchanged.** They already parse the
  `Location` rather than substring-matching it (with a comment noting yarl's
  behaviour is legal), so the change is non-breaking by construction.
- **New regression test** `test_ha_auth_authorize_percent_encodes_the_forwarded_query`
  asserts no `[a-zA-Z0-9_]=http://` survives the hop and that `redirect_uri` and
  `state` are unchanged after parsing. Confirmed it **fails on the previous
  behaviour** and passes on the new one, rather than being a tautology.
- **The output shape was checked against a real proxy.** Against a live NPM with
  "Block Common Exploits" enabled, `redirect_uri=http://localhost:.../callback`
  returns **403** and the percent-encoded equivalent returns **200**.
- `ruff check` and `ruff format --check` are clean on all four changed files.
- Not verified: the patched component running in situ end-to-end. The reporting
  user unblocked themselves by signing in over a path that bypasses the proxy, so
  the live 403 was not re-exercised against a patched build.

## Checklist
- [x] I have updated documentation if needed — no user-facing docs affected; the
      rationale lives in a code comment at the change site.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed authorization redirects containing callback URLs that could be blocked by reverse-proxy security rules.
  * Ensured redirect query parameters are safely percent-encoded while preserving their values.
  * Removed the unnecessary trailing `?` when redirects contain no query parameters.

* **Tests**
  * Added coverage verifying encoded callback URLs and preserved authorization state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->