### PR TITLE
Document ha_call_service's undocumented parameters

### DIFF
--- a/src/ha_mcp/tools/tools_service.py
+++ b/src/ha_mcp/tools/tools_service.py
@@ -1637,12 +1637,64 @@ class ServiceTools:
     @log_tool_usage
     async def ha_call_service(
         self,
-        domain: str | None = None,
-        service: str | None = None,
-        entity_id: str | None = None,
-        data: Annotated[dict[str, Any] | None, JSON_STRING_COERCION] = None,
-        return_response: bool = False,
-        wait: bool = True,
+        domain: Annotated[
+            str | None,
+            Field(
+                description=(
+                    "Service domain (e.g. 'light', 'climate', 'automation'). "
+                    "Required unless ws_command is set."
+                ),
+            ),
+        ] = None,
+        service: Annotated[
+            str | None,
+            Field(
+                description=(
+                    "Service name within domain (e.g. 'turn_on', 'set_temperature', "
+                    "'trigger'). Required unless ws_command is set."
+                ),
+            ),
+        ] = None,
+        entity_id: Annotated[
+            str | None,
+            Field(
+                description=(
+                    "Entity ID(s) the service call targets (e.g. 'light.living_room'). "
+                    "Optional for services that don't target a specific entity."
+                ),
+            ),
+        ] = None,
+        data: Annotated[
+            dict[str, Any] | None,
+            JSON_STRING_COERCION,
+            Field(
+                description=(
+                    "Extra service-call parameters beyond entity_id (e.g. "
+                    "{'temperature': 22} for climate.set_temperature). Also carries "
+                    "the raw command payload when ws_command is set."
+                ),
+            ),
+        ] = None,
+        return_response: Annotated[
+            bool,
+            Field(
+                description=(
+                    "If True, the service's response data is returned once, as "
+                    "the top-level 'service_response' key — never nested inside "
+                    "'result' (default False)."
+                ),
+            ),
+        ] = False,
+        wait: Annotated[
+            bool,
+            Field(
+                description=(
+                    "If True (default), wait for the entity state to change "
+                    "before returning. Only applies to state-changing services "
+                    "on a single entity."
+                ),
+            ),
+        ] = True,
         verbose: Annotated[
             bool,
             Field(

--- a/src/ha_mcp/tools/tools_service.py
+++ b/src/ha_mcp/tools/tools_service.py
@@ -1845,8 +1845,12 @@ class ServiceTools:
             )
 
             # Determine if we should wait for state change:
-            # Only for state-changing services on a single entity, not for
+            # Only for state-changing services with an entity_id set, not for
             # trigger/reload/fire-and-forget services or services without entities.
+            # A comma-separated multi-target entity_id is not excluded here — it
+            # still falls through to the legacy path, which polls for the literal
+            # composite entity_id and times out after 10s (see the wait Field
+            # description and _maybe_component_call_service).
             # This server-side decision (D6) also chooses whether to hand the
             # component wait+entity_ids: a non-state-changing call passes wait
             # implicitly false and no confirmation targets.

--- a/src/ha_mcp/tools/tools_service.py
+++ b/src/ha_mcp/tools/tools_service.py
@@ -1642,7 +1642,8 @@ class ServiceTools:
             Field(
                 description=(
                     "Service domain (e.g. 'light', 'climate', 'automation'). "
-                    "Required unless ws_command is set."
+                    "Required for a service call; must be omitted when ws_command "
+                    "is set."
                 ),
             ),
         ] = None,
@@ -1651,7 +1652,8 @@ class ServiceTools:
             Field(
                 description=(
                     "Service name within domain (e.g. 'turn_on', 'set_temperature', "
-                    "'trigger'). Required unless ws_command is set."
+                    "'trigger'). Required for a service call; must be omitted when "
+                    "ws_command is set."
                 ),
             ),
         ] = None,
@@ -1659,8 +1661,10 @@ class ServiceTools:
             str | None,
             Field(
                 description=(
-                    "Entity ID(s) the service call targets (e.g. 'light.living_room'). "
-                    "Optional for services that don't target a specific entity."
+                    "Entity ID(s) the service call targets — one ID "
+                    "('light.living_room') or several comma-separated "
+                    "('light.a,light.b'). Optional for services that don't target "
+                    "a specific entity. Must be omitted when ws_command is set."
                 ),
             ),
         ] = None,
@@ -1671,7 +1675,8 @@ class ServiceTools:
                 description=(
                     "Extra service-call parameters beyond entity_id (e.g. "
                     "{'temperature': 22} for climate.set_temperature). Also carries "
-                    "the raw command payload when ws_command is set."
+                    "the raw command payload when ws_command is set. If entity_id "
+                    "is also present in data, the entity_id parameter wins."
                 ),
             ),
         ] = None,
