### PR TITLE
ci: collect coverage on one unit and one e2e lane

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -92,6 +92,7 @@ jobs:
         echo "All registries failed" && exit 1
 
     - name: Run full E2E test suite
+      id: e2e-suite
       # Per-test coverage rides along on this lane only (#2311). It sits on the
       # master-push workflow rather than on a PR lane so no pull request pays
       # for it, and on THIS lane because the server under test runs inside the
@@ -131,9 +132,14 @@ jobs:
         COVERAGE_FILE: ${{ github.workspace }}/coverage-e2e.dat
 
     - name: Upload e2e coverage data
-      # Not `always()`: a cancelled run leaves a partial data file, and an
-      # artifact holding one is indistinguishable from a real measurement.
-      if: ${{ !cancelled() }}
+      # Gated on the suite step SUCCEEDING, not merely on the run surviving.
+      # `tests/pytest.ini` stops after three failures, so a failed run leaves a
+      # data file covering only the tests reached before the stop — a partial
+      # measurement under a name that promises a complete one, which is the
+      # exact confusion the rest of this lane exists to prevent. An explicit
+      # status-check function also suppresses the implicit `success()`, so the
+      # step outcome has to be named here rather than assumed.
+      if: ${{ !cancelled() && steps.e2e-suite.outcome == 'success' }}
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       with:
         name: coverage-e2e

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -92,6 +92,26 @@ jobs:
         echo "All registries failed" && exit 1
 
     - name: Run full E2E test suite
+      # Per-test coverage rides along on this lane only (#2311). It sits on the
+      # master-push workflow rather than on a PR lane so no pull request pays
+      # for it, and on THIS lane because the server under test runs inside the
+      # pytest process here, which is what makes its lines measurable at all.
+      #
+      # Three properties of the instrument, each of which fails silently when
+      # got wrong, so none of the flags below is decoration:
+      #   * `--cov-config` is explicit because this step runs pytest from
+      #     `tests/`, and coverage.py reads its configuration from the working
+      #     directory only. Without it the root pyproject.toml is never seen
+      #     and the run measures a different, smaller set of files.
+      #   * the default `ctrace` core is deliberate. With COVERAGE_CORE=sysmon
+      #     the same tests recorded contexts for 27 of 35 of them and reported
+      #     nothing about the other 8. sysmon does not support dynamic contexts
+      #     (coverage.py configuration reference) and, as of coverage 7.10.6 on
+      #     the Python this repo pins, neither warns nor falls back to a core that
+      #     does.
+      #   * no JSON report is written. `coverage json` with contexts ran to
+      #     roughly 500x the size of the data file it came from; whoever
+      #     reports on this downloads the artifact and reports locally.
       run: |
         echo "🚀 Running full E2E test suite with 3 workers..."
         cd tests
@@ -99,11 +119,30 @@ jobs:
           -n3 \
           --dist loadscope \
           --tb=short \
-          -v
+          -v \
+          --cov \
+          --cov-config=../pyproject.toml \
+          --cov-context=test \
+          --cov-report=term
         echo "✅ Full E2E test suite passed"
       env:
         HAMCP_ENV_FILE: "tests/.env.test"
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        COVERAGE_FILE: ${{ github.workspace }}/coverage-e2e.dat
+
+    - name: Upload e2e coverage data
+      # Not `always()`: a cancelled run leaves a partial data file, and an
+      # artifact holding one is indistinguishable from a real measurement.
+      if: ${{ !cancelled() }}
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+      with:
+        name: coverage-e2e
+        # Named rather than left as coverage.py's default `.coverage`: this
+        # action skips hidden files unless told otherwise, so the dotfile would
+        # have produced an empty artifact and no error.
+        path: coverage-e2e.dat
+        if-no-files-found: error
+        retention-days: 14
 
   # Container backend with the ha_mcp_tools component ABSENT (#2292): mirrors
   # pr.yml's e2e-validation-no-component on master push. The same full E2E

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -494,6 +494,7 @@ jobs:
       run: cd tests/js && corepack npm ci
 
     - name: Run unit tests
+      id: unit-suite
       # Coverage rides along here (#2311) so the cost and the reach of a test
       # can be read off data instead of argued from heuristics.
       #
