### PR TITLE
ci: fold the CodeQL matrix and its gate into one job

### DIFF
--- a/.github/workflows/codeql-quality.yml
+++ b/.github/workflows/codeql-quality.yml
@@ -90,26 +90,42 @@ jobs:
   code-quality-gate:
     name: CodeQL Gate
     runs-on: ubuntu-latest
-    # BACKSTOP ONLY - the per-language step caps below are the real control.
-    # It has to exceed their sum: a JOB cap "automatically cancels" the job
-    # (workflow-syntax docs), and a cancelled run skips every
-    # `success() || failure()` step, so a job cap that fired first would take
-    # the second language's report down with it. A STEP cap instead kills only
-    # that step's process ("killing the process"), so the step FAILS and
-    # `failure()` stays true, and the later steps still report.
-    timeout-minutes: 45
+    # BACKSTOP ONLY, and it must never be the cap that fires. A JOB cap
+    # "automatically cancels" the job (workflow-syntax docs), and a cancelled
+    # run skips every `success() || failure()` step, so a job cap that fired
+    # first would take the second language's report down with it. A STEP cap
+    # instead kills only that step's process ("killing the process"), so the
+    # step FAILS, `failure()` stays true, and the later steps still report.
+    #
+    # That only holds if EVERY step is capped and this number exceeds their
+    # sum - otherwise the uncapped steps eat the margin and the job cap
+    # becomes the binding constraint after all. Every step below therefore
+    # carries a budget; they total 57. The 3 minutes of slack cover what
+    # cannot carry a budget of its own: job setup, per-step overhead, and the
+    # implicit post-job steps. test_codeql_workflow_shape.py asserts all three
+    # halves - no uncapped step, and a slack of at least those 3 minutes.
+    #
+    # The budgets are sized off an observed run, generously, but they do turn
+    # slow infrastructure into a red required check where it used to be merely
+    # slow: a cold Python setup or a stalled artifact upload now fails the
+    # gate rather than dragging it out. That is the trade for a hung analysis
+    # no longer being able to hide the other language's result.
+    timeout-minutes: 60
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        timeout-minutes: 2
         with:
           persist-credentials: false
 
       - name: Set up Python
+        timeout-minutes: 2
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: "3.13"
 
       - name: Install CodeQL CLI
+        timeout-minutes: 5
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -141,6 +157,7 @@ jobs:
 
       - name: Upload SARIF artifact (python)
         if: success() || failure()
+        timeout-minutes: 2
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: codeql-quality-sarif-python
@@ -149,6 +166,7 @@ jobs:
 
       - name: Gate on findings (python)
         if: success() || failure()
+        timeout-minutes: 2
         run: python scripts/codeql_quality_gate.py quality-python.sarif
 
       - name: Create CodeQL database (javascript)
@@ -178,6 +196,7 @@ jobs:
 
       - name: Upload SARIF artifact (javascript)
         if: success() || failure()
+        timeout-minutes: 2
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: codeql-quality-sarif-javascript
@@ -186,4 +205,5 @@ jobs:
 
       - name: Gate on findings (javascript)
         if: success() || failure()
+        timeout-minutes: 2
         run: python scripts/codeql_quality_gate.py quality-javascript.sarif

--- a/.github/workflows/codeql-quality.yml
+++ b/.github/workflows/codeql-quality.yml
@@ -11,7 +11,41 @@ name: CodeQL Code Quality
 # merge — that is how alerts 33-40 landed. Running the same default
 # code-scanning suite in this gate catches them pre-merge.
 #
