### PR TITLE
ci: move the E2E Home Assistant image to 2026.9.0

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -21,7 +21,7 @@ env:
   PYTHON_VERSION: "3.13"
   UV_CACHE_DIR: /tmp/.uv-cache
   # renovate: datasource=docker depName=ghcr.io/home-assistant/home-assistant
-  HA_IMAGE_GHCR: "ghcr.io/home-assistant/home-assistant:2026.8.3"
+  HA_IMAGE_GHCR: "ghcr.io/home-assistant/home-assistant:2026.9.0"
   # Disable Testcontainers' Ryuk reaper: it has been reported to leave
   # zombie containers on GHA runners (see #366, Ilya0527 2026-05-18).
   # The E2E fixture in tests/src/e2e/conftest.py relies instead on the

--- a/.github/workflows/performance-tests.yml
+++ b/.github/workflows/performance-tests.yml
@@ -36,7 +36,7 @@ env:
   PYTHON_VERSION: "3.13"
   UV_CACHE_DIR: /tmp/.uv-cache
   # renovate: datasource=docker depName=ghcr.io/home-assistant/home-assistant
-  HA_IMAGE_GHCR: "ghcr.io/home-assistant/home-assistant:2026.8.3"
+  HA_IMAGE_GHCR: "ghcr.io/home-assistant/home-assistant:2026.9.0"
   # Disable Testcontainers' Ryuk reaper: it has been reported to leave
   # zombie containers on GHA runners (see #366, Ilya0527 2026-05-18).
   # The E2E fixture in tests/src/e2e/conftest.py relies instead on the

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -23,7 +23,7 @@ env:
   PYTHON_VERSION: "3.13"
   UV_CACHE_DIR: /tmp/.uv-cache
   # renovate: datasource=docker depName=ghcr.io/home-assistant/home-assistant
-  HA_IMAGE_GHCR: "ghcr.io/home-assistant/home-assistant:2026.8.3"
+  HA_IMAGE_GHCR: "ghcr.io/home-assistant/home-assistant:2026.9.0"
   # Disable Testcontainers' Ryuk reaper: it has been reported to leave
   # zombie containers on GHA runners (see #366, Ilya0527 2026-05-18).
   # The E2E fixture in tests/src/e2e/conftest.py relies instead on the

--- a/renovate.json
+++ b/renovate.json
@@ -104,7 +104,10 @@
       "matchDepNames": [
         "ghcr.io/home-assistant/home-assistant"
       ],
-      "minimumReleaseAge": null
+      "minimumReleaseAge": null,
+      "schedule": [
+        "at any time"
+      ]
     },
     {
       "description": "Keep Python interpreter changes coordinated while allowing same-tag digest refreshes",

--- a/tests/src/unit/test_ha_constraint_alignment.py
+++ b/tests/src/unit/test_ha_constraint_alignment.py
@@ -103,19 +103,19 @@ class TestRepoPyprojectIsAligned:
         dependencies = checker.direct_dependencies(
             (_REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8")
         )
-        # Verbatim from homeassistant/package_constraints.txt @ 2026.8.0.
-        frozen_2026_8_0 = "\n".join(
+        # Verbatim from homeassistant/package_constraints.txt @ 2026.9.0.
+        frozen_2026_9_0 = "\n".join(
             [
                 "websockets>=15.0.1",
                 "httpx==0.28.1",
                 "pydantic==2.13.4",
                 "cryptography==48.0.1",
                 "packaging>=23.1",
-                "typing-extensions>=4.15.0,<5.0",
+                "typing-extensions>=4.16.0,<5.0",
             ]
         )
         violations = checker.check_alignment(
-            dependencies, checker.parse_requirement_lines(frozen_2026_8_0)
+            dependencies, checker.parse_requirement_lines(frozen_2026_9_0)
         )
         assert violations == []
 

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -25,7 +25,7 @@ NON_ADMIN_TEST_TOKEN = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiIzNzkyOTc
 # lane (.github/workflows/e2e-beta-tests.yml) points it at the current
 # beta Core image resolved at run time.
 # renovate: datasource=docker depName=ghcr.io/home-assistant/home-assistant
-_DEFAULT_HA_TEST_IMAGE = "ghcr.io/home-assistant/home-assistant:2026.8.3"
+_DEFAULT_HA_TEST_IMAGE = "ghcr.io/home-assistant/home-assistant:2026.9.0"
 HA_TEST_IMAGE = os.environ.get("HA_TEST_IMAGE", _DEFAULT_HA_TEST_IMAGE)
 
 # Test user credentials (for UI access)


### PR DESCRIPTION
## What does this PR do?

Moves the four pinned E2E Home Assistant images (pr.yml, e2e-tests.yml, performance-tests.yml, tests/test_constants.py) from 2026.8.3 to 2026.9.0, the Core release that replaced voluptuous-openapi with Probatio and broke the LLM API (#2361). With this, every container lane on every PR runs the affected Core, which is what lets the regression tests for #2361 discriminate.

Also gives the Home Assistant image Renovate rule its own `schedule: at any time`. #2362 lifted the 7-day age gate and Renovate then computed this exact update on dispatch (run 33871075811), but the global `after 3pm on tuesday` schedule reported the branch as `not-scheduled` and opened nothing. The rule-level schedule lets a release-day dispatch open the bump next time; the weekly cron is unchanged.

## Type of change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [x] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [ ] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

This PR's own CI is the test: all container lanes, including update-path against the released `stable` component, run on 2026.9.0. The same job set already passed on 2026.9.0 through the new beta lane on a fork (#2362 links both runs).

## Checklist
- [x] I have updated documentation if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated automated testing and validation to use Home Assistant 2026.9.0.
  * Adjusted update monitoring so Home Assistant Core image updates can be evaluated at any time.
  * Refreshed the default test configuration and dependency constraints to align with the newer Home Assistant release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->