@@ -522,9 +523,12 @@ jobs:
         --ignore=tests/addon/test_addon_startup.py
 
     - name: Upload unit coverage data
-      # Not `always()`: a cancelled run leaves a partial data file, and an
-      # artifact holding one is indistinguishable from a real measurement.
-      if: ${{ !cancelled() }}
+      # Gated on the suite step SUCCEEDING: a failed or cancelled run leaves a
+      # partial data file, and an artifact holding one is indistinguishable by
+      # name from a complete measurement. Naming the step outcome rather than
+      # relying on step ordering also keeps the upload alive when a LATER step
+      # fails, where the coverage data is in fact complete.
+      if: ${{ !cancelled() && steps.unit-suite.outcome == 'success' }}
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       with:
         name: coverage-unit

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -494,7 +494,23 @@ jobs:
       run: cd tests/js && corepack npm ci
 
     - name: Run unit tests
-      run: uv run pytest tests/src/unit/ -n auto --tb=short -v
+      # Coverage rides along here (#2311) so the cost and the reach of a test
+      # can be read off data instead of argued from heuristics.
+      #
+      # `sysmon` is the cheap core. Measured over the full unit suite on one
+      # noisy box: three uninstrumented runs at 145-177 s, two sysmon runs at
+      # 162-182 s, one default-core run at 247 s. The first two ranges overlap;
+      # the default core sits well outside both. It is safe on THIS lane
+      # because the lane asks for line coverage only, which the two cores
+      # record identically (13,344 lines over 222 files, no difference either
+      # way). It is NOT safe with `--cov-context`, and the e2e lane in
+      # e2e-tests.yml carries that measurement.
+      env:
+        COVERAGE_FILE: coverage-unit.dat
+        COVERAGE_CORE: sysmon
+      run: >-
+        uv run pytest tests/src/unit/ -n auto --tb=short -v
+        --cov --cov-report=term
 
     - name: Run add-on structure tests
       # tests/addon/ validates add-on packaging / config.yaml structure (e.g.
@@ -504,6 +520,20 @@ jobs:
       run: >-
         uv run pytest tests/addon/ -n auto --tb=short -v
         --ignore=tests/addon/test_addon_startup.py
+
+    - name: Upload unit coverage data
+      # Not `always()`: a cancelled run leaves a partial data file, and an
+      # artifact holding one is indistinguishable from a real measurement.
+      if: ${{ !cancelled() }}
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+      with:
+        name: coverage-unit
+        # Named rather than left as coverage.py's default `.coverage`: this
+        # action skips hidden files unless told otherwise, so the dotfile would
+        # have produced an empty artifact and no error.
+        path: coverage-unit.dat
+        if-no-files-found: error
+        retention-days: 14
 
   # Comprehensive E2E validation for all PRs
   e2e-validation:

--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,9 @@ logs/
 # Test files
 pytest_cache/
 .coverage
+# The CI lanes name their data file so upload-artifact does not skip it as a
+# hidden file; xdist's per-worker shards share the prefix.
+coverage-*.dat*
 htmlcov/
 
 # Test environment runtime data

--- a/docs/agents/development.md
+++ b/docs/agents/development.md
@@ -65,6 +65,38 @@ tests take more than 25 minutes serial, so run them in parallel as shown.
 a report with three failures may be an early stop; use `--maxfail=0` only when
 the complete failure set is actually needed.
 