-# Languages gated (one matrix leg each), both scanning the whole tree
+# ONE JOB, BOTH LANGUAGES (#2311): python and javascript used to be a two-leg
+# matrix plus an aggregating gate job — three check runs for two analyses.
+# They are folded into this single job so the workflow reports ONE check run
+# and pays for ONE checkout / Python setup / CodeQL CLI install instead of
+# two. The job keeps the name `CodeQL Gate`, so the required-status-check
+# context on the master ruleset is unchanged and needs no maintainer edit.
+#
+# The matrix also gave each language its OWN runner and its own 20-minute
+# budget. Serially they share one job, so the create+analyze steps carry
+# per-language step caps summing to that same 20 minutes each. Without them a
+# hung python analysis would consume javascript's time and the job cap would
+# then cancel the run, which skips the javascript steps entirely.
+#
+# FAILURE ATTRIBUTION IS LOAD-BEARING: the matrix ran `fail-fast: false`, so a
+# python finding never hid a javascript one. Running the two serially in one
+# job removes that for free, so it is restored by hand — every step from the
+# first SARIF upload onward carries `if: success() || failure()`, which keeps
+# later steps reporting after an earlier red while still stopping a cancelled
+# run. `always()` is deliberately NOT used: it would keep burning runner
+# minutes after a cancel. Same idiom as pr.yml's Fast Checks lane; both
+# clauses are pinned by tests/src/unit/test_codeql_workflow_shape.py.
+#
+# Each language gets its OWN CodeQL database directory and its OWN SARIF file.
+# Separate matrix legs had separate filesystems, so sharing either name was
+# harmless; serially in one job it is not. A shared SARIF name would let a
+# failed analysis leave the previous language's file in place and the next
+# gate step would report python findings as javascript ones; a shared database
+# directory would strand the wrong language's database for the same reason.
+#
+# The SARIF upload steps moved from `if: always()` to the same
+# `if: success() || failure()` as the rest of the job. Deliberate: a cancelled
+# run no longer uploads a partial artifact, which is the price of not paying
+# for the remainder of the job after a cancel.
+#
+# Languages gated (one step group each), both scanning the whole tree
 # (--source-root .):
 #   - python      vendored fixtures under tests/initial_test_state/ are dropped
 #                 by scripts/codeql_quality_gate.py's PATHS_IGNORE.
@@ -53,21 +87,17 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  code-quality:
-    name: CodeQL Code Quality (${{ matrix.language }})
+  code-quality-gate:
+    name: CodeQL Gate
     runs-on: ubuntu-latest
-    timeout-minutes: 20
-
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - language: python
-            suite: codeql/python-queries:codeql-suites/python-code-quality.qls
-            security_suite: codeql/python-queries:codeql-suites/python-code-scanning.qls
-          - language: javascript
-            suite: codeql/javascript-queries:codeql-suites/javascript-code-quality.qls
-            security_suite: codeql/javascript-queries:codeql-suites/javascript-code-scanning.qls
+    # BACKSTOP ONLY - the per-language step caps below are the real control.
+    # It has to exceed their sum: a JOB cap "automatically cancels" the job
+    # (workflow-syntax docs), and a cancelled run skips every
+    # `success() || failure()` step, so a job cap that fired first would take
+    # the second language's report down with it. A STEP cap instead kills only
+    # that step's process ("killing the process"), so the step FAILS and
+    # `failure()` stays true, and the later steps still report.
+    timeout-minutes: 45
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -86,43 +116,74 @@ jobs:
           gh extensions install github/gh-codeql
           gh codeql set-version latest
 
-      - name: Create CodeQL database (${{ matrix.language }})
+      - name: Create CodeQL database (python)
+        timeout-minutes: 8
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh codeql database create ha-mcp-db \
-            --language=${{ matrix.language }} \
+          gh codeql database create ha-mcp-db-python \
+            --language=python \
             --build-mode=none \
             --source-root . \
             --overwrite
 
-      - name: Analyze with ${{ matrix.language }} quality + security suites
+      - name: Analyze with python quality + security suites
+        timeout-minutes: 12
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh codeql database analyze ha-mcp-db \
-            ${{ matrix.suite }} \
-            ${{ matrix.security_suite }} \
+          gh codeql database analyze ha-mcp-db-python \
+            codeql/python-queries:codeql-suites/python-code-quality.qls \
+            codeql/python-queries:codeql-suites/python-code-scanning.qls \
             --format=sarif-latest \
-            --output quality.sarif \
+            --output quality-python.sarif \
             --download
 
