### PR TITLE
fix(search): boost ha_manage_energy_prefs for tariff/price queries

### DIFF
--- a/src/ha_mcp/server.py
+++ b/src/ha_mcp/server.py
@@ -655,6 +655,19 @@ class HomeAssistantSmartMCPServer:
             "ssh samba grafana influxdb deconz motioneye compile validate upload "
             "deploy firmware ota flash yaml device logs flows events stats"
         ),
+        # #2322: the Energy Dashboard's tariffs live in .storage/energy, not
+        # in the state machine, so an agent hunting for electricity prices
+        # searches entities, finds none, and invents input_number helpers.
+        # The docstring says "cost tariffs" but never "price", "peak" or
+        # "kWh" — the words agents actually query with — and the title reads
+        # write-only ("Manage ..."), so lead the boost with the read verbs.
+        "ha_manage_energy_prefs": (
+            "read get inspect energy dashboard preferences prefs "
+            "electricity price prices pricing tariff tariffs rate rates "
+            "cost costs kwh peak off-peak offpeak contract utility bill "
+            "grid solar battery gas water consumption "
+            "number_energy_price entity_energy_price stat_energy_from"
+        ),
         # Old tool names from before #1134 consolidation. BM25 retrieval
         # on agents that still know the previous catalog ("call
         # ha_list_resources", "use ha_get_skill_home_assistant_best_practices")

--- a/src/ha_mcp/transforms/categorized_search.py
+++ b/src/ha_mcp/transforms/categorized_search.py
@@ -100,8 +100,10 @@ class SearchKeywordsTransform(Transform):
       a narrower one so BM25 ranks the tool *lower* for broad queries.
 
     The original description is preserved unless an override is applied.
-    Only active when added to the transform pipeline (i.e., behind
-    the ``enable_tool_search`` toggle).
+
+    Added to the transform pipeline unconditionally (#940), so ``keywords``
+    reach every client regardless of ``enable_tool_search``; only
+    ``overrides`` are gated behind that toggle.
     """
 
     def __init__(

--- a/tests/src/unit/test_categorized_search.py
+++ b/tests/src/unit/test_categorized_search.py
@@ -929,3 +929,44 @@ class TestApplySearchKeywordEnrichment:
         )
         for term in ("create", "update", "modify", "edit", "new", "save"):
             assert term in enriched.description.lower()
+
+    @pytest.mark.anyio
+    async def test_energy_prefs_keywords_cover_tariff_vocabulary(self):
+        """Energy-tariff queries must reach ha_manage_energy_prefs (#2322).
+
+        The Energy Dashboard's contract prices live in ``.storage/energy``,
+        never in entity state, so an agent that only knows the tool's own
+        wording ("cost tariffs") searches the state machine instead. The
+        boost adds the vocabulary agents actually query with, plus read
+        verbs to offset the write-only "Manage ..." title.
+        """
+        from ha_mcp.server import HomeAssistantSmartMCPServer
+
+        keywords = HomeAssistantSmartMCPServer._SEARCH_KEYWORDS
+        assert "ha_manage_energy_prefs" in keywords
+
+        transform = SearchKeywordsTransform(keywords=keywords)
+        tool = _make_tool(
+            "ha_manage_energy_prefs",
+            destructive=True,
+            description="Manage the Home Assistant Energy Dashboard preferences.",
+        )
+        enriched = (await transform.list_tools([tool]))[0]
+
+        assert enriched.description.startswith(
+            "Manage the Home Assistant Energy Dashboard preferences."
+        )
+        for term in (
+            "price",
+            "tariff",
+            "cost",
+            "kwh",
+            "rate",
+            "peak",
+            "off-peak",
+            "electricity",
+            "contract",
+            "read",
+            "get",
+        ):
+            assert term in enriched.description.lower(), f"{term!r} missing"


### PR DESCRIPTION
## What does this PR do?

Closes #2322.

The Energy Dashboard's contract prices live in `.storage/energy`, never in the state machine. An agent asked to compute appliance cycle costs searched entity state for "price"/"tariff", found nothing, concluded no tariffs were configured, and invented `input_number` helpers with guessed defaults — while `ha_manage_energy_prefs(mode='get')` held the exact contract prices the whole time.

The tool's description says "cost tariffs" but never **price**, **peak**, **off-peak**, **kWh**, **rate**, **electricity** or **contract** — the vocabulary agents actually query with. Its title also reads write-only ("Manage Energy Dashboard Preferences", `destructiveHint: True`), so an agent doing read-only research passes over it; `mode='get'` only survives Read Only Mode via a `ReadOnlyExemption`. This adds a `_SEARCH_KEYWORDS` boost covering that vocabulary and leading with read verbs.

`SearchKeywordsTransform` is added to the pipeline unconditionally, so the boost lands in the tool description for **every** client, not only those running `ENABLE_TOOL_SEARCH`. That matters here: the reporter had tool search off, all ~84 tools inlined, in a client with no deferred tool loading.

Also corrects the `SearchKeywordsTransform` docstring, which still claimed the transform sits behind `enable_tool_search`; only `overrides` have been gated that way since #940.

**Not doing** the reporter's first suggestion (index energy prefs in `ha_search`). Its config surface walks *collections of named configs* — automations, scripts, scenes, helpers, dashboards — each with an id and entity references. Energy prefs is a single global blob with no id, and to help a naive `"tariff"` query it would have to join the *default* `search_types`, adding an `energy/get_prefs` WS round-trip to every keyword search — with the same claim then open for pipelines, themes, radio, zones and backup prefs.

## Type of change
- [x] 🐛 Bug fix

## Testing
- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

`tests/src/unit/test_categorized_search.py` — 100 passed. Adds `test_energy_prefs_keywords_cover_tariff_vocabulary`, asserting the enriched description preserves the original text and carries the full query vocabulary.

## Checklist
- [x] I have updated documentation if needed (docstring correction; no user-facing docs affected)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved searchability for energy preferences using terms related to tariffs, electricity pricing, rates, consumption, and energy costs.

* **Bug Fixes**
  * Energy preference tools are now easier to find using common tariff and energy-related queries.

* **Tests**
  * Added coverage to verify keyword-based search while preserving the existing tool description.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->