### PR TITLE
fix(component): prove the LLM-API schema conversion inside Home Assistant and finish #2361

### DIFF
--- a/.github/workflows/e2e-beta-tests.yml
+++ b/.github/workflows/e2e-beta-tests.yml
@@ -74,10 +74,24 @@ jobs:
     outputs:
       core_version: ${{ steps.versions.outputs.core_version }}
       image: ${{ steps.versions.outputs.image }}
+      superfluous: ${{ steps.versions.outputs.superfluous }}
 
     steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+          # Only the stable lane's image pin is read here.
+          sparse-checkout: .github/workflows/e2e-tests.yml
+          sparse-checkout-cone-mode: false
+
       - name: Resolve current beta Core version
         id: versions
+        # ``superfluous`` is true when the beta Core is the version the stable
+        # container lanes already pin: every job below would then repeat
+        # e2e-tests.yml on the same image, so they are skipped. Compared against
+        # the pin rather than stable.json on purpose: while the Renovate bump
+        # lags a release, beta equals the new stable and this lane is the only
+        # container lane on it.
         run: |
           metadata=$(curl --fail --silent --show-error \
             https://version.home-assistant.io/beta.json)
@@ -88,14 +102,27 @@ jobs:
             echo "::error::Unexpected beta Core version: $core_version"
             exit 1
           fi
+          stable_pin=$(sed -n 's#^  HA_IMAGE_GHCR: "ghcr.io/home-assistant/home-assistant:\(.*\)"$#\1#p' \
+            .github/workflows/e2e-tests.yml)
+          if [ -z "$stable_pin" ]; then
+            echo "::error::Could not read the stable HA image pin from e2e-tests.yml"
+            exit 1
+          fi
+          superfluous=false
+          if [ "$core_version" = "$stable_pin" ]; then
+            superfluous=true
+            echo "::notice::Beta Core $core_version equals the stable lane pin; skipping the beta jobs"
+          fi
           echo "core_version=$core_version" >> "$GITHUB_OUTPUT"
           echo "image=ghcr.io/home-assistant/home-assistant:$core_version" >> "$GITHUB_OUTPUT"
+          echo "superfluous=$superfluous" >> "$GITHUB_OUTPUT"
 
   # Comprehensive E2E validation against the beta Core image.
   e2e-tests:
     name: E2E Tests
     runs-on: ubuntu-latest
     needs: resolve-beta
+    if: needs.resolve-beta.outputs.superfluous != 'true'
     env:
       HA_IMAGE_GHCR: ${{ needs.resolve-beta.outputs.image }}
       HA_TEST_IMAGE: ${{ needs.resolve-beta.outputs.image }}
@@ -186,6 +213,7 @@ jobs:
     name: E2E Tests (No Component)
     runs-on: ubuntu-latest
     needs: resolve-beta
+    if: needs.resolve-beta.outputs.superfluous != 'true'
     env:
       HA_IMAGE_GHCR: ${{ needs.resolve-beta.outputs.image }}
       HA_TEST_IMAGE: ${{ needs.resolve-beta.outputs.image }}
@@ -279,6 +307,7 @@ jobs:
     name: E2E Tests (Embedded Server, ${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     needs: resolve-beta
+    if: needs.resolve-beta.outputs.superfluous != 'true'
     env:
       HA_IMAGE_GHCR: ${{ needs.resolve-beta.outputs.image }}
       HA_TEST_IMAGE: ${{ needs.resolve-beta.outputs.image }}
@@ -381,6 +410,7 @@ jobs:
     name: E2E Tests (Embedded Server, server entry only)
     runs-on: ubuntu-latest
     needs: resolve-beta
+    if: needs.resolve-beta.outputs.superfluous != 'true'
     env:
       HA_IMAGE_GHCR: ${{ needs.resolve-beta.outputs.image }}
       HA_TEST_IMAGE: ${{ needs.resolve-beta.outputs.image }}
@@ -475,6 +505,7 @@ jobs:
     name: E2E Tests (Update Path)
     runs-on: ubuntu-latest
     needs: resolve-beta
+    if: needs.resolve-beta.outputs.superfluous != 'true'
     env:
       HA_IMAGE_GHCR: ${{ needs.resolve-beta.outputs.image }}
       HA_TEST_IMAGE: ${{ needs.resolve-beta.outputs.image }}

--- a/.github/workflows/e2e-beta-tests.yml
+++ b/.github/workflows/e2e-beta-tests.yml
@@ -86,11 +86,14 @@ jobs:
 
       - name: Resolve current beta Core version
         id: versions
-        # ``superfluous`` is true when the beta Core is the version the stable
-        # container lanes already pin: every job below would then repeat
-        # e2e-tests.yml on the same image, so they are skipped. Compared against
-        # the pin rather than stable.json on purpose: while the Renovate bump
-        # lags a release, beta equals the new stable and this lane is the only
+        # ``superfluous`` is true when the beta Core equals the stable lane's
+        # pin. The stable lanes run that exact image on every pull request, so
+        # the jobs below are skipped on push and schedule -- including the
+        # nightly, which therefore does not run while beta and stable agree.
+        # A manual dispatch always runs: it is a deliberate request, often a
+        # targeted one via pytest_args/pytest_paths. Compared against the pin
+        # rather than stable.json on purpose: while the Renovate bump lags a
+        # release, beta equals the new stable and this lane is the only
         # container lane on it.
         run: |
           metadata=$(curl --fail --silent --show-error \
@@ -122,7 +125,7 @@ jobs:
     name: E2E Tests
     runs-on: ubuntu-latest
     needs: resolve-beta
-    if: needs.resolve-beta.outputs.superfluous != 'true'
+    if: github.event_name == 'workflow_dispatch' || needs.resolve-beta.outputs.superfluous != 'true'
     env:
       HA_IMAGE_GHCR: ${{ needs.resolve-beta.outputs.image }}
       HA_TEST_IMAGE: ${{ needs.resolve-beta.outputs.image }}
@@ -213,7 +216,7 @@ jobs:
     name: E2E Tests (No Component)
     runs-on: ubuntu-latest
     needs: resolve-beta
-    if: needs.resolve-beta.outputs.superfluous != 'true'
+    if: github.event_name == 'workflow_dispatch' || needs.resolve-beta.outputs.superfluous != 'true'
     env:
       HA_IMAGE_GHCR: ${{ needs.resolve-beta.outputs.image }}
       HA_TEST_IMAGE: ${{ needs.resolve-beta.outputs.image }}
@@ -307,7 +310,7 @@ jobs:
     name: E2E Tests (Embedded Server, ${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     needs: resolve-beta
-    if: needs.resolve-beta.outputs.superfluous != 'true'
+    if: github.event_name == 'workflow_dispatch' || needs.resolve-beta.outputs.superfluous != 'true'
     env:
       HA_IMAGE_GHCR: ${{ needs.resolve-beta.outputs.image }}
       HA_TEST_IMAGE: ${{ needs.resolve-beta.outputs.image }}
@@ -410,7 +413,7 @@ jobs:
     name: E2E Tests (Embedded Server, server entry only)
     runs-on: ubuntu-latest
     needs: resolve-beta
-    if: needs.resolve-beta.outputs.superfluous != 'true'
+    if: github.event_name == 'workflow_dispatch' || needs.resolve-beta.outputs.superfluous != 'true'
     env:
       HA_IMAGE_GHCR: ${{ needs.resolve-beta.outputs.image }}
       HA_TEST_IMAGE: ${{ needs.resolve-beta.outputs.image }}
@@ -505,7 +508,7 @@ jobs:
     name: E2E Tests (Update Path)
     runs-on: ubuntu-latest
     needs: resolve-beta
-    if: needs.resolve-beta.outputs.superfluous != 'true'
+    if: github.event_name == 'workflow_dispatch' || needs.resolve-beta.outputs.superfluous != 'true'
     env:
       HA_IMAGE_GHCR: ${{ needs.resolve-beta.outputs.image }}
       HA_TEST_IMAGE: ${{ needs.resolve-beta.outputs.image }}

--- a/.github/workflows/e2e-beta-tests.yml
+++ b/.github/workflows/e2e-beta-tests.yml
@@ -80,21 +80,25 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
-          # Only the stable lane's image pin is read here.
-          sparse-checkout: .github/workflows/e2e-tests.yml
+          # Only the E2E fixtures' image pin is read here.
+          sparse-checkout: tests/test_constants.py
           sparse-checkout-cone-mode: false
 
       - name: Resolve current beta Core version
         id: versions
-        # ``superfluous`` is true when the beta Core equals the stable lane's
-        # pin. The stable lanes run that exact image on every pull request, so
-        # the jobs below are skipped on push and schedule -- including the
-        # nightly, which therefore does not run while beta and stable agree.
-        # A manual dispatch always runs: it is a deliberate request, often a
-        # targeted one via pytest_args/pytest_paths. Compared against the pin
-        # rather than stable.json on purpose: while the Renovate bump lags a
-        # release, beta equals the new stable and this lane is the only
-        # container lane on it.
+        # ``superfluous`` is true when the beta Core equals the image the E2E
+        # fixtures build their container from: HA_TEST_IMAGE's default in
+        # tests/test_constants.py, the literal the stable lanes run (the
+        # workflow-level HA_IMAGE_GHCR pins are pre-pull and cache-key inputs;
+        # a unit guard keeps all of them equal). The stable lanes run that
+        # exact image on every pull request, so the jobs below are skipped on
+        # push and schedule -- including the nightly, which therefore does
+        # not run while beta and stable agree. A manual dispatch always runs:
+        # it is a deliberate request, often a targeted one via
+        # pytest_args/pytest_paths. Compared against the pin rather than
+        # stable.json on purpose: while the Renovate bump lags a release,
+        # beta equals the new stable and this lane is the only container
+        # lane on it.
         run: |
           metadata=$(curl --fail --silent --show-error \
             https://version.home-assistant.io/beta.json)
@@ -105,10 +109,10 @@ jobs:
             echo "::error::Unexpected beta Core version: $core_version"
             exit 1
           fi
-          stable_pin=$(sed -n 's#^  HA_IMAGE_GHCR: "ghcr.io/home-assistant/home-assistant:\(.*\)"$#\1#p' \
-            .github/workflows/e2e-tests.yml)
+          stable_pin=$(sed -n 's#^_DEFAULT_HA_TEST_IMAGE = "ghcr.io/home-assistant/home-assistant:\(.*\)"$#\1#p' \
+            tests/test_constants.py)
           if [ -z "$stable_pin" ]; then
-            echo "::error::Could not read the stable HA image pin from e2e-tests.yml"
+            echo "::error::Could not read the stable HA image pin from tests/test_constants.py"
             exit 1
           fi
           superfluous=false

--- a/.github/workflows/haos-e2e-beta-tests.yml
+++ b/.github/workflows/haos-e2e-beta-tests.yml
@@ -59,11 +59,12 @@ env:
 jobs:
   # Decide once whether beta is currently distinct from stable. The gate checks
   # one thing: whether beta.json and stable.json name the same Supervisor and
-  # Core. When they do, the stable HAOS lanes bake that same Core and
-  # Supervisor from the stable channel on every pull request, so both lanes
-  # below are skipped on push and schedule; a manual dispatch always runs.
-  # Each lane still resolves the versions itself for its cache key and build
-  # inputs.
+  # Core. When they do, the stable HAOS lanes' image (baked from the stable
+  # channel, so it follows the current stable release as of its last bake;
+  # keyed on the bake inputs and re-primed weekly) is taken to cover it, and
+  # both lanes below are skipped on push and schedule; a manual dispatch
+  # always runs. Each lane still resolves the versions itself for its cache
+  # key and build inputs.
   resolve-beta:
     name: Resolve beta versions
     runs-on: ubuntu-latest

--- a/.github/workflows/haos-e2e-beta-tests.yml
+++ b/.github/workflows/haos-e2e-beta-tests.yml
@@ -61,7 +61,8 @@ jobs:
   # one thing: whether beta.json and stable.json name the same Supervisor and
   # Core. When they do, the stable HAOS lanes' image (baked from the stable
   # channel, so it follows the current stable release as of its last bake;
-  # keyed on the bake inputs and re-primed weekly) is taken to cover it, and
+  # keyed on the bake inputs, so it is rebaked whenever those change and
+  # otherwise lives until cache eviction) is taken to cover it, and
   # both lanes below are skipped on push and schedule; a manual dispatch
   # always runs. Each lane still resolves the versions itself for its cache
   # key and build inputs.

--- a/.github/workflows/haos-e2e-beta-tests.yml
+++ b/.github/workflows/haos-e2e-beta-tests.yml
@@ -57,11 +57,13 @@ env:
   LIBGUESTFS_BACKEND: direct
 
 jobs:
-  # Decide once whether beta is currently distinct from stable. When beta.json
-  # and stable.json name the same Supervisor and Core, the stable HAOS lanes
-  # (which bake from the stable channel) already ran exactly this image on the
-  # PR, and both lanes below are skipped. Each lane still resolves the versions
-  # itself for its cache key and build inputs.
+  # Decide once whether beta is currently distinct from stable. The gate checks
+  # one thing: whether beta.json and stable.json name the same Supervisor and
+  # Core. When they do, the stable HAOS lanes bake that same Core and
+  # Supervisor from the stable channel on every pull request, so both lanes
+  # below are skipped on push and schedule; a manual dispatch always runs.
+  # Each lane still resolves the versions itself for its cache key and build
+  # inputs.
   resolve-beta:
     name: Resolve beta versions
     runs-on: ubuntu-latest
@@ -77,12 +79,38 @@ jobs:
             https://version.home-assistant.io/beta.json)
           stable=$(curl --fail --silent --show-error \
             https://version.home-assistant.io/stable.json)
-          read -r beta_supervisor beta_core <<<"$(python3 -c \
-            'import json, sys; d = json.load(sys.stdin); print(d["supervisor"], d["homeassistant"]["qemux86-64"])' \
-            <<<"$beta")"
-          read -r stable_supervisor stable_core <<<"$(python3 -c \
-            'import json, sys; d = json.load(sys.stdin); print(d["supervisor"], d["homeassistant"]["qemux86-64"])' \
-            <<<"$stable")"
+          # Each value is captured separately so a failing python3 call aborts
+          # the job. A ``read`` over a failed substitution would leave the
+          # variables empty, make the comparison below trivially true, and skip
+          # both lanes silently; the fail-safe direction here is to run them.
+          supervisor_re='^[0-9]{4}\.[0-9]{1,2}\.[0-9]+([.]dev[0-9]+)?$'
+          core_re='^[0-9]{4}\.[0-9]{1,2}\.[0-9]+([.]dev[0-9]+|b[0-9]+)?$'
+          check() {
+            if [ -z "$2" ]; then
+              echo "::error::Empty $1 version in the channel metadata"
+              exit 1
+            fi
+            if ! [[ "$2" =~ $3 ]]; then
+              echo "::error::Unexpected $1 version: $2"
+              exit 1
+            fi
+          }
+          beta_supervisor=$(python3 -c \
+            'import json, sys; print(json.load(sys.stdin)["supervisor"])' \
+            <<<"$beta") || exit 1
+          beta_core=$(python3 -c \
+            'import json, sys; print(json.load(sys.stdin)["homeassistant"]["qemux86-64"])' \
+            <<<"$beta") || exit 1
+          stable_supervisor=$(python3 -c \
+            'import json, sys; print(json.load(sys.stdin)["supervisor"])' \
+            <<<"$stable") || exit 1
+          stable_core=$(python3 -c \
+            'import json, sys; print(json.load(sys.stdin)["homeassistant"]["qemux86-64"])' \
+            <<<"$stable") || exit 1
+          check "beta Supervisor" "$beta_supervisor" "$supervisor_re"
+          check "beta Core" "$beta_core" "$core_re"
+          check "stable Supervisor" "$stable_supervisor" "$supervisor_re"
+          check "stable Core" "$stable_core" "$core_re"
           superfluous=false
           if [ "$beta_supervisor" = "$stable_supervisor" ] && [ "$beta_core" = "$stable_core" ]; then
             superfluous=true
@@ -95,7 +123,7 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 75
     needs: resolve-beta
-    if: needs.resolve-beta.outputs.superfluous != 'true'
+    if: github.event_name == 'workflow_dispatch' || needs.resolve-beta.outputs.superfluous != 'true'
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -375,7 +403,7 @@ jobs:
     # run if the inaddon suite fails after saving it, and build locally if that
     # lane failed before the save; only a cancelled workflow suppresses this.
     needs: [resolve-beta, haos-e2e-inaddon-beta]
-    if: ${{ !cancelled() && needs.resolve-beta.result == 'success' && needs.resolve-beta.outputs.superfluous != 'true' }}
+    if: ${{ !cancelled() && needs.resolve-beta.result == 'success' && (github.event_name == 'workflow_dispatch' || needs.resolve-beta.outputs.superfluous != 'true') }}
     runs-on: ubuntu-22.04
     # The embedded beta lane receives extra headroom for the per-worker runtime
     # package installation inside the resource-constrained QEMU guest.

--- a/.github/workflows/haos-e2e-beta-tests.yml
+++ b/.github/workflows/haos-e2e-beta-tests.yml
@@ -57,10 +57,45 @@ env:
   LIBGUESTFS_BACKEND: direct
 
 jobs:
+  # Decide once whether beta is currently distinct from stable. When beta.json
+  # and stable.json name the same Supervisor and Core, the stable HAOS lanes
+  # (which bake from the stable channel) already ran exactly this image on the
+  # PR, and both lanes below are skipped. Each lane still resolves the versions
+  # itself for its cache key and build inputs.
+  resolve-beta:
+    name: Resolve beta versions
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      superfluous: ${{ steps.compare.outputs.superfluous }}
+
+    steps:
+      - name: Compare the beta channel with stable
+        id: compare
+        run: |
+          beta=$(curl --fail --silent --show-error \
+            https://version.home-assistant.io/beta.json)
+          stable=$(curl --fail --silent --show-error \
+            https://version.home-assistant.io/stable.json)
+          read -r beta_supervisor beta_core <<<"$(python3 -c \
+            'import json, sys; d = json.load(sys.stdin); print(d["supervisor"], d["homeassistant"]["qemux86-64"])' \
+            <<<"$beta")"
+          read -r stable_supervisor stable_core <<<"$(python3 -c \
+            'import json, sys; d = json.load(sys.stdin); print(d["supervisor"], d["homeassistant"]["qemux86-64"])' \
+            <<<"$stable")"
+          superfluous=false
+          if [ "$beta_supervisor" = "$stable_supervisor" ] && [ "$beta_core" = "$stable_core" ]; then
+            superfluous=true
+            echo "::notice::Beta (Supervisor $beta_supervisor, Core $beta_core) equals stable; skipping the beta lanes"
+          fi
+          echo "superfluous=$superfluous" >> "$GITHUB_OUTPUT"
+
   haos-e2e-inaddon-beta:
     name: HAOS E2E Tests (inaddon beta)
     runs-on: ubuntu-22.04
     timeout-minutes: 75
+    needs: resolve-beta
+    if: needs.resolve-beta.outputs.superfluous != 'true'
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -339,8 +374,8 @@ jobs:
     # Wait for the sole cache writer to finish priming a new beta image. Still
     # run if the inaddon suite fails after saving it, and build locally if that
     # lane failed before the save; only a cancelled workflow suppresses this.
-    needs: haos-e2e-inaddon-beta
-    if: ${{ !cancelled() }}
+    needs: [resolve-beta, haos-e2e-inaddon-beta]
+    if: ${{ !cancelled() && needs.resolve-beta.result == 'success' && needs.resolve-beta.outputs.superfluous != 'true' }}
     runs-on: ubuntu-22.04
     # The embedded beta lane receives extra headroom for the per-worker runtime
     # package installation inside the resource-constrained QEMU guest.

--- a/custom_components/ha_mcp_tools/const.py
+++ b/custom_components/ha_mcp_tools/const.py
@@ -39,8 +39,9 @@ ENTRY_TYPE_SERVER = "server"
 # carrying the legacy default (a user-customized title is left alone).
 TOOLS_ENTRY_TITLE = "HA-MCP File & YAML Tools"
 TOOLS_ENTRY_LEGACY_TITLE = "HA MCP Tools"
-# Kept level with the HACS floor in hacs.json: from 2026.9 the manifest declares
-# voluptuous-openapi, which resolves only against Core 2026.7+ constraints, and
+# Kept level with the HACS floor in hacs.json: from component 2.1.3 the manifest
+# declares voluptuous-openapi, which Core releases before 2026.7 pin to an older
+# version so the requirement cannot resolve there, and
 # that requirement gates the whole integration before any entry's config flow
 # runs, so a lower runtime floor here would promise what the load cannot keep.
 MIN_EMBEDDED_HOME_ASSISTANT_VERSION = "2026.8.0"

--- a/custom_components/ha_mcp_tools/const.py
+++ b/custom_components/ha_mcp_tools/const.py
@@ -39,7 +39,11 @@ ENTRY_TYPE_SERVER = "server"
 # carrying the legacy default (a user-customized title is left alone).
 TOOLS_ENTRY_TITLE = "HA-MCP File & YAML Tools"
 TOOLS_ENTRY_LEGACY_TITLE = "HA MCP Tools"
-MIN_EMBEDDED_HOME_ASSISTANT_VERSION = "2026.6.0"
+# Kept level with the HACS floor in hacs.json: from 2026.9 the manifest declares
+# voluptuous-openapi, which resolves only against Core 2026.7+ constraints, and
+# that requirement gates the whole integration before any entry's config flow
+# runs, so a lower runtime floor here would promise what the load cannot keep.
+MIN_EMBEDDED_HOME_ASSISTANT_VERSION = "2026.8.0"
 
 # Allowed directories for file operations (relative to config dir).
 # "blueprints" is read-only BY DEFAULT — in ALLOWED_READ_DIRS but not

--- a/custom_components/ha_mcp_tools/llm_api.py
+++ b/custom_components/ha_mcp_tools/llm_api.py
@@ -186,8 +186,17 @@ _INSTANCE_VALUES: frozenset[str] = frozenset(
 # OpenAPI's ``discriminator`` holds a ``propertyName`` and a ``mapping`` of
 # author-chosen tags to ``$ref`` strings; a tag spelled like a bound is one of
 # those names, and its ``$ref`` value would read as a non-numeric bound and be
-# dropped, corrupting a valid discriminated union.
+# dropped, corrupting a valid discriminated union. OpenAPI ``x-`` specification
+# extensions carry arbitrary vendor objects the same way and are matched by
+# prefix in ``_is_opaque_key``.
 _OPAQUE_KEYWORDS: frozenset[str] = frozenset({"discriminator"})
+
+
+def _is_opaque_key(key: str) -> bool:
+    """True for a keyword whose value must be copied through untouched."""
+    return key in _OPAQUE_KEYWORDS or key.startswith("x-")
+
+
 # Each exclusive keyword, the inclusive twin it folds into, the picker that
 # keeps the tighter of the two when both are present, and the step to the
 # nearest integer the bound still admits.
@@ -241,7 +250,7 @@ def _to_inclusive_bounds(schema: Any, rewrite: _Rewrite | None = None) -> Any:
 
     result: dict[str, Any] = {}
     for key, value in schema.items():
-        if key in _INSTANCE_VALUES or key in _OPAQUE_KEYWORDS:
+        if key in _INSTANCE_VALUES or _is_opaque_key(key):
             # Copied, not aliased: the result is handed to Core and kept in
             # the search catalog, and neither may reach back into the MCP
             # result object this schema came from.

--- a/custom_components/ha_mcp_tools/llm_api.py
+++ b/custom_components/ha_mcp_tools/llm_api.py
@@ -986,7 +986,9 @@ async def async_register_llm_api(
             exc_info=True,
         )
         return
-    # The embedded e2e (test_llm_api_registered_inside_ha) asserts on this
+    # The embedded e2e (test_llm_api_registered_inside_ha) and the in-HA
+    # probe tests (tests/src/e2e/workflows/embedded/test_llm_api_in_ha.py)
+    # assert on this
     # message to prove the registration ran inside a real HA — keep the
     # "Registered the HA-MCP toolset as LLM API" prefix stable.
     _LOGGER.info(

--- a/docs/agents/github-workflow.md
+++ b/docs/agents/github-workflow.md
@@ -172,8 +172,8 @@ summary only when the pull request actually reaches that state.
 | `pr.yml` | Pull request | Fast checks and validation orchestration. |
 | `e2e-tests.yml` | Push to `master` touching code, or manual | Full container-backend E2E validation on the pinned stable Core image. |
 | `haos-e2e-tests.yml` | Pull request or manual | Six HAOS lanes against a baked qcow2; required status checks. |
-| `haos-e2e-beta-tests.yml` | Push to `master`, nightly, or manual | The inaddon and embedded HAOS lanes against the current beta Supervisor and Core. |
-| `e2e-beta-tests.yml` | Push to `master`, nightly, or manual | The container-backend E2E jobs against the current beta Core image. |
+| `haos-e2e-beta-tests.yml` | Push to `master`, nightly, or manual | The inaddon and embedded HAOS lanes against the current beta Supervisor and Core; skipped when beta equals stable. |
+| `e2e-beta-tests.yml` | Push to `master`, nightly, or manual | The container-backend E2E jobs against the current beta Core image; skipped when beta equals the stable lane's pin. |
 | `publish-dev.yml` | Push to `master` | Development `.devN` release. |
 | `notify-dev-channel.yml` | Push to `master` touching `src/` | Development-testing notices. |
 | `semver-release.yml` | Biweekly or manual | Stable version tag and GitHub release. |

--- a/docs/agents/github-workflow.md
+++ b/docs/agents/github-workflow.md
@@ -172,8 +172,8 @@ summary only when the pull request actually reaches that state.
 | `pr.yml` | Pull request | Fast checks and validation orchestration. |
 | `e2e-tests.yml` | Push to `master` touching code, or manual | Full container-backend E2E validation on the pinned stable Core image. |
 | `haos-e2e-tests.yml` | Pull request or manual | Six HAOS lanes against a baked qcow2; required status checks. |
-| `haos-e2e-beta-tests.yml` | Push to `master`, nightly, or manual | The inaddon and embedded HAOS lanes against the current beta Supervisor and Core; skipped when beta equals stable. |
-| `e2e-beta-tests.yml` | Push to `master`, nightly, or manual | The container-backend E2E jobs against the current beta Core image; skipped when beta equals the stable lane's pin. |
+| `haos-e2e-beta-tests.yml` | Push to `master`, nightly, or manual | The inaddon and embedded HAOS lanes against the current beta Supervisor and Core; skipped on push and nightly when beta equals stable. |
+| `e2e-beta-tests.yml` | Push to `master`, nightly, or manual | The container-backend E2E jobs against the current beta Core image; skipped on push and nightly when beta equals the stable lane's pin. |
 | `publish-dev.yml` | Push to `master` | Development `.devN` release. |
 | `notify-dev-channel.yml` | Push to `master` touching `src/` | Development-testing notices. |
 | `semver-release.yml` | Biweekly or manual | Stable version tag and GitHub release. |

--- a/docs/in-process-server.md
+++ b/docs/in-process-server.md
@@ -47,11 +47,13 @@ The bring-up runs in the background, so it never delays Home Assistant startup.
 
 ## Requirements
 
-The in-process server requires **Home Assistant 2026.6.0 or newer**. Older Core
-releases constrain dependencies to versions that cannot run current `ha-mcp`
-servers. On older releases, the component remains available for its File & YAML
-services entry with an external app or Docker server, but its config flow blocks
-creation of the incompatible in-process server entry.
+The component requires **Home Assistant 2026.8.0 or newer** (the floor HACS
+enforces). Older Core releases constrain dependencies to versions that cannot
+run current `ha-mcp` servers, and from component 2.1.3 the manifest declares
+`voluptuous-openapi`, which Core releases before 2026.7 pin to an older version,
+so the integration does not load there at all. On a Core between that and the
+floor, the config flow still blocks creation of the in-process server entry
+when the running version is older than the floor.
 
 ## Setup
 

--- a/docs/in-process-server.md
+++ b/docs/in-process-server.md
@@ -47,13 +47,21 @@ The bring-up runs in the background, so it never delays Home Assistant startup.
 
 ## Requirements
 
-The component requires **Home Assistant 2026.8.0 or newer** (the floor HACS
-enforces). Older Core releases constrain dependencies to versions that cannot
-run current `ha-mcp` servers, and from component 2.1.3 the manifest declares
-`voluptuous-openapi`, which Core releases before 2026.7 pin to an older version,
-so the integration does not load there at all. On a Core between that and the
-floor, the config flow still blocks creation of the in-process server entry
-when the running version is older than the floor.
+Three floors apply, from the outside in:
+
+- **HACS installs the component only on Home Assistant 2026.8.0 or newer**
+  (`hacs.json`), the floor the config flow also enforces for the in-process
+  server entry.
+- **The integration does not load at all before Core 2026.7.** From component
+  2.1.3 the manifest declares `voluptuous-openapi`, and earlier Core releases
+  pin that package to an older version, so the requirement cannot resolve and
+  Home Assistant refuses to set up the integration, File & YAML entry included.
+- **Between 2026.7 and 2026.8.0 a manual copy loads**, but the config flow
+  blocks creation of the in-process server entry; the File & YAML services
+  entry still works with an external app or Docker server.
+
+Older Core releases also constrain other dependencies to versions that cannot
+run current `ha-mcp` servers.
 
 ## Setup
 

--- a/tests/initial_test_state/configuration.yaml
+++ b/tests/initial_test_state/configuration.yaml
@@ -85,3 +85,11 @@ template:
         device_class: humidity
         state_class: measurement
         unit_of_measurement: "%"
+# e2e: default_config loads the logger integration at WARNING, so the
+# component's INFO lines never reach home-assistant.log or the console. The
+# in-HA LLM-API proof (tests/src/e2e/workflows/embedded/test_llm_api_in_ha.py)
+# asserts on the component's INFO registration line, on the container and
+# HAOS embedded lanes alike, so raise just this component's logger here.
+logger:
+  logs:
+    custom_components.ha_mcp_tools: info

--- a/tests/src/e2e/basic/test_backend_dispatch_smoke.py
+++ b/tests/src/e2e/basic/test_backend_dispatch_smoke.py
@@ -123,8 +123,13 @@ _SKIP_CEILING_PER_LANE = {
     # and observed slightly LOWER counts than their stable siblings
     # (haos_embedded beta 125, haos_inaddon beta 93), so the stable-lane numbers
     # here cover both.
-    "container": 88,  # was 79; +8 #2292 no_tools_only; +1 #2357 haos_embedded_only
-    "haos": 67,  # was 58; +8 #2292 no_tools_only; +1 #2357 haos_embedded_only
+    # #2361 adds tests/src/e2e/workflows/embedded/test_llm_api_in_ha.py: one
+    # ``embedded_only`` item and one ``haos_embedded_only`` item. Each lane
+    # gains a collection-time skip for every one of the two it does not run —
+    # two on every lane except embedded and haos_embedded (and their no-tools
+    # variants), which run one and skip the other.
+    "container": 90,  # was 88; +2 #2361 in-HA LLM-API probe
+    "haos": 69,  # was 67; +2 #2361 in-HA LLM-API probe
     # HAOS stdio is the external HAOS set plus ``external_only`` tests, whose
     # test-process monkeypatches cannot reach the subprocess server. The first
     # full lane run on 2026-08-18 observed 103 collection-time marker skips
@@ -136,8 +141,8 @@ _SKIP_CEILING_PER_LANE = {
     # This entry moved 117 -> 119 rather than by that 8: the 117 was a ceiling
     # carrying headroom above its own observed count, so part of the +8 landed
     # inside that headroom and 119 is what round-1 CI actually observed.
-    "haos_stdio": 120,  # +1 #2357 haos_embedded_only
-    "haos_inaddon": 95,  # was 86; +8 #2292 no_tools_only; +1 #2357 haos_embedded_only
+    "haos_stdio": 122,  # was 120; +2 #2361 in-HA LLM-API probe
+    "haos_inaddon": 97,  # was 95; +2 #2361 in-HA LLM-API probe
     # Embedded backend (#1527, E2E_BACKEND=embedded). Skips exactly the container
     # lane's marker-skips PLUS two embedded-specific additions:
     #   - haos_only + inaddon_only tests skip on embedded just like on container
@@ -153,7 +158,7 @@ _SKIP_CEILING_PER_LANE = {
     # +1 visibility e2e (haos_stdio_only) and +1 #2241 haos_tls scenario
     # (haos_only) bridge 133 -> 135.
     # Read future changes from CI instead of deriving them.
-    "embedded": 146,  # was 137; +8 #2292 no_tools_only; +1 #2357 haos_embedded_only
+    "embedded": 147,  # was 146; +1 #2361 (its haos_embedded_only half)
     # HAOS embedded backend (#1527, HAOS_TEST_MODE=embedded). A HAOS lane, so it
     # skips the SAME set as the external HAOS lane (container_only + inaddon_only)
     # PLUS two haos_embedded-specific additions:
@@ -171,7 +176,7 @@ _SKIP_CEILING_PER_LANE = {
     # 107 in the 2026-08-18 CI run (106 before the self-restart e2e).
     # Read future changes from CI instead of deriving them.
     # #2270 stable observed 118 marker skips; beta observed 117.
-    "haos_embedded": 126,  # was 118; +8 #2292 no_tools_only
+    "haos_embedded": 127,  # was 126; +1 #2361 (its embedded_only half)
     # No-tools topology keys (#2292). On the ``E2E_NO_TOOLS_ENTRY=1`` lanes the
     # lookup key gains a ``_no_tools`` suffix, because those lanes skip a
     # completely different — and much larger — set: every ``requires_tools_entry``
@@ -182,10 +187,10 @@ _SKIP_CEILING_PER_LANE = {
     # The haos (external) and haos_stdio backends have no no-tools lane today,
     # so they deliberately have no key here — an unknown backend fails loudly in
     # the test below rather than silently skipping the ceiling check.
-    "container_no_tools": 193,  # observed 187; +1 #2357 haos_embedded_only
-    "embedded_no_tools": 250,  # observed 244; +1 #2357 haos_embedded_only
-    "haos_embedded_no_tools": 230,  # observed 225
-    "haos_inaddon_no_tools": 199,  # observed 193; +1 #2357 haos_embedded_only
+    "container_no_tools": 195,  # was 193; +2 #2361 in-HA LLM-API probe
+    "embedded_no_tools": 251,  # was 250; +1 #2361 (its haos_embedded_only half)
+    "haos_embedded_no_tools": 231,  # was 230; +1 #2361 (its embedded_only half)
+    "haos_inaddon_no_tools": 201,  # was 199; +2 #2361 in-HA LLM-API probe
 }
 
 

--- a/tests/src/e2e/basic/test_backend_dispatch_smoke.py
+++ b/tests/src/e2e/basic/test_backend_dispatch_smoke.py
@@ -128,8 +128,8 @@ _SKIP_CEILING_PER_LANE = {
     # gains a collection-time skip for every one of the two it does not run —
     # two on every lane except embedded and haos_embedded (and their no-tools
     # variants), which run one and skip the other.
-    "container": 90,  # was 88; +2 #2361 in-HA LLM-API probe
-    "haos": 69,  # was 67; +2 #2361 in-HA LLM-API probe
+    "container": 90,  # was 79; +8 #2292 no_tools_only; +1 #2357 haos_embedded_only; +2 #2361 in-HA LLM-API probe
+    "haos": 69,  # was 58; +8 #2292 no_tools_only; +1 #2357 haos_embedded_only; +2 #2361 in-HA LLM-API probe
     # HAOS stdio is the external HAOS set plus ``external_only`` tests, whose
     # test-process monkeypatches cannot reach the subprocess server. The first
     # full lane run on 2026-08-18 observed 103 collection-time marker skips
@@ -141,8 +141,8 @@ _SKIP_CEILING_PER_LANE = {
     # This entry moved 117 -> 119 rather than by that 8: the 117 was a ceiling
     # carrying headroom above its own observed count, so part of the +8 landed
     # inside that headroom and 119 is what round-1 CI actually observed.
-    "haos_stdio": 122,  # was 120; +2 #2361 in-HA LLM-API probe
-    "haos_inaddon": 97,  # was 95; +2 #2361 in-HA LLM-API probe
+    "haos_stdio": 122,  # +1 #2357 haos_embedded_only; +2 #2361 in-HA LLM-API probe
+    "haos_inaddon": 97,  # was 86; +8 #2292 no_tools_only; +1 #2357 haos_embedded_only; +2 #2361 in-HA LLM-API probe
     # Embedded backend (#1527, E2E_BACKEND=embedded). Skips exactly the container
     # lane's marker-skips PLUS two embedded-specific additions:
     #   - haos_only + inaddon_only tests skip on embedded just like on container
@@ -158,7 +158,7 @@ _SKIP_CEILING_PER_LANE = {
     # +1 visibility e2e (haos_stdio_only) and +1 #2241 haos_tls scenario
     # (haos_only) bridge 133 -> 135.
     # Read future changes from CI instead of deriving them.
-    "embedded": 147,  # was 146; +1 #2361 (its haos_embedded_only half)
+    "embedded": 147,  # was 137; +8 #2292 no_tools_only; +1 #2357 haos_embedded_only; +1 #2361 (its haos_embedded_only half)
     # HAOS embedded backend (#1527, HAOS_TEST_MODE=embedded). A HAOS lane, so it
     # skips the SAME set as the external HAOS lane (container_only + inaddon_only)
     # PLUS two haos_embedded-specific additions:
@@ -176,7 +176,7 @@ _SKIP_CEILING_PER_LANE = {
     # 107 in the 2026-08-18 CI run (106 before the self-restart e2e).
     # Read future changes from CI instead of deriving them.
     # #2270 stable observed 118 marker skips; beta observed 117.
-    "haos_embedded": 127,  # was 126; +1 #2361 (its embedded_only half)
+    "haos_embedded": 127,  # was 118; +8 #2292 no_tools_only; +1 #2361 (its embedded_only half)
     # No-tools topology keys (#2292). On the ``E2E_NO_TOOLS_ENTRY=1`` lanes the
     # lookup key gains a ``_no_tools`` suffix, because those lanes skip a
     # completely different — and much larger — set: every ``requires_tools_entry``
@@ -187,10 +187,10 @@ _SKIP_CEILING_PER_LANE = {
     # The haos (external) and haos_stdio backends have no no-tools lane today,
     # so they deliberately have no key here — an unknown backend fails loudly in
     # the test below rather than silently skipping the ceiling check.
-    "container_no_tools": 195,  # was 193; +2 #2361 in-HA LLM-API probe
-    "embedded_no_tools": 251,  # was 250; +1 #2361 (its haos_embedded_only half)
-    "haos_embedded_no_tools": 231,  # was 230; +1 #2361 (its embedded_only half)
-    "haos_inaddon_no_tools": 201,  # was 199; +2 #2361 in-HA LLM-API probe
+    "container_no_tools": 195,  # observed 187; +1 #2357 haos_embedded_only; +2 #2361 in-HA LLM-API probe
+    "embedded_no_tools": 251,  # observed 244; +1 #2357 haos_embedded_only; +1 #2361 (its haos_embedded_only half)
+    "haos_embedded_no_tools": 231,  # observed 225; +1 #2361 (its embedded_only half)
+    "haos_inaddon_no_tools": 201,  # observed 193; +1 #2357 haos_embedded_only; +2 #2361 in-HA LLM-API probe
 }
 
 

--- a/tests/src/e2e/haos_only/test_zz_reentrant_log_deadlock.py
+++ b/tests/src/e2e/haos_only/test_zz_reentrant_log_deadlock.py
@@ -123,14 +123,40 @@ PROBE_MANIFEST = """\
 }
 """
 
-PROBE_YAML = """
+PROBE_COMPONENT_YAML = """
 # --- ha-mcp #2357 probe (removed by the test) ---
 reentrant_log_probe:
-logger:
-  logs:
-    custom_components.reentrant_log_probe: debug
 # --- end ha-mcp #2357 probe ---
 """
+PROBE_LOGGER_ENTRY = (
+    "    custom_components.reentrant_log_probe: debug  # ha-mcp #2357 probe\n"
+)
+
+
+def _with_probe_config(existing: str) -> str:
+    """Return ``existing`` with the probe's component key and debug logger.
+
+    The seeded configuration.yaml already carries a ``logger:`` block (it
+    raises the ha_mcp_tools component to INFO for test_llm_api_in_ha.py), and
+    a second top-level ``logger:`` would be a duplicate YAML key, so the
+    probe's entry is merged under that block's ``logs:`` mapping. A seed
+    without the block gets a whole one appended.
+    """
+    lines = existing.splitlines(keepends=True)
+    for index, line in enumerate(lines):
+        if not line.startswith("logger:"):
+            continue
+        for inner in range(index + 1, len(lines)):
+            if lines[inner].startswith("  logs:"):
+                lines.insert(inner + 1, PROBE_LOGGER_ENTRY)
+                return "".join(lines) + PROBE_COMPONENT_YAML
+            if lines[inner].strip() and not lines[inner].startswith((" ", "#")):
+                break
+        raise AssertionError(
+            "the seeded `logger:` block has no `logs:` mapping to merge the "
+            "probe's debug entry into"
+        )
+    return existing + PROBE_COMPONENT_YAML + "logger:\n  logs:\n" + PROBE_LOGGER_ENTRY
 
 
 def _sh(script: str, *, timeout: float = 60.0) -> str:
@@ -265,19 +291,14 @@ def test_reentrant_debug_log_does_not_freeze_home_assistant(
     config_yaml = f"{config_dir}/configuration.yaml"
     backup_yaml = f"{config_dir}/configuration.yaml.2357.bak"
 
-    existing = _sh(f"grep -c '^logger:' {shlex.quote(config_yaml)} || true").strip()
-    assert existing in ("", "0"), (
-        "the seeded configuration.yaml already declares `logger:` — appending a "
-        "second block would be a duplicate YAML key. Merge the probe's logger "
-        "entry into the existing block instead."
-    )
-
     body_failed = False
     try:
         _sh(f"cp {shlex.quote(config_yaml)} {shlex.quote(backup_yaml)}")
         _write_in_vm(f"{probe_dir}/__init__.py", PROBE_INIT_PY)
         _write_in_vm(f"{probe_dir}/manifest.json", PROBE_MANIFEST)
-        _write_in_vm(config_yaml, _sh(f"cat {shlex.quote(backup_yaml)}") + PROBE_YAML)
+        _write_in_vm(
+            config_yaml, _with_probe_config(_sh(f"cat {shlex.quote(backup_yaml)}"))
+        )
 
         logger.info("Restarting Core with the re-entrant log probe installed")
         assert _restart_core(), "could not restart Core to load the probe"

--- a/tests/src/e2e/haos_only/test_zz_reentrant_log_deadlock.py
+++ b/tests/src/e2e/haos_only/test_zz_reentrant_log_deadlock.py
@@ -30,6 +30,8 @@ from posixpath import dirname
 import pytest
 from haos_runtime import _wait_http_ok, ssh_exec
 
+from ..utilities.logger_seed import with_probe_logger_config
+
 logger = logging.getLogger(__name__)
 
 # ``haos_embedded_only``: ha_mcp's log handler only shares a process (and an
@@ -131,32 +133,6 @@ reentrant_log_probe:
 PROBE_LOGGER_ENTRY = (
     "    custom_components.reentrant_log_probe: debug  # ha-mcp #2357 probe\n"
 )
-
-
-def _with_probe_config(existing: str) -> str:
-    """Return ``existing`` with the probe's component key and debug logger.
-
-    The seeded configuration.yaml already carries a ``logger:`` block (it
-    raises the ha_mcp_tools component to INFO for test_llm_api_in_ha.py), and
-    a second top-level ``logger:`` would be a duplicate YAML key, so the
-    probe's entry is merged under that block's ``logs:`` mapping. A seed
-    without the block gets a whole one appended.
-    """
-    lines = existing.splitlines(keepends=True)
-    for index, line in enumerate(lines):
-        if not line.startswith("logger:"):
-            continue
-        for inner in range(index + 1, len(lines)):
-            if lines[inner].startswith("  logs:"):
-                lines.insert(inner + 1, PROBE_LOGGER_ENTRY)
-                return "".join(lines) + PROBE_COMPONENT_YAML
-            if lines[inner].strip() and not lines[inner].startswith((" ", "#")):
-                break
-        raise AssertionError(
-            "the seeded `logger:` block has no `logs:` mapping to merge the "
-            "probe's debug entry into"
-        )
-    return existing + PROBE_COMPONENT_YAML + "logger:\n  logs:\n" + PROBE_LOGGER_ENTRY
 
 
 def _sh(script: str, *, timeout: float = 60.0) -> str:
@@ -297,7 +273,12 @@ def test_reentrant_debug_log_does_not_freeze_home_assistant(
         _write_in_vm(f"{probe_dir}/__init__.py", PROBE_INIT_PY)
         _write_in_vm(f"{probe_dir}/manifest.json", PROBE_MANIFEST)
         _write_in_vm(
-            config_yaml, _with_probe_config(_sh(f"cat {shlex.quote(backup_yaml)}"))
+            config_yaml,
+            with_probe_logger_config(
+                _sh(f"cat {shlex.quote(backup_yaml)}"),
+                PROBE_COMPONENT_YAML,
+                PROBE_LOGGER_ENTRY,
+            ),
         )
 
         logger.info("Restarting Core with the re-entrant log probe installed")

--- a/tests/src/e2e/utilities/llm_api_probe.py
+++ b/tests/src/e2e/utilities/llm_api_probe.py
@@ -34,6 +34,7 @@ LLM_API_SCHEMA_PROBE = f"""
 import asyncio
 import json
 import os
+import signal
 import sys
 
 sys.path.insert(0, "/config")
@@ -45,6 +46,9 @@ URL_ENV = "{PROBE_URL_ENV}"
 # The list/convert budget for the whole catalog; the caller's own exec timeout
 # sits above it so a hang reports here rather than as an opaque kill.
 TIMEOUT_S = 120
+
+# Filled by _run; module-level so the timeout backstop can still print it.
+REPORT = {{}}
 
 
 def _walk(node):
@@ -101,7 +105,9 @@ async def _run():
     # measure. It reads nothing from self, so the class attribute is called
     # directly. None means the component would have skipped the tool.
     convert_parameters = llm_api.HaMcpLlmApi._convert_parameters
-    report = {{
+    report = REPORT
+    report.update({{
+        "timed_out": False,
         "tool_count": 0,
         "converter": getattr(converter, "__module__", "") or repr(converter),
         "probatio": False,
@@ -111,7 +117,7 @@ async def _run():
         "integer_lost": [],
         "draft2020_invalid": [],
         "ha_version": "unknown",
-    }}
+    }})
 
     try:
         from homeassistant.const import __version__ as ha_version
@@ -161,8 +167,15 @@ def _convert_all(tools, convert_parameters, probatio, Draft202012Validator, repo
             continue
         try:
             # Exactly what homeassistant/components/anthropic/entity.py's
-            # _format_tool hands the model (default OpenAPI 3.0 dialect).
+            # _format_tool hands the model: to_openapi in its default OpenAPI
+            # 3.0 dialect, then the ROOT-level combinators dropped. Nested
+            # ones stay, which is where the reported bound lived.
             emitted = probatio.to_openapi(params)
+            emitted = {{
+                key: value
+                for key, value in emitted.items()
+                if key not in ("oneOf", "anyOf", "allOf")
+            }}
         except Exception as err:  # collecting, not suppressing
             report["conversion_failures"].append(
                 tool.name + ": to_openapi: " + _short(err)
@@ -179,7 +192,27 @@ def _convert_all(tools, convert_parameters, probatio, Draft202012Validator, repo
                 report["draft2020_invalid"].append(tool.name + ": " + _short(err))
 
 
-asyncio.run(_run())
+def _on_alarm(signum, frame):
+    # asyncio.timeout can only cancel at an await; a converter that blocks
+    # never reaches one. SIGALRM interrupts the main thread regardless, so
+    # the probe still reports what it had instead of hanging until the exec
+    # wrapper kills it with no output.
+    raise TimeoutError("probe exceeded " + str(TIMEOUT_S) + "s")
+
+
+signal.signal(signal.SIGALRM, _on_alarm)
+signal.alarm(TIMEOUT_S + 5)
+try:
+    asyncio.run(_run())
+except TimeoutError as err:
+    REPORT["timed_out"] = True
+    REPORT["conversion_failures"] = list(REPORT.get("conversion_failures", [])) + [
+        "probe: " + str(err)
+    ]
+    print(SENTINEL + " " + json.dumps(REPORT))
+    sys.exit(3)
+finally:
+    signal.alarm(0)
 """
 
 

--- a/tests/src/e2e/utilities/llm_api_probe.py
+++ b/tests/src/e2e/utilities/llm_api_probe.py
@@ -95,6 +95,12 @@ async def _run():
 
     converter = llm_api._schema_converter()
     normaliser = getattr(llm_api, "_to_inclusive_bounds", None)
+    # The production path, not a re-implementation of it: whatever
+    # HaMcpLlmApi._convert_parameters does to a tool's schema before Core sees
+    # it (normalisation included, once #2363 lands) is what this probe must
+    # measure. It reads nothing from self, so the class attribute is called
+    # directly. None means the component would have skipped the tool.
+    convert_parameters = llm_api.HaMcpLlmApi._convert_parameters
     report = {{
         "tool_count": 0,
         "converter": getattr(converter, "__module__", "") or repr(converter),
@@ -129,15 +135,27 @@ async def _run():
     async with asyncio.timeout(TIMEOUT_S):
         async with llm_api._mcp_session(url) as (session, _init):
             tools = (await session.list_tools()).tools
+        _convert_all(tools, convert_parameters, probatio, Draft202012Validator, report)
 
+    print(SENTINEL + " " + json.dumps(report))
+
+
+def _convert_all(tools, convert_parameters, probatio, Draft202012Validator, report):
+    # Inside the caller's timeout on purpose: the conversion loop is the
+    # operation under test, so a converter that hangs on one schema must
+    # surface as the probe's own timeout, not as an opaque exec kill.
     report["tool_count"] = len(tools)
     for tool in tools:
         schema = tool.inputSchema
         try:
-            normalised = normaliser(schema) if normaliser else schema
-            params = llm_api.convert_to_voluptuous(normalised)
+            params = convert_parameters(None, tool)
         except Exception as err:  # collecting, not suppressing
             report["conversion_failures"].append(tool.name + ": " + _short(err))
+            continue
+        if params is None:
+            report["conversion_failures"].append(
+                tool.name + ": _convert_parameters returned None (tool skipped)"
+            )
             continue
         if probatio is None:
             continue
@@ -159,8 +177,6 @@ async def _run():
                 Draft202012Validator.check_schema(emitted)
             except Exception as err:  # collecting, not suppressing
                 report["draft2020_invalid"].append(tool.name + ": " + _short(err))
-
-    print(SENTINEL + " " + json.dumps(report))
 
 
 asyncio.run(_run())

--- a/tests/src/e2e/utilities/llm_api_probe.py
+++ b/tests/src/e2e/utilities/llm_api_probe.py
@@ -1,0 +1,197 @@
+"""In-HA probe for the component's LLM-API schema conversion (issue #2361).
+
+The LLM-API E2E in ``tests/src/e2e/workflows/embedded/test_embedded_server.py``
+drives the transport from the TEST HOST, so its schema conversion runs the
+host's ``voluptuous_openapi`` — not the converter Home Assistant actually
+resolves inside the container/VM. Core 2026.9 replaced that library with
+``probatio`` and re-emits every converted schema through
+``probatio.to_openapi`` before handing it to a conversation agent, which is
+where the defect this probe exists to catch lives: a ``gt=`` bound turned into
+the draft-4 ``{"minimum": 0, "exclusiveMinimum": true}`` shape and broke every
+Anthropic turn.
+
+``LLM_API_SCHEMA_PROBE`` is Python source executed by Home Assistant's OWN
+interpreter (``python3`` inside the HA container), so it exercises the exact
+component module, the exact converter Core installed, and the exact re-emission
+the conversation integrations perform. It prints one sentinel-prefixed JSON
+line; :func:`parse_probe_report` turns that back into a dict for the tests,
+which own the pass/fail decision.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+#: Prefix of the single report line the probe prints on stdout.
+PROBE_SENTINEL = "LLM_API_PROBE_REPORT"
+
+#: Env var carrying the webhook URL into the probe process. ``sys.argv[1]``
+#: takes precedence so the source can also be run by hand.
+PROBE_URL_ENV = "HAMCP_PROBE_WEBHOOK_URL"
+
+LLM_API_SCHEMA_PROBE = f"""
+import asyncio
+import json
+import os
+import sys
+
+sys.path.insert(0, "/config")
+
+from custom_components.ha_mcp_tools import llm_api
+
+SENTINEL = "{PROBE_SENTINEL}"
+URL_ENV = "{PROBE_URL_ENV}"
+# The list/convert budget for the whole catalog; the caller's own exec timeout
+# sits above it so a hang reports here rather than as an opaque kill.
+TIMEOUT_S = 120
+
+
+def _walk(node):
+    # Every mapping anywhere in a JSON-schema-shaped structure.
+    if isinstance(node, dict):
+        yield node
+        for value in node.values():
+            yield from _walk(value)
+    elif isinstance(node, list):
+        for item in node:
+            yield from _walk(item)
+
+
+def _is_integer_node(node):
+    declared = node.get("type")
+    if isinstance(declared, str):
+        return declared == "integer"
+    if isinstance(declared, list):
+        return "integer" in declared
+    return False
+
+
+def _count_integer_nodes(node):
+    return sum(1 for sub in _walk(node) if _is_integer_node(sub))
+
+
+def _boolean_exclusive_bounds(node):
+    # Draft-4 spelling: the 2020-12 keywords carry a NUMBER, never a bool.
+    for sub in _walk(node):
+        for keyword in ("exclusiveMinimum", "exclusiveMaximum"):
+            if isinstance(sub.get(keyword), bool):
+                return True
+    return False
+
+
+def _short(err):
+    text = str(err).strip().splitlines()
+    head = text[0] if text else ""
+    return "{{}}: {{}}".format(type(err).__name__, head[:200])
+
+
+async def _run():
+    url = sys.argv[1] if len(sys.argv) > 1 else os.environ.get(URL_ENV)
+    if not url:
+        raise SystemExit(
+            "no webhook URL: pass it as the first argument or set " + URL_ENV
+        )
+
+    converter = llm_api._schema_converter()
+    normaliser = getattr(llm_api, "_to_inclusive_bounds", None)
+    report = {{
+        "tool_count": 0,
+        "converter": getattr(converter, "__module__", "") or repr(converter),
+        "probatio": False,
+        "inclusive_bounds_normaliser": normaliser is not None,
+        "conversion_failures": [],
+        "boolean_exclusive": [],
+        "integer_lost": [],
+        "draft2020_invalid": [],
+        "ha_version": "unknown",
+    }}
+
+    try:
+        from homeassistant.const import __version__ as ha_version
+    except ImportError:
+        pass
+    else:
+        report["ha_version"] = ha_version
+
+    try:
+        import probatio
+    except ImportError:
+        # Core <= 2026.8 still ships voluptuous_openapi and never re-emits.
+        probatio = None
+    report["probatio"] = probatio is not None
+
+    try:
+        from jsonschema import Draft202012Validator
+    except ImportError:
+        Draft202012Validator = None
+
+    async with asyncio.timeout(TIMEOUT_S):
+        async with llm_api._mcp_session(url) as (session, _init):
+            tools = (await session.list_tools()).tools
+
+    report["tool_count"] = len(tools)
+    for tool in tools:
+        schema = tool.inputSchema
+        try:
+            normalised = normaliser(schema) if normaliser else schema
+            params = llm_api.convert_to_voluptuous(normalised)
+        except Exception as err:  # collecting, not suppressing
+            report["conversion_failures"].append(tool.name + ": " + _short(err))
+            continue
+        if probatio is None:
+            continue
+        try:
+            # Exactly what homeassistant/components/anthropic/entity.py's
+            # _format_tool hands the model (default OpenAPI 3.0 dialect).
+            emitted = probatio.to_openapi(params)
+        except Exception as err:  # collecting, not suppressing
+            report["conversion_failures"].append(
+                tool.name + ": to_openapi: " + _short(err)
+            )
+            continue
+        if _boolean_exclusive_bounds(emitted):
+            report["boolean_exclusive"].append(tool.name)
+        if _count_integer_nodes(emitted) < _count_integer_nodes(schema):
+            report["integer_lost"].append(tool.name)
+        if Draft202012Validator is not None:
+            try:
+                Draft202012Validator.check_schema(emitted)
+            except Exception as err:  # collecting, not suppressing
+                report["draft2020_invalid"].append(tool.name + ": " + _short(err))
+
+    print(SENTINEL + " " + json.dumps(report))
+
+
+asyncio.run(_run())
+"""
+
+
+def parse_probe_report(stdout: str) -> dict[str, Any]:
+    """Return the probe's report dict from its captured stdout.
+
+    Raises ``AssertionError`` with the raw output when the sentinel line is
+    absent or unparseable — that means the probe died before printing, and the
+    output is the only diagnosis available.
+    """
+    for line in stdout.splitlines():
+        if not line.startswith(PROBE_SENTINEL):
+            continue
+        payload = line[len(PROBE_SENTINEL) :].strip()
+        try:
+            report = json.loads(payload)
+        except json.JSONDecodeError as err:
+            raise AssertionError(
+                f"the in-HA LLM-API probe printed an unparseable report ({err}): "
+                f"{payload[:500]}"
+            ) from err
+        if not isinstance(report, dict):
+            raise AssertionError(
+                f"the in-HA LLM-API probe printed a {type(report).__name__}, "
+                f"not a report object: {payload[:500]}"
+            )
+        return report
+    raise AssertionError(
+        "the in-HA LLM-API probe printed no "
+        f"{PROBE_SENTINEL} line; full output:\n{stdout[-4000:]}"
+    )

--- a/tests/src/e2e/utilities/llm_api_probe.py
+++ b/tests/src/e2e/utilities/llm_api_probe.py
@@ -144,7 +144,6 @@ async def _run():
         "probatio_import_error": None,
         "draft2020_checked": False,
         "jsonschema_import_error": None,
-        "inclusive_bounds_normaliser": hasattr(llm_api, "_to_inclusive_bounds"),
         "normalise_schema": normalise_schema is not None,
         "conversion_failures": [],
         "boolean_exclusive": [],

--- a/tests/src/e2e/utilities/llm_api_probe.py
+++ b/tests/src/e2e/utilities/llm_api_probe.py
@@ -1,21 +1,22 @@
 """In-HA probe for the component's LLM-API schema conversion (issue #2361).
 
 The LLM-API E2E in ``tests/src/e2e/workflows/embedded/test_embedded_server.py``
-drives the transport from the TEST HOST, so its schema conversion runs the
-host's ``voluptuous_openapi`` — not the converter Home Assistant actually
-resolves inside the container/VM. Core 2026.9 replaced that library with
-``probatio`` and re-emits every converted schema through
-``probatio.to_openapi`` before handing it to a conversation agent, which is
-where the defect this probe exists to catch lives: a ``gt=`` bound turned into
-the draft-4 ``{"minimum": 0, "exclusiveMinimum": true}`` shape and broke every
-Anthropic turn.
+used to convert every tool schema in the pytest process against the test host's
+``voluptuous_openapi``. That proved nothing about Home Assistant: since Core
+2026.9 the converter HA resolves is ``probatio``, and before a conversation
+turn reaches the model Core re-emits every converted schema through
+``probatio.to_openapi``. That round trip is invisible from the host and is where
+the reported defect lived: a ``gt=`` bound came back in the draft-4
+``{"minimum": 0, "exclusiveMinimum": true}`` spelling and broke every Anthropic
+turn. The host-side loop was removed; this probe replaces it.
 
 ``LLM_API_SCHEMA_PROBE`` is Python source executed by Home Assistant's OWN
 interpreter (``python3`` inside the HA container), so it exercises the exact
 component module, the exact converter Core installed, and the exact re-emission
 the conversation integrations perform. It prints one sentinel-prefixed JSON
-line; :func:`parse_probe_report` turns that back into a dict for the tests,
-which own the pass/fail decision.
+line; :func:`parse_probe_report` turns that back into a dict and
+:func:`assert_report_clean` owns the pass/fail decision, so both halves are
+unit-testable without a lane.
 """
 
 from __future__ import annotations
@@ -30,32 +31,32 @@ PROBE_SENTINEL = "LLM_API_PROBE_REPORT"
 #: takes precedence so the source can also be run by hand.
 PROBE_URL_ENV = "HAMCP_PROBE_WEBHOOK_URL"
 
-LLM_API_SCHEMA_PROBE = f"""
-import asyncio
-import json
-import os
-import signal
-import sys
+#: Exit status the probe uses when it printed a partial report after a timeout.
+PROBE_TIMEOUT_EXIT = 3
 
-sys.path.insert(0, "/config")
+#: Minimum tool inventory the probe must see; the catalog has 88 tools and the
+#: no-tools lanes still expose well above this.
+MIN_TOOL_COUNT = 60
 
-from custom_components.ha_mcp_tools import llm_api
+#: Pure helpers the probe runs on schemas. Kept as a separate source string so
+#: the unit tier can ``exec`` them without the runner's imports and side effects.
+PROBE_HELPERS_SOURCE = """
+import traceback
 
-SENTINEL = "{PROBE_SENTINEL}"
-URL_ENV = "{PROBE_URL_ENV}"
-# The list/convert budget for the whole catalog; the caller's own exec timeout
-# sits above it so a hang reports here rather than as an opaque kill.
-TIMEOUT_S = 120
-
-# Filled by _run; module-level so the timeout backstop can still print it.
-REPORT = {{}}
+# Mirrors the component: the values under these keys are instance data or
+# vendor extensions that llm_api._INSTANCE_VALUES / llm_api._is_opaque_key copy
+# through untouched, so a bound-like key inside them is not a bound and an
+# integer type inside them is not a parameter type.
+_OPAQUE_VALUE_KEYS = ("default", "const", "enum", "examples", "example")
 
 
 def _walk(node):
-    # Every mapping anywhere in a JSON-schema-shaped structure.
+    # Every SUBSCHEMA mapping anywhere in a JSON-schema-shaped structure.
     if isinstance(node, dict):
         yield node
-        for value in node.values():
+        for key, value in node.items():
+            if key in _OPAQUE_VALUE_KEYS or key.startswith("x-"):
+                continue
             yield from _walk(value)
     elif isinstance(node, list):
         for item in node:
@@ -85,9 +86,38 @@ def _boolean_exclusive_bounds(node):
 
 
 def _short(err):
+    # One line: type, first message line, and the innermost frame, which is
+    # the only location a remote interpreter can hand back.
     text = str(err).strip().splitlines()
     head = text[0] if text else ""
-    return "{{}}: {{}}".format(type(err).__name__, head[:200])
+    frames = traceback.extract_tb(err.__traceback__) if err.__traceback__ else []
+    where = ""
+    if frames:
+        last = frames[-1]
+        where = " at {}:{} in {}".format(last.filename, last.lineno, last.name)
+    return "{}: {}{}".format(type(err).__name__, head[:200], where)
+"""
+
+_PROBE_RUNNER_SOURCE = f"""
+import asyncio
+import json
+import os
+import signal
+import sys
+
+sys.path.insert(0, "/config")
+
+from custom_components.ha_mcp_tools import llm_api
+
+SENTINEL = "{PROBE_SENTINEL}"
+URL_ENV = "{PROBE_URL_ENV}"
+TIMEOUT_EXIT = {PROBE_TIMEOUT_EXIT}
+# The list/convert budget for the whole catalog; both callers pass an exec
+# timeout above it so a hang reports here rather than as an opaque kill.
+TIMEOUT_S = 120
+
+# Filled by _run; module-level so the timeout backstop can still print it.
+REPORT = {{}}
 
 
 async def _run():
@@ -98,16 +128,12 @@ async def _run():
         )
 
     converter = llm_api._schema_converter()
-    normaliser = getattr(llm_api, "_to_inclusive_bounds", None)
-    # The production path, not a re-implementation of it: whatever
-    # HaMcpLlmApi._convert_parameters does to a tool's schema before Core sees
-    # it (normalisation included, once #2363 lands) is what this probe must
-    # measure. It reads nothing from self, so the class attribute is called
-    # directly. None means the component would have skipped the tool.
+    # The production path, not a re-implementation of it: the mirror paths
+    # normalise once per tool (_normalise_schema) and hand the result to
+    # HaMcpLlmApi._convert_parameters(self, tool, schema). That method reads
+    # nothing from self, so the class attribute is called directly. None
+    # means the component would have skipped the tool.
     convert_parameters = llm_api.HaMcpLlmApi._convert_parameters
-    # Since #2363 the mirror paths normalise once per tool and hand the
-    # result to _convert_parameters(self, tool, schema); before that the
-    # method took only the tool. Follow whichever shape this build has.
     normalise_schema = getattr(llm_api, "_normalise_schema", None)
     report = REPORT
     report.update({{
@@ -115,32 +141,50 @@ async def _run():
         "tool_count": 0,
         "converter": getattr(converter, "__module__", "") or repr(converter),
         "probatio": False,
-        "inclusive_bounds_normaliser": normaliser is not None,
+        "probatio_import_error": None,
+        "draft2020_checked": False,
+        "jsonschema_import_error": None,
+        "inclusive_bounds_normaliser": hasattr(llm_api, "_to_inclusive_bounds"),
+        "normalise_schema": normalise_schema is not None,
         "conversion_failures": [],
         "boolean_exclusive": [],
         "integer_lost": [],
         "draft2020_invalid": [],
         "ha_version": "unknown",
+        "ha_version_error": None,
     }})
 
     try:
         from homeassistant.const import __version__ as ha_version
-    except ImportError:
-        pass
+    except ImportError as err:
+        report["ha_version_error"] = _short(err)
     else:
         report["ha_version"] = ha_version
 
     try:
         import probatio
-    except ImportError:
-        # Core <= 2026.8 still ships voluptuous_openapi and never re-emits.
+    except ImportError as err:
+        # probatio is not importable, so no re-emission step exists in this
+        # interpreter. Whether that is legitimate is the caller's call, from
+        # ha_version: Core ships probatio from 2026.9.
         probatio = None
+        report["probatio_import_error"] = _short(err)
     report["probatio"] = probatio is not None
 
     try:
         from jsonschema import Draft202012Validator
-    except ImportError:
+    except ImportError as err:
         Draft202012Validator = None
+        report["jsonschema_import_error"] = _short(err)
+    report["draft2020_checked"] = Draft202012Validator is not None
+
+    if normalise_schema is None:
+        report["conversion_failures"].append(
+            "probe: the component under test has no _normalise_schema; the "
+            "probe cannot measure the production path"
+        )
+        print(SENTINEL + " " + json.dumps(report))
+        return
 
     async with asyncio.timeout(TIMEOUT_S):
         async with llm_api._mcp_session(url) as (session, _init):
@@ -167,12 +211,7 @@ def _convert_all(
     for tool in tools:
         schema = tool.inputSchema
         try:
-            if normalise_schema is not None:
-                params = convert_parameters(
-                    None, tool, normalise_schema(schema, tool.name)
-                )
-            else:
-                params = convert_parameters(None, tool)
+            params = convert_parameters(None, tool, normalise_schema(schema, tool.name))
         except Exception as err:  # collecting, not suppressing
             report["conversion_failures"].append(tool.name + ": " + _short(err))
             continue
@@ -231,16 +270,22 @@ signal.signal(signal.SIGALRM, _on_alarm)
 signal.alarm(TIMEOUT_S + 5)
 try:
     asyncio.run(_run())
-except _ProbeTimeout as err:
+except (TimeoutError, _ProbeTimeout) as err:
+    # TimeoutError is the asyncio budget firing at an await (a stalled
+    # list_tools); _ProbeTimeout is the alarm firing in blocking code. Both
+    # print the partial report so the stage that stalled is on record.
     REPORT["timed_out"] = True
     REPORT["conversion_failures"] = list(REPORT.get("conversion_failures", [])) + [
-        "probe: " + str(err)
+        "probe: " + (str(err) or type(err).__name__)
     ]
     print(SENTINEL + " " + json.dumps(REPORT))
-    sys.exit(3)
+    sys.exit(TIMEOUT_EXIT)
 finally:
     signal.alarm(0)
 """
+
+#: The complete probe: helpers first, then the runner that uses them.
+LLM_API_SCHEMA_PROBE = PROBE_HELPERS_SOURCE + _PROBE_RUNNER_SOURCE
 
 
 def parse_probe_report(stdout: str) -> dict[str, Any]:
@@ -270,4 +315,94 @@ def parse_probe_report(stdout: str) -> dict[str, Any]:
     raise AssertionError(
         "the in-HA LLM-API probe printed no "
         f"{PROBE_SENTINEL} line; full output:\n{stdout[-4000:]}"
+    )
+
+
+def _year_month(version: str) -> tuple[int, int] | None:
+    """``(2026, 9)`` for ``"2026.9.0"``; None when the prefix is not numeric."""
+    parts = version.split(".")
+    if len(parts) < 2 or not (parts[0].isdigit() and parts[1].isdigit()):
+        return None
+    return int(parts[0]), int(parts[1])
+
+
+def assert_report_clean(report: dict[str, Any]) -> None:
+    """Fail with the offending tool names when the in-HA conversion misbehaved.
+
+    Pure: takes the parsed report, raises ``AssertionError``. The order is the
+    order a maintainer wants the diagnosis in: a timed-out or mis-run probe
+    first, then the inventory, then the conversion, then the re-emission.
+    """
+    converter = report.get("converter")
+    ha_version = str(report.get("ha_version", "unknown"))
+    context = (
+        f"converter={converter!r}, probatio={report.get('probatio')!r}, "
+        f"normalise_schema={report.get('normalise_schema')!r}, "
+        f"HA {ha_version}"
+    )
+
+    assert not report.get("timed_out"), (
+        f"the in-HA probe hit its own timeout ({context}); partial report: {report}"
+    )
+
+    assert ha_version != "unknown", (
+        "the probe could not read Home Assistant's version "
+        f"({report.get('ha_version_error')!r}); it is not running in HA's "
+        f"interpreter, so nothing else in this report is trustworthy ({context})"
+    )
+
+    tool_count = report.get("tool_count", 0)
+    assert tool_count > MIN_TOOL_COUNT, (
+        f"expected the full tool inventory from inside HA, got {tool_count} "
+        f"({context}) — a handful would mean a truncated or wrong server"
+    )
+
+    failures = report.get("conversion_failures") or []
+    assert not failures, (
+        f"{len(failures)}/{tool_count} tool schemas failed to convert inside "
+        f"Home Assistant ({context}). At runtime each of these is skipped with "
+        "only a warning, so the toolset would silently shrink:\n" + "\n".join(failures)
+    )
+
+    if not report.get("probatio"):
+        # Without probatio there is no re-emission step, so conversion success
+        # is the whole contract. That is only legitimate on a Core that
+        # predates probatio; from 2026.9 its absence means a broken image.
+        year_month = _year_month(ha_version)
+        assert year_month is not None and year_month < (2026, 9), (
+            f"probatio is not importable on HA {ha_version} "
+            f"({report.get('probatio_import_error')!r}) — from 2026.9 Core "
+            "re-emits every schema through it, so this is a broken image, not "
+            f"an image without the re-emission step ({context})"
+        )
+        return
+
+    assert report.get("draft2020_checked"), (
+        "jsonschema was not importable inside Home Assistant "
+        f"({report.get('jsonschema_import_error')!r}), so the draft 2020-12 "
+        "validation — the check that reproduces the reported Anthropic "
+        f"failure — never ran ({context})"
+    )
+
+    boolean_exclusive = report.get("boolean_exclusive") or []
+    assert not boolean_exclusive, (
+        "probatio.to_openapi re-emitted a BOOLEAN exclusiveMinimum/"
+        "exclusiveMaximum (the draft-4 spelling) for "
+        f"{boolean_exclusive} ({context}) — that is what breaks every "
+        "conversation turn on an agent that validates draft 2020-12"
+    )
+
+    integer_lost = report.get("integer_lost") or []
+    assert not integer_lost, (
+        f"the schema re-emitted through {converter!r} and probatio.to_openapi "
+        f"has fewer integer-typed nodes than the tool's own schema for "
+        f"{integer_lost} ({context}) — a count comparison, so a lost integer "
+        "type may have been masked by an added one, but a lower count is "
+        "always a looser schema than the tool accepts"
+    )
+
+    draft_invalid = report.get("draft2020_invalid") or []
+    assert not draft_invalid, (
+        "the re-emitted schema is not valid JSON Schema draft 2020-12 for "
+        f"{len(draft_invalid)} tool(s) ({context}):\n" + "\n".join(draft_invalid)
     )

--- a/tests/src/e2e/utilities/llm_api_probe.py
+++ b/tests/src/e2e/utilities/llm_api_probe.py
@@ -192,19 +192,28 @@ def _convert_all(tools, convert_parameters, probatio, Draft202012Validator, repo
                 report["draft2020_invalid"].append(tool.name + ": " + _short(err))
 
 
+class _ProbeTimeout(BaseException):
+    # BaseException, not Exception, on purpose: the per-tool ``except
+    # Exception`` handlers in _convert_all must not be able to swallow the
+    # alarm, or the one-shot signal would be consumed and the probe would
+    # carry on into the next blocking conversion and finish with
+    # timed_out=False.
+    pass
+
+
 def _on_alarm(signum, frame):
     # asyncio.timeout can only cancel at an await; a converter that blocks
     # never reaches one. SIGALRM interrupts the main thread regardless, so
     # the probe still reports what it had instead of hanging until the exec
     # wrapper kills it with no output.
-    raise TimeoutError("probe exceeded " + str(TIMEOUT_S) + "s")
+    raise _ProbeTimeout("probe exceeded " + str(TIMEOUT_S) + "s")
 
 
 signal.signal(signal.SIGALRM, _on_alarm)
 signal.alarm(TIMEOUT_S + 5)
 try:
     asyncio.run(_run())
-except TimeoutError as err:
+except _ProbeTimeout as err:
     REPORT["timed_out"] = True
     REPORT["conversion_failures"] = list(REPORT.get("conversion_failures", [])) + [
         "probe: " + str(err)

--- a/tests/src/e2e/utilities/llm_api_probe.py
+++ b/tests/src/e2e/utilities/llm_api_probe.py
@@ -105,6 +105,10 @@ async def _run():
     # measure. It reads nothing from self, so the class attribute is called
     # directly. None means the component would have skipped the tool.
     convert_parameters = llm_api.HaMcpLlmApi._convert_parameters
+    # Since #2363 the mirror paths normalise once per tool and hand the
+    # result to _convert_parameters(self, tool, schema); before that the
+    # method took only the tool. Follow whichever shape this build has.
+    normalise_schema = getattr(llm_api, "_normalise_schema", None)
     report = REPORT
     report.update({{
         "timed_out": False,
@@ -141,12 +145,21 @@ async def _run():
     async with asyncio.timeout(TIMEOUT_S):
         async with llm_api._mcp_session(url) as (session, _init):
             tools = (await session.list_tools()).tools
-        _convert_all(tools, convert_parameters, probatio, Draft202012Validator, report)
+        _convert_all(
+            tools,
+            convert_parameters,
+            normalise_schema,
+            probatio,
+            Draft202012Validator,
+            report,
+        )
 
     print(SENTINEL + " " + json.dumps(report))
 
 
-def _convert_all(tools, convert_parameters, probatio, Draft202012Validator, report):
+def _convert_all(
+    tools, convert_parameters, normalise_schema, probatio, Draft202012Validator, report
+):
     # Inside the caller's timeout on purpose: the conversion loop is the
     # operation under test, so a converter that hangs on one schema must
     # surface as the probe's own timeout, not as an opaque exec kill.
@@ -154,7 +167,12 @@ def _convert_all(tools, convert_parameters, probatio, Draft202012Validator, repo
     for tool in tools:
         schema = tool.inputSchema
         try:
-            params = convert_parameters(None, tool)
+            if normalise_schema is not None:
+                params = convert_parameters(
+                    None, tool, normalise_schema(schema, tool.name)
+                )
+            else:
+                params = convert_parameters(None, tool)
         except Exception as err:  # collecting, not suppressing
             report["conversion_failures"].append(tool.name + ": " + _short(err))
             continue

--- a/tests/src/e2e/utilities/logger_seed.py
+++ b/tests/src/e2e/utilities/logger_seed.py
@@ -1,0 +1,40 @@
+"""Merge a test-only logger entry into a seeded ``configuration.yaml``.
+
+The shared seed (``tests/initial_test_state/configuration.yaml``) carries a
+top-level ``logger:`` block that raises the ha_mcp_tools component to INFO for
+the in-HA LLM-API proof. A test that needs its own logger entry cannot append a
+second ``logger:`` key, which is a duplicate mapping key Home Assistant refuses
+to load, so it merges the entry under the seed's ``logs:`` mapping instead.
+Pure string function, unit-tested in ``tests/src/unit/test_logger_seed.py``.
+"""
+
+from __future__ import annotations
+
+
+def with_probe_logger_config(
+    existing: str, component_yaml: str, logger_entry: str
+) -> str:
+    """Return ``existing`` plus ``component_yaml`` and ``logger_entry``.
+
+    ``logger_entry`` is one indented ``logs:`` line (four spaces, trailing
+    newline) and is merged under the seed's existing ``logger:`` block. A seed
+    with no ``logger:`` block gets a whole one appended. A ``logger:`` block
+    with no ``logs:`` mapping raises: the seed is then in a shape this helper
+    cannot merge into, and appending blindly would produce the duplicate key
+    this function exists to avoid.
+    """
+    lines = existing.splitlines(keepends=True)
+    for index, line in enumerate(lines):
+        if not line.startswith("logger:"):
+            continue
+        for inner in range(index + 1, len(lines)):
+            if lines[inner].startswith("  logs:"):
+                lines.insert(inner + 1, logger_entry)
+                return "".join(lines) + component_yaml
+            if lines[inner].strip() and not lines[inner].startswith((" ", "#")):
+                break
+        raise AssertionError(
+            "the seeded `logger:` block has no `logs:` mapping to merge the "
+            "probe's logger entry into"
+        )
+    return existing + component_yaml + "logger:\n  logs:\n" + logger_entry

--- a/tests/src/e2e/workflows/embedded/test_embedded_dependency_conflict.py
+++ b/tests/src/e2e/workflows/embedded/test_embedded_dependency_conflict.py
@@ -339,19 +339,9 @@ def _seed_config(config_path: Path, wheel_name: str, wheel_version: str) -> None
     )
     storage_file.write_text(json.dumps(data, indent=2))
 
-    # This HA writes only WARNING+ to home-assistant.log without a `logger:`
-    # block. The two lines asserted here are WARNING and ERROR, so they would
-    # land either way; raising the component to INFO additionally captures the
-    # success line the fixture polls for as its "the repro premise is gone"
-    # tripwire, and the surrounding bring-up context when something else fails.
-    config_yaml = config_path / "configuration.yaml"
-    config_yaml.write_text(
-        config_yaml.read_text(encoding="utf-8")
-        + "\n# e2e: surface the component's INFO lines"
-        " (#2239 dependency-conflict e2e).\n"
-        "logger:\n  logs:\n    custom_components.ha_mcp_tools: info\n",
-        encoding="utf-8",
-    )
+    # The seeded configuration.yaml already raises custom_components.ha_mcp_tools
+    # to INFO (tests/initial_test_state/configuration.yaml), so the component's
+    # success lines reach home-assistant.log here without a second logger: block.
 
     # HA runs as uid 0 in the test image but the bind mount must be traversable.
     for path in config_path.rglob("*"):

--- a/tests/src/e2e/workflows/embedded/test_embedded_server.py
+++ b/tests/src/e2e/workflows/embedded/test_embedded_server.py
@@ -10,10 +10,15 @@ real MCP protocol over ``POST /api/webhook/<id>`` — ``initialize`` → ``tools
 full tool inventory is present.
 
 Also proves the conversation-agent LLM API (#1745) for real: the bring-up
-registered it inside HA (log assertion), and the exact client stack
-``llm_api.py`` uses — mcp SDK streamable-HTTP session + ``convert_to_voluptuous``
-— works against the real server and the REAL tool-schema catalog with zero
-conversion failures.
+registered it inside HA (log assertion), and the transport half of the client
+stack ``llm_api.py`` uses — mcp SDK streamable-HTTP session, ``initialize``
+instructions, the full ``tools/list`` catalog, one read-only call, and the
+per-tool exposure stamps — works against the real server. The CONVERSION half
+is not provable from here: this process runs the test host's schema library,
+not the one Home Assistant resolved, and Core re-emits every converted schema
+before a conversation turn sees it. That proof lives in
+``test_llm_api_in_ha.py``, which runs the component's own client path inside
+Home Assistant's interpreter (#2361).
 
 This uses a DEDICATED, module-scoped container (not the shared session one): the
 always-on server would otherwise runtime-install the whole fastmcp tree and run a
@@ -478,23 +483,25 @@ class TestEmbeddedServerEndToEnd:
         ``homeassistant.*`` imports need a running HA), so this makes the
         same call sequence it makes, with the real SDK, against the real
         server: streamable-HTTP session -> ``initialize`` (whose
-        ``instructions`` become the API prompt) -> ``tools/list`` ->
-        ``convert_to_voluptuous`` on EVERY tool's schema -> one read-only
-        ``call_tool`` dumped the way ``HaMcpTool.async_call`` returns it.
-        The transport is NOT the same: this drives the webhook relay URL
+        ``instructions`` become the API prompt) -> ``tools/list`` -> one
+        read-only ``call_tool`` dumped the way ``HaMcpTool.async_call``
+        returns it, plus the per-tool exposure stamps the component filters
+        on. The transport is NOT the same: this drives the webhook relay URL
         and lets the SDK build its own default httpx client, whereas
         ``_mcp_session`` targets the loopback URL with a dedicated client
         (explicit generous timeout, ``verify=False``, ``trust_env=False``).
 
-        The zero-conversion-failures assertion is the point: at runtime an
-        unconvertible schema is skipped per-tool with only a warning, so a
-        systemic ``voluptuous_openapi`` incompatibility with the real
-        catalog would silently shrink the toolset — this test fails loudly
-        instead.
+        Schema conversion is deliberately NOT asserted here. Converting in
+        this process runs the TEST HOST's library, which since Core 2026.9 is
+        not even the one Home Assistant resolves (``probatio.from_openapi``),
+        and it never performs the re-emission Core applies before a
+        conversation turn — so a green run here says nothing about whether
+        the toolset converts inside HA. ``test_llm_api_in_ha.py`` runs the
+        component's own conversion path in Home Assistant's own interpreter
+        and owns that proof (#2361).
         """
         from mcp.client.session import ClientSession
         from mcp.client.streamable_http import streamable_http_client
-        from voluptuous_openapi import convert_to_voluptuous
 
         base_url, _session_id, _config, _container = embedded_ha
         url = f"{base_url}/api/webhook/{_WEBHOOK_ID}"
@@ -512,19 +519,6 @@ class TestEmbeddedServerEndToEnd:
                 listed = await session.list_tools()
                 assert len(listed.tools) > 60, (
                     f"expected the full tool inventory, got {len(listed.tools)}"
-                )
-
-                failures = []
-                for tool in listed.tools:
-                    try:
-                        convert_to_voluptuous(tool.inputSchema)
-                    except Exception as err:  # collecting, not suppressing
-                        failures.append(f"{tool.name}: {err!r}")
-                assert not failures, (
-                    "convert_to_voluptuous failed for "
-                    f"{len(failures)}/{len(listed.tools)} tools — these would "
-                    "be silently skipped from every conversation turn:\n"
-                    + "\n".join(failures)
                 )
 
                 call = await session.call_tool("ha_get_state", {"entity_id": "sun.sun"})

--- a/tests/src/e2e/workflows/embedded/test_embedded_server.py
+++ b/tests/src/e2e/workflows/embedded/test_embedded_server.py
@@ -208,19 +208,9 @@ def _seed_config(config_path: Path, wheel_name: str) -> None:
     )
     storage_file.write_text(json.dumps(data, indent=2))
 
-    # The seeded configuration.yaml carries no `logger:` block and this HA
-    # writes only WARNING+ to home-assistant.log (CI-observed), while the
-    # LLM-API registration proof asserts on the component's INFO success
-    # line. Raise just this component's logger, in this container's private
-    # copy of the config dir only.
-    config_yaml = config_path / "configuration.yaml"
-    config_yaml.write_text(
-        config_yaml.read_text(encoding="utf-8")
-        + "\n# e2e: surface the component's INFO lines"
-        " (test_llm_api_registered_inside_ha).\n"
-        "logger:\n  logs:\n    custom_components.ha_mcp_tools: info\n",
-        encoding="utf-8",
-    )
+    # The seeded configuration.yaml already raises custom_components.ha_mcp_tools
+    # to INFO (tests/initial_test_state/configuration.yaml), so the component's
+    # success lines reach home-assistant.log here without a second logger: block.
 
     # HA runs as uid 0 in the test image but the bind mount must be traversable.
     for path in config_path.rglob("*"):

--- a/tests/src/e2e/workflows/embedded/test_embedded_update_path.py
+++ b/tests/src/e2e/workflows/embedded/test_embedded_update_path.py
@@ -439,14 +439,17 @@ def _dump_ha_log(config_path: Path) -> str:
     """Return a labelled tail of ``home-assistant.log``; never raises.
 
     Empty string when the file does not exist yet (HA never got far enough to
-    write one), so the caller can concatenate it unconditionally.
+    write one) or is empty; a labelled reason when it exists but cannot be
+    read, since silence there would read as "nothing to show". The caller
+    concatenates the result unconditionally.
     """
     log_file = config_path / "home-assistant.log"
     if not log_file.is_file():
         return ""
-    text = ""
-    with contextlib.suppress(OSError):
+    try:
         text = log_file.read_text(encoding="utf-8", errors="replace")
+    except OSError as err:
+        return f"\n(could not read {log_file}: {err})"
     if not text:
         return ""
     return (

--- a/tests/src/e2e/workflows/embedded/test_embedded_update_path.py
+++ b/tests/src/e2e/workflows/embedded/test_embedded_update_path.py
@@ -428,6 +428,33 @@ def _dump_logs(container: Any) -> Any:
     return logs
 
 
+# Container stdout carries HA's console handler only. The component's own
+# install / LLM-API / bring-up errors land in ``home-assistant.log`` under the
+# bind-mounted /config, and on 2026-09-04 a phase-1 timeout was diagnosable
+# only from there — the container log showed nothing about the real cause.
+_HA_LOG_TAIL_CHARS = 4000
+
+
+def _dump_ha_log(config_path: Path) -> str:
+    """Return a labelled tail of ``home-assistant.log``; never raises.
+
+    Empty string when the file does not exist yet (HA never got far enough to
+    write one), so the caller can concatenate it unconditionally.
+    """
+    log_file = config_path / "home-assistant.log"
+    if not log_file.is_file():
+        return ""
+    text = ""
+    with contextlib.suppress(OSError):
+        text = log_file.read_text(encoding="utf-8", errors="replace")
+    if not text:
+        return ""
+    return (
+        f"\nhome-assistant.log (last {_HA_LOG_TAIL_CHARS} chars of "
+        f"{log_file}):\n{text[-_HA_LOG_TAIL_CHARS:]}"
+    )
+
+
 def _submit_options_update(
     base_url: str, entry_id: str, user_input: dict[str, Any], container: Any
 ) -> dict[str, Any]:
@@ -548,7 +575,15 @@ def update_path_ha(request):
         base_url = f"http://{host}:{port}"
         headers = {"Authorization": f"Bearer {TEST_TOKEN}"}
 
-        _wait_http_ok(f"{base_url}/api/", headers, _API_READY_TIMEOUT_S)
+        try:
+            _wait_http_ok(f"{base_url}/api/", headers, _API_READY_TIMEOUT_S)
+        except AssertionError as err:
+            # Same reason as the phase-1 raise below: the component's failures
+            # are in home-assistant.log, not on container stdout.
+            raise AssertionError(
+                f"{err}\nContainer logs:\n{_dump_logs(container)}"
+                f"{_dump_ha_log(config_path)}"
+            ) from err
 
         phase1_version, _ = _wait_for_server(base_url, _PHASE1_READY_TIMEOUT_S)
         # Reject the "unknown" fallback as well as None: a server that answers
@@ -559,6 +594,7 @@ def update_path_ha(request):
                 "the PyPI-installed in-process server never reported a usable "
                 f"version within {_PHASE1_READY_TIMEOUT_S}s (got "
                 f"{phase1_version!r}). Container logs:\n{_dump_logs(container)}"
+                f"{_dump_ha_log(config_path)}"
             )
         yield {
             "base_url": base_url,

--- a/tests/src/e2e/workflows/embedded/test_llm_api_in_ha.py
+++ b/tests/src/e2e/workflows/embedded/test_llm_api_in_ha.py
@@ -231,6 +231,7 @@ def _assert_registration_logged_in_haos() -> None:
         remaining = max(5.0, deadline - time.monotonic())
         try:
             count = ssh_exec(["sh", "-c", script], timeout=remaining).stdout.strip()
+            last_error = None
         except RuntimeError as err:
             # A failing ``ha core logs`` (Supervisor still settling, a
             # transient API error) is retried inside the budget; only a

--- a/tests/src/e2e/workflows/embedded/test_llm_api_in_ha.py
+++ b/tests/src/e2e/workflows/embedded/test_llm_api_in_ha.py
@@ -223,6 +223,7 @@ def _assert_registration_logged_in_haos() -> None:
     )
     deadline = time.monotonic() + _REGISTRATION_TIMEOUT_S
     count = ""
+    last_error: RuntimeError | None = None
     while True:
         # Bound each ssh call by what is left of the deadline (with a small
         # floor so a near-expired deadline still gets one real attempt), so a
@@ -231,10 +232,16 @@ def _assert_registration_logged_in_haos() -> None:
         try:
             count = ssh_exec(["sh", "-c", script], timeout=remaining).stdout.strip()
         except RuntimeError as err:
-            raise AssertionError(
-                f"could not read Core's journal on HAOS while checking for "
-                f"{_REGISTRATION_LINE!r}:\n{err}"
-            ) from err
+            # A failing ``ha core logs`` (Supervisor still settling, a
+            # transient API error) is retried inside the budget; only a
+            # failure that persists to the deadline is reported, with its
+            # stderr. ssh_exec itself retries transport errors only.
+            last_error = err
+            LOG.debug("journal read failed on HAOS, retrying: %s", err)
+            if time.monotonic() >= deadline:
+                break
+            time.sleep(_REGISTRATION_POLL_S)
+            continue
         except subprocess.TimeoutExpired as err:
             raise AssertionError(
                 f"reading Core's journal on HAOS did not return within {remaining:.0f}s "
@@ -247,6 +254,10 @@ def _assert_registration_logged_in_haos() -> None:
             break
         LOG.debug("LLM-API registration line not in Core's log yet (count=%r)", count)
         time.sleep(_REGISTRATION_POLL_S)
+    assert last_error is None, (
+        f"could not read Core's journal on HAOS within {_REGISTRATION_TIMEOUT_S}s "
+        f"while checking for {_REGISTRATION_LINE!r}; last error:\n{last_error}"
+    )
     assert count.isdigit(), (
         "the journal command on HAOS did not print a bare match count "
         f"({count!r}); the registration check could not run, which says "

--- a/tests/src/e2e/workflows/embedded/test_llm_api_in_ha.py
+++ b/tests/src/e2e/workflows/embedded/test_llm_api_in_ha.py
@@ -75,6 +75,10 @@ def _assert_report_clean(report: dict[str, Any]) -> None:
         f"HA {report.get('ha_version')}"
     )
 
+    assert not report.get("timed_out"), (
+        f"the in-HA probe hit its own timeout ({context}); partial report: {report}"
+    )
+
     tool_count = report.get("tool_count", 0)
     assert tool_count > 60, (
         f"expected the full tool inventory from inside HA, got {tool_count} "

--- a/tests/src/e2e/workflows/embedded/test_llm_api_in_ha.py
+++ b/tests/src/e2e/workflows/embedded/test_llm_api_in_ha.py
@@ -147,9 +147,11 @@ def test_llm_api_schemas_survive_core_reemission_container(
         "the in-HA LLM-API probe exited "
         f"{result.exit_code} instead of completing:\n{output[-4000:]}"
     )
-    _assert_report_clean(parse_probe_report(output))
-
+    # Registration first: it is the cheaper, lane-plumbing half, and it must
+    # keep being exercised while the report assertion is expectedly red on a
+    # Core that carries the #2361 defect.
     _assert_registration_logged_in_container(Path(info["config_path"]))
+    _assert_report_clean(parse_probe_report(output))
 
 
 def _assert_registration_logged_in_container(config_path: Path) -> None:
@@ -213,8 +215,9 @@ def test_llm_api_schemas_survive_core_reemission_haos(
         # as RuntimeError carrying stdout+stderr.
         raise AssertionError(f"the in-HA LLM-API probe failed in HAOS:\n{err}") from err
 
-    _assert_report_clean(parse_probe_report(result.stdout))
+    # Same order as the container test: registration plumbing first.
     _assert_registration_logged_in_haos()
+    _assert_report_clean(parse_probe_report(result.stdout))
 
 
 def _assert_registration_logged_in_haos() -> None:

--- a/tests/src/e2e/workflows/embedded/test_llm_api_in_ha.py
+++ b/tests/src/e2e/workflows/embedded/test_llm_api_in_ha.py
@@ -63,6 +63,10 @@ _HAOS_WEBHOOK_URL = f"http://127.0.0.1:8123/api/webhook/{HA_MCP_SERVER_WEBHOOK_I
 # The HAOS core container, addressed the same way the other HAOS tests address
 # it (``docker restart homeassistant`` in test_zz_reentrant_log_deadlock.py).
 _HAOS_CORE_CONTAINER = "homeassistant"
+# Journal window for the HAOS registration check: with the component's logger
+# at INFO, a full lane run logs a few thousand Core lines, so this reaches
+# back to boot with margin.
+_HAOS_LOG_WINDOW_LINES = 20000
 
 
 def _assert_report_clean(report: dict[str, Any]) -> None:
@@ -223,17 +227,18 @@ def test_llm_api_schemas_survive_core_reemission_haos(
 def _assert_registration_logged_in_haos() -> None:
     """The HAOS-side counterpart of the container registration assertion.
 
-    Reads ``home-assistant.log`` inside the Core container, the same file the
-    container lane reads through its bind mount. ``ha core logs`` was tried
-    first and does not carry the line: it serves a bounded tail of the Core
-    journal, and by the time this test runs the boot-time registration line
-    is outside that window. The ``|| true`` keeps grep's no-match exit status
-    from tripping ssh_exec's ``check=True``.
+    Core disables its file log when it runs under the Supervisor
+    (``LOG_FILE_DISABLED_REASON_SUPERVISOR`` in bootstrap.py), so there is no
+    ``home-assistant.log`` to read on HAOS and the Core journal is the only
+    source. ``ha core logs`` alone serves a bounded tail that no longer holds
+    the boot-time registration line by the time this test runs, so ask for a
+    window large enough to reach back to boot (``--lines`` becomes a Range
+    header on the Supervisor's logs endpoint). The ``|| true`` keeps grep's
+    no-match exit status from tripping ssh_exec's ``check=True``.
     """
     script = (
-        f"docker exec {_HAOS_CORE_CONTAINER} sh -c "
-        f"\"grep -c '{_REGISTRATION_LINE}' /config/home-assistant.log 2>/dev/null"
-        ' || true"'
+        f"ha core logs --lines {_HAOS_LOG_WINDOW_LINES} 2>/dev/null"
+        f" | grep -c '{_REGISTRATION_LINE}' || true"
     )
     deadline = time.monotonic() + _REGISTRATION_TIMEOUT_S
     count = ""
@@ -250,8 +255,8 @@ def _assert_registration_logged_in_haos() -> None:
         LOG.debug("LLM-API registration line not in Core's log yet (count=%r)", count)
         time.sleep(_REGISTRATION_POLL_S)
     raise AssertionError(
-        f"{_REGISTRATION_LINE!r} never appeared in /config/home-assistant.log "
-        f"inside the {_HAOS_CORE_CONTAINER} container within "
+        f"{_REGISTRATION_LINE!r} never appeared in the last "
+        f"{_HAOS_LOG_WINDOW_LINES} Core journal lines within "
         f"{_REGISTRATION_TIMEOUT_S}s (grep count: {count!r}), so the toolset "
         "was never registered as an LLM API inside this Home Assistant"
     )

--- a/tests/src/e2e/workflows/embedded/test_llm_api_in_ha.py
+++ b/tests/src/e2e/workflows/embedded/test_llm_api_in_ha.py
@@ -1,0 +1,239 @@
+"""The LLM API's schema conversion, proved INSIDE Home Assistant (issue #2361).
+
+``test_embedded_server.py::test_llm_api_client_path_full_catalog`` drives the
+same transport, but its conversion runs in the pytest process against the test
+host's ``voluptuous_openapi``. Home Assistant resolves its own converter
+(``probatio.from_openapi`` since Core 2026.9) and, before a conversation turn
+reaches the model, re-emits every converted schema through
+``probatio.to_openapi``. That round trip is invisible from the host and is
+exactly where the reported defect lived: an exclusive bound came back in the
+draft-4 ``{"minimum": 0, "exclusiveMinimum": true}`` spelling, which is not
+valid JSON Schema draft 2020-12, and every Anthropic turn failed.
+
+So these tests run the component's own client path in Home Assistant's own
+interpreter through ``utilities.llm_api_probe``, and assert on the report it
+prints. The probe never decides pass or fail; the assertions below do.
+
+The two tests cover the two lanes where the in-process server is the session
+backend: the container embedded lane (``embedded_only``) and the HAOS embedded
+lane (``haos_embedded_only``). Both use the session fixture's already-running
+server rather than booting one of their own.
+
+NOTE (skip-ceiling coupling): both tests are marker-gated, so each adds a
+collection-time skip on every lane it does not run on. That consumes
+``_SKIP_CEILING_PER_LANE`` budget in
+tests/src/e2e/basic/test_backend_dispatch_smoke.py — see that module's
+docstring; the ceilings were bumped when these landed.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from pathlib import Path
+from typing import Any
+
+import pytest
+from haos_runtime import HA_MCP_SERVER_WEBHOOK_ID, ssh_exec
+
+from ...conftest import _EMBEDDED_WEBHOOK_ID
+from ...utilities.llm_api_probe import (
+    LLM_API_SCHEMA_PROBE,
+    PROBE_URL_ENV,
+    parse_probe_report,
+)
+
+LOG = logging.getLogger(__name__)
+
+# The component logs this on a successful ``llm.async_register_api`` (llm_api.py
+# keeps the prefix stable for exactly these assertions).
+_REGISTRATION_LINE = "Registered the HA-MCP toolset as LLM API"
+_REGISTRATION_TIMEOUT_S = 60
+_REGISTRATION_POLL_S = 2
+
+# The probe's own budget is 120s; give the exec wrapper room above it so a hang
+# surfaces as the probe's timeout rather than an opaque kill.
+_PROBE_EXEC_TIMEOUT_S = 180
+
+# Home Assistant answers its own webhook on loopback from inside the container /
+# VM; the host-facing URL in ``container_info`` is not reachable from there.
+_CONTAINER_WEBHOOK_URL = f"http://127.0.0.1:8123/api/webhook/{_EMBEDDED_WEBHOOK_ID}"
+_HAOS_WEBHOOK_URL = f"http://127.0.0.1:8123/api/webhook/{HA_MCP_SERVER_WEBHOOK_ID}"
+
+# The HAOS core container, addressed the same way the other HAOS tests address
+# it (``docker restart homeassistant`` in test_zz_reentrant_log_deadlock.py).
+_HAOS_CORE_CONTAINER = "homeassistant"
+
+
+def _assert_report_clean(report: dict[str, Any]) -> None:
+    """Fail with the offending tool names when the in-HA conversion misbehaved."""
+    converter = report.get("converter")
+    context = (
+        f"converter={converter!r}, probatio={report.get('probatio')!r}, "
+        f"inclusive-bounds normaliser="
+        f"{report.get('inclusive_bounds_normaliser')!r}, "
+        f"HA {report.get('ha_version')}"
+    )
+
+    tool_count = report.get("tool_count", 0)
+    assert tool_count > 60, (
+        f"expected the full tool inventory from inside HA, got {tool_count} "
+        f"({context}) — a handful would mean a truncated or wrong server"
+    )
+
+    failures = report.get("conversion_failures") or []
+    assert not failures, (
+        f"{len(failures)}/{tool_count} tool schemas failed to convert inside "
+        f"Home Assistant ({context}). At runtime each of these is skipped with "
+        "only a warning, so the toolset would silently shrink:\n" + "\n".join(failures)
+    )
+
+    if not report.get("probatio"):
+        # Core <= 2026.8: no re-emission step exists, so conversion success is
+        # the whole contract on this image.
+        LOG.info("probatio is absent in this HA image; re-emission checks skipped")
+        return
+
+    boolean_exclusive = report.get("boolean_exclusive") or []
+    assert not boolean_exclusive, (
+        "probatio.to_openapi re-emitted a BOOLEAN exclusiveMinimum/"
+        "exclusiveMaximum (the draft-4 spelling) for "
+        f"{boolean_exclusive} ({context}) — that is what breaks every "
+        "conversation turn on an agent that validates draft 2020-12"
+    )
+
+    integer_lost = report.get("integer_lost") or []
+    assert not integer_lost, (
+        f"the round trip through {converter!r} and probatio.to_openapi lost "
+        f"integer typing for {integer_lost} ({context}) — the model would be "
+        "handed a looser schema than the tool actually accepts"
+    )
+
+    draft_invalid = report.get("draft2020_invalid") or []
+    assert not draft_invalid, (
+        "the re-emitted schema is not valid JSON Schema draft 2020-12 for "
+        f"{len(draft_invalid)} tool(s) ({context}):\n" + "\n".join(draft_invalid)
+    )
+
+
+@pytest.mark.embedded_only
+def test_llm_api_schemas_survive_core_reemission_container(
+    ha_container_with_fresh_config: dict[str, Any],
+) -> None:
+    """Run the probe in the embedded lane's container and assert its report.
+
+    The session backend of this lane IS the in-process server, so the probe
+    talks to the same server the rest of the suite drives — through the
+    component's own ``_mcp_session``, with Home Assistant's own interpreter,
+    converter and probatio.
+    """
+    info = ha_container_with_fresh_config
+    container = info["container"]
+    assert container is not None, (
+        "the embedded lane must expose its testcontainer handle; got "
+        f"container=None with backend={info.get('backend')!r}"
+    )
+
+    result = container.get_wrapped_container().exec_run(
+        ["python3", "-c", LLM_API_SCHEMA_PROBE],
+        environment={PROBE_URL_ENV: _CONTAINER_WEBHOOK_URL},
+    )
+    output = (result.output or b"").decode("utf-8", "replace")
+    assert result.exit_code == 0, (
+        "the in-HA LLM-API probe exited "
+        f"{result.exit_code} instead of completing:\n{output[-4000:]}"
+    )
+    _assert_report_clean(parse_probe_report(output))
+
+    _assert_registration_logged_in_container(Path(info["config_path"]))
+
+
+def _assert_registration_logged_in_container(config_path: Path) -> None:
+    """The component registered the toolset as an LLM API inside this HA.
+
+    The probe proves the schemas convert; this proves Home Assistant was
+    actually handed the API. Polled: registration runs right after webhook
+    bring-up, so it can trail the readiness gate by a few seconds.
+    """
+    log_file = config_path / "home-assistant.log"
+    deadline = time.monotonic() + _REGISTRATION_TIMEOUT_S
+    log_text = ""
+    while time.monotonic() < deadline:
+        if log_file.exists():
+            log_text = log_file.read_text(encoding="utf-8", errors="replace")
+            if _REGISTRATION_LINE in log_text:
+                return
+        time.sleep(_REGISTRATION_POLL_S)
+    raise AssertionError(
+        f"{_REGISTRATION_LINE!r} never appeared in {log_file} within "
+        f"{_REGISTRATION_TIMEOUT_S}s, so the toolset was never registered as "
+        f"an LLM API inside this Home Assistant; tail:\n{log_text[-3000:]}"
+    )
+
+
+@pytest.mark.haos_embedded_only
+def test_llm_api_schemas_survive_core_reemission_haos(
+    ha_container_with_fresh_config: dict[str, Any],
+) -> None:
+    """The same probe, in the HAOS core container, on the real HAOS image.
+
+    Uses the session fixture rather than ``test_embedded_server_haos.py``'s
+    ``embedded_server`` fixture: that module is ``not_on_haos_embedded``
+    precisely because this lane's session backend already enables the entry and
+    waits for the webhook, and re-running its enable step here would
+    double-enable the entry and race that backend.
+    """
+    info = ha_container_with_fresh_config
+    assert info.get("embedded_webhook_url"), (
+        "the haos_embedded lane must expose embedded_webhook_url; got "
+        f"{info.get('embedded_webhook_url')!r} with "
+        f"backend={info.get('backend')!r}"
+    )
+
+    try:
+        result = ssh_exec(
+            [
+                "docker",
+                "exec",
+                "-e",
+                f"{PROBE_URL_ENV}={_HAOS_WEBHOOK_URL}",
+                _HAOS_CORE_CONTAINER,
+                "python3",
+                "-c",
+                LLM_API_SCHEMA_PROBE,
+            ],
+            timeout=_PROBE_EXEC_TIMEOUT_S,
+        )
+    except RuntimeError as err:
+        # ssh_exec runs with check=True and re-raises a failed remote command
+        # as RuntimeError carrying stdout+stderr.
+        raise AssertionError(f"the in-HA LLM-API probe failed in HAOS:\n{err}") from err
+
+    _assert_report_clean(parse_probe_report(result.stdout))
+    _assert_registration_logged_in_haos()
+
+
+def _assert_registration_logged_in_haos() -> None:
+    """The HAOS-side counterpart of the container registration assertion.
+
+    ``ha core logs`` is the established way to read Core's log inside the VM
+    (test_zz_reentrant_log_deadlock.py uses the same ``| grep -c ... || true``
+    shape, which keeps grep's no-match exit status from tripping ssh_exec's
+    ``check=True``).
+    """
+    script = f"ha core logs 2>/dev/null | grep -c '{_REGISTRATION_LINE}' || true"
+    deadline = time.monotonic() + _REGISTRATION_TIMEOUT_S
+    count = ""
+    while True:
+        count = ssh_exec(["sh", "-c", script], timeout=180.0).stdout.strip()
+        if count.isdigit() and int(count) > 0:
+            return
+        if time.monotonic() >= deadline:
+            break
+        LOG.debug("LLM-API registration line not in Core's log yet (count=%r)", count)
+        time.sleep(_REGISTRATION_POLL_S)
+    raise AssertionError(
+        f"{_REGISTRATION_LINE!r} never appeared in Core's log within "
+        f"{_REGISTRATION_TIMEOUT_S}s (grep count: {count!r}), so the toolset "
+        "was never registered as an LLM API inside this Home Assistant"
+    )

--- a/tests/src/e2e/workflows/embedded/test_llm_api_in_ha.py
+++ b/tests/src/e2e/workflows/embedded/test_llm_api_in_ha.py
@@ -232,7 +232,11 @@ def _assert_registration_logged_in_haos() -> None:
     deadline = time.monotonic() + _REGISTRATION_TIMEOUT_S
     count = ""
     while True:
-        count = ssh_exec(["sh", "-c", script], timeout=180.0).stdout.strip()
+        # Bound each ssh call by what is left of the deadline (with a small
+        # floor so a near-expired deadline still gets one real attempt), so a
+        # stalled `ha core logs` cannot outlive the deadline it polls for.
+        remaining = max(5.0, deadline - time.monotonic())
+        count = ssh_exec(["sh", "-c", script], timeout=remaining).stdout.strip()
         if count.isdigit() and int(count) > 0:
             return
         if time.monotonic() >= deadline:

--- a/tests/src/e2e/workflows/embedded/test_llm_api_in_ha.py
+++ b/tests/src/e2e/workflows/embedded/test_llm_api_in_ha.py
@@ -1,14 +1,16 @@
 """The LLM API's schema conversion, proved INSIDE Home Assistant (issue #2361).
 
-``test_embedded_server.py::test_llm_api_client_path_full_catalog`` drives the
-same transport, but its conversion runs in the pytest process against the test
-host's ``voluptuous_openapi``. Home Assistant resolves its own converter
-(``probatio.from_openapi`` since Core 2026.9) and, before a conversation turn
-reaches the model, re-emits every converted schema through
-``probatio.to_openapi``. That round trip is invisible from the host and is
-exactly where the reported defect lived: an exclusive bound came back in the
-draft-4 ``{"minimum": 0, "exclusiveMinimum": true}`` spelling, which is not
-valid JSON Schema draft 2020-12, and every Anthropic turn failed.
+``test_embedded_server.py::test_llm_api_client_path_full_catalog`` used to
+convert every schema in the pytest process against the test host's
+``voluptuous_openapi``; that loop was removed because it proved nothing about
+Home Assistant. HA resolves its own converter (``probatio.from_openapi`` since
+Core 2026.9 unless the component's manifest requirement restores
+``voluptuous_openapi``) and, before a conversation turn reaches the model,
+re-emits every converted schema through ``probatio.to_openapi``. That round
+trip is invisible from the host and is exactly where the reported defect lived:
+an exclusive bound came back in the draft-4 ``{"minimum": 0,
+"exclusiveMinimum": true}`` spelling, which is not valid JSON Schema draft
+2020-12, and every Anthropic turn failed.
 
 So these tests run the component's own client path in Home Assistant's own
 interpreter through ``utilities.llm_api_probe``, and assert on the report it
@@ -29,6 +31,7 @@ docstring; the ceilings were bumped when these landed.
 from __future__ import annotations
 
 import logging
+import subprocess
 import time
 from pathlib import Path
 from typing import Any
@@ -39,7 +42,9 @@ from haos_runtime import HA_MCP_SERVER_WEBHOOK_ID, ssh_exec
 from ...conftest import _EMBEDDED_WEBHOOK_ID
 from ...utilities.llm_api_probe import (
     LLM_API_SCHEMA_PROBE,
+    PROBE_SENTINEL,
     PROBE_URL_ENV,
+    assert_report_clean,
     parse_probe_report,
 )
 
@@ -51,8 +56,10 @@ _REGISTRATION_LINE = "Registered the HA-MCP toolset as LLM API"
 _REGISTRATION_TIMEOUT_S = 60
 _REGISTRATION_POLL_S = 2
 
-# The probe's own budget is 120s; give the exec wrapper room above it so a hang
-# surfaces as the probe's timeout rather than an opaque kill.
+# The probe's own budget is 120s (plus a 5s alarm margin). Both callers pass
+# this larger wrapper timeout, the docker client on the container lane and
+# ssh_exec on HAOS, so a hang surfaces as the probe's own partial report rather
+# than as an opaque kill by the wrapper.
 _PROBE_EXEC_TIMEOUT_S = 180
 
 # Home Assistant answers its own webhook on loopback from inside the container /
@@ -67,61 +74,6 @@ _HAOS_CORE_CONTAINER = "homeassistant"
 # at INFO, a full lane run logs a few thousand Core lines, so this reaches
 # back to boot with margin.
 _HAOS_LOG_WINDOW_LINES = 20000
-
-
-def _assert_report_clean(report: dict[str, Any]) -> None:
-    """Fail with the offending tool names when the in-HA conversion misbehaved."""
-    converter = report.get("converter")
-    context = (
-        f"converter={converter!r}, probatio={report.get('probatio')!r}, "
-        f"inclusive-bounds normaliser="
-        f"{report.get('inclusive_bounds_normaliser')!r}, "
-        f"HA {report.get('ha_version')}"
-    )
-
-    assert not report.get("timed_out"), (
-        f"the in-HA probe hit its own timeout ({context}); partial report: {report}"
-    )
-
-    tool_count = report.get("tool_count", 0)
-    assert tool_count > 60, (
-        f"expected the full tool inventory from inside HA, got {tool_count} "
-        f"({context}) — a handful would mean a truncated or wrong server"
-    )
-
-    failures = report.get("conversion_failures") or []
-    assert not failures, (
-        f"{len(failures)}/{tool_count} tool schemas failed to convert inside "
-        f"Home Assistant ({context}). At runtime each of these is skipped with "
-        "only a warning, so the toolset would silently shrink:\n" + "\n".join(failures)
-    )
-
-    if not report.get("probatio"):
-        # Core <= 2026.8: no re-emission step exists, so conversion success is
-        # the whole contract on this image.
-        LOG.info("probatio is absent in this HA image; re-emission checks skipped")
-        return
-
-    boolean_exclusive = report.get("boolean_exclusive") or []
-    assert not boolean_exclusive, (
-        "probatio.to_openapi re-emitted a BOOLEAN exclusiveMinimum/"
-        "exclusiveMaximum (the draft-4 spelling) for "
-        f"{boolean_exclusive} ({context}) — that is what breaks every "
-        "conversation turn on an agent that validates draft 2020-12"
-    )
-
-    integer_lost = report.get("integer_lost") or []
-    assert not integer_lost, (
-        f"the round trip through {converter!r} and probatio.to_openapi lost "
-        f"integer typing for {integer_lost} ({context}) — the model would be "
-        "handed a looser schema than the tool actually accepts"
-    )
-
-    draft_invalid = report.get("draft2020_invalid") or []
-    assert not draft_invalid, (
-        "the re-emitted schema is not valid JSON Schema draft 2020-12 for "
-        f"{len(draft_invalid)} tool(s) ({context}):\n" + "\n".join(draft_invalid)
-    )
 
 
 @pytest.mark.embedded_only
@@ -142,20 +94,30 @@ def test_llm_api_schemas_survive_core_reemission_container(
         f"container=None with backend={info.get('backend')!r}"
     )
 
-    result = container.get_wrapped_container().exec_run(
-        ["python3", "-c", LLM_API_SCHEMA_PROBE],
-        environment={PROBE_URL_ENV: _CONTAINER_WEBHOOK_URL},
-    )
-    output = (result.output or b"").decode("utf-8", "replace")
-    assert result.exit_code == 0, (
-        "the in-HA LLM-API probe exited "
-        f"{result.exit_code} instead of completing:\n{output[-4000:]}"
-    )
     # Registration first: it is the cheaper, lane-plumbing half, and it must
     # keep being exercised while the report assertion is expectedly red on a
     # Core that carries the #2361 defect.
     _assert_registration_logged_in_container(Path(info["config_path"]))
-    _assert_report_clean(parse_probe_report(output))
+
+    # A client with an explicit timeout above the probe's own budget: the
+    # testcontainers handle's client keeps docker-py's 60s default, which sits
+    # BELOW the probe's 120s and would kill a slow probe with no report.
+    import docker
+
+    client = docker.from_env(timeout=_PROBE_EXEC_TIMEOUT_S)
+    result = client.containers.get(container.get_wrapped_container().id).exec_run(
+        ["python3", "-c", LLM_API_SCHEMA_PROBE],
+        environment={PROBE_URL_ENV: _CONTAINER_WEBHOOK_URL},
+    )
+    output = (result.output or b"").decode("utf-8", "replace")
+    # Report first, exit code second: a timed-out probe exits non-zero AFTER
+    # printing a partial report, and that report is the better diagnosis.
+    # parse_probe_report raises with the raw output when there is none.
+    assert_report_clean(parse_probe_report(output))
+    assert result.exit_code == 0, (
+        "the in-HA LLM-API probe exited "
+        f"{result.exit_code} despite a clean report:\n{output[-4000:]}"
+    )
 
 
 def _assert_registration_logged_in_container(config_path: Path) -> None:
@@ -200,6 +162,9 @@ def test_llm_api_schemas_survive_core_reemission_haos(
         f"backend={info.get('backend')!r}"
     )
 
+    # Same order as the container test: registration plumbing first.
+    _assert_registration_logged_in_haos()
+
     try:
         result = ssh_exec(
             [
@@ -216,12 +181,25 @@ def test_llm_api_schemas_survive_core_reemission_haos(
         )
     except RuntimeError as err:
         # ssh_exec runs with check=True and re-raises a failed remote command
-        # as RuntimeError carrying stdout+stderr.
+        # as RuntimeError carrying stdout+stderr. A timed-out probe exits
+        # non-zero after printing its partial report, which is the better
+        # diagnosis, so parse it out of the error text when it is there.
+        text = str(err)
+        if PROBE_SENTINEL in text:
+            assert_report_clean(parse_probe_report(text))
         raise AssertionError(f"the in-HA LLM-API probe failed in HAOS:\n{err}") from err
+    except subprocess.TimeoutExpired as err:
+        stdout = (
+            err.stdout.decode("utf-8", "replace")
+            if isinstance(err.stdout, bytes)
+            else err.stdout
+        )
+        raise AssertionError(
+            f"the in-HA LLM-API probe did not return within {_PROBE_EXEC_TIMEOUT_S}s "
+            f"over ssh; captured stdout:\n{(stdout or '')[-4000:]}"
+        ) from err
 
-    # Same order as the container test: registration plumbing first.
-    _assert_registration_logged_in_haos()
-    _assert_report_clean(parse_probe_report(result.stdout))
+    assert_report_clean(parse_probe_report(result.stdout))
 
 
 def _assert_registration_logged_in_haos() -> None:
@@ -257,12 +235,23 @@ def _assert_registration_logged_in_haos() -> None:
                 f"could not read Core's journal on HAOS while checking for "
                 f"{_REGISTRATION_LINE!r}:\n{err}"
             ) from err
+        except subprocess.TimeoutExpired as err:
+            raise AssertionError(
+                f"reading Core's journal on HAOS did not return within {remaining:.0f}s "
+                f"while checking for {_REGISTRATION_LINE!r}; captured stdout: "
+                f"{err.stdout!r}"
+            ) from err
         if count.isdigit() and int(count) > 0:
             return
         if time.monotonic() >= deadline:
             break
         LOG.debug("LLM-API registration line not in Core's log yet (count=%r)", count)
         time.sleep(_REGISTRATION_POLL_S)
+    assert count.isdigit(), (
+        "the journal command on HAOS did not print a bare match count "
+        f"({count!r}); the registration check could not run, which says "
+        "nothing about whether the toolset was registered"
+    )
     raise AssertionError(
         f"{_REGISTRATION_LINE!r} never appeared in the last "
         f"{_HAOS_LOG_WINDOW_LINES} Core journal lines within "

--- a/tests/src/e2e/workflows/embedded/test_llm_api_in_ha.py
+++ b/tests/src/e2e/workflows/embedded/test_llm_api_in_ha.py
@@ -233,12 +233,15 @@ def _assert_registration_logged_in_haos() -> None:
     source. ``ha core logs`` alone serves a bounded tail that no longer holds
     the boot-time registration line by the time this test runs, so ask for a
     window large enough to reach back to boot (``--lines`` becomes a Range
-    header on the Supervisor's logs endpoint). The ``|| true`` keeps grep's
-    no-match exit status from tripping ssh_exec's ``check=True``.
+    header on the Supervisor's logs endpoint).
     """
+    # Only grep's own no-match status (1) is tolerated; a failing
+    # ``ha core logs`` propagates as a non-zero exit so ssh_exec raises with
+    # its stderr instead of the poll reading it as "0 matches".
     script = (
-        f"ha core logs --lines {_HAOS_LOG_WINDOW_LINES} 2>/dev/null"
-        f" | grep -c '{_REGISTRATION_LINE}' || true"
+        f"out=$(ha core logs --lines {_HAOS_LOG_WINDOW_LINES}) || exit $?; "
+        f"printf '%s\\n' \"$out\" | grep -c '{_REGISTRATION_LINE}'; "
+        "rc=$?; [ $rc -le 1 ] || exit $rc"
     )
     deadline = time.monotonic() + _REGISTRATION_TIMEOUT_S
     count = ""
@@ -247,7 +250,13 @@ def _assert_registration_logged_in_haos() -> None:
         # floor so a near-expired deadline still gets one real attempt), so a
         # stalled call cannot outlive the deadline it polls for.
         remaining = max(5.0, deadline - time.monotonic())
-        count = ssh_exec(["sh", "-c", script], timeout=remaining).stdout.strip()
+        try:
+            count = ssh_exec(["sh", "-c", script], timeout=remaining).stdout.strip()
+        except RuntimeError as err:
+            raise AssertionError(
+                f"could not read Core's journal on HAOS while checking for "
+                f"{_REGISTRATION_LINE!r}:\n{err}"
+            ) from err
         if count.isdigit() and int(count) > 0:
             return
         if time.monotonic() >= deadline:

--- a/tests/src/e2e/workflows/embedded/test_llm_api_in_ha.py
+++ b/tests/src/e2e/workflows/embedded/test_llm_api_in_ha.py
@@ -223,18 +223,24 @@ def test_llm_api_schemas_survive_core_reemission_haos(
 def _assert_registration_logged_in_haos() -> None:
     """The HAOS-side counterpart of the container registration assertion.
 
-    ``ha core logs`` is the established way to read Core's log inside the VM
-    (test_zz_reentrant_log_deadlock.py uses the same ``| grep -c ... || true``
-    shape, which keeps grep's no-match exit status from tripping ssh_exec's
-    ``check=True``).
+    Reads ``home-assistant.log`` inside the Core container, the same file the
+    container lane reads through its bind mount. ``ha core logs`` was tried
+    first and does not carry the line: it serves a bounded tail of the Core
+    journal, and by the time this test runs the boot-time registration line
+    is outside that window. The ``|| true`` keeps grep's no-match exit status
+    from tripping ssh_exec's ``check=True``.
     """
-    script = f"ha core logs 2>/dev/null | grep -c '{_REGISTRATION_LINE}' || true"
+    script = (
+        f"docker exec {_HAOS_CORE_CONTAINER} sh -c "
+        f"\"grep -c '{_REGISTRATION_LINE}' /config/home-assistant.log 2>/dev/null"
+        ' || true"'
+    )
     deadline = time.monotonic() + _REGISTRATION_TIMEOUT_S
     count = ""
     while True:
         # Bound each ssh call by what is left of the deadline (with a small
         # floor so a near-expired deadline still gets one real attempt), so a
-        # stalled `ha core logs` cannot outlive the deadline it polls for.
+        # stalled call cannot outlive the deadline it polls for.
         remaining = max(5.0, deadline - time.monotonic())
         count = ssh_exec(["sh", "-c", script], timeout=remaining).stdout.strip()
         if count.isdigit() and int(count) > 0:
@@ -244,7 +250,8 @@ def _assert_registration_logged_in_haos() -> None:
         LOG.debug("LLM-API registration line not in Core's log yet (count=%r)", count)
         time.sleep(_REGISTRATION_POLL_S)
     raise AssertionError(
-        f"{_REGISTRATION_LINE!r} never appeared in Core's log within "
+        f"{_REGISTRATION_LINE!r} never appeared in /config/home-assistant.log "
+        f"inside the {_HAOS_CORE_CONTAINER} container within "
         f"{_REGISTRATION_TIMEOUT_S}s (grep count: {count!r}), so the toolset "
         "was never registered as an LLM API inside this Home Assistant"
     )

--- a/tests/src/unit/_embedded_stubs.py
+++ b/tests/src/unit/_embedded_stubs.py
@@ -654,7 +654,7 @@ def install() -> None:
     setmod("homeassistant.exceptions", HomeAssistantError=HomeAssistantError)
     setmod(
         "homeassistant.const",
-        __version__="2026.6.0",
+        __version__="2026.8.0",
         Platform=Platform,
         EVENT_HOMEASSISTANT_STARTED=EVENT_HOMEASSISTANT_STARTED,
     )

--- a/tests/src/unit/test_component_metadata.py
+++ b/tests/src/unit/test_component_metadata.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import importlib.util
 import json
 from pathlib import Path
 
@@ -25,6 +26,16 @@ def test_hacs_requires_supported_home_assistant_version() -> None:
     rather than at it (#2361).
     """
     metadata = json.loads((_REPO_ROOT / "hacs.json").read_text(encoding="utf-8"))
+
+    # The runtime floor the config flow enforces for the in-process server
+    # entry must not admit a Core the integration cannot load on. const.py is
+    # loaded by path: importing the package would pull in homeassistant.
+    const_path = _REPO_ROOT / "custom_components" / "ha_mcp_tools" / "const.py"
+    spec = importlib.util.spec_from_file_location("ha_mcp_tools_const", const_path)
+    assert spec is not None and spec.loader is not None
+    const = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(const)
+    assert metadata["homeassistant"] == const.MIN_EMBEDDED_HOME_ASSISTANT_VERSION
 
     assert metadata["homeassistant"] == "2026.8.0"
 

--- a/tests/src/unit/test_config_flow.py
+++ b/tests/src/unit/test_config_flow.py
@@ -60,7 +60,7 @@ _core.callback = lambda func: func  # identity so async_get_options_flow builds
 sys.modules["homeassistant.core"] = _core
 
 _ha_const = MagicMock()
-_ha_const.__version__ = "2026.6.0"
+_ha_const.__version__ = "2026.8.0"
 sys.modules["homeassistant.const"] = _ha_const
 
 
@@ -231,7 +231,7 @@ class TestServerBranch:
         assert result["reason"] == "unsupported_home_assistant"
         assert result["description_placeholders"] == {
             "installed": "2025.9.4",
-            "required": "2026.6.0",
+            "required": "2026.8.0",
         }
         flow.async_set_unique_id.assert_not_awaited()
 

--- a/tests/src/unit/test_embedded_server.py
+++ b/tests/src/unit/test_embedded_server.py
@@ -2932,7 +2932,7 @@ class TestLifecycle:
 
         with pytest.raises(
             es.EmbeddedServerError,
-            match=r"requires Home Assistant 2026\.6\.0 or newer",
+            match=r"requires Home Assistant 2026\.8\.0 or newer",
         ) as exc:
             await mgr.async_start()
 

--- a/tests/src/unit/test_haos_image_workflow_shape.py
+++ b/tests/src/unit/test_haos_image_workflow_shape.py
@@ -426,25 +426,39 @@ def test_container_beta_lane_resolves_the_beta_core_image_once() -> None:
         "image": "${{ steps.versions.outputs.image }}",
         "superfluous": "${{ steps.versions.outputs.superfluous }}",
     }
-    # The skip compares against the stable lane's PIN, not stable.json: while
-    # the Renovate bump lags a release, beta equals the new stable and this
-    # lane is the only container lane on it. The resolver reads that pin with
-    # sed; pin the extraction here so a reformatted pin cannot silently turn
-    # into an empty comparison on the nightly.
-    assert ".github/workflows/e2e-tests.yml" in resolve["run"]
+    # The skip compares against the image the E2E fixtures actually build
+    # from (tests/test_constants.HA_TEST_IMAGE's default), not stable.json:
+    # while the Renovate bump lags a release, beta equals the new stable and
+    # this lane is the only container lane on it. The resolver reads that
+    # literal with sed; pin the extraction here so a reformatted pin cannot
+    # silently turn into an empty comparison on the nightly.
+    assert "tests/test_constants.py" in resolve["run"]
     assert "superfluous=$superfluous" in resolve["run"]
-    stable_workflow = (_WORKFLOW_DIR / "e2e-tests.yml").read_text(encoding="utf-8")
+    constants = (_REPO_ROOT / "tests" / "test_constants.py").read_text(encoding="utf-8")
     pins = re.findall(
-        r'^  HA_IMAGE_GHCR: "ghcr\.io/home-assistant/home-assistant:(.*)"$',
-        stable_workflow,
+        r'^_DEFAULT_HA_TEST_IMAGE = "ghcr\.io/home-assistant/home-assistant:(.*)"$',
+        constants,
         flags=re.MULTILINE,
     )
     assert len(pins) == 1 and re.fullmatch(r"\d{4}\.\d{1,2}\.\d+", pins[0]), (
-        f"the resolver's sed over e2e-tests.yml would not find one version pin: {pins}"
+        f"the resolver's sed over tests/test_constants.py would not find one pin: {pins}"
     )
+    # The workflow-level pins are pre-pull and cache-key inputs for the same
+    # image; Renovate moves all four together, and the skip's premise (the
+    # stable lanes ran exactly this image) holds only while they agree.
+    for pinned_workflow in ("pr.yml", "e2e-tests.yml", "performance-tests.yml"):
+        text = (_WORKFLOW_DIR / pinned_workflow).read_text(encoding="utf-8")
+        workflow_pins = re.findall(
+            r'^  HA_IMAGE_GHCR: "ghcr\.io/home-assistant/home-assistant:(.*)"$',
+            text,
+            flags=re.MULTILINE,
+        )
+        assert workflow_pins == pins, (
+            f"{pinned_workflow} pins {workflow_pins} but the fixtures run {pins}"
+        )
     checkout = _job_steps(resolver)[0]
     assert str(checkout.get("uses", "")).startswith("actions/checkout@")
-    assert checkout["with"]["sparse-checkout"] == ".github/workflows/e2e-tests.yml"
+    assert checkout["with"]["sparse-checkout"] == "tests/test_constants.py"
 
     image_ref = "${{ needs.resolve-beta.outputs.image }}"
     test_jobs = {

--- a/tests/src/unit/test_haos_image_workflow_shape.py
+++ b/tests/src/unit/test_haos_image_workflow_shape.py
@@ -459,6 +459,9 @@ def test_container_beta_lane_resolves_the_beta_core_image_once() -> None:
     checkout = _job_steps(resolver)[0]
     assert str(checkout.get("uses", "")).startswith("actions/checkout@")
     assert checkout["with"]["sparse-checkout"] == "tests/test_constants.py"
+    # A single-file pattern needs non-cone mode; actions/checkout defaults
+    # cone mode to true, which would leave the file out of the checkout.
+    assert checkout["with"]["sparse-checkout-cone-mode"] is False
 
     image_ref = "${{ needs.resolve-beta.outputs.image }}"
     test_jobs = {

--- a/tests/src/unit/test_haos_image_workflow_shape.py
+++ b/tests/src/unit/test_haos_image_workflow_shape.py
@@ -216,7 +216,10 @@ def test_beta_lanes_share_a_current_supervisor_and_core_image() -> None:
     assert _beta_lane_jobs() == {
         (_BETA_WORKFLOW, beta_job_id, mode)
         for beta_job_id, mode, _stable_job_id in lane_specs
-    } | {(_CONTAINER_BETA_WORKFLOW, "resolve-beta", "None")}
+    } | {
+        (_BETA_WORKFLOW, "resolve-beta", "None"),
+        (_CONTAINER_BETA_WORKFLOW, "resolve-beta", "None"),
+    }
 
     beta_path = _WORKFLOW_DIR / _BETA_WORKFLOW
     assert beta_path.is_file(), "both beta lanes live in one workflow file"
@@ -244,19 +247,37 @@ def test_beta_lanes_share_a_current_supervisor_and_core_image() -> None:
         "means it can never authorize a skip (#2311)"
     )
 
+    # Both lanes are skipped when beta.json and stable.json agree: the stable
+    # HAOS lanes bake from the stable channel, so an identical beta would only
+    # repeat them. The compare job reads both channels once.
+    resolver = workflow["jobs"]["resolve-beta"]
+    assert resolver["outputs"] == {
+        "superfluous": "${{ steps.compare.outputs.superfluous }}"
+    }
+    compare = next(step for step in _job_steps(resolver) if step.get("id") == "compare")
+    assert "version.home-assistant.io/beta.json" in compare["run"]
+    assert "version.home-assistant.io/stable.json" in compare["run"]
+    assert '["supervisor"]' in compare["run"]
+    assert '["homeassistant"]["qemux86-64"]' in compare["run"]
+    skip_guard = "needs.resolve-beta.outputs.superfluous != 'true'"
+
     for beta_job_id, mode, stable_job_id in lane_specs:
         job = workflow["jobs"][beta_job_id]
 
         if mode == "inaddon":
-            assert "needs" not in job
-            assert "if" not in job
+            assert job["needs"] == "resolve-beta"
+            assert job["if"] == skip_guard
         else:
-            assert job["needs"] == "haos-e2e-inaddon-beta", (
+            assert job["needs"] == ["resolve-beta", "haos-e2e-inaddon-beta"], (
                 "the embedded lane must wait for the sole cache writer"
             )
-            assert job["if"] == "${{ !cancelled() }}", (
+            assert job["if"] == (
+                "${{ !cancelled() && needs.resolve-beta.result == 'success' "
+                f"&& {skip_guard} }}}}"
+            ), (
                 "the embedded lane must continue after a writer failure, but "
-                "not after a superseding run cancels the workflow"
+                "not after a superseding run cancels the workflow, and never "
+                "when the compare job failed or found beta equal to stable"
             )
         steps = _job_steps(job)
 
@@ -396,7 +417,16 @@ def test_container_beta_lane_resolves_the_beta_core_image_once() -> None:
     assert resolver["outputs"] == {
         "core_version": "${{ steps.versions.outputs.core_version }}",
         "image": "${{ steps.versions.outputs.image }}",
+        "superfluous": "${{ steps.versions.outputs.superfluous }}",
     }
+    # The skip compares against the stable lane's PIN, not stable.json: while
+    # the Renovate bump lags a release, beta equals the new stable and this
+    # lane is the only container lane on it.
+    assert ".github/workflows/e2e-tests.yml" in resolve["run"]
+    assert "superfluous=$superfluous" in resolve["run"]
+    checkout = _job_steps(resolver)[0]
+    assert str(checkout.get("uses", "")).startswith("actions/checkout@")
+    assert checkout["with"]["sparse-checkout"] == ".github/workflows/e2e-tests.yml"
 
     image_ref = "${{ needs.resolve-beta.outputs.image }}"
     test_jobs = {
@@ -413,6 +443,9 @@ def test_container_beta_lane_resolves_the_beta_core_image_once() -> None:
     }, "the beta workflow mirrors e2e-tests.yml job for job"
     for job_id, job in test_jobs.items():
         assert job["needs"] == "resolve-beta", job_id
+        assert job["if"] == "needs.resolve-beta.outputs.superfluous != 'true'", (
+            f"{job_id} must be skipped when beta equals the stable pin"
+        )
         assert job["env"]["HA_IMAGE_GHCR"] == image_ref, job_id
         assert job["env"]["HA_TEST_IMAGE"] == image_ref, (
             f"{job_id}: the E2E fixtures build their container from "

--- a/tests/src/unit/test_haos_image_workflow_shape.py
+++ b/tests/src/unit/test_haos_image_workflow_shape.py
@@ -430,8 +430,10 @@ def test_container_beta_lane_resolves_the_beta_core_image_once() -> None:
     # from (tests/test_constants.HA_TEST_IMAGE's default), not stable.json:
     # while the Renovate bump lags a release, beta equals the new stable and
     # this lane is the only container lane on it. The resolver reads that
-    # literal with sed; pin the extraction here so a reformatted pin cannot
-    # silently turn into an empty comparison on the nightly.
+    # literal with sed and aborts on an empty result, so a reformatted pin
+    # can never reach the comparison; pinning the extraction here surfaces
+    # such a reformat on the pull request instead of as a failed resolver on
+    # the next push or nightly.
     assert "tests/test_constants.py" in resolve["run"]
     assert "superfluous=$superfluous" in resolve["run"]
     constants = (_REPO_ROOT / "tests" / "test_constants.py").read_text(encoding="utf-8")
@@ -460,7 +462,9 @@ def test_container_beta_lane_resolves_the_beta_core_image_once() -> None:
     assert str(checkout.get("uses", "")).startswith("actions/checkout@")
     assert checkout["with"]["sparse-checkout"] == "tests/test_constants.py"
     # A single-file pattern needs non-cone mode; actions/checkout defaults
-    # cone mode to true, which would leave the file out of the checkout.
+    # cone mode to true, which would leave the file out of the checkout, the
+    # sed would find nothing, and the resolver's empty-pin check would abort
+    # the job. The pin protects the job, not the comparison.
     assert checkout["with"]["sparse-checkout-cone-mode"] is False
 
     image_ref = "${{ needs.resolve-beta.outputs.image }}"

--- a/tests/src/unit/test_haos_image_workflow_shape.py
+++ b/tests/src/unit/test_haos_image_workflow_shape.py
@@ -1,5 +1,6 @@
 """Guard shared HAOS workflow contracts without restructuring proven lanes."""
 
+import re
 from pathlib import Path
 from typing import Any
 
@@ -247,9 +248,10 @@ def test_beta_lanes_share_a_current_supervisor_and_core_image() -> None:
         "means it can never authorize a skip (#2311)"
     )
 
-    # Both lanes are skipped when beta.json and stable.json agree: the stable
-    # HAOS lanes bake from the stable channel, so an identical beta would only
-    # repeat them. The compare job reads both channels once.
+    # The skip gate; its rationale is the resolve-beta job comment in the
+    # workflow itself. Pinned here: both channels read, every value validated
+    # (a failed parse must fail the job, never skip the lanes), and a manual
+    # dispatch always runs.
     resolver = workflow["jobs"]["resolve-beta"]
     assert resolver["outputs"] == {
         "superfluous": "${{ steps.compare.outputs.superfluous }}"
@@ -259,7 +261,12 @@ def test_beta_lanes_share_a_current_supervisor_and_core_image() -> None:
     assert "version.home-assistant.io/stable.json" in compare["run"]
     assert '["supervisor"]' in compare["run"]
     assert '["homeassistant"]["qemux86-64"]' in compare["run"]
-    skip_guard = "needs.resolve-beta.outputs.superfluous != 'true'"
+    assert compare["run"].count("|| exit 1") == 4
+    assert "::error::" in compare["run"]
+    skip_guard = (
+        "github.event_name == 'workflow_dispatch' || "
+        "needs.resolve-beta.outputs.superfluous != 'true'"
+    )
 
     for beta_job_id, mode, stable_job_id in lane_specs:
         job = workflow["jobs"][beta_job_id]
@@ -273,7 +280,7 @@ def test_beta_lanes_share_a_current_supervisor_and_core_image() -> None:
             )
             assert job["if"] == (
                 "${{ !cancelled() && needs.resolve-beta.result == 'success' "
-                f"&& {skip_guard} }}}}"
+                f"&& ({skip_guard}) }}}}"
             ), (
                 "the embedded lane must continue after a writer failure, but "
                 "not after a superseding run cancels the workflow, and never "
@@ -421,9 +428,20 @@ def test_container_beta_lane_resolves_the_beta_core_image_once() -> None:
     }
     # The skip compares against the stable lane's PIN, not stable.json: while
     # the Renovate bump lags a release, beta equals the new stable and this
-    # lane is the only container lane on it.
+    # lane is the only container lane on it. The resolver reads that pin with
+    # sed; pin the extraction here so a reformatted pin cannot silently turn
+    # into an empty comparison on the nightly.
     assert ".github/workflows/e2e-tests.yml" in resolve["run"]
     assert "superfluous=$superfluous" in resolve["run"]
+    stable_workflow = (_WORKFLOW_DIR / "e2e-tests.yml").read_text(encoding="utf-8")
+    pins = re.findall(
+        r'^  HA_IMAGE_GHCR: "ghcr\.io/home-assistant/home-assistant:(.*)"$',
+        stable_workflow,
+        flags=re.MULTILINE,
+    )
+    assert len(pins) == 1 and re.fullmatch(r"\d{4}\.\d{1,2}\.\d+", pins[0]), (
+        f"the resolver's sed over e2e-tests.yml would not find one version pin: {pins}"
+    )
     checkout = _job_steps(resolver)[0]
     assert str(checkout.get("uses", "")).startswith("actions/checkout@")
     assert checkout["with"]["sparse-checkout"] == ".github/workflows/e2e-tests.yml"
@@ -441,10 +459,15 @@ def test_container_beta_lane_resolves_the_beta_core_image_once() -> None:
         "e2e-tests-embedded-server-only",
         "e2e-tests-update-path",
     }, "the beta workflow mirrors e2e-tests.yml job for job"
+    skip_guard = (
+        "github.event_name == 'workflow_dispatch' || "
+        "needs.resolve-beta.outputs.superfluous != 'true'"
+    )
     for job_id, job in test_jobs.items():
         assert job["needs"] == "resolve-beta", job_id
-        assert job["if"] == "needs.resolve-beta.outputs.superfluous != 'true'", (
-            f"{job_id} must be skipped when beta equals the stable pin"
+        assert job["if"] == skip_guard, (
+            f"{job_id} must be skipped when beta equals the stable pin, except "
+            "on a manual dispatch"
         )
         assert job["env"]["HA_IMAGE_GHCR"] == image_ref, job_id
         assert job["env"]["HA_TEST_IMAGE"] == image_ref, (

--- a/tests/src/unit/test_llm_api.py
+++ b/tests/src/unit/test_llm_api.py
@@ -1486,6 +1486,23 @@ class TestExclusiveBoundNormalisation:
         assert set(guard._EXCLUSIVE_KEYWORDS) == {
             exclusive for exclusive, *_ in llm_api._EXCLUSIVE_BOUNDS
         }
+        # The fourth copy is a prefix rule rather than a set: OpenAPI ``x-``
+        # extensions are opaque to the component and skipped by the guard.
+        assert llm_api._is_opaque_key("x-anything")
+        assert guard._exclusive_bounds({"x-a": {"exclusiveMinimum": 1}}, "r") == []
+        # ...but only as a KEYWORD: a property literally named ``x-limit`` is a
+        # subschema on both sides, so its bound is normalised and reported.
+        named = {
+            "type": "object",
+            "properties": {"x-limit": {"type": "number", "exclusiveMinimum": 0}},
+        }
+        assert llm_api._to_inclusive_bounds(named)["properties"]["x-limit"] == {
+            "type": "number",
+            "minimum": 0,
+        }
+        assert guard._exclusive_bounds(named, "r") == [
+            "r.properties.x-limit: exclusiveMinimum"
+        ]
 
     def test_an_untouched_schema_is_not_reported(self, caplog):
         """Nothing changed, so nothing is worth an operator's attention."""

--- a/tests/src/unit/test_llm_api.py
+++ b/tests/src/unit/test_llm_api.py
@@ -1123,6 +1123,20 @@ class TestExclusiveBoundNormalisation:
 
         assert llm_api._to_inclusive_bounds(schema) == schema
 
+    def test_a_specification_extension_is_opaque(self):
+        """``x-`` keys hold arbitrary vendor objects, not subschemas.
+
+        The OpenAPI specification allows any value under an ``x-`` extension,
+        so a bound-like key inside one is vendor data; rewriting it would
+        corrupt the extension while leaving the schema itself unchanged.
+        """
+        schema = {
+            "type": "number",
+            "x-ui": {"exclusiveMinimum": 5, "nested": {"exclusiveMaximum": True}},
+        }
+
+        assert llm_api._to_inclusive_bounds(schema) == schema
+
     def test_a_property_named_like_the_keyword_is_left_alone(self):
         schema = {
             "type": "object",

--- a/tests/src/unit/test_llm_api.py
+++ b/tests/src/unit/test_llm_api.py
@@ -1137,6 +1137,17 @@ class TestExclusiveBoundNormalisation:
 
         assert llm_api._to_inclusive_bounds(schema) == schema
 
+    def test_a_specification_extension_is_copied_not_aliased(self):
+        """Like instance values: the result must not share the input's objects."""
+        extension = {"exclusiveMinimum": 5, "nested": {"list": [1, 2]}}
+        schema = {"type": "number", "x-ui": extension}
+
+        result = llm_api._to_inclusive_bounds(schema)
+        result["x-ui"]["nested"]["list"].append(3)
+
+        assert extension["nested"]["list"] == [1, 2]
+        assert result["x-ui"] is not extension
+
     def test_a_property_named_like_the_keyword_is_left_alone(self):
         schema = {
             "type": "object",

--- a/tests/src/unit/test_llm_api_probe.py
+++ b/tests/src/unit/test_llm_api_probe.py
@@ -10,6 +10,8 @@ table-tested.
 
 from __future__ import annotations
 
+import ast
+import inspect
 import sys
 from pathlib import Path
 from typing import Any
@@ -20,6 +22,7 @@ _E2E_UTILITIES = Path(__file__).resolve().parents[1] / "e2e" / "utilities"
 if str(_E2E_UTILITIES) not in sys.path:
     sys.path.insert(0, str(_E2E_UTILITIES))
 
+import llm_api_probe  # noqa: E402
 from llm_api_probe import (  # noqa: E402
     LLM_API_SCHEMA_PROBE,
     MIN_TOOL_COUNT,
@@ -39,7 +42,6 @@ def _clean_report(**overrides: Any) -> dict[str, Any]:
         "probatio_import_error": None,
         "draft2020_checked": True,
         "jsonschema_import_error": None,
-        "inclusive_bounds_normaliser": True,
         "normalise_schema": True,
         "conversion_failures": [],
         "boolean_exclusive": [],
@@ -58,9 +60,61 @@ def _helpers() -> dict[str, Any]:
     return namespace
 
 
+def _written_report_keys() -> set[str]:
+    """Keys of the ``report.update({...})`` literal the runner writes."""
+    tree = ast.parse(llm_api_probe._PROBE_RUNNER_SOURCE)
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "update"
+            and node.args
+            and isinstance(node.args[0], ast.Dict)
+        ):
+            return {
+                key.value for key in node.args[0].keys if isinstance(key, ast.Constant)
+            }
+    raise AssertionError("no report.update({...}) literal found in the probe runner")
+
+
+def _read_report_keys() -> set[str]:
+    """Every ``report.get("...")`` and ``report["..."]`` key the reader uses."""
+    tree = ast.parse(inspect.getsource(assert_report_clean))
+    keys: set[str] = set()
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "get"
+            and node.args
+            and isinstance(node.args[0], ast.Constant)
+        ):
+            keys.add(node.args[0].value)
+        elif (
+            isinstance(node, ast.Subscript)
+            and isinstance(node.slice, ast.Constant)
+            and isinstance(node.slice.value, str)
+        ):
+            keys.add(node.slice.value)
+    return keys
+
+
 class TestProbeSource:
     def test_the_probe_source_compiles(self) -> None:
         compile(LLM_API_SCHEMA_PROBE, "<probe>", "exec")
+
+    def test_every_key_the_reader_uses_is_one_the_runner_writes(self) -> None:
+        """A renamed defect-signal key must fail here, not degrade to green.
+
+        The reader goes through ``report.get``, so a key the runner stopped
+        writing reads as "no problem"; bind the two statically.
+        """
+        written = _written_report_keys()
+        read = _read_report_keys()
+
+        assert read, "the reader reads no keys at all?"
+        assert read <= written, f"read but never written: {sorted(read - written)}"
+        assert written <= read, f"written but never read: {sorted(written - read)}"
 
     def test_the_helpers_compile_and_load_standalone(self) -> None:
         helpers = _helpers()

--- a/tests/src/unit/test_llm_api_probe.py
+++ b/tests/src/unit/test_llm_api_probe.py
@@ -1,0 +1,206 @@
+"""The in-HA LLM-API probe's host-side halves, pinned without a lane (#2361).
+
+The probe source runs only inside a Home Assistant interpreter on the embedded
+lanes, and the test that consumes its report reads it through string keys the
+source writes. A brace slip in the source or a misspelled key degrades to a
+green lane that proves nothing, so the source is compiled here, its pure
+helpers are exercised, and the report parser and the pass/fail decision are
+table-tested.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+_E2E_UTILITIES = Path(__file__).resolve().parents[1] / "e2e" / "utilities"
+if str(_E2E_UTILITIES) not in sys.path:
+    sys.path.insert(0, str(_E2E_UTILITIES))
+
+from llm_api_probe import (  # noqa: E402
+    LLM_API_SCHEMA_PROBE,
+    MIN_TOOL_COUNT,
+    PROBE_HELPERS_SOURCE,
+    PROBE_SENTINEL,
+    assert_report_clean,
+    parse_probe_report,
+)
+
+
+def _clean_report(**overrides: Any) -> dict[str, Any]:
+    report: dict[str, Any] = {
+        "timed_out": False,
+        "tool_count": 88,
+        "converter": "voluptuous_openapi",
+        "probatio": True,
+        "probatio_import_error": None,
+        "draft2020_checked": True,
+        "jsonschema_import_error": None,
+        "inclusive_bounds_normaliser": True,
+        "normalise_schema": True,
+        "conversion_failures": [],
+        "boolean_exclusive": [],
+        "integer_lost": [],
+        "draft2020_invalid": [],
+        "ha_version": "2026.9.0",
+        "ha_version_error": None,
+    }
+    report.update(overrides)
+    return report
+
+
+def _helpers() -> dict[str, Any]:
+    namespace: dict[str, Any] = {}
+    exec(PROBE_HELPERS_SOURCE, namespace)
+    return namespace
+
+
+class TestProbeSource:
+    def test_the_probe_source_compiles(self) -> None:
+        compile(LLM_API_SCHEMA_PROBE, "<probe>", "exec")
+
+    def test_the_helpers_compile_and_load_standalone(self) -> None:
+        helpers = _helpers()
+        assert callable(helpers["_boolean_exclusive_bounds"])
+
+    def test_the_walk_skips_instance_data_and_extensions(self) -> None:
+        """Mirrors the component: data under default/enum/x- is not a bound."""
+        helpers = _helpers()
+        schema = {
+            "type": "object",
+            "properties": {
+                "n": {"type": "number", "default": {"exclusiveMinimum": True}}
+            },
+            "enum": [{"exclusiveMaximum": True}],
+            "x-ui": {"exclusiveMinimum": True, "type": "integer"},
+        }
+
+        assert helpers["_boolean_exclusive_bounds"](schema) is False
+        assert helpers["_count_integer_nodes"](schema) == 0
+
+    def test_the_walk_reports_a_real_draft4_bound(self) -> None:
+        helpers = _helpers()
+        schema = {
+            "type": "object",
+            "properties": {
+                "budget": {
+                    "anyOf": [
+                        {"type": "number", "minimum": 0, "exclusiveMinimum": True},
+                        {"type": "null"},
+                    ]
+                }
+            },
+        }
+
+        assert helpers["_boolean_exclusive_bounds"](schema) is True
+
+    def test_integer_nodes_are_counted_in_subschemas_only(self) -> None:
+        helpers = _helpers()
+        schema = {
+            "type": "object",
+            "properties": {
+                "a": {"type": "integer"},
+                "b": {"type": ["integer", "null"], "x-hint": {"type": "integer"}},
+            },
+        }
+
+        assert helpers["_count_integer_nodes"](schema) == 2
+
+    def test_short_names_the_innermost_frame(self) -> None:
+        helpers = _helpers()
+
+        def boom() -> None:
+            raise ValueError("first line\nsecond line")
+
+        try:
+            boom()
+        except ValueError as err:
+            text = helpers["_short"](err)
+
+        assert text.startswith("ValueError: first line at ")
+        assert text.endswith(" in boom")
+        assert "second line" not in text
+
+
+class TestParseProbeReport:
+    def test_returns_the_report_after_the_sentinel(self) -> None:
+        stdout = f'noise\n{PROBE_SENTINEL} {{"tool_count": 3}}\n'
+
+        assert parse_probe_report(stdout) == {"tool_count": 3}
+
+    def test_no_sentinel_fails_with_the_output(self) -> None:
+        with pytest.raises(
+            AssertionError, match="printed no LLM_API_PROBE_REPORT line"
+        ):
+            parse_probe_report("Traceback (most recent call last):\nboom\n")
+
+    def test_bad_json_fails_with_the_payload(self) -> None:
+        with pytest.raises(AssertionError, match="unparseable report"):
+            parse_probe_report(f"{PROBE_SENTINEL} {{not json")
+
+    def test_a_non_object_payload_fails(self) -> None:
+        with pytest.raises(AssertionError, match="printed a list, not a report object"):
+            parse_probe_report(f"{PROBE_SENTINEL} [1, 2]")
+
+
+class TestAssertReportClean:
+    def test_a_clean_report_passes(self) -> None:
+        assert_report_clean(_clean_report())
+
+    @pytest.mark.parametrize(
+        ("overrides", "fragment"),
+        [
+            ({"timed_out": True}, "hit its own timeout"),
+            ({"ha_version": "unknown"}, "could not read Home Assistant's version"),
+            ({"tool_count": MIN_TOOL_COUNT}, "expected the full tool inventory"),
+            ({"conversion_failures": ["ha_x: TypeError: boom"]}, "failed to convert"),
+            ({"boolean_exclusive": ["ha_search"]}, "BOOLEAN exclusiveMinimum"),
+            ({"integer_lost": ["ha_search"]}, "fewer integer-typed nodes"),
+            (
+                {"draft2020_invalid": ["ha_search: SchemaError"]},
+                "not valid JSON Schema",
+            ),
+            ({"draft2020_checked": False}, "jsonschema was not importable"),
+        ],
+        ids=lambda value: value if isinstance(value, str) else next(iter(value)),
+    )
+    def test_each_dirty_field_fails_with_its_own_message(
+        self, overrides: dict[str, Any], fragment: str
+    ) -> None:
+        with pytest.raises(AssertionError, match=fragment):
+            assert_report_clean(_clean_report(**overrides))
+
+    def test_the_offending_tools_are_named(self) -> None:
+        with pytest.raises(AssertionError, match=r"\['ha_search', 'ha_get_state'\]"):
+            assert_report_clean(
+                _clean_report(boolean_exclusive=["ha_search", "ha_get_state"])
+            )
+
+    def test_missing_probatio_is_fine_on_a_pre_probatio_core(self) -> None:
+        """No re-emission step exists there, so conversion is the contract."""
+        assert_report_clean(
+            _clean_report(
+                probatio=False,
+                draft2020_checked=False,
+                ha_version="2026.8.3",
+                boolean_exclusive=["ignored: no re-emission happened"],
+            )
+        )
+
+    def test_missing_probatio_on_a_probatio_core_is_a_broken_image(self) -> None:
+        with pytest.raises(AssertionError, match="broken image"):
+            assert_report_clean(
+                _clean_report(
+                    probatio=False,
+                    ha_version="2026.9.0",
+                    probatio_import_error="ImportError: boom",
+                )
+            )
+
+    def test_timed_out_wins_over_everything_else(self) -> None:
+        """The partial report is the diagnosis; nothing else is trustworthy."""
+        with pytest.raises(AssertionError, match="partial report"):
+            assert_report_clean(_clean_report(timed_out=True, tool_count=0))

--- a/tests/src/unit/test_logger_seed.py
+++ b/tests/src/unit/test_logger_seed.py
@@ -1,0 +1,64 @@
+"""The seeded-config logger merge used by the HAOS deadlock e2e (#2357/#2361).
+
+Three branches, all pure string work, so they are pinned here rather than
+discovered inside a 75-minute HAOS lane the first time the seed changes.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+_E2E_UTILITIES = Path(__file__).resolve().parents[1] / "e2e" / "utilities"
+if str(_E2E_UTILITIES) not in sys.path:
+    sys.path.insert(0, str(_E2E_UTILITIES))
+
+from logger_seed import with_probe_logger_config  # noqa: E402
+
+_COMPONENT = "\nreentrant_log_probe:\n"
+_ENTRY = "    custom_components.reentrant_log_probe: debug\n"
+
+
+def test_merges_into_the_seeds_logs_mapping() -> None:
+    seed = "default_config:\n\nlogger:\n  logs:\n    custom_components.ha_mcp_tools: info\n"
+
+    merged = with_probe_logger_config(seed, _COMPONENT, _ENTRY)
+
+    assert merged.count("\nlogger:") == 1
+    assert yaml.safe_load(merged)["logger"]["logs"] == {
+        "custom_components.ha_mcp_tools": "info",
+        "custom_components.reentrant_log_probe": "debug",
+    }
+    assert "reentrant_log_probe" in yaml.safe_load(merged)
+
+
+def test_appends_a_whole_block_when_the_seed_has_none() -> None:
+    merged = with_probe_logger_config("default_config:\n", _COMPONENT, _ENTRY)
+
+    assert yaml.safe_load(merged)["logger"]["logs"] == {
+        "custom_components.reentrant_log_probe": "debug"
+    }
+
+
+def test_refuses_a_logger_block_without_a_logs_mapping() -> None:
+    seed = "logger:\n  default: warning\n\nfrontend:\n"
+
+    with pytest.raises(AssertionError, match="no `logs:` mapping"):
+        with_probe_logger_config(seed, _COMPONENT, _ENTRY)
+
+
+def test_the_real_seed_merges_cleanly() -> None:
+    """The committed seed is the shape the HAOS lane will actually hand over."""
+    seed = (
+        Path(__file__).resolve().parents[2]
+        / "initial_test_state"
+        / "configuration.yaml"
+    ).read_text(encoding="utf-8")
+
+    merged = with_probe_logger_config(seed, _COMPONENT, _ENTRY)
+
+    assert merged.count("\nlogger:") == 1
+    assert "custom_components.reentrant_log_probe: debug" in merged

--- a/tests/src/unit/test_tool_schema_exclusive_bounds.py
+++ b/tests/src/unit/test_tool_schema_exclusive_bounds.py
@@ -98,7 +98,10 @@ def _exclusive_bounds(node: Any, path: str) -> list[str]:
             f"{path}: {keyword}" for keyword in _EXCLUSIVE_KEYWORDS if keyword in node
         )
         for key, value in node.items():
-            if key in _NOT_SUBSCHEMAS:
+            # OpenAPI ``x-`` extensions hold vendor data the component copies
+            # through untouched (llm_api._is_opaque_key), so a bound-like key
+            # inside one is not a bound this guard should reject either.
+            if key in _NOT_SUBSCHEMAS or key.startswith("x-"):
                 continue
             if key in _NAME_MAPS and isinstance(value, dict):
                 for name, sub in value.items():
@@ -122,6 +125,17 @@ def test_the_walk_reports_a_bound_wherever_it_hides() -> None:
         "t.$defs.Item: exclusiveMaximum",
         "t.properties.a.anyOf[0]: exclusiveMinimum",
     ]
+
+
+def test_the_walk_does_not_report_extension_data() -> None:
+    """An ``x-`` extension is opaque to the component, so also to the guard."""
+    schema = {
+        "type": "object",
+        "x-ui": {"exclusiveMinimum": 5},
+        "properties": {"n": {"type": "number", "x-hint": {"exclusiveMaximum": 9}}},
+    }
+
+    assert _exclusive_bounds(schema, "root") == []
 
 
 def test_the_walk_does_not_report_names_or_instance_data() -> None:


### PR DESCRIPTION
## What does this PR do?

Closes out #2361: proves the LLM-API schema conversion inside Home Assistant on every lane where the in-process server is the backend, carries the two component follow-ups from the #2363 review, and stops the beta lanes repeating the stable ones.

**Component (custom_components/ha_mcp_tools, pending 2.1.3)**
- `_to_inclusive_bounds` treats OpenAPI `x-` specification extensions as opaque, like `discriminator`, and deep-copies them; the registry-wide bound guard skips the same prefix. Two regression tests. (CodeRabbit on #2363.)
- `MIN_EMBEDDED_HOME_ASSISTANT_VERSION` moves to 2026.8.0, level with the HACS floor #2363 set, and docs/in-process-server.md says why: the manifest's `voluptuous-openapi` requirement resolves only against Core 2026.7+ constraints and gates the whole integration before any config flow. (Codex on #2363.)

**In-HA proof (tests)**
- `tests/src/e2e/utilities/llm_api_probe.py`: Python run by HA's own interpreter inside the container or VM. It imports the component's `llm_api`, lists tools through the component's `_mcp_session`, converts each schema through the production `_normalise_schema` + `_convert_parameters`, then re-emits through `probatio.to_openapi` and drops root-level combinators exactly as Core's Anthropic integration does. It reports boolean `exclusiveMinimum`/`exclusiveMaximum`, lost `integer` typing, draft 2020-12 validation failures, conversion failures, and which converter Core resolved. SIGALRM backstop prints a partial report if a converter blocks.
- `test_llm_api_in_ha.py`: `embedded_only` runs it via `exec_run` in the session container; `haos_embedded_only` via `ssh_exec` + `docker exec homeassistant`. Both first assert the component's registration line reached Core's log (file on the container lane; `ha core logs --lines 20000` on HAOS, where Core disables the file log under the Supervisor), then assert the report is clean.
- `test_embedded_server.py` no longer converts schemas on the test host; that loop ran the host's `voluptuous_openapi`, not what HA resolves, and could not see the defect.
- `initial_test_state/configuration.yaml` raises `custom_components.ha_mcp_tools` to INFO (`default_config` keeps the logger at WARNING), and the two tests that appended their own `logger:` block now rely on it; the #2357 deadlock test merges its entry into the seeded block.
- Update-path bring-up timeouts append the bind-mounted `home-assistant.log` tail; container stdout alone hid the real cause of a phase-1 timeout on 2026-09-04.
- Skip ceilings bumped for the two marker-gated tests.
- Unit coverage for the proof machinery itself: `test_llm_api_probe.py` compiles the probe source, binds the runner's report keys to the reader's with `ast`, exercises the schema walk, and table-tests the report parser and the pass/fail decision (`assert_report_clean`, now in the utilities module); `test_logger_seed.py` covers the seeded-config logger merge the HAOS deadlock test uses.

**CI**
- `e2e-beta-tests.yml` skips its five jobs when the beta Core equals the image the E2E fixtures build from (`HA_TEST_IMAGE`'s default in tests/test_constants.py; a guard asserts the three workflow-level pins agree with it); `haos-e2e-beta-tests.yml` skips both lanes when beta.json and stable.json agree on Supervisor and Core. With #2362 and #2364 moving the stable lanes to each release on release day, an identical beta only repeated them. A manual dispatch always runs, and the HAOS compare validates every value so a failed parse fails the job rather than skipping the lanes. Both gates are pinned by the workflow-shape unit guards, including the stable-pin extraction.

Closes #2361.

## Type of change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [x] 🔧 Maintenance/refactor
- [x] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [ ] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

Red-then-green, measured on this PR's own lanes. Before #2363 merged, all five embedded lanes (container x64, container arm, container server-entry-only, HAOS embedded, HAOS embedded no-tools) failed on exactly one assertion: `ha_search` re-emitted with a boolean `exclusiveMinimum` through `probatio.codecs.jsonschema`, no normaliser present, HA 2026.9.0; every other test on those lanes passed. After merging master with #2363, the same probe reports `converter='voluptuous_openapi'` with the normaliser present, and the lanes are expected green on the current head. Unit guards for both beta workflows, the embedded-server floor test, and the normaliser tests were run locally on the touched files; nothing else locally.

## Checklist
- [x] I have updated documentation if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Compatibility**
  - Raised the minimum supported Home Assistant version to 2026.8.0.
  - Clarified version requirements and supported server options in the documentation.

- **Reliability**
  - Improved handling of vendor extensions and metadata during tool registration.
  - Enhanced diagnostics for schema validation, logging, and timeout conditions.

- **CI and Testing**
  - Beta workflows now avoid redundant push and nightly runs while supporting manual validation.
  - Expanded coverage for schema processing, logging configuration, and end-to-end API validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->