-      - name: Upload SARIF artifact
-        if: always()
+      - name: Upload SARIF artifact (python)
+        if: success() || failure()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: codeql-quality-sarif-${{ matrix.language }}
-          path: quality.sarif
+          name: codeql-quality-sarif-python
+          path: quality-python.sarif
           if-no-files-found: warn
 
-      - name: Gate on findings
-        run: python scripts/codeql_quality_gate.py quality.sarif
+      - name: Gate on findings (python)
+        if: success() || failure()
+        run: python scripts/codeql_quality_gate.py quality-python.sarif
 
-  code-quality-gate:
-    name: CodeQL Gate
-    if: ${{ always() }}
-    needs: code-quality
-    runs-on: ubuntu-latest
-    steps:
-      - name: Require every CodeQL analysis to pass
-        run: test "${{ needs.code-quality.result }}" = "success"
+      - name: Create CodeQL database (javascript)
+        if: success() || failure()
+        timeout-minutes: 8
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh codeql database create ha-mcp-db-javascript \
+            --language=javascript \
+            --build-mode=none \
+            --source-root . \
+            --overwrite
+
+      - name: Analyze with javascript quality + security suites
+        if: success() || failure()
+        timeout-minutes: 12
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh codeql database analyze ha-mcp-db-javascript \
+            codeql/javascript-queries:codeql-suites/javascript-code-quality.qls \
+            codeql/javascript-queries:codeql-suites/javascript-code-scanning.qls \
+            --format=sarif-latest \
+            --output quality-javascript.sarif \
+            --download
+
+      - name: Upload SARIF artifact (javascript)
+        if: success() || failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: codeql-quality-sarif-javascript
+          path: quality-javascript.sarif
+          if-no-files-found: warn
+
+      - name: Gate on findings (javascript)
+        if: success() || failure()
+        run: python scripts/codeql_quality_gate.py quality-javascript.sarif

--- a/tests/src/unit/test_codeql_workflow_shape.py
+++ b/tests/src/unit/test_codeql_workflow_shape.py
@@ -1,7 +1,40 @@
-"""Guard the always-reported CodeQL merge gate."""
+"""Shape pins for the always-reported CodeQL merge gate.
+
+The workflow folds what were a two-leg language matrix and an aggregating gate
+job into ONE job (#2311), so the four properties that used to be free from
+GitHub's matrix semantics now have to be held by hand:
+
+* ``fail-fast: false`` guaranteed that a python finding never hid a javascript
+  one. Serially that only holds while every step from the first SARIF upload
+  onward carries ``if: success() || failure()``. ``always()`` is deliberately
+  rejected, exactly as in pr.yml's Fast Checks lane: it would keep burning
+  runner minutes after a cancel.
+* The matrix could not lose a language by editing one step. A flat step list
+  can, so the analyzed language set is asserted directly.
+* Separate legs wrote to separate filesystems, so sharing a SARIF filename or
+  a CodeQL database directory between the languages was harmless. In one job
+  neither is, and they fail one step apart: a shared SARIF name lets a failed
+  analysis leave the previous language's file in place, so the next GATE step
+  reports its findings under the wrong language; a shared database directory
+  strands the wrong language's database, so the next ANALYZE step runs its
+  suites against the other language's source.
+* Each leg had its own runner and its own 20-minute budget, so python could
+  not starve javascript of time. Serially they share one job, and the job cap
+  is the wrong instrument for it: per the workflow-syntax docs a job
+  ``timeout-minutes`` "automatically cancels" the job, and a cancelled run
+  skips every ``success() || failure()`` step, so javascript would report
+  nothing. A step ``timeout-minutes`` kills only that step's process
+  ("killing the process"), so the step FAILS and ``failure()`` stays true
+  ("Returns true when any previous step of a job fails"), and the later steps
+  still report.
+
+A comment is not a gate — these tests read the workflow YAML directly, pass on
+arrival, and fire only when an edit drops a clause.
+"""
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 from typing import Any
 
