### PR TITLE
fix(logging): stop StartupLogCollector deadlocking Home Assistant (#2357)

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -450,8 +450,10 @@ jobs:
       image: ghcr.io/astral-sh/uv:0.12.8-python3.13-trixie-slim
     # Bumped 5 → 8 for the issue #2027 regression tests, which spawn real
     # subprocesses — including a full stdio server session — costing tens
-    # of seconds on a slow runner.
-    timeout-minutes: 8
+    # of seconds on a slow runner. 8 → 10 after #2360: pytest alone is ~3.6
+    # min and the `npm ci` step swung from 1s to 4 min during an npm registry
+    # incident, so 8 left no room for one slow install.
+    timeout-minutes: 10
 
     steps:
     - name: Restore apt download cache

--- a/src/ha_mcp/utils/usage_logger.py
+++ b/src/ha_mcp/utils/usage_logger.py
@@ -2,6 +2,7 @@
 Usage logging for MCP tool calls to track usage patterns and performance metrics.
 """
 
+import copy
 import json
 import logging
 import threading
@@ -103,7 +104,13 @@ class StartupLogCollector(logging.Handler):
             )
             # Honour the stdlib path too (logging.raiseExceptions / stderr);
             # at DEBUG on root this may be the only handler that saw the record.
-            self.handleError(record)
+            # Hand it a copy carrying the synthetic message and no args:
+            # handleError() formats ``record.args`` again and re-raises a
+            # RecursionError from that, which would escape into the caller.
+            safe = copy.copy(record)
+            safe.msg = message
+            safe.args = ()
+            self.handleError(safe)
         finally:
             self._formatting.active = False
 

--- a/src/ha_mcp/utils/usage_logger.py
+++ b/src/ha_mcp/utils/usage_logger.py
@@ -29,6 +29,13 @@ AVG_LOG_ENTRIES_PER_TOOL = 3
 # Startup log collection duration in seconds
 STARTUP_LOG_DURATION_SECONDS = 60
 
+# Hard cap on collected startup entries. The collector sits on the root logger
+# at DEBUG with no filter, so an instance with `logger:` debug overrides on a
+# chatty integration can emit tens of thousands of records inside the window.
+# Keep the earliest ones — ha_report_issue's startup diagnostics care about the
+# boot sequence, and the tail of a debug flood is noise.
+MAX_STARTUP_LOG_ENTRIES = 5000
+
 
 class StartupLogCollector(logging.Handler):
     """Collects log messages during the first minute of server startup."""
@@ -40,10 +47,31 @@ class StartupLogCollector(logging.Handler):
         self._logs: list[dict[str, Any]] = []
         self._lock = threading.Lock()
         self._active = True
+        self._formatting = threading.local()
 
     def emit(self, record: logging.LogRecord) -> None:
-        """Capture log record if within startup window."""
+        """Capture log record if within startup window.
+
+        ``record.getMessage()`` is deliberately called OUTSIDE ``self._lock``
+        and under a per-thread reentrancy guard. Formatting a record runs
+        arbitrary third-party code: ``%s`` of an entity invokes
+        ``Entity.__repr__`` -> ``_stringify_state`` -> the entity's ``state``
+        property, and an integration whose property logs at debug re-enters
+        this handler on the same thread. This handler runs in-process with
+        Home Assistant in embedded mode, so that thread is the event loop.
+
+        Formatting inside the lock made that re-entry a hard self-deadlock on a
+        non-reentrant ``threading.Lock``, freezing the whole HA process — no
+        port 8123, no recorder writes, and no log line explaining it, because
+        the freeze happens inside logging itself (#2357).
+        """
         if not self._active:
+            return
+
+        # Nested emit from within our own formatting: drop the record rather
+        # than recurse. The outer record still gets collected, and the chain
+        # (repr -> log -> repr -> log) cannot run away.
+        if getattr(self._formatting, "active", False):
             return
 
         elapsed = time.time() - self._start_time
@@ -51,13 +79,25 @@ class StartupLogCollector(logging.Handler):
             self._active = False
             return
 
+        self._formatting.active = True
+        try:
+            message = record.getMessage()
+        except Exception as exc:
+            # Mirrors logging's own contract: a handler never propagates.
+            message = f"<unformattable {record.name} record: {type(exc).__name__}>"
+        finally:
+            self._formatting.active = False
+
         with self._lock:
+            if len(self._logs) >= MAX_STARTUP_LOG_ENTRIES:
+                self._active = False
+                return
             self._logs.append(
                 {
                     "timestamp": datetime.now(UTC).isoformat(),
                     "level": record.levelname,
                     "logger": record.name,
-                    "message": record.getMessage(),
+                    "message": message,
                     "elapsed_seconds": round(elapsed, 2),
                 }
             )

--- a/src/ha_mcp/utils/usage_logger.py
+++ b/src/ha_mcp/utils/usage_logger.py
@@ -47,7 +47,13 @@ class StartupLogCollector(logging.Handler):
         self._logs: list[dict[str, Any]] = []
         self._lock = threading.Lock()
         self._active = True
+        # Per-thread, not an instance flag: emit() runs on every thread that
+        # logs, and a shared flag would drop unrelated records from other
+        # threads while one thread is mid-format.
         self._formatting = threading.local()
+        # Nested records the guard dropped; surfaced by get_logs() so the
+        # startup diagnostics show the hole instead of hiding it.
+        self._dropped_nested = 0
 
     def emit(self, record: logging.LogRecord) -> None:
         """Capture log record if within startup window.
@@ -70,8 +76,11 @@ class StartupLogCollector(logging.Handler):
 
         # Nested emit from within our own formatting: drop the record rather
         # than recurse. The outer record still gets collected, and the chain
-        # (repr -> log -> repr -> log) cannot run away.
+        # (repr -> log -> repr -> log) cannot run away. The lock is free on
+        # this path (formatting happens outside it), so counting is safe.
         if getattr(self._formatting, "active", False):
+            with self._lock:
+                self._dropped_nested += 1
             return
 
         elapsed = time.time() - self._start_time
@@ -83,8 +92,18 @@ class StartupLogCollector(logging.Handler):
         try:
             message = record.getMessage()
         except Exception as exc:
-            # Mirrors logging's own contract: a handler never propagates.
-            message = f"<unformattable {record.name} record: {type(exc).__name__}>"
+            # Mirrors logging's own contract: a handler never propagates. Only
+            # attributes the logging machinery itself set are interpolated —
+            # ``exc``'s repr or ``record.msg`` could run the code that just
+            # failed. pathname:lineno names the broken call site, which the
+            # logger name alone does not.
+            message = (
+                f"<unformattable record from {record.pathname}:{record.lineno}: "
+                f"{type(exc).__name__}>"
+            )
+            # Honour the stdlib path too (logging.raiseExceptions / stderr);
+            # at DEBUG on root this may be the only handler that saw the record.
+            self.handleError(record)
         finally:
             self._formatting.active = False
 
@@ -103,9 +122,29 @@ class StartupLogCollector(logging.Handler):
             )
 
     def get_logs(self) -> list[dict[str, Any]]:
-        """Get collected startup logs."""
+        """Get collected startup logs.
+
+        If the reentrancy guard dropped any nested records, one synthetic
+        trailing entry says how many, so a reader of the diagnostics can tell
+        "the integration logged nothing" from "records were swallowed".
+        """
         with self._lock:
-            return list(self._logs)
+            logs = list(self._logs)
+            dropped = self._dropped_nested
+        if dropped:
+            logs.append(
+                {
+                    "timestamp": datetime.now(UTC).isoformat(),
+                    "level": "WARNING",
+                    "logger": __name__,
+                    "message": (
+                        f"<{dropped} nested log record(s) emitted during message "
+                        "formatting were dropped by the reentrancy guard>"
+                    ),
+                    "elapsed_seconds": round(time.time() - self._start_time, 2),
+                }
+            )
+        return logs
 
     def is_active(self) -> bool:
         """Check if still collecting startup logs."""

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -25,6 +25,7 @@ before adding a gate:
 | `external_only` | anywhere the server-under-test runs IN the pytest process: plain testcontainer and HAOS external. Skips stdio, inaddon, container-embedded and HAOS-embedded, which cannot be reconfigured via test-process env / monkeypatch or reach an in-process mock. The name is historical — it does NOT mean "HAOS external only" |
 | `inaddon_only` | HAOS inaddon mode only (`HAOS_TEST_MODE=inaddon`), where `is_running_in_addon()` paths are live |
 | `haos_stdio_only` | HAOS stdio mode only (`HAOS_TEST_MODE=stdio`), where the installed `ha-mcp` command is exercised through a real subprocess transport |
+| `haos_embedded_only` | HAOS embedded mode only (`HAOS_TEST_MODE=embedded`), where the in-process server shares Home Assistant's process and event loop — for tests whose subject is that shared loop (#2357). Skips every other lane at collection, so no VM boots just to skip |
 | `not_on_embedded` / `not_on_haos_embedded` | everywhere except that lane, for tests the lane's own session backend already covers |
 | `requires_tools_entry` | every lane EXCEPT the no-tools lanes (`E2E_NO_TOOLS_ENTRY=1`), where the File & YAML Tools entry is absent (#2292) |
 | `no_tools_only` | the no-tools lanes only — the mirror of `requires_tools_entry` |

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -67,6 +67,7 @@ markers =
     inaddon_only: HAOS inaddon mode only — exercises is_running_in_addon()=True paths; #1349
     haos_stdio_only: HAOS stdio mode only — exercises the installed ha-mcp command over a real stdio subprocess transport; #2233
     haos_tls: final HAOS embedded scenario that restarts Core with HTTPS in the existing worker VM, then restores HTTP; #2241
+    haos_embedded_only: HAOS embedded mode only (HAOS_TEST_MODE=embedded) — the server shares Home Assistant's process and event loop; #2357
     not_on_embedded: skip on the embedded backend (E2E_BACKEND=embedded) — provably redundant with the lane's own in-process ha_mcp_server session backend; #1527
     not_on_haos_embedded: skip on the haos_embedded backend (HAOS_TEST_MODE=embedded) — provably redundant with the lane's own session backend, which enables the entry once and drives the in-process server for the whole suite; #1527
     requires_tools_entry: needs the File & YAML Tools config entry — skipped on E2E_NO_TOOLS_ENTRY=1 lanes (#2292)

--- a/tests/src/e2e/basic/test_backend_dispatch_smoke.py
+++ b/tests/src/e2e/basic/test_backend_dispatch_smoke.py
@@ -123,8 +123,8 @@ _SKIP_CEILING_PER_LANE = {
     # and observed slightly LOWER counts than their stable siblings
     # (haos_embedded beta 125, haos_inaddon beta 93), so the stable-lane numbers
     # here cover both.
-    "container": 87,  # was 79; +8 #2292 no_tools_only
-    "haos": 66,  # was 58; +8 #2292 no_tools_only
+    "container": 88,  # was 79; +8 #2292 no_tools_only; +1 #2357 haos_embedded_only
+    "haos": 67,  # was 58; +8 #2292 no_tools_only; +1 #2357 haos_embedded_only
     # HAOS stdio is the external HAOS set plus ``external_only`` tests, whose
     # test-process monkeypatches cannot reach the subprocess server. The first
     # full lane run on 2026-08-18 observed 103 collection-time marker skips
@@ -136,8 +136,8 @@ _SKIP_CEILING_PER_LANE = {
     # This entry moved 117 -> 119 rather than by that 8: the 117 was a ceiling
     # carrying headroom above its own observed count, so part of the +8 landed
     # inside that headroom and 119 is what round-1 CI actually observed.
-    "haos_stdio": 119,
-    "haos_inaddon": 94,  # was 86; +8 #2292 no_tools_only
+    "haos_stdio": 120,  # +1 #2357 haos_embedded_only
+    "haos_inaddon": 95,  # was 86; +8 #2292 no_tools_only; +1 #2357 haos_embedded_only
     # Embedded backend (#1527, E2E_BACKEND=embedded). Skips exactly the container
     # lane's marker-skips PLUS two embedded-specific additions:
     #   - haos_only + inaddon_only tests skip on embedded just like on container
@@ -153,7 +153,7 @@ _SKIP_CEILING_PER_LANE = {
     # +1 visibility e2e (haos_stdio_only) and +1 #2241 haos_tls scenario
     # (haos_only) bridge 133 -> 135.
     # Read future changes from CI instead of deriving them.
-    "embedded": 145,  # was 137; +8 #2292 no_tools_only
+    "embedded": 146,  # was 137; +8 #2292 no_tools_only; +1 #2357 haos_embedded_only
     # HAOS embedded backend (#1527, HAOS_TEST_MODE=embedded). A HAOS lane, so it
     # skips the SAME set as the external HAOS lane (container_only + inaddon_only)
     # PLUS two haos_embedded-specific additions:
@@ -182,10 +182,10 @@ _SKIP_CEILING_PER_LANE = {
     # The haos (external) and haos_stdio backends have no no-tools lane today,
     # so they deliberately have no key here — an unknown backend fails loudly in
     # the test below rather than silently skipping the ceiling check.
-    "container_no_tools": 192,  # observed 187
-    "embedded_no_tools": 249,  # observed 244
+    "container_no_tools": 193,  # observed 187; +1 #2357 haos_embedded_only
+    "embedded_no_tools": 250,  # observed 244; +1 #2357 haos_embedded_only
     "haos_embedded_no_tools": 230,  # observed 225
-    "haos_inaddon_no_tools": 198,  # observed 193
+    "haos_inaddon_no_tools": 199,  # observed 193; +1 #2357 haos_embedded_only
 }
 
 

--- a/tests/src/e2e/conftest.py
+++ b/tests/src/e2e/conftest.py
@@ -278,6 +278,17 @@ def _apply_haos_tls_skip(item: Any, enabled: bool, skip_marker: Any) -> None:
         item.add_marker(skip_marker)
 
 
+def _apply_haos_embedded_only_skip(
+    item: Any, haos_embedded: bool, skip_marker: Any
+) -> None:
+    """Skip a ``haos_embedded_only`` item everywhere but the HAOS embedded lane.
+
+    Out-of-line for the same reason as ``_apply_haos_tls_skip``.
+    """
+    if "haos_embedded_only" in item.keywords and not haos_embedded:
+        item.add_marker(skip_marker)
+
+
 def _apply_embedded_only_skip(
     item: Any, embedded_selected: bool, skip_marker: Any
 ) -> None:
@@ -347,6 +358,9 @@ def pytest_collection_modifyitems(config, items):
       installed ``ha-mcp`` command and uses real stdio JSON-RPC framing).
     - ``haos_tls``: final HAOS-embedded scenario. It restarts Core with HTTPS,
       exercises the same VM, and restores HTTP before session teardown.
+    - ``haos_embedded_only``: HAOS embedded mode only — the in-process server
+      shares Home Assistant's process and event loop, which is the property
+      under test (#2357).
     - ``requires_tools_entry`` / ``no_tools_only``: the two directions of the
       no-tools lane gate (``E2E_NO_TOOLS_ENTRY=1``, #2292). The first needs the
       component's "File & YAML Tools" config entry and skips where it is
@@ -395,6 +409,9 @@ def pytest_collection_modifyitems(config, items):
     skip_haos_tls = pytest.mark.skip(
         reason="final Core TLS scenario runs only in the existing HAOS embedded worker"
     )
+    skip_haos_embedded_only = pytest.mark.skip(
+        reason="HAOS embedded mode required (set HAOS_TEST_MODE=embedded)"
+    )
     skip_external_only = pytest.mark.skip(
         reason="out-of-process server (stdio/inaddon/embedded); test needs an "
         "in-process server it can reconfigure via env/monkeypatch or reach an "
@@ -438,6 +455,7 @@ def pytest_collection_modifyitems(config, items):
         if "haos_stdio_only" in keywords and not haos_stdio:
             item.add_marker(skip_haos_stdio_only)
         _apply_haos_tls_skip(item, haos_embedded, skip_haos_tls)
+        _apply_haos_embedded_only_skip(item, haos_embedded, skip_haos_embedded_only)
         _apply_beta_haos_only_skip(item, beta_haos, skip_beta_haos_only)
         _apply_no_tools_entry_skips(
             item, no_tools_entry, skip_requires_tools_entry, skip_no_tools_only

--- a/tests/src/e2e/haos_only/test_zz_reentrant_log_deadlock.py
+++ b/tests/src/e2e/haos_only/test_zz_reentrant_log_deadlock.py
@@ -41,6 +41,12 @@ PROBE_DOMAIN = "reentrant_log_probe"
 # the wait that turns a freeze into a failure rather than an infinite hang.
 HA_RETURN_TIMEOUT_S = 300.0
 
+# How long to keep the probe firing after HA answers again, and how long HA then
+# gets to prove it is still alive. The freeze does not have to happen during
+# startup: the reported instance served requests first and locked up later.
+SOAK_SECONDS = 120.0
+SOAK_RECHECK_TIMEOUT_S = 60.0
+
 # Candidate mounts for HA's config dir inside the Advanced SSH addon container.
 CONFIG_DIR_CANDIDATES = (
     "/homeassistant",
@@ -204,6 +210,23 @@ def _py_spy_dump() -> str:
         return f"(py-spy dump unavailable: {type(exc).__name__}: {exc})"
 
 
+def _require_ha_responsive(ready_url: str, timeout: float, what: str) -> None:
+    """Poll HA, and on timeout fail with an in-VM stack dump of the freeze.
+
+    Both readiness checks in this test go through here: the pre-fix handler can
+    freeze the loop either during startup or a few records into normal running,
+    and either way the useful evidence is the stack of the blocked thread.
+    """
+    try:
+        _wait_http_ok(ready_url, timeout=timeout)
+    except TimeoutError as exc:
+        raise AssertionError(
+            f"{what} ({timeout:.0f}s) — the event loop is frozen inside "
+            f"logging (#2357).\n\n{exc}\n\n"
+            f"py-spy dump of the frozen process:\n{_py_spy_dump()}"
+        ) from exc
+
+
 @pytest.mark.timeout(1800)
 def test_reentrant_debug_log_does_not_freeze_home_assistant(
     ha_container_with_fresh_config,
@@ -244,22 +267,24 @@ def test_reentrant_debug_log_does_not_freeze_home_assistant(
         restarted_at = time.monotonic()
         _restart_core()
 
-        try:
-            _wait_http_ok(ready_url, timeout=HA_RETURN_TIMEOUT_S)
-        except TimeoutError as exc:
-            raise AssertionError(
-                "Home Assistant never came back after a re-entrant debug log "
-                f"record ({HA_RETURN_TIMEOUT_S:.0f}s) — the event loop is "
-                f"frozen inside logging (#2357).\n\n{exc}\n\n"
-                f"py-spy dump of the frozen process:\n{_py_spy_dump()}"
-            ) from exc
+        _require_ha_responsive(
+            ready_url,
+            HA_RETURN_TIMEOUT_S,
+            "Home Assistant never came back after the probe restart",
+        )
 
         # Stay past the collector's 60s window so the probe (firing every 2s
         # from setup) is guaranteed to have been formatted by it while it was
-        # active, and confirm HA is still answering afterwards.
-        while time.monotonic() - restarted_at < 120.0:
+        # active, then confirm HA is STILL answering. Both checks matter: the
+        # pre-fix handler can let the boot complete and freeze the loop a few
+        # records later, which is what the reported instance did.
+        while time.monotonic() - restarted_at < SOAK_SECONDS:
             time.sleep(5.0)
-        _wait_http_ok(ready_url, timeout=60.0)
+        _require_ha_responsive(
+            ready_url,
+            SOAK_RECHECK_TIMEOUT_S,
+            "Home Assistant stopped answering during the probe soak",
+        )
 
         # Guard against a vacuous pass: if the probe never logged, the test
         # proved nothing about re-entrant records.

--- a/tests/src/e2e/haos_only/test_zz_reentrant_log_deadlock.py
+++ b/tests/src/e2e/haos_only/test_zz_reentrant_log_deadlock.py
@@ -306,24 +306,33 @@ def test_reentrant_debug_log_does_not_freeze_home_assistant(
         body_failed = True
         raise
     finally:
-        _sh(
-            f"rm -rf {shlex.quote(probe_dir)}; "
-            f"[ -f {shlex.quote(backup_yaml)} ] && "
-            f"mv {shlex.quote(backup_yaml)} {shlex.quote(config_yaml)} || true"
-        )
-        # Hand a healthy VM back to the rest of the worker's session — the
-        # Supervisor CLI restarts Core even when its loop is wedged. Later
-        # modules on this xdist worker share the VM, so a cleanup that leaves
-        # Core down is a failure of this test — unless the body already
-        # failed, in which case that failure must stay the one reported.
+        # Hand a healthy VM back to the rest of the worker's session. Later
+        # modules on this xdist worker share it, so a restore that leaves the
+        # probe config behind or a restart that leaves Core down is a failure
+        # of this test — unless the body already failed, in which case that
+        # failure must stay the one reported.
+        cleanup_error: Exception | None = None
+        try:
+            _sh(f"rm -rf {shlex.quote(probe_dir)}")
+            # The backup exists from the moment the body's first step ran; a
+            # failed mv here must not be papered over.
+            _sh(
+                f"if [ -f {shlex.quote(backup_yaml)} ]; then "
+                f"mv {shlex.quote(backup_yaml)} {shlex.quote(config_yaml)}; fi"
+            )
+        except AssertionError as exc:
+            cleanup_error = exc
+        # The Supervisor CLI restarts Core even when its loop is wedged.
         _restart_core()
         try:
             _wait_http_ok(ready_url, timeout=HA_RETURN_TIMEOUT_S)
         except TimeoutError as exc:
+            cleanup_error = cleanup_error or exc
+        if cleanup_error is not None:
             if body_failed:
-                logger.error("Home Assistant did not recover after probe cleanup")
+                logger.error("probe cleanup did not fully recover: %s", cleanup_error)
             else:
                 raise AssertionError(
-                    "Home Assistant did not recover after probe cleanup; the "
-                    "worker's VM is unusable for later modules"
-                ) from exc
+                    "probe cleanup did not fully recover the worker's VM, which "
+                    f"later modules share: {cleanup_error}"
+                ) from cleanup_error

--- a/tests/src/e2e/haos_only/test_zz_reentrant_log_deadlock.py
+++ b/tests/src/e2e/haos_only/test_zz_reentrant_log_deadlock.py
@@ -172,20 +172,21 @@ def _find_config_dir() -> str:
     )
 
 
-def _restart_core() -> None:
-    """Restart HA Core from inside the VM.
+def _restart_core() -> bool:
+    """Restart HA Core from inside the VM; True if a restart was issued.
 
     Driven through the Supervisor CLI rather than HA's own restart service so
     it still works when Core's event loop is wedged — which is exactly the
     state this test's cleanup has to recover from. Falls back to restarting the
-    container directly, and never raises: the caller polls for readiness itself,
-    and this runs in a ``finally`` where an exception would mask the real
-    failure.
+    container directly, and never raises: this runs in a ``finally`` where an
+    exception would mask the real failure. The caller must not treat a later
+    readiness check as proof of a restart — the OLD process answers it just as
+    well — so a double failure is reported through the return value.
     """
     try:
         result = ssh_exec(["sh", "-c", "ha core restart"], timeout=300.0)
         if result.returncode == 0:
-            return
+            return True
         logger.warning(
             "`ha core restart` exited %s (%s); restarting the container",
             result.returncode,
@@ -194,9 +195,18 @@ def _restart_core() -> None:
     except Exception as exc:
         logger.warning("`ha core restart` failed (%s); restarting the container", exc)
     try:
-        ssh_exec(["sh", "-c", "docker restart homeassistant"], timeout=300.0)
+        result = ssh_exec(["sh", "-c", "docker restart homeassistant"], timeout=300.0)
     except Exception as exc:
         logger.error("container restart also failed: %s", exc)
+        return False
+    if result.returncode != 0:
+        logger.error(
+            "container restart also failed (%s): %s",
+            result.returncode,
+            (result.stderr or result.stdout).strip()[:200],
+        )
+        return False
+    return True
 
 
 def _py_spy_dump() -> str:
@@ -267,7 +277,7 @@ def test_reentrant_debug_log_does_not_freeze_home_assistant(
         _write_in_vm(config_yaml, _sh(f"cat {shlex.quote(backup_yaml)}") + PROBE_YAML)
 
         logger.info("Restarting Core with the re-entrant log probe installed")
-        _restart_core()
+        assert _restart_core(), "could not restart Core to load the probe"
 
         _require_ha_responsive(
             ready_url,
@@ -311,19 +321,28 @@ def test_reentrant_debug_log_does_not_freeze_home_assistant(
         # probe config behind or a restart that leaves Core down is a failure
         # of this test — unless the body already failed, in which case that
         # failure must stay the one reported.
+        # Each step is attempted regardless of the previous one — a failed
+        # probe removal must not skip the config restore, and vice versa — and
+        # the first failure is what gets reported.
         cleanup_error: Exception | None = None
-        try:
-            _sh(f"rm -rf {shlex.quote(probe_dir)}")
+        for step in (
+            f"rm -rf {shlex.quote(probe_dir)}",
             # The backup exists from the moment the body's first step ran; a
             # failed mv here must not be papered over.
-            _sh(
-                f"if [ -f {shlex.quote(backup_yaml)} ]; then "
-                f"mv {shlex.quote(backup_yaml)} {shlex.quote(config_yaml)}; fi"
+            f"if [ -f {shlex.quote(backup_yaml)} ]; then "
+            f"mv {shlex.quote(backup_yaml)} {shlex.quote(config_yaml)}; fi",
+        ):
+            try:
+                _sh(step)
+            except AssertionError as exc:
+                cleanup_error = cleanup_error or exc
+        # The Supervisor CLI restarts Core even when its loop is wedged. A
+        # restart that never happened leaves the probe loaded even though the
+        # old process still answers the readiness check below.
+        if not _restart_core():
+            cleanup_error = cleanup_error or AssertionError(
+                "Core restart failed during cleanup; the probe is still loaded"
             )
-        except AssertionError as exc:
-            cleanup_error = exc
-        # The Supervisor CLI restarts Core even when its loop is wedged.
-        _restart_core()
         try:
             _wait_http_ok(ready_url, timeout=HA_RETURN_TIMEOUT_S)
         except TimeoutError as exc:

--- a/tests/src/e2e/haos_only/test_zz_reentrant_log_deadlock.py
+++ b/tests/src/e2e/haos_only/test_zz_reentrant_log_deadlock.py
@@ -134,14 +134,17 @@ logger:
 
 
 def _sh(script: str, *, timeout: float = 60.0) -> str:
-    """Run a shell script inside the VM via the Advanced SSH addon."""
-    result = ssh_exec(["sh", "-c", script], timeout=timeout)
-    if result.returncode != 0:
-        raise AssertionError(
-            f"in-VM command failed ({result.returncode}): {script}\n"
-            f"stdout: {result.stdout}\nstderr: {result.stderr}"
-        )
-    return result.stdout
+    """Run a shell script inside the VM via the Advanced SSH addon.
+
+    ``ssh_exec`` runs with ``check=True`` and re-raises a failed remote command
+    as ``RuntimeError`` (carrying stdout+stderr); it never returns a non-zero
+    exit. Normalised to ``AssertionError`` here so the test body and its
+    cleanup handle one exception type.
+    """
+    try:
+        return ssh_exec(["sh", "-c", script], timeout=timeout).stdout
+    except RuntimeError as exc:
+        raise AssertionError(f"in-VM command failed: {script}\n{exc}") from exc
 
 
 def _write_in_vm(path: str, content: str) -> None:

--- a/tests/src/e2e/haos_only/test_zz_reentrant_log_deadlock.py
+++ b/tests/src/e2e/haos_only/test_zz_reentrant_log_deadlock.py
@@ -32,7 +32,10 @@ from haos_runtime import _wait_http_ok, ssh_exec
 
 logger = logging.getLogger(__name__)
 
-pytestmark = [pytest.mark.system, pytest.mark.slow]
+# ``haos_embedded_only``: ha_mcp's log handler only shares a process (and an
+# event loop) with Home Assistant on the embedded lane. Gated at collection so
+# the other HAOS lanes do not boot a VM just to skip this module.
+pytestmark = [pytest.mark.haos_embedded_only, pytest.mark.system, pytest.mark.slow]
 
 PROBE_DOMAIN = "reentrant_log_probe"
 
@@ -52,6 +55,14 @@ CONFIG_DIR_CANDIDATES = (
     "/homeassistant",
     "/config",
     "/mnt/data/supervisor/homeassistant",
+)
+
+# The reporter's recipe: a throwaway python container sharing the host pid
+# namespace dumps every thread of the frozen Core process.
+PY_SPY_DUMP_COMMAND = (
+    "docker run --rm --pid host --privileged python:3.13 sh -c "
+    + "'pip install -q py-spy && py-spy dump --pid "
+    + "$(docker inspect --format {{.State.Pid}} homeassistant)'"
 )
 
 PROBE_INIT_PY = '''\
@@ -199,9 +210,7 @@ def _py_spy_dump() -> str:
             [
                 "sh",
                 "-c",
-                "docker run --rm --pid host --privileged python:3.13 sh -c "
-                "'pip install -q py-spy && py-spy dump --pid "
-                "$(docker inspect --format {{.State.Pid}} homeassistant)'",
+                PY_SPY_DUMP_COMMAND,
             ],
             timeout=420.0,
         )
@@ -236,14 +245,7 @@ def test_reentrant_debug_log_does_not_freeze_home_assistant(
     Fails by TIMEOUT on the pre-fix handler: Core never answers again, which is
     the reported #2357 symptom (port 8123 dead, recorder silent, no log line).
     """
-    container = ha_container_with_fresh_config
-    if container.get("backend") != "haos_embedded":
-        pytest.skip(
-            "ha_mcp's log handler only shares a process (and an event loop) "
-            "with Home Assistant on the embedded lane"
-        )
-
-    base_url = container["base_url"]
+    base_url = ha_container_with_fresh_config["base_url"]
     ready_url = f"{base_url}/manifest.json"
     config_dir = _find_config_dir()
     probe_dir = f"{config_dir}/custom_components/{PROBE_DOMAIN}"
@@ -257,6 +259,7 @@ def test_reentrant_debug_log_does_not_freeze_home_assistant(
         "entry into the existing block instead."
     )
 
+    body_failed = False
     try:
         _sh(f"cp {shlex.quote(config_yaml)} {shlex.quote(backup_yaml)}")
         _write_in_vm(f"{probe_dir}/__init__.py", PROBE_INIT_PY)
@@ -264,7 +267,6 @@ def test_reentrant_debug_log_does_not_freeze_home_assistant(
         _write_in_vm(config_yaml, _sh(f"cat {shlex.quote(backup_yaml)}") + PROBE_YAML)
 
         logger.info("Restarting Core with the re-entrant log probe installed")
-        restarted_at = time.monotonic()
         _restart_core()
 
         _require_ha_responsive(
@@ -272,13 +274,17 @@ def test_reentrant_debug_log_does_not_freeze_home_assistant(
             HA_RETURN_TIMEOUT_S,
             "Home Assistant never came back after the probe restart",
         )
+        # The soak is measured from readiness, not from the restart: a slow
+        # boot must not eat the window in which continued responsiveness is
+        # what is being checked.
+        ready_at = time.monotonic()
 
         # Stay past the collector's 60s window so the probe (firing every 2s
         # from setup) is guaranteed to have been formatted by it while it was
         # active, then confirm HA is STILL answering. Both checks matter: the
         # pre-fix handler can let the boot complete and freeze the loop a few
         # records later, which is what the reported instance did.
-        while time.monotonic() - restarted_at < SOAK_SECONDS:
+        while time.monotonic() - ready_at < SOAK_SECONDS:
             time.sleep(5.0)
         _require_ha_responsive(
             ready_url,
@@ -296,6 +302,9 @@ def test_reentrant_debug_log_does_not_freeze_home_assistant(
             "the probe integration never emitted its debug record, so this run "
             f"did not exercise the re-entrant path (grep count: {fired!r})"
         )
+    except BaseException:
+        body_failed = True
+        raise
     finally:
         _sh(
             f"rm -rf {shlex.quote(probe_dir)}; "
@@ -303,9 +312,18 @@ def test_reentrant_debug_log_does_not_freeze_home_assistant(
             f"mv {shlex.quote(backup_yaml)} {shlex.quote(config_yaml)} || true"
         )
         # Hand a healthy VM back to the rest of the worker's session — the
-        # Supervisor CLI restarts Core even when its loop is wedged.
+        # Supervisor CLI restarts Core even when its loop is wedged. Later
+        # modules on this xdist worker share the VM, so a cleanup that leaves
+        # Core down is a failure of this test — unless the body already
+        # failed, in which case that failure must stay the one reported.
         _restart_core()
         try:
             _wait_http_ok(ready_url, timeout=HA_RETURN_TIMEOUT_S)
-        except TimeoutError:
-            logger.error("Home Assistant did not recover after probe cleanup")
+        except TimeoutError as exc:
+            if body_failed:
+                logger.error("Home Assistant did not recover after probe cleanup")
+            else:
+                raise AssertionError(
+                    "Home Assistant did not recover after probe cleanup; the "
+                    "worker's VM is unusable for later modules"
+                ) from exc

--- a/tests/src/e2e/haos_only/test_zz_reentrant_log_deadlock.py
+++ b/tests/src/e2e/haos_only/test_zz_reentrant_log_deadlock.py
@@ -1,0 +1,286 @@
+"""Live proof for #2357: a re-entrant log record must not freeze Home Assistant.
+
+``StartupLogCollector`` sits on the ROOT logger at DEBUG for the first minute of
+the process. In embedded mode that process IS Home Assistant, so every debug
+record from every integration is formatted on the event loop. Formatting runs
+third-party code — ``%s`` of an entity reaches its ``state`` property — and an
+integration whose property logs at debug re-enters the handler on the same
+thread. Before the fix that re-entry blocked forever on a non-reentrant
+``threading.Lock`` held by the outer frame: the entire HA process froze, with no
+log line to show for it (the freeze is inside logging itself).
+
+The unit coverage in ``tests/src/unit/test_startup_log_collector.py`` pins the
+handler's behaviour. This test pins the consequence: a probe integration that
+reproduces the reporter's shape (tapo_control's ``latest_version`` property
+logging at debug, reached via an entity repr) is installed into the real HAOS
+VM, Core is restarted so the collector's window reopens, and Home Assistant is
+required to come back.
+
+Run it against the pre-fix handler and HA never returns — that is the whole
+point of the test, and the reason it restores the config and restarts Core in a
+``finally`` no matter how it ends.
+"""
+
+import logging
+import shlex
+import time
+from base64 import b64encode
+from posixpath import dirname
+
+import pytest
+from haos_runtime import _wait_http_ok, ssh_exec
+
+logger = logging.getLogger(__name__)
+
+pytestmark = [pytest.mark.system, pytest.mark.slow]
+
+PROBE_DOMAIN = "reentrant_log_probe"
+
+# How long Home Assistant gets to come back after the probe restart. A healthy
+# boot on the runner is ~60-120s; the pre-fix deadlock never returns, so this is
+# the wait that turns a freeze into a failure rather than an infinite hang.
+HA_RETURN_TIMEOUT_S = 300.0
+
+# Candidate mounts for HA's config dir inside the Advanced SSH addon container.
+CONFIG_DIR_CANDIDATES = (
+    "/homeassistant",
+    "/config",
+    "/mnt/data/supervisor/homeassistant",
+)
+
+PROBE_INIT_PY = '''\
+"""Probe integration for ha-mcp issue #2357 (test fixture, not shipped).
+
+Mirrors the reported chain: a debug record whose formatting reaches a property
+that itself logs at debug. In the real report the outer record came from
+tapo_control's coordinator and the inner one from its ``latest_version``
+property, reached through ``Entity.__repr__`` -> ``_stringify_state`` ->
+``state``. The shape is what matters, not the integration.
+"""
+
+import logging
+from datetime import timedelta
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.event import async_track_time_interval
+
+DOMAIN = "reentrant_log_probe"
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class _LogsOnRepr:
+    """Stands in for an entity whose repr reaches a property that logs."""
+
+    def __repr__(self) -> str:
+        _LOGGER.debug("reentrant inner record")
+        return "<probe-entity>"
+
+
+async def async_setup(hass: HomeAssistant, config: dict) -> bool:
+    """Emit the re-entrant record on the event loop, repeatedly.
+
+    Repeatedly, not once: ha_mcp's startup collector only formats records for
+    the first 60 seconds after ITS module import, and component setup order
+    between this probe and the embedded server is not guaranteed. Firing every
+    two seconds guarantees at least one record lands while that window is open.
+    """
+
+    async def _fire(_now=None) -> None:
+        _LOGGER.debug("reentrant outer record %s", _LogsOnRepr())
+
+    await _fire()
+    async_track_time_interval(hass, _fire, timedelta(seconds=2))
+    return True
+'''
+
+PROBE_MANIFEST = """\
+{
+  "domain": "reentrant_log_probe",
+  "name": "Reentrant Log Probe",
+  "version": "1.0.0",
+  "documentation": "https://github.com/homeassistant-ai/ha-mcp/issues/2357",
+  "codeowners": [],
+  "dependencies": [],
+  "iot_class": "calculated"
+}
+"""
+
+PROBE_YAML = """
+# --- ha-mcp #2357 probe (removed by the test) ---
+reentrant_log_probe:
+logger:
+  logs:
+    custom_components.reentrant_log_probe: debug
+# --- end ha-mcp #2357 probe ---
+"""
+
+
+def _sh(script: str, *, timeout: float = 60.0) -> str:
+    """Run a shell script inside the VM via the Advanced SSH addon."""
+    result = ssh_exec(["sh", "-c", script], timeout=timeout)
+    if result.returncode != 0:
+        raise AssertionError(
+            f"in-VM command failed ({result.returncode}): {script}\n"
+            f"stdout: {result.stdout}\nstderr: {result.stderr}"
+        )
+    return result.stdout
+
+
+def _write_in_vm(path: str, content: str) -> None:
+    """Write ``content`` to ``path`` inside the VM.
+
+    Base64 rather than a heredoc: ssh_exec joins the command into a single
+    shell string, so anything with quotes or newlines has to survive two
+    rounds of tokenisation.
+    """
+    encoded = b64encode(content.encode()).decode()
+    _sh(
+        f"mkdir -p {shlex.quote(dirname(path))} && "
+        f"echo {encoded} | base64 -d > {shlex.quote(path)}"
+    )
+
+
+def _find_config_dir() -> str:
+    for candidate in CONFIG_DIR_CANDIDATES:
+        found = _sh(
+            f"[ -f {shlex.quote(candidate)}/configuration.yaml ] "
+            f"&& echo {shlex.quote(candidate)} || true"
+        ).strip()
+        if found:
+            return found
+    raise AssertionError(
+        "could not locate HA's configuration.yaml inside the VM; tried "
+        f"{', '.join(CONFIG_DIR_CANDIDATES)}"
+    )
+
+
+def _restart_core() -> None:
+    """Restart HA Core from inside the VM.
+
+    Driven through the Supervisor CLI rather than HA's own restart service so
+    it still works when Core's event loop is wedged — which is exactly the
+    state this test's cleanup has to recover from. Falls back to restarting the
+    container directly, and never raises: the caller polls for readiness itself,
+    and this runs in a ``finally`` where an exception would mask the real
+    failure.
+    """
+    try:
+        result = ssh_exec(["sh", "-c", "ha core restart"], timeout=300.0)
+        if result.returncode == 0:
+            return
+        logger.warning(
+            "`ha core restart` exited %s (%s); restarting the container",
+            result.returncode,
+            (result.stderr or result.stdout).strip()[:200],
+        )
+    except Exception as exc:
+        logger.warning("`ha core restart` failed (%s); restarting the container", exc)
+    try:
+        ssh_exec(["sh", "-c", "docker restart homeassistant"], timeout=300.0)
+    except Exception as exc:
+        logger.error("container restart also failed: %s", exc)
+
+
+def _py_spy_dump() -> str:
+    """Best-effort in-VM py-spy dump of the frozen Core process.
+
+    The same recipe the reporter used on #2357. Purely diagnostic: if the image
+    pull or the dump fails, the test failure stands on its own.
+    """
+    try:
+        result = ssh_exec(
+            [
+                "sh",
+                "-c",
+                "docker run --rm --pid host --privileged python:3.13 sh -c "
+                "'pip install -q py-spy && py-spy dump --pid "
+                "$(docker inspect --format {{.State.Pid}} homeassistant)'",
+            ],
+            timeout=420.0,
+        )
+        return result.stdout or result.stderr
+    except Exception as exc:
+        return f"(py-spy dump unavailable: {type(exc).__name__}: {exc})"
+
+
+@pytest.mark.timeout(1800)
+def test_reentrant_debug_log_does_not_freeze_home_assistant(
+    ha_container_with_fresh_config,
+):
+    """HA must survive an integration whose debug logging re-enters logging.
+
+    Fails by TIMEOUT on the pre-fix handler: Core never answers again, which is
+    the reported #2357 symptom (port 8123 dead, recorder silent, no log line).
+    """
+    container = ha_container_with_fresh_config
+    if container.get("backend") != "haos_embedded":
+        pytest.skip(
+            "ha_mcp's log handler only shares a process (and an event loop) "
+            "with Home Assistant on the embedded lane"
+        )
+
+    base_url = container["base_url"]
+    ready_url = f"{base_url}/manifest.json"
+    config_dir = _find_config_dir()
+    probe_dir = f"{config_dir}/custom_components/{PROBE_DOMAIN}"
+    config_yaml = f"{config_dir}/configuration.yaml"
+    backup_yaml = f"{config_dir}/configuration.yaml.2357.bak"
+
+    existing = _sh(f"grep -c '^logger:' {shlex.quote(config_yaml)} || true").strip()
+    assert existing in ("", "0"), (
+        "the seeded configuration.yaml already declares `logger:` — appending a "
+        "second block would be a duplicate YAML key. Merge the probe's logger "
+        "entry into the existing block instead."
+    )
+
+    try:
+        _sh(f"cp {shlex.quote(config_yaml)} {shlex.quote(backup_yaml)}")
+        _write_in_vm(f"{probe_dir}/__init__.py", PROBE_INIT_PY)
+        _write_in_vm(f"{probe_dir}/manifest.json", PROBE_MANIFEST)
+        _write_in_vm(config_yaml, _sh(f"cat {shlex.quote(backup_yaml)}") + PROBE_YAML)
+
+        logger.info("Restarting Core with the re-entrant log probe installed")
+        restarted_at = time.monotonic()
+        _restart_core()
+
+        try:
+            _wait_http_ok(ready_url, timeout=HA_RETURN_TIMEOUT_S)
+        except TimeoutError as exc:
+            raise AssertionError(
+                "Home Assistant never came back after a re-entrant debug log "
+                f"record ({HA_RETURN_TIMEOUT_S:.0f}s) — the event loop is "
+                f"frozen inside logging (#2357).\n\n{exc}\n\n"
+                f"py-spy dump of the frozen process:\n{_py_spy_dump()}"
+            ) from exc
+
+        # Stay past the collector's 60s window so the probe (firing every 2s
+        # from setup) is guaranteed to have been formatted by it while it was
+        # active, and confirm HA is still answering afterwards.
+        while time.monotonic() - restarted_at < 120.0:
+            time.sleep(5.0)
+        _wait_http_ok(ready_url, timeout=60.0)
+
+        # Guard against a vacuous pass: if the probe never logged, the test
+        # proved nothing about re-entrant records.
+        fired = _sh(
+            "ha core logs 2>/dev/null | grep -c 'reentrant outer record' || true",
+            timeout=180.0,
+        ).strip()
+        assert fired.isdigit() and int(fired) > 0, (
+            "the probe integration never emitted its debug record, so this run "
+            f"did not exercise the re-entrant path (grep count: {fired!r})"
+        )
+    finally:
+        _sh(
+            f"rm -rf {shlex.quote(probe_dir)}; "
+            f"[ -f {shlex.quote(backup_yaml)} ] && "
+            f"mv {shlex.quote(backup_yaml)} {shlex.quote(config_yaml)} || true"
+        )
+        # Hand a healthy VM back to the rest of the worker's session — the
+        # Supervisor CLI restarts Core even when its loop is wedged.
+        _restart_core()
+        try:
+            _wait_http_ok(ready_url, timeout=HA_RETURN_TIMEOUT_S)
+        except TimeoutError:
+            logger.error("Home Assistant did not recover after probe cleanup")

--- a/tests/src/unit/test_startup_log_collector.py
+++ b/tests/src/unit/test_startup_log_collector.py
@@ -1,0 +1,128 @@
+"""Regression tests for StartupLogCollector reentrancy (issue #2357).
+
+The collector is attached to the ROOT logger at DEBUG with no filter, and in
+embedded mode it runs inside the Home Assistant process — so every debug record
+from every integration is formatted on the event loop thread. Formatting is not
+inert: ``%s`` of an entity calls ``Entity.__repr__`` -> ``_stringify_state`` ->
+the entity's ``state`` property, and an integration whose property logs at debug
+re-enters ``emit`` on the same thread.
+
+That re-entry used to land on ``with self._lock`` while the outer frame still
+held the same non-reentrant ``threading.Lock`` — a self-deadlock that froze all
+of Home Assistant (reported against tapo_control's ``latest_version`` property).
+"""
+
+import logging
+import threading
+
+from ha_mcp.utils.usage_logger import (
+    MAX_STARTUP_LOG_ENTRIES,
+    StartupLogCollector,
+)
+
+# Generous enough that a slow CI runner never flakes, short enough that the
+# pre-fix deadlock (which never completes) is caught quickly.
+DEADLOCK_TIMEOUT_SECONDS = 10.0
+
+
+class _LogsOnRepr:
+    """Stand-in for an entity whose ``__repr__`` reaches a logging property.
+
+    Models the real chain without importing Home Assistant: tapo_control's
+    ``latest_version`` property calls ``_LOGGER.debug()``, and HA's update
+    entity reaches that property from ``__repr__`` via ``state``.
+    """
+
+    def __init__(self, log: logging.Logger, depth: int = 1):
+        self._log = log
+        self._depth = depth
+
+    def __repr__(self) -> str:
+        if self._depth > 0:
+            self._log.debug("nested %s", _LogsOnRepr(self._log, self._depth - 1))
+        return "<entity>"
+
+
+def _make_logger(name: str, collector: StartupLogCollector) -> logging.Logger:
+    log = logging.getLogger(name)
+    log.setLevel(logging.DEBUG)
+    log.propagate = False
+    log.handlers = [collector]
+    return log
+
+
+def _emit_in_thread(target) -> bool:
+    """Run ``target`` in a worker thread; return True if it finished in time.
+
+    A deadlocked thread cannot be killed, so the worker is a daemon: a failure
+    here leaves it wedged for the rest of the session rather than hanging the
+    whole pytest run.
+    """
+    thread = threading.Thread(target=target, daemon=True)
+    thread.start()
+    thread.join(DEADLOCK_TIMEOUT_SECONDS)
+    return not thread.is_alive()
+
+
+class TestStartupLogCollectorReentrancy:
+    """A log record whose formatting logs again must not wedge the thread."""
+
+    def test_reentrant_formatting_does_not_deadlock(self):
+        collector = StartupLogCollector()
+        log = _make_logger("test_2357.deadlock", collector)
+
+        finished = _emit_in_thread(lambda: log.debug("outer %s", _LogsOnRepr(log)))
+
+        assert finished, (
+            "emit() deadlocked on a re-entrant log record — this is the #2357 "
+            "freeze: formatting inside self._lock re-enters emit on the same "
+            "thread and blocks on a non-reentrant Lock."
+        )
+
+    def test_outer_record_survives_nested_drop(self):
+        collector = StartupLogCollector()
+        log = _make_logger("test_2357.outer", collector)
+
+        assert _emit_in_thread(lambda: log.debug("outer %s", _LogsOnRepr(log)))
+
+        messages = [entry["message"] for entry in collector.get_logs()]
+        # The nested record is dropped by the reentrancy guard; the outer one,
+        # which is the record that was actually logged, is still collected.
+        assert messages == ["outer <entity>"]
+
+    def test_deeply_nested_formatting_terminates(self):
+        collector = StartupLogCollector()
+        log = _make_logger("test_2357.deep", collector)
+
+        assert _emit_in_thread(
+            lambda: log.debug("outer %s", _LogsOnRepr(log, depth=25))
+        )
+
+    def test_unformattable_record_is_recorded_not_raised(self):
+        class Explodes:
+            def __repr__(self) -> str:
+                raise ValueError("boom")
+
+        collector = StartupLogCollector()
+        log = _make_logger("test_2357.unformattable", collector)
+
+        log.debug("bad %s", Explodes())
+
+        entries = collector.get_logs()
+        assert len(entries) == 1
+        assert "unformattable" in entries[0]["message"]
+        assert "ValueError" in entries[0]["message"]
+
+    def test_collection_stops_at_entry_cap(self):
+        collector = StartupLogCollector()
+        log = _make_logger("test_2357.cap", collector)
+
+        for index in range(MAX_STARTUP_LOG_ENTRIES + 50):
+            log.debug("entry %d", index)
+
+        entries = collector.get_logs()
+        assert len(entries) == MAX_STARTUP_LOG_ENTRIES
+        # Earliest entries are the ones kept — boot order is what the startup
+        # diagnostics are for.
+        assert entries[0]["message"] == "entry 0"
+        assert collector.is_active() is False

--- a/tests/src/unit/test_startup_log_collector.py
+++ b/tests/src/unit/test_startup_log_collector.py
@@ -105,8 +105,13 @@ class TestStartupLogCollectorReentrancy:
         collector = StartupLogCollector()
         log = _make_logger("test_2357.reset", collector)
 
-        assert _emit_in_thread(lambda: log.debug("outer %s", _LogsOnRepr(log)))
-        log.debug("later record")
+        def outer_then_later() -> None:
+            log.debug("outer %s", _LogsOnRepr(log))
+            log.debug("later record")
+
+        # Both on the same thread: the guard is per-thread, so a flag left set
+        # by the reentrant record would only ever affect that thread.
+        assert _emit_in_thread(outer_then_later)
 
         messages = [entry["message"] for entry in collector.get_logs()]
         # A stuck per-thread flag would silently drop every later record on

--- a/tests/src/unit/test_startup_log_collector.py
+++ b/tests/src/unit/test_startup_log_collector.py
@@ -85,10 +85,33 @@ class TestStartupLogCollectorReentrancy:
 
         assert _emit_in_thread(lambda: log.debug("outer %s", _LogsOnRepr(log)))
 
-        messages = [entry["message"] for entry in collector.get_logs()]
+        entries = collector.get_logs()
         # The nested record is dropped by the reentrancy guard; the outer one,
-        # which is the record that was actually logged, is still collected.
-        assert messages == ["outer <entity>"]
+        # which is the record that was actually logged, is still collected —
+        # and the drop is accounted for, not hidden, in the diagnostics.
+        assert [entry["message"] for entry in entries[:-1]] == ["outer <entity>"]
+        assert entries[-1]["level"] == "WARNING"
+        assert "1 nested log record(s)" in entries[-1]["message"]
+
+    def test_no_drop_marker_when_nothing_was_dropped(self):
+        collector = StartupLogCollector()
+        log = _make_logger("test_2357.clean", collector)
+
+        log.debug("plain record")
+
+        assert [entry["message"] for entry in collector.get_logs()] == ["plain record"]
+
+    def test_guard_clears_after_reentrant_record(self):
+        collector = StartupLogCollector()
+        log = _make_logger("test_2357.reset", collector)
+
+        assert _emit_in_thread(lambda: log.debug("outer %s", _LogsOnRepr(log)))
+        log.debug("later record")
+
+        messages = [entry["message"] for entry in collector.get_logs()]
+        # A stuck per-thread flag would silently drop every later record on
+        # that thread for the rest of the startup window.
+        assert "later record" in messages
 
     def test_deeply_nested_formatting_terminates(self):
         collector = StartupLogCollector()
@@ -106,12 +129,19 @@ class TestStartupLogCollectorReentrancy:
         collector = StartupLogCollector()
         log = _make_logger("test_2357.unformattable", collector)
 
+        handled: list[logging.LogRecord] = []
+        collector.handleError = handled.append  # type: ignore[method-assign]
+
         log.debug("bad %s", Explodes())
 
         entries = collector.get_logs()
         assert len(entries) == 1
         assert "unformattable" in entries[0]["message"]
         assert "ValueError" in entries[0]["message"]
+        # Names the call site, not just the logger.
+        assert f"{__file__}:" in entries[0]["message"]
+        # The stdlib error path still runs, so raiseExceptions/stderr apply.
+        assert len(handled) == 1
 
     def test_collection_stops_at_entry_cap(self):
         collector = StartupLogCollector()


### PR DESCRIPTION
## What does this PR do?

Fixes the full Home Assistant freeze in #2357.

`StartupLogCollector.emit()` called `record.getMessage()` while holding a non-reentrant `threading.Lock`. Formatting a record runs third-party code — `%s` of an entity goes `Entity.__repr__` -> `_stringify_state` -> the entity's `state` property — and an integration whose property logs at debug re-enters this handler on the same thread. In embedded mode that thread is HA's event loop, so the nested `emit()` blocked forever on the lock the outer frame held: port 8123 dead, recorder silent, and no log line, because the freeze is inside logging itself. HA core deliberately keeps formatting off the loop (`HomeAssistantQueueHandler` formats in the listener thread); this handler sits on the root logger at DEBUG and reintroduced it.

Changes to `src/ha_mcp/utils/usage_logger.py`:
- format outside the lock, under a per-thread reentrancy guard that drops a nested record instead of recursing;
- count dropped nested records and surface the count as one trailing entry from `get_logs()`, so `ha_report_issue` diagnostics show the hole rather than hide it;
- a raising `__repr__` no longer escapes the handler — the entry records `pathname:lineno` and the exception type (nothing that could re-run the failing code), and `handleError()` still runs;
- cap the collector at 5000 entries, keeping the earliest — it is unfiltered on root, so a debug-flooded boot could grow without bound.

Verification, all on real HAOS (`haos-e2e-embedded` lane, same image, same test):
- master's handler: HA answers after the probe restart, then stops answering — [run](https://github.com/homeassistant-ai/ha-mcp/actions/runs/33803466778)
- this handler: HA stays up through the soak — [run](https://github.com/homeassistant-ai/ha-mcp/actions/runs/33803461914)

Supersedes #2359 if that PR does not pick up its requested changes; #2359 stays open until this merges.

## Type of change
- [x] 🐛 Bug fix

## Testing
- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`) — targeted: `tests/src/unit/test_startup_log_collector.py` (7 tests; the reentrancy cases deadlock against master's handler) and the HAOS runs above
- [x] Code follows style guidelines (`uv run ruff check`)

New tests:
- `tests/src/unit/test_startup_log_collector.py` — reentrant record does not deadlock; outer record kept, nested dropped and counted; no marker when nothing dropped; guard clears for later records; 25-deep nesting terminates; unformattable record recorded with call site, `handleError` invoked; entry cap holds.
- `tests/src/e2e/haos_only/test_zz_reentrant_log_deadlock.py` — embedded lane only: installs a probe integration reproducing the reported shape into the live VM over SSH, restarts Core, requires HA to come back and stay up, grep-guards against a vacuous pass, and restores config plus restarts Core in a `finally`. On timeout the failure carries an in-VM py-spy dump.

## Checklist
- [x] I have updated documentation if needed (none needed)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved startup reliability when log messages trigger additional logging during formatting.
  - Prevented startup logging from becoming unresponsive due to recursive log activity.
  - Limited startup log collection to prevent excessive memory use.
  - Added diagnostics indicating when nested log records are skipped.
  - Improved handling of records that cannot be formatted normally.
  - Ensured startup logging continues safely when individual records contain formatting errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->