+### Coverage data
+
+Two CI lanes collect coverage (#2311) and upload the data file as a build
+artifact: `Unit Tests` in `pr.yml` (line coverage, artifact `coverage-unit`)
+and `E2E Tests` in `e2e-tests.yml`, the master-push lane, which additionally
+records a context per test (artifact `coverage-e2e`). No pull-request lane pays
+for the e2e measurement.
+
+The two lanes run pytest from different directories, and `relative_files` is
+relative to the working directory, so the unit data file records repo-relative
+paths and the e2e one absolute paths. `coverage combine` reconciles them
+through `[tool.coverage.paths]` **when run from the repository root**; run
+anywhere else the canonical path does not resolve and the two data files stay
+two unrelated file sets.
+
+```bash
+# Report on a downloaded artifact, or diff two of them.
+uv run coverage combine --keep coverage-unit.dat coverage-e2e.dat
+uv run coverage json          # per-test contexts included; see below
+```
+
+A JSON report is much larger than the data file it comes from — in one probe
+roughly 500x — because `[tool.coverage.json] show_contexts` writes every
+context of every line. Report locally from the artifact rather than having CI
+produce JSON.
+
+Collecting contexts requires the default measurement core. Under
+`COVERAGE_CORE=sysmon`, coverage 7.10.6 on Python 3.13 records only some of the
+contexts and reports no error, so leave the core alone whenever `--cov-context` is in play;
+for line coverage alone the two cores agree exactly and sysmon is the cheaper
+one, which is why the unit lane selects it.
+
 Do not set `HOMEASSISTANT_URL` manually before testcontainer E2E tests.
 `tests/.env.test` contains placeholders, and the fixture supplies the real
 URL dynamically. The shared token is in `tests/test_constants.py`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -308,6 +308,35 @@ dev = [
     "pyyaml>=6.0",
 ]
 
+# Coverage measurement (#2311). CI collects coverage on two lanes so the cost
+# of a test can be argued from data rather than from heuristics; the settings
+# that make those two runs comparable belong here rather than on either lane's
+# command line.
+[tool.coverage.run]
+# `source` has to live in the config file, not on the command line, or
+# `relative_files` cannot resolve the origin (coverage.py config reference).
+# That is also why the lanes pass a bare `--cov`.
+source = ["ha_mcp"]
+# Store repo-relative paths, so a data file collected on one lane can be
+# reported or diffed against one collected on another.
+relative_files = true
+
+[tool.coverage.paths]
+# The two lanes run pytest from different directories — the unit lane from the
+# repository root, the e2e lane from `tests/` — and `relative_files` is
+# relative to the working directory, so the e2e lane records absolute paths
+# whatever this file says. `coverage combine` RUN FROM THE REPOSITORY ROOT maps
+# both spellings onto the first entry; run from anywhere else the canonical
+# path does not resolve and the two lanes stay two separate file sets.
+source = ["src/ha_mcp", "*/src/ha_mcp"]
+
+[tool.coverage.json]
+# A JSON report drops per-test contexts unless this is on (default false), and
+# says nothing about having dropped them: the report is well-formed, every
+# `contexts` map is simply empty. Anything downstream that keys off contexts
+# would then measure an empty set and read it as "no test touches this line".
+show_contexts = true
+
 # Semantic versioning configuration
 [tool.semantic_release]
 version_toml = ["pyproject.toml:project.version"]

--- a/tests/src/unit/test_coverage_lane_shape.py
+++ b/tests/src/unit/test_coverage_lane_shape.py
@@ -217,3 +217,60 @@ def test_coverage_source_is_configured_in_the_file_not_on_the_command_line() -> 
         "[tool.coverage.run] relative_files must stay on, or a data file can "
         "only be reported on the machine that wrote it"
     )
+
+    coverage_config = config["tool"]["coverage"]
+    # relative_files is relative to the WORKING DIRECTORY, so the e2e lane -
+    # which runs pytest from tests/ - records absolute paths whatever the run
+    # section says. This mapping is the only thing that lets the two lanes'
+    # data files combine into one file set instead of two.
+    assert coverage_config.get("paths", {}).get("source") == [
+        "src/ha_mcp",
+        "*/src/ha_mcp",
+    ], (
+        "[tool.coverage.paths] source must map both spellings onto the first "
+        "entry, or a combine across the two lanes silently yields two "
+        "unrelated file sets rather than one"
+    )
+    # Default is false, and a JSON report written without it is well-formed
+    # with every `contexts` map empty - so anything downstream reads "no test
+    # touches this line" from data that simply was not written.
+    assert coverage_config.get("json", {}).get("show_contexts") is True, (
+        "[tool.coverage.json] show_contexts must stay on, or the per-test "
+        "contexts the e2e lane collects never reach a JSON report"
+    )
+
+
+@pytest.mark.parametrize(("workflow", "job_id", "step_name"), _COVERAGE_LANES)
+def test_the_upload_waits_for_a_run_that_actually_finished(
+    workflow: str, job_id: str, step_name: str
+) -> None:
+    """A failed run leaves a partial data file under a complete-sounding name.
+
+    `tests/pytest.ini` stops the e2e suite after three failures, so the data
+    file from a red run describes only the tests reached before the stop. An
+    artifact of that is not distinguishable from a real measurement by anything
+    a consumer can see, which is worse than no artifact.
+
+    Gating on `!cancelled()` alone does not do it: cancellation is one of the
+    ways a run ends early, and the ordinary one - a failing test - is the other.
+    So the upload has to name the producing step's outcome, which also means
+    that step has to keep its `id`.
+    """
+    step = _step(workflow, job_id, step_name)
+    step_id = step.get("id")
+    assert step_id, (
+        f"{workflow}::{job_id} pytest step lost its `id`, so no later step can "
+        "condition on whether it succeeded"
+    )
+    upload = next(
+        candidate
+        for candidate in _job(workflow, job_id).get("steps", [])
+        if isinstance(candidate, dict)
+        and "upload-artifact" in str(candidate.get("uses", ""))
+    )
+    condition = str(upload.get("if", ""))
+    assert f"steps.{step_id}.outcome == 'success'" in condition, (
+        f"{workflow}::{job_id} uploads its coverage artifact without requiring "
+        f"that {step_id} succeeded, so a red run publishes a partial data file "
+        "under a name that promises a complete one"
+    )

