### PR TITLE
ci: cancel superseded PR runs instead of letting them finish

### DIFF
--- a/.github/workflows/build-binary.yml
+++ b/.github/workflows/build-binary.yml
@@ -21,6 +21,13 @@ on:
 permissions:
   contents: read
 
+# Cancel the previous commit's build when a PR is pushed again; non-PR events
+# fall back to the unique run id, so they are never cancelled. See pr.yml for
+# the full rationale.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   build:
     permissions:

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -6,6 +6,13 @@ permissions:
   contents: write
   pull-requests: write
 
+# Cancel the previous commit's run when the PR is pushed again — the approval
+# is pinned to a commit sha, so only the latest run's verdict is meaningful.
+# See pr.yml for the full rationale.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   dependabot:
     if: >-

--- a/.github/workflows/haos-e2e-tests.yml
+++ b/.github/workflows/haos-e2e-tests.yml
@@ -56,6 +56,18 @@ on:
 permissions:
   contents: read
 
+# Cancel the previous commit's lanes when a PR is pushed again — six HAOS
+# runners per push is the most expensive fan-out in the repo, and nothing
+# merges on a superseded commit's result. Non-PR events (dispatch) fall back
+# to the unique run id, so they are never cancelled. Note for the image
+# cache: `haos-e2e` is the sole writer of the shared ``haos-image-*`` key,
+# and a cancelled run saves nothing, so a rapid push train can leave the
+# cache cold one extra run. Rebuilding one image still costs far less than
+# six superseded lanes running to completion.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 env:
   PYTHON_VERSION: "3.13"
   UV_CACHE_DIR: /tmp/.uv-cache

--- a/.github/workflows/haos-e2e-tests.yml
+++ b/.github/workflows/haos-e2e-tests.yml
@@ -59,11 +59,12 @@ permissions:
 # Cancel the previous commit's lanes when a PR is pushed again — six HAOS
 # runners per push is the most expensive fan-out in the repo, and nothing
 # merges on a superseded commit's result. Non-PR events (dispatch) fall back
-# to the unique run id, so they are never cancelled. Note for the image
-# cache: `haos-e2e` is the sole writer of the shared ``haos-image-*`` key,
-# and a cancelled run saves nothing, so a rapid push train can leave the
-# cache cold one extra run. Rebuilding one image still costs far less than
-# six superseded lanes running to completion.
+# to the unique run id, so they are never cancelled. The image cache is
+# unaffected in the normal case: its key hashes the baked build inputs, not
+# the commit, so cancelling a run that restored a cache hit throws away
+# nothing. Only in the window right after those inputs change does a lane
+# actually build and save the qcow2, and cancelling that one run defers the
+# prime to the next run.
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true

--- a/.github/workflows/performance-tests.yml
+++ b/.github/workflows/performance-tests.yml
@@ -24,6 +24,14 @@ on:
 permissions:
   contents: read
 
+# Cancel the previous commit's run when a PR is pushed again. push/schedule/
+# dispatch runs fall back to the unique run id, so master keeps one run per
+# commit — the perf history is per-commit and must not be thinned out. See
+# pr.yml for the full rationale.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 env:
   PYTHON_VERSION: "3.13"
   UV_CACHE_DIR: /tmp/.uv-cache

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -7,6 +7,18 @@ on:
     branches: [ master ]
   workflow_dispatch:
 
+# A new push to a PR makes the previous commit's lanes dead weight: nothing
+# merges on their result, so cancel them instead of paying for a full second
+# fan-out. Grouping on the PR number (rather than github.head_ref) keeps two
+# fork PRs that happen to share a branch name in separate groups. Non-PR
+# events (manual dispatch) fall back to the run id, which is unique per run,
+# so they land in a group of one and are never cancelled or queued behind
+# anything. Cancelled runs report against the superseded commit, so they
+# cannot leave a required check pending on the new head.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 env:
   PYTHON_VERSION: "3.13"
   UV_CACHE_DIR: /tmp/.uv-cache

--- a/.github/workflows/test-installer-scripts.yml
+++ b/.github/workflows/test-installer-scripts.yml
@@ -2,6 +2,12 @@ name: Test Installer Scripts
 
 on:
   push:
+    # master only. Without a branch filter this fired on every in-repo branch
+    # push as well, so a push to an open PR's branch ran these seven jobs twice
+    # — once for `push`, once for `pull_request` — on the same commit. The
+    # `pull_request` trigger below still covers every PR, and the daily cron
+    # plus manual dispatch still cover the scripts outside one.
+    branches: [master]
     paths:
       - 'scripts/install.sh'
       - 'scripts/install-macos.sh'

--- a/.github/workflows/test-installer-scripts.yml
+++ b/.github/workflows/test-installer-scripts.yml
@@ -22,6 +22,13 @@ on:
 permissions:
   contents: read
 
+# Cancel the previous commit's lanes when a PR is pushed again; push/schedule/
+# dispatch runs fall back to the unique run id and are never cancelled. See
+# pr.yml for the full rationale.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   test-macos:
     runs-on: macos-latest