@@ -10,20 +43,202 @@ import yaml
 _REPO_ROOT = Path(__file__).resolve().parents[3]
 _WORKFLOW = _REPO_ROOT / ".github" / "workflows" / "codeql-quality.yml"
 
+# The required-status-check context on the master ruleset. Renaming the job
+# silently un-gates master until a maintainer edits the ruleset by hand.
+_REQUIRED_CONTEXT = "CodeQL Gate"
+
+_LANGUAGES = ("python", "javascript")
+
 
 def _workflow() -> dict[str, Any]:
     return yaml.safe_load(_WORKFLOW.read_text(encoding="utf-8"))
 
 
-def test_pull_requests_always_emit_codeql_gate() -> None:
-    workflow = _workflow()
-    pull_request = workflow[True]["pull_request"]
-    gate = workflow["jobs"]["code-quality-gate"]
+def _gate_job() -> dict[str, Any]:
+    return _workflow()["jobs"]["code-quality-gate"]
 
-    assert "paths" not in pull_request
-    assert gate["name"] == "CodeQL Gate"
-    assert gate["needs"] == "code-quality"
-    assert gate["if"] == "${{ always() }}"
-    assert gate["steps"][0]["run"] == (
-        'test "${{ needs.code-quality.result }}" = "success"'
+
+def _steps() -> list[dict[str, Any]]:
+    return _gate_job()["steps"]
+
+
+def _step_name(step: dict[str, Any]) -> str:
+    return step.get("name") or "(checkout)"
+
+
+def _run(step: dict[str, Any]) -> str:
+    return str(step.get("run", ""))
+
+
+def test_pull_requests_always_emit_the_required_context() -> None:
+    """A ``paths`` filter would leave the required check permanently pending
+    on a PR that touches nothing matching it."""
+    workflow = _workflow()
+    # PyYAML resolves the bare ``on:`` key to the boolean True.
+    assert "paths" not in workflow[True]["pull_request"]
+    assert _gate_job()["name"] == _REQUIRED_CONTEXT
+
+
+def test_the_gate_is_a_single_job() -> None:
+    """The fold's whole point: one check run, not a matrix plus an aggregator.
+    A second job here means the ruleset's single context no longer covers
+    everything the workflow runs."""
+    assert list(_workflow()["jobs"]) == ["code-quality-gate"]
+    assert "strategy" not in _gate_job()
+
+
+def test_every_step_after_the_first_upload_reports_on_a_red_run() -> None:
+    """The failure-attribution requirement the matrix used to give for free:
+    one red language cannot hide the other."""
+    steps = _steps()
+    first_upload = next(
+        index
+        for index, step in enumerate(steps)
+        if _step_name(step).startswith("Upload SARIF artifact")
     )
+    for step in steps[first_upload:]:
+        assert step.get("if") == "success() || failure()", (
+            f"step {_step_name(step)!r} would be skipped after an earlier red "
+            "step, hiding its own result - and `always()` is deliberately "
+            "rejected so a cancelled run stops"
+        )
+
+
+def test_no_step_uses_always() -> None:
+    """``always()`` keeps a cancelled run paying for the remaining analysis."""
+    for step in _steps():
+        assert "always()" not in str(step.get("if", ""))
+
+
+def test_both_languages_are_still_analyzed() -> None:
+    """A flat step list can lose a language to a single deletion; the matrix
+    could not."""
+    analyzed = {
+        language
+        for language in _LANGUAGES
+        for step in _steps()
+        if "database create ha-mcp-db" in _run(step)
+        and f"--language={language}" in _run(step)
+    }
+    assert analyzed == set(_LANGUAGES)
+
+
+def test_each_language_runs_both_its_quality_and_security_suites() -> None:
+    """The security suite is gated here because GitHub default setup only
+    analyzes master post-merge (workflow header)."""
+    analyses = "\n".join(
+        _run(step) for step in _steps() if "database analyze" in _run(step)
+    )
+    for language in _LANGUAGES:
+        for kind in ("code-quality", "code-scanning"):
+            suite = f"codeql/{language}-queries:codeql-suites/{language}-{kind}.qls"
+            assert suite in analyses, f"{suite} is no longer analyzed"
+
+
+def test_each_language_gates_on_its_own_sarif_file() -> None:
+    """Sharing one filename lets a failed analysis leave the previous
+    language's SARIF in place, so the next gate step reports findings under
+    the wrong language."""
+    outputs = [
+        match.group(1)
+        for step in _steps()
+        for match in re.finditer(r"--output (\S+\.sarif)", _run(step))
+    ]
+    gated = [
+        match.group(1)
+        for step in _steps()
+        for match in re.finditer(
+            r"scripts/codeql_quality_gate\.py (\S+\.sarif)", _run(step)
+        )
+    ]
+    assert len(set(outputs)) == len(outputs) == len(_LANGUAGES)
+    assert gated == outputs, (
+        "every analysis must be gated, each on the file it wrote, in order"
+    )
+    for language, sarif in zip(_LANGUAGES, outputs, strict=True):
+        assert language in sarif, (
+            f"{sarif!r} does not name its language - a reordering would swap "
+            "the two gates without any test noticing"
+        )
+
+
+def test_uploaded_artifacts_are_named_per_language() -> None:
+    """One artifact name for two files means the second upload collides."""
+    names = [
+        step["with"]["name"]
+        for step in _steps()
+        if _step_name(step).startswith("Upload SARIF artifact")
+    ]
+    assert len(set(names)) == len(names) == len(_LANGUAGES)
+
+
+def test_each_language_has_a_step_budget_the_job_cap_cannot_pre_empt() -> None:
+    """A hung python analysis must not cost javascript its report.
+
+    Only step-level caps can do that: a job-level cap cancels, and a cancelled
+    run skips the ``success() || failure()`` steps this file pins above. The
+    relation - not either number - is what is load-bearing, so it is asserted
+    as a relation.
+    """
+    job = _gate_job()
+    heavy = [step for step in _steps() if "gh codeql database" in _run(step)]
+    assert len(heavy) == 2 * len(_LANGUAGES), (
+        "expected a create and an analyze step per language"
+    )
+    budgets = [step.get("timeout-minutes") for step in heavy]
+    assert all(isinstance(value, int) for value in budgets), (
+        "an uncapped create/analyze step can burn the whole job budget and "
+        "let the job cap cancel the other language out of its report"
+    )
+    total = sum(value for value in budgets if isinstance(value, int))
+    assert job["timeout-minutes"] >= total, (
+        f"job cap {job['timeout-minutes']} is below the sum of the step caps "
+        f"{total} - the job would cancel before a step cap fires, and a "
+        "cancelled run skips the remaining language entirely"
+    )
+
+
+def test_each_language_builds_and_analyzes_its_own_database_directory() -> None:
+    """The SARIF filename is not the only shared name the fold created.
+
+    Separate matrix legs had separate filesystems; one job does not. A shared
+    database directory strands the wrong language's database, and the next
+    analyze step then runs its suites against the other language's source.
+
+    A tally of database names is not enough here: swapping the two analyze
+    steps' databases keeps every count identical while cross-wiring both
+    languages, so each database is bound to the language of the step that
+    uses it - the `--language=` flag for a create, the query suites for an
+    analyze.
+    """
+    creates: list[tuple[str, str]] = []
+    analyses: list[tuple[str, set[str]]] = []
+    for step in _steps():
+        run = _run(step)
+        for match in re.finditer(r"gh codeql database create (\S+)", run):
+            language_flag = re.search(r"--language=(\S+)", run)
+            assert language_flag, f"create step {_step_name(step)!r} names no language"
+            creates.append((match.group(1), language_flag.group(1)))
+        analyses.extend(
+            (match.group(1), set(re.findall(r"codeql/(\w+)-queries", run)))
+            for match in re.finditer(r"gh codeql database analyze (\S+)", run)
+        )
+
+    assert len(creates) == len(analyses) == len(_LANGUAGES)
+    assert len({database for database, _ in creates}) == len(_LANGUAGES), (
+        f"the languages share a database directory: {creates}"
+    )
+
+    for database, language in creates:
+        assert database.endswith(language), (
+            f"database {database!r} is built with --language={language} - the "
+            "name and the language must agree or the pairing is unreadable"
+        )
+    for database, suites in analyses:
+        assert len(suites) == 1, f"analyze of {database!r} mixes languages: {suites}"
+        (language,) = suites
+        assert database.endswith(language), (
+            f"{language} suites are analyzed against database {database!r} - "
+            "cross-wiring the two analyze steps keeps every name present and "
+            "every count identical, so only this pairing catches it"
+        )

--- a/tests/src/unit/test_codeql_workflow_shape.py
+++ b/tests/src/unit/test_codeql_workflow_shape.py
@@ -49,24 +49,45 @@ _REQUIRED_CONTEXT = "CodeQL Gate"
 
 _LANGUAGES = ("python", "javascript")
 
+# Minutes the job cap must clear the step-cap sum by. Job setup, per-step
+# overhead and the implicit post-job steps count against the job cap and
+# cannot carry a `timeout-minutes` of their own.
+_JOB_CAP_SLACK = 3
+
+
+def _is_budget(value: object) -> bool:
+    """True for a value a workflow can actually use as `timeout-minutes`.
+
+    `bool` is a subclass of `int`, so a stray `true` would pass an
+    `isinstance(value, int)` check and then sum as 1, quietly shrinking the
+    total the job cap is measured against. The docs also require a positive
+    integer, so 0 is not a budget either.
+    """
+    return isinstance(value, int) and not isinstance(value, bool) and value > 0
+
 
 def _workflow() -> dict[str, Any]:
+    """The workflow as YAML, re-read on every call so no test caches it."""
     return yaml.safe_load(_WORKFLOW.read_text(encoding="utf-8"))
 
 
 def _gate_job() -> dict[str, Any]:
+    """The single job the fold produced, keyed by its id."""
     return _workflow()["jobs"]["code-quality-gate"]
 
 
 def _steps() -> list[dict[str, Any]]:
+    """The gate job's steps, in workflow order - order is load-bearing here."""
     return _gate_job()["steps"]
 
 
 def _step_name(step: dict[str, Any]) -> str:
+    """A step's name, or a placeholder for the unnamed checkout step."""
     return step.get("name") or "(checkout)"
 
 
 def _run(step: dict[str, Any]) -> str:
+    """A step's shell body, empty for `uses:` steps that have none."""
     return str(step.get("run", ""))
 
 
@@ -172,30 +193,59 @@ def test_uploaded_artifacts_are_named_per_language() -> None:
     assert len(set(names)) == len(names) == len(_LANGUAGES)
 
 
-def test_each_language_has_a_step_budget_the_job_cap_cannot_pre_empt() -> None:
-    """A hung python analysis must not cost javascript its report.
+def test_the_job_cap_can_never_be_the_cap_that_fires() -> None:
+    """A hung step must not cost the other language its report.
 
-    Only step-level caps can do that: a job-level cap cancels, and a cancelled
-    run skips the ``success() || failure()`` steps this file pins above. The
-    relation - not either number - is what is load-bearing, so it is asserted
-    as a relation.
+    Only a step cap can do that: a job cap cancels, and a cancelled run skips
+    the ``success() || failure()`` steps this file pins above. So the job cap
+    has to be unreachable, and it is unreachable only when EVERY step carries
+    a budget and the job cap exceeds their sum. Capping just the analyses
+    leaves the uncapped steps free to eat the margin, which puts the job cap
+    back in play as the binding constraint - the exact hole two reviewers
+    found in the first version of this guard.
+
+    Strictly greater, not `>=`: equality leaves nothing for the implicit
+    post-job steps, which take time and cannot be capped.
     """
     job = _gate_job()
-    heavy = [step for step in _steps() if "gh codeql database" in _run(step)]
-    assert len(heavy) == 2 * len(_LANGUAGES), (
-        "expected a create and an analyze step per language"
+    budgets = [step.get("timeout-minutes") for step in _steps()]
+    uncapped = [
+        _step_name(step)
+        for step, budget in zip(_steps(), budgets, strict=True)
+        if not _is_budget(budget)
+    ]
+    assert not uncapped, (
+        f"steps without a usable budget: {uncapped} - an uncapped step can "
+        "consume the job budget, and the job cap then cancels the run instead "
+        "of a step cap failing it, taking the remaining reports with it"
     )
-    budgets = [step.get("timeout-minutes") for step in heavy]
-    assert all(isinstance(value, int) for value in budgets), (
-        "an uncapped create/analyze step can burn the whole job budget and "
-        "let the job cap cancel the other language out of its report"
+    total = sum(value for value in budgets if _is_budget(value))
+    slack = job["timeout-minutes"] - total
+    assert slack >= _JOB_CAP_SLACK, (
+        f"job cap {job['timeout-minutes']} leaves {slack} minutes over the "
+        f"step-cap sum {total}, under the {_JOB_CAP_SLACK} the workflow "
+        "comment claims - job setup, per-step overhead and the implicit "
+        "post-job steps all run against the job cap and none can be capped, "
+        "so the margin is the only thing covering them"
     )
-    total = sum(value for value in budgets if isinstance(value, int))
-    assert job["timeout-minutes"] >= total, (
-        f"job cap {job['timeout-minutes']} is below the sum of the step caps "
-        f"{total} - the job would cancel before a step cap fires, and a "
-        "cancelled run skips the remaining language entirely"
-    )
+
+
+def test_each_language_keeps_the_budget_its_matrix_leg_had() -> None:
+    """The matrix gave each leg its own runner and its own 20 minutes.
+
+    Serially the two share a job, so the guarantee survives only as
+    per-language step budgets that still add up to the same 20 minutes.
+    """
+    for language in _LANGUAGES:
+        budget = sum(
+            step["timeout-minutes"]
+            for step in _steps()
+            if "gh codeql database" in _run(step) and language in _step_name(step)
+        )
+        assert budget == 20, (
+            f"{language} now gets {budget} minutes of analysis budget, not the "
+            "20 its matrix leg had"
+        )
 
 
 def test_each_language_builds_and_analyzes_its_own_database_directory() -> None:


### PR DESCRIPTION
Refs #2311

## What does this PR do?

Folds `codeql-quality.yml`'s two-leg language matrix and its aggregating gate job into a single job. This is the CodeQL step of the #2311 lane-consolidation sequence, after #2314 folded the seven fast checks.

The workflow produced three check runs for two analyses, and each matrix leg paid separately for its own checkout, Python setup and CodeQL CLI install. Both languages now run serially in one job whose `name:` is still `CodeQL Gate`, so the required-status-check context on the master ruleset is unchanged: no ruleset edit at merge, and no open PR blocked on a renamed context. The two per-language contexts that disappear, `CodeQL Code Quality (python)` and `(javascript)`, are not required contexts.

That is 3 check runs down to 1 on any PR. Measured on PR #2327's head `5f279ff0` — two concurrent workflow runs on that one commit: the python leg 6.6 min, javascript 1.3 min and the gate 0.1 min in the `codeql-quality.yml` run, against `HAOS E2E Tests (inaddon)` at 24.1 min in the `haos-e2e-tests.yml` run. This PR's own run now measures the folded lane at 5 min 57 s — python create 1:38 and analyze 3:11, javascript 0:11 and 0:30, on 17 s of shared CodeQL CLI install, with every step green and both languages visibly analyzed. That is well inside the critical path.

### What the matrix supplied for free, and how each property is restored

Four properties came from the matrix rather than from the workflow body. Each is now explicit and pinned in `tests/src/unit/test_codeql_workflow_shape.py`:

1. **`fail-fast: false`** kept a python finding from hiding a javascript one. Every step from the first SARIF upload onward carries `if: success() || failure()`, the idiom `pr.yml`'s Fast Checks lane already uses; `always()` is rejected so a cancelled run still stops.

2. **Independent time budgets.** Each leg had its own runner and its own job-level `timeout-minutes: 20`. Serially they share one job, and a job-level cap cannot substitute: per the workflow-syntax reference a job `timeout-minutes` "automatically cancels" the job, and a cancelled run skips every `success() || failure()` step, so a hung python analysis would take javascript's report down with it. A step `timeout-minutes` kills only that step's process ("killing the process"), so the step fails while `failure()` stays true ("Returns `true` when any previous step of a job fails"), leaving the later steps to report. Every step therefore carries a budget, and the job cap sits above their sum so it can never be the cap that binds: the analyses keep 20 minutes per language, the remaining steps are sized off the measured run, the budgets total 57 and the job cap is 60. The 3 minutes of slack cover what cannot carry a budget of its own — job setup, per-step overhead and the implicit post-job steps — and the shape test asserts each part separately. Capping only the analyses was not enough: it left the other seven steps free to consume the margin, which both review bots caught.

The scope of that guarantee is execution time. Whether the job timer also counts queue time is not settleable from the public sources — the reference defines the cap as the minutes to let a job run and compares it against the runner's execution-time limit, but the runner does not enforce the cap at all; it receives a cancellation the service decides on. The step budgets stand either way.

3. **A language could not be lost to one edit.** A flat step list can lose one, so the analyzed language set is asserted directly.

4. **Separate filesystems made shared names harmless.** Sharing a SARIF filename or a CodeQL database directory between the legs cost nothing when each leg ran alone. In one job neither does, and the two fail one step apart: a shared SARIF name lets a failed analysis leave the previous language's file in place, so the next *gate* step reports its findings under the wrong language; a shared database directory strands the wrong language's database, so the next *analyze* step runs its suites against the other language's source. Each language now builds, analyzes, uploads and gates under its own names.

### What this does change

Three things, none of them accidental:

- **Per-language check-run attribution goes away.** That is the point of the fold and the same trade #2314 made for the seven fast checks: attribution moves into the job log, where each language's create, analyze and gate steps are separately named and separately red.
- **The SARIF upload steps move off `if: always()`,** which they used before, onto the same `if: success() || failure()` the rest of the job's steps carry. A cancelled run therefore no longer uploads a partial artifact — the price of not paying for the remainder of the job after a cancel.
- **The worst case gets slower, while the measured case does not.** Two 20-minute legs used to run in parallel; 57 minutes of step caps now run serially under a 60-minute job cap. A pathological run can exceed the 24.1-minute HAOS lane it is compared against, where before it could not. The per-language analysis budget also grew slightly: the old 20 minutes covered checkout, Python setup and the CLI install as well, the new 20 covers create and analyze only.

## Type of change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [x] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [ ] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

`ruff check` and `ruff format --check` were run over the same path list `pr.yml` passes to them, and both pass. The other two boxes stay unchecked on purpose: the full test suite was not run locally, and a workflow change is only really exercised by this PR's own CI run.

What was run: `tests/src/unit/test_codeql_workflow_shape.py`, rewritten for the new shape, 11 passing. The tests were then checked for discrimination rather than read — seventeen mutations, one condition or value at a time, each confirmed to turn the suite red with the control green before and after. They cover the attribution clause and `always()`, the job name against the required context, a second job, both database directories and both SARIF filenames, cross-wiring an analyze step to the other language's database, the artifact names, a language's query suites, and every part of the budget arithmetic: a step left uncapped, a budget of `0` or `true`, a language's analysis budget cut below its 20 minutes, the job cap dropped below the sum, and the slack shrunk below the 3 minutes the workflow comment claims. Every one of the eleven tests is reddened by at least one of them.

The cross-wiring arm is why the database check pairs each database with the language of the step that uses it rather than tallying names: swapping the two analyze steps' databases leaves every name present and every count identical, and an earlier version of that test stayed green through exactly that mutation.

## Checklist
- [x] I have updated documentation if needed

No documentation references this workflow: `codeql-quality.yml` does not appear in the CI/CD table in `docs/agents/github-workflow.md`, and the invariants that do live in prose are in the workflow's own header comment, updated here.