--- a/tests/src/unit/test_coverage_lane_shape.py
+++ b/tests/src/unit/test_coverage_lane_shape.py
@@ -1,0 +1,219 @@
+"""Pin the two coverage lanes (#2311) against silent, green data loss.
+
+Coverage is collected so that decisions about the test suite — which lanes a
+test needs to run on, what a test costs — can be read off measurements. Every
+failure mode below produces a passing lane and a well-formed artifact that
+happens to describe less than it claims, which is worse than no measurement at
+all: nobody re-checks a number that arrived without an error.
+
+Each assertion here stands for one measured failure, not for a style
+preference:
+
+* ``COVERAGE_CORE=sysmon`` with ``--cov-context``: measured on
+  ``test_helper_response_shape.py``, the sysmon core recorded contexts for 27
+  of the 35 tests and said nothing about the remaining 8, while the ctrace core
+  recorded all 35. The coverage.py configuration reference lists dynamic
+  contexts as unsupported by that core; as of coverage 7.10.6 on Python 3.13 it
+  neither warns nor falls back. Without contexts the two cores agree exactly (13,344 lines over 222
+  files, zero difference either way), which is why the unit lane may use it.
+* A missing ``--cov-config`` on a lane that runs pytest from ``tests/``:
+  coverage.py reads its configuration from the working directory only, so the
+  root ``pyproject.toml`` is never seen and the run measures a different set of
+  files (118 rather than 222 in the same probe).
+* The default data-file name: ``actions/upload-artifact`` skips hidden files
+  unless told otherwise, so a ``.coverage`` artifact uploads nothing and
+  reports success.
+* ``source`` on the command line rather than in the config file: the
+  configuration reference makes it a precondition for ``relative_files``, and
+  without relative paths a data file cannot be reported or diffed anywhere but
+  the machine that produced it.
+"""
+
+from __future__ import annotations
+
+import re
+import tomllib
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+# `--cov` as its own flag. A plain substring test is satisfied by
+# `--cov-report`, so a lane that stopped collecting coverage while still
+# printing a report would read as instrumented.
+_BARE_COV = re.compile(r"(?<![\w-])--cov(?![\w-])")
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_WORKFLOW_DIR = _REPO_ROOT / ".github" / "workflows"
+
+# (workflow, job_id, step name fragment) for every lane that collects coverage.
+_UNIT_LANE = ("pr.yml", "unit-tests", "Run unit tests")
+_E2E_LANE = ("e2e-tests.yml", "e2e-tests", "Run full E2E test suite")
+# Explicit ids: the default would embed the step name, whose spaces truncate the
+# test id in any reader that splits pytest's summary line on whitespace.
+_COVERAGE_LANES = (
+    pytest.param(*_UNIT_LANE, id="pr.yml::unit-tests"),
+    pytest.param(*_E2E_LANE, id="e2e-tests.yml::e2e-tests"),
+)
+
+
+def _workflow(name: str) -> dict[str, Any]:
+    data = yaml.safe_load((_WORKFLOW_DIR / name).read_text(encoding="utf-8"))
+    assert isinstance(data, dict), f"{name} must parse as a workflow mapping"
+    return data
+
+
+def _job(workflow: str, job_id: str) -> dict[str, Any]:
+    job = _workflow(workflow)["jobs"][job_id]
+    assert isinstance(job, dict), f"{workflow}::{job_id} must be a job mapping"
+    return job
+
+
+def _step(workflow: str, job_id: str, name_fragment: str) -> dict[str, Any]:
+    steps = [
+        step
+        for step in _job(workflow, job_id).get("steps", [])
+        if isinstance(step, dict) and name_fragment in str(step.get("name", ""))
+    ]
+    assert len(steps) == 1, (
+        f"{workflow}::{job_id} must have exactly one step named like "
+        f"{name_fragment!r}, found {[s.get('name') for s in steps]}"
+    )
+    return steps[0]
+
+
+def _env_in_scope(workflow: str, job_id: str, step: dict[str, Any]) -> dict[str, Any]:
+    """Every env var the step sees, across the three scopes that set them.
+
+    Workflow-level env is inherited by every job, and job-level by every step,
+    so a core selected two scopes up governs this step as surely as its own
+    ``env:`` block does — and is the easier place to set one by accident.
+    """
+    return {
+        **(_workflow(workflow).get("env") or {}),
+        **(_job(workflow, job_id).get("env") or {}),
+        **(step.get("env") or {}),
+    }
+
+
+@pytest.mark.parametrize(("workflow", "job_id", "step_name"), _COVERAGE_LANES)
+def test_coverage_lane_still_collects_coverage(
+    workflow: str, job_id: str, step_name: str
+) -> None:
+    """The lane this module pins must still be a coverage lane at all.
+
+    Without this, every check below passes vacuously the moment the flag is
+    dropped: no ``--cov`` means no contexts to lose, no config to miss and no
+    data file to misname.
+    """
+    run = str(_step(workflow, job_id, step_name).get("run", ""))
+    assert _BARE_COV.search(run), (
+        f"{workflow}::{job_id} no longer collects coverage, so the guarantees "
+        "in this module are about a lane that stopped existing (#2311)"
+    )
+
+
+@pytest.mark.parametrize(("workflow", "job_id", "step_name"), _COVERAGE_LANES)
+def test_coverage_lane_names_its_data_file(
+    workflow: str, job_id: str, step_name: str
+) -> None:
+    """A hidden ``.coverage`` uploads as an empty artifact, successfully."""
+    env = _env_in_scope(workflow, job_id, _step(workflow, job_id, step_name))
+    data_file = str(env.get("COVERAGE_FILE", ""))
+    assert data_file, (
+        f"{workflow}::{job_id} leaves COVERAGE_FILE unset, so coverage.py "
+        "writes the hidden default `.coverage` and upload-artifact skips it "
+        "without failing"
+    )
+    assert not Path(data_file).name.startswith("."), (
+        f"{workflow}::{job_id} writes {data_file!r}, a hidden file that "
+        "upload-artifact excludes by default"
+    )
+
+
+@pytest.mark.parametrize(("workflow", "job_id", "step_name"), _COVERAGE_LANES)
+def test_the_uploaded_artifact_is_the_file_the_lane_wrote(
+    workflow: str, job_id: str, step_name: str
+) -> None:
+    """An upload pointing somewhere else is the same empty artifact again.
+
+    Matched on the file name rather than on a substring: `coverage-unit.dat`
+    occurs inside `not-coverage-unit.dat` too, and an upload of the wrong file
+    is the failure this check exists to catch.
+    """
+    step = _step(workflow, job_id, step_name)
+    written = Path(str(_env_in_scope(workflow, job_id, step)["COVERAGE_FILE"])).name
+    uploads = [
+        candidate
+        for candidate in _job(workflow, job_id).get("steps", [])
+        if isinstance(candidate, dict)
+        and "upload-artifact" in str(candidate.get("uses", ""))
+        and Path(str((candidate.get("with") or {}).get("path", "")).strip()).name
+        == written
+    ]
+    assert len(uploads) == 1, (
+        f"{workflow}::{job_id} writes {written} but no upload-artifact step "
+        "takes that path — the measurement stays on the runner"
+    )
+    assert (uploads[0].get("with") or {}).get("if-no-files-found") == "error", (
+        f"{workflow}::{job_id} uploads {written} without if-no-files-found: "
+        "error, so a run that produced no data reports a green upload"
+    )
+
+
+def test_the_context_lane_does_not_select_a_core_that_drops_contexts() -> None:
+    """sysmon records a fraction of the contexts, greenly (#2311).
+
+    The check is on the lane that asks for contexts, in every env scope, rather
+    than a blanket ban: the unit lane's line-only run is measurably identical
+    on either core, and forbidding the fast core there would cost wall clock on
+    a required lane for no gain.
+    """
+    workflow, job_id, step_name = _E2E_LANE
+    step = _step(workflow, job_id, step_name)
+    assert "--cov-context" in str(step.get("run", "")), (
+        f"{workflow}::{job_id} stopped collecting per-test contexts, which is "
+        "the whole reason this lane carries coverage"
+    )
+    core = str(_env_in_scope(workflow, job_id, step).get("COVERAGE_CORE", ""))
+    assert core != "sysmon", (
+        f"{workflow}::{job_id} asks for dynamic contexts under the sysmon "
+        "core, which does not support them: it records only part of them and "
+        "neither warns nor falls back. Leave COVERAGE_CORE unset here."
+    )
+
+
+def test_a_lane_running_pytest_from_a_subdirectory_points_at_the_config() -> None:
+    """coverage.py reads its config from the working directory only."""
+    workflow, job_id, step_name = _E2E_LANE
+    run = str(_step(workflow, job_id, step_name).get("run", ""))
+    assert "cd tests" in run, (
+        f"{workflow}::{job_id} no longer runs pytest from tests/, so this "
+        "check no longer describes it — confirm the config is still found and "
+        "update the reason here"
+    )
+    assert "--cov-config" in run, (
+        f"{workflow}::{job_id} runs pytest from tests/ without --cov-config, "
+        "so coverage.py never reads the root pyproject.toml: the run silently "
+        "measures a different set of files than every other lane"
+    )
+
+
+def test_coverage_source_is_configured_in_the_file_not_on_the_command_line() -> None:
+    """`relative_files` needs `source` in the config, per coverage.py's docs.
+
+    Absolute paths in a data file pin it to the machine that produced it, which
+    defeats collecting on one lane and comparing against another.
+    """
+    config = tomllib.loads((_REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    run_config = config["tool"]["coverage"]["run"]
+    assert run_config.get("source") == ["ha_mcp"], (
+        "[tool.coverage.run] source must name the package in the config file: "
+        "passed as `--cov=ha_mcp` instead, relative_files cannot resolve the "
+        "source origin and the data file records absolute paths"
+    )
+    assert run_config.get("relative_files") is True, (
+        "[tool.coverage.run] relative_files must stay on, or a data file can "
+        "only be reported on the machine that wrote it"
+    )


### PR DESCRIPTION
## What does this PR do?

Refs #2311.

Part of #2311 already rests on coverage data: the per-test context run behind the `single_lane` proposal is entirely a coverage measurement, and a unit-suite coverage figure is quoted in the argument that unit-test tidying is a maintenance question rather than a CI one. What that data does not rest on is anything a second person can reproduce or watch move — no workflow in `.github/workflows/` collects coverage, so every coverage number in that thread is one local run, correct or not, and stale the moment the suite changes. Two lanes now collect it in CI and upload the data file as an artifact. This PR saves no runner minutes by itself; it makes the measurements behind the ones that do into something the repository produces rather than something a maintainer has to re-derive by hand.

**Where it runs, and why there.**

- `Unit Tests` in `pr.yml` takes line coverage. Artifact `coverage-unit`.
- `E2E Tests` in `e2e-tests.yml` — the master-push lane, not a pull-request lane — additionally records one context per test. Artifact `coverage-e2e`.

The e2e half sits on the master-push workflow so that no pull request pays for it, and on that lane specifically because the server under test runs inside the pytest process there, which is what makes its lines measurable at all. `e2e-tests.yml` triggers on `push` to `main` or `master` and on `workflow_dispatch`, so this half does not run on this PR at all. I dispatched it against this branch in my fork instead. The instrumented lane passed and produced an 820 KB artifact holding 1,788 contexts over 1,138 distinct tests, 222 files and 40,072 covered lines. `client/websocket_client.py` is among them, and every constructor of that client lives in server code with no test fixture building one, so its coverage is the in-process server this lane was chosen for actually running. (`rest_client.py` appears too but proves less: the e2e `ha_client` fixture instantiates it in the pytest process for direct HA verification, on any backend.) Downloading that artifact and running the documented combine from the repository root resolved all 222 absolute runner paths to repo-relative ones with every context preserved, so the recipe below is verified against real CI output rather than a local probe. One unrelated job in that workflow, `E2E Tests (Update Path)`, failed on a 600-second timeout installing the published wheel from PyPI; it runs no coverage, this diff does not touch it, and the same lane passed on the same commit in this PR's own checks.

**Cost, measured.** Full unit suite, `-n auto`, on one noisy local box:

| Run | Wall clock |
|---|---|
| uninstrumented | 176.5 s / 149.0 s / 144.5 s |
| `--cov`, sysmon core | 161.5 s / 182.3 s |
| `--cov`, default `ctrace` core | 247.2 s |

The first two ranges overlap; the default core sits well outside both. That is why the unit lane selects sysmon — and why the e2e lane must not, which is the next point.

**Five ways this feature fails silently.** Each produces a green lane and a well-formed artifact describing less than it claims, so each is pinned by `tests/src/unit/test_coverage_lane_shape.py` rather than left to a comment:

1. **The sysmon core drops contexts.** On `tests/src/unit/test_helper_response_shape.py`, `COVERAGE_CORE=sysmon` recorded contexts for 27 of the 35 tests and said nothing about the other 8; the default core recorded all 35. coverage.py's configuration reference lists dynamic contexts as unsupported by that core, and as of 7.10.6 on Python 3.13 it neither warns nor falls back. Without contexts the two cores agree exactly — 13,344 lines over 222 files, zero difference either way — which is what makes it safe on the unit lane.
2. **Config discovery is working-directory-scoped.** The e2e step runs pytest from `tests/`, where coverage.py never sees the root `pyproject.toml`. Same probe: 118 files measured instead of 222. Hence the explicit `--cov-config=../pyproject.toml`.
3. **`upload-artifact` skips hidden files** unless told otherwise, so an artifact of coverage.py's default `.coverage` uploads nothing and reports success. Both lanes name their data file instead of working around the default.
4. **`relative_files` needs `source` in the config file**, not on the command line, per the same reference — which is why the lanes pass a bare `--cov`. Without it a data file records absolute paths and can only be reported on the machine that wrote it.
5. **A failed run publishes a partial data file.** Both uploads were gated on `!cancelled()`, which lets a red run upload coverage for the tests reached before the stop — `tests/pytest.ini` halts the e2e suite after three failures — under a name that promises a complete measurement. An explicit status-check function also suppresses the implicit `success()`, so the producing step's outcome has to be named rather than assumed. Flagged by Codex on the e2e lane; the unit lane had the same hole, which no bot flagged, and is gated the same way.

**Using the artifacts.** The two lanes run pytest from different directories and `relative_files` is relative to the working directory, so the unit data file records repo-relative paths and the e2e one absolute paths. `coverage combine` reconciles them through `[tool.coverage.paths]` when run from the repository root; run anywhere else the canonical path does not resolve and the two files stay two unrelated sets. `docs/agents/development.md` carries the recipe. No JSON report is produced in CI: with `show_contexts` on, one probe's JSON was about 500x the size of the data file it came from.

## Type of change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [x] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

Unit suite with `--maxfail=0` so the count is a count and not a lower bound: 11,799 passed, 357 skipped. The eleven new tests were proved to bite by fifteen mutation arms, one condition at a time, with the control green before and after and every file restored byte-identically; each arm reintroduces one of the failure modes above and turns exactly the test that pins it red. The e2e suite is not runnable locally in my environment; the dispatched fork run named above is the evidence for that half, and its numbers are quoted from the artifact it produced.

## Checklist
- [x] I have updated documentation if needed
