### PR TITLE
chore(coderabbit): disable docstring coverage check

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,5 +1,11 @@
 # yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
 reviews:
+  # Disable only the repository-wide percentage quota (default: warning at
+  # 80%). Ordinary review still applies the docstring rules in the code
+  # guidelines to new and modified tool docstrings.
+  pre_merge_checks:
+    docstrings:
+      mode: "off"
   auto_review:
     drafts: true
     base_branches:

--- a/docs/agents/github-workflow.md
+++ b/docs/agents/github-workflow.md
@@ -19,6 +19,9 @@ CodeRabbit reviews drafts. `.coderabbit.yaml` deliberately sets:
 - `reviews.auto_review.drafts: true`
 - `auto_pause_after_reviewed_commits: 0`
   (the schema default pauses after five reviewed commits)
+- `reviews.pre_merge_checks.docstrings.mode: "off"`
+  (the default 80% repository-wide coverage quota is disabled; ordinary
+  guideline-based docstring review remains enabled)
 
 The second setting spends the per-developer hourly review allowance faster. A
 rate-limited push reports that state in a comment and does not block merging;

--- a/tests/src/unit/test_coderabbit_config.py
+++ b/tests/src/unit/test_coderabbit_config.py
@@ -141,6 +141,20 @@ def test_draft_reviews_are_enabled() -> None:
     )
 
 
+def test_docstring_coverage_pre_merge_check_is_disabled() -> None:
+    """Docstrings stay reviewable without enforcing a repository-wide quota."""
+    pre_merge_checks = _config()["reviews"].get("pre_merge_checks")
+
+    assert pre_merge_checks is not None, (
+        "reviews.pre_merge_checks is missing — CodeRabbit would restore its "
+        "default docstring coverage warning"
+    )
+    assert pre_merge_checks.get("docstrings", {}).get("mode") == "off", (
+        "reviews.pre_merge_checks.docstrings.mode must be 'off' — this disables "
+        "only the percentage-based coverage check, not ordinary docstring review"
+    )
+
+
 def test_bot_authors_stay_unreviewed() -> None:
     """The skip list is exact in both directions.
 


### PR DESCRIPTION
## What does this PR do?

Disables only the percentage-based CodeRabbit docstring coverage pre-merge check, whose schema default is a warning at 80%. Normal review against the repository docstring guidelines remains enabled.

Adds a regression assertion that pins the string enum `"off"` (rather than the YAML boolean `false`) and documents the policy in the GitHub workflow guide.

## Type of change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [x] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [ ] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

## Checklist
- [x] I have updated documentation if needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Documented the option to disable the repository-wide docstring coverage quota while retaining standard docstring review guidelines.

- **Configuration**
  - Disabled the default pre-merge docstring coverage warning threshold.

- **Tests**
  - Added coverage to verify the docstring quota setting remains disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->