### PR TITLE
fix(oauth): serve the protected-resource document only at its path-scoped URL

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -277,6 +277,18 @@ mode** option in the entry options:
     metadata-honoring clients are unaffected; metadata-ignoring clients that
     guess root paths reach the app instead.
 
+Discovery never publishes the webhook id, in any of the three modes. The only
+protected-resource document the entry serves is the path-scoped one at
+`/.well-known/oauth-protected-resource/api/webhook/<id>`, which a caller can
+reach only by already holding the id, and the webhook's 401 challenge points
+there rather than at a fixed, guessable path. Switching from `ha_auth` or
+`legacy` back to the secret-URL posture therefore does not promote a published
+value into the sole credential. Component versions before 2.1.1 also served the
+document at a fixed path, where it handed the full webhook URL to any
+unauthenticated GET while `ha_auth` or `legacy` was on; an install that ran
+either mode reachable from the internet on such a version should use the
+entry's **Regenerate connect secrets now** option once.
+
 The connect notification deliberately carries no secrets: Home Assistant
 shows persistent notifications to every authenticated user, so the webhook
 URL (the credential in the default posture) is surfaced only on
@@ -302,11 +314,13 @@ the proxy returns 503 whenever the server is not running.
 ### Webhook Proxy app (`ha_mcp_webhook_proxy`)
 
 In the app's `ha_auth` mode the Home Assistant login is the credential, not
-the webhook URL. The URL without a Bearer gets a 401, and the URL is not
-withheld: as in any OAuth mode, the RFC 9728 protected-resource document
-advertises it at a fixed unauthenticated path so clients can discover the
-endpoint. (This is the difference from the app's default posture with OAuth
-disabled, where the URL is withheld because it alone is the credential.)
+the webhook URL. The URL without a Bearer gets a 401, and that 401 points at
+the RFC 9728 protected-resource document served under the webhook's own path
+(`/.well-known/oauth-protected-resource/api/webhook/<id>`) — the only
+protected-resource document the app serves, and one a caller can reach only by
+already holding the id. Discovery therefore never publishes the webhook id in
+any mode, which is what lets the default posture with OAuth disabled keep
+treating that URL as the sole credential.
 
 **`ha_auth` is an access gate, not per-user authorization.** It validates the
 inbound Bearer against Home Assistant core and accepts any token core still
@@ -330,11 +344,18 @@ deactivate the account, which Home Assistant honors immediately by dropping that
 user's refresh tokens. Turning the app's OAuth mode off revokes nobody, and
 loosens the boundary: the webhook id persists across the switch, so that posture
 falls back to treating as the sole credential a URL every `ha_auth` client
-already holds — and one that was advertised anonymously the whole time `ha_auth`
-was on. Treat any webhook id that has served `ha_auth` as public, and rotate it
-(the app's DOCS.md, "Rotating the webhook URL") when moving to the URL-secret
-posture. The in-process entry's admin restriction is a property of that entry,
-not a guarantee of the app.
+already holds. Rotate the id (the app's DOCS.md, "Rotating the webhook URL")
+when moving to the URL-secret posture. A fixed-path protected-resource document
+also handed that URL to any anonymous GET the whole time `ha_auth` or `legacy`
+was on, on app versions before 3.0.3.dev2 (dev channel) and before the stable
+release that promotes it: an install that ran either mode reachable from the
+internet on such a version should treat its webhook id as public and rotate
+once, whichever posture it is moving to. From this version no anonymous URL publishes the id,
+and a rotation takes effect immediately — the previous id's discovery URL
+answers 404 as soon as the app restarts with the new id, and a Repair prompts
+for the Home Assistant restart that binds the new id's discovery URL. The
+in-process entry's admin restriction is a property of that entry, not a
+guarantee of the app.
 
 The app's `legacy` mode carries the same properties as the in-process
 `legacy` mode described above — the component's implementation was ported from

--- a/custom_components/ha_mcp_tools/const.py
+++ b/custom_components/ha_mcp_tools/const.py
@@ -25,7 +25,7 @@ DOMAIN = "ha_mcp_tools"
 # in CI. The
 # capability negotiation — not this version — gates each WS command (see
 # ``websocket_api.CAPABILITIES``).
-COMPONENT_VERSION = "2.1.0"
+COMPONENT_VERSION = "2.1.1"
 
 # Config-entry discriminator (``entry.data[CONF_ENTRY_TYPE]``). A missing value
 # means "tools" so the pre-existing services entry keeps working across the

--- a/custom_components/ha_mcp_tools/manifest.json
+++ b/custom_components/ha_mcp_tools/manifest.json
@@ -22,5 +22,5 @@
     "requirements": [
         "ruamel.yaml>=0.18.0"
     ],
-    "version": "2.1.0"
+    "version": "2.1.1"
 }

--- a/custom_components/ha_mcp_tools/mcp_webhook.py
+++ b/custom_components/ha_mcp_tools/mcp_webhook.py
@@ -29,7 +29,7 @@ mapping); the ``ha_auth`` bearer check + discovery documents mirror the add-on's
 ``auth_native.py`` + the ``ha_auth`` subset of ``oauth.py``; the ``legacy``
 provider + its root ``/authorize`` + ``/token`` views live in
 :mod:`oauth_legacy`, ported from the ``legacy`` subset of the add-on's
-``oauth.py``. The seven RFC 8414 / RFC 9728 discovery views below are shared by
+``oauth.py``. The six RFC 8414 / RFC 9728 discovery views below are shared by
 ``ha_auth``, ``legacy``, and ``none`` (which serves a distinct auto-approve
 authorization-server document pointing at :mod:`oauth_autoapprove`'s endpoints)
 — see :func:`active_auth_mode`.
@@ -387,39 +387,6 @@ def _none_mode_authorization_server_document(base: str) -> dict[str, Any]:
     }
 
 
-class _ProtectedResourceMetadataView(HomeAssistantView):
-    """RFC 9728 Protected Resource Metadata."""
-
-    requires_auth = False
-    cors_allowed = True
-    url = f"{OAUTH_BASE}/protected-resource"
-    name = "ha_mcp_tools:oauth:protected-resource"
-
-    def __init__(self, hass: HomeAssistant) -> None:
-        """Bind the view to the HA instance; liveness is resolved per request."""
-        self._hass = hass
-
-    async def get(self, request: web.Request) -> web.Response:
-        """Serve the protected-resource document for the bearer-gated modes only.
-
-        SECURITY (#1976 review): this ANONYMOUS, fixed (guessable) path exposes
-        ``resource: <base>/api/webhook/<id>``. In none mode the webhook id is the
-        SOLE credential, so serving it here would leak it to any unauthenticated
-        GET. Serve only for ``ha_auth``/``legacy`` (where the id is not a secret
-        and the 401 ``WWW-Authenticate`` pointer legitimately directs a client
-        here); 404 otherwise. The PATH-SCOPED well-known view still serves in none
-        mode — its caller must already know the id (it is a route parameter).
-        """
-        if active_auth_mode(self._hass) not in (WEBHOOK_AUTH_HA, WEBHOOK_AUTH_LEGACY):
-            return _json_not_found()
-        webhook_id = _active_webhook_id(self._hass)
-        if webhook_id is None:
-            return _json_not_found()
-        return web.json_response(
-            _protected_resource_document(webhook_id, _build_base_url(request))
-        )
-
-
 class _AuthorizationServerMetadataView(HomeAssistantView):
     """RFC 8414 Authorization Server Metadata.
 
@@ -450,12 +417,23 @@ class _AuthorizationServerMetadataView(HomeAssistantView):
 
 
 class _WellKnownProtectedResourceView(HomeAssistantView):
-    """RFC 9728 §3.1 path-scoped Protected Resource Metadata.
+    """RFC 9728 §3.1 path-scoped Protected Resource Metadata — the ONLY
+    protected-resource document this integration serves.
 
-    Same document as :class:`_ProtectedResourceMetadataView`, served at the
-    well-known location derived from the webhook resource URL — claude.ai's
-    first fallback probe when the 401's ``resource_metadata`` pointer is
-    missing. The webhook id is a ROUTE PARAMETER (not baked into the path at
+    Served at the well-known location derived from the webhook resource URL
+    (``/.well-known/oauth-protected-resource/api/webhook/<id>``), which is also
+    where the webhook's 401 ``resource_metadata`` challenge points, and which is
+    claude.ai's first fallback probe when that pointer is missing.
+
+    SECURITY (#1976 review): there is deliberately NO fixed-path variant of this
+    document. A fixed, guessable path handed ``resource: <base>/api/webhook/<id>``
+    to any anonymous GET while ``ha_auth``/``legacy`` was on, and a later switch
+    back to ``none`` mode — where the webhook id is the SOLE credential —
+    promoted that already-published value into the credential. This view's
+    caller must already hold the id (it is a route parameter), so the document
+    discloses nothing in any mode.
+
+    The webhook id is a ROUTE PARAMETER (not baked into the path at
     registration): a remove + re-add of the entry mints a new webhook id in the
     same HA session, and the bound view must serve whichever id is currently
     live (404 for any other). Standalone view (not a subclass of the plain
@@ -496,10 +474,11 @@ class _WellKnownAuthorizationServerMetadataView(_AuthorizationServerMetadataView
 
 
 def _metadata_views(hass: HomeAssistant) -> list[HomeAssistantView]:
-    """Build the seven discovery-document views, shared by ha_auth and legacy
-    (mode-agnostic — each view resolves the active mode per request)."""
+    """Build the six discovery-document views, shared by ha_auth and legacy
+    (mode-agnostic — each view resolves the active mode per request): the
+    path-scoped protected-resource document, the authorization-server document,
+    and the four RFC 8414 / OIDC well-known authorization-server locations."""
     views: list[HomeAssistantView] = [
-        _ProtectedResourceMetadataView(hass),
         _AuthorizationServerMetadataView(hass),
         _WellKnownProtectedResourceView(hass),
     ]
@@ -528,7 +507,7 @@ def _metadata_views(hass: HomeAssistant) -> list[HomeAssistantView]:
 
 
 def _register_metadata_views(hass: HomeAssistant) -> None:
-    """Register the seven discovery views at most once per HA session.
+    """Register the six discovery views at most once per HA session.
 
     aiohttp cannot unregister a bound view, so a reload / re-enable / re-add /
     ha_auth<->legacy mode switch must all reuse the already-bound views — they
@@ -551,15 +530,21 @@ def _register_metadata_views(hass: HomeAssistant) -> None:
     hass.data[_OAUTH_VIEWS_REGISTERED_KEY] = True
 
 
-def _build_unauthorized_response(request: web.Request) -> web.Response:
+def _build_unauthorized_response(request: web.Request, webhook_id: str) -> web.Response:
     """Build the 401 + ``WWW-Authenticate`` challenge MCP clients use to discover.
 
