### PR TITLE
ci: add container beta E2E lane and drop the release-age gate on HA images

### DIFF
--- a/.github/workflows/e2e-beta-tests.yml
+++ b/.github/workflows/e2e-beta-tests.yml
@@ -1,0 +1,568 @@
+name: E2E Tests (beta)
+
+# Container-backend counterpart of the beta HAOS lanes
+# (haos-e2e-beta-tests.yml). Every job here mirrors the stable container lane
+# job of the same id, but runs against the current Home Assistant beta Core
+# image resolved from https://version.home-assistant.io/beta.json at run time
+# instead of the renovate-managed stable pin.
+#
+# The stable container lanes cannot see a break that only exists in the next
+# Core release while they are pinned to the current one: #2361 (the LLM-API
+# schema regression on Core 2026.9) landed in beta while every container lane
+# still ran 2026.8, so nothing red-lit until the release shipped to users.
+
+on:
+  # Test committed ha-mcp code against the upcoming beta Core release. Run on
+  # each master update so regressions from our changes surface after merge, and
+  # nightly so deliberate upstream beta changes that require an ha-mcp
+  # adaptation surface before stable release.
+  #
+  # Do not run on pull_request pushes: the stable container lanes cover PR
+  # changes, while maintainers own beta compatibility fixes after changes land.
+  # No paths filter either — a nightly run must happen regardless of what the
+  # last master commit touched.
+  push:
+    branches: [master]
+  schedule:
+    # 03:37 UTC is 11:37 PM EDT, staggered off the HAOS beta lanes' 03:17.
+    - cron: '37 3 * * *'
+  workflow_dispatch:
+    inputs:
+      pytest_args:
+        description: 'Extra pytest args (e.g. "-k test_simple_connection") for targeted iteration'
+        type: string
+        required: false
+        default: ''
+      pytest_paths:
+        description: 'Test paths to run (default: full src/e2e/ — markers handle external_only / haos_only skips)'
+        type: string
+        required: false
+        default: 'src/e2e/'
+
+# Limit GITHUB_TOKEN permissions to minimum required
+permissions:
+  contents: read
+
+# Push and scheduled runs are full compatibility checks, so a newer one
+# supersedes an older one. Manual dispatches may target only part of the suite;
+# give each one a unique group so it cannot cancel or replace a full run.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && github.run_id || 'full' }}
+  cancel-in-progress: true
+
+env:
+  PYTHON_VERSION: "3.13"
+  UV_CACHE_DIR: /tmp/.uv-cache
+  # No HA image pin here: resolve-beta below computes it per run and every job
+  # sets HA_IMAGE_GHCR / HA_TEST_IMAGE from that job's outputs.
+  # Disable Testcontainers' Ryuk reaper: it has been reported to leave
+  # zombie containers on GHA runners (see #366, Ilya0527 2026-05-18).
+  # The E2E fixture in tests/src/e2e/conftest.py relies instead on the
+  # enclosing ``with container:`` context manager — Python guarantees
+  # its ``__exit__`` fires on both normal and exception flows, so the
+  # Ryuk safety net is not needed for deterministic cleanup. Refs #366.
+  TESTCONTAINERS_RYUK_DISABLED: "true"
+
+jobs:
+  # Resolve the current beta Core release once, so every lane below tests the
+  # same image. The docker lanes want the ``default`` key (the multi-arch
+  # container tag); the HAOS lanes read ``qemux86-64`` for their qcow2 instead.
+  resolve-beta:
+    name: Resolve beta Core image
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      core_version: ${{ steps.versions.outputs.core_version }}
+      image: ${{ steps.versions.outputs.image }}
+
+    steps:
+      - name: Resolve current beta Core version
+        id: versions
+        run: |
+          metadata=$(curl --fail --silent --show-error \
+            https://version.home-assistant.io/beta.json)
+          core_version=$(python3 -c \
+            'import json, sys; print(json.load(sys.stdin)["homeassistant"]["default"])' \
+            <<<"$metadata")
+          if ! [[ "$core_version" =~ ^[0-9]{4}\.[0-9]{1,2}\.[0-9]+([.]dev[0-9]+|b[0-9]+)?$ ]]; then
+            echo "::error::Unexpected beta Core version: $core_version"
+            exit 1
+          fi
+          echo "core_version=$core_version" >> "$GITHUB_OUTPUT"
+          echo "image=ghcr.io/home-assistant/home-assistant:$core_version" >> "$GITHUB_OUTPUT"
+
+  # Comprehensive E2E validation against the beta Core image.
+  e2e-tests:
+    name: E2E Tests
+    runs-on: ubuntu-latest
+    needs: resolve-beta
+    env:
+      HA_IMAGE_GHCR: ${{ needs.resolve-beta.outputs.image }}
+      HA_TEST_IMAGE: ${{ needs.resolve-beta.outputs.image }}
+    timeout-minutes: 15
+
+    steps:
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      with:
+        persist-credentials: false
+        submodules: true
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4
+      with:
+        cache-binary: true
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+      with:
+        # renovate: datasource=github-releases depName=astral-sh/uv
+        version: "0.12.7"
+
+    - name: Set up Python
+      run: uv python install ${{ env.PYTHON_VERSION }}
+
+    - name: Install dependencies
+      run: uv sync --all-extras --dev
+
+    - name: Cache HA Docker image
+      id: cache-ha-image
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+      with:
+        path: /tmp/ha-image.tar
+        key: ha-image-${{ env.HA_IMAGE_GHCR }}-${{ runner.arch }}
+
+    - name: Load cached HA image
+      if: steps.cache-ha-image.outputs.cache-hit == 'true'
+      run: docker load -i /tmp/ha-image.tar
+
+    - name: Pull HA image (GHCR → Docker Hub fallback)
+      if: steps.cache-ha-image.outputs.cache-hit != 'true'
+      run: |
+        HA_VERSION="${HA_IMAGE_GHCR##*:}"
+        HA_IMAGE_DOCKERHUB="homeassistant/home-assistant:${HA_VERSION}"
+        for registry in "$HA_IMAGE_GHCR" "$HA_IMAGE_DOCKERHUB"; do
+          echo "Trying $registry..."
+          if docker pull "$registry"; then
+            if [ "$registry" != "$HA_IMAGE_GHCR" ]; then
+              docker tag "$registry" "$HA_IMAGE_GHCR"
+            fi
+            docker save "$HA_IMAGE_GHCR" -o /tmp/ha-image.tar
+            echo "Pulled and cached from $registry"
+            exit 0
+          fi
+          echo "Failed to pull from $registry, trying next..."
+          sleep 15
+        done
+        echo "All registries failed" && exit 1
+
+    - name: Run full E2E test suite
+      run: |
+        echo "🚀 Running full E2E test suite with 3 workers..."
+        cd tests
+        uv run pytest $PYTEST_PATHS \
+          -n3 \
+          --dist loadscope \
+          --tb=short \
+          -v $PYTEST_ARGS
+        echo "✅ Full E2E test suite passed"
+      env:
+        PYTEST_PATHS: ${{ github.event.inputs.pytest_paths || 'src/e2e/' }}
+        PYTEST_ARGS: ${{ github.event.inputs.pytest_args }}
+        HAMCP_ENV_FILE: "tests/.env.test"
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # Container backend with the ha_mcp_tools component ABSENT (#2292): mirrors
+  # pr.yml's e2e-validation-no-component on master push. The same full E2E
+  # suite runs with the component's "File & YAML Tools" config entry never
+  # created (E2E_NO_TOOLS_ENTRY=1) — the app (add-on) / Docker / PyPI user who never
+  # installed the component from HACS: the majority install, and the one every
+  # component-present lane hides, because the e2e fixtures set the component up
+  # everywhere. Every component-backed capability must therefore either fall
+  # back to a server-side path or fail with an actionable "install the
+  # component" error; a raw service-not-found is the bug this lane catches (the
+  # HAOS inaddon no-tools lane shares this topology and catches it too).
+  e2e-tests-no-component:
+    name: E2E Tests (No Component)
+    runs-on: ubuntu-latest
+    needs: resolve-beta
+    env:
+      HA_IMAGE_GHCR: ${{ needs.resolve-beta.outputs.image }}
+      HA_TEST_IMAGE: ${{ needs.resolve-beta.outputs.image }}
+    timeout-minutes: 20
+
+    steps:
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      with:
+        persist-credentials: false
+        submodules: true
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4
+      with:
+        cache-binary: true
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+      with:
+        # renovate: datasource=github-releases depName=astral-sh/uv
+        version: "0.12.7"
+
+    - name: Set up Python
+      run: uv python install ${{ env.PYTHON_VERSION }}
+
+    - name: Install dependencies
+      run: uv sync --all-extras --dev
+
+    - name: Cache HA Docker image
+      id: cache-ha-image
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+      with:
+        path: /tmp/ha-image.tar
+        key: ha-image-${{ env.HA_IMAGE_GHCR }}-${{ runner.arch }}
+
+    - name: Load cached HA image
+      if: steps.cache-ha-image.outputs.cache-hit == 'true'
+      run: docker load -i /tmp/ha-image.tar
+
+    - name: Pull HA image (GHCR → Docker Hub fallback)
+      if: steps.cache-ha-image.outputs.cache-hit != 'true'
+      run: |
+        HA_VERSION="${HA_IMAGE_GHCR##*:}"
+        HA_IMAGE_DOCKERHUB="homeassistant/home-assistant:${HA_VERSION}"
+        for registry in "$HA_IMAGE_GHCR" "$HA_IMAGE_DOCKERHUB"; do
+          echo "Trying $registry..."
+          if docker pull "$registry"; then
+            if [ "$registry" != "$HA_IMAGE_GHCR" ]; then
+              docker tag "$registry" "$HA_IMAGE_GHCR"
+            fi
+            docker save "$HA_IMAGE_GHCR" -o /tmp/ha-image.tar
+            echo "Pulled and cached from $registry"
+            exit 0
+          fi
+          echo "Failed to pull from $registry, trying next..."
+          sleep 15
+        done
+        echo "All registries failed" && exit 1
+
+    - name: Run full E2E test suite (no component)
+      run: |
+        echo "🚀 Running full E2E test suite without the ha_mcp_tools component with 3 workers..."
+        # --maxfail=0 overrides pytest.ini's --maxfail=3: this topology audit is only useful if it reports every failure, not the first three.
+        cd tests
+        uv run pytest $PYTEST_PATHS \
+          -n3 \
+          --dist loadscope \
+          --tb=short \
+          -v \
+          --maxfail=0 $PYTEST_ARGS
+        echo "✅ Full E2E test suite (no component) passed"
+      env:
+        PYTEST_PATHS: ${{ github.event.inputs.pytest_paths || 'src/e2e/' }}
+        PYTEST_ARGS: ${{ github.event.inputs.pytest_args }}
+        E2E_NO_TOOLS_ENTRY: "1"
+        HAMCP_ENV_FILE: "tests/.env.test"
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # In-process MCP server backend (#1527): the SAME full E2E suite, but the
+  # server-under-test is the in-process MCP server (ha_mcp_tools entry) running inside
+  # each worker's testcontainer (E2E_BACKEND=embedded), driven over its ingress
+  # webhook. Runs in parallel with the container lane above (a separate job — it
+  # does not extend that job's runtime). Matrixed x64 + arm64 to mirror the PR
+  # lane (pr.yml's e2e-validation-embedded). -n2/-n3 (vs the container lane's -n3):
+  # each worker additionally builds a ha-mcp wheel and its container preinstalls
+  # the fastmcp dependency tree before HA boots, so a lower worker count keeps peak
+  # memory + concurrent-pip pressure in check (arm gets +1). The larger timeout
+  # covers that per-worker preinstall window.
+  e2e-tests-embedded:
+    name: E2E Tests (Embedded Server, ${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    needs: resolve-beta
+    env:
+      HA_IMAGE_GHCR: ${{ needs.resolve-beta.outputs.image }}
+      HA_TEST_IMAGE: ${{ needs.resolve-beta.outputs.image }}
+    timeout-minutes: 25
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest           # Linux x64
+          - ubuntu-24.04-arm        # Linux ARM64
+        include:
+          - os: ubuntu-latest
+            pytest_workers: 2
+          - os: ubuntu-24.04-arm
+            pytest_workers: 3
+
+    steps:
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      with:
+        persist-credentials: false
+        submodules: true
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4
+      with:
+        cache-binary: true
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+      with:
+        # renovate: datasource=github-releases depName=astral-sh/uv
+        version: "0.12.7"
+
+    - name: Set up Python
+      run: uv python install ${{ env.PYTHON_VERSION }}
+
+    - name: Install dependencies
+      run: uv sync --all-extras --dev
+
+    - name: Cache HA Docker image
+      id: cache-ha-image
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+      with:
+        path: /tmp/ha-image.tar
+        key: ha-image-${{ env.HA_IMAGE_GHCR }}-${{ runner.arch }}
+
+    - name: Load cached HA image
+      if: steps.cache-ha-image.outputs.cache-hit == 'true'
+      run: docker load -i /tmp/ha-image.tar
+
+    - name: Pull HA image (GHCR → Docker Hub fallback)
+      if: steps.cache-ha-image.outputs.cache-hit != 'true'
+      run: |
+        HA_VERSION="${HA_IMAGE_GHCR##*:}"
+        HA_IMAGE_DOCKERHUB="homeassistant/home-assistant:${HA_VERSION}"
+        for registry in "$HA_IMAGE_GHCR" "$HA_IMAGE_DOCKERHUB"; do
+          echo "Trying $registry..."
+          if docker pull "$registry"; then
+            if [ "$registry" != "$HA_IMAGE_GHCR" ]; then
+              docker tag "$registry" "$HA_IMAGE_GHCR"
+            fi
+            docker save "$HA_IMAGE_GHCR" -o /tmp/ha-image.tar
+            echo "Pulled and cached from $registry"
+            exit 0
+          fi
+          echo "Failed to pull from $registry, trying next..."
+          sleep 15
+        done
+        echo "All registries failed" && exit 1
+
+    - name: Run full E2E test suite (embedded backend)
+      run: |
+        echo "🚀 Running full E2E suite through the in-process MCP server (embedded backend) with ${{ matrix.pytest_workers }} workers..."
+        cd tests
+        uv run pytest $PYTEST_PATHS \
+          -n${{ matrix.pytest_workers }} \
+          --dist loadscope \
+          --tb=short \
+          -v $PYTEST_ARGS
+        echo "✅ Full E2E test suite (embedded backend) passed"
+      env:
+        PYTEST_PATHS: ${{ github.event.inputs.pytest_paths || 'src/e2e/' }}
+        PYTEST_ARGS: ${{ github.event.inputs.pytest_args }}
+        E2E_BACKEND: "embedded"
+        HAMCP_ENV_FILE: "tests/.env.test"
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # Embedded backend with ONLY the server entry (#2292): mirrors pr.yml's
+  # e2e-validation-embedded-server-only on master push, and is the exact
+  # topology the issue reports. The in-process MCP server entry is present — the
+  # WS command surface rides that entry (#2289/#2291), so search and the other
+  # command-backed reads keep working — while the component's "File & YAML
+  # Tools" entry stays absent (E2E_NO_TOOLS_ENTRY=1), so the filesystem/YAML
+  # services are not registered. Both entries belong to the same component and
+  # every other lane creates both, which is why the split is invisible until a
+  # user hits it. One ubuntu-latest lane at -n2, matching the per-worker wheel
+  # build + in-container preinstall cost of the embedded matrix above.
+  e2e-tests-embedded-server-only:
+    name: E2E Tests (Embedded Server, server entry only)
+    runs-on: ubuntu-latest
+    needs: resolve-beta
+    env:
+      HA_IMAGE_GHCR: ${{ needs.resolve-beta.outputs.image }}
+      HA_TEST_IMAGE: ${{ needs.resolve-beta.outputs.image }}
+    timeout-minutes: 25
+
+    steps:
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      with:
+        persist-credentials: false
+        submodules: true
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4
+      with:
+        cache-binary: true
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+      with:
+        # renovate: datasource=github-releases depName=astral-sh/uv
+        version: "0.12.7"
+
+    - name: Set up Python
+      run: uv python install ${{ env.PYTHON_VERSION }}
+
+    - name: Install dependencies
+      run: uv sync --all-extras --dev
+
+    - name: Cache HA Docker image
+      id: cache-ha-image
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+      with:
+        path: /tmp/ha-image.tar
+        key: ha-image-${{ env.HA_IMAGE_GHCR }}-${{ runner.arch }}
+
+    - name: Load cached HA image
+      if: steps.cache-ha-image.outputs.cache-hit == 'true'
+      run: docker load -i /tmp/ha-image.tar
+
+    - name: Pull HA image (GHCR → Docker Hub fallback)
+      if: steps.cache-ha-image.outputs.cache-hit != 'true'
+      run: |
+        HA_VERSION="${HA_IMAGE_GHCR##*:}"
+        HA_IMAGE_DOCKERHUB="homeassistant/home-assistant:${HA_VERSION}"
+        for registry in "$HA_IMAGE_GHCR" "$HA_IMAGE_DOCKERHUB"; do
+          echo "Trying $registry..."
+          if docker pull "$registry"; then
+            if [ "$registry" != "$HA_IMAGE_GHCR" ]; then
+              docker tag "$registry" "$HA_IMAGE_GHCR"
+            fi
+            docker save "$HA_IMAGE_GHCR" -o /tmp/ha-image.tar
+            echo "Pulled and cached from $registry"
+            exit 0
+          fi
+          echo "Failed to pull from $registry, trying next..."
+          sleep 15
+        done
+        echo "All registries failed" && exit 1
+
+    - name: Run full E2E test suite (embedded backend, server entry only)
+      run: |
+        echo "🚀 Running full E2E suite through the in-process MCP server with only the server entry (no tools entry) with 2 workers..."
+        # --maxfail=0 overrides pytest.ini's --maxfail=3: this topology audit is only useful if it reports every failure, not the first three.
+        cd tests
+        uv run pytest $PYTEST_PATHS \
+          -n2 \
+          --dist loadscope \
+          --tb=short \
+          -v \
+          --maxfail=0 $PYTEST_ARGS
+        echo "✅ Full E2E test suite (embedded backend, server entry only) passed"
+      env:
+        PYTEST_PATHS: ${{ github.event.inputs.pytest_paths || 'src/e2e/' }}
+        PYTEST_ARGS: ${{ github.event.inputs.pytest_args }}
+        E2E_BACKEND: "embedded"
+        E2E_NO_TOOLS_ENTRY: "1"
+        HAMCP_ENV_FILE: "tests/.env.test"
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # Update-path e2e lane (#1783/#1785): mirrors pr.yml's e2e-validation-update-path
+  # on master push. Each run parametrizes over the component source — the released
+  # ``stable`` git tag (proves a new server release won't break existing installs)
+  # AND this checkout's working tree (proves the PR's own update machinery still
+  # works) — with the ha-mcp server installed from PyPI stable in both. The test
+  # then drives the in-process update that installs THIS commit's freshly built
+  # wheel over the running server (the real reload/purge/restart path) and asserts
+  # the server survives. A single ubuntu-latest lane runs both scenarios serially
+  # (no -n), not the parallel suite. fetch-depth 0 is REQUIRED — the default
+  # shallow checkout omits the ``stable`` tag the stable scenario checks out from.
+  e2e-tests-update-path:
+    name: E2E Tests (Update Path)
+    runs-on: ubuntu-latest
+    needs: resolve-beta
+    env:
+      HA_IMAGE_GHCR: ${{ needs.resolve-beta.outputs.image }}
+      HA_TEST_IMAGE: ${{ needs.resolve-beta.outputs.image }}
+    # 30m: each of the two scenarios (component@stable and component@working-tree)
+    # does a first bring-up that installs ha-mcp plus the full fastmcp dependency
+    # tree from PyPI stable before the in-process update swaps in the PR wheel. The
+    # two containers run sequentially in this one job (observed ~50s per scenario),
+    # so 30m still fits comfortably.
+    timeout-minutes: 30
+
+    steps:
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      with:
+        persist-credentials: false
+        submodules: true
+        # fetch-depth 0: the update-path scenario checks the custom component
+        # out at the released ``stable`` git tag, which the default shallow
+        # checkout does not fetch.
+        fetch-depth: 0
+
+    - name: Verify stable tag is present
+      run: |
+        if ! git rev-parse --verify refs/tags/stable >/dev/null 2>&1; then
+          echo "::error::The 'stable' git tag is missing — the update-path lane checks the released component out from it. Ensure checkout uses fetch-depth: 0."
+          exit 1
+        fi
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4
+      with:
+        cache-binary: true
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+      with:
+        # renovate: datasource=github-releases depName=astral-sh/uv
+        version: "0.12.7"
+
+    - name: Set up Python
+      run: uv python install ${{ env.PYTHON_VERSION }}
+
+    - name: Install dependencies
+      run: uv sync --all-extras --dev
+
+    - name: Cache HA Docker image
+      id: cache-ha-image
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+      with:
+        path: /tmp/ha-image.tar
+        key: ha-image-${{ env.HA_IMAGE_GHCR }}-${{ runner.arch }}
+
+    - name: Load cached HA image
+      if: steps.cache-ha-image.outputs.cache-hit == 'true'
+      run: docker load -i /tmp/ha-image.tar
+
+    - name: Pull HA image (GHCR → Docker Hub fallback)
+      if: steps.cache-ha-image.outputs.cache-hit != 'true'
+      run: |
+        HA_VERSION="${HA_IMAGE_GHCR##*:}"
+        HA_IMAGE_DOCKERHUB="homeassistant/home-assistant:${HA_VERSION}"
+        for registry in "$HA_IMAGE_GHCR" "$HA_IMAGE_DOCKERHUB"; do
+          echo "Trying $registry..."
+          if docker pull "$registry"; then
+            if [ "$registry" != "$HA_IMAGE_GHCR" ]; then
+              docker tag "$registry" "$HA_IMAGE_GHCR"
+            fi
+            docker save "$HA_IMAGE_GHCR" -o /tmp/ha-image.tar
+            echo "Pulled and cached from $registry"
+            exit 0
+          fi
+          echo "Failed to pull from $registry, trying next..."
+          sleep 15
+        done
+        echo "All registries failed" && exit 1
+
+    - name: Run update-path e2e test
+      # E2E_BACKEND deliberately UNSET (container backend): the test drives its
+      # own dedicated container end to end and never touches the session
+      # backend, but conftest's autouse session fixture boots one regardless —
+      # the default container backend boots it cheaply, while
+      # E2E_BACKEND=embedded would add a wheel build + in-container preinstall
+      # of the whole fastmcp tree that nothing in this lane uses.
+      run: |
+        echo "🚀 Running the update-path e2e lane (released component + PyPI server → PR wheel)..."
+        cd tests
+        uv run pytest src/e2e/workflows/embedded/test_embedded_update_path.py \
+          -m update_path \
+          --tb=short \
+          -v $PYTEST_ARGS
+        echo "✅ Update-path e2e lane passed"
+      env:
+        PYTEST_ARGS: ${{ github.event.inputs.pytest_args }}
+        E2E_UPDATE_PATH: "1"
+        HAMCP_ENV_FILE: "tests/.env.test"
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/e2e-beta-tests.yml
+++ b/.github/workflows/e2e-beta-tests.yml
@@ -159,6 +159,7 @@ jobs:
       run: |
         echo "🚀 Running full E2E test suite with 3 workers..."
         cd tests
+        # shellcheck disable=SC2086
         uv run pytest $PYTEST_PATHS \
           -n3 \
           --dist loadscope \
@@ -249,6 +250,7 @@ jobs:
         echo "🚀 Running full E2E test suite without the ha_mcp_tools component with 3 workers..."
         # --maxfail=0 overrides pytest.ini's --maxfail=3: this topology audit is only useful if it reports every failure, not the first three.
         cd tests
+        # shellcheck disable=SC2086
         uv run pytest $PYTEST_PATHS \
           -n3 \
           --dist loadscope \
@@ -351,6 +353,7 @@ jobs:
       run: |
         echo "🚀 Running full E2E suite through the in-process MCP server (embedded backend) with ${{ matrix.pytest_workers }} workers..."
         cd tests
+        # shellcheck disable=SC2086
         uv run pytest $PYTEST_PATHS \
           -n${{ matrix.pytest_workers }} \
           --dist loadscope \
@@ -442,6 +445,7 @@ jobs:
         echo "🚀 Running full E2E suite through the in-process MCP server with only the server entry (no tools entry) with 2 workers..."
         # --maxfail=0 overrides pytest.ini's --maxfail=3: this topology audit is only useful if it reports every failure, not the first three.
         cd tests
+        # shellcheck disable=SC2086
         uv run pytest $PYTEST_PATHS \
           -n2 \
           --dist loadscope \
@@ -547,6 +551,11 @@ jobs:
         echo "All registries failed" && exit 1
 
     - name: Run update-path e2e test
+      # The dispatch inputs are deliberately NOT plumbed into this job: it runs
+      # one fixed module with a single test, so a targeted `pytest_args` such as
+      # `-k test_simple_connection` would deselect it and pytest exits 5 (no
+      # tests collected), failing a dispatch whose requested tests passed in
+      # the other jobs. A narrowed dispatch simply runs this lane in full.
       # E2E_BACKEND deliberately UNSET (container backend): the test drives its
       # own dedicated container end to end and never touches the session
       # backend, but conftest's autouse session fixture boots one regardless —
@@ -559,10 +568,9 @@ jobs:
         uv run pytest src/e2e/workflows/embedded/test_embedded_update_path.py \
           -m update_path \
           --tb=short \
-          -v $PYTEST_ARGS
+          -v
         echo "✅ Update-path e2e lane passed"
       env:
-        PYTEST_ARGS: ${{ github.event.inputs.pytest_args }}
         E2E_UPDATE_PATH: "1"
         HAMCP_ENV_FILE: "tests/.env.test"
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/agents/github-workflow.md
+++ b/docs/agents/github-workflow.md
@@ -170,7 +170,10 @@ summary only when the pull request actually reaches that state.
 | Workflow | Trigger | Purpose |
 |---|---|---|
 | `pr.yml` | Pull request | Fast checks and validation orchestration. |
-| `e2e-tests.yml` | Pull request to `master` | Full E2E validation, normally about three minutes. |
+| `e2e-tests.yml` | Push to `master` touching code, or manual | Full container-backend E2E validation on the pinned stable Core image. |
+| `haos-e2e-tests.yml` | Pull request or manual | Six HAOS lanes against a baked qcow2; required status checks. |
+| `haos-e2e-beta-tests.yml` | Push to `master`, nightly, or manual | The inaddon and embedded HAOS lanes against the current beta Supervisor and Core. |
+| `e2e-beta-tests.yml` | Push to `master`, nightly, or manual | The container-backend E2E jobs against the current beta Core image. |
 | `publish-dev.yml` | Push to `master` | Development `.devN` release. |
 | `notify-dev-channel.yml` | Push to `master` touching `src/` | Development-testing notices. |
 | `semver-release.yml` | Biweekly or manual | Stable version tag and GitHub release. |

--- a/renovate.json
+++ b/renovate.json
@@ -100,6 +100,13 @@
       "groupName": "uv"
     },
     {
+      "description": "Home Assistant Core images move the day a release ships. The beta lanes (haos-e2e-beta-tests.yml, e2e-beta-tests.yml) have already exercised each release for a month before it goes stable, so the 7-day age gate only holds the stable lanes behind what users are running (#2361)",
+      "matchDepNames": [
+        "ghcr.io/home-assistant/home-assistant"
+      ],
+      "minimumReleaseAge": null
+    },
+    {
       "description": "Keep Python interpreter changes coordinated while allowing same-tag digest refreshes",
       "matchManagers": [
         "dockerfile"

--- a/tests/src/unit/test_e2e_lane_env_shape.py
+++ b/tests/src/unit/test_e2e_lane_env_shape.py
@@ -134,6 +134,7 @@ _PR = "pr.yml"
 _E2E = "e2e-tests.yml"
 _HAOS = "haos-e2e-tests.yml"
 _BETA = "haos-e2e-beta-tests.yml"
+_CBETA = "e2e-beta-tests.yml"
 
 # (workflow, job) -> the backend selectors that step's env must carry, exactly.
 # An absent selector is as load-bearing as a present one: the two no-component
@@ -146,11 +147,14 @@ _NO_TOOLS_LANES: dict[tuple[str, str], dict[str, str]] = {
     (_E2E, "e2e-tests-embedded-server-only"): {"E2E_BACKEND": "embedded"},
     (_HAOS, "haos-e2e-embedded-no-tools"): {"HAOS_TEST_MODE": "embedded"},
     (_HAOS, "haos-e2e-inaddon-no-tools"): {"HAOS_TEST_MODE": "inaddon"},
+    (_CBETA, "e2e-tests-no-component"): {},
+    (_CBETA, "e2e-tests-embedded-server-only"): {"E2E_BACKEND": "embedded"},
 }
 
 # Every component-present lane: the siblings each no-tools lane is paired
-# against, plus the beta lanes, which have no no-tools counterpart but are
-# component-present all the same. If one of these ever grows
+# against, plus the HAOS beta lanes, which have no no-tools counterpart but
+# are component-present all the same. (The container beta workflow mirrors
+# e2e-tests.yml job for job, so its no-tools lanes are paired the same way.) If one of these ever grows
 # E2E_NO_TOOLS_ENTRY, a pair stops being a comparison and a beta lane stops
 # covering the topology it was built to run on beta images.
 _ORDINARY_LANES: tuple[tuple[str, str], ...] = (
@@ -166,6 +170,9 @@ _ORDINARY_LANES: tuple[tuple[str, str], ...] = (
     (_HAOS, "haos-e2e-stdio"),
     (_BETA, "haos-e2e-inaddon-beta"),
     (_BETA, "haos-e2e-embedded-beta"),
+    (_CBETA, "e2e-tests"),
+    (_CBETA, "e2e-tests-embedded"),
+    (_CBETA, "e2e-tests-update-path"),
 )
 
 # The container no-tools lanes are whole-topology audits: pytest.ini's
@@ -177,6 +184,8 @@ _AUDIT_LANES: tuple[tuple[str, str], ...] = (
     (_PR, "e2e-validation-embedded-server-only"),
     (_E2E, "e2e-tests-no-component"),
     (_E2E, "e2e-tests-embedded-server-only"),
+    (_CBETA, "e2e-tests-no-component"),
+    (_CBETA, "e2e-tests-embedded-server-only"),
 )
 
 _SELECTOR_NAMES = ("E2E_BACKEND", "HAOS_TEST_MODE")
@@ -213,7 +222,7 @@ _E2E_SUITE_TARGET = re.compile(r"(?:tests/)?src/e2e/([^\s\"']*)")
 # Floor on the discovered count, so a predicate that quietly stops matching (a
 # workflow restructure, a renamed input) fails here rather than reporting an
 # empty sweep as full coverage.
-_MIN_DISCOVERED_LANES = 18
+_MIN_DISCOVERED_LANES = 23
 
 
 def _job(workflow: str, job_id: str) -> dict[str, Any]:

--- a/tests/src/unit/test_haos_image_workflow_shape.py
+++ b/tests/src/unit/test_haos_image_workflow_shape.py
@@ -12,6 +12,7 @@ _WORKFLOW_DIR = _REPO_ROOT / ".github" / "workflows"
 # lanes participate in every surviving workflow event.
 _STABLE_WORKFLOW = "haos-e2e-tests.yml"
 _BETA_WORKFLOW = "haos-e2e-beta-tests.yml"
+_CONTAINER_BETA_WORKFLOW = "e2e-beta-tests.yml"
 # 7 actual consumers (the six HAOS lanes + the image builder); the floor is what
 # catches a lane that silently loses its image-cache step.
 _CACHE_KEY_CONSUMER_FLOOR = 7
@@ -209,10 +210,13 @@ def test_beta_lanes_share_a_current_supervisor_and_core_image() -> None:
     )
     beta_resolvers: list[str] = []
     beta_cache_keys: list[str] = []
+    # The container beta workflow's resolver job is the only other beta.json
+    # consumer; it has no HAOS mode and is pinned down by
+    # test_container_beta_lane_resolves_the_beta_core_image_once below.
     assert _beta_lane_jobs() == {
         (_BETA_WORKFLOW, beta_job_id, mode)
         for beta_job_id, mode, _stable_job_id in lane_specs
-    }
+    } | {(_CONTAINER_BETA_WORKFLOW, "resolve-beta", "None")}
 
     beta_path = _WORKFLOW_DIR / _BETA_WORKFLOW
     assert beta_path.is_file(), "both beta lanes live in one workflow file"
@@ -341,3 +345,81 @@ def test_beta_lanes_share_a_current_supervisor_and_core_image() -> None:
 
     assert beta_resolvers[0] == beta_resolvers[1]
     assert beta_cache_keys[0] == beta_cache_keys[1]
+
+
+def test_container_beta_lane_resolves_the_beta_core_image_once() -> None:
+    """The container beta lanes mirror the HAOS beta trigger shape (#2361).
+
+    One resolver job reads the beta Core version and every test job pins its
+    HA image to that job's output, so all five lanes test the same image and
+    the stable renovate pin never leaks into a beta run.
+    """
+    path = _WORKFLOW_DIR / _CONTAINER_BETA_WORKFLOW
+    assert path.is_file()
+    workflow = _workflow(path)
+
+    triggers = workflow[True]
+    assert "pull_request" not in triggers, (
+        "beta compatibility runs after changes land on master, not on every "
+        "push to an open PR"
+    )
+    assert triggers["push"] == {"branches": ["master"]}, (
+        "no paths filter: a nightly must run regardless of the last commit"
+    )
+    assert triggers["schedule"] == [{"cron": "37 3 * * *"}]
+    assert set(triggers["workflow_dispatch"]["inputs"]) == {
+        "pytest_args",
+        "pytest_paths",
+    }
+    assert workflow["concurrency"] == {
+        "group": (
+            "${{ github.workflow }}-${{ github.event_name == "
+            "'workflow_dispatch' && github.run_id || 'full' }}"
+        ),
+        "cancel-in-progress": True,
+    }
+    assert "changes" not in workflow["jobs"]
+    assert "HA_IMAGE_GHCR" not in workflow.get("env", {}), (
+        "the beta workflow must not carry the stable image pin"
+    )
+
+    resolver = workflow["jobs"]["resolve-beta"]
+    resolve = next(
+        step
+        for step in _job_steps(resolver)
+        if "version.home-assistant.io/beta.json" in str(step.get("run", ""))
+    )
+    assert '["homeassistant"]["default"]' in resolve["run"], (
+        "the container lanes want the multi-arch docker tag, not qemux86-64"
+    )
+    assert "image=ghcr.io/home-assistant/home-assistant:$core_version" in resolve["run"]
+    assert resolver["outputs"] == {
+        "core_version": "${{ steps.versions.outputs.core_version }}",
+        "image": "${{ steps.versions.outputs.image }}",
+    }
+
+    image_ref = "${{ needs.resolve-beta.outputs.image }}"
+    test_jobs = {
+        job_id: job
+        for job_id, job in workflow["jobs"].items()
+        if job_id != "resolve-beta"
+    }
+    assert set(test_jobs) == {
+        "e2e-tests",
+        "e2e-tests-no-component",
+        "e2e-tests-embedded",
+        "e2e-tests-embedded-server-only",
+        "e2e-tests-update-path",
+    }, "the beta workflow mirrors e2e-tests.yml job for job"
+    for job_id, job in test_jobs.items():
+        assert job["needs"] == "resolve-beta", job_id
+        assert job["env"]["HA_IMAGE_GHCR"] == image_ref, job_id
+        assert job["env"]["HA_TEST_IMAGE"] == image_ref, (
+            f"{job_id}: the E2E fixtures build their container from "
+            "tests/test_constants.HA_TEST_IMAGE, which only the environment "
+            "can override"
+        )
+        assert not any(
+            "version.home-assistant.io" in str(step.get("run", ""))
+            for step in _job_steps(job)
+        ), f"{job_id} must not resolve the beta version a second time"

--- a/tests/src/unit/test_haos_image_workflow_shape.py
+++ b/tests/src/unit/test_haos_image_workflow_shape.py
@@ -420,6 +420,6 @@ def test_container_beta_lane_resolves_the_beta_core_image_once() -> None:
             "can override"
         )
         assert not any(
-            "version.home-assistant.io" in str(step.get("run", ""))
+            "version.home-assistant.io/beta.json" in str(step.get("run", ""))
             for step in _job_steps(job)
         ), f"{job_id} must not resolve the beta version a second time"

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -5,6 +5,8 @@ This module centralizes test configuration values to ensure consistency
 across all test environments.
 """
 
+import os
+
 # Long-lived access token for test Home Assistant instance
 # This token is embedded in tests/initial_test_state/.storage/auth
 # Expires: 2035 (10+ years from token creation)
@@ -19,8 +21,12 @@ NON_ADMIN_TEST_TOKEN = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiIzNzkyOTc
 
 # Home Assistant Docker image for E2E/performance/UAT tests.
 # Keep in sync with .github/workflows/e2e-tests.yml and pr.yml.
+# HA_TEST_IMAGE in the environment overrides the pin: the container beta
+# lane (.github/workflows/e2e-beta-tests.yml) points it at the current
+# beta Core image resolved at run time.
 # renovate: datasource=docker depName=ghcr.io/home-assistant/home-assistant
-HA_TEST_IMAGE = "ghcr.io/home-assistant/home-assistant:2026.8.3"
+_DEFAULT_HA_TEST_IMAGE = "ghcr.io/home-assistant/home-assistant:2026.8.3"
+HA_TEST_IMAGE = os.environ.get("HA_TEST_IMAGE", _DEFAULT_HA_TEST_IMAGE)
 
 # Test user credentials (for UI access)
 TEST_USER = "mcp"


### PR DESCRIPTION
## What does this PR do?

Adds a container-backend beta E2E lane and lets the stable Home Assistant image pins move on release day.

- `.github/workflows/e2e-beta-tests.yml`: the container counterpart of the HAOS beta lanes. Same five jobs as `e2e-tests.yml` (container, no-component, embedded matrix, embedded server-entry-only, update path), but the Core image is resolved at run time from `version.home-assistant.io/beta.json` instead of a pin. Runs on master push, nightly, and manual dispatch with the same `pytest_args` / `pytest_paths` inputs as `haos-e2e-beta-tests.yml`; never on pull requests.
- `tests/test_constants.py`: `HA_TEST_IMAGE` is now overridable from the environment. The E2E fixtures build their container from that constant, so a workflow env var alone could not switch the image; the pinned literal stays in place for Renovate.
- `renovate.json`: `ghcr.io/home-assistant/home-assistant` is exempt from the 7-day `minimumReleaseAge`. The beta lanes have exercised each Core release for a month before it goes stable, so the age gate only held the stable container lanes behind what users run.
- `docs/agents/github-workflow.md`: inventory rows for the HAOS and container beta lanes.

Motivation: #2361. Core 2026.9 changed the LLM-API schema conversion and broke every Anthropic conversation turn, and no container lane could see it while pinned to 2026.8.3. The HAOS beta lane was already on 2026.9 but the LLM-API tests are container-only, so nothing caught it. This PR is the CI prerequisite; the fix and the test retargeting follow in the issue.

## Type of change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [x] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [ ] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

The new workflow only runs after merge (push to master, nightly, or dispatch), so this PR's CI cannot exercise it. It was exercised by dispatching it on a fork against beta.json's current Core, 2026.9.0:

- Full run: https://github.com/kingpanther13/ha-mcp-fork/actions/runs/33866222448. The resolver and five of six jobs passed; the update-path job failed because that fork's `stable` tag was stale (component 0.3.0, February), so its `component@stable` scenario tested a component with no LLM API. The `head` scenario passed.
- Re-run with the tag synced to upstream's `stable`, narrowed to the update-path module: https://github.com/kingpanther13/ha-mcp-fork/actions/runs/33867622934. All six jobs passed.

The stale-tag failure also showed that the update-path fixture's timeout message carries only the container's stdout, not `home-assistant.log`; that diagnostics gap is queued for the follow-up test PR from #2361. Also verified locally: workflow YAML parses, `renovate.json` parses, the two workflow-shape unit guards pass, and the stable lanes still pull the pinned image through the unchanged env plumbing.

## Checklist
- [x] I have updated documentation if needed