--- a/.github/workflows/webhook-proxy-dev-version-guard.yml
+++ b/.github/workflows/webhook-proxy-dev-version-guard.yml
@@ -8,6 +8,13 @@ on:
 permissions:
   contents: read
 
+# Cancel the previous commit's guard run when the PR is pushed again — the
+# guard's verdict only means anything for the current head. See pr.yml for the
+# full rationale.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   require-version-bump:
     runs-on: ubuntu-latest

--- a/.github/workflows/webhook-proxy-stable-guard.yml
+++ b/.github/workflows/webhook-proxy-stable-guard.yml
@@ -20,6 +20,13 @@ permissions:
   contents: read
   pull-requests: read
 
+# Cancel the previous run when the PR is pushed or (un)labeled again — the
+# guard's verdict only means anything for the current head and label set. See
+# pr.yml for the full rationale.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   guard-stable-edits:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What does this PR do?

Part of #2311 (consolidate CI lanes to reduce concurrent-runner pressure).

That issue is about fitting our lanes inside the plan's 20-concurrent-runner
ceiling. This PR attacks the same ceiling from the other side: instead of
reducing how many lanes a commit needs, it stops *superseded* commits from
holding runners they can no longer justify. Pushing a new commit to an open PR
started a second full fan-out while the previous commit's 30-40 lanes kept
running to completion, so a single PR under active iteration could occupy the
whole 20-slot budget with work that nothing will ever merge on — starving every
other PR in the queue. It does not consolidate any lane, so it stacks with
every item in #2311 rather than overlapping them.

**Commit 1 — cancel superseded PR runs.** Every `pull_request`-triggered
workflow now carries a workflow-level concurrency group:

    concurrency:
      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
      cancel-in-progress: true

- On a PR, the group keys on the PR number, so a new push cancels the previous
  commit's run. Keying on the PR number rather than `github.head_ref` keeps two
  fork PRs that happen to share a branch name (`master`, `main`) in separate
  groups.
- On any non-PR event (push / schedule / manual dispatch) the group falls back
  to `github.run_id`, which is unique per run — so those runs land in a group
  of one and are never cancelled and never queued behind another run. This
  matters for `performance-tests`, which also runs on master: its per-commit
  history stays intact.
- Cancelled runs report their checks against the superseded commit, so they
  cannot leave a required check pending on the new head.

Workflows covered: `pr.yml`, `haos-e2e-tests.yml`, `build-binary.yml`,
`performance-tests.yml`, `test-installer-scripts.yml`,
`dependabot-auto-merge.yml`, `webhook-proxy-dev-version-guard.yml`,
`webhook-proxy-stable-guard.yml`.

Two deliberate exclusions:

- `codeql-quality.yml` already has an equivalent group
  (`codeql-quality-${{ github.ref }}`, `cancel-in-progress: true`) and is left
  untouched.
- `pr-codex-review-request.yml` fires only on `opened` / `ready_for_review`,
  never `synchronize`, so it has no superseded runs to cancel — and its
  job-level `codex-review-global-admission` group is a rate limiter that a
  workflow-level cancel would fight.

**Commit 2 — stop `test-installer-scripts` double-running.** Its `push:`
trigger carried no `branches:` filter, so a push to an in-repo branch with an
open PR ran all seven installer jobs twice on the same commit: once for `push`,
once for `pull_request`. Restricted to `branches: [master]`. Every PR is still
covered by the `pull_request` trigger, and the daily cron and manual dispatch
still cover the scripts outside a PR.

The HAOS image cache is unaffected in the normal case: its key hashes the baked
build inputs, not the commit, so a cancelled lane that restored a cache hit
discards nothing. Only in the window right after those inputs change does a
lane actually build and save the qcow2, and cancelling that one run defers the
prime to the next.

## Type of change
- [x] 🔧 Maintenance/refactor

## Testing
- [ ] I have tested these changes with a LLM agent
- [ ] All automated tests pass (`uv run pytest`)
- [ ] Code follows style guidelines (`uv run ruff check`)

CI config only — no Python touched, so neither pytest nor ruff has anything to
say about this diff. All ten workflow files parse as valid YAML, and the
concurrency expressions use only contexts GitHub documents as available at
workflow level.

**Verified live on this PR.** Commit `93ac88b` is an empty commit pushed while
the previous commit's lanes were still in flight. Every run that was still
live on the superseded commit was cancelled; the two that had already finished
were left alone:

| Workflow on the superseded commit | State at push | Final |
| --- | --- | --- |
| PR Validation Pipeline | in progress | cancelled |
| HAOS E2E Tests | queued | cancelled |
| Performance Tests | in progress | cancelled |
| Build Binary (Test Only) | queued | cancelled |
| CodeQL Code Quality | in progress | cancelled |
| Test Installer Scripts | already completed | success (kept) |
| Admit Codex PR Review | already completed | success (kept) |

The same run also confirms commit 2: `Test Installer Scripts` now appears once
per commit instead of twice.

## Checklist
- [x] I have updated documentation if needed