-    Per RFC 9728 §5.1 / MCP spec, the ``resource_metadata`` parameter points to
-    the protected-resource metadata URL where the client finds the authorization
-    server.
+    Per RFC 9728 §5.1 / MCP 2026-07-28 Authorization Server Discovery, the
+    ``resource_metadata`` parameter points to the protected-resource metadata
+    URL where the client finds the authorization server.
     """
     base = _build_base_url(request)
-    metadata_url = f"{base}{OAUTH_BASE}/protected-resource"
+    # RFC 9728 §3.1 path-scoped location. The pointer names the id, but this
+    # 401 is only produced on a request TO /api/webhook/<id>, so the caller
+    # already holds it; there is no fixed-path document to point at (see
+    # _WellKnownProtectedResourceView).
+    metadata_url = (
+        f"{base}/.well-known/oauth-protected-resource/api/webhook/{webhook_id}"
+    )
     return web.Response(
         status=401,
         text="Unauthorized",
@@ -592,10 +577,10 @@ async def _check_webhook_auth(
     if resource_server is not None and not await resource_server.validate_request(
         request
     ):
-        return _build_unauthorized_response(request)
+        return _build_unauthorized_response(request, cfg.get("webhook_id", ""))
     oauth_provider: LegacyOAuthProvider | None = cfg.get("oauth_provider")
     if oauth_provider is not None and not oauth_provider.validate_bearer(request):
-        return _build_unauthorized_response(request)
+        return _build_unauthorized_response(request, cfg.get("webhook_id", ""))
     return None
 
 

--- a/custom_components/ha_mcp_tools/mcp_webhook.py
+++ b/custom_components/ha_mcp_tools/mcp_webhook.py
@@ -577,10 +577,10 @@ async def _check_webhook_auth(
     if resource_server is not None and not await resource_server.validate_request(
         request
     ):
-        return _build_unauthorized_response(request, cfg.get("webhook_id", ""))
+        return _build_unauthorized_response(request, cfg["webhook_id"])
     oauth_provider: LegacyOAuthProvider | None = cfg.get("oauth_provider")
     if oauth_provider is not None and not oauth_provider.validate_bearer(request):
-        return _build_unauthorized_response(request, cfg.get("webhook_id", ""))
+        return _build_unauthorized_response(request, cfg["webhook_id"])
     return None
 
 

--- a/custom_components/ha_mcp_tools/oauth_autoapprove.py
+++ b/custom_components/ha_mcp_tools/oauth_autoapprove.py
@@ -303,13 +303,24 @@ class AutoApproveAuthorizeView(HomeAssistantView):
         if forward_id != client_id:
             params.popall("client_id", None)
             params["client_id"] = forward_id
-        import yarl
+        from urllib.parse import urlencode
 
         # Keep the browser hop relative, matching the token leg. Browsers cannot
         # be made to send X-Forwarded-Host, so this is consistency rather than a
         # vulnerability fix.
-        target = yarl.URL("/auth/authorize").with_query(params)
-        return web.Response(status=302, headers={"Location": str(target)})
+        #
+        # Percent-encode the query instead of handing the params to yarl: yarl
+        # legally leaves ":" and "/" literal inside query values (RFC 3986
+        # permits both in the query component), so a loopback client's callback
+        # forwards as ``redirect_uri=http://127.0.0.1:1234/callback``. Reverse
+        # proxies shipping a generic "block common exploits" ruleset -- Nginx
+        # Proxy Manager enables one per host with a checkbox -- match
+        # ``[a-zA-Z0-9_]=http://`` and answer 403 before core ever sees the
+        # request, stranding every native-app client behind such a proxy.
+        # Full encoding is semantically identical and survives those filters.
+        query = urlencode(list(params.items()))
+        target = f"/auth/authorize?{query}" if query else "/auth/authorize"
+        return web.Response(status=302, headers={"Location": target})
 
     async def post(self, request: web.Request) -> web.Response:
         """Handle a legacy-mode consent submission on the scoped route."""

--- a/custom_components/ha_mcp_tools/oauth_autoapprove.py
+++ b/custom_components/ha_mcp_tools/oauth_autoapprove.py
@@ -49,7 +49,7 @@ from __future__ import annotations
 import logging
 import secrets
 from typing import TYPE_CHECKING, Any
-from urllib.parse import urlparse
+from urllib.parse import urlencode, urlparse
 
 import aiohttp
 from aiohttp import web
@@ -303,12 +303,11 @@ class AutoApproveAuthorizeView(HomeAssistantView):
         if forward_id != client_id:
             params.popall("client_id", None)
             params["client_id"] = forward_id
-        from urllib.parse import urlencode
 
         # Keep the browser hop relative, matching the token leg. Browsers cannot
         # be made to send X-Forwarded-Host, so this is consistency rather than a
         # vulnerability fix.
-        #
+
         # Percent-encode the query instead of handing the params to yarl: yarl
         # legally leaves ":" and "/" literal inside query values (RFC 3986
         # permits both in the query component), so a loopback client's callback

--- a/homeassistant-addon-webhook-proxy-dev/CHANGELOG.md
+++ b/homeassistant-addon-webhook-proxy-dev/CHANGELOG.md
@@ -9,6 +9,28 @@ history from before the fork.
 -->
 
 
+## v3.0.3.dev2 (2026-08-30)
+
+### Security
+
+- The webhook id is no longer published by any anonymous discovery URL. The
+  fixed-path protected-resource document (`/api/mcp_proxy_dev/oauth/protected-resource`)
+  handed the full webhook URL to any unauthenticated GET while `ha_auth` or
+  `legacy` mode was on; it is removed. The webhook's 401 challenge now points at
+  the RFC 9728 path-scoped document, whose URL already contains the id.
+- After the operator rotates the webhook id (`/data/webhook_id.txt`), the old
+  id's discovery URL stops answering immediately instead of serving the new id
+  until the next Home Assistant restart. A restart Repair is raised so the new
+  id's discovery URL gets bound; existing installs that ran `ha_auth` or `legacy`
+  reachable from the internet before this version may wish to rotate once.
+
+### Bug Fixes
+
+- `ha_auth`: percent-encode the query forwarded to core's `/auth/authorize`, so a
+  native-app client's loopback callback is not rejected by reverse proxies that
+  block `=http://` in query strings (Nginx Proxy Manager "Block Common Exploits").
+
+
 ## v3.0.1.dev1 (2026-08-16)
 
 Version line rebased onto the 3.0.0 stable base by the promote PR

--- a/homeassistant-addon-webhook-proxy-dev/DOCS.md
+++ b/homeassistant-addon-webhook-proxy-dev/DOCS.md
@@ -124,9 +124,10 @@ The URL stays the same across app restarts because the webhook ID is persisted a
 1. **Stop** the Webhook Proxy app.
 2. **Delete** the persisted webhook ID file. Open the app's filesystem (e.g. via the SSH/Terminal app or a file browser) and remove `/data/webhook_id.txt` for the proxy app. (Stopping then uninstalling and reinstalling the app also achieves this.)
 3. **Start** the app. A fresh webhook ID and URL are generated on first launch.
-4. **Copy the new URL** from the app logs and paste it into your MCP client(s). The old URL is now dead.
+4. **Restart Home Assistant** when the *Restart Home Assistant* Repair card appears (Settings → System → Repairs). The old URL stops answering as soon as the app starts; the new URL's OAuth discovery is served after the restart.
+5. **Copy the new URL** from the app logs and paste it into your MCP client(s). The old URL is now dead.
 
-The old webhook ID is not retained anywhere on disk after the file is deleted, and the integration's previous registration is dropped when the app stops.
+The old webhook ID is not retained anywhere on disk after the file is deleted, the integration's previous registration is dropped when the app stops, and the previous URL's OAuth discovery document answers 404 from the first start with the new ID — it never serves the new ID to whoever held the old one.
 
 #### Enable OAuth (Beta) for stronger protection
 

--- a/homeassistant-addon-webhook-proxy-dev/DOCS.md
+++ b/homeassistant-addon-webhook-proxy-dev/DOCS.md
@@ -124,7 +124,7 @@ The URL stays the same across app restarts because the webhook ID is persisted a
 1. **Stop** the Webhook Proxy app.
 2. **Delete** the persisted webhook ID file. Open the app's filesystem (e.g. via the SSH/Terminal app or a file browser) and remove `/data/webhook_id.txt` for the proxy app. (Stopping then uninstalling and reinstalling the app also achieves this.)
 3. **Start** the app. A fresh webhook ID and URL are generated on first launch.
-4. **Restart Home Assistant** when the *Restart Home Assistant* Repair card appears (Settings → System → Repairs). The old URL stops answering as soon as the app starts; the new URL's OAuth discovery is served after the restart.
+4. **Restart Home Assistant** when the *Restart Home Assistant to finish the MCP Webhook Proxy setup* Repair card appears (Settings → System → Repairs). The old URL stops answering as soon as the app starts; the new URL's OAuth discovery is served after the restart.
 5. **Copy the new URL** from the app logs and paste it into your MCP client(s). The old URL is now dead.
 
 The old webhook ID is not retained anywhere on disk after the file is deleted, the integration's previous registration is dropped when the app stops, and the previous URL's OAuth discovery document answers 404 from the first start with the new ID — it never serves the new ID to whoever held the old one.

--- a/homeassistant-addon-webhook-proxy-dev/DOCS.md
+++ b/homeassistant-addon-webhook-proxy-dev/DOCS.md
@@ -185,7 +185,7 @@ The generated values are persisted at `/data/oauth_creds.json` inside the app, s
 
 All three behaviors advertise proxy-owned endpoints under `/api/mcp_proxy_dev/oauth` (plus the webhook-scoped `.well-known` document), so a cached client configuration remains on the proxy across mode switches:
 
-- `/.well-known/oauth-protected-resource/api/webhook/<webhook-id>` — RFC 9728 protected-resource metadata, served in every mode at the path derived from the webhook URL (the only location: a caller must already hold the webhook ID to reach it, so discovery never reveals the credential-bearing URL; the webhook's 401 challenge points here)
+- `/.well-known/oauth-protected-resource/api/webhook/<webhook-id>` — RFC 9728 protected-resource metadata, served in every mode at the path derived from the webhook URL (the only location: a caller must already hold the webhook ID to reach it, so callers without the webhook ID cannot use discovery to obtain the credential-bearing URL; the webhook's 401 challenge points here)
 - `/api/mcp_proxy_dev/oauth/authorization-server` — RFC 8414 authorization-server metadata
 - `/api/mcp_proxy_dev/oauth/authorize` — mode-dispatched authorization endpoint
 - `/api/mcp_proxy_dev/oauth/token` — mode-dispatched token endpoint

--- a/homeassistant-addon-webhook-proxy-dev/DOCS.md
+++ b/homeassistant-addon-webhook-proxy-dev/DOCS.md
@@ -183,9 +183,9 @@ The generated values are persisted at `/data/oauth_creds.json` inside the app, s
 
 **OAuth endpoints:**
 
-All three behaviors advertise proxy-owned endpoints under `/api/mcp_proxy_dev/oauth`, so a cached client configuration remains on the proxy across mode switches:
+All three behaviors advertise proxy-owned endpoints under `/api/mcp_proxy_dev/oauth` (plus the webhook-scoped `.well-known` document), so a cached client configuration remains on the proxy across mode switches:
 
-- `/api/mcp_proxy_dev/oauth/protected-resource` — RFC 9728 protected-resource metadata (`legacy` and `ha_auth` only: in none mode this fixed route returns 404, because its metadata would reveal the credential-bearing webhook URL — none-mode clients use the webhook-ID-scoped `.well-known` route instead)
+- `/.well-known/oauth-protected-resource/api/webhook/<webhook-id>` — RFC 9728 protected-resource metadata, served in every mode at the path derived from the webhook URL (the only location: a caller must already hold the webhook ID to reach it, so discovery never reveals the credential-bearing URL; the webhook's 401 challenge points here)
 - `/api/mcp_proxy_dev/oauth/authorization-server` — RFC 8414 authorization-server metadata
 - `/api/mcp_proxy_dev/oauth/authorize` — mode-dispatched authorization endpoint
 - `/api/mcp_proxy_dev/oauth/token` — mode-dispatched token endpoint

--- a/homeassistant-addon-webhook-proxy-dev/config.yaml
+++ b/homeassistant-addon-webhook-proxy-dev/config.yaml
@@ -1,6 +1,6 @@
 name: "Nabu Casa - Webhook Proxy for HA MCP (Dev)"
 description: "DEV CHANNEL (unstable) — remote access proxy via Nabu Casa or any reverse proxy. Cannot run alongside the stable Webhook Proxy add-on."
-version: "3.0.3.dev1"
+version: "3.0.3.dev2"
 slug: "ha_mcp_webhook_proxy_dev"
 url: "https://github.com/homeassistant-ai/ha-mcp"
 stage: experimental

--- a/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/__init__.py
+++ b/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/__init__.py
@@ -870,24 +870,28 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     hass.data[DOMAIN] = hass_data
 
-    # The integration is set up. If OAuth was (re)configured on a mid-session
-    # setup, its root views aren't live until a full HA restart, so surface the
-    # HACS-style restart Repair; otherwise (OAuth off, or set up cleanly during
-    # HA boot) any prior "needs HA restart for OAuth" marker is now stale, so
-    # clear it. Marker writes/cleanup are filesystem I/O and run in the
-    # executor; the issue-registry calls are synchronous and safe on the loop.
+    # The integration is set up. Two things can only take effect at HA
+    # startup — OAuth (re)configured mid-session, whose root views aren't live
+    # yet, and a webhook id rotated mid-session, whose path-scoped discovery
+    # URL cannot be bound — so either surfaces the HACS-style restart Repair.
+    # Otherwise (set up cleanly during HA boot, nothing pending) any prior
+    # restart marker is now stale, so clear it. Marker writes/cleanup are
+    # filesystem I/O and run in the executor; the issue-registry calls are
+    # synchronous and safe on the loop.
     from .repairs import _clear_marker, _delete_issue_only, _write_marker, create_issue
 
     if oauth_restart_needed:
-        # OAuth was (re)configured on a mid-session setup — it isn't live until
-        # a full HA restart. Surface the HACS-style restart Repair (+ marker so
-        # it survives to the next boot). A boot-time setup takes the else branch
-        # and clears it once OAuth is genuinely active.
+        # Something needs a full HA restart to become live: OAuth
+        # (re)configured mid-session, or — with OAuth OFF too — a rotated
+        # webhook id whose discovery URL only binds at startup. Surface the
+        # HACS-style restart Repair (+ marker so it survives to the next boot).
+        # A boot-time setup takes the else branch and clears it once the
+        # pending change is genuinely live.
         await hass.async_add_executor_job(_write_marker)
         create_issue(hass, DOMAIN)
     else:
-        # OAuth off, or set up during HA boot (views bound cleanly) — no restart
-        # needed; clear any stale marker/issue.
+        # Set up during HA boot (views bound cleanly) with no rotated id —
+        # no restart needed; clear any stale marker/issue.
         await hass.async_add_executor_job(_clear_marker)
         _delete_issue_only(hass, DOMAIN)
 

--- a/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/__init__.py
+++ b/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/__init__.py
@@ -411,17 +411,22 @@ def _bind_legacy_oauth_views(
     """Register the root OAuth /authorize + /token views for the legacy provider,
     or detect a mid-session credential change that needs an HA restart. Returns
     oauth_restart_needed."""
+    from .oauth import register_metadata_views
+
     bound_fp = hass.data.get(OAUTH_ROUTE_KEY_FINGERPRINT)
     if route_owner == DOMAIN and bound_fp == fingerprint:
         # Reload of our own entry with the SAME credentials + key: the
         # root views are already bound and current. Reuse them (HA can't
         # re-register mid-session; re-registering would only pile up
-        # shadowed duplicates). OAuth is live — no restart.
+        # shadowed duplicates). OAuth is live — no restart, UNLESS the
+        # webhook id itself rotated: the discovery views are guarded by their
+        # own flag (not this fingerprint) and register_metadata_views is the
+        # only thing that can see the id change.
         _LOGGER.debug(
             "MCP Proxy: root OAuth views already bound with the current "
             "credentials this session; reusing them (no restart)."
         )
-        return False
+        return register_metadata_views(hass, oauth_provider)
     if route_owner == DOMAIN:
         # Reload of our own entry but the credentials/key CHANGED
         # (regenerated) mid-session. HA can't re-bind the root views
@@ -437,12 +442,14 @@ def _bind_legacy_oauth_views(
         )
         return True
     # First registration this HA session.
-    oauth_provider.register_views()
+    metadata_restart = oauth_provider.register_views()
     hass.data[OAUTH_ROUTE_OWNER_KEY] = DOMAIN
     hass.data[OAUTH_ROUTE_KEY_FINGERPRINT] = fingerprint
     # A first registration happening mid-session isn't live until a
-    # full HA restart; flag it. At HA boot it binds cleanly.
-    return bool(hass.is_running)
+    # full HA restart; flag it. At HA boot it binds cleanly. The discovery
+    # views carry their own verdict (another mode may already have bound them
+    # this session under a now-rotated webhook id), so honour both.
+    return metadata_restart or bool(hass.is_running)
 
 
 async def _setup_ha_auth_oauth(
@@ -451,9 +458,10 @@ async def _setup_ha_auth_oauth(
     oauth_section: dict,
     session: aiohttp.ClientSession,
     hass_data: dict,
-) -> None:
+) -> bool:
     """Set up ha_auth OAuth (HA core is the authorization server). Mutates
-    hass_data with the resource server + mode; raises ConfigEntryError on error."""
+    hass_data with the resource server + mode; raises ConfigEntryError on error.
+    Returns oauth_restart_needed."""
     # ── ha_auth: HA core is the authorization server (see auth_native) ──
     # Hard mutual exclusion: a ha_auth section carries NO legacy credentials.
     # If client_id/client_secret keys are present the config is ambiguous
@@ -506,14 +514,16 @@ async def _setup_ha_auth_oauth(
             connector=aiohttp.TCPConnector(limit=_CIMD_CONNECTOR_LIMIT)
         )
         resource_server = ResourceServer(hass, webhook_id, None)
-        # Registers the seven discovery-document views at most once per HA
+        # Registers the six discovery-document views at most once per HA
         # session (register_metadata_views no-ops when either mode already
         # bound them — see oauth._METADATA_VIEWS_REGISTERED_KEY), so a
         # config-entry reload or a live legacy->ha_auth switch doesn't stack
         # shadowed duplicates. The scoped handlers redirect/relay into core;
         # the bare /authorize + /token remain legacy-only aliases, so there is
-        # no owner-key / fingerprint bookkeeping and no restart concept.
-        register_metadata_views(hass, resource_server)
+        # no owner-key / fingerprint bookkeeping. The one restart case is a
+        # webhook id rotated mid-session: the already-bound path-scoped
+        # discovery URL still names the OLD id, so it reports the mismatch.
+        restart_needed = register_metadata_views(hass, resource_server)
         register_autoapprove_views(hass)
         bind_dcr_view(hass)
     except Exception as err:
