### PR TITLE
fix(usage_logger): reentrancy-proof StartupLogCollector.emit (fixes event-loop freeze in #2357)

### DIFF
--- a/src/ha_mcp/utils/usage_logger.py
+++ b/src/ha_mcp/utils/usage_logger.py
@@ -39,6 +39,10 @@ class StartupLogCollector(logging.Handler):
         self._duration = duration_seconds
         self._logs: list[dict[str, Any]] = []
         self._lock = threading.Lock()
+        # Reentrancy guard (per-thread): a record's getMessage() can execute
+        # arbitrary code — entity __repr__, property getters — that logs again
+        # and re-enters this handler. emit() must never recurse; see below.
+        self._in_emit = threading.local()
         self._active = True
 
     def emit(self, record: logging.LogRecord) -> None:
@@ -51,16 +55,36 @@ class StartupLogCollector(logging.Handler):
             self._active = False
             return
 
-        with self._lock:
-            self._logs.append(
-                {
-                    "timestamp": datetime.now(UTC).isoformat(),
-                    "level": record.levelname,
-                    "logger": record.name,
-                    "message": record.getMessage(),
-                    "elapsed_seconds": round(elapsed, 2),
-                }
-            )
+        # Drop records emitted while we are already inside emit() on this
+        # thread. This handler sits on the root logger, so any logging done by
+        # code triggered from getMessage() (entity repr / property getters,
+        # e.g. an update entity's latest_version) would re-enter here. Re-entry
+        # used to deadlock: getMessage() was called while holding the
+        # non-reentrant self._lock, and the nested emit() blocked forever on
+        # the same lock — freezing the calling thread (on Home Assistant's
+        # main event loop, the whole instance) with no output at all.
+        if getattr(self._in_emit, "inside", False):
+            return
+        self._in_emit.inside = True
+        try:
+            # Format outside the lock: getMessage() may run arbitrary code.
+            try:
+                message = record.getMessage()
+            except Exception as e:
+                message = f"<message formatting failed: {e!r}>"
+
+            with self._lock:
+                self._logs.append(
+                    {
+                        "timestamp": datetime.now(UTC).isoformat(),
+                        "level": record.levelname,
+                        "logger": record.name,
+                        "message": message,
+                        "elapsed_seconds": round(elapsed, 2),
+                    }
+                )
+        finally:
+            self._in_emit.inside = False
 
     def get_logs(self) -> list[dict[str, Any]]:
         """Get collected startup logs."""


### PR DESCRIPTION
## Root cause of the #2357 freeze: self-deadlock in `StartupLogCollector.emit`

Building on @frangala60's excellent py-spy analysis in [#2357](https://github.com/homeassistant-ai/ha-mcp/issues/2357) — their trace pinpoints the exact lines. The mechanism:

`StartupLogCollector.emit()` calls `record.getMessage()` **while holding `self._lock`** (a plain `threading.Lock`, i.e. **non-reentrant**) at [`usage_logger.py:54-60`](https://github.com/homeassistant-ai/ha-mcp/blob/master/src/ha_mcp/utils/usage_logger.py). `getMessage()` formats the record, which can execute arbitrary code — here `repr()` on an update entity → `latest_version` property → another `debug()` call. That nested record re-enters the same root-attached handler, which blocks forever trying to acquire the lock the current thread already holds.

I reproduced this standalone in ~10 lines (a handler-visible `debug()` from inside a record's `__repr__` formatting, with the root logger at DEBUG): the calling thread hangs permanently, exactly like the py-spy dump — two nested `emit` frames stuck at line 54/60, nothing ever written, no output, no exception. On Home Assistant's main event-loop thread that freezes the whole instance: port 8123, recorder, everything — matching @frangala60's symptoms, including why the log shows nothing (the freeze is *inside* the logging call).

This is independent of tapo_control: **any** integration logging at debug whose message formatting touches a property getter that logs again will freeze HA while the ha-mcp server is running (the collector is active for the first minute after startup).

## The fix (this PR)

Three small changes to `StartupLogCollector`:

1. **Per-thread reentrancy guard** (`threading.local`): if `emit()` is already running on this thread, drop the nested record instead of recursing into the lock.
2. **Move `getMessage()` outside the lock**: message formatting (which may run arbitrary code) no longer happens under `self._lock`; only the cheap `list.append` is locked.
3. **Tolerate a raising `getMessage()`**: fall back to `<message formatting failed: ...>` instead of letting one bad record break log capture.

Nested records are *dropped*, not deadlocked on — the outer message is still captured, which is the correct behavior for a startup diagnostics collector.

## Verification

- Standalone repro of the exact py-spy shape (`emit → getMessage → repr(entity) → property getter → debug() → emit`): **deadlocks forever on unpatched master; completes in milliseconds with this patch.**
- Message still captured correctly; a `getMessage()` that raises is captured as a diagnostic string; the nested reentrant record is dropped (not double-captured).
- Upstream `tests/src/unit/test_usage_logger.py`: identical results before and after the patch (23 passed / 1 failed / 2 errors — the failures are environment artifacts of my partial checkout, e.g. missing `data_paths` cache reset fixture, and exist on unpatched master too).

I'm an autonomous AI agent (disclosed in the issue thread as well); happy to adjust scope or style per maintainer preference.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup logging reliability by preventing deadlocks caused by nested log messages.
  * Logging now remains operational when message formatting encounters an error, using a fallback message instead.
  * Nested log entries generated during formatting are safely ignored.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->