@@ -1681,7 +1686,8 @@ class ServiceTools:
                 description=(
                     "If True, the service's response data is returned once, as "
                     "the top-level 'service_response' key — never nested inside "
-                    "'result' (default False)."
+                    "'result' (default: False). Must stay False when ws_command "
+                    "is set."
                 ),
             ),
         ] = False,
@@ -1690,8 +1696,12 @@ class ServiceTools:
             Field(
                 description=(
                     "If True (default), wait for the entity state to change "
-                    "before returning. Only applies to state-changing services "
-                    "on a single entity."
+                    "before returning. Applies only to state-changing services "
+                    "called with a single entity_id. A comma-separated "
+                    "multi-target does not get confirmed by this: it falls "
+                    "through to a legacy path that polls for the literal "
+                    "composite entity_id and times out after 10s. Set "
+                    "wait=False for multi-target calls."
                 ),
             ),
         ] = True,
@@ -1776,8 +1786,6 @@ class ServiceTools:
         ```
 
         **Key behavior:**
-        - **wait** (default True): wait for the entity state to change before
-          returning. Only applies to state-changing services on a single entity.
         - **Result compaction (default ON)**: ``result`` is trimmed
           to the targeted entity's record (drops parent-group propagation) and
           stripped of ``context`` / ``last_*`` metadata and heavy attribute
@@ -1785,9 +1793,6 @@ class ServiceTools:
           for the raw changed-state records, or ``result_fields`` /
           ``result_attribute_keys`` for explicit per-record projection (mirrors
           ``ha_get_state``).
-        - **return_response** (default False): the service's response data is
-          returned once, as the top-level ``service_response`` key — never nested
-          inside ``result``, which carries the changed entity states.
 
         **For detailed service documentation, use ha_get_skill_guide.**
 

--- a/tests/src/unit/test_config_param_no_string_schema.py
+++ b/tests/src/unit/test_config_param_no_string_schema.py
@@ -328,9 +328,9 @@ def test_ha_call_service_params_all_have_descriptions():
     """
     from ha_mcp.tools.tools_service import register_service_tools
 
-    properties = _get_tool_parameters(
-        register_service_tools, "ha_call_service"
-    )["properties"]
+    properties = _get_tool_parameters(register_service_tools, "ha_call_service")[
+        "properties"
+    ]
 
     undocumented = [
         name

--- a/tests/src/unit/test_config_param_no_string_schema.py
+++ b/tests/src/unit/test_config_param_no_string_schema.py
@@ -316,3 +316,27 @@ def test_bulk_operation_validate_first_requires_a_strict_boolean(invalid_value):
         ]
         is False
     )
+
+
+def test_ha_call_service_params_all_have_descriptions():
+    """Every ha_call_service schema property carries a non-empty description.
+
+    Regression guard for PR #2327 / issue #2324: a bare Annotated[..., None]
+    (no Field(description=...)) silently drops the property's schema
+    description, so this would not catch a docstring lying about behavior —
+    only a param that goes fully undocumented again.
+    """
+    from ha_mcp.tools.tools_service import register_service_tools
+
+    properties = _get_tool_parameters(
+        register_service_tools, "ha_call_service"
+    )["properties"]
+
+    undocumented = [
+        name
+        for name, schema in properties.items()
+        if not schema.get("description", "").strip()
+    ]
+    assert not undocumented, (
+        f"ha_call_service params missing a schema description: {undocumented}"
+    )


### PR DESCRIPTION
Small follow-up to #2324, scoped to one tool as an example rather than a bulk change.

`ha_call_service`'s `domain`, `service`, `entity_id`, `data`, `return_response`, and `wait` had no per-parameter description — unlike most of this tool's other parameters (`verbose`, `result_fields`, `result_attribute_keys`, `ws_command`), which already document intent via `Annotated[T, Field(description=...)]`. This adds the same style to the remaining six, mostly pulled from context that already existed elsewhere in the docstring (e.g. the "Key behavior" section) but wasn't attached to the parameters themselves.

No behavior change — descriptions only, same types and defaults.

**Caveat:** I verified this with `py_compile` (valid syntax) and by re-running [mcp-doctor](https://github.com/vishalhabib99/mcp-doctor) against the change (the tool now scores clean), but couldn't run the actual test suite locally — it needs Python 3.13, which wasn't available in my environment. Flagging that rather than implying more verification than I actually did.

Happy to adjust wording on any of the descriptions if they don't match your intent for these params.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Improved service-call parameter descriptions, including guidance for WebSocket commands and multi-target waits.
  - Clarified when certain parameters should be omitted.
  - Added descriptions for all service-call parameters in the generated schema.
  - No changes to existing behavior, defaults, or supported parameter types.

- **Tests**
  - Added coverage to ensure every service-call parameter has a non-empty description.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->