@@ -539,6 +549,7 @@ async def _setup_ha_auth_oauth(
     hass_data["oauth_mode"] = OAUTH_MODE_HA_AUTH
     hass_data["dcr_signing_key"] = dcr_signing_key
     hass_data["cimd_session"] = cimd_session
+    return restart_needed
 
 
 async def _setup_legacy_oauth(
@@ -665,7 +676,7 @@ async def _setup_legacy_oauth(
 
 async def _setup_none_autoapprove(
     hass: HomeAssistant, webhook_id: str, hass_data: dict
-) -> None:
+) -> bool:
     """Set up none-mode auto-approve discovery (OAuth off — issue #1969).
 
     Serves our own corrected RFC 8414/9728 discovery documents plus an invisible
@@ -680,6 +691,8 @@ async def _setup_none_autoapprove(
     enhancement layered on top of the already-working proxy. A failure must not
     tear the working webhook down — it only means claude.ai's rare discovery
     fallback isn't helped; the endpoint still forwards.
+
+    Returns oauth_restart_needed (False on the fail-open path).
     """
     try:
         from .oauth import register_metadata_views
@@ -694,8 +707,11 @@ async def _setup_none_autoapprove(
         # install must work via any external URL.
         provider = AutoApproveProvider(hass, webhook_id, None)
         # All three view bundles bind at most once per HA session (guarded); a
-        # none<->ha_auth switch reuses them, so no restart is needed.
-        register_metadata_views(hass, provider)
+        # none<->ha_auth switch reuses them, so no restart is needed. The one
+        # exception is a webhook id rotated mid-session: the path-scoped
+        # discovery URL bound earlier this session still names the OLD id and
+        # HA cannot rebind it, so register_metadata_views reports that.
+        restart_needed = register_metadata_views(hass, provider)
         register_autoapprove_views(hass)
         bind_dcr_view(hass)
     except Exception:
@@ -705,7 +721,7 @@ async def _setup_none_autoapprove(
             "forwards — only claude.ai's rare OAuth-discovery fallback is "
             "unassisted)."
         )
-        return
+        return False
     hass_data["dcr_signing_key"] = dcr_signing_key
     hass_data[AUTOAPPROVE_PROVIDER_KEY] = provider
     hass_data["oauth_mode"] = OAUTH_MODE_NONE_AUTOAPPROVE
@@ -714,6 +730,7 @@ async def _setup_none_autoapprove(
         "MCP connectors that run OAuth discovery still resolve against this "
         "add-on (issue #1969). The webhook itself stays unauthenticated."
     )
+    return restart_needed
 
 
 async def _setup_oauth_section(
@@ -737,8 +754,9 @@ async def _setup_oauth_section(
     oauth_section = proxy_config.get("oauth")
     oauth_mode = oauth_section.get("mode") if isinstance(oauth_section, dict) else None
     if isinstance(oauth_section, dict) and oauth_mode == OAUTH_MODE_HA_AUTH:
-        await _setup_ha_auth_oauth(hass, webhook_id, oauth_section, session, hass_data)
-        return False
+        return await _setup_ha_auth_oauth(
+            hass, webhook_id, oauth_section, session, hass_data
+        )
     if isinstance(oauth_section, dict) and oauth_mode not in (
         None,
         OAUTH_MODE_LEGACY,
@@ -761,10 +779,10 @@ async def _setup_oauth_section(
     # server so claude.ai's intermittent OAuth discovery resolves against us, not
     # HA core's broken origin-root doc (issue #1969). Fails open — the webhook
     # forwarder stays unauthenticated and never 401s (see _setup_none_autoapprove
-    # / the AUTOAPPROVE_PROVIDER_KEY-not-"oauth" split). No restart is ever
-    # needed, so oauth_restart_needed stays False.
-    await _setup_none_autoapprove(hass, webhook_id, hass_data)
-    return False
+    # / the AUTOAPPROVE_PROVIDER_KEY-not-"oauth" split). None mode still has ONE
+    # restart case: the operator rotated the webhook id mid-session, and the
+    # path-scoped discovery URL for the new id can only be bound at startup.
+    return await _setup_none_autoapprove(hass, webhook_id, hass_data)
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/manifest.json
+++ b/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/manifest.json
@@ -7,5 +7,5 @@
   "dependencies": ["webhook"],
   "documentation": "https://github.com/homeassistant-ai/ha-mcp",
   "iot_class": "local_push",
-  "version": "3.0.3.dev1"
+  "version": "3.0.3.dev2"
 }

--- a/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/oauth.py
+++ b/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/oauth.py
@@ -852,10 +852,16 @@ class WellKnownProtectedResourceView(HomeAssistantView):
     serves, steering the flow into HA-core native OAuth where the proxy's
     client_id can never work.
 
-    Exact-path bind, deliberately not a `{webhook_id}` route parameter: aiohttp
-    resolves an exact path before a dynamic one under the same prefix, which is
-    what lets this view and the in-process component's parameterised view
-    coexist on one HA (each answers its own id). The cost is that HA cannot
+    Exact-path bind, deliberately not a `{webhook_id}` route parameter: aiohttp's
+    `UrlDispatcher.resolve` walks the request path from the most specific
+    segment upwards and consults the resources indexed under each key in turn,
+    so an exact-path resource (indexed under the full path) is tried before a
+    `{webhook_id}` resource (indexed under the prefix) whatever their
+    registration order — registration order only breaks ties between resources
+    sharing one index key. That is what lets this view and the in-process
+    component's parameterised view coexist on one HA (each answers its own id);
+    `tests/src/unit/test_prm_route_precedence.py` pins it against the real
+    router. The cost is that HA cannot
     rebind this URL when the operator rotates the webhook id mid-session, so
     `get` 404s once the bound id is no longer the live one (the old URL must
     not keep serving the NEW id to whoever held the old one), and

--- a/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/oauth.py
+++ b/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/oauth.py
@@ -66,12 +66,12 @@ SECRET_FILE = Path("/config/.mcp_proxy_dev_oauth_secret")
 DOMAIN = "mcp_proxy_dev"
 
 # TOP-LEVEL hass.data key (deliberately NOT under DOMAIN, so it survives
-# async_unload_entry's hass.data.pop(DOMAIN)) recording that the seven
+# async_unload_entry's hass.data.pop(DOMAIN)) recording that the six
 # discovery-document metadata views are bound to aiohttp for this HA session.
 # HA registers views with no route name and leaves the router unfrozen, so a
 # duplicate registration does NOT raise — aiohttp lets the first-registered
 # path win and silently shadows the later one; HA also can't unregister a bound
-# view until it restarts. So register_metadata_views must bind the seven at
+# view until it restarts. So register_metadata_views must bind the six at
 # most once: a same-mode ha_auth reload, a legacy->ha_auth switch, or a
 # ha_auth->legacy switch all reuse the already-bound views instead of stacking
 # silently-shadowed duplicate routes on every reload/switch.
@@ -83,6 +83,17 @@ DOMAIN = "mcp_proxy_dev"
 # once this dev code promotes to stable.
 _METADATA_VIEWS_REGISTERED_KEY = (
     f"webhook_proxy_oauth_metadata_views_registered_{DOMAIN}"
+)
+
+# Companion to the flag above: the webhook id the bound path-scoped
+# protected-resource view embeds in its URL. HA cannot rebind a view
+# mid-session, so when a later setup arrives with a DIFFERENT id (the operator
+# rotated /data/webhook_id.txt), the scoped URL for the new id cannot exist
+# until HA restarts — register_metadata_views reports that so the caller can
+# raise the restart Repair. Top-level (not under DOMAIN) for the same reason
+# as the flag: it must survive async_unload_entry's hass.data.pop(DOMAIN).
+_METADATA_VIEWS_BOUND_WEBHOOK_ID_KEY = (
+    f"webhook_proxy_oauth_metadata_views_webhook_id_{DOMAIN}"
 )
 
 # OAuth mode markers. Mirrored as auth_native.HA_AUTH_MODE and __init__.py's
@@ -608,10 +619,10 @@ class OAuthProvider:
     # View registration
     # -----------------------------------------------------------------
 
-    def register_views(self) -> None:
+    def register_views(self) -> bool:
         """Register the legacy OAuth endpoints with HA's HTTP layer.
 
-        Delegates the seven discovery-document views to the shared,
+        Delegates the six discovery-document views to the shared,
         flag-guarded `register_metadata_views` (which binds them at most once
         per HA session — see `_METADATA_VIEWS_REGISTERED_KEY`), then registers
         ONLY the two root views (`AuthorizeView` + `TokenView`). The unified
@@ -621,10 +632,13 @@ class OAuthProvider:
         metadata registrar avoids silently-shadowed duplicate discovery views.
         The two root aliases stay gated by the caller's route-owner/fingerprint
         logic in __init__.py.
+
+        Returns `register_metadata_views`'s restart-needed verdict.
         """
-        register_metadata_views(self._hass, self)
+        restart_needed = register_metadata_views(self._hass, self)
         for view in (AuthorizeView(self), TokenView(self)):
             self._hass.http.register_view(view)
+        return restart_needed
 
     # -----------------------------------------------------------------
     # Token issuance / validation
@@ -754,56 +768,6 @@ class OAuthProvider:
 # ---------------------------------------------------------------------------
 
 
-class ProtectedResourceMetadataView(HomeAssistantView):
-    """RFC 9728 Protected Resource Metadata (fixed, guessable path)."""
-
-    requires_auth = False
-    cors_allowed = True
-    url = f"{OAUTH_BASE}/protected-resource"
-    name = "mcp_proxy_dev:oauth:protected-resource"
-
-    # SECURITY (#1976 review): this fixed path exposes ``resource:
-    # <base>/api/webhook/<id>``. In none-autoapprove mode the webhook id is the
-    # SOLE credential, so this ANONYMOUS, guessable path must NOT serve it there.
-    # The path-scoped subclass flips this True — its URL already embeds the id,
-    # so its caller must already know it (no leak).
-    _serves_in_none_mode = False
-
-    def __init__(self, provider: MetadataProvider) -> None:
-        self._provider = provider
-
-    async def get(self, request: web.Request) -> web.Response:
-        hass = getattr(self._provider, "_hass", None)
-        if hass is None or not await _addon_alive(hass):
-            return _json_not_found()
-        # The protected-resource document has the same shape in every OAuth
-        # mode; 404 when no mode is live (entry unloaded / OAuth off) so a
-        # stale-bound view acts like an unregistered route. URLs are built via
-        # the ACTIVE mode's provider, not the instance this view was bound with,
-        # so a live mode switch also switches the base-URL policy (legacy:
-        # pinned; ha_auth: host-derived).
-        mode = _active_oauth_mode(self._provider)
-        if mode is None:
-            return _json_not_found()
-        # In none-autoapprove mode only the path-scoped subclass may serve (see
-        # _serves_in_none_mode above); the fixed-path view 404s to avoid leaking
-        # the credential-bearing webhook id anonymously (#1976 review).
-        if mode == MODE_NONE_AUTOAPPROVE and not self._serves_in_none_mode:
-            return _json_not_found()
-        provider = _active_provider(self._provider)
-        base = provider.base_url_for(request)
-        return web.json_response(
-            {
-                "resource": provider.resource_url(base),
-                "authorization_servers": [provider.authorization_server_url(base)],
-                "bearer_methods_supported": ["header"],
-                "resource_documentation": (
-                    "https://github.com/homeassistant-ai/ha-mcp"
-                ),
-            }
-        )
-
-
 class AuthorizationServerMetadataView(HomeAssistantView):
     """RFC 8414 Authorization Server Metadata."""
 
@@ -868,36 +832,77 @@ class AuthorizationServerMetadataView(HomeAssistantView):
         )
 
 
-class WellKnownProtectedResourceView(ProtectedResourceMetadataView):
-    """RFC 9728 §3.1 path-scoped Protected Resource Metadata.
+class WellKnownProtectedResourceView(HomeAssistantView):
+    """RFC 9728 §3.1 path-scoped Protected Resource Metadata — the ONLY
+    protected-resource document this integration serves.
 
-    Same document as `ProtectedResourceMetadataView`, served at the
-    well-known location derived from the webhook resource URL
-    (`/.well-known/oauth-protected-resource/api/webhook/<id>`). Captured
-    live in issue #1714: when the 401's `WWW-Authenticate`
-    `resource_metadata` pointer is missing (stripped by a proxy in front,
-    or a transient setup window), this path is claude.ai's FIRST fallback
-    probe — and when it 404s the client falls through to the HOST-ROOT
-    `/.well-known/oauth-protected-resource`, which HA core itself serves
-    whenever it can resolve an external URL, steering the flow into
-    HA-core native OAuth (`/auth/authorize`) where the proxy's client_id
-    can never work. Serving this view keeps discovery on the proxy even
-    without the pointer.
+    Served at the well-known location derived from the webhook resource URL
+    (`/.well-known/oauth-protected-resource/api/webhook/<id>`), which is also
+    where the webhook's 401 `resource_metadata` challenge points. Its caller
+    must already hold the id (it is part of the path), so the document never
+    discloses it — that is why there is no fixed-path variant: a fixed,
+    guessable path handed the id to any anonymous GET in ha_auth/legacy mode,
+    and a later switch to none mode then promoted that published value into
+    the sole credential.
+
+    Captured live in issue #1714: when the 401's pointer is missing (stripped
+    by a proxy in front, or a transient setup window), this path is claude.ai's
+    FIRST fallback probe — and when it 404s the client falls through to the
+    HOST-ROOT `/.well-known/oauth-protected-resource`, which HA core itself
+    serves, steering the flow into HA-core native OAuth where the proxy's
+    client_id can never work.
+
+    Exact-path bind, deliberately not a `{webhook_id}` route parameter: aiohttp
+    resolves an exact path before a dynamic one under the same prefix, which is
+    what lets this view and the in-process component's parameterised view
+    coexist on one HA (each answers its own id). The cost is that HA cannot
+    rebind this URL when the operator rotates the webhook id mid-session, so
+    `get` 404s once the bound id is no longer the live one (the old URL must
+    not keep serving the NEW id to whoever held the old one), and
+    `register_metadata_views` reports the mismatch so setup raises the
+    click-to-restart Repair that binds the new id's URL.
     """
 
+    requires_auth = False
+    cors_allowed = True
     name = "mcp_proxy_dev:oauth:wellknown-protected-resource"
 
-    # Path-scoped: the URL already embeds the webhook id, so the caller must
-    # already know it — serving in none-autoapprove mode leaks nothing (#1976).
-    # This is the doc claude.ai's none-mode discovery actually uses.
-    _serves_in_none_mode = True
-
     def __init__(self, provider: MetadataProvider) -> None:
-        super().__init__(provider)
+        self._provider = provider
+        self._bound_webhook_id = provider.webhook_id
         # Instance-level URL: the well-known path embeds this install's
         # webhook id, which is only known at runtime.
         self.url = (
             f"/.well-known/oauth-protected-resource/api/webhook/{provider.webhook_id}"
+        )
+
+    async def get(self, request: web.Request) -> web.Response:
+        hass = getattr(self._provider, "_hass", None)
+        if hass is None or not await _addon_alive(hass):
+            return _json_not_found()
+        # Same document shape in every OAuth mode; 404 when no mode is live
+        # (entry unloaded / OAuth off) so a stale-bound view acts like an
+        # unregistered route. URLs are built via the ACTIVE mode's provider,
+        # not the instance this view was bound with, so a live mode switch also
+        # switches the base-URL policy (legacy: pinned; ha_auth: host-derived).
+        if _active_oauth_mode(self._provider) is None:
+            return _json_not_found()
+        provider = _active_provider(self._provider)
+        # The id in this view's URL is no longer the live one: the operator
+        # rotated it. Anyone still holding the OLD id must not learn the new
+        # one here — 404 exactly as an unregistered route would.
+        if provider.webhook_id != self._bound_webhook_id:
+            return _json_not_found()
+        base = provider.base_url_for(request)
+        return web.json_response(
+            {
+                "resource": provider.resource_url(base),
+                "authorization_servers": [provider.authorization_server_url(base)],
+                "bearer_methods_supported": ["header"],
+                "resource_documentation": (
+                    "https://github.com/homeassistant-ai/ha-mcp"
+                ),
+            }
         )
 
 
@@ -1206,17 +1211,16 @@ class TokenView(HomeAssistantView):
 
 
 def _metadata_views(provider: MetadataProvider) -> list[HomeAssistantView]:
-    """Build the seven discovery-document views bound to ``provider``.
+    """Build the six discovery-document views bound to ``provider``.
 
-    The canonical protected-resource + authorization-server documents, the
-    path-scoped protected-resource document, and the four RFC 8414 / OIDC
-    well-known authorization-server locations (issue #1714). These serve the
-    same content in both OAuth modes (the AS view dispatches per-request); the
-    root `AuthorizeView` + `TokenView` are legacy-only and added by
-    `OAuthProvider.register_views`, never here.
+    The path-scoped protected-resource document, the authorization-server
+    document, and the four RFC 8414 / OIDC well-known authorization-server
+    locations (issue #1714). These serve the same content in both OAuth modes
+    (the AS view dispatches per-request); the root `AuthorizeView` +
+    `TokenView` are legacy-only and added by `OAuthProvider.register_views`,
+    never here.
     """
     views: list[HomeAssistantView] = [
-        ProtectedResourceMetadataView(provider),
         AuthorizationServerMetadataView(provider),
         WellKnownProtectedResourceView(provider),
     ]
@@ -1244,27 +1248,45 @@ def _metadata_views(provider: MetadataProvider) -> list[HomeAssistantView]:
     return views
 
 
-def register_metadata_views(hass: HomeAssistant, provider: MetadataProvider) -> None:
-    """Register the seven shared OAuth discovery-document views.
+def register_metadata_views(hass: HomeAssistant, provider: MetadataProvider) -> bool:
+    """Register the six shared OAuth discovery-document views.
 
-    ``provider`` is an `auth_native.ResourceServer` (ha_auth) or an
-    `OAuthProvider` (legacy, which routes its seven views through here); the
-    views read its `base_url_for`, `resource_url`, `authorization_server_url`,
-    `webhook_id`, and `_hass` (read by `_active_oauth_mode` AND
-    `_active_provider` for per-request mode/provider dispatch).
+    ``provider`` is an `auth_native.ResourceServer` (ha_auth), an
+    `OAuthProvider` (legacy, which routes its views through here) or the
+    none-mode `AutoApproveProvider`; the views read its `base_url_for`,
+    `resource_url`, `authorization_server_url`, `webhook_id`, and `_hass`
+    (read by `_active_oauth_mode` AND `_active_provider` for per-request
+    mode/provider dispatch).
 
-    Idempotent per HA session: the seven views bind at most once — a same-mode
-    reload or a legacy<->ha_auth switch reuses the already-bound views rather
-    than stacking silently-shadowed duplicate routes (a duplicate registration
-    does not raise — aiohttp lets the first-registered path win — and HA can't
-    drop a bound view until it restarts). The guard flag lives at a top-level
-    hass.data key so it survives async_unload_entry's pop(DOMAIN).
+    Idempotent per HA session: the six views bind at most once — a same-mode
+    reload or a mode switch reuses the already-bound views rather than
+    stacking silently-shadowed duplicates (a duplicate registration does not
+    raise — aiohttp lets the first-registered path win — and HA can't drop a
+    bound view until it restarts). Both guard keys live at top-level
+    hass.data keys so they survive async_unload_entry's pop(DOMAIN).
+
+    Returns True when the already-bound path-scoped protected-resource view
+    embeds a DIFFERENT webhook id than ``provider`` carries — the operator
+    rotated the id mid-session, so the new id's discovery URL cannot be bound
+    until HA restarts (the old one already 404s). The caller surfaces that as
+    the restart Repair. False on a fresh bind or an unchanged id.
     """
     if hass.data.get(_METADATA_VIEWS_REGISTERED_KEY):
-        return
+        bound_id = hass.data.get(_METADATA_VIEWS_BOUND_WEBHOOK_ID_KEY)
+        if bound_id != provider.webhook_id:
+            _LOGGER.warning(
+                "MCP Proxy: the webhook id changed since the OAuth discovery "
+                "views were bound this session; the discovery URL for the new "
+                "id is served only after a Home Assistant restart (the old "
+                "id's URL no longer answers)."
+            )
+            return True
+        return False
     for view in _metadata_views(provider):
         hass.http.register_view(view)
     hass.data[_METADATA_VIEWS_REGISTERED_KEY] = True
+    hass.data[_METADATA_VIEWS_BOUND_WEBHOOK_ID_KEY] = provider.webhook_id
+    return False
 
 
 # ---------------------------------------------------------------------------
@@ -1278,14 +1300,20 @@ def build_unauthorized_response(
     """Build the 401 + WWW-Authenticate response that MCP clients use to
     discover the OAuth endpoints.
 
-    Per RFC 9728 §5.1 / MCP 2025-06-18 spec: WWW-Authenticate's
-    resource_metadata parameter points to the protected-resource metadata
-    URL, where the client finds the authorization server URL. We use the
-    provider's configured public base URL (when set) so the metadata URL
-    isn't built from attacker-supplied Host headers.
+    Per RFC 9728 §5.1 / MCP 2026-07-28 Authorization Server Discovery:
+    WWW-Authenticate's resource_metadata parameter points to the
+    protected-resource metadata URL, where the client finds the authorization
+    server URL. We use the provider's configured public base URL (when set) so
+    the metadata URL isn't built from attacker-supplied Host headers.
     """
     base = provider.base_url_for(request)
-    metadata_url = f"{base}{OAUTH_BASE}/protected-resource"
+    # RFC 9728 §3.1 path-scoped location: the pointer names the id, but this
+    # 401 is only ever produced on a request TO /api/webhook/<id>, so the
+    # caller already holds it. There is no fixed-path document to point at —
+    # see WellKnownProtectedResourceView for why.
+    metadata_url = (
+        f"{base}/.well-known/oauth-protected-resource/api/webhook/{provider.webhook_id}"
+    )
     return web.Response(
         status=401,
         text="Unauthorized",

--- a/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/oauth_autoapprove.py
+++ b/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/oauth_autoapprove.py
@@ -353,10 +353,20 @@ class AutoApproveAuthorizeView(HomeAssistantView):
             params.popall("client_id", None)
             params["client_id"] = forward_id
 
-        import yarl
+        from urllib.parse import urlencode
 
-        target = yarl.URL("/auth/authorize").with_query(params)
-        return web.Response(status=302, headers={"Location": str(target)})
+        # Percent-encode the query instead of handing the params to yarl: yarl
+        # legally leaves ":" and "/" literal inside query values (RFC 3986
+        # permits both in the query component), so a loopback client's callback
+        # forwards as ``redirect_uri=http://127.0.0.1:1234/callback``. Reverse
+        # proxies shipping a generic "block common exploits" ruleset -- Nginx
+        # Proxy Manager enables one per host with a checkbox -- match
+        # ``[a-zA-Z0-9_]=http://`` and answer 403 before core ever sees the
+        # request, stranding every native-app client behind such a proxy.
+        # Full encoding is semantically identical and survives those filters.
+        query = urlencode(list(params.items()))
+        target = f"/auth/authorize?{query}" if query else "/auth/authorize"
+        return web.Response(status=302, headers={"Location": target})
 
     async def post(self, request: web.Request) -> web.Response:
         """Handle legacy consent submissions on the scoped authorize route."""

--- a/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/oauth_autoapprove.py
+++ b/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/oauth_autoapprove.py
@@ -39,7 +39,7 @@ from __future__ import annotations
 import logging
 import secrets
 from typing import TYPE_CHECKING, Any
-from urllib.parse import urlparse
+from urllib.parse import urlencode, urlparse
 
 import aiohttp
 from aiohttp import web
@@ -352,8 +352,6 @@ class AutoApproveAuthorizeView(HomeAssistantView):
         if forward_id != client_id:
             params.popall("client_id", None)
             params["client_id"] = forward_id
-
-        from urllib.parse import urlencode
 
         # Percent-encode the query instead of handing the params to yarl: yarl
         # legally leaves ":" and "/" literal inside query values (RFC 3986

--- a/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/repairs.py
+++ b/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/repairs.py
@@ -1,21 +1,25 @@
 """Repairs flow for MCP Webhook Proxy.
 
-Surfaces a HACS-style "click submit to restart" card in HA's Repairs UI
-when OAuth is enabled but the root OAuth views aren't live in the running
-HA session yet — either because the add-on's fail-closed gate detected that
-the integration code currently loaded doesn't enforce OAuth, or because the
-integration itself enabled OAuth mid-session (HA binds the root /authorize +
-/token views cleanly only at startup). The card is the more discoverable
-counterpart to the persistent_notification the addon also posts; submitting
-the fix flow restarts HA so the OAuth-aware code / freshly bound root views
-take over.
+Surfaces a HACS-style "click submit to restart" card in HA's Repairs UI when
+something can only take effect at HA startup and the running session has not
+picked it up. Three causes reach the same card: the add-on's fail-closed gate
+detected that the integration code currently loaded doesn't enforce OAuth; the
+integration enabled OAuth mid-session (HA binds the root /authorize + /token
+views cleanly only at startup); or the webhook id was rotated mid-session, so
+the path-scoped discovery URL for the new id cannot be bound until a restart —
+that last one happens with OAuth OFF as well, which is why the issue's strings
+name every cause rather than only the OAuth one. The card is the more
+discoverable counterpart to the persistent_notification the addon also posts;
+submitting the fix flow restarts HA so the new code / freshly bound views take
+over.
 
 Lifecycle:
 - The marker file (RESTART_MARKER_FILE) has two writers: the add-on's
   fail-closed gate (a separate process that writes the path directly), and
   the integration's `async_setup_entry` (in __init__.py) via `_write_marker`
-  when it enables OAuth mid-session — that same path also calls `create_issue`
-  to raise the Repair immediately.
+  when a mid-session setup leaves something pending a restart (OAuth enabled,
+  or a rotated webhook id) — that same path also calls `create_issue` to raise
+  the Repair immediately.
 - Integration's `async_setup` (in __init__.py) also checks the marker on HA
   boot; if present, it calls `async_create_issue` with this domain's
   `oauth_restart_required` ID and `is_fixable=True` so the user sees
@@ -109,7 +113,7 @@ def _clear_marker() -> None:
         RESTART_MARKER_FILE.unlink(missing_ok=True)
     except OSError as e:
         _LOGGER.warning(
-            "MCP Proxy: could not delete OAuth restart marker at %s "
+            "MCP Proxy: could not delete the restart marker at %s "
             "(%s: %s) — Repair card may re-appear on next HA boot until "
             "the file is removed manually.",
             RESTART_MARKER_FILE,
@@ -119,14 +123,20 @@ def _clear_marker() -> None:
 
 
 def _write_marker() -> None:
-    """Write the OAuth restart marker (idempotent). Blocking I/O — call via
+    """Write the restart marker (idempotent). Blocking I/O — call via
     hass.async_add_executor_job. Any OSError is logged at WARNING (the Repair
-    just won't persist to the next boot; the in-memory issue is still created)."""
+    just won't persist to the next boot; the in-memory issue is still created).
+
+    The payload records why a restart is pending. Nothing reads it back —
+    `marker_present` only tests `exists()` — so it is a breadcrumb for anyone
+    looking at the file, and it must not claim OAuth when a rotated webhook id
+    with OAuth off is equally a cause.
+    """
     try:
-        RESTART_MARKER_FILE.write_text('{"reason": "oauth_enabled_mid_session"}')
+        RESTART_MARKER_FILE.write_text('{"reason": "startup_change_pending"}')
     except OSError as e:
         _LOGGER.warning(
-            "MCP Proxy: could not write OAuth restart marker at %s (%s: %s).",
+            "MCP Proxy: could not write the restart marker at %s (%s: %s).",
             RESTART_MARKER_FILE,
             type(e).__name__,
             e,

--- a/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/strings.json
+++ b/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/strings.json
@@ -12,12 +12,12 @@
   },
   "issues": {
     "oauth_restart_required": {
-      "title": "Restart Home Assistant to enable OAuth",
+      "title": "Restart Home Assistant to finish the MCP Webhook Proxy setup",
       "fix_flow": {
         "step": {
           "confirm": {
             "title": "Restart Home Assistant?",
-            "description": "OAuth was enabled in the MCP Webhook Proxy add-on, but the new OAuth-enforcing integration code has not been loaded into Home Assistant yet. Submitting this form will restart Home Assistant so the new code takes effect; the webhook URL will then enforce OAuth.\n\nClick **Submit** to restart now."
+            "description": "The MCP Webhook Proxy add-on changed something Home Assistant can only apply at startup, and the running instance has not picked it up yet. Either OAuth was enabled and the OAuth-enforcing integration code is not loaded, or the webhook ID was rotated and the new URL's OAuth discovery route is not bound. Submitting this form will restart Home Assistant so the change takes effect.\n\nClick **Submit** to restart now."
           }
         }
       }

--- a/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/translations/en.json
+++ b/homeassistant-addon-webhook-proxy-dev/mcp_proxy_dev/translations/en.json
@@ -12,12 +12,12 @@
   },
   "issues": {
     "oauth_restart_required": {
-      "title": "Restart Home Assistant to enable OAuth",
+      "title": "Restart Home Assistant to finish the MCP Webhook Proxy setup",
       "fix_flow": {
         "step": {
           "confirm": {
             "title": "Restart Home Assistant?",
-            "description": "OAuth was enabled in the MCP Webhook Proxy add-on, but the new OAuth-enforcing integration code has not been loaded into Home Assistant yet. Submitting this form will restart Home Assistant so the new code takes effect; the webhook URL will then enforce OAuth.\n\nClick **Submit** to restart now."
+            "description": "The MCP Webhook Proxy add-on changed something Home Assistant can only apply at startup, and the running instance has not picked it up yet. Either OAuth was enabled and the OAuth-enforcing integration code is not loaded, or the webhook ID was rotated and the new URL's OAuth discovery route is not bound. Submitting this form will restart Home Assistant so the change takes effect.\n\nClick **Submit** to restart now."
           }
         }
       }

--- a/homeassistant-addon-webhook-proxy-dev/start.py
+++ b/homeassistant-addon-webhook-proxy-dev/start.py
@@ -734,7 +734,13 @@ def _read_integration_domain() -> str | None:
 
 
 def _probe_oauth_active(attempts: int = 3, delay: int = 2) -> bool:
-    """Probe the OAuth protected-resource metadata endpoint.
+    """Probe the OAuth authorization-server metadata endpoint.
+
+    The RFC 8414 authorization-server document is the right probe target: it
+    is public by design, carries no webhook id, and is served in every OAuth
+    mode — but only by the OAuth-aware integration module. (The
+    protected-resource document is no longer served at a fixed path; its only
+    location now embeds the webhook id, which this probe must not publish.)
 
     Returns True only if HA serves the metadata URL — which means the
     OAuth-enforcing integration code is the one actually loaded in HA's
@@ -758,8 +764,8 @@ def _probe_oauth_active(attempts: int = 3, delay: int = 2) -> bool:
     for attempt in range(attempts):
         domain = _read_integration_domain()
         if domain:
-            result = _ha_core_api("GET", f"/{domain}/oauth/protected-resource")
-            if isinstance(result, dict) and "authorization_servers" in result:
+            result = _ha_core_api("GET", f"/{domain}/oauth/authorization-server")
+            if isinstance(result, dict) and "authorization_endpoint" in result:
                 return True
         if attempt < attempts - 1:
             time.sleep(delay)

--- a/homeassistant-addon-webhook-proxy/mcp_proxy/oauth_autoapprove.py
+++ b/homeassistant-addon-webhook-proxy/mcp_proxy/oauth_autoapprove.py
@@ -353,10 +353,20 @@ class AutoApproveAuthorizeView(HomeAssistantView):
             params.popall("client_id", None)
             params["client_id"] = forward_id
 
-        import yarl
+        from urllib.parse import urlencode
 
-        target = yarl.URL("/auth/authorize").with_query(params)
-        return web.Response(status=302, headers={"Location": str(target)})
+        # Percent-encode the query instead of handing the params to yarl: yarl
+        # legally leaves ":" and "/" literal inside query values (RFC 3986
+        # permits both in the query component), so a loopback client's callback
+        # forwards as ``redirect_uri=http://127.0.0.1:1234/callback``. Reverse
+        # proxies shipping a generic "block common exploits" ruleset -- Nginx
+        # Proxy Manager enables one per host with a checkbox -- match
+        # ``[a-zA-Z0-9_]=http://`` and answer 403 before core ever sees the
+        # request, stranding every native-app client behind such a proxy.
+        # Full encoding is semantically identical and survives those filters.
+        query = urlencode(list(params.items()))
+        target = f"/auth/authorize?{query}" if query else "/auth/authorize"
+        return web.Response(status=302, headers={"Location": target})
 
     async def post(self, request: web.Request) -> web.Response:
         """Handle legacy consent submissions on the scoped authorize route."""

--- a/homeassistant-addon-webhook-proxy/mcp_proxy/oauth_autoapprove.py
+++ b/homeassistant-addon-webhook-proxy/mcp_proxy/oauth_autoapprove.py
@@ -353,20 +353,10 @@ class AutoApproveAuthorizeView(HomeAssistantView):
             params.popall("client_id", None)
             params["client_id"] = forward_id
 
-        from urllib.parse import urlencode
+        import yarl
 
-        # Percent-encode the query instead of handing the params to yarl: yarl
-        # legally leaves ":" and "/" literal inside query values (RFC 3986
-        # permits both in the query component), so a loopback client's callback
-        # forwards as ``redirect_uri=http://127.0.0.1:1234/callback``. Reverse
-        # proxies shipping a generic "block common exploits" ruleset -- Nginx
-        # Proxy Manager enables one per host with a checkbox -- match
-        # ``[a-zA-Z0-9_]=http://`` and answer 403 before core ever sees the
-        # request, stranding every native-app client behind such a proxy.
-        # Full encoding is semantically identical and survives those filters.
-        query = urlencode(list(params.items()))
-        target = f"/auth/authorize?{query}" if query else "/auth/authorize"
-        return web.Response(status=302, headers={"Location": target})
+        target = yarl.URL("/auth/authorize").with_query(params)
+        return web.Response(status=302, headers={"Location": str(target)})
 
     async def post(self, request: web.Request) -> web.Response:
         """Handle legacy consent submissions on the scoped authorize route."""

--- a/tests/addon/test_webhook_proxy.py
+++ b/tests/addon/test_webhook_proxy.py
@@ -2486,6 +2486,29 @@ def _wellknown_oauth_urls(oauth_mod, webhook_id):
     }
 
 
+def _scoped_only_prm(oauth_mod):
+    """True when the flavor serves ONLY the path-scoped protected-resource
+    document (fixed-path view removed; scoped view carries the bound id)."""
+    return not hasattr(oauth_mod, "ProtectedResourceMetadataView")
+
+
+def _probe_metadata_target(start_mod):
+    """The (path suffix, required key) the flavor's `_probe_oauth_active` uses.
+
+    Feature-DETECTED from the flavor's own start.py source, for the same reason
+    as `_wellknown_oauth_urls`: the promote workflow copies dev's code onto
+    stable without touching tests. Dev probes the RFC 8414 authorization-server
+    document (public by design, carries no webhook id); stable still probes the
+    fixed-path protected-resource one.
+    """
+    import inspect
+
+    src = inspect.getsource(start_mod._probe_oauth_active)
+    if "authorization-server" in src:
+        return "authorization-server", "authorization_endpoint"
+    return "protected-resource", "authorization_servers"
+
+
 class TestOAuthSetupEntry:
     """async_setup_entry creates and registers an OAuthProvider when the
     config has an oauth section with non-empty creds."""
@@ -2537,12 +2560,14 @@ class TestOAuthSetupEntry:
         provider = hass.data[mod.DOMAIN]["oauth"]
         assert provider is not None
         assert provider.client_id == "client-1234567890ABCDEF"
-        # 4 core OAuth views, plus the well-known metadata variants on flavors
-        # that ship them (feature-detected — see _wellknown_oauth_urls), plus
-        # the two unified scoped dispatchers that legacy mode now also binds,
-        # plus the scoped revocation dispatcher bound with them (#2248).
+        # 4 core OAuth views (3 on flavors that dropped the fixed-path
+        # protected-resource document), plus the well-known metadata variants
+        # on flavors that ship them (feature-detected — see
+        # _wellknown_oauth_urls), plus the two unified scoped dispatchers that
+        # legacy mode now also binds, plus the scoped revocation dispatcher
+        # bound with them (#2248).
         expected_views = (
-            4
+            (3 if _scoped_only_prm(oauth) else 4)
             + len(_wellknown_oauth_urls(oauth, "mcp_test"))
             + (2 if _unified_oauth_routes() else 0)
             + (1 if _scoped_revoke_supported() else 0)
@@ -2817,6 +2842,16 @@ class TestOAuthRestartRepairTrigger:
             hass.data[
                 f"webhook_proxy_oauth_autoapprove_views_registered_{mod.DOMAIN}"
             ] = True
+        # Same premise again for the discovery-document bundle: register_views
+        # bound it in the earlier session too, under this config's webhook id.
+        # The reuse branch now re-consults the metadata registrar (it is the
+        # only thing that can notice a rotated webhook id), so an unseeded
+        # guard would read as "never bound" and re-register the bundle.
+        hass.data[oauth._METADATA_VIEWS_REGISTERED_KEY] = True
+        if hasattr(oauth, "_METADATA_VIEWS_BOUND_WEBHOOK_ID_KEY"):
+            hass.data[oauth._METADATA_VIEWS_BOUND_WEBHOOK_ID_KEY] = (
+                self._oauth_config()["webhook_id"]
+            )
         repairs.RESTART_MARKER_FILE.write_text('{"reason": "stale"}')
         with (
             patch.object(mod, "_read_config", return_value=self._oauth_config()),
@@ -3497,7 +3532,13 @@ class TestProtectedResourceView:
         oauth, provider = _provider_for_view_tests(
             tmp_path, public_base_url="https://legit.example"
         )
-        view = oauth.ProtectedResourceMetadataView(provider)
+        # Same document either way; on scoped-only flavors the path-scoped view
+        # is the only one that serves it.
+        view = (
+            oauth.WellKnownProtectedResourceView(provider)
+            if _scoped_only_prm(oauth)
+            else oauth.ProtectedResourceMetadataView(provider)
+        )
         request = _make_view_request(headers={"Host": "evil.example"})
 
         with patch.object(oauth.web, "json_response") as json_resp:
@@ -3573,6 +3614,16 @@ class TestWellKnownMetadataViews:
         with patch.object(oauth.web, "json_response") as json_resp:
             await view.get(request)
         wellknown_body = json_resp.call_args.args[0]
+        if _scoped_only_prm(oauth):
+            # Nothing left to compare against — this IS the only
+            # protected-resource document, so pin its content literally.
+            assert wellknown_body == {
+                "resource": "https://legit.example/api/webhook/mcp_webhook_id_aaaa",
+                "authorization_servers": [f"https://legit.example{oauth.OAUTH_BASE}"],
+                "bearer_methods_supported": ["header"],
+                "resource_documentation": "https://github.com/homeassistant-ai/ha-mcp",
+            }
+            return
         with patch.object(oauth.web, "json_response") as json_resp:
             await oauth.ProtectedResourceMetadataView(provider).get(request)
         assert wellknown_body == json_resp.call_args.args[0]
@@ -3603,6 +3654,64 @@ class TestWellKnownMetadataViews:
         # No DCR: the proxy has fixed credentials, so the document must not
         # advertise a registration endpoint (clients would try it and fail).
         assert "registration_endpoint" not in canonical
+
+    async def test_scoped_prm_404s_once_bound_id_is_no_longer_live(self, tmp_path):
+        """A rotated webhook id must not be served through the OLD id's URL.
+
+        The scoped view is an exact-path bind, so HA keeps serving the old URL
+        until it restarts; whoever holds the old id must get a 404 there, never
+        the new id.
+        """
+        oauth, bound = _provider_for_view_tests(
+            tmp_path, public_base_url="https://legit.example"
+        )
+        self._skip_unless_shipped(oauth)
+        if not _scoped_only_prm(oauth):
+            pytest.skip("flavor does not carry the bound-id check yet")
+        view = oauth.WellKnownProtectedResourceView(bound)
+        rotated = oauth.OAuthProvider(
+            hass=bound._hass,
+            client_id="client-id-1234567890ABCDEF",
+            client_secret="client-secret-very-secret",
+            webhook_id="mcp_webhook_id_bbbb",
+            signing_key=b"\x00" * 32,
+            public_base_url="https://legit.example",
+        )
+        bound._hass.data = {
+            oauth.DOMAIN: {"oauth": rotated, "oauth_mode": oauth.MODE_LEGACY}
+        }
+        request = _make_view_request(headers={"Host": "legit.example"})
+        with patch.object(oauth.web, "json_response") as jr:
+            await view.get(request)
+        assert jr.call_args.kwargs["status"] == 404
+        assert "mcp_webhook_id_bbbb" not in json.dumps(jr.call_args.args[0])
+
+    def test_register_metadata_views_reports_restart_when_webhook_id_changes(
+        self, tmp_path
+    ):
+        """The registrar reports the one case a restart is genuinely needed."""
+        oauth, first = _provider_for_view_tests(tmp_path)
+        self._skip_unless_shipped(oauth)
+        if not _scoped_only_prm(oauth):
+            pytest.skip("flavor's register_metadata_views returns no verdict")
+        hass = first._hass
+        hass.data = {}
+        hass.http = MagicMock()
+        assert oauth.register_metadata_views(hass, first) is False
+        assert hass.http.register_view.call_count == 6
+        # Same id on a reload: bound views are reused, no restart.
+        assert oauth.register_metadata_views(hass, first) is False
+        rotated = oauth.OAuthProvider(
+            hass=hass,
+            client_id="client-id-1234567890ABCDEF",
+            client_secret="client-secret-very-secret",
+            webhook_id="mcp_webhook_id_bbbb",
+            signing_key=b"\x00" * 32,
+            public_base_url=None,
+        )
+        assert oauth.register_metadata_views(hass, rotated) is True
+        # It never rebinds — HA cannot drop a bound view until it restarts.
+        assert hass.http.register_view.call_count == 6
 
 
 class TestAuthorizeViewGet:
@@ -4708,15 +4817,18 @@ class TestProbeOAuthActive:
         return _import_start()
 
     def test_probe_returns_true_when_metadata_endpoint_returns_json(self, start):
+        _path, key = _probe_metadata_target(start)
+        value = (
+            "https://h/api/mcp_proxy/oauth/authorize"
+            if key == "authorization_endpoint"
+            else ["https://h/api/mcp_proxy/oauth"]
+        )
         with (
             patch.object(start, "_read_integration_domain", return_value="mcp_proxy"),
             patch.object(
                 start,
                 "_ha_core_api",
-                return_value={
-                    "resource": "https://h/api/webhook/x",
-                    "authorization_servers": ["https://h/api/mcp_proxy/oauth"],
-                },
+                return_value={"resource": "https://h/api/webhook/x", key: value},
             ),
         ):
             assert start._probe_oauth_active() is True
@@ -4745,7 +4857,7 @@ class TestProbeOAuthActive:
             assert start._probe_oauth_active() is False
         assert sleep.call_count == 2
 
-    def test_probe_returns_false_when_authorization_servers_missing(self, start):
+    def test_probe_returns_false_when_authorization_endpoint_missing(self, start):
         # A different endpoint accidentally exists at the same URL
         sleep = MagicMock()
         with (
@@ -4770,7 +4882,13 @@ class TestProbeOAuthActive:
         path: the probe retries and returns True once the endpoint reports
         active on a later attempt."""
         sleep = MagicMock()
-        results = [None, {"authorization_servers": ["https://h/oauth"]}]
+        _path, key = _probe_metadata_target(start)
+        value = (
+            "https://h/oauth/authorize"
+            if key == "authorization_endpoint"
+            else ["https://h/oauth"]
+        )
+        results = [None, {key: value}]
         with (
             patch.object(start, "_read_integration_domain", return_value="mcp_proxy"),
             patch.object(start, "_ha_core_api", side_effect=results),
@@ -4785,11 +4903,12 @@ class TestProbeOAuthActive:
         it works for both the prod variant (mcp_proxy) and the fork-dev
         variant (mcp_proxy_dev) without any code change."""
         captured = {}
+        doc_path, key = _probe_metadata_target(start)
 
         def fake_api(method, path):
             captured["method"] = method
             captured["path"] = path
-            return {"authorization_servers": []}
+            return {key: "https://h/oauth/authorize"}
 
         with (
             patch.object(
@@ -4799,7 +4918,7 @@ class TestProbeOAuthActive:
         ):
             start._probe_oauth_active()
 
-        assert captured["path"] == "/mcp_proxy_dev/oauth/protected-resource"
+        assert captured["path"] == f"/mcp_proxy_dev/oauth/{doc_path}"
 
 
 class TestOAuthSetupEntryRegistersExpectedViews:
@@ -4851,11 +4970,12 @@ class TestOAuthSetupEntryRegistersExpectedViews:
         # issue-#1714 well-known metadata variants register those too
         # (feature-detected — see _wellknown_oauth_urls).
         expected = {
-            f"{CURRENT['oauth_base']}/protected-resource",
             f"{CURRENT['oauth_base']}/authorization-server",
             "/authorize",
             "/token",
         } | _wellknown_oauth_urls(oauth, "mcp_test")
+        if not _scoped_only_prm(oauth):
+            expected.add(f"{CURRENT['oauth_base']}/protected-resource")
         if _unified_oauth_routes():
             # The unified scoped dispatchers bind in every mode; the root
             # views above stay as the legacy compatibility aliases.
@@ -4889,7 +5009,17 @@ class TestUnauthorizedResponseShape:
         ww = kwargs["headers"]["WWW-Authenticate"]
         # Pinned base means evil.example is NOT in the metadata URL
         assert "evil.example" not in ww
-        assert f"https://legit.example{CURRENT['oauth_base']}/protected-resource" in ww
+        if _scoped_only_prm(oauth):
+            # The pointer is the RFC 9728 §3.1 path-scoped URL — the only
+            # protected-resource document left.
+            assert (
+                "https://legit.example/.well-known/oauth-protected-resource"
+                "/api/webhook/mcp_webhook_id_aaaa" in ww
+            )
+        else:
+            assert (
+                f"https://legit.example{CURRENT['oauth_base']}/protected-resource" in ww
+            )
 
 
 class TestHaAuthMode:
@@ -4978,9 +5108,10 @@ class TestHaAuthMode:
             call.args[0].url for call in hass.http.register_view.call_args_list
         }
         expected = {
-            f"{CURRENT['oauth_base']}/protected-resource",
             f"{CURRENT['oauth_base']}/authorization-server",
         } | _wellknown_oauth_urls(oauth, "mcp_test")
+        if not _scoped_only_prm(oauth):
+            expected.add(f"{CURRENT['oauth_base']}/protected-resource")
         if _unified_oauth_routes():
             expected |= {
                 f"{CURRENT['oauth_base']}/authorize",
@@ -5134,7 +5265,7 @@ class TestHaAuthMode:
             # A second setup (config-entry reload) must NOT re-register the views.
             await mod.async_setup_entry(hass, MagicMock())
         assert first == (
-            7
+            (6 if _scoped_only_prm(oauth) else 7)
             + (2 if _unified_oauth_routes() else 0)
             + (1 if _scoped_revoke_supported() else 0)
             + (1 if _dcr_registration_supported() else 0)
@@ -5143,6 +5274,42 @@ class TestHaAuthMode:
         # The register-once flag lives in oauth.py (a top-level hass.data key),
         # not on the integration package.
         assert hass.data[oauth._METADATA_VIEWS_REGISTERED_KEY] is True
+
+    async def test_ha_auth_setup_reports_restart_when_webhook_id_changed(
+        self, hass, tmp_path
+    ):
+        """A webhook id rotated mid-session raises the restart Repair.
+
+        The path-scoped discovery URL bound this session names the OLD id and
+        HA cannot rebind it, so the new id has no discovery URL until a
+        restart — the one case where a reload is not enough.
+        """
+        mod, oauth, _an = _import_ha_auth_stack(tmp_secret_dir=tmp_path)
+        if not _scoped_only_prm(oauth):
+            pytest.skip("flavor does not detect a rotated webhook id yet")
+        repairs = _bind_repairs(mod, tmp_path)
+        rotated = self._ha_auth_config() | {"webhook_id": "mcp_rotated"}
+        with (
+            patch.object(
+                mod,
+                "_read_config",
+                side_effect=[self._ha_auth_config(), rotated],
+            ),
+            patch.object(mod, "async_register"),
+            patch.object(mod.aiohttp, "ClientSession", return_value=MagicMock()),
+            patch.object(repairs, "create_issue") as mock_create,
+            patch.object(repairs, "_write_marker"),
+            patch.object(repairs, "_delete_issue_only"),
+        ):
+            await mod.async_setup_entry(hass, MagicMock())
+            mock_create.assert_not_called()
+            hass.http.register_view.reset_mock()
+            await mod.async_setup_entry(hass, MagicMock())
+        mock_create.assert_called_once_with(hass, mod.DOMAIN)
+        # HA cannot rebind a bound view, so nothing was registered again...
+        assert hass.http.register_view.call_count == 0
+        # ...and the recorded bound id stays the one the URLs actually carry.
+        assert hass.data[oauth._METADATA_VIEWS_BOUND_WEBHOOK_ID_KEY] == "mcp_test"
 
     async def test_register_once_flag_survives_unload(self, hass, tmp_path):
         """The register-once flags outlive the config-entry data they gate.
@@ -5162,7 +5329,7 @@ class TestHaAuthMode:
         ):
             await mod.async_setup_entry(hass, MagicMock())
             assert hass.http.register_view.call_count == (
-                7
+                (6 if _scoped_only_prm(oauth) else 7)
                 + (2 if _unified_oauth_routes() else 0)
                 + (1 if _scoped_revoke_supported() else 0)
                 + (1 if _dcr_registration_supported() else 0)
@@ -5194,10 +5361,10 @@ class TestHaAuthMode:
     async def test_ha_auth_then_legacy_does_not_reregister_metadata(
         self, hass, tmp_path
     ):
-        """A live ha_auth -> legacy switch reuses the already-bound seven
+        """A live ha_auth -> legacy switch reuses the already-bound
         metadata views: legacy's register_views() routes them through the same
         flag-guarded registrar, so the second setup registers ONLY the two root
-        views, never a duplicate of the seven."""
+        views, never a duplicate of the metadata bundle."""
         mod, oauth, auth_native = _import_ha_auth_stack(tmp_secret_dir=tmp_path)
         _bind_repairs(mod, tmp_path)
         # Boot-time so legacy binds its root views cleanly (no restart Repair).
@@ -5213,7 +5380,7 @@ class TestHaAuthMode:
         ):
             await mod.async_setup_entry(hass, MagicMock())  # ha_auth discovery
             assert hass.http.register_view.call_count == (
-                7
+                (6 if _scoped_only_prm(oauth) else 7)
                 + (2 if _unified_oauth_routes() else 0)
                 + (1 if _scoped_revoke_supported() else 0)
                 + (1 if _dcr_registration_supported() else 0)
@@ -5224,7 +5391,7 @@ class TestHaAuthMode:
             call.args[0].url for call in hass.http.register_view.call_args_list
         }
         assert registered == {"/authorize", "/token"}
-        # None of the seven metadata views were registered a second time.
+        # None of the metadata views were registered a second time.
         assert not (registered & _wellknown_oauth_urls(oauth, "mcp_test"))
         assert hass.data[mod.DOMAIN]["oauth_mode"] == mod.OAUTH_MODE_LEGACY
 
@@ -5245,8 +5412,11 @@ class TestHaAuthMode:
             patch.object(mod.aiohttp, "ClientSession", return_value=MagicMock()),
         ):
             await mod.async_setup_entry(hass, MagicMock())  # legacy views + root
+            # metadata bundle + the two root aliases legacy binds.
             assert hass.http.register_view.call_count == (
-                (11 if _unified_oauth_routes() else 9)
+                (6 if _scoped_only_prm(oauth) else 7)
+                + 2
+                + (2 if _unified_oauth_routes() else 0)
                 + (1 if _scoped_revoke_supported() else 0)
             )
             hass.http.register_view.reset_mock()
@@ -5415,8 +5585,13 @@ class TestHaAuthMode:
     async def test_prm_document_ha_auth_matches_legacy_shape(self, tmp_path):
         oauth, rs = self._resource_server(tmp_path)
         request = _make_view_request(headers={"Host": "ignored"})
+        prm_view = (
+            oauth.WellKnownProtectedResourceView(rs)
+            if _scoped_only_prm(oauth)
+            else oauth.ProtectedResourceMetadataView(rs)
+        )
         with patch.object(oauth.web, "json_response") as jr:
-            await oauth.ProtectedResourceMetadataView(rs).get(request)
+            await prm_view.get(request)
         body = jr.call_args.args[0]
         assert body["resource"] == (
             "https://legit.example/api/webhook/mcp_webhook_id_aaaa"
@@ -5707,10 +5882,12 @@ class TestHaAuthMode:
             signing_key=b"\x00" * 32,
         )
         req = _make_view_request(headers={"Host": "h"})
-        for view in (
-            oauth.ProtectedResourceMetadataView(provider),
-            oauth.AuthorizationServerMetadataView(provider),
-        ):
+        prm_view = (
+            oauth.WellKnownProtectedResourceView(provider)
+            if _scoped_only_prm(oauth)
+            else oauth.ProtectedResourceMetadataView(provider)
+        )
+        for view in (prm_view, oauth.AuthorizationServerMetadataView(provider)):
             with patch.object(oauth.web, "json_response") as jr:
                 await view.get(req)
             assert jr.call_args.kwargs.get("status") == 404
@@ -5760,10 +5937,12 @@ class TestHaAuthMode:
             signing_key=b"\x00" * 32,
         )
         req = _make_view_request(headers={"Host": "h"})
-        for view in (
-            oauth.ProtectedResourceMetadataView(provider),
-            oauth.AuthorizationServerMetadataView(provider),
-        ):
+        prm_view = (
+            oauth.WellKnownProtectedResourceView(provider)
+            if _scoped_only_prm(oauth)
+            else oauth.ProtectedResourceMetadataView(provider)
+        )
+        for view in (prm_view, oauth.AuthorizationServerMetadataView(provider)):
             with patch.object(oauth.web, "json_response") as jr:
                 await view.get(req)
             assert jr.call_args.kwargs.get("status") == 404
@@ -5812,10 +5991,17 @@ class TestHaAuthMode:
             oauth.build_unauthorized_response(req, ha)
         ha_ww = rc.call_args.kwargs["headers"]["WWW-Authenticate"]
         assert legacy_ww == ha_ww
-        assert legacy_ww == (
-            'Bearer realm="MCP Proxy", resource_metadata='
-            f'"https://myhost.example{oauth.OAUTH_BASE}/protected-resource"'
-        )
+        if _scoped_only_prm(oauth):
+            assert legacy_ww == (
+                'Bearer realm="MCP Proxy", resource_metadata='
+                '"https://myhost.example/.well-known/oauth-protected-resource'
+                '/api/webhook/mcp_webhook_id_aaaa"'
+            )
+        else:
+            assert legacy_ww == (
+                'Bearer realm="MCP Proxy", resource_metadata='
+                f'"https://myhost.example{oauth.OAUTH_BASE}/protected-resource"'
+            )
 
     # ---- the ha_auth AS document is served identically at all 4 well-known URLs ----
 
@@ -6480,11 +6666,70 @@ class TestNoneAutoApproveMode:
         # NOT leak the webhook id (the sole credential in none mode) to an
         # anonymous GET — it 404s in none-autoapprove mode.
         _mod, oauth, autoapprove, _an = _import_none_autoapprove_stack()
+        if _scoped_only_prm(oauth):
+            pytest.skip("flavor no longer ships the fixed-path document")
         hass, provider = self._none_live_hass(oauth, autoapprove)
         request = _make_view_request(headers={"Host": "legit.example"})
         with patch.object(oauth.web, "json_response") as jr:
             await oauth.ProtectedResourceMetadataView(provider).get(request)
         assert jr.call_args.kwargs["status"] == 404
+
+    async def test_no_fixed_path_view_reveals_webhook_id_in_any_mode(self):
+        # The webhook id must never appear in a document reachable without
+        # already presenting it: every metadata view whose URL does not embed
+        # the id is fetched in each live mode and its body checked. The
+        # #1976 mode gate is gone because there is no fixed-path document left
+        # to gate — this pins that there is none in ANY mode, not just none.
+        _mod, oauth, autoapprove, auth_native = _import_none_autoapprove_stack()
+        if not _scoped_only_prm(oauth):
+            pytest.skip("flavor still ships the fixed-path document")
+        webhook_id = "mcp_test"
+        request = _make_view_request(headers={"Host": "legit.example"})
+        for provider in (
+            self._none_live_hass(oauth, autoapprove, webhook_id)[1],
+            self._ha_auth_live_provider(oauth, auth_native, webhook_id),
+            self._legacy_live_provider(oauth, webhook_id),
+        ):
+            for view in oauth._metadata_views(provider):
+                if webhook_id in view.url:
+                    continue
+                with patch.object(oauth.web, "json_response") as jr:
+                    await view.get(request)
+                body = json.dumps(jr.call_args.args[0])
+                assert webhook_id not in body, f"{view.url} leaks the webhook id"
+
+    @staticmethod
+    def _ha_auth_live_provider(oauth, auth_native, webhook_id):
+        """A ResourceServer whose hass reports ha_auth as the live mode."""
+        hass = MagicMock()
+        hass.data = {}
+        rs = auth_native.ResourceServer(hass, webhook_id, None)
+        hass.data[oauth.DOMAIN] = {
+            "webhook_id": webhook_id,
+            "oauth": rs,
+            "oauth_mode": oauth.MODE_HA_AUTH,
+        }
+        return rs
+
+    @staticmethod
+    def _legacy_live_provider(oauth, webhook_id):
+        """An OAuthProvider whose hass reports legacy as the live mode."""
+        hass = MagicMock()
+        hass.data = {}
+        provider = oauth.OAuthProvider(
+            hass=hass,
+            client_id="client-id-1234567890ABCDEF",
+            client_secret="client-secret-very-secret",
+            webhook_id=webhook_id,
+            signing_key=b"\x00" * 32,
+            public_base_url=None,
+        )
+        hass.data[oauth.DOMAIN] = {
+            "webhook_id": webhook_id,
+            "oauth": provider,
+            "oauth_mode": oauth.MODE_LEGACY,
+        }
+        return provider
 
     async def test_path_scoped_protected_resource_still_serves_in_none_mode(self):
         # The path-scoped view (URL embeds the id) KEEPS serving in none mode —
@@ -6803,9 +7048,10 @@ class TestNoneAutoApproveMode:
             call.args[0].url for call in hass.http.register_view.call_args_list
         }
         metadata = {
-            f"{CURRENT['oauth_base']}/protected-resource",
             f"{CURRENT['oauth_base']}/authorization-server",
         } | _wellknown_oauth_urls(oauth, "mcp_test")
+        if not _scoped_only_prm(oauth):
+            metadata.add(f"{CURRENT['oauth_base']}/protected-resource")
         autoapprove_urls = {
             f"{CURRENT['oauth_base']}/authorize",
             f"{CURRENT['oauth_base']}/token",

--- a/tests/addon/test_webhook_proxy.py
+++ b/tests/addon/test_webhook_proxy.py
@@ -7085,6 +7085,53 @@ class TestNoneAutoApproveMode:
         mock_create.assert_not_called()
         mock_write.assert_not_called()
 
+    async def test_none_mode_rotation_raises_the_shared_restart_repair(
+        self, hass, tmp_path
+    ):
+        """A rotation with OAuth OFF must raise the same restart Repair.
+
+        Review finding: the none branch now forwards register_metadata_views'
+        verdict, so this path reaches create_issue for the first time. Pin
+        WHICH Repair that becomes — the shared restart issue, whose strings
+        cover both causes — not merely that the verdict was True.
+        """
+        mod, oauth, _aa, _an = _import_none_autoapprove_stack(tmp_path)
+        if not _scoped_only_prm(oauth):
+            pytest.skip("flavor does not detect a rotated webhook id yet")
+        repairs = _bind_repairs(mod, tmp_path)
+        base = {
+            "target_url": "http://127.0.0.1:9583/private_zctpwlX7ZkIAr7oqdfLPxw",
+            "webhook_id": "mcp_test",
+        }
+        rotated = base | {"webhook_id": "mcp_rotated"}
+        with (
+            patch.object(mod, "_read_config", side_effect=[base, rotated]),
+            patch.object(mod, "async_register"),
+            patch.object(mod.aiohttp, "ClientSession", return_value=MagicMock()),
+            patch.object(repairs, "create_issue") as mock_create,
+            patch.object(repairs, "_write_marker"),
+            patch.object(repairs, "_delete_issue_only"),
+        ):
+            await mod.async_setup_entry(hass, MagicMock())
+            mock_create.assert_not_called()
+            await mod.async_setup_entry(hass, MagicMock())
+        mock_create.assert_called_once_with(hass, mod.DOMAIN)
+        # The default issue id is the shared restart Repair, and its strings
+        # must not be the OAuth-only wording any more (the operator here never
+        # enabled OAuth).
+        assert repairs.ISSUE_ID == "oauth_restart_required"
+        strings = json.loads(
+            (Path(PROXY_ADDON_DIR) / CURRENT["component"] / "strings.json").read_text(
+                encoding="utf-8"
+            )
+        )
+        issue = strings["issues"][repairs.ISSUE_ID]
+        blurb = issue["title"] + issue["fix_flow"]["step"]["confirm"]["description"]
+        assert "webhook ID was rotated" in blurb, (
+            "the shared Repair's strings must describe the rotation cause too, "
+            "or a none-mode operator is told OAuth was enabled"
+        )
+
     async def test_setup_failure_fails_open_keeps_plain_proxy(self, hass, tmp_path):
         """Unlike ha_auth/legacy, a none-mode auto-approve setup failure must NOT
         tear down the (intentionally unauthenticated) webhook — it just skips the

--- a/tests/src/e2e/workflows/hacs/test_auto_refresh_startup.py
+++ b/tests/src/e2e/workflows/hacs/test_auto_refresh_startup.py
@@ -51,7 +51,10 @@ import pytest
 from fastmcp import Client
 from fastmcp.client.transports import StdioTransport
 
-from ha_mcp.client.rest_client import HomeAssistantCommandError
+from ha_mcp.client.rest_client import (
+    HomeAssistantCommandError,
+    HomeAssistantCommandTimeout,
+)
 from ha_mcp.client.websocket_client import (
     DEFAULT_COMMAND_WAIT_TIMEOUT,
     HomeAssistantWebSocketClient,
@@ -127,6 +130,14 @@ async def _wait_for_hacs_ws_ready(container_info: dict) -> None:
             try:
                 await client.send_command("hacs/repositories/list")
                 return
+            except HomeAssistantCommandTimeout:
+                # HACS registered the handler but has not answered yet — it
+                # populates its catalogue on the first boot after the
+                # fresh-config restart. That is the slow-runner case this
+                # helper exists for, and HomeAssistantCommandTimeout is a
+                # SIBLING of HomeAssistantCommandError, not a subclass, so it
+                # needs its own arm. The deadline below is the only stop.
+                pass
             except HomeAssistantCommandError as err:
                 if not (
                     err.code == "unknown_command"

--- a/tests/src/e2e/workflows/hacs/test_auto_refresh_startup.py
+++ b/tests/src/e2e/workflows/hacs/test_auto_refresh_startup.py
@@ -51,11 +51,11 @@ import pytest
 from fastmcp import Client
 from fastmcp.client.transports import StdioTransport
 
+from ha_mcp.client.rest_client import HomeAssistantCommandError
 from ha_mcp.client.websocket_client import (
     DEFAULT_COMMAND_WAIT_TIMEOUT,
     HomeAssistantWebSocketClient,
 )
-from ha_mcp.client.rest_client import HomeAssistantCommandError
 from ha_mcp.hacs_auto_refresh import MARKER_FILENAME_PREFIX, RETRY_DELAYS
 from ha_mcp.tools.hacs_registration import HACS_REFRESH_TIMEOUT
 

--- a/tests/src/e2e/workflows/hacs/test_auto_refresh_startup.py
+++ b/tests/src/e2e/workflows/hacs/test_auto_refresh_startup.py
@@ -107,8 +107,13 @@ async def _wait_for_hacs_ws_ready(container_info: dict) -> None:
     client = HomeAssistantWebSocketClient(
         container_info["base_url"], container_info.get("token", TEST_TOKEN)
     )
-    assert await client.connect(), "could not open the HA WebSocket for the probe"
+    # connect() opens the socket and starts its reader before it returns, and
+    # a cancellation in between bypasses its own cleanup — so the finally must
+    # already be armed when connect() runs; disconnect() tolerates a client
+    # that never got that far.
     try:
+        if not await client.connect():
+            pytest.fail("could not open the HA WebSocket for the HACS probe")
         deadline = asyncio.get_running_loop().time() + HACS_WS_READY_TIMEOUT
         while True:
             try:
@@ -345,7 +350,7 @@ async def test_web_launcher_runs_the_startup_nudge(
     container_info = ha_container_with_fresh_config
     await _wait_for_hacs_ws_ready(container_info)
     env = _http_launcher_env(container_info["base_url"], tmp_path)
-    env["HOMEASSISTANT_TOKEN"] = TEST_TOKEN
+    env["HOMEASSISTANT_TOKEN"] = container_info.get("token", TEST_TOKEN)
 
     def marker_files():
         return list(tmp_path.glob(f"{MARKER_FILENAME_PREFIX}_*.json"))

--- a/tests/src/e2e/workflows/hacs/test_auto_refresh_startup.py
+++ b/tests/src/e2e/workflows/hacs/test_auto_refresh_startup.py
@@ -51,7 +51,11 @@ import pytest
 from fastmcp import Client
 from fastmcp.client.transports import StdioTransport
 
-from ha_mcp.client.websocket_client import DEFAULT_COMMAND_WAIT_TIMEOUT
+from ha_mcp.client.websocket_client import (
+    DEFAULT_COMMAND_WAIT_TIMEOUT,
+    HomeAssistantWebSocketClient,
+)
+from ha_mcp.client.rest_client import HomeAssistantCommandError
 from ha_mcp.hacs_auto_refresh import MARKER_FILENAME_PREFIX, RETRY_DELAYS
 from ha_mcp.tools.hacs_registration import HACS_REFRESH_TIMEOUT
 
@@ -85,6 +89,48 @@ NUDGE_MARKER_TIMEOUT = (
 )
 
 
+# HACS registers its WebSocket handlers late in HA's boot, and this fixture
+# restarts HA with a fresh config before each test. Until those handlers exist
+# ``hacs/repositories/list`` answers ``unknown_command`` FAST, so the nudge's
+# attempts at 0 s, 30 s and 90 s can all fall inside that window on a slow
+# runner — and the next one, at 210 s, lands after NUDGE_MARKER_TIMEOUT below.
+# The budget below deliberately covers only the happy path plus ONE slow
+# failure; it is not a HACS-boot timeout. So wait for HACS to be reachable
+# BEFORE launching, from the test process, and the launcher's first attempt
+# succeeds. Bound it by the nudge's own schedule: if HACS is not up by then the
+# lane could never have passed anyway, and the message says which it was.
+HACS_WS_READY_TIMEOUT = sum(RETRY_DELAYS) + DEFAULT_COMMAND_WAIT_TIMEOUT
+
+
+async def _wait_for_hacs_ws_ready(container_info: dict) -> None:
+    """Block until the container's HACS answers ``hacs/repositories/list``."""
+    client = HomeAssistantWebSocketClient(
+        container_info["base_url"], container_info.get("token", TEST_TOKEN)
+    )
+    assert await client.connect(), "could not open the HA WebSocket for the probe"
+    try:
+        deadline = asyncio.get_running_loop().time() + HACS_WS_READY_TIMEOUT
+        while True:
+            try:
+                await client.send_command("hacs/repositories/list")
+                return
+            except HomeAssistantCommandError as err:
+                if not (
+                    err.code == "unknown_command"
+                    or "unknown command" in str(err).lower()
+                ):
+                    raise
+            if asyncio.get_running_loop().time() >= deadline:
+                pytest.fail(
+                    "HACS never registered its WebSocket handlers within "
+                    f"{HACS_WS_READY_TIMEOUT:.0f}s of the fresh-config restart, "
+                    "so no launcher could complete the startup nudge here."
+                )
+            await asyncio.sleep(2.0)
+    finally:
+        await client.disconnect()
+
+
 @pytest.mark.hacs
 async def test_stdio_launcher_runs_the_startup_nudge(
     ha_container_with_fresh_config, tmp_path
@@ -93,6 +139,7 @@ async def test_stdio_launcher_runs_the_startup_nudge(
     logger.info("Testing the HACS startup nudge through the stdio launcher...")
 
     container_info = ha_container_with_fresh_config
+    await _wait_for_hacs_ws_ready(container_info)
 
     # Use the same explicit environment as the stdio fixtures, plus this test's
     # config dir. HA_MCP_DISABLE_UPDATE_CHECK is intentionally absent because it
@@ -296,6 +343,7 @@ async def test_web_launcher_runs_the_startup_nudge(
     logger.info("Testing the HACS startup nudge through the ha-mcp-web launcher...")
 
     container_info = ha_container_with_fresh_config
+    await _wait_for_hacs_ws_ready(container_info)
     env = _http_launcher_env(container_info["base_url"], tmp_path)
     env["HOMEASSISTANT_TOKEN"] = TEST_TOKEN
 

--- a/tests/src/e2e/workflows/hacs/test_auto_refresh_startup.py
+++ b/tests/src/e2e/workflows/hacs/test_auto_refresh_startup.py
@@ -101,6 +101,14 @@ NUDGE_MARKER_TIMEOUT = (
 # lane could never have passed anyway, and the message says which it was.
 HACS_WS_READY_TIMEOUT = sum(RETRY_DELAYS) + DEFAULT_COMMAND_WAIT_TIMEOUT
 
+# pytest.ini caps every test FUNCTION at 300 s, which the readiness wait alone
+# can exceed on a genuinely broken HACS — and then the timeout kills the test
+# before the helper's own message says which stage never came up. Each
+# positive lane therefore carries its own budget: readiness + the marker window
+# + slack for the launcher to start and stop. Derived, not a literal, so
+# raising either schedule cannot silently outgrow it.
+POSITIVE_LANE_TIMEOUT = HACS_WS_READY_TIMEOUT + NUDGE_MARKER_TIMEOUT + 60.0
+
 
 async def _wait_for_hacs_ws_ready(container_info: dict) -> None:
     """Block until the container's HACS answers ``hacs/repositories/list``."""
@@ -137,6 +145,7 @@ async def _wait_for_hacs_ws_ready(container_info: dict) -> None:
 
 
 @pytest.mark.hacs
+@pytest.mark.timeout(POSITIVE_LANE_TIMEOUT)
 async def test_stdio_launcher_runs_the_startup_nudge(
     ha_container_with_fresh_config, tmp_path
 ):
@@ -341,6 +350,7 @@ async def _spawn_http_launcher(command: str, env: dict[str, str]) -> _HttpLaunch
 
 
 @pytest.mark.hacs
+@pytest.mark.timeout(POSITIVE_LANE_TIMEOUT)
 async def test_web_launcher_runs_the_startup_nudge(
     ha_container_with_fresh_config, tmp_path
 ):

--- a/tests/src/unit/test_component_ws_search.py
+++ b/tests/src/unit/test_component_ws_search.py
@@ -807,7 +807,7 @@ class TestInfo:
                 _REPO_ROOT / "custom_components" / "ha_mcp_tools" / "manifest.json"
             ).read_text(encoding="utf-8")
         )
-        assert manifest["version"] == COMPONENT_VERSION == "2.1.0"
+        assert manifest["version"] == COMPONENT_VERSION == "2.1.1"
 
 
 # =============================================================================

--- a/tests/src/unit/test_embedded_entry.py
+++ b/tests/src/unit/test_embedded_entry.py
@@ -355,8 +355,8 @@ class TestPrebindOAuthViews:
 
         eentry._prebind_oauth_views(hass, self._legacy_entry())
 
-        # 7 discovery + 3 scoped authorize/token/revoke + 2 root legacy aliases.
-        assert hass.http.register_view.call_count == 12
+        # 6 discovery + 3 scoped authorize/token/revoke + 2 root legacy aliases.
+        assert hass.http.register_view.call_count == 11
         assert hass.data.get(oauth_legacy.OAUTH_ROUTE_OWNER_KEY) == oauth_legacy._DOMAIN
 
     @pytest.mark.parametrize(
@@ -374,9 +374,9 @@ class TestPrebindOAuthViews:
 
         eentry._prebind_oauth_views(hass, entry)
 
-        # 7 discovery + 3 scoped authorize/token/revoke + 1 DCR registration
+        # 6 discovery + 3 scoped authorize/token/revoke + 1 DCR registration
         # route.
-        assert hass.http.register_view.call_count == 11
+        assert hass.http.register_view.call_count == 10
 
     def test_webhook_disabled_binds_nothing(self):
         hass = _make_hass()
@@ -401,9 +401,9 @@ class TestPrebindOAuthViews:
         eentry._prebind_oauth_views(hass, entry)
 
         # Root aliases wait for credentials, but advertised scoped routes must
-        # still beat Home Assistant's HTTP freeze: 7 discovery + 3 scoped
+        # still beat Home Assistant's HTTP freeze: 6 discovery + 3 scoped
         # authorize/token/revoke.
-        assert hass.http.register_view.call_count == 10
+        assert hass.http.register_view.call_count == 9
 
     def test_route_conflict_is_swallowed_at_setup(self):
         # The webhook-proxy add-on owning the root routes makes
@@ -420,8 +420,8 @@ class TestPrebindOAuthViews:
 
         assert hass.data[oauth_legacy.OAUTH_ROUTE_OWNER_KEY] == "webhook_proxy_addon"
         # The foreign owner blocks only the root aliases; scoped routes remain
-        # (7 discovery + 3 scoped authorize/token/revoke).
-        assert hass.http.register_view.call_count == 10
+        # (6 discovery + 3 scoped authorize/token/revoke).
+        assert hass.http.register_view.call_count == 9
 
 
 class TestEnsureSecretsLegacyWiring:

--- a/tests/src/unit/test_mcp_webhook.py
+++ b/tests/src/unit/test_mcp_webhook.py
@@ -1120,7 +1120,7 @@ class TestRegisterWebhook:
     async def test_ha_auth_re_enable_reuses_bound_views(self, monkeypatch):
         # aiohttp cannot unregister a bound view; the once-per-session guard
         # lives at a TOP-LEVEL hass.data key precisely so a none->ha_auth->
-        # none->ha_auth cycle re-USES the 9 views instead of re-binding them
+        # none->ha_auth cycle re-USES the 10 views instead of re-binding them
         # (which raises and takes the whole bring-up down). Review finding:
         # only the first registration was tested.
         hass = _register_hass()

--- a/tests/src/unit/test_mcp_webhook.py
+++ b/tests/src/unit/test_mcp_webhook.py
@@ -11,6 +11,7 @@ the fakes are installed before ``mcp_webhook`` binds them).
 
 from __future__ import annotations
 
+import json
 import secrets
 from types import SimpleNamespace
 from unittest.mock import MagicMock
@@ -383,8 +384,8 @@ class TestHaAuthGate:
         assert www.startswith("Bearer realm=")
         assert 'realm="HA-MCP"' in www
         assert (
-            f'resource_metadata="https://example.nabu.casa{OAUTH_BASE}/protected-resource"'
-            in www
+            'resource_metadata="https://example.nabu.casa'
+            f'/.well-known/oauth-protected-resource/api/webhook/{WEBHOOK_ID}"' in www
         )
 
     async def test_invalid_bearer_returns_401(self):
@@ -648,9 +649,9 @@ class TestDiscoveryViews:
 
     async def test_protected_resource_view_payload_when_live(self):
         hass = _live_hass()
-        view = mw._ProtectedResourceMetadataView(hass)
+        view = mw._WellKnownProtectedResourceView(hass)
         request = make_request(headers={"Host": "abc.ui.nabu.casa"})
-        resp = await view.get(request)
+        resp = await view.get(request, webhook_id=WEBHOOK_ID)
         assert resp.status == 200
         body = resp.json_body
         assert body["resource"] == f"https://abc.ui.nabu.casa/api/webhook/{WEBHOOK_ID}"
@@ -660,9 +661,13 @@ class TestDiscoveryViews:
         assert body["bearer_methods_supported"] == ["header"]
 
     async def test_protected_resource_view_404_when_not_live(self):
+        # Local-only cfg: no provider, so no mode is live and the scoped view
+        # 404s for the id it would otherwise serve.
         hass = _live_hass(auth_mode=WEBHOOK_AUTH_NONE)
-        view = mw._ProtectedResourceMetadataView(hass)
-        resp = await view.get(make_request(headers={"Host": "x"}))
+        view = mw._WellKnownProtectedResourceView(hass)
+        resp = await view.get(
+            make_request(headers={"Host": "x"}), webhook_id=WEBHOOK_ID
+        )
         assert resp.status == 404
 
     async def test_authorization_server_view_payload_when_live(self):
@@ -706,8 +711,10 @@ class TestDiscoveryViews:
 
     async def test_protected_resource_views_live_in_legacy_mode(self):
         hass = _live_hass(auth_mode=WEBHOOK_AUTH_LEGACY)
-        plain = mw._ProtectedResourceMetadataView(hass)
-        resp = await plain.get(make_request(headers={"Host": "abc.ui.nabu.casa"}))
+        scoped = mw._WellKnownProtectedResourceView(hass)
+        resp = await scoped.get(
+            make_request(headers={"Host": "abc.ui.nabu.casa"}), webhook_id=WEBHOOK_ID
+        )
         assert resp.status == 200
 
     def test_wellknown_protected_resource_url_is_parameterized(self):
@@ -731,25 +738,30 @@ class TestDiscoveryViews:
         # The live-found stale-binding scenario: views registered during the
         # FIRST entry keep working for a SECOND entry with a new webhook id.
         hass = _live_hass()
-        view = mw._ProtectedResourceMetadataView(hass)
+        view = mw._WellKnownProtectedResourceView(hass)
         hass.data[DOMAIN][DATA_WEBHOOK] = {
             "webhook_id": "mcp_second_entry_id",
             "auth_mode": WEBHOOK_AUTH_HA,
             "resource_server": mw.ResourceServer(hass, "mcp_second_entry_id"),
         }
-        resp = await view.get(make_request(headers={"Host": "abc.ui.nabu.casa"}))
+        request = make_request(headers={"Host": "abc.ui.nabu.casa"})
+        resp = await view.get(request, webhook_id="mcp_second_entry_id")
         assert resp.status == 200
         assert resp.json_body["resource"] == (
             "https://abc.ui.nabu.casa/api/webhook/mcp_second_entry_id"
         )
+        # The flip side of the route parameter: the FIRST entry's id stops
+        # answering, so whoever held it never learns the new one.
+        stale = await view.get(request, webhook_id=WEBHOOK_ID)
+        assert stale.status == 404
 
-    def test_metadata_views_bundle_is_seven_unique_named_views(self):
+    def test_metadata_views_bundle_is_six_unique_named_views(self):
         views = mw._metadata_views(_make_hass())
-        assert len(views) == 7
+        assert len(views) == 6
         names = {v.name for v in views}
-        assert len(names) == 7  # all unique route names
+        assert len(names) == 6  # all unique route names
         urls = {v.url for v in views}
-        assert len(urls) == 7  # all unique route paths
+        assert len(urls) == 6  # all unique route paths
 
 
 # ---------------------------------------------------------------------------
@@ -806,15 +818,26 @@ class TestNoneModeDiscovery:
         )
         assert doc["token_endpoint_auth_methods_supported"] == ["none"]
 
-    async def test_fixed_path_protected_resource_404s_in_none_mode(self):
-        # SECURITY (#1976): the fixed, guessable /protected-resource path must
-        # NOT leak the webhook id (the sole credential in none mode) to an
-        # anonymous GET. It 404s in none mode, serving only the bearer-gated
-        # modes (see test_protected_resource_view_payload_when_live for ha_auth).
-        hass = _none_live_hass()
-        request = make_request(headers={"Host": "abc.ui.nabu.casa"})
-        plain = mw._ProtectedResourceMetadataView(hass)
-        assert (await plain.get(request)).status == 404
+    async def test_no_fixed_path_view_reveals_webhook_id_in_any_mode(self):
+        # SECURITY (#1976): the webhook id must never appear in a document
+        # reachable without already presenting it. Every metadata view whose
+        # URL does NOT embed the id is fetched in each live mode and its body
+        # checked — a re-added fixed-path protected-resource document would
+        # fail here in ha_auth/legacy, which is exactly the leak that turned
+        # into a credential disclosure on a later switch back to none mode.
+        for hass in (
+            _live_hass(auth_mode=WEBHOOK_AUTH_HA),
+            _live_hass(auth_mode=WEBHOOK_AUTH_LEGACY),
+            _none_live_hass(),
+        ):
+            assert mw.active_auth_mode(hass) is not None  # the mode really is live
+            for view in mw._metadata_views(hass):
+                if "{webhook_id}" in view.url:
+                    continue
+                resp = await view.get(
+                    make_request(headers={"Host": "abc.ui.nabu.casa"})
+                )
+                assert WEBHOOK_ID not in json.dumps(resp.json_body)
 
     async def test_path_scoped_protected_resource_still_serves_in_none_mode(self):
         # The path-scoped view claude.ai's none-mode discovery actually uses
@@ -969,7 +992,7 @@ class TestRegisterWebhook:
 
     async def test_none_auth_binds_discovery_and_autoapprove_views(self, monkeypatch):
         # #1969: none mode now serves our corrected discovery + the auto-approve
-        # authorization server, so it binds the 7 discovery views, the 2
+        # authorization server, so it binds the 6 discovery views, the 2
         # unified OAuth views, and the DCR view, then registers an
         # AutoApproveProvider in cfg.
         hass = _register_hass()
@@ -988,9 +1011,9 @@ class TestRegisterWebhook:
         assert isinstance(cfg[mw.CFG_AUTOAPPROVE_PROVIDER], mw.AutoApproveProvider)
         assert cfg["resource_server"] is None
         assert cfg["oauth_provider"] is None
-        # 7 discovery views + 3 unified OAuth views (authorize/token/revoke)
+        # 6 discovery views + 3 unified OAuth views (authorize/token/revoke)
         # + 1 DCR view.
-        assert hass.http.register_view.call_count == 11
+        assert hass.http.register_view.call_count == 10
         assert mw.active_auth_mode(hass) == WEBHOOK_AUTH_NONE
 
     async def test_none_ha_auth_none_switch_reuses_bound_views(self, monkeypatch):
@@ -1007,7 +1030,7 @@ class TestRegisterWebhook:
             secret_path="/private_x",
             auth_mode=WEBHOOK_AUTH_NONE,
         )
-        assert hass.http.register_view.call_count == 11
+        assert hass.http.register_view.call_count == 10
         assert mw.active_auth_mode(hass) == WEBHOOK_AUTH_NONE
         await mw.async_unregister_webhook(hass)
 
@@ -1020,7 +1043,7 @@ class TestRegisterWebhook:
             secret_path="/private_x",
             auth_mode=WEBHOOK_AUTH_HA,
         )
-        assert hass.http.register_view.call_count == 11
+        assert hass.http.register_view.call_count == 10
         assert mw.active_auth_mode(hass) == WEBHOOK_AUTH_HA
         await mw.async_unregister_webhook(hass)
 
@@ -1032,7 +1055,7 @@ class TestRegisterWebhook:
             secret_path="/private_x",
             auth_mode=WEBHOOK_AUTH_NONE,
         )
-        assert hass.http.register_view.call_count == 11
+        assert hass.http.register_view.call_count == 10
         assert mw.active_auth_mode(hass) == WEBHOOK_AUTH_NONE
 
     async def test_ha_auth_registers_resource_server_and_views(self, monkeypatch):
@@ -1052,9 +1075,9 @@ class TestRegisterWebhook:
 
         cfg = hass.data[DOMAIN][DATA_WEBHOOK]
         assert isinstance(cfg["resource_server"], mw.ResourceServer)
-        # Seven discovery + three unified OAuth (authorize/token/revoke) + one
+        # Six discovery + three unified OAuth (authorize/token/revoke) + one
         # DCR view were bound.
-        assert hass.http.register_view.call_count == 11
+        assert hass.http.register_view.call_count == 10
         assert hass.data.get(mw._OAUTH_VIEWS_REGISTERED_KEY) is True
 
     async def test_ha_auth_isolates_cimd_fetches_from_forwarding(self, monkeypatch):
@@ -1097,7 +1120,7 @@ class TestRegisterWebhook:
     async def test_ha_auth_re_enable_reuses_bound_views(self, monkeypatch):
         # aiohttp cannot unregister a bound view; the once-per-session guard
         # lives at a TOP-LEVEL hass.data key precisely so a none->ha_auth->
-        # none->ha_auth cycle re-USES the 10 views instead of re-binding them
+        # none->ha_auth cycle re-USES the 9 views instead of re-binding them
         # (which raises and takes the whole bring-up down). Review finding:
         # only the first registration was tested.
         hass = _register_hass()
@@ -1110,7 +1133,7 @@ class TestRegisterWebhook:
             secret_path="/private_x",
             auth_mode=WEBHOOK_AUTH_HA,
         )
-        assert hass.http.register_view.call_count == 11
+        assert hass.http.register_view.call_count == 10
         await mw.async_unregister_webhook(hass)
 
         # Second enable in the same HA session: no new bindings, no raise.
@@ -1121,7 +1144,7 @@ class TestRegisterWebhook:
             secret_path="/private_x",
             auth_mode=WEBHOOK_AUTH_HA,
         )
-        assert hass.http.register_view.call_count == 11
+        assert hass.http.register_view.call_count == 10
         assert isinstance(
             hass.data[DOMAIN][DATA_WEBHOOK]["resource_server"], mw.ResourceServer
         )
@@ -1181,9 +1204,9 @@ class TestRegisterWebhook:
         cfg = hass.data[DOMAIN][DATA_WEBHOOK]
         assert isinstance(cfg["oauth_provider"], LegacyOAuthProvider)
         assert cfg["resource_server"] is None
-        # 7 discovery + 3 unified scoped (authorize/token/revoke) + 2 root
+        # 6 discovery + 3 unified scoped (authorize/token/revoke) + 2 root
         # legacy views.
-        assert hass.http.register_view.call_count == 12
+        assert hass.http.register_view.call_count == 11
         assert hass.data.get(OAUTH_ROUTE_OWNER_KEY) == DOMAIN
         assert restart_needed is False
 
@@ -1223,7 +1246,7 @@ class TestRegisterWebhook:
         assert hass.data[OAUTH_ROUTE_OWNER_KEY] == "webhook_proxy"
         # Only metadata + the three unified scoped views bind; root remains
         # add-on-owned.
-        assert hass.http.register_view.call_count == 10
+        assert hass.http.register_view.call_count == 9
         assert any(
             record.levelname == "WARNING"
             and record.name == mw.__name__
@@ -1380,7 +1403,7 @@ class TestRegisterWebhook:
         # metadata route, 404-ing clients that probe it. bind_autoapprove_views
         # uses the same flag-only-after-all-register pattern.
         hass = _register_hass()
-        # 7 metadata views; fail on the 3rd register_view, mid-bundle.
+        # 6 metadata views; fail on the 3rd register_view, mid-bundle.
         hass.http.register_view.side_effect = [None, None, RuntimeError("frozen")]
         with pytest.raises(RuntimeError):
             mw._register_metadata_views(hass)

--- a/tests/src/unit/test_oauth_autoapprove.py
+++ b/tests/src/unit/test_oauth_autoapprove.py
@@ -716,6 +716,40 @@ async def test_ha_auth_authorize_preserves_repeated_resource_parameters(
     ]
 
 
+async def test_ha_auth_authorize_percent_encodes_the_forwarded_query(
+    unified_view_client_factory,
+):
+    """Forward a loopback callback percent-encoded, not as a literal URL.
+
+    yarl legally leaves ":" and "/" unencoded inside a query value, which
+    renders a native-app callback as ``redirect_uri=http://127.0.0.1:1234/cb``.
+    Reverse proxies shipping a generic "block common exploits" ruleset -- Nginx
+    Proxy Manager enables one per host with a checkbox -- match
+    ``[a-zA-Z0-9_]=http://`` and answer 403 before core ever sees the request,
+    stranding every native-app client behind such a proxy.
+    """
+    import re
+    from urllib.parse import parse_qs, urlparse
+
+    client = await unified_view_client_factory(mode="ha_auth")
+    resp = await client.get(
+        "/api/ha_mcp_tools/oauth/authorize"
+        "?response_type=code&client_id=http%3A%2F%2F127.0.0.1%3A19877"
+        "&redirect_uri=http%3A%2F%2F127.0.0.1%3A19877%2Fmcp%2Foauth%2Fcallback"
+        "&code_challenge=" + "a" * 43 + "&code_challenge_method=S256"
+        "&state=xyz",
+        allow_redirects=False,
+    )
+    assert resp.status == 302
+    location = resp.headers["Location"]
+    # The exact pattern those proxy rulesets match must not survive the hop.
+    assert re.search(r"[a-zA-Z0-9_]=http://", location) is None
+    # ...while the parameters themselves are untouched.
+    query = parse_qs(urlparse(location).query)
+    assert query["redirect_uri"] == ["http://127.0.0.1:19877/mcp/oauth/callback"]
+    assert query["state"] == ["xyz"]
+
+
 async def test_ha_auth_token_forwards_translated_client_id(
     unified_view_client_factory, monkeypatch
 ):

--- a/tests/src/unit/test_oauth_autoapprove.py
+++ b/tests/src/unit/test_oauth_autoapprove.py
@@ -649,8 +649,9 @@ async def test_scoped_authorize_redirects_into_core_when_ha_auth_live(
         allow_redirects=False,
     )
     assert resp.status == 302
-    # Parse rather than substring-match: yarl legally leaves ':' and '/'
-    # unencoded inside query values (RFC 3986 permits them in the query).
+    # Parse rather than substring-match: the forwarded query is fully
+    # percent-encoded, so the raw Location never carries a literal ':' or '/'
+    # in a value.
     from urllib.parse import parse_qs, urlparse
 
     location_header = resp.headers["Location"]
@@ -721,12 +722,14 @@ async def test_ha_auth_authorize_percent_encodes_the_forwarded_query(
 ):
     """Forward a loopback callback percent-encoded, not as a literal URL.
 
-    yarl legally leaves ":" and "/" unencoded inside a query value, which
-    renders a native-app callback as ``redirect_uri=http://127.0.0.1:1234/cb``.
-    Reverse proxies shipping a generic "block common exploits" ruleset -- Nginx
-    Proxy Manager enables one per host with a checkbox -- match
-    ``[a-zA-Z0-9_]=http://`` and answer 403 before core ever sees the request,
-    stranding every native-app client behind such a proxy.
+    The forward was previously built with ``yarl.URL().with_query()``, which
+    legally leaves ":" and "/" unencoded inside a query value and so rendered
+    a native-app callback as
+    ``redirect_uri=http://127.0.0.1:19877/mcp/oauth/callback``. Reverse
+    proxies shipping a generic "block common exploits" ruleset (Nginx Proxy
+    Manager is a common one) match ``[a-zA-Z0-9_]=http://`` and answer 403
+    before core ever sees the request, stranding every native-app client
+    behind such a proxy.
     """
     import re
     from urllib.parse import parse_qs, urlparse
@@ -744,9 +747,15 @@ async def test_ha_auth_authorize_percent_encodes_the_forwarded_query(
     location = resp.headers["Location"]
     # The exact pattern those proxy rulesets match must not survive the hop.
     assert re.search(r"[a-zA-Z0-9_]=http://", location) is None
-    # ...while the parameters themselves are untouched.
-    query = parse_qs(urlparse(location).query)
+    # Stronger than the ruleset's own pattern: nothing in the forwarded query
+    # is left in a form a "block common exploits" filter could latch onto.
+    raw_query = urlparse(location).query
+    assert ":" not in raw_query and "/" not in raw_query
+    # ...while redirect_uri, client_id and state survive the encoding
+    # round-trip unchanged.
+    query = parse_qs(raw_query)
     assert query["redirect_uri"] == ["http://127.0.0.1:19877/mcp/oauth/callback"]
+    assert query["client_id"] == ["http://127.0.0.1:19877"]
     assert query["state"] == ["xyz"]
 
 

--- a/tests/src/unit/test_prm_route_precedence.py
+++ b/tests/src/unit/test_prm_route_precedence.py
@@ -1,0 +1,52 @@
+"""Pin the aiohttp routing property the two PRM views rely on to coexist.
+
+The Webhook Proxy app binds its RFC 9728 path-scoped document at an EXACT
+path (``/.well-known/oauth-protected-resource/api/webhook/<its id>``) while
+the in-process component binds a ``{webhook_id}`` route parameter under the
+same prefix and 404s any id that is not its own. Both can be installed on one
+Home Assistant, so the app's document must win for the app's id no matter
+which integration registered first. aiohttp's ``UrlDispatcher`` guarantees
+that: ``resolve`` walks the request path from the most specific segment
+upwards, and an exact-path resource is indexed under the full path while a
+dynamic one is indexed under its static prefix, so registration order only
+breaks ties between resources that share an index key. This test exercises the
+real router in both registration orders so a future aiohttp change surfaces
+here rather than as a dead discovery URL on a both-installed instance.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+aiohttp_web = pytest.importorskip("aiohttp.web")
+from aiohttp.test_utils import make_mocked_request  # noqa: E402
+
+PREFIX = "/.well-known/oauth-protected-resource/api/webhook"
+APP_ID = "mcp_app_id_aaaa"
+COMPONENT_ID = "mcp_component_id_bbbb"
+
+
+async def _exact(request):  # the app's view: bound at its own id
+    return aiohttp_web.Response(text="app")
+
+
+async def _dynamic(request):  # the component's view: route parameter
+    return aiohttp_web.Response(text=f"component:{request.match_info['webhook_id']}")
+
+
+@pytest.mark.parametrize("dynamic_first", [False, True])
+async def test_exact_path_wins_regardless_of_registration_order(dynamic_first):
+    router = aiohttp_web.UrlDispatcher()
+    if dynamic_first:
+        router.add_get(f"{PREFIX}/{{webhook_id}}", _dynamic)
+        router.add_get(f"{PREFIX}/{APP_ID}", _exact)
+    else:
+        router.add_get(f"{PREFIX}/{APP_ID}", _exact)
+        router.add_get(f"{PREFIX}/{{webhook_id}}", _dynamic)
+
+    match = await router.resolve(make_mocked_request("GET", f"{PREFIX}/{APP_ID}"))
+    assert match.handler is _exact
+
+    match = await router.resolve(make_mocked_request("GET", f"{PREFIX}/{COMPONENT_ID}"))
+    assert match.handler is _dynamic
+    assert match.get("webhook_id") == COMPONENT_ID

--- a/tests/src/unit/test_prm_route_precedence.py
+++ b/tests/src/unit/test_prm_route_precedence.py
@@ -16,37 +16,76 @@ here rather than as a dead discovery URL on a both-installed instance.
 
 from __future__ import annotations
 
-import pytest
+import importlib
+import sys
 
-aiohttp_web = pytest.importorskip("aiohttp.web")
-from aiohttp.test_utils import make_mocked_request  # noqa: E402
+import pytest
 
 PREFIX = "/.well-known/oauth-protected-resource/api/webhook"
 APP_ID = "mcp_app_id_aaaa"
 COMPONENT_ID = "mcp_component_id_bbbb"
 
 
-async def _exact(request):  # the app's view: bound at its own id
-    return aiohttp_web.Response(text="app")
+def _module_is(name: str, root: str) -> bool:
+    return name == root or name.startswith(f"{root}.")
 
 
-async def _dynamic(request):  # the component's view: route parameter
-    return aiohttp_web.Response(text=f"component:{request.match_info['webhook_id']}")
+@pytest.fixture
+def real_aiohttp():
+    """Import the REAL aiohttp for this test, then restore whatever was there.
+
+    Other unit modules install a stub ``aiohttp`` in ``sys.modules`` (see
+    ``_embedded_stubs``) at import time, and under xdist this file may collect
+    after one of them in the same worker — so the real package has to be loaded
+    behind the stub's back and put back afterwards, exactly as
+    ``test_oauth_autoapprove.unified_view_client_factory`` does.
+    """
+    package_roots = ("aiohttp", "yarl")
+    saved = {
+        name: module
+        for name, module in tuple(sys.modules.items())
+        if any(_module_is(name, root) for root in package_roots)
+    }
+    for name in saved:
+        sys.modules.pop(name, None)
+    try:
+        web = importlib.import_module("aiohttp.web")
+        test_utils = importlib.import_module("aiohttp.test_utils")
+        yield web, test_utils
+    finally:
+        for name in tuple(sys.modules):
+            if any(_module_is(name, root) for root in package_roots):
+                sys.modules.pop(name, None)
+        sys.modules.update(saved)
 
 
 @pytest.mark.parametrize("dynamic_first", [False, True])
-async def test_exact_path_wins_regardless_of_registration_order(dynamic_first):
-    router = aiohttp_web.UrlDispatcher()
+async def test_exact_path_wins_regardless_of_registration_order(
+    real_aiohttp, dynamic_first
+):
+    web, test_utils = real_aiohttp
+
+    async def exact(request):  # the app's view: bound at its own id
+        return web.Response(text="app")
+
+    async def dynamic(request):  # the component's view: route parameter
+        return web.Response(text=f"component:{request.match_info['webhook_id']}")
+
+    router = web.UrlDispatcher()
     if dynamic_first:
-        router.add_get(f"{PREFIX}/{{webhook_id}}", _dynamic)
-        router.add_get(f"{PREFIX}/{APP_ID}", _exact)
+        router.add_get(f"{PREFIX}/{{webhook_id}}", dynamic)
+        router.add_get(f"{PREFIX}/{APP_ID}", exact)
     else:
-        router.add_get(f"{PREFIX}/{APP_ID}", _exact)
-        router.add_get(f"{PREFIX}/{{webhook_id}}", _dynamic)
+        router.add_get(f"{PREFIX}/{APP_ID}", exact)
+        router.add_get(f"{PREFIX}/{{webhook_id}}", dynamic)
 
-    match = await router.resolve(make_mocked_request("GET", f"{PREFIX}/{APP_ID}"))
-    assert match.handler is _exact
+    match = await router.resolve(
+        test_utils.make_mocked_request("GET", f"{PREFIX}/{APP_ID}")
+    )
+    assert match.handler is exact
 
-    match = await router.resolve(make_mocked_request("GET", f"{PREFIX}/{COMPONENT_ID}"))
-    assert match.handler is _dynamic
+    match = await router.resolve(
+        test_utils.make_mocked_request("GET", f"{PREFIX}/{COMPONENT_ID}")
+    )
+    assert match.handler is dynamic
     assert match.get("webhook_id") == COMPONENT_ID

--- a/tests/src/unit/test_webhook_proxy_oauth_unified.py
+++ b/tests/src/unit/test_webhook_proxy_oauth_unified.py
@@ -680,6 +680,62 @@ async def test_ha_auth_authorize_uses_dedicated_cimd_session(oauth_stack, monkey
     assert forwarded["client_id"] == ["https://callback.example"]
 
 
+async def test_ha_auth_authorize_percent_encodes_the_forwarded_query(
+    oauth_stack, monkeypatch
+):
+    """The proxy flavor forwards a loopback callback percent-encoded (#2318).
+
+    Mirrors the component test: the proxy copy is hand-maintained, and nothing
+    else pins the two implementations together. The forward was previously
+    built with ``yarl.URL().with_query()``, which legally leaves ":" and "/"
+    unencoded inside a query value, so a native-app callback rendered as
+    ``redirect_uri=http://127.0.0.1:19877/mcp/oauth/callback``. Reverse proxies
+    shipping a generic "block common exploits" ruleset (Nginx Proxy Manager is
+    a common one) match ``[a-zA-Z0-9_]=http://`` and answer 403 before core
+    ever sees the request.
+    """
+    import re
+
+    oauth = oauth_stack.oauth
+    autoapprove = oauth_stack.autoapprove
+    indirect = oauth_stack.indirect
+    hass = _hass(oauth, oauth.MODE_HA_AUTH)
+    hass.data[oauth.DOMAIN][autoapprove.CFG_CIMD_SESSION] = object()
+    monkeypatch.setattr(
+        indirect,
+        "resolve_forward_client_id",
+        AsyncMock(return_value="http://127.0.0.1:19877"),
+    )
+
+    response = await autoapprove.AutoApproveAuthorizeView(hass).get(
+        _oauth_request(
+            query={
+                "response_type": "code",
+                "client_id": "http://127.0.0.1:19877",
+                "redirect_uri": "http://127.0.0.1:19877/mcp/oauth/callback",
+                "code_challenge": "a" * 43,
+                "code_challenge_method": "S256",
+                "state": "xyz",
+            }
+        )
+    )
+
+    assert response.status == 302
+    location = response.headers["Location"]
+    # The exact pattern those proxy rulesets match must not survive the hop.
+    assert re.search(r"[a-zA-Z0-9_]=http://", location) is None
+    # Stronger than the ruleset's own pattern: nothing in the forwarded query
+    # is left in a form a "block common exploits" filter could latch onto.
+    raw_query = urlparse(location).query
+    assert ":" not in raw_query and "/" not in raw_query
+    # ...while redirect_uri, client_id and state survive the encoding
+    # round-trip unchanged.
+    forwarded = parse_qs(raw_query)
+    assert forwarded["redirect_uri"] == ["http://127.0.0.1:19877/mcp/oauth/callback"]
+    assert forwarded["client_id"] == ["http://127.0.0.1:19877"]
+    assert forwarded["state"] == ["xyz"]
+
+
 async def test_ha_auth_token_307s_passthrough_identity(oauth_stack):
     """An unchanged token body stays client-side so core sees the real IP."""
     oauth, autoapprove = oauth_stack.oauth, oauth_stack.autoapprove


### PR DESCRIPTION
## What does this PR do?

Stops publishing the webhook id through any anonymous OAuth discovery URL, in both the in-process component and the Webhook Proxy app (dev flavor), and folds in #2318.

**The disclosure.** The fixed-path RFC 9728 document (`/api/<domain>/oauth/protected-resource`) is anonymous and guessable and carries `resource: <base>/api/webhook/<id>`. It was gated to 404 in `none` mode (#1976), but in `ha_auth` and `legacy` it handed the full webhook URL to any unauthenticated GET. That is harmless while those modes are on, and becomes the sole credential the moment the operator switches back to the secret-URL posture — nothing rotated the id on that switch, and SECURITY.md only warned about it for the app, not the component. The document was also redundant: the RFC 9728 §3.1 path-scoped document (`/.well-known/oauth-protected-resource/api/webhook/<id>`) has served the identical content since #1714, and a caller can only reach it by already holding the id. The fixed-path view is removed in both integrations and the webhook's 401 `resource_metadata` challenge now points at the path-scoped URL, which is also the form the MCP 2026-07-28 Authorization Server Discovery section uses for path-hosted servers. The app's start-up stale-code probe, the only other consumer, now probes the RFC 8414 authorization-server document instead (public by design, no id in it).

**The rotation defeat (app only).** The app's path-scoped view is an exact-path bind and its handler never checked the path, so after the documented rotation (delete `/data/webhook_id.txt`, restart the app — no HA restart) the OLD id's URL kept serving the NEW id to whoever held the old one, until HA happened to restart. The view now records the id it was bound with and 404s once that is no longer the live id, and `register_metadata_views` reports the mismatch so setup raises the existing click-to-restart Repair, which binds the new id's URL. The bind stays exact-path on purpose: aiohttp resolves an exact path before a dynamic one, which is what lets the app's view and the component's `{webhook_id}` view coexist on one HA. No webhook id is ever changed, generated, or rotated by this PR — rotation remains the operator's manual action.

**Folded in from #2318** (Space-Venom, credited as co-author): percent-encode the query `_ha_auth_authorize` forwards to core's `/auth/authorize`, so a native-app client's loopback callback survives reverse proxies that block `=http://` in query strings, plus the review follow-ups — dev-only (stable is promote-only), version bumps, the proxy-flavor regression test, hoisted import, stale comments, and a stronger assertion.

## Type of change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [ ] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

## Checklist
- [x] I have updated documentation if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Protected-resource discovery now uses webhook-scoped URLs and no longer exposes webhook details through a fixed public path.
  * Rotated webhook URLs stop working immediately; a restart prompt activates the new discovery URL.
  * Added guidance for affected installations to rotate webhook credentials.

* **Bug Fixes**
  * OAuth authorization redirects now safely encode query parameters for improved reverse-proxy and loopback callback compatibility.

* **Documentation**
  * Updated webhook rotation instructions and upgrade guidance.

* **Chores**
  * Updated component and add-on versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->