### PR TITLE
fix(devices): support Core 2026.9 child devices and effective areas

### DIFF
--- a/custom_components/ha_mcp_tools/websocket_api.py
+++ b/custom_components/ha_mcp_tools/websocket_api.py
@@ -1022,8 +1022,13 @@ class _RegistryView:
     label: Any = None
     device: Any = None
 
-    # One request-local, conflict-filtered semantic snapshot.
+    # One request-local, conflict-filtered semantic snapshot plus the identities
+    # removed from it. Visibility filtering consumes the former and its warning
+    # projection consumes the latter, so both paths observe the same evidence.
     _device_entries_by_id_cache: dict[str, Any] | None = dataclass_field(
+        default=None, init=False, repr=False, compare=False
+    )
+    _device_conflicting_ids_cache: frozenset[str] | None = dataclass_field(
         default=None, init=False, repr=False, compare=False
     )
 
@@ -1106,10 +1111,11 @@ def _do_search(
     view = _resolve_registries(hass)
     diagnostics: dict[str, int] = {}
     partial_reasons: list[str] = []
-    # Visibility degradation warnings (unknown category / empty-registry allowlist /
-    # Assist unavailable), collected in the entity block below when a visibility
-    # filter is applied. Surfaced additively so the fast path isn't silent about
-    # incomplete filtering (parity with the server's load_hidden_set warnings).
+    # Visibility degradation warnings (unknown category / conflicting device /
+    # empty-registry allowlist / Assist unavailable), collected in the entity block
+    # below when a visibility filter is applied. Surfaced additively so the fast
+    # path isn't silent about incomplete filtering (parity with the server's
+    # load_hidden_set warnings).
     visibility_warnings: list[str] = []
     hidden: set[str] = set()
 
@@ -2385,6 +2391,7 @@ def _unambiguous_device_entries(view: _RegistryView) -> dict[str, Any]:
     reg = view.device
     if reg is None:
         view._device_entries_by_id_cache = {}
+        view._device_conflicting_ids_cache = frozenset()
         return view._device_entries_by_id_cache
     main_collection = getattr(reg, "devices", None)
     if hasattr(reg, "child_devices"):
@@ -2420,12 +2427,19 @@ def _unambiguous_device_entries(view: _RegistryView) -> dict[str, Any]:
                 device_id,
             )
     view._device_entries_by_id_cache = by_id
+    view._device_conflicting_ids_cache = frozenset(conflicts)
     return view._device_entries_by_id_cache
 
 
 def _all_device_entries(view: _RegistryView) -> list[Any]:
     """Return every unambiguous main and child device entry once."""
     return list(_unambiguous_device_entries(view).values())
+
+
+def _conflicting_device_ids(view: _RegistryView) -> frozenset[str]:
+    """Return device identities excluded from this request as conflicting."""
+    _unambiguous_device_entries(view)
+    return view._device_conflicting_ids_cache or frozenset()
 
 
 def _effective_device_area_id(view: _RegistryView, device: Any) -> str | None:
@@ -5171,6 +5185,11 @@ _ALLOWLIST_REGISTRY_EMPTY_WARNING = (
     "this request (an allow_entity_ids list, if set, still applies) so the filter "
     "does not blank every entity."
 )
+_DEVICE_REGISTRY_CONFLICT_WARNING = (
+    "Entity visibility filter is enabled with an area/label dimension but the "
+    "device registry contained conflicting identities; ambiguous device-derived "
+    "placement and labels were excluded."
+)
 
 
 class _AllowlistState(NamedTuple):
@@ -5349,8 +5368,9 @@ def _visibility_warnings(
 
     Companion to :func:`_visibility_hidden_set`: the hidden-set function silently
     fails open on a degraded dimension (an unknown ``exclude_category``, an
-    area/label allowlist against an empty registry, or a requested-but-unavailable
-    Assist dimension), so this returns the operator-facing warnings the server's
+    area/label dimension against conflicting device identities, an area/label
+    allowlist against an empty registry, or a requested-but-unavailable Assist
+    dimension), so this returns the operator-facing warnings the server's
     ``load_hidden_set`` would emit for the same config. The ha_search consumer
     merges them into the response so the component fast path is no longer silent
     about incomplete filtering. Byte-identical to ``visibility.resolver``'s warning
@@ -5367,6 +5387,15 @@ def _visibility_warnings(
     unknown = exclude_categories - _KNOWN_ENTITY_CATEGORIES
     if unknown:
         warnings.append(_unknown_categories_warning(unknown))
+
+    area_or_label_dimension_active = bool(
+        visibility.get("exclude_areas")
+        or visibility.get("exclude_labels")
+        or visibility.get("allow_areas")
+        or visibility.get("allow_labels")
+    )
+    if area_or_label_dimension_active and _conflicting_device_ids(view):
+        warnings.append(_DEVICE_REGISTRY_CONFLICT_WARNING)
 
     if inventory is None:
         inventory = _visibility_inventory(view, states, visibility)

--- a/custom_components/ha_mcp_tools/websocket_api.py
+++ b/custom_components/ha_mcp_tools/websocket_api.py
@@ -2339,7 +2339,7 @@ def _device(view: _RegistryView, device_id: str | None) -> Any:
     return _call_lookup(view.device, "async_get", device_id)
 
 
-def _device_collection_values(collection: Any) -> list[Any]:
+def _device_collection_values(collection: Any, *, collection_name: str) -> list[Any]:
     """Enumerate a Core device collection across old and 2026.9 shapes.
 
     Before Core 2026.9 ``registry.devices`` was a mapping-like container. Core
@@ -2354,10 +2354,20 @@ def _device_collection_values(collection: Any) -> list[Any]:
         try:
             return list(collection.values())
         except Exception:  # pragma: no cover - defensive
+            _LOGGER.warning(
+                "failed to enumerate device registry collection %s",
+                collection_name,
+                exc_info=True,
+            )
             return []
     try:
         return list(collection)
     except Exception:  # pragma: no cover - defensive
+        _LOGGER.warning(
+            "failed to enumerate device registry collection %s",
+            collection_name,
+            exc_info=True,
+        )
         return []
 
 
@@ -2377,9 +2387,13 @@ def _unambiguous_device_entries(view: _RegistryView) -> dict[str, Any]:
         return view._device_entries_by_id_cache
     main_collection = getattr(reg, "devices", None)
     if hasattr(reg, "child_devices"):
-        candidates = _device_collection_values(main_collection)
+        candidates = _device_collection_values(
+            main_collection, collection_name="devices"
+        )
         candidates.extend(
-            _device_collection_values(getattr(reg, "child_devices", None))
+            _device_collection_values(
+                getattr(reg, "child_devices", None), collection_name="child_devices"
+            )
         )
     else:
         # The pre-2026.9 container is mapping-like and iterates ids, not entries.
@@ -2399,6 +2413,11 @@ def _unambiguous_device_entries(view: _RegistryView) -> dict[str, Any]:
         if prior != current or prior is None:
             conflicts.add(device_id)
             del by_id[device_id]
+            _LOGGER.warning(
+                "device registry contained conflicting device identity %r; "
+                "excluding it from this request",
+                device_id,
+            )
     view._device_entries_by_id_cache = by_id
     return view._device_entries_by_id_cache
 
@@ -2420,7 +2439,7 @@ def _effective_device_area_id(view: _RegistryView, device: Any) -> str | None:
         return None
     direct_area = getattr(device, "area_id", None)
     if direct_area is not None:
-        return direct_area if isinstance(direct_area, str) else None
+        return direct_area if isinstance(direct_area, str) and direct_area else None
     parent_id = getattr(device, "parent_device_id", None)
     if not isinstance(parent_id, str) or not parent_id:
         return None
@@ -2429,7 +2448,7 @@ def _effective_device_area_id(view: _RegistryView, device: Any) -> str | None:
         # Core requires a main-device parent. This also bounds malformed cycles.
         return None
     parent_area = getattr(parent, "area_id", None)
-    return parent_area if isinstance(parent_area, str) else None
+    return parent_area if isinstance(parent_area, str) and parent_area else None
 
 
 def _area_name(view: _RegistryView, area_id: str | None) -> str | None:
@@ -3242,9 +3261,10 @@ _BlueprintLoader.add_multi_constructor("!", _drop_blueprint_tag)
 def _do_device_get(hass: HomeAssistant, params: dict[str, Any]) -> dict[str, Any]:
     """Return one device registry entry by id, optionally with its entities.
 
-    ``{device: <DeviceEntry.dict_repr> | None}`` — ``registry.async_get(device_id)``
-    is a pure O(1) in-memory dict read, and the emitted body is core's
-    ``DeviceEntry.dict_repr`` returned UNMODIFIED — exactly the shape
+    ``{device: <DeviceEntry.dict_repr> | None}`` — a request-local snapshot over
+    Core's supported main and child collections rejects conflicting identities,
+    and the emitted body is core's ``DeviceEntry.dict_repr`` returned UNMODIFIED —
+    exactly the shape
     ``config/device_registry/list`` serializes (it sends
     ``json_bytes(entry.dict_repr)``), so a component-served record is byte-identical
     to one legacy list element by construction (the WS transport JSON-encodes the
@@ -3261,12 +3281,14 @@ def _do_device_get(hass: HomeAssistant, params: dict[str, Any]) -> dict[str, Any
     to match what ``config/entity_registry/list`` returns (it lists disabled entities
     too). The DeviceEntry dict itself stays exactly the raw shape — the join is a
     sibling, so consumers keep their own transforms. The ``entities`` key is present
-    only when requested.
+    only when requested. A child-device result may also carry a sibling
+    ``effective_area_id`` computed from its direct-or-parent placement; that
+    transport-only field is absent from the raw ``device`` mapping.
     """
     device_id = params.get("device_id")
     include_entities = params.get("include_entities", False)
     view = _resolve_registries(hass)
-    entry = _device(view, device_id) if device_id else None
+    entry = _unambiguous_device_entries(view).get(device_id) if device_id else None
     result: dict[str, Any] = {
         "device": _device_dict_repr(entry) if entry is not None else None
     }
@@ -5459,7 +5481,7 @@ def _entity_allowed(
 
 
 def _effective_area_for_entry(view: _RegistryView, entry: Any) -> str | None:
-    """An entity's ``area_id`` falling back to its device's (HA area inheritance)."""
+    """Resolve entity direct area, then its device's direct-or-parent effective area."""
     area_id = getattr(entry, "area_id", None)
     if area_id is not None:
         return area_id if isinstance(area_id, str) and area_id else None

--- a/custom_components/ha_mcp_tools/websocket_api.py
+++ b/custom_components/ha_mcp_tools/websocket_api.py
@@ -1516,7 +1516,7 @@ def _registry_enrichment(view: _RegistryView, entity_id: str) -> dict[str, Any]:
         if reg
         else []
     )
-    area_id = getattr(reg, "area_id", None) if reg else None
+    area_id = _effective_area_for_entry(view, reg) if reg else None
     device_id = getattr(reg, "device_id", None) if reg else None
     labels = set(getattr(reg, "labels", None) or []) if reg else set()
     hidden = bool(getattr(reg, "hidden_by", None)) if reg else False
@@ -1524,8 +1524,6 @@ def _registry_enrichment(view: _RegistryView, entity_id: str) -> dict[str, Any]:
     dev = _device(view, device_id) if device_id else None
     dev_texts: list[str] = []
     if dev is not None:
-        if area_id is None:
-            area_id = _effective_device_area_id(view, dev)
         labels |= set(getattr(dev, "labels", None) or [])
         for attr in ("name_by_user", "name", "manufacturer", "model"):
             val = getattr(dev, attr, None)
@@ -5432,8 +5430,8 @@ def _entity_allowed(
 def _effective_area_for_entry(view: _RegistryView, entry: Any) -> str | None:
     """An entity's ``area_id`` falling back to its device's (HA area inheritance)."""
     area_id = getattr(entry, "area_id", None)
-    if isinstance(area_id, str) and area_id:
-        return area_id
+    if area_id is not None:
+        return area_id if isinstance(area_id, str) and area_id else None
     device_id = getattr(entry, "device_id", None)
     if isinstance(device_id, str) and device_id:
         dev = _device(view, device_id)

--- a/custom_components/ha_mcp_tools/websocket_api.py
+++ b/custom_components/ha_mcp_tools/websocket_api.py
@@ -1525,7 +1525,7 @@ def _registry_enrichment(view: _RegistryView, entity_id: str) -> dict[str, Any]:
     dev_texts: list[str] = []
     if dev is not None:
         if area_id is None:
-            area_id = getattr(dev, "area_id", None)
+            area_id = _effective_device_area_id(view, dev)
         labels |= set(getattr(dev, "labels", None) or [])
         for attr in ("name_by_user", "name", "manufacturer", "model"):
             val = getattr(dev, attr, None)
@@ -2325,6 +2325,84 @@ def _device(view: _RegistryView, device_id: str | None) -> Any:
     return _call_lookup(view.device, "async_get", device_id)
 
 
+def _device_collection_values(collection: Any) -> list[Any]:
+    """Enumerate a Core device collection across old and 2026.9 shapes.
+
+    Before Core 2026.9 ``registry.devices`` was a mapping-like container. Core
+    2026.9 exposes supported iterable collections for both ``devices`` and
+    ``child_devices``. Mapping fakes and older containers still use ``values``;
+    modern collections are consumed by iteration so the deprecated mapping API
+    on ``registry.devices`` is not invoked.
+    """
+    if collection is None:
+        return []
+    if isinstance(collection, Mapping):
+        try:
+            return list(collection.values())
+        except Exception:  # pragma: no cover - defensive
+            return []
+    try:
+        return list(collection)
+    except Exception:  # pragma: no cover - defensive
+        return []
+
+
+def _all_device_entries(view: _RegistryView) -> list[Any]:
+    """Return every unambiguous main and child device entry once.
+
+    Core 2026.9 stores child devices in a separate collection. Older releases
+    have only the mapping-like ``devices`` container. Duplicate ids cannot occur
+    in a valid Core registry; if a drifted/corrupt view supplies conflicting
+    entries, remove that identity rather than choosing one arbitrarily.
+    """
+    reg = view.device
+    if reg is None:
+        return []
+    main_collection = getattr(reg, "devices", None)
+    if hasattr(reg, "child_devices"):
+        candidates = _device_collection_values(main_collection)
+        candidates.extend(
+            _device_collection_values(getattr(reg, "child_devices", None))
+        )
+    else:
+        # The pre-2026.9 container is mapping-like and iterates ids, not entries.
+        candidates = _mapping_values(main_collection)
+
+    order: list[str] = []
+    by_id: dict[str, Any] = {}
+    conflicts: set[str] = set()
+    for entry in candidates:
+        device_id = getattr(entry, "id", None)
+        if not isinstance(device_id, str) or not device_id or device_id in conflicts:
+            continue
+        if device_id not in by_id:
+            order.append(device_id)
+            by_id[device_id] = entry
+            continue
+        prior = _device_dict_repr(by_id[device_id])
+        current = _device_dict_repr(entry)
+        if prior != current or prior is None:
+            conflicts.add(device_id)
+            del by_id[device_id]
+    return [by_id[device_id] for device_id in order if device_id in by_id]
+
+
+def _effective_device_area_id(view: _RegistryView, device: Any) -> str | None:
+    """Return Core 2026.9's direct-or-parent effective device area."""
+    direct_area = getattr(device, "area_id", None)
+    if direct_area is not None:
+        return direct_area if isinstance(direct_area, str) else None
+    parent_id = getattr(device, "parent_device_id", None)
+    if not isinstance(parent_id, str) or not parent_id:
+        return None
+    parent = _device(view, parent_id)
+    if parent is None or getattr(parent, "parent_device_id", None) is not None:
+        # Core requires a main-device parent. This also bounds malformed cycles.
+        return None
+    parent_area = getattr(parent, "area_id", None)
+    return parent_area if isinstance(parent_area, str) else None
+
+
 def _area_name(view: _RegistryView, area_id: str | None) -> str | None:
     if not area_id:
         return None
@@ -2780,17 +2858,14 @@ def _overview_entity_registry(view: _RegistryView) -> list[dict[str, Any]]:
 def _overview_device_registry(view: _RegistryView) -> list[dict[str, Any]]:
     """Device registry as a bare list (id + area + labels + name/manufacturer/model)."""
     out: list[dict[str, Any]] = []
-    reg = view.device
-    devices = getattr(reg, "devices", None) if reg is not None else None
-    values = _mapping_values(devices)
-    for dev in values:
+    for dev in _all_device_entries(view):
         dev_id = getattr(dev, "id", None)
         if not dev_id:
             continue
         out.append(
             {
                 "id": dev_id,
-                "area_id": getattr(dev, "area_id", None),
+                "area_id": _effective_device_area_id(view, dev),
                 "labels": sorted(str(x) for x in (getattr(dev, "labels", None) or [])),
                 "name": getattr(dev, "name", None),
                 "name_by_user": getattr(dev, "name_by_user", None),
@@ -3166,6 +3241,11 @@ def _do_device_get(hass: HomeAssistant, params: dict[str, Any]) -> dict[str, Any
     result: dict[str, Any] = {
         "device": _device_dict_repr(entry) if entry is not None else None
     }
+    if entry is not None and isinstance(getattr(entry, "parent_device_id", None), str):
+        # Additive internal transport metadata. The raw child ``dict_repr`` stays
+        # byte-identical to Core while the server can expose its existing area_id
+        # field using Core's effective placement without a whole-registry read.
+        result["effective_area_id"] = _effective_device_area_id(view, entry)
     if include_entities:
         result["entities"] = _device_entities(view, device_id) if device_id else []
     return result
@@ -3181,10 +3261,8 @@ def _do_device_list(hass: HomeAssistant, params: dict[str, Any]) -> dict[str, An
     than emitted as a partial record.
     """
     view = _resolve_registries(hass)
-    reg = view.device
-    devices = getattr(reg, "devices", None) if reg is not None else None
     out: list[dict[str, Any]] = []
-    for dev in _mapping_values(devices):
+    for dev in _all_device_entries(view):
         repr_dict = _device_dict_repr(dev)
         if repr_dict is not None:
             out.append(repr_dict)
@@ -5359,7 +5437,7 @@ def _effective_area_for_entry(view: _RegistryView, entry: Any) -> str | None:
     device_id = getattr(entry, "device_id", None)
     if isinstance(device_id, str) and device_id:
         dev = _device(view, device_id)
-        dev_area = getattr(dev, "area_id", None) if dev is not None else None
+        dev_area = _effective_device_area_id(view, dev) if dev is not None else None
         return dev_area if isinstance(dev_area, str) and dev_area else None
     return None
 

--- a/custom_components/ha_mcp_tools/websocket_api.py
+++ b/custom_components/ha_mcp_tools/websocket_api.py
@@ -274,6 +274,7 @@ import logging
 import re
 from collections.abc import Collection, Mapping
 from dataclasses import dataclass
+from dataclasses import field as dataclass_field
 from difflib import SequenceMatcher
 from pathlib import Path
 from typing import Any, NamedTuple
@@ -1015,6 +1016,11 @@ class _RegistryView:
     label: Any = None
     device: Any = None
 
+    # One request-local, conflict-filtered semantic snapshot.
+    _device_entries_by_id_cache: dict[str, Any] | None = dataclass_field(
+        default=None, init=False, repr=False, compare=False
+    )
+
 
 def _resolve_registries(hass: HomeAssistant) -> _RegistryView:
     """Snapshot the five registries. Test seam — monkeypatched in unit tests."""
@@ -1521,7 +1527,11 @@ def _registry_enrichment(view: _RegistryView, entity_id: str) -> dict[str, Any]:
     labels = set(getattr(reg, "labels", None) or []) if reg else set()
     hidden = bool(getattr(reg, "hidden_by", None)) if reg else False
 
-    dev = _device(view, device_id) if device_id else None
+    dev = (
+        _unambiguous_device_entries(view).get(device_id)
+        if isinstance(device_id, str) and device_id
+        else None
+    )
     dev_texts: list[str] = []
     if dev is not None:
         labels |= set(getattr(dev, "labels", None) or [])
@@ -2345,17 +2355,20 @@ def _device_collection_values(collection: Any) -> list[Any]:
         return []
 
 
-def _all_device_entries(view: _RegistryView) -> list[Any]:
-    """Return every unambiguous main and child device entry once.
+def _unambiguous_device_entries(view: _RegistryView) -> dict[str, Any]:
+    """Return one request-local map of unambiguous main and child devices.
 
     Core 2026.9 stores child devices in a separate collection. Older releases
     have only the mapping-like ``devices`` container. Duplicate ids cannot occur
     in a valid Core registry; if a drifted/corrupt view supplies conflicting
     entries, remove that identity rather than choosing one arbitrarily.
     """
+    if view._device_entries_by_id_cache is not None:
+        return view._device_entries_by_id_cache
     reg = view.device
     if reg is None:
-        return []
+        view._device_entries_by_id_cache = {}
+        return view._device_entries_by_id_cache
     main_collection = getattr(reg, "devices", None)
     if hasattr(reg, "child_devices"):
         candidates = _device_collection_values(main_collection)
@@ -2366,7 +2379,6 @@ def _all_device_entries(view: _RegistryView) -> list[Any]:
         # The pre-2026.9 container is mapping-like and iterates ids, not entries.
         candidates = _mapping_values(main_collection)
 
-    order: list[str] = []
     by_id: dict[str, Any] = {}
     conflicts: set[str] = set()
     for entry in candidates:
@@ -2374,7 +2386,6 @@ def _all_device_entries(view: _RegistryView) -> list[Any]:
         if not isinstance(device_id, str) or not device_id or device_id in conflicts:
             continue
         if device_id not in by_id:
-            order.append(device_id)
             by_id[device_id] = entry
             continue
         prior = _device_dict_repr(by_id[device_id])
@@ -2382,18 +2393,32 @@ def _all_device_entries(view: _RegistryView) -> list[Any]:
         if prior != current or prior is None:
             conflicts.add(device_id)
             del by_id[device_id]
-    return [by_id[device_id] for device_id in order if device_id in by_id]
+    view._device_entries_by_id_cache = by_id
+    return view._device_entries_by_id_cache
+
+
+def _all_device_entries(view: _RegistryView) -> list[Any]:
+    """Return every unambiguous main and child device entry once."""
+    return list(_unambiguous_device_entries(view).values())
 
 
 def _effective_device_area_id(view: _RegistryView, device: Any) -> str | None:
     """Return Core 2026.9's direct-or-parent effective device area."""
+    devices_by_id = _unambiguous_device_entries(view)
+    device_id = getattr(device, "id", None)
+    if not isinstance(device_id, str) or not device_id:
+        return None
+    device = devices_by_id.get(device_id)
+    if device is None:
+        # Conflicting identities never contribute semantic placement.
+        return None
     direct_area = getattr(device, "area_id", None)
     if direct_area is not None:
         return direct_area if isinstance(direct_area, str) else None
     parent_id = getattr(device, "parent_device_id", None)
     if not isinstance(parent_id, str) or not parent_id:
         return None
-    parent = _device(view, parent_id)
+    parent = devices_by_id.get(parent_id)
     if parent is None or getattr(parent, "parent_device_id", None) is not None:
         # Core requires a main-device parent. This also bounds malformed cycles.
         return None
@@ -5434,7 +5459,7 @@ def _effective_area_for_entry(view: _RegistryView, entry: Any) -> str | None:
         return area_id if isinstance(area_id, str) and area_id else None
     device_id = getattr(entry, "device_id", None)
     if isinstance(device_id, str) and device_id:
-        dev = _device(view, device_id)
+        dev = _unambiguous_device_entries(view).get(device_id)
         dev_area = _effective_device_area_id(view, dev) if dev is not None else None
         return dev_area if isinstance(dev_area, str) and dev_area else None
     return None
@@ -5445,7 +5470,7 @@ def _effective_labels_for_entry(view: _RegistryView, entry: Any) -> set[str]:
     labels = set(getattr(entry, "labels", None) or [])
     device_id = getattr(entry, "device_id", None)
     if isinstance(device_id, str) and device_id:
-        dev = _device(view, device_id)
+        dev = _unambiguous_device_entries(view).get(device_id)
         if dev is not None:
             labels |= set(getattr(dev, "labels", None) or [])
     return labels

--- a/custom_components/ha_mcp_tools/websocket_api.py
+++ b/custom_components/ha_mcp_tools/websocket_api.py
@@ -1031,6 +1031,9 @@ class _RegistryView:
     _device_conflicting_ids_cache: frozenset[str] | None = dataclass_field(
         default=None, init=False, repr=False, compare=False
     )
+    _device_invalid_area_ids_cache: frozenset[str] | None = dataclass_field(
+        default=None, init=False, repr=False, compare=False
+    )
 
 
 def _resolve_registries(hass: HomeAssistant) -> _RegistryView:
@@ -2392,6 +2395,7 @@ def _unambiguous_device_entries(view: _RegistryView) -> dict[str, Any]:
     if reg is None:
         view._device_entries_by_id_cache = {}
         view._device_conflicting_ids_cache = frozenset()
+        view._device_invalid_area_ids_cache = frozenset()
         return view._device_entries_by_id_cache
     main_collection = getattr(reg, "devices", None)
     if hasattr(reg, "child_devices"):
@@ -2440,6 +2444,42 @@ def _conflicting_device_ids(view: _RegistryView) -> frozenset[str]:
     """Return device identities excluded from this request as conflicting."""
     _unambiguous_device_entries(view)
     return view._device_conflicting_ids_cache or frozenset()
+
+
+def _invalid_device_area_ids(view: _RegistryView) -> frozenset[str]:
+    """Return device ids whose area evidence is malformed or has invalid ancestry."""
+    devices_by_id = _unambiguous_device_entries(view)
+    if view._device_invalid_area_ids_cache is not None:
+        return view._device_invalid_area_ids_cache
+    invalid: set[str] = set()
+    for device_id, device in devices_by_id.items():
+        row = _device_dict_repr(device)
+        if row is None:
+            invalid.add(device_id)
+            continue
+        direct_area = row.get("area_id")
+        if direct_area is not None:
+            if not isinstance(direct_area, str) or not direct_area:
+                invalid.add(device_id)
+            continue
+        parent_id = row.get("parent_device_id")
+        if parent_id is None:
+            continue
+        if not isinstance(parent_id, str) or not parent_id:
+            invalid.add(device_id)
+            continue
+        parent = devices_by_id.get(parent_id)
+        parent_row = _device_dict_repr(parent) if parent is not None else None
+        if parent_row is None or parent_row.get("parent_device_id") is not None:
+            invalid.add(device_id)
+            continue
+        parent_area = parent_row.get("area_id")
+        if parent_area is not None and (
+            not isinstance(parent_area, str) or not parent_area
+        ):
+            invalid.add(device_id)
+    view._device_invalid_area_ids_cache = frozenset(invalid)
+    return view._device_invalid_area_ids_cache
 
 
 def _effective_device_area_id(view: _RegistryView, device: Any) -> str | None:
@@ -5190,6 +5230,11 @@ _DEVICE_REGISTRY_CONFLICT_WARNING = (
     "device registry contained conflicting identities; ambiguous device-derived "
     "placement and labels were excluded."
 )
+_DEVICE_REGISTRY_INVALID_AREA_WARNING = (
+    "Entity visibility filter is enabled with an area dimension but the device "
+    "registry contained invalid area relationships; affected device-derived "
+    "placement was excluded."
+)
 
 
 class _AllowlistState(NamedTuple):
@@ -5368,9 +5413,10 @@ def _visibility_warnings(
 
     Companion to :func:`_visibility_hidden_set`: the hidden-set function silently
     fails open on a degraded dimension (an unknown ``exclude_category``, an
-    area/label dimension against conflicting device identities, an area/label
-    allowlist against an empty registry, or a requested-but-unavailable Assist
-    dimension), so this returns the operator-facing warnings the server's
+    area/label dimension against conflicting device identities, an area dimension
+    against invalid device ancestry, an area/label allowlist against an empty
+    registry, or a requested-but-unavailable Assist dimension), so this returns
+    the operator-facing warnings the server's
     ``load_hidden_set`` would emit for the same config. The ha_search consumer
     merges them into the response so the component fast path is no longer silent
     about incomplete filtering. Byte-identical to ``visibility.resolver``'s warning
@@ -5396,6 +5442,10 @@ def _visibility_warnings(
     )
     if area_or_label_dimension_active and _conflicting_device_ids(view):
         warnings.append(_DEVICE_REGISTRY_CONFLICT_WARNING)
+    if (
+        visibility.get("exclude_areas") or visibility.get("allow_areas")
+    ) and _invalid_device_area_ids(view):
+        warnings.append(_DEVICE_REGISTRY_INVALID_AREA_WARNING)
 
     if inventory is None:
         inventory = _visibility_inventory(view, states, visibility)

--- a/custom_components/ha_mcp_tools/websocket_api.py
+++ b/custom_components/ha_mcp_tools/websocket_api.py
@@ -1540,9 +1540,10 @@ def _registry_enrichment(view: _RegistryView, entity_id: str) -> dict[str, Any]:
     )
     dev_texts: list[str] = []
     if dev is not None:
-        labels |= set(getattr(dev, "labels", None) or [])
+        dev_row = _device_dict_repr(dev) or {}
+        labels |= set(dev_row.get("labels") or [])
         for attr in ("name_by_user", "name", "manufacturer", "model"):
-            val = getattr(dev, attr, None)
+            val = dev_row.get(attr)
             if val:
                 dev_texts.append(str(val))
 
@@ -2430,24 +2431,31 @@ def _all_device_entries(view: _RegistryView) -> list[Any]:
 def _effective_device_area_id(view: _RegistryView, device: Any) -> str | None:
     """Return Core 2026.9's direct-or-parent effective device area."""
     devices_by_id = _unambiguous_device_entries(view)
-    device_id = getattr(device, "id", None)
+    device_row = _device_dict_repr(device)
+    if device_row is None:
+        return None
+    device_id = device_row.get("id")
     if not isinstance(device_id, str) or not device_id:
         return None
     device = devices_by_id.get(device_id)
     if device is None:
         # Conflicting identities never contribute semantic placement.
         return None
-    direct_area = getattr(device, "area_id", None)
+    device_row = _device_dict_repr(device)
+    if device_row is None:
+        return None
+    direct_area = device_row.get("area_id")
     if direct_area is not None:
         return direct_area if isinstance(direct_area, str) and direct_area else None
-    parent_id = getattr(device, "parent_device_id", None)
+    parent_id = device_row.get("parent_device_id")
     if not isinstance(parent_id, str) or not parent_id:
         return None
     parent = devices_by_id.get(parent_id)
-    if parent is None or getattr(parent, "parent_device_id", None) is not None:
+    parent_row = _device_dict_repr(parent) if parent is not None else None
+    if parent_row is None or parent_row.get("parent_device_id") is not None:
         # Core requires a main-device parent. This also bounds malformed cycles.
         return None
-    parent_area = getattr(parent, "area_id", None)
+    parent_area = parent_row.get("area_id")
     return parent_area if isinstance(parent_area, str) and parent_area else None
 
 
@@ -2907,18 +2915,21 @@ def _overview_device_registry(view: _RegistryView) -> list[dict[str, Any]]:
     """Device registry as a bare list (id + area + labels + name/manufacturer/model)."""
     out: list[dict[str, Any]] = []
     for dev in _all_device_entries(view):
-        dev_id = getattr(dev, "id", None)
+        dev_row = _device_dict_repr(dev)
+        if dev_row is None:
+            continue
+        dev_id = dev_row.get("id")
         if not dev_id:
             continue
         out.append(
             {
                 "id": dev_id,
                 "area_id": _effective_device_area_id(view, dev),
-                "labels": sorted(str(x) for x in (getattr(dev, "labels", None) or [])),
-                "name": getattr(dev, "name", None),
-                "name_by_user": getattr(dev, "name_by_user", None),
-                "manufacturer": getattr(dev, "manufacturer", None),
-                "model": getattr(dev, "model", None),
+                "labels": sorted(str(x) for x in (dev_row.get("labels") or [])),
+                "name": dev_row.get("name"),
+                "name_by_user": dev_row.get("name_by_user"),
+                "manufacturer": dev_row.get("manufacturer"),
+                "model": dev_row.get("model"),
             }
         )
     return out
@@ -3289,10 +3300,13 @@ def _do_device_get(hass: HomeAssistant, params: dict[str, Any]) -> dict[str, Any
     include_entities = params.get("include_entities", False)
     view = _resolve_registries(hass)
     entry = _unambiguous_device_entries(view).get(device_id) if device_id else None
-    result: dict[str, Any] = {
-        "device": _device_dict_repr(entry) if entry is not None else None
-    }
-    if entry is not None and isinstance(getattr(entry, "parent_device_id", None), str):
+    entry_row = _device_dict_repr(entry) if entry is not None else None
+    result: dict[str, Any] = {"device": entry_row}
+    if (
+        entry is not None
+        and isinstance(entry_row, dict)
+        and isinstance(entry_row.get("parent_device_id"), str)
+    ):
         # Additive internal transport metadata. The raw child ``dict_repr`` stays
         # byte-identical to Core while the server can expose its existing area_id
         # field using Core's effective placement without a whole-registry read.
@@ -5500,7 +5514,9 @@ def _effective_labels_for_entry(view: _RegistryView, entry: Any) -> set[str]:
     if isinstance(device_id, str) and device_id:
         dev = _unambiguous_device_entries(view).get(device_id)
         if dev is not None:
-            labels |= set(getattr(dev, "labels", None) or [])
+            dev_row = _device_dict_repr(dev)
+            if dev_row is not None:
+                labels |= set(dev_row.get("labels") or [])
     return labels
 
 

--- a/custom_components/ha_mcp_tools/websocket_api.py
+++ b/custom_components/ha_mcp_tools/websocket_api.py
@@ -2,10 +2,10 @@
 
 This module registers versioned ``ha_mcp_tools/*`` WebSocket commands that the
 ha-mcp server calls in-process (same HA core, no REST/WS round-trips) behind a
-capability gate. It registers twenty-three commands. It advertises twenty-six
-capabilities: twenty-two command capabilities plus four additive flags
-(dashboards_doc_search, search_visibility, search_entity_membership, and
-search_visibility_allowlist_authorization);
+capability gate. It registers twenty-three commands. It advertises twenty-seven
+capabilities: twenty-two command capabilities plus five additive flags
+(dashboards_doc_search, device_registry_child_semantics, search_visibility,
+search_entity_membership, and search_visibility_allowlist_authorization);
 the info handshake carries no capability entry:
 
 * ``ha_mcp_tools/info`` — the handshake: ``schema_version`` + ``capabilities[]``

--- a/custom_components/ha_mcp_tools/websocket_api.py
+++ b/custom_components/ha_mcp_tools/websocket_api.py
@@ -362,6 +362,12 @@ CAPABILITIES: list[str] = [
     "blueprint_get",
     "device_get",
     "device_list",
+    # A semantic flag shared by every device-registry-backed read. Components
+    # predating this flag enumerate only Core's main ``devices`` collection and
+    # cannot provide authoritative Core 2026.9 child-device/effective-area data.
+    # A newer server therefore falls back to Core's native registry endpoints
+    # unless this flag accompanies the individual command capability.
+    "device_registry_child_semantics",
     "entity_enrich",
     "exposure",
     "config_entries",

--- a/src/ha_mcp/tools/bulk_selector.py
+++ b/src/ha_mcp/tools/bulk_selector.py
@@ -13,6 +13,11 @@ from typing import Annotated, Any, NamedTuple, NotRequired, TypedDict
 from pydantic import ConfigDict, Field
 
 from ..client.rest_client import HomeAssistantClient
+from ..utils.device_registry_semantics import (
+    DeviceRegistrySnapshot,
+    build_device_registry_snapshot,
+    effective_entity_area_id,
+)
 from ..utils.domain_handlers import get_domain_handler
 from ..utils.entity_membership import normalize_member_entity_ids
 from ..visibility.resolver import VisibilityDataUnavailable, load_hidden_set
@@ -259,8 +264,10 @@ def _registry_rows(result: Any, label: str) -> list[dict[str, Any]]:
     return rows
 
 
-def _validate_device_registry_rows(device_rows: list[dict[str, Any]]) -> None:
-    """Fail closed on a device row missing ``id``.
+def _validate_device_registry_rows(
+    device_rows: list[dict[str, Any]],
+) -> DeviceRegistrySnapshot:
+    """Return a canonical snapshot or fail closed on ambiguous device evidence.
 
     ``visibility.resolver._parse_device_registry`` silently skips any device
     entry without an ``id`` even when the hidden-set resolver runs
@@ -272,11 +279,18 @@ def _validate_device_registry_rows(device_rows: list[dict[str, Any]]) -> None:
     resolver. Infrastructure-class (HA's own registry data is malformed),
     not the caller's selector to fix.
     """
-    if any(not row.get("id") for row in device_rows):
+    if any(not isinstance(row.get("id"), str) or not row["id"] for row in device_rows):
         raise BulkSelectorInfrastructureError(
             "Home Assistant device registry returned a malformed entry",
             cause=InfrastructureErrorCause.MALFORMED_DEVICE_REGISTRY,
         )
+    snapshot = build_device_registry_snapshot(device_rows)
+    if snapshot.conflicting_ids:
+        raise BulkSelectorInfrastructureError(
+            "Home Assistant device registry returned a conflicting device identity",
+            cause=InfrastructureErrorCause.MALFORMED_DEVICE_REGISTRY,
+        )
+    return snapshot
 
 
 def _string_list(selector: Mapping[str, Any], key: str) -> list[str]:
@@ -305,10 +319,7 @@ def _entity_area_id(
     entry = entity_registry.get(entity_id)
     if not entry:
         return None
-    if area_id := entry.get("area_id"):
-        return str(area_id)
-    device_id = entry.get("device_id")
-    return device_areas.get(str(device_id)) if device_id else None
+    return effective_entity_area_id(entry, device_areas)
 
 
 def _expand_entity(
@@ -686,7 +697,7 @@ async def resolve_bulk_selector(
         )
     entity_rows = _registry_rows(topology.entities, "entity registry")
     device_rows = _registry_rows(topology.devices, "device registry")
-    _validate_device_registry_rows(device_rows)
+    device_snapshot = _validate_device_registry_rows(device_rows)
     selected_areas = _select_area_ids(
         _registry_rows(topology.areas, "area registry"),
         _registry_rows(topology.floors, "floor registry"),
@@ -704,9 +715,7 @@ async def resolve_bulk_selector(
         for row in entity_rows
         if isinstance(row.get("entity_id"), str)
     }
-    device_areas = {
-        str(row["id"]): row.get("area_id") for row in device_rows if row.get("id")
-    }
+    device_areas = device_snapshot.effective_area_by_id
     hidden, visibility_warnings = await _load_hidden_entities(
         client, topology.entities, topology.states, topology.devices, entity_registry
     )

--- a/src/ha_mcp/tools/component_api.py
+++ b/src/ha_mcp/tools/component_api.py
@@ -56,6 +56,13 @@ UNKNOWN_COMMAND_CODE = "unknown_command"
 # routing gate can't trust command payloads shaped for a different generation.
 SUPPORTED_SCHEMA_VERSION = 1
 
+# Additive semantic capability shared by every component path whose result is
+# enriched from the device registry.  The pre-2.1.3 ``device_list``/``device_get``
+# commands (and search/overview/entity enrichment built on the same registry)
+# predate Core 2026.9 child devices.  Because component and server releases update
+# independently, command presence alone cannot authorize the newer semantics.
+DEVICE_REGISTRY_CHILD_SEMANTICS = "device_registry_child_semantics"
+
 # Negative (None) caps entries expire after this many seconds of monotonic
 # time, so a component installed / upgraded mid-session is re-probed and
 # adopted instead of being pinned to "absent" for the whole process lifetime

--- a/src/ha_mcp/tools/component_devices.py
+++ b/src/ha_mcp/tools/component_devices.py
@@ -44,6 +44,7 @@ from ..client.rest_client import (
 )
 from ..client.websocket_client import get_websocket_client
 from .component_api import (
+    DEVICE_REGISTRY_CHILD_SEMANTICS,
     component_supports,
     get_component_caps,
     invalidate_caps,
@@ -85,7 +86,10 @@ async def fetch_device_via_component(
     only the device (``_resolve_ieee`` / capture / remove) are unchanged.
     """
     caps = await get_component_caps(client)
-    if not component_supports(caps, "device_get"):
+    if not (
+        component_supports(caps, "device_get")
+        and component_supports(caps, DEVICE_REGISTRY_CHILD_SEMANTICS)
+    ):
         return None
     kwargs: dict[str, Any] = {"device_id": device_id}
     if include_entities:
@@ -167,7 +171,10 @@ async def fetch_device_list_via_component(client: Any) -> dict[str, Any] | None:
     fallback as :func:`fetch_device_via_component`.
     """
     caps = await get_component_caps(client)
-    if not component_supports(caps, "device_list"):
+    if not (
+        component_supports(caps, "device_list")
+        and component_supports(caps, DEVICE_REGISTRY_CHILD_SEMANTICS)
+    ):
         return None
     try:
         ws = await get_websocket_client(

--- a/src/ha_mcp/tools/smart_search/_entities.py
+++ b/src/ha_mcp/tools/smart_search/_entities.py
@@ -5,6 +5,7 @@ import logging
 from collections.abc import Mapping
 from typing import Any
 
+from ...utils.device_registry_semantics import build_device_registry_snapshot
 from ...utils.entity_membership import normalize_member_entity_ids
 from ...utils.fuzzy_search import calculate_partial_ratio, calculate_ratio
 from ...visibility.resolver import (
@@ -652,12 +653,8 @@ class EntitySearchMixin(_SearchBase):
         cls, result: Any, warnings: list[str] | None = None
     ) -> dict[str, str | None]:
         """Parse the device registry into ``device_id -> area_id``."""
-        device_area_map: dict[str, str | None] = {}
-        for device in cls._extract_registry_list(result, "device registry", warnings):
-            device_id = device.get("id", "")
-            if device_id:
-                device_area_map[device_id] = device.get("area_id")
-        return device_area_map
+        device_rows = cls._extract_registry_list(result, "device registry", warnings)
+        return build_device_registry_snapshot(list(device_rows)).effective_area_by_id
 
     @staticmethod
     def _match_exact_registry_ids(

--- a/src/ha_mcp/tools/smart_search/_entities.py
+++ b/src/ha_mcp/tools/smart_search/_entities.py
@@ -5,7 +5,10 @@ import logging
 from collections.abc import Mapping
 from typing import Any
 
-from ...utils.device_registry_semantics import build_device_registry_snapshot
+from ...utils.device_registry_semantics import (
+    build_device_registry_snapshot,
+    effective_entity_area_id,
+)
 from ...utils.entity_membership import normalize_member_entity_ids
 from ...utils.fuzzy_search import calculate_partial_ratio, calculate_ratio
 from ...visibility.resolver import (
@@ -889,10 +892,7 @@ class EntitySearchMixin(_SearchBase):
                 continue
             if is_hidden:
                 hidden_entity_ids.add(entity_id)
-            area_id = reg_info.get("area_id")
-            device_id = reg_info.get("device_id")
-            if not area_id and device_id:
-                area_id = device_area_map.get(device_id)
+            area_id = effective_entity_area_id(reg_info, device_area_map)
             if area_id:
                 entity_area_resolved[entity_id] = area_id
         return entity_area_resolved, hidden_entity_ids

--- a/src/ha_mcp/tools/smart_search/_entities.py
+++ b/src/ha_mcp/tools/smart_search/_entities.py
@@ -655,7 +655,7 @@ class EntitySearchMixin(_SearchBase):
     def _parse_device_area_map(
         cls, result: Any, warnings: list[str] | None = None
     ) -> dict[str, str | None]:
-        """Parse the device registry into ``device_id -> area_id``."""
+        """Parse devices into IDs mapped to direct-or-parent effective areas."""
         device_rows = cls._extract_registry_list(result, "device registry", warnings)
         return build_device_registry_snapshot(list(device_rows)).effective_area_by_id
 
@@ -875,7 +875,7 @@ class EntitySearchMixin(_SearchBase):
         include_hidden: bool,
         visibility_hidden: set[str],
     ) -> tuple[dict[str, str], set[str]]:
-        """Map entity_id -> resolved area_id (entity area > device area).
+        """Map entity IDs to direct area, then device direct-or-parent effective area.
 
         Hidden entities are filtered only when include_hidden is False;
         otherwise they pass through and downstream applies the score penalty so

--- a/src/ha_mcp/tools/smart_search/_overview.py
+++ b/src/ha_mcp/tools/smart_search/_overview.py
@@ -6,6 +6,7 @@ import random
 from itertools import islice
 from typing import Any
 
+from ...utils.device_registry_semantics import build_device_registry_snapshot
 from ...visibility.resolver import load_hidden_set
 from ..helpers import exception_to_structured_error
 from ._base import _SearchBase
@@ -238,17 +239,15 @@ class SystemOverviewMixin(_SearchBase):
         device_registry: list[dict[str, Any]],
     ) -> dict[str, str | None]:
         """Map entity_id -> area_id. Priority: entity direct area_id > device area_id."""
-        device_area_map: dict[str, str | None] = {}
-        for device in device_registry:
-            device_id = device.get("id", "")
-            if device_id:
-                device_area_map[device_id] = device.get("area_id")
+        device_area_map = build_device_registry_snapshot(
+            list(device_registry)
+        ).effective_area_by_id
 
         entity_area_map: dict[str, str | None] = {}
         for entry in entity_registry:
             entity_id = entry.get("entity_id")
             area_id = entry.get("area_id")
-            if not area_id:
+            if area_id is None:
                 device_id = entry.get("device_id")
                 if device_id:
                     area_id = device_area_map.get(device_id)

--- a/src/ha_mcp/tools/smart_search/_overview.py
+++ b/src/ha_mcp/tools/smart_search/_overview.py
@@ -241,7 +241,7 @@ class SystemOverviewMixin(_SearchBase):
         entity_registry: list[dict[str, Any]],
         device_registry: list[dict[str, Any]],
     ) -> dict[str, str | None]:
-        """Map entity_id -> area_id. Priority: entity direct area_id > device area_id."""
+        """Map entity IDs to direct area, then device direct-or-parent effective area."""
         device_area_map = build_device_registry_snapshot(
             list(device_registry)
         ).effective_area_by_id

--- a/src/ha_mcp/tools/smart_search/_overview.py
+++ b/src/ha_mcp/tools/smart_search/_overview.py
@@ -6,7 +6,10 @@ import random
 from itertools import islice
 from typing import Any
 
-from ...utils.device_registry_semantics import build_device_registry_snapshot
+from ...utils.device_registry_semantics import (
+    build_device_registry_snapshot,
+    effective_entity_area_id,
+)
 from ...visibility.resolver import load_hidden_set
 from ..helpers import exception_to_structured_error
 from ._base import _SearchBase
@@ -246,13 +249,10 @@ class SystemOverviewMixin(_SearchBase):
         entity_area_map: dict[str, str | None] = {}
         for entry in entity_registry:
             entity_id = entry.get("entity_id")
-            area_id = entry.get("area_id")
-            if area_id is None:
-                device_id = entry.get("device_id")
-                if device_id:
-                    area_id = device_area_map.get(device_id)
             if entity_id:
-                entity_area_map[entity_id] = area_id
+                entity_area_map[entity_id] = effective_entity_area_id(
+                    entry, device_area_map
+                )
         return entity_area_map
 
     @staticmethod

--- a/src/ha_mcp/tools/tools_entities.py
+++ b/src/ha_mcp/tools/tools_entities.py
@@ -22,6 +22,7 @@ from ..client.websocket_client import get_websocket_client
 from ..errors import ErrorCode, create_error_response
 from .auto_backup import with_auto_backup
 from .component_api import (
+    DEVICE_REGISTRY_CHILD_SEMANTICS,
     component_supports,
     get_component_caps,
     invalidate_caps,
@@ -118,7 +119,10 @@ async def fetch_entity_enrichment_via_component(
     if not entity_ids:
         return None
     caps = await get_component_caps(client)
-    if not component_supports(caps, "entity_enrich"):
+    if not (
+        component_supports(caps, "entity_enrich")
+        and component_supports(caps, DEVICE_REGISTRY_CHILD_SEMANTICS)
+    ):
         return None
     ids = list(entity_ids)
     chunks = [

--- a/src/ha_mcp/tools/tools_registry.py
+++ b/src/ha_mcp/tools/tools_registry.py
@@ -162,6 +162,25 @@ def _get_device_info(device: dict[str, Any]) -> dict[str, Any]:
     return device_info
 
 
+def _device_config_entries(device: dict[str, Any]) -> list[str]:
+    """Return the exact owning config-entry IDs for a main or child row.
+
+    Ordinary ``DeviceEntry`` rows carry ``config_entries`` while Core 2026.9
+    ``ChildDeviceEntry`` rows carry one singular ``config_entry_id``. Never mix,
+    coerce, or repair malformed ownership evidence: an explicitly present plural
+    field is authoritative and must be a list of non-empty strings.
+    """
+    if "config_entries" in device:
+        raw = device.get("config_entries")
+        if not isinstance(raw, list) or not all(
+            isinstance(entry_id, str) and entry_id for entry_id in raw
+        ):
+            return []
+        return list(raw)
+    entry_id = device.get("config_entry_id")
+    return [entry_id] if isinstance(entry_id, str) and entry_id else []
+
+
 def _build_entity_maps(
     all_entities: list[dict[str, Any]], need_full: bool
 ) -> tuple[dict[str, str], dict[str, list[dict[str, Any]]]]:
@@ -556,7 +575,7 @@ async def _get_single_device_result(
     device_info["serial_number"] = device.get("serial_number")
     device_info["disabled_by"] = device.get("disabled_by")
     device_info["labels"] = device.get("labels", [])
-    device_info["config_entries"] = device.get("config_entries", [])
+    device_info["config_entries"] = _device_config_entries(device)
     device_info["connections"] = device.get("connections", [])
     device_info["identifiers"] = device.get("identifiers", [])
 
@@ -1144,7 +1163,7 @@ class RegistryTools:
             )
             device = await _lookup_device_for_remove(self._client, device_id)
 
-            config_entries = device.get("config_entries", [])
+            config_entries = _device_config_entries(device)
             device_name = device.get("name_by_user") or device.get("name")
             if not config_entries:
                 raise_tool_error(

--- a/src/ha_mcp/tools/tools_registry.py
+++ b/src/ha_mcp/tools/tools_registry.py
@@ -16,6 +16,10 @@ from pydantic import Field
 
 from ..client.rest_client import HomeAssistantAPIError, HomeAssistantConnectionError
 from ..errors import ErrorCode, create_error_response
+from ..utils.device_registry_semantics import (
+    EFFECTIVE_AREA_MARKER,
+    annotate_device_rows_with_effective_area,
+)
 from .auto_backup import with_auto_backup
 from .component_devices import (
     fetch_device_list_via_component,
@@ -137,7 +141,7 @@ def _get_device_info(device: dict[str, Any]) -> dict[str, Any]:
         "manufacturer": device.get("manufacturer"),
         "model": device.get("model"),
         "sw_version": device.get("sw_version"),
-        "area_id": device.get("area_id"),
+        "area_id": device.get(EFFECTIVE_AREA_MARKER, device.get("area_id")),
         "integration_type": integration_type,
         "integration_sources": integration_sources,
         "via_device_id": device.get("via_device_id"),
@@ -251,8 +255,8 @@ async def _fetch_device_rows(client: Any) -> list[dict[str, Any]]:
     """
     result = await fetch_device_list_via_component(client)
     if result is not None:
-        return list(result.get("devices", []))
-    return await _legacy_device_rows(client)
+        return annotate_device_rows_with_effective_area(list(result.get("devices", [])))
+    return annotate_device_rows_with_effective_area(await _legacy_device_rows(client))
 
 
 # HA core replies with this error code (ERR_NOT_FOUND) from
@@ -342,6 +346,9 @@ async def _single_device_and_entities(
         device = result.get("device")
         entities = result.get("entities")
         if isinstance(device, dict) and isinstance(entities, list):
+            device = dict(device)
+            if "effective_area_id" in result:
+                device[EFFECTIVE_AREA_MARKER] = result.get("effective_area_id")
             _, device_to_entities = _build_entity_maps(entities, need_full=True)
             return [device], device_to_entities
         # Either an authoritative not-found (device is None) — fall through so the
@@ -350,7 +357,9 @@ async def _single_device_and_entities(
         # entity registries.
     # Device registry first, then entity registry — the legacy wire order,
     # which the #1297 error-contract test pins with an ordered mock.
-    all_devices = await _legacy_device_rows(client)
+    all_devices = annotate_device_rows_with_effective_area(
+        await _legacy_device_rows(client)
+    )
     all_entities = await _fetch_entity_rows(client)
     _, device_to_entities = _build_entity_maps(all_entities, need_full=True)
     return all_devices, device_to_entities
@@ -597,7 +606,8 @@ def _filter_devices(
     named_types = ["zigbee2mqtt", "zha", "zwave_js"]
     matched: list[dict[str, Any]] = []
     for device in all_devices:
-        if area_id and device.get("area_id") != area_id:
+        effective_area = device.get(EFFECTIVE_AREA_MARKER, device.get("area_id"))
+        if area_id and effective_area != area_id:
             continue
         device_man = (device.get("manufacturer") or "").lower()
         if manufacturer_lower and manufacturer_lower not in device_man:

--- a/src/ha_mcp/tools/tools_search.py
+++ b/src/ha_mcp/tools/tools_search.py
@@ -38,6 +38,7 @@ from ..visibility.resolver import (
     visibility_state_and_wire,
 )
 from .component_api import (
+    DEVICE_REGISTRY_CHILD_SEMANTICS,
     component_supports,
     get_component_caps,
     invalidate_caps,
@@ -2435,9 +2436,13 @@ class SearchTools:
             and _component_serves_search_types(req)
         ):
             caps = await get_component_caps(self._client)
-            if component_supports(caps, "search") and (
-                not _requested_membership(parsed_result_fields)
-                or component_supports(caps, "search_entity_membership")
+            if (
+                component_supports(caps, "search")
+                and component_supports(caps, DEVICE_REGISTRY_CHILD_SEMANTICS)
+                and (
+                    not _requested_membership(parsed_result_fields)
+                    or component_supports(caps, "search_entity_membership")
+                )
             ):
                 (
                     route_component,
@@ -4399,7 +4404,9 @@ class SearchTools:
         applied by ``ha_get_overview`` after this, identically on both paths.
         """
         caps = await get_component_caps(self._client)
-        if component_supports(caps, "overview"):
+        if component_supports(caps, "overview") and component_supports(
+            caps, DEVICE_REGISTRY_CHILD_SEMANTICS
+        ):
             component_result = await self._overview_via_component(inputs)
             if component_result is not None:
                 return component_result

--- a/src/ha_mcp/tools/tools_search.py
+++ b/src/ha_mcp/tools/tools_search.py
@@ -27,7 +27,7 @@ from ..errors import create_validation_error
 from ..transforms.categorized_search import DEFAULT_PINNED_TOOLS
 from ..utils.device_registry_semantics import (
     build_device_registry_snapshot,
-    effective_device_area_id,
+    effective_entity_area_id,
 )
 from ..utils.entity_membership import normalize_member_entity_ids
 from ..utils.fuzzy_search import apply_hidden_penalty
@@ -914,6 +914,7 @@ def _entity_enrichment_fields(
     floors: dict[str, dict[str, Any]],
     labels: dict[str, dict[str, Any]],
     devices: dict[str, dict[str, Any]],
+    device_areas: dict[str, str | None],
     requested: tuple[str, ...],
 ) -> dict[str, Any]:
     """Compute the requested enrichment fields for one entity from registry data.
@@ -931,13 +932,11 @@ def _entity_enrichment_fields(
     the sentinel stands for is already matched via the friendly name).
     """
     aliases = sorted(a for a in (entry.get("aliases") or []) if isinstance(a, str))
-    area_id = entry.get("area_id")
+    area_id = effective_entity_area_id(entry, device_areas)
     label_ids = set(entry.get("labels") or [])
     device_id = entry.get("device_id")
     device = devices.get(device_id) if device_id else None
     if device:
-        if area_id is None:
-            area_id = effective_device_area_id(device, devices)
         label_ids |= set(device.get("labels") or [])
     area = areas.get(area_id) if area_id else None
     area_name = area.get("name") if area else None
@@ -3166,10 +3165,18 @@ class SearchTools:
         floors = _ws_registry_index(names[1], "floor_id") if need_names else {}
         labels = _ws_registry_index(names[2], "label_id") if need_names else {}
         device_rows = _ws_registry_rows(names[3]) if need_names else []
-        devices = build_device_registry_snapshot(device_rows).by_id
+        device_snapshot = build_device_registry_snapshot(device_rows)
+        devices = device_snapshot.by_id
+        device_areas = device_snapshot.effective_area_by_id
         enrichment = {
             eid: _entity_enrichment_fields(
-                entries.get(eid) or {}, areas, floors, labels, devices, requested
+                entries.get(eid) or {},
+                areas,
+                floors,
+                labels,
+                devices,
+                device_areas,
+                requested,
             )
             for eid in entity_ids
         }

--- a/src/ha_mcp/tools/tools_search.py
+++ b/src/ha_mcp/tools/tools_search.py
@@ -922,7 +922,8 @@ def _entity_enrichment_fields(
 
     Mirrors the component's ``_registry_enrichment`` so the legacy and
     component-served ``result_fields`` values agree: device-inherited area/labels
-    (the entity's own value wins, else the device's), area→floor resolution, and
+    (the entity's own value wins, else the device's direct-or-parent effective
+    area), area→floor resolution, and
     label id→name (falling back to the id when a label has no name). ``aliases``
     pass through from the registry entry. Only the requested keys are returned.
 

--- a/src/ha_mcp/tools/tools_search.py
+++ b/src/ha_mcp/tools/tools_search.py
@@ -25,6 +25,10 @@ from ..client.websocket_client import get_websocket_client
 from ..config import get_global_settings
 from ..errors import create_validation_error
 from ..transforms.categorized_search import DEFAULT_PINNED_TOOLS
+from ..utils.device_registry_semantics import (
+    build_device_registry_snapshot,
+    effective_device_area_id,
+)
 from ..utils.entity_membership import normalize_member_entity_ids
 from ..utils.fuzzy_search import apply_hidden_penalty
 from ..visibility.model import VisibilityWire, wire_has_allowlist_dimensions
@@ -869,6 +873,15 @@ def _ws_result_map(resp: Any) -> dict[str, dict[str, Any]]:
     return {}
 
 
+def _ws_registry_rows(resp: Any) -> list[Any]:
+    """Return rows from a successful registry-list response, else an empty list."""
+    if isinstance(resp, dict) and resp.get("success"):
+        result = resp.get("result")
+        if isinstance(result, list):
+            return result
+    return []
+
+
 def _ws_registry_index(resp: Any, key: str) -> dict[str, dict[str, Any]]:
     """Index a ``config/*_registry/list`` reply by its id field (area_id/floor_id/…).
 
@@ -877,10 +890,9 @@ def _ws_registry_index(resp: Any, key: str) -> dict[str, dict[str, Any]]:
     empty rather than raising.
     """
     out: dict[str, dict[str, Any]] = {}
-    if isinstance(resp, dict) and resp.get("success"):
-        for item in resp.get("result") or []:
-            if isinstance(item, dict) and item.get(key):
-                out[item[key]] = item
+    for item in _ws_registry_rows(resp):
+        if isinstance(item, dict) and item.get(key):
+            out[item[key]] = item
     return out
 
 
@@ -925,7 +937,7 @@ def _entity_enrichment_fields(
     device = devices.get(device_id) if device_id else None
     if device:
         if area_id is None:
-            area_id = device.get("area_id")
+            area_id = effective_device_area_id(device, devices)
         label_ids |= set(device.get("labels") or [])
     area = areas.get(area_id) if area_id else None
     area_name = area.get("name") if area else None
@@ -3153,7 +3165,8 @@ class SearchTools:
         areas = _ws_registry_index(names[0], "area_id") if need_names else {}
         floors = _ws_registry_index(names[1], "floor_id") if need_names else {}
         labels = _ws_registry_index(names[2], "label_id") if need_names else {}
-        devices = _ws_registry_index(names[3], "id") if need_names else {}
+        device_rows = _ws_registry_rows(names[3]) if need_names else []
+        devices = build_device_registry_snapshot(device_rows).by_id
         enrichment = {
             eid: _entity_enrichment_fields(
                 entries.get(eid) or {}, areas, floors, labels, devices, requested

--- a/src/ha_mcp/tools/tools_voice_assistant.py
+++ b/src/ha_mcp/tools/tools_voice_assistant.py
@@ -24,6 +24,7 @@ from ..client.rest_client import (
 from ..client.websocket_client import get_websocket_client
 from ..errors import ErrorCode, create_error_response
 from .component_api import (
+    DEVICE_REGISTRY_CHILD_SEMANTICS,
     component_supports,
     get_component_caps,
     invalidate_caps,
@@ -89,7 +90,10 @@ class VoiceAssistantTools:
         ``component_devices.fetch_device_via_component``.
         """
         caps = await get_component_caps(self._client)
-        if not component_supports(caps, "exposure"):
+        if not (
+            component_supports(caps, "exposure")
+            and component_supports(caps, DEVICE_REGISTRY_CHILD_SEMANTICS)
+        ):
             return None
         kwargs: dict[str, Any] = {}
         if entity_id is not None:

--- a/src/ha_mcp/utils/device_registry_semantics.py
+++ b/src/ha_mcp/utils/device_registry_semantics.py
@@ -28,12 +28,35 @@ logger = logging.getLogger(__name__)
 
 @dataclass(frozen=True, slots=True)
 class DeviceRegistrySnapshot:
-    """Validated unique registry rows and their bounded placement relationships."""
+    """Validated rows plus bounded placement and ambiguity evidence."""
 
     rows: tuple[dict[str, Any], ...]
     by_id: dict[str, dict[str, Any]]
     effective_area_by_id: dict[str, str | None]
     conflicting_ids: frozenset[str]
+    invalid_area_ids: frozenset[str]
+
+
+def _device_area_evidence_is_invalid(
+    device: Mapping[str, Any], devices_by_id: Mapping[str, Mapping[str, Any]]
+) -> bool:
+    """Whether a row's area evidence is malformed or has invalid ancestry."""
+    direct_area = device.get("area_id")
+    if direct_area is not None:
+        return not (isinstance(direct_area, str) and bool(direct_area))
+
+    parent_id = device.get("parent_device_id")
+    if parent_id is None:
+        return False
+    if not isinstance(parent_id, str) or not parent_id:
+        return True
+    parent = devices_by_id.get(parent_id)
+    if parent is None or parent.get("parent_device_id") is not None:
+        return True
+    parent_area = parent.get("area_id")
+    return parent_area is not None and not (
+        isinstance(parent_area, str) and bool(parent_area)
+    )
 
 
 def effective_device_area_id(
@@ -121,14 +144,18 @@ def build_device_registry_snapshot(rows: list[Any]) -> DeviceRegistrySnapshot:
         )
 
     effective_area_by_id: dict[str, str | None] = {}
+    invalid_area_ids: set[str] = set()
     for device_id, device in by_id.items():
         effective_area_by_id[device_id] = effective_device_area_id(device, by_id)
+        if _device_area_evidence_is_invalid(device, by_id):
+            invalid_area_ids.add(device_id)
 
     return DeviceRegistrySnapshot(
         rows=ordered_rows,
         by_id=by_id,
         effective_area_by_id=effective_area_by_id,
         conflicting_ids=frozenset(conflicts),
+        invalid_area_ids=frozenset(invalid_area_ids),
     )
 
 

--- a/src/ha_mcp/utils/device_registry_semantics.py
+++ b/src/ha_mcp/utils/device_registry_semantics.py
@@ -14,6 +14,7 @@ or placement.
 
 from __future__ import annotations
 
+import logging
 from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Any
@@ -22,6 +23,8 @@ from typing import Any
 # device shaper. It never appears in a public response.
 EFFECTIVE_AREA_MARKER = "_ha_mcp_effective_area_id"
 
+logger = logging.getLogger(__name__)
+
 
 @dataclass(frozen=True, slots=True)
 class DeviceRegistrySnapshot:
@@ -29,8 +32,8 @@ class DeviceRegistrySnapshot:
 
     rows: tuple[dict[str, Any], ...]
     by_id: dict[str, dict[str, Any]]
-    parent_by_id: dict[str, str | None]
     effective_area_by_id: dict[str, str | None]
+    conflicting_ids: frozenset[str]
 
 
 def effective_device_area_id(
@@ -44,7 +47,7 @@ def effective_device_area_id(
     """
     direct_area = device.get("area_id")
     if direct_area is not None:
-        return direct_area if isinstance(direct_area, str) else None
+        return direct_area if isinstance(direct_area, str) and direct_area else None
 
     parent_id = device.get("parent_device_id")
     if not isinstance(parent_id, str) or not parent_id:
@@ -57,7 +60,7 @@ def effective_device_area_id(
     if parent.get("parent_device_id") is not None:
         return None
     parent_area = parent.get("area_id")
-    return parent_area if isinstance(parent_area, str) else None
+    return parent_area if isinstance(parent_area, str) and parent_area else None
 
 
 def effective_entity_area_id(
@@ -110,20 +113,22 @@ def build_device_registry_snapshot(rows: list[Any]) -> DeviceRegistrySnapshot:
             del by_id[device_id]
 
     ordered_rows = tuple(by_id[device_id] for device_id in order if device_id in by_id)
-    parent_by_id: dict[str, str | None] = {}
+    if conflicts:
+        logger.warning(
+            "Device registry contained conflicting device registry identity rows; "
+            "excluding %d ambiguous device id(s)",
+            len(conflicts),
+        )
+
     effective_area_by_id: dict[str, str | None] = {}
     for device_id, device in by_id.items():
-        parent_id = device.get("parent_device_id")
-        parent_by_id[device_id] = (
-            parent_id if isinstance(parent_id, str) and parent_id else None
-        )
         effective_area_by_id[device_id] = effective_device_area_id(device, by_id)
 
     return DeviceRegistrySnapshot(
         rows=ordered_rows,
         by_id=by_id,
-        parent_by_id=parent_by_id,
         effective_area_by_id=effective_area_by_id,
+        conflicting_ids=frozenset(conflicts),
     )
 
 

--- a/src/ha_mcp/utils/device_registry_semantics.py
+++ b/src/ha_mcp/utils/device_registry_semantics.py
@@ -1,0 +1,117 @@
+"""Shared read-side semantics for Home Assistant device-registry rows.
+
+Home Assistant Core 2026.9 added reduced ``ChildDeviceEntry`` rows to
+``config/device_registry/list``. A child keeps its own ``area_id`` when set and
+otherwise inherits the direct parent device's area. The parent is always a main
+device in Core's supported model; this module deliberately does not invent a
+recursive hierarchy for malformed external payloads.
+
+The helpers are pure over bounded registry responses. They preserve the first
+appearance order, collapse equivalent duplicate mappings, and remove conflicting
+identities from the semantic snapshot so no consumer chooses an arbitrary parent
+or placement.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any
+
+# Private marker used only between registry acquisition and the existing public
+# device shaper. It never appears in a public response.
+EFFECTIVE_AREA_MARKER = "_ha_mcp_effective_area_id"
+
+
+@dataclass(frozen=True, slots=True)
+class DeviceRegistrySnapshot:
+    """Validated unique registry rows and their bounded placement relationships."""
+
+    rows: tuple[dict[str, Any], ...]
+    by_id: dict[str, dict[str, Any]]
+    parent_by_id: dict[str, str | None]
+    effective_area_by_id: dict[str, str | None]
+
+
+def effective_device_area_id(
+    device: Mapping[str, Any], devices_by_id: Mapping[str, Mapping[str, Any]]
+) -> str | None:
+    """Return Core's effective area for one main or child device row.
+
+    A present direct area wins. A child with no direct area inherits exactly one
+    level from a valid main parent. Missing parents, malformed ids/areas, a child
+    used as a parent, and cycles all resolve to ``None`` rather than guessing.
+    """
+    direct_area = device.get("area_id")
+    if direct_area is not None:
+        return direct_area if isinstance(direct_area, str) else None
+
+    parent_id = device.get("parent_device_id")
+    if not isinstance(parent_id, str) or not parent_id:
+        return None
+    parent = devices_by_id.get(parent_id)
+    if parent is None:
+        return None
+    # Core requires a child parent to be a main device. Refuse malformed chains
+    # (including cycles) instead of recursively resolving an invented hierarchy.
+    if parent.get("parent_device_id") is not None:
+        return None
+    parent_area = parent.get("area_id")
+    return parent_area if isinstance(parent_area, str) else None
+
+
+def build_device_registry_snapshot(rows: list[Any]) -> DeviceRegistrySnapshot:
+    """Build one deterministic semantic snapshot from a registry list response.
+
+    Invalid rows and ids are ignored under the existing partial-read convention.
+    Identical duplicate mappings collapse. If the same id names different rows,
+    every copy of that identity is excluded so enrichment never picks first/last.
+    """
+    order: list[str] = []
+    by_id: dict[str, dict[str, Any]] = {}
+    conflicts: set[str] = set()
+
+    for item in rows:
+        if not isinstance(item, dict):
+            continue
+        device_id = item.get("id")
+        if not isinstance(device_id, str) or not device_id:
+            continue
+        if device_id in conflicts:
+            continue
+        if device_id not in by_id:
+            order.append(device_id)
+            by_id[device_id] = dict(item)
+            continue
+        if by_id[device_id] != item:
+            conflicts.add(device_id)
+            del by_id[device_id]
+
+    ordered_rows = tuple(by_id[device_id] for device_id in order if device_id in by_id)
+    parent_by_id: dict[str, str | None] = {}
+    effective_area_by_id: dict[str, str | None] = {}
+    for device_id, device in by_id.items():
+        parent_id = device.get("parent_device_id")
+        parent_by_id[device_id] = (
+            parent_id if isinstance(parent_id, str) and parent_id else None
+        )
+        effective_area_by_id[device_id] = effective_device_area_id(device, by_id)
+
+    return DeviceRegistrySnapshot(
+        rows=ordered_rows,
+        by_id=by_id,
+        parent_by_id=parent_by_id,
+        effective_area_by_id=effective_area_by_id,
+    )
+
+
+def annotate_device_rows_with_effective_area(rows: list[Any]) -> list[dict[str, Any]]:
+    """Return unique row copies carrying the private effective-area marker."""
+    snapshot = build_device_registry_snapshot(rows)
+    annotated: list[dict[str, Any]] = []
+    for row in snapshot.rows:
+        copy = dict(row)
+        device_id = copy["id"]
+        copy[EFFECTIVE_AREA_MARKER] = snapshot.effective_area_by_id.get(device_id)
+        annotated.append(copy)
+    return annotated

--- a/src/ha_mcp/utils/device_registry_semantics.py
+++ b/src/ha_mcp/utils/device_registry_semantics.py
@@ -60,6 +60,28 @@ def effective_device_area_id(
     return parent_area if isinstance(parent_area, str) else None
 
 
+def effective_entity_area_id(
+    entity: Mapping[str, Any],
+    effective_device_areas: Mapping[str, str | None],
+) -> str | None:
+    """Return an entity's direct area or its device's effective area.
+
+    Core gives a present entity ``area_id`` precedence over device placement.
+    Preserve that presence distinction for malformed external payloads: an
+    empty or non-string direct value is invalid and must not silently fall back
+    to a device area.
+    """
+    direct_area = entity.get("area_id")
+    if direct_area is not None:
+        return direct_area if isinstance(direct_area, str) and direct_area else None
+
+    device_id = entity.get("device_id")
+    if not isinstance(device_id, str) or not device_id:
+        return None
+    device_area = effective_device_areas.get(device_id)
+    return device_area if isinstance(device_area, str) and device_area else None
+
+
 def build_device_registry_snapshot(rows: list[Any]) -> DeviceRegistrySnapshot:
     """Build one deterministic semantic snapshot from a registry list response.
 

--- a/src/ha_mcp/visibility/resolver.py
+++ b/src/ha_mcp/visibility/resolver.py
@@ -82,6 +82,11 @@ _ALLOWLIST_REGISTRY_EMPTY_WARNING = (
     "this request (an allow_entity_ids list, if set, still applies) so the filter "
     "does not blank every entity."
 )
+_DEVICE_REGISTRY_CONFLICT_WARNING = (
+    "Entity visibility filter is enabled with an area/label dimension but the "
+    "device registry contained conflicting identities; ambiguous device-derived "
+    "placement and labels were excluded."
+)
 
 
 class VisibilityDataUnavailable(Exception):
@@ -115,7 +120,7 @@ def _normalize_labels(raw: object) -> list[str]:
 
 def _parse_device_registry(
     device_registry_result: object,
-) -> tuple[dict[str, str], dict[str, list[str]]]:
+) -> tuple[dict[str, str], dict[str, list[str]], frozenset[str]]:
     """Parse ``config/device_registry/list`` into device_id -> area_id / labels.
 
     Tolerates a missing/degraded payload (returns empty maps) so the area/label
@@ -124,10 +129,10 @@ def _parse_device_registry(
     device_area: dict[str, str] = {}
     device_labels: dict[str, list[str]] = {}
     if not isinstance(device_registry_result, dict):
-        return device_area, device_labels
+        return device_area, device_labels, frozenset()
     raw_devices = device_registry_result.get("result", [])
     if not isinstance(raw_devices, list):
-        return device_area, device_labels
+        return device_area, device_labels, frozenset()
     snapshot = build_device_registry_snapshot(raw_devices)
     for device_id, device in snapshot.by_id.items():
         area_id = snapshot.effective_area_by_id.get(device_id)
@@ -136,11 +141,11 @@ def _parse_device_registry(
         labels = _normalize_labels(device.get("labels"))
         if labels:
             device_labels[device_id] = labels
-    return device_area, device_labels
+    return device_area, device_labels, snapshot.conflicting_ids
 
 
 def _effective_area(entry: dict[str, Any], device_area: dict[str, str]) -> str | None:
-    """Entity ``area_id`` falling back to its device's area (HA's inheritance)."""
+    """Resolve entity direct area, then its device's direct-or-parent effective area."""
     return effective_entity_area_id(entry, device_area)
 
 
@@ -153,6 +158,21 @@ def _effective_labels(
     if isinstance(device_id, str) and device_id in device_labels:
         result = result + device_labels[device_id]
     return result
+
+
+def _handle_device_registry_conflicts(
+    conflicting_device_ids: frozenset[str],
+    *,
+    area_or_label_dimension_active: bool,
+    strict: bool,
+    warnings: list[str],
+) -> None:
+    """Surface ambiguous device-derived visibility evidence at its authority seam."""
+    if not conflicting_device_ids or not area_or_label_dimension_active:
+        return
+    if strict:
+        raise VisibilityDataUnavailable(_DEVICE_REGISTRY_CONFLICT_WARNING)
+    warnings.append(_DEVICE_REGISTRY_CONFLICT_WARNING)
 
 
 def _is_assist_exposed(
@@ -389,7 +409,8 @@ def hidden_entity_ids(
 
     ``device_registry_result`` (``config/device_registry/list``) supplies the
     device area/labels an entity inherits: HA resolves an entity's effective area
-    as its own ``area_id`` falling back to its device's, and a device's labels
+    as its own ``area_id`` falling back to its device's direct-or-parent effective
+    area, and a device's labels
     apply to its entities. The area/label exclude and allow dimensions match on
     that effective area/labels, so a device-bound entity (registry ``area_id``
     None + a ``device_id``) is filtered by its device's area/labels. Without the
@@ -453,12 +474,21 @@ def hidden_entity_ids(
     # own area_id else its device's, and device labels apply to its entities. A
     # missing/degraded device payload leaves both maps empty, so the area/label
     # dimensions fall back to entity-level matching.
-    device_area, device_labels = _parse_device_registry(device_registry_result)
-
     areas = set(config.exclude_areas)
     labels = set(config.exclude_labels)
     allow_areas = set(config.allow_areas)
     allow_labels = set(config.allow_labels)
+    device_area, device_labels, conflicting_device_ids = _parse_device_registry(
+        device_registry_result
+    )
+    _handle_device_registry_conflicts(
+        conflicting_device_ids,
+        area_or_label_dimension_active=bool(
+            areas or labels or allow_areas or allow_labels
+        ),
+        strict=strict,
+        warnings=warnings,
+    )
     # An allowlist is active only when at least one allow_* dimension is set. When
     # active it inverts the default: an entity is hidden unless it matches one of
     # the allow dimensions, and a match authorizes it past the broad

--- a/src/ha_mcp/visibility/resolver.py
+++ b/src/ha_mcp/visibility/resolver.py
@@ -14,6 +14,7 @@ import logging
 from typing import Any
 
 from ..utils.data_paths import get_data_dir
+from ..utils.device_registry_semantics import build_device_registry_snapshot
 from .model import VisibilityConfig, VisibilityWire
 from .persistence import load_visibility_config
 
@@ -121,16 +122,12 @@ def _parse_device_registry(
     device_labels: dict[str, list[str]] = {}
     if not isinstance(device_registry_result, dict):
         return device_area, device_labels
-    devices = device_registry_result.get("result", [])
-    if not isinstance(devices, list):
+    raw_devices = device_registry_result.get("result", [])
+    if not isinstance(raw_devices, list):
         return device_area, device_labels
-    for device in devices:
-        if not isinstance(device, dict):
-            continue
-        device_id = device.get("id")
-        if not device_id:
-            continue
-        area_id = device.get("area_id")
+    snapshot = build_device_registry_snapshot(raw_devices)
+    for device_id, device in snapshot.by_id.items():
+        area_id = snapshot.effective_area_by_id.get(device_id)
         if area_id:
             device_area[device_id] = area_id
         labels = _normalize_labels(device.get("labels"))

--- a/src/ha_mcp/visibility/resolver.py
+++ b/src/ha_mcp/visibility/resolver.py
@@ -14,7 +14,10 @@ import logging
 from typing import Any
 
 from ..utils.data_paths import get_data_dir
-from ..utils.device_registry_semantics import build_device_registry_snapshot
+from ..utils.device_registry_semantics import (
+    build_device_registry_snapshot,
+    effective_entity_area_id,
+)
 from .model import VisibilityConfig, VisibilityWire
 from .persistence import load_visibility_config
 
@@ -138,13 +141,7 @@ def _parse_device_registry(
 
 def _effective_area(entry: dict[str, Any], device_area: dict[str, str]) -> str | None:
     """Entity ``area_id`` falling back to its device's area (HA's inheritance)."""
-    area_id = entry.get("area_id")
-    if isinstance(area_id, str) and area_id:
-        return area_id
-    device_id = entry.get("device_id")
-    if isinstance(device_id, str) and device_id:
-        return device_area.get(device_id)
-    return None
+    return effective_entity_area_id(entry, device_area)
 
 
 def _effective_labels(

--- a/src/ha_mcp/visibility/resolver.py
+++ b/src/ha_mcp/visibility/resolver.py
@@ -87,6 +87,11 @@ _DEVICE_REGISTRY_CONFLICT_WARNING = (
     "device registry contained conflicting identities; ambiguous device-derived "
     "placement and labels were excluded."
 )
+_DEVICE_REGISTRY_INVALID_AREA_WARNING = (
+    "Entity visibility filter is enabled with an area dimension but the device "
+    "registry contained invalid area relationships; affected device-derived "
+    "placement was excluded."
+)
 
 
 class VisibilityDataUnavailable(Exception):
@@ -99,8 +104,9 @@ class VisibilityDataUnavailable(Exception):
     it must conceal — so it calls the resolver with ``strict=True``, turning every
     degradation that would otherwise surface a degraded-dimension warning
     (``_REGISTRY_UNAVAILABLE_WARNING``, ``_ALLOWLIST_REGISTRY_EMPTY_WARNING``,
-    ``_ASSIST_UNAVAILABLE_WARNING``, or a config-load failure) into this exception
-    (fail closed). Benign notes (unknown ``exclude_categories``) never raise.
+    ``_ASSIST_UNAVAILABLE_WARNING``, invalid device-area evidence, or a config-load
+    failure) into this exception (fail closed). Benign notes (unknown
+    ``exclude_categories``) never raise.
     """
 
 
@@ -120,7 +126,7 @@ def _normalize_labels(raw: object) -> list[str]:
 
 def _parse_device_registry(
     device_registry_result: object,
-) -> tuple[dict[str, str], dict[str, list[str]], frozenset[str]]:
+) -> tuple[dict[str, str], dict[str, list[str]], frozenset[str], frozenset[str]]:
     """Parse ``config/device_registry/list`` into device_id -> area_id / labels.
 
     Tolerates a missing/degraded payload (returns empty maps) so the area/label
@@ -129,10 +135,10 @@ def _parse_device_registry(
     device_area: dict[str, str] = {}
     device_labels: dict[str, list[str]] = {}
     if not isinstance(device_registry_result, dict):
-        return device_area, device_labels, frozenset()
+        return device_area, device_labels, frozenset(), frozenset()
     raw_devices = device_registry_result.get("result", [])
     if not isinstance(raw_devices, list):
-        return device_area, device_labels, frozenset()
+        return device_area, device_labels, frozenset(), frozenset()
     snapshot = build_device_registry_snapshot(raw_devices)
     for device_id, device in snapshot.by_id.items():
         area_id = snapshot.effective_area_by_id.get(device_id)
@@ -141,7 +147,12 @@ def _parse_device_registry(
         labels = _normalize_labels(device.get("labels"))
         if labels:
             device_labels[device_id] = labels
-    return device_area, device_labels, snapshot.conflicting_ids
+    return (
+        device_area,
+        device_labels,
+        snapshot.conflicting_ids,
+        snapshot.invalid_area_ids,
+    )
 
 
 def _effective_area(entry: dict[str, Any], device_area: dict[str, str]) -> str | None:
@@ -173,6 +184,21 @@ def _handle_device_registry_conflicts(
     if strict:
         raise VisibilityDataUnavailable(_DEVICE_REGISTRY_CONFLICT_WARNING)
     warnings.append(_DEVICE_REGISTRY_CONFLICT_WARNING)
+
+
+def _handle_invalid_device_area_evidence(
+    invalid_area_ids: frozenset[str],
+    *,
+    area_dimension_active: bool,
+    strict: bool,
+    warnings: list[str],
+) -> None:
+    """Surface invalid device ancestry wherever area filtering relies on it."""
+    if not invalid_area_ids or not area_dimension_active:
+        return
+    if strict:
+        raise VisibilityDataUnavailable(_DEVICE_REGISTRY_INVALID_AREA_WARNING)
+    warnings.append(_DEVICE_REGISTRY_INVALID_AREA_WARNING)
 
 
 def _is_assist_exposed(
@@ -478,14 +504,23 @@ def hidden_entity_ids(
     labels = set(config.exclude_labels)
     allow_areas = set(config.allow_areas)
     allow_labels = set(config.allow_labels)
-    device_area, device_labels, conflicting_device_ids = _parse_device_registry(
-        device_registry_result
-    )
+    (
+        device_area,
+        device_labels,
+        conflicting_device_ids,
+        invalid_device_area_ids,
+    ) = _parse_device_registry(device_registry_result)
     _handle_device_registry_conflicts(
         conflicting_device_ids,
         area_or_label_dimension_active=bool(
             areas or labels or allow_areas or allow_labels
         ),
+        strict=strict,
+        warnings=warnings,
+    )
+    _handle_invalid_device_area_evidence(
+        invalid_device_area_ids,
+        area_dimension_active=bool(areas or allow_areas),
         strict=strict,
         warnings=warnings,
     )

--- a/tests/initial_test_state/custom_packages/core_2026_9_child_devices.yaml
+++ b/tests/initial_test_state/custom_packages/core_2026_9_child_devices.yaml
@@ -1,0 +1,4 @@
+# Core 2026.9 fixture with one main power-strip device and child outlet devices.
+# Device-registry E2E tests use this to prove real child-device enumeration and
+# effective parent-area behavior rather than only replaying synthetic rows.
+kitchen_sink:

--- a/tests/src/e2e/workflows/registry/test_device_registry.py
+++ b/tests/src/e2e/workflows/registry/test_device_registry.py
@@ -24,6 +24,114 @@ from ...utilities.assertions import parse_mcp_result, safe_call_tool
 logger = logging.getLogger(__name__)
 
 
+async def _core_2026_9_child_fixture(ha_client):
+    """Return one real kitchen-sink parent, child, entity, and original area."""
+    info = await ha_client.send_websocket_message({"type": "ha_mcp_tools/info"})
+    assert info.get("success") is True, info
+    assert "device_registry_child_semantics" in info["result"]["capabilities"]
+
+    device_reply = await ha_client.send_websocket_message(
+        {"type": "config/device_registry/list"}
+    )
+    entity_reply = await ha_client.send_websocket_message(
+        {"type": "config/entity_registry/list"}
+    )
+    assert device_reply.get("success") is True, device_reply
+    assert entity_reply.get("success") is True, entity_reply
+    device_rows = device_reply.get("result")
+    entity_rows = entity_reply.get("result")
+    assert isinstance(device_rows, list)
+    assert isinstance(entity_rows, list)
+
+    devices_by_id = {
+        row["id"]: row
+        for row in device_rows
+        if isinstance(row, dict) and isinstance(row.get("id"), str)
+    }
+    switch_entities_by_device: dict[str, list[str]] = {}
+    for row in entity_rows:
+        if not isinstance(row, dict):
+            continue
+        device_id = row.get("device_id")
+        entity_id = row.get("entity_id")
+        if (
+            isinstance(device_id, str)
+            and isinstance(entity_id, str)
+            and entity_id.startswith("switch.")
+        ):
+            switch_entities_by_device.setdefault(device_id, []).append(entity_id)
+
+    children_by_parent: dict[str, list[dict]] = {}
+    for row in device_rows:
+        if not isinstance(row, dict):
+            continue
+        parent_id = row.get("parent_device_id")
+        child_id = row.get("id")
+        if (
+            isinstance(parent_id, str)
+            and parent_id
+            and isinstance(child_id, str)
+            and switch_entities_by_device.get(child_id)
+        ):
+            children_by_parent.setdefault(parent_id, []).append(row)
+
+    candidates = [
+        (parent_id, sorted(children, key=lambda row: row["id"]))
+        for parent_id, children in children_by_parent.items()
+        if parent_id in devices_by_id and len(children) >= 2
+    ]
+    assert candidates, (
+        "Core 2026.9 kitchen_sink did not create the expected power-strip "
+        "parent with at least two child switch devices"
+    )
+    parent_id, children = sorted(candidates, key=lambda item: item[0])[0]
+    child_id = children[0]["id"]
+    child_entity_id = sorted(switch_entities_by_device[child_id])[0]
+    return (
+        parent_id,
+        child_id,
+        child_entity_id,
+        devices_by_id[parent_id].get("area_id"),
+    )
+
+
+async def _error_log_total(mcp_client) -> int:
+    """Return the authoritative current error-log line count."""
+    result = parse_mcp_result(
+        await mcp_client.call_tool("ha_get_logs", {"source": "error_log", "limit": 1})
+    )
+    assert result.get("success") is True, result
+    return result["total_lines"]
+
+
+async def _error_log_lines_since(mcp_client, baseline_total: int) -> list[str]:
+    """Read only the bounded newest window added since a line-count boundary."""
+    current_total = await _error_log_total(mcp_client)
+    assert current_total >= baseline_total, (
+        "Error-log history rotated during the child-device read assertion"
+    )
+    new_line_count = current_total - baseline_total
+    new_log_lines: list[str] = []
+    offset = 0
+    while offset < new_line_count:
+        page = parse_mcp_result(
+            await mcp_client.call_tool(
+                "ha_get_logs",
+                {
+                    "source": "error_log",
+                    "limit": min(1000, new_line_count - offset),
+                    "offset": offset,
+                },
+            )
+        )
+        assert page.get("success") is True, page
+        assert page["offset"] == offset, page
+        assert page["window_lines"] > 0, page
+        new_log_lines.extend(page["log"].splitlines())
+        offset += page["window_lines"]
+    return new_log_lines
+
+
 @pytest.mark.registry
 class TestDeviceList:
     """Test ha_get_device functionality."""
@@ -313,68 +421,12 @@ async def test_core_2026_9_child_devices_inherit_parent_area(mcp_client, ha_clie
     The mutation is always restored, and the component must not touch Core's
     deprecated mapping methods while serving the reads.
     """
-    info = await ha_client.send_websocket_message({"type": "ha_mcp_tools/info"})
-    assert info.get("success") is True, info
-    assert "device_registry_child_semantics" in info["result"]["capabilities"]
-
-    device_reply = await ha_client.send_websocket_message(
-        {"type": "config/device_registry/list"}
-    )
-    entity_reply = await ha_client.send_websocket_message(
-        {"type": "config/entity_registry/list"}
-    )
-    assert device_reply.get("success") is True, device_reply
-    assert entity_reply.get("success") is True, entity_reply
-    device_rows = device_reply.get("result")
-    entity_rows = entity_reply.get("result")
-    assert isinstance(device_rows, list)
-    assert isinstance(entity_rows, list)
-
-    devices_by_id = {
-        row["id"]: row
-        for row in device_rows
-        if isinstance(row, dict) and isinstance(row.get("id"), str)
-    }
-    switch_entities_by_device: dict[str, list[str]] = {}
-    for row in entity_rows:
-        if not isinstance(row, dict):
-            continue
-        device_id = row.get("device_id")
-        entity_id = row.get("entity_id")
-        if (
-            isinstance(device_id, str)
-            and isinstance(entity_id, str)
-            and entity_id.startswith("switch.")
-        ):
-            switch_entities_by_device.setdefault(device_id, []).append(entity_id)
-
-    children_by_parent: dict[str, list[dict]] = {}
-    for row in device_rows:
-        if not isinstance(row, dict):
-            continue
-        parent_id = row.get("parent_device_id")
-        child_id = row.get("id")
-        if (
-            isinstance(parent_id, str)
-            and parent_id
-            and isinstance(child_id, str)
-            and switch_entities_by_device.get(child_id)
-        ):
-            children_by_parent.setdefault(parent_id, []).append(row)
-
-    candidates = [
-        (parent_id, sorted(children, key=lambda row: row["id"]))
-        for parent_id, children in children_by_parent.items()
-        if parent_id in devices_by_id and len(children) >= 2
-    ]
-    assert candidates, (
-        "Core 2026.9 kitchen_sink did not create the expected power-strip "
-        "parent with at least two child switch devices"
-    )
-    parent_id, children = sorted(candidates, key=lambda item: item[0])[0]
-    child_id = children[0]["id"]
-    child_entity_id = sorted(switch_entities_by_device[child_id])[0]
-    original_parent_area = devices_by_id[parent_id].get("area_id")
+    (
+        parent_id,
+        child_id,
+        child_entity_id,
+        original_parent_area,
+    ) = await _core_2026_9_child_fixture(ha_client)
 
     update = parse_mcp_result(
         await mcp_client.call_tool(
@@ -383,7 +435,11 @@ async def test_core_2026_9_child_devices_inherit_parent_area(mcp_client, ha_clie
     )
     assert update.get("success") is True, update
 
+    body_error: Exception | None = None
+    restore_error: Exception | None = None
     try:
+        baseline_total_lines = await _error_log_total(mcp_client)
+
         search = parse_mcp_result(
             await mcp_client.call_tool(
                 "ha_search",
@@ -416,24 +472,38 @@ async def test_core_2026_9_child_devices_inherit_parent_area(mcp_client, ha_clie
         assert area_list.get("success") is True, area_list
         assert child_id in {row["device_id"] for row in area_list["devices"]}
 
-        error_log = (await ha_client.get_error_log(lines=1000)).text
         deprecated_component_lines = [
             line
-            for line in error_log.splitlines()
+            for line in await _error_log_lines_since(mcp_client, baseline_total_lines)
             if "helpers.frame" in line and "ha_mcp_tools" in line
         ]
         assert deprecated_component_lines == []
+    except Exception as err:
+        body_error = err
     finally:
-        restore = parse_mcp_result(
-            await mcp_client.call_tool(
-                "ha_set_device",
-                {
-                    "device_id": parent_id,
-                    "area_id": original_parent_area or "",
-                },
+        try:
+            restore = parse_mcp_result(
+                await mcp_client.call_tool(
+                    "ha_set_device",
+                    {
+                        "device_id": parent_id,
+                        "area_id": original_parent_area or "",
+                    },
+                )
             )
+            assert restore.get("success") is True, restore
+        except Exception as err:
+            restore_error = err
+
+    if body_error is not None and restore_error is not None:
+        raise ExceptionGroup(
+            "Core 2026.9 child-device read assertions and cleanup both failed",
+            [body_error, restore_error],
         )
-        assert restore.get("success") is True, restore
+    if body_error is not None:
+        raise body_error
+    if restore_error is not None:
+        raise restore_error
 
 
 @pytest.mark.registry

--- a/tests/src/e2e/workflows/registry/test_device_registry.py
+++ b/tests/src/e2e/workflows/registry/test_device_registry.py
@@ -428,16 +428,16 @@ async def test_core_2026_9_child_devices_inherit_parent_area(mcp_client, ha_clie
         original_parent_area,
     ) = await _core_2026_9_child_fixture(ha_client)
 
-    update = parse_mcp_result(
-        await mcp_client.call_tool(
-            "ha_set_device", {"device_id": parent_id, "area_id": "living_room"}
-        )
-    )
-    assert update.get("success") is True, update
-
     body_error: Exception | None = None
     restore_error: Exception | None = None
     try:
+        update = parse_mcp_result(
+            await mcp_client.call_tool(
+                "ha_set_device", {"device_id": parent_id, "area_id": "living_room"}
+            )
+        )
+        assert update.get("success") is True, update
+
         baseline_total_lines = await _error_log_total(mcp_client)
 
         search = parse_mcp_result(

--- a/tests/src/e2e/workflows/registry/test_device_registry.py
+++ b/tests/src/e2e/workflows/registry/test_device_registry.py
@@ -25,10 +25,11 @@ logger = logging.getLogger(__name__)
 
 
 async def _core_2026_9_child_fixture(ha_client):
-    """Return one real kitchen-sink parent, child, entity, and original area."""
+    """Return one real child fixture and whether the component is available."""
     info = await ha_client.send_websocket_message({"type": "ha_mcp_tools/info"})
-    assert info.get("success") is True, info
-    assert "device_registry_child_semantics" in info["result"]["capabilities"]
+    component_available = info.get("success") is True
+    if component_available:
+        assert "device_registry_child_semantics" in info["result"]["capabilities"]
 
     device_reply = await ha_client.send_websocket_message(
         {"type": "config/device_registry/list"}
@@ -92,6 +93,7 @@ async def _core_2026_9_child_fixture(ha_client):
         child_id,
         child_entity_id,
         devices_by_id[parent_id].get("area_id"),
+        component_available,
     )
 
 
@@ -426,6 +428,7 @@ async def test_core_2026_9_child_devices_inherit_parent_area(mcp_client, ha_clie
         child_id,
         child_entity_id,
         original_parent_area,
+        component_available,
     ) = await _core_2026_9_child_fixture(ha_client)
 
     body_error: Exception | None = None
@@ -438,7 +441,9 @@ async def test_core_2026_9_child_devices_inherit_parent_area(mcp_client, ha_clie
         )
         assert update.get("success") is True, update
 
-        baseline_total_lines = await _error_log_total(mcp_client)
+        baseline_total_lines = (
+            await _error_log_total(mcp_client) if component_available else None
+        )
 
         search = parse_mcp_result(
             await mcp_client.call_tool(
@@ -472,12 +477,15 @@ async def test_core_2026_9_child_devices_inherit_parent_area(mcp_client, ha_clie
         assert area_list.get("success") is True, area_list
         assert child_id in {row["device_id"] for row in area_list["devices"]}
 
-        deprecated_component_lines = [
-            line
-            for line in await _error_log_lines_since(mcp_client, baseline_total_lines)
-            if "helpers.frame" in line and "ha_mcp_tools" in line
-        ]
-        assert deprecated_component_lines == []
+        if baseline_total_lines is not None:
+            deprecated_component_lines = [
+                line
+                for line in await _error_log_lines_since(
+                    mcp_client, baseline_total_lines
+                )
+                if "helpers.frame" in line and "ha_mcp_tools" in line
+            ]
+            assert deprecated_component_lines == []
     except Exception as err:
         body_error = err
     finally:

--- a/tests/src/e2e/workflows/registry/test_device_registry.py
+++ b/tests/src/e2e/workflows/registry/test_device_registry.py
@@ -304,6 +304,139 @@ class TestDeviceGet:
 
 
 @pytest.mark.registry
+async def test_core_2026_9_child_devices_inherit_parent_area(mcp_client, ha_client):
+    """Exercise the real Core 2026.9 kitchen-sink child-device topology.
+
+    The fixture creates one power-strip parent with multiple child outlets. The
+    test assigns only the parent to ``living_room`` and proves the same inherited
+    placement through search, single-device lookup, and area-filtered device list.
+    The mutation is always restored, and the component must not touch Core's
+    deprecated mapping methods while serving the reads.
+    """
+    info = await ha_client.send_websocket_message({"type": "ha_mcp_tools/info"})
+    assert info.get("success") is True, info
+    assert "device_registry_child_semantics" in info["result"]["capabilities"]
+
+    device_reply = await ha_client.send_websocket_message(
+        {"type": "config/device_registry/list"}
+    )
+    entity_reply = await ha_client.send_websocket_message(
+        {"type": "config/entity_registry/list"}
+    )
+    assert device_reply.get("success") is True, device_reply
+    assert entity_reply.get("success") is True, entity_reply
+    device_rows = device_reply.get("result")
+    entity_rows = entity_reply.get("result")
+    assert isinstance(device_rows, list)
+    assert isinstance(entity_rows, list)
+
+    devices_by_id = {
+        row["id"]: row
+        for row in device_rows
+        if isinstance(row, dict) and isinstance(row.get("id"), str)
+    }
+    switch_entities_by_device: dict[str, list[str]] = {}
+    for row in entity_rows:
+        if not isinstance(row, dict):
+            continue
+        device_id = row.get("device_id")
+        entity_id = row.get("entity_id")
+        if (
+            isinstance(device_id, str)
+            and isinstance(entity_id, str)
+            and entity_id.startswith("switch.")
+        ):
+            switch_entities_by_device.setdefault(device_id, []).append(entity_id)
+
+    children_by_parent: dict[str, list[dict]] = {}
+    for row in device_rows:
+        if not isinstance(row, dict):
+            continue
+        parent_id = row.get("parent_device_id")
+        child_id = row.get("id")
+        if (
+            isinstance(parent_id, str)
+            and parent_id
+            and isinstance(child_id, str)
+            and switch_entities_by_device.get(child_id)
+        ):
+            children_by_parent.setdefault(parent_id, []).append(row)
+
+    candidates = [
+        (parent_id, sorted(children, key=lambda row: row["id"]))
+        for parent_id, children in children_by_parent.items()
+        if parent_id in devices_by_id and len(children) >= 2
+    ]
+    assert candidates, (
+        "Core 2026.9 kitchen_sink did not create the expected power-strip "
+        "parent with at least two child switch devices"
+    )
+    parent_id, children = sorted(candidates, key=lambda item: item[0])[0]
+    child_id = children[0]["id"]
+    child_entity_id = sorted(switch_entities_by_device[child_id])[0]
+    original_parent_area = devices_by_id[parent_id].get("area_id")
+
+    update = parse_mcp_result(
+        await mcp_client.call_tool(
+            "ha_set_device", {"device_id": parent_id, "area_id": "living_room"}
+        )
+    )
+    assert update.get("success") is True, update
+
+    try:
+        search = parse_mcp_result(
+            await mcp_client.call_tool(
+                "ha_search",
+                {
+                    "query": child_entity_id,
+                    "domain_filter": "switch",
+                    "exact_match": True,
+                    "result_fields": ["area"],
+                },
+            )
+        )
+        assert search.get("success") is True, search
+        assert any(row.get("area") == "Living Room" for row in search["entities"]), (
+            search
+        )
+
+        single = parse_mcp_result(
+            await mcp_client.call_tool("ha_get_device", {"device_id": child_id})
+        )
+        assert single.get("success") is True, single
+        assert single["device"]["device_id"] == child_id
+        assert single["device"]["area_id"] == "living_room"
+        assert single["device"]["config_entries"]
+
+        area_list = parse_mcp_result(
+            await mcp_client.call_tool(
+                "ha_get_device", {"area_id": "living_room", "limit": 200}
+            )
+        )
+        assert area_list.get("success") is True, area_list
+        assert child_id in {row["device_id"] for row in area_list["devices"]}
+
+        error_log = (await ha_client.get_error_log(lines=1000)).text
+        deprecated_component_lines = [
+            line
+            for line in error_log.splitlines()
+            if "helpers.frame" in line and "ha_mcp_tools" in line
+        ]
+        assert deprecated_component_lines == []
+    finally:
+        restore = parse_mcp_result(
+            await mcp_client.call_tool(
+                "ha_set_device",
+                {
+                    "device_id": parent_id,
+                    "area_id": original_parent_area or "",
+                },
+            )
+        )
+        assert restore.get("success") is True, restore
+
+
+@pytest.mark.registry
 class TestDeviceSet:
     """Test ha_set_device functionality."""
 

--- a/tests/src/unit/test_area_filter_search.py
+++ b/tests/src/unit/test_area_filter_search.py
@@ -234,6 +234,40 @@ class TestAreaFilterAccuracy:
         assert returned_ids == {"sensor.child"}
 
     @pytest.mark.asyncio
+    async def test_present_invalid_entity_area_does_not_inherit_child_area(self):
+        """A present invalid direct area blocks device-area fallback."""
+        client = MockClientWithRegistries(
+            entities=[
+                {
+                    "entity_id": "sensor.child",
+                    "attributes": {"friendly_name": "Child Sensor"},
+                    "state": "21",
+                }
+            ],
+            areas=[{"area_id": "office", "name": "Office"}],
+            entity_registry=[
+                {
+                    "entity_id": "sensor.child",
+                    "area_id": "",
+                    "device_id": "child",
+                }
+            ],
+            device_registry=[
+                {"id": "parent", "area_id": "office"},
+                {
+                    "id": "child",
+                    "area_id": None,
+                    "parent_device_id": "parent",
+                },
+            ],
+        )
+        tools = SmartSearchTools(client=client, fuzzy_threshold=60)
+
+        result = await tools.get_entities_by_area("office")
+
+        assert result["total_entities"] == 0
+
+    @pytest.mark.asyncio
     async def test_unassigned_entities_excluded(self, two_area_setup):
         """Entities without any area assignment are not returned."""
         client = MockClientWithRegistries(

--- a/tests/src/unit/test_area_filter_search.py
+++ b/tests/src/unit/test_area_filter_search.py
@@ -193,6 +193,47 @@ class TestAreaFilterAccuracy:
         assert "climate.abc" in all_entity_ids
 
     @pytest.mark.asyncio
+    async def test_child_device_inherits_parent_area_for_filtering(self):
+        """Core 2026.9 child placement participates in exact area filtering."""
+        client = MockClientWithRegistries(
+            entities=[
+                {
+                    "entity_id": "sensor.child",
+                    "attributes": {"friendly_name": "Child Sensor"},
+                    "state": "21",
+                }
+            ],
+            areas=[{"area_id": "office", "name": "Office"}],
+            entity_registry=[
+                {
+                    "entity_id": "sensor.child",
+                    "area_id": None,
+                    "device_id": "child",
+                }
+            ],
+            device_registry=[
+                {"id": "parent", "area_id": "office"},
+                {
+                    "id": "child",
+                    "area_id": None,
+                    "parent_device_id": "parent",
+                },
+            ],
+        )
+        tools = SmartSearchTools(client=client, fuzzy_threshold=60)
+
+        result = await tools.get_entities_by_area("office")
+
+        assert result["total_entities"] == 1
+        office_entities = result["areas"]["office"]["entities"]
+        returned_ids = {
+            entity["entity_id"]
+            for domain_entities in office_entities.values()
+            for entity in domain_entities
+        }
+        assert returned_ids == {"sensor.child"}
+
+    @pytest.mark.asyncio
     async def test_unassigned_entities_excluded(self, two_area_setup):
         """Entities without any area assignment are not returned."""
         client = MockClientWithRegistries(

--- a/tests/src/unit/test_bulk_selector.py
+++ b/tests/src/unit/test_bulk_selector.py
@@ -137,6 +137,72 @@ async def test_floor_and_device_area_inheritance_resolve_exactly() -> None:
 
 
 @pytest.mark.asyncio
+async def test_child_device_inherits_parent_area_for_action_selection() -> None:
+    """A Core 2026.9 child entity is selected through its parent's area."""
+    client = SelectorClient(
+        states=[_state("switch.child_outlet"), _state("switch.other")],
+        entities=[
+            {
+                "entity_id": "switch.child_outlet",
+                "area_id": None,
+                "device_id": "child",
+            },
+            {"entity_id": "switch.other", "area_id": None, "device_id": "other"},
+        ],
+        devices=[
+            {"id": "parent", "area_id": "salon"},
+            {"id": "child", "area_id": None, "parent_device_id": "parent"},
+            {"id": "other", "area_id": "other"},
+        ],
+        areas=[
+            {"area_id": "salon", "floor_id": None},
+            {"area_id": "other", "floor_id": None},
+        ],
+    )
+
+    result = await resolve_bulk_selector(
+        client,
+        {"domain": "switch", "area_ids": ["salon"]},
+        action="off",
+        parameters=None,
+        timeout_seconds=None,
+        validate_first=True,
+    )
+
+    assert result.resolved_entity_ids == ("switch.child_outlet",)
+
+
+@pytest.mark.asyncio
+async def test_conflicting_device_identity_fails_before_action_selection() -> None:
+    client = SelectorClient(
+        states=[_state("switch.ambiguous")],
+        entities=[
+            {
+                "entity_id": "switch.ambiguous",
+                "area_id": None,
+                "device_id": "duplicate",
+            }
+        ],
+        devices=[
+            {"id": "duplicate", "area_id": "salon"},
+            {"id": "duplicate", "area_id": "other"},
+        ],
+    )
+
+    with pytest.raises(
+        BulkSelectorInfrastructureError, match="conflicting device identity"
+    ):
+        await resolve_bulk_selector(
+            client,
+            {"domain": "switch", "area_ids": ["salon"]},
+            action="off",
+            parameters=None,
+            timeout_seconds=None,
+            validate_first=True,
+        )
+
+
+@pytest.mark.asyncio
 async def test_membership_cycle_fails_before_returning_operations() -> None:
     """A cyclic aggregate graph is an all-or-nothing preflight failure."""
     client = SelectorClient(

--- a/tests/src/unit/test_component_readapi_contract.py
+++ b/tests/src/unit/test_component_readapi_contract.py
@@ -40,6 +40,7 @@ from ha_mcp.tools.tools_config_scripts import ConfigScriptTools
 from ._component_routing_helpers import patch_ws
 from .test_component_ws_search import (
     FakeArea,
+    FakeChildDevice,
     FakeConfig,
     FakeConfigEntry,
     FakeDevice,
@@ -104,6 +105,7 @@ from .test_ha_remove_device_component_routing import (
 from .test_ha_remove_device_component_routing import (
     _build_remove_device,
 )
+from .test_ha_search_component_routing import _build_ha_search
 from .test_radio_zigbee_component_routing import (
     RoutingClient as ZigbeeRoutingClient,
 )
@@ -262,9 +264,11 @@ class TestConfigGetSeam:
 
 # --- overview -------------------------------------------------------------------
 class TestOverviewSeam:
-    def _hass(self) -> FakeHass:
+    def _hass(self, states: list[FakeState] | None = None) -> FakeHass:
         return FakeHass(
-            states=[
+            states=states
+            if states is not None
+            else [
                 FakeState("light.lamp", "on", friendly_name="Lamp"),
                 FakeState("sensor.temp", "21", friendly_name="Temp"),
             ],
@@ -320,6 +324,82 @@ class TestOverviewSeam:
         assert client.total_legacy_fetches() == 0, (
             "overview must be fully component-served"
         )
+
+    @pytest.mark.asyncio
+    async def test_child_device_counts_in_parent_effective_area(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        hass = self._hass(
+            [FakeState("sensor.child", "21", friendly_name="Child Sensor")]
+        )
+        monkeypatch.setattr(
+            wsapi,
+            "_resolve_registries",
+            lambda h: make_view(
+                entity={
+                    "sensor.child": FakeRegEntry("sensor.child", device_id="child")
+                },
+                areas=[FakeArea("office", "Office", floor_id="upstairs")],
+                floors=[FakeFloor("upstairs", "Upstairs")],
+                devices=[FakeDevice("parent", area_id="office")],
+                child_devices=[FakeChildDevice("child", "parent")],
+            ),
+        )
+        _setup_visibility_disabled(tmp_path, monkeypatch)
+        client = OverviewRoutingClient()
+        tool = _build_overview_tool(client)
+        with patch_ws(_real_component_ws(hass), tools_search):
+            resp = await tool()
+
+        assert resp["success"] is True
+        assert resp["area_analysis"]["office"]["count"] == 1
+        assert client.total_legacy_fetches() == 0
+
+
+# --- search ---------------------------------------------------------------------
+class TestSearchSeam:
+    @pytest.mark.asyncio
+    async def test_child_device_effective_area_and_floor_reach_public_tool(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        view = make_view(
+            entity={"sensor.child": FakeRegEntry("sensor.child", device_id="child")},
+            areas=[FakeArea("office", "Office", floor_id="upstairs")],
+            floors=[FakeFloor("upstairs", "Upstairs")],
+            devices=[FakeDevice("parent", area_id="office")],
+            child_devices=[FakeChildDevice("child", "parent")],
+        )
+        monkeypatch.setattr(wsapi, "_resolve_registries", lambda h: view)
+        _setup_visibility_disabled(tmp_path, monkeypatch)
+        client = OverviewRoutingClient()
+        hass = FakeHass(
+            states=[FakeState("sensor.child", "21", friendly_name="Child Sensor")]
+        )
+        tool = _build_ha_search(client)
+        ws = AsyncMock()
+
+        async def _send(command_type: str, **kwargs: Any) -> dict[str, Any]:
+            if command_type == "ha_mcp_tools/info":
+                return {"success": True, "result": wsapi._do_info()}
+            if command_type == "ha_mcp_tools/search":
+                return {
+                    "success": True,
+                    "result": wsapi._do_search(hass, kwargs),
+                }
+            raise AssertionError(f"unexpected component command {command_type!r}")
+
+        ws.send_command = AsyncMock(side_effect=_send)
+        with patch_ws(ws, tools_search):
+            resp = await tool(
+                query="child sensor",
+                result_fields=["entity_id", "area", "floor"],
+            )
+
+        assert resp["success"] is True
+        assert resp["entities"] == [
+            {"entity_id": "sensor.child", "area": "Office", "floor": "Upstairs"}
+        ]
+        assert client.total_legacy_fetches() == 0
 
 
 # --- helpers_list ----------------------------------------------------------------
@@ -643,6 +723,39 @@ class TestDeviceSeam:
         assert raw_row["name"] == "Kitchen Temp"
 
     @pytest.mark.asyncio
+    async def test_core_2026_9_child_device_is_retained_with_effective_area(
+        self, monkeypatch
+    ) -> None:
+        """The public device list retains Core's reduced child row.
+
+        Its direct ``area_id`` is absent, so the existing public ``area_id`` field
+        must carry Core's effective parent-derived area without mutating the raw
+        component record. The raw record keeps ``parent_device_id`` internally.
+        """
+        parent = FakeDevice("parent-1", name="Bridge", area_id="office")
+        child = FakeChildDevice(
+            "child-1", "parent-1", name="Channel 1", identifiers=(("demo", "1"),)
+        )
+        monkeypatch.setattr(
+            wsapi,
+            "_resolve_registries",
+            lambda h: make_view(devices=[parent], child_devices=[child]),
+        )
+        client = GetDeviceRoutingClient()
+        ws = _real_component_ws(FakeHass())
+        get_device = _build_get_device(client)
+        with patch_ws(ws, component_devices):
+            resp = await get_device()
+
+        by_id = {row["device_id"]: row for row in resp["devices"]}
+        assert set(by_id) == {"parent-1", "child-1"}
+        assert by_id["child-1"]["area_id"] == "office"
+        raw = wsapi._do_device_list(FakeHass(), {})["devices"]
+        raw_child = next(row for row in raw if row["id"] == "child-1")
+        assert raw_child["parent_device_id"] == "parent-1"
+        assert raw_child["area_id"] is None
+
+    @pytest.mark.asyncio
     async def test_remove_device_config_entries_from_real_component(
         self, monkeypatch
     ) -> None:
@@ -745,6 +858,35 @@ class TestEntityEnrichSeam:
         assert by_id["light.plain"]["area"] is None
         assert by_id["light.plain"]["label_names"] == []
 
+    @pytest.mark.asyncio
+    async def test_core_2026_9_child_device_inherits_parent_area_and_floor(
+        self, monkeypatch
+    ) -> None:
+        parent = FakeDevice("parent-1", area_id="a1")
+        child = FakeChildDevice("child-1", "parent-1")
+        view = make_view(
+            entity={"sensor.child": FakeRegEntry("sensor.child", device_id="child-1")},
+            areas=[FakeArea("a1", "Office", floor_id="f1")],
+            floors=[FakeFloor("f1", "Upstairs")],
+            devices=[parent],
+            child_devices=[child],
+        )
+        monkeypatch.setattr(wsapi, "_resolve_registries", lambda h: view)
+        client = EntityRoutingClient(
+            {
+                "sensor.child": _raw_entry("sensor.child", area_id=None, labels=[])
+                | {"device_id": "child-1"}
+            }
+        )
+        ws = _real_component_ws(FakeHass())
+        tool = _build_get_entity(client)
+        with patch_ws(ws, tools_entities):
+            resp = await tool("sensor.child")
+
+        entry = resp["entity_entry"]
+        assert entry["area"] == "Office"
+        assert entry["floor"] == "Upstairs"
+
 
 # --- exposure -------------------------------------------------------------------
 class TestExposureSeam:
@@ -827,4 +969,34 @@ class TestExposureSeam:
         assert resp["exposed_entities"] == {"light.lamp": {"conversation": True}}
         assert set(resp["entity_info"]) == {"light.lamp"}
         assert resp["entity_info"]["light.lamp"]["area"] == "Office"
+        assert client.legacy_calls == 0
+
+    @pytest.mark.asyncio
+    async def test_child_device_effective_area_and_floor_enrich_exposure(
+        self, monkeypatch
+    ) -> None:
+        view = make_view(
+            entity={"sensor.child": FakeRegEntry("sensor.child", device_id="child")},
+            areas=[FakeArea("office", "Office", floor_id="upstairs")],
+            floors=[FakeFloor("upstairs", "Upstairs")],
+            devices=[FakeDevice("parent", area_id="office")],
+            child_devices=[FakeChildDevice("child", "parent")],
+        )
+        monkeypatch.setattr(wsapi, "_resolve_registries", lambda h: view)
+        monkeypatch.setattr(
+            wsapi,
+            "_async_get_entity_settings",
+            lambda h, entity_id: {"conversation": {"should_expose": True}},
+        )
+        monkeypatch.setattr(wsapi, "_legacy_exposed_entity_ids", lambda h: [])
+        client = ExposureRoutingClient({"sensor.child": {"conversation": True}})
+        hass = FakeHass(
+            states=[FakeState("sensor.child", "21", friendly_name="Child Sensor")]
+        )
+        tool = _build_exposure(client)
+        with patch_ws(_real_component_ws(hass), tools_voice_assistant):
+            resp = await tool(entity_id="sensor.child")
+
+        assert resp["area"] == "Office"
+        assert resp["floor"] == "Upstairs"
         assert client.legacy_calls == 0

--- a/tests/src/unit/test_component_search_contract.py
+++ b/tests/src/unit/test_component_search_contract.py
@@ -514,6 +514,58 @@ def test_child_device_effective_area_and_floor_reach_public_search(
     ]
 
 
+def test_conflicting_device_identity_does_not_enrich_public_search(
+    monkeypatch,
+) -> None:
+    """Ambiguous device rows cannot assign an arbitrary area or floor."""
+    office = FakeDevice("duplicate", area_id="office")
+    garage = FakeDevice("duplicate", area_id="garage")
+
+    class _ConflictingRegistry:
+        devices = (office, garage)
+        child_devices = ()
+
+        def async_get(self, device_id):
+            return office if device_id == "duplicate" else None
+
+    view = make_view(
+        entity={
+            "sensor.enrichmarker": FakeRegEntry(
+                "sensor.enrichmarker", device_id="duplicate"
+            )
+        },
+        areas=[FakeArea("office", "Office", floor_id="upstairs")],
+        floors=[FakeFloor("upstairs", "Upstairs")],
+    )
+    view.device = _ConflictingRegistry()
+    monkeypatch.setattr(wsapi, "_resolve_registries", lambda hass: view)
+
+    result = wsapi._do_search(
+        FakeHass(
+            states=[
+                FakeState("sensor.enrichmarker", "on", friendly_name="Enrichmarker")
+            ]
+        ),
+        {
+            "query": "enrichmarker",
+            "search_types": ["entity"],
+            "result_fields": ["area", "floor"],
+        },
+    )
+
+    shaped = _shape_component_search_response(
+        _resolved_result_fields(["entity_id", "area", "floor"]), result
+    )
+
+    assert shaped["entities"] == [
+        {
+            "entity_id": "sensor.enrichmarker",
+            "area": None,
+            "floor": None,
+        }
+    ]
+
+
 def test_result_fields_membership_additive(monkeypatch) -> None:
     """Explicit HA membership is generic, deterministic, and opt-in."""
     result = _enrichment_component_result(monkeypatch, membership=True)

--- a/tests/src/unit/test_component_search_contract.py
+++ b/tests/src/unit/test_component_search_contract.py
@@ -42,7 +42,9 @@ from ha_mcp.utils.entity_membership import normalize_member_entity_ids
 
 from .test_component_ws_search import (
     FakeArea,
+    FakeChildDevice,
     FakeConfigEntries,
+    FakeDevice,
     FakeFloor,
     FakeHass,
     FakeLabel,
@@ -461,6 +463,55 @@ def test_result_fields_enrichment_additive(monkeypatch) -> None:
         "labels": ["Favorites"],
         "aliases": ["desk"],
     }
+
+
+def test_child_device_effective_area_and_floor_reach_public_search(
+    monkeypatch,
+) -> None:
+    """The public ``ha_search`` projection uses Core's child placement rules."""
+    view = make_view(
+        entity={
+            "sensor.enrichmarker": FakeRegEntry(
+                "sensor.enrichmarker", device_id="child"
+            )
+        },
+        areas=[
+            FakeArea("office", "Office", floor_id="upstairs"),
+            FakeArea("garage", "Garage", floor_id="ground"),
+        ],
+        floors=[
+            FakeFloor("upstairs", "Upstairs"),
+            FakeFloor("ground", "Ground"),
+        ],
+        devices=[FakeDevice("parent", area_id="office")],
+        child_devices=[FakeChildDevice("child", "parent", area_id="garage")],
+    )
+    monkeypatch.setattr(wsapi, "_resolve_registries", lambda hass: view)
+    result = wsapi._do_search(
+        FakeHass(
+            states=[
+                FakeState("sensor.enrichmarker", "on", friendly_name="Enrichmarker")
+            ]
+        ),
+        {
+            "query": "enrichmarker",
+            "search_types": ["entity"],
+            "result_fields": ["area", "floor"],
+        },
+    )
+
+    shaped = _shape_component_search_response(
+        _resolved_result_fields(["entity_id", "area", "floor"]), result
+    )
+
+    # The child's direct area wins over its parent's area, exactly as Core does.
+    assert shaped["entities"] == [
+        {
+            "entity_id": "sensor.enrichmarker",
+            "area": "Garage",
+            "floor": "Ground",
+        }
+    ]
 
 
 def test_result_fields_membership_additive(monkeypatch) -> None:

--- a/tests/src/unit/test_component_search_visibility_contract.py
+++ b/tests/src/unit/test_component_search_visibility_contract.py
@@ -589,6 +589,10 @@ def test_component_warning_constants_match_resolver() -> None:
         wsapi._DEVICE_REGISTRY_CONFLICT_WARNING
         == resolver._DEVICE_REGISTRY_CONFLICT_WARNING
     )
+    assert (
+        wsapi._DEVICE_REGISTRY_INVALID_AREA_WARNING
+        == resolver._DEVICE_REGISTRY_INVALID_AREA_WARNING
+    )
     # The known-entity-category set is duplicated for the same HACS reason; pin it
     # equal to the resolver's so an unknown-category divergence can't creep in.
     assert wsapi._KNOWN_ENTITY_CATEGORIES == resolver.KNOWN_ENTITY_CATEGORIES

--- a/tests/src/unit/test_component_search_visibility_contract.py
+++ b/tests/src/unit/test_component_search_visibility_contract.py
@@ -575,7 +575,7 @@ async def test_component_warnings_match_legacy(
 def test_component_warning_constants_match_resolver() -> None:
     """The component's duplicated warning strings equal the server resolver's.
 
-    The component ships over HACS and cannot import the server package, so the two
+    The component ships over HACS and cannot import the server package, so its
     degradation strings are duplicated in ``websocket_api.py``; this pins them equal
     to ``visibility.resolver`` so a future edit to one side fails here instead of
     silently drifting the cross-path warning text.
@@ -584,6 +584,10 @@ def test_component_warning_constants_match_resolver() -> None:
     assert (
         wsapi._ALLOWLIST_REGISTRY_EMPTY_WARNING
         == resolver._ALLOWLIST_REGISTRY_EMPTY_WARNING
+    )
+    assert (
+        wsapi._DEVICE_REGISTRY_CONFLICT_WARNING
+        == resolver._DEVICE_REGISTRY_CONFLICT_WARNING
     )
     # The known-entity-category set is duplicated for the same HACS reason; pin it
     # equal to the resolver's so an unknown-category divergence can't creep in.

--- a/tests/src/unit/test_component_ws_phase2_async.py
+++ b/tests/src/unit/test_component_ws_phase2_async.py
@@ -1255,6 +1255,56 @@ class TestVisibilityWarnings:
         )
         assert warnings == []
 
+    def test_conflicting_device_registry_warns_for_area_dimension(self):
+        office = FakeDevice("duplicate", area_id="office")
+        garage = FakeDevice("duplicate", area_id="garage")
+
+        class _ConflictingRegistry:
+            devices = (office, garage)
+            child_devices = ()
+
+        view = make_view(
+            entity={
+                "sensor.ambiguous": FakeRegEntry(
+                    "sensor.ambiguous", device_id="duplicate"
+                )
+            }
+        )
+        view.device = _ConflictingRegistry()
+
+        warnings = wsapi._visibility_warnings(
+            view,
+            [FakeState("sensor.ambiguous")],
+            {"exclude_areas": ["office"]},
+        )
+
+        assert warnings == [wsapi._DEVICE_REGISTRY_CONFLICT_WARNING]
+
+    def test_conflicting_device_registry_is_irrelevant_without_area_or_label(self):
+        office = FakeDevice("duplicate", area_id="office")
+        garage = FakeDevice("duplicate", area_id="garage")
+
+        class _ConflictingRegistry:
+            devices = (office, garage)
+            child_devices = ()
+
+        view = make_view(
+            entity={
+                "sensor.ambiguous": FakeRegEntry(
+                    "sensor.ambiguous", device_id="duplicate"
+                )
+            }
+        )
+        view.device = _ConflictingRegistry()
+
+        warnings = wsapi._visibility_warnings(
+            view,
+            [FakeState("sensor.ambiguous")],
+            {"exclude_hidden": True},
+        )
+
+        assert warnings == []
+
     def test_empty_registry_allowlist_warns(self):
         # Area/label allowlist with an empty registry but states-only candidates
         # would blank everything; the guard fires and warns.
@@ -1490,6 +1540,34 @@ class TestSearchVisibilityPlacement:
         )
         assert {e["entity_id"] for e in res["entities"]} == {"light.a", "light.b"}
         assert res["visibility_warnings"] == [wsapi._ASSIST_UNAVAILABLE_WARNING]
+
+    def test_conflicting_device_visibility_is_disclosed_in_search(self, monkeypatch):
+        office = FakeDevice("duplicate", area_id="office")
+        garage = FakeDevice("duplicate", area_id="garage")
+
+        class _ConflictingRegistry:
+            devices = (office, garage)
+            child_devices = ()
+
+        view = make_view(
+            entity={
+                "sensor.ambiguous": FakeRegEntry(
+                    "sensor.ambiguous", device_id="duplicate"
+                )
+            }
+        )
+        view.device = _ConflictingRegistry()
+        monkeypatch.setattr(wsapi, "_resolve_registries", lambda hass: view)
+
+        res = wsapi._do_search(
+            FakeHass(states=[FakeState("sensor.ambiguous", "on", "Ambiguous")]),
+            {"query": "", "visibility": {"exclude_areas": ["office"]}},
+        )
+
+        assert [entity["entity_id"] for entity in res["entities"]] == [
+            "sensor.ambiguous"
+        ]
+        assert res["visibility_warnings"] == [wsapi._DEVICE_REGISTRY_CONFLICT_WARNING]
 
 
 class TestSearchVisibilitySchema:

--- a/tests/src/unit/test_component_ws_phase2_async.py
+++ b/tests/src/unit/test_component_ws_phase2_async.py
@@ -877,6 +877,35 @@ class TestVisibilityHiddenSet:
         )
         assert hidden == set()
 
+    def test_conflicting_device_area_is_not_used_for_visibility(self):
+        office = FakeDevice("duplicate", area_id="office")
+        garage = FakeDevice("duplicate", area_id="garage")
+
+        class _ConflictingRegistry:
+            devices = (office, garage)
+            child_devices = ()
+
+            def async_get(self, device_id):
+                return office if device_id == "duplicate" else None
+
+        view = make_view(
+            entity={
+                "sensor.ambiguous": FakeRegEntry(
+                    "sensor.ambiguous", device_id="duplicate"
+                )
+            }
+        )
+        view.device = _ConflictingRegistry()
+
+        hidden = wsapi._visibility_hidden_set(
+            view,
+            [FakeState("sensor.ambiguous")],
+            {"exclude_areas": ["office"]},
+            _always_expose,
+        )
+
+        assert hidden == set()
+
     def test_exclude_label_direct_and_device_inherited(self):
         view = make_view(
             entity={

--- a/tests/src/unit/test_component_ws_phase2_async.py
+++ b/tests/src/unit/test_component_ws_phase2_async.py
@@ -42,6 +42,7 @@ from ha_mcp.tools.reference_validator import build_entity_set, build_service_ind
 # Mirrors test_component_search_contract.py's ``wsapi`` re-import.
 from . import test_component_ws_search as _base
 from .test_component_ws_search import (
+    FakeChildDevice,
     FakeConfigEntry,
     FakeDevice,
     FakeHass,
@@ -857,6 +858,24 @@ class TestVisibilityHiddenSet:
             view, states, {"exclude_areas": ["garage"]}, _always_expose
         )
         assert hidden == {"light.direct", "light.viadev"}
+
+    def test_present_invalid_entity_area_blocks_child_device_area_fallback(self):
+        view = make_view(
+            entity={
+                "sensor.child": FakeRegEntry(
+                    "sensor.child", area_id="", device_id="child"
+                )
+            },
+            devices=[FakeDevice("parent", area_id="office")],
+            child_devices=[FakeChildDevice("child", "parent")],
+        )
+        hidden = wsapi._visibility_hidden_set(
+            view,
+            [FakeState("sensor.child")],
+            {"exclude_areas": ["office"]},
+            _always_expose,
+        )
+        assert hidden == set()
 
     def test_exclude_label_direct_and_device_inherited(self):
         view = make_view(

--- a/tests/src/unit/test_component_ws_phase2_async.py
+++ b/tests/src/unit/test_component_ws_phase2_async.py
@@ -1305,6 +1305,34 @@ class TestVisibilityWarnings:
 
         assert warnings == []
 
+    def test_missing_parent_warns_for_area_dimension(self):
+        view = make_view(
+            entity={"sensor.orphan": FakeRegEntry("sensor.orphan", device_id="child")},
+            child_devices=[FakeChildDevice("child", "missing")],
+        )
+
+        warnings = wsapi._visibility_warnings(
+            view,
+            [FakeState("sensor.orphan")],
+            {"exclude_areas": ["office"]},
+        )
+
+        assert warnings == [wsapi._DEVICE_REGISTRY_INVALID_AREA_WARNING]
+
+    def test_missing_parent_is_irrelevant_to_label_dimension(self):
+        view = make_view(
+            entity={"sensor.orphan": FakeRegEntry("sensor.orphan", device_id="child")},
+            child_devices=[FakeChildDevice("child", "missing")],
+        )
+
+        warnings = wsapi._visibility_warnings(
+            view,
+            [FakeState("sensor.orphan")],
+            {"exclude_labels": ["private"]},
+        )
+
+        assert warnings == []
+
     def test_empty_registry_allowlist_warns(self):
         # Area/label allowlist with an empty registry but states-only candidates
         # would blank everything; the guard fires and warns.
@@ -1568,6 +1596,23 @@ class TestSearchVisibilityPlacement:
             "sensor.ambiguous"
         ]
         assert res["visibility_warnings"] == [wsapi._DEVICE_REGISTRY_CONFLICT_WARNING]
+
+    def test_missing_parent_visibility_is_disclosed_in_search(self, monkeypatch):
+        view = make_view(
+            entity={"sensor.orphan": FakeRegEntry("sensor.orphan", device_id="child")},
+            child_devices=[FakeChildDevice("child", "missing")],
+        )
+        monkeypatch.setattr(wsapi, "_resolve_registries", lambda hass: view)
+
+        res = wsapi._do_search(
+            FakeHass(states=[FakeState("sensor.orphan", "on", "Orphan")]),
+            {"query": "", "visibility": {"exclude_areas": ["office"]}},
+        )
+
+        assert [entity["entity_id"] for entity in res["entities"]] == ["sensor.orphan"]
+        assert res["visibility_warnings"] == [
+            wsapi._DEVICE_REGISTRY_INVALID_AREA_WARNING
+        ]
 
 
 class TestSearchVisibilitySchema:

--- a/tests/src/unit/test_component_ws_search.py
+++ b/tests/src/unit/test_component_ws_search.py
@@ -553,16 +553,33 @@ class FakeChildDevice:
         }
 
 
+class _IterOnlyDeviceCollection:
+    """Core 2026.9 collection: iteration is the only supported read API."""
+
+    def __init__(self, entries):
+        self._entries = tuple(entries)
+
+    def __iter__(self):
+        return iter(self._entries)
+
+    def values(self):
+        raise AssertionError("Core 2026.9 device collections are not mappings")
+
+    def get(self, _device_id):
+        raise AssertionError("Core 2026.9 device collections do not support get")
+
+    def __getitem__(self, _device_id):
+        raise AssertionError("Core 2026.9 device collections are not subscriptable")
+
+
 class FakeDeviceReg:
     def __init__(self, devices, child_devices=()):
         self._devices = {d.id: d for d in devices}
         self._child_devices = {d.id: d for d in child_devices}
-        # Real HA exposes ``registry.devices`` as a mapping (overview reads it).
-        self.devices = dict(self._devices)
-        # Core 2026.9 exposes child devices as a separate collection. Older Core
-        # releases simply have no such attribute; tests that omit children still
-        # exercise the ordinary-device shape used before 2026.9.
-        self.child_devices = tuple(self._child_devices.values())
+        # Core 2026.9's public contract is iteration-only for both collections.
+        # The dedicated pre-2026.9 test below retains a dict-backed registry.
+        self.devices = _IterOnlyDeviceCollection(self._devices.values())
+        self.child_devices = _IterOnlyDeviceCollection(self._child_devices.values())
 
     def async_get(self, device_id):
         return self._devices.get(device_id) or self._child_devices.get(device_id)
@@ -3139,6 +3156,42 @@ class TestDeviceGet:
         assert res["device"]["area_id"] is None
         assert res["effective_area_id"] == "office"
 
+    def test_child_empty_direct_area_is_invalid_not_parent_fallback(self, monkeypatch):
+        parent = FakeDevice("parent", area_id="office")
+        child = FakeChildDevice("child", "parent", area_id="")
+        monkeypatch.setattr(
+            wsapi,
+            "_resolve_registries",
+            lambda h: make_view(devices=[parent], child_devices=[child]),
+        )
+
+        result = wsapi._do_device_get(FakeHass(), {"device_id": "child"})
+
+        assert result["effective_area_id"] is None
+
+    def test_conflicting_identity_is_not_returned_by_single_lookup(
+        self, monkeypatch, caplog
+    ):
+        office = FakeDevice("duplicate", area_id="office")
+        garage = FakeDevice("duplicate", area_id="garage")
+
+        class _ConflictingRegistry:
+            devices = (office, garage)
+            child_devices = ()
+
+            def async_get(self, device_id):
+                return office if device_id == "duplicate" else None
+
+        view = make_view()
+        view.device = _ConflictingRegistry()
+        monkeypatch.setattr(wsapi, "_resolve_registries", lambda h: view)
+
+        with caplog.at_level(logging.WARNING):
+            result = wsapi._do_device_get(FakeHass(), {"device_id": "duplicate"})
+
+        assert result == {"device": None}
+        assert any("conflicting device identity" in r.message for r in caplog.records)
+
 
 class TestDeviceList:
     def test_lists_all_dict_reprs(self, monkeypatch):
@@ -3210,6 +3263,27 @@ class TestDeviceList:
         monkeypatch.setattr(wsapi, "_resolve_registries", lambda h: view)
 
         assert wsapi._do_device_list(FakeHass(), {}) == {"devices": []}
+
+    def test_collection_enumeration_failure_is_logged(self, monkeypatch, caplog):
+        class _BrokenCollection:
+            def __iter__(self):
+                raise RuntimeError("enumeration failed")
+
+        class _BrokenRegistry:
+            devices = _BrokenCollection()
+            child_devices = ()
+
+        view = make_view()
+        view.device = _BrokenRegistry()
+        monkeypatch.setattr(wsapi, "_resolve_registries", lambda h: view)
+
+        with caplog.at_level(logging.WARNING):
+            assert wsapi._do_device_list(FakeHass(), {}) == {"devices": []}
+
+        assert any(
+            "failed to enumerate device registry collection" in r.message
+            for r in caplog.records
+        )
 
     def test_conflicting_device_cannot_supply_effective_area(self):
         office = FakeDevice("duplicate", area_id="office")

--- a/tests/src/unit/test_component_ws_search.py
+++ b/tests/src/unit/test_component_ws_search.py
@@ -532,6 +532,13 @@ class FakeChildDevice:
         self.config_subentry_id = config_subentry_id
         self.disabled_by = disabled_by
 
+    def __getattr__(self, name):
+        if name in {"manufacturer", "model", "connections"}:
+            raise AssertionError(
+                f"Core 2026.9 ChildDeviceEntry does not expose {name} as an attribute"
+            )
+        raise AttributeError(name)
+
     @property
     def dict_repr(self):
         # Exact Core 2026.9 child-device wire fields. In particular, child entries

--- a/tests/src/unit/test_component_ws_search.py
+++ b/tests/src/unit/test_component_ws_search.py
@@ -790,6 +790,7 @@ class TestInfo:
             "blueprint_get",
             "device_get",
             "device_list",
+            "device_registry_child_semantics",
             "entity_enrich",
             "exposure",
             "config_entries",

--- a/tests/src/unit/test_component_ws_search.py
+++ b/tests/src/unit/test_component_ws_search.py
@@ -504,14 +504,68 @@ class FakeDevice:
         }
 
 
+class FakeChildDevice:
+    """Core 2026.9 ``ChildDeviceEntry`` with its deliberately reduced shape."""
+
+    def __init__(
+        self,
+        device_id,
+        parent_device_id,
+        *,
+        name=None,
+        name_by_user=None,
+        area_id=None,
+        labels=(),
+        identifiers=(),
+        config_entry_id="cfg-1",
+        config_subentry_id=None,
+        disabled_by=None,
+    ):
+        self.id = device_id
+        self.parent_device_id = parent_device_id
+        self.name = name
+        self.name_by_user = name_by_user
+        self.area_id = area_id
+        self.labels = set(labels)
+        self.identifiers = set(identifiers)
+        self.config_entry_id = config_entry_id
+        self.config_subentry_id = config_subentry_id
+        self.disabled_by = disabled_by
+
+    @property
+    def dict_repr(self):
+        # Exact Core 2026.9 child-device wire fields. In particular, child entries
+        # do not grow the ordinary DeviceEntry-only manufacturer/model/connection
+        # fields just to satisfy a consumer written against the older registry.
+        return {
+            "area_id": self.area_id,
+            "config_entry_id": self.config_entry_id,
+            "config_subentry_id": self.config_subentry_id,
+            "created_at": 0.0,
+            "disabled_by": self.disabled_by,
+            "id": self.id,
+            "identifiers": list(self.identifiers),
+            "labels": list(self.labels),
+            "modified_at": 0.0,
+            "name_by_user": self.name_by_user,
+            "name": self.name,
+            "parent_device_id": self.parent_device_id,
+        }
+
+
 class FakeDeviceReg:
-    def __init__(self, devices):
+    def __init__(self, devices, child_devices=()):
         self._devices = {d.id: d for d in devices}
+        self._child_devices = {d.id: d for d in child_devices}
         # Real HA exposes ``registry.devices`` as a mapping (overview reads it).
         self.devices = dict(self._devices)
+        # Core 2026.9 exposes child devices as a separate collection. Older Core
+        # releases simply have no such attribute; tests that omit children still
+        # exercise the ordinary-device shape used before 2026.9.
+        self.child_devices = tuple(self._child_devices.values())
 
     def async_get(self, device_id):
-        return self._devices.get(device_id)
+        return self._devices.get(device_id) or self._child_devices.get(device_id)
 
 
 class FakeConfigEntity:
@@ -696,13 +750,15 @@ class FakeIssueRegModule:
         return self._registry
 
 
-def make_view(entity=None, areas=(), floors=(), labels=(), devices=()):
+def make_view(
+    entity=None, areas=(), floors=(), labels=(), devices=(), child_devices=()
+):
     return wsapi._RegistryView(
         entity=FakeEntityReg(entity or {}),
         area=FakeAreaReg(areas),
         floor=FakeFloorReg(floors),
         label=FakeLabelReg(labels),
-        device=FakeDeviceReg(devices),
+        device=FakeDeviceReg(devices, child_devices),
     )
 
 
@@ -3064,6 +3120,24 @@ class TestDeviceGet:
         res = wsapi._do_device_get(FakeHass(), {"device_id": "dev-x"})
         assert res == {"device": None}
 
+    def test_child_get_preserves_reduced_row_and_reports_effective_area(
+        self, monkeypatch
+    ):
+        parent = FakeDevice("parent", area_id="office")
+        child = FakeChildDevice("child", "parent", name="Channel")
+        monkeypatch.setattr(
+            wsapi,
+            "_resolve_registries",
+            lambda h: make_view(devices=[parent], child_devices=[child]),
+        )
+
+        res = wsapi._do_device_get(FakeHass(), {"device_id": "child"})
+
+        assert res["device"] == child.dict_repr
+        assert res["device"]["parent_device_id"] == "parent"
+        assert res["device"]["area_id"] is None
+        assert res["effective_area_id"] == "office"
+
 
 class TestDeviceList:
     def test_lists_all_dict_reprs(self, monkeypatch):
@@ -3080,6 +3154,60 @@ class TestDeviceList:
 
     def test_empty_registry(self, monkeypatch):
         monkeypatch.setattr(wsapi, "_resolve_registries", lambda h: make_view())
+        assert wsapi._do_device_list(FakeHass(), {}) == {"devices": []}
+
+    def test_core_2026_9_lists_main_and_child_in_stable_collection_order(
+        self, monkeypatch
+    ):
+        parent = FakeDevice("parent", area_id="office")
+        ordinary = FakeDevice("ordinary", area_id="garage")
+        child = FakeChildDevice("child", "parent")
+        monkeypatch.setattr(
+            wsapi,
+            "_resolve_registries",
+            lambda h: make_view(devices=[parent, ordinary], child_devices=[child]),
+        )
+
+        first = wsapi._do_device_list(FakeHass(), {})["devices"]
+        second = wsapi._do_device_list(FakeHass(), {})["devices"]
+
+        assert [row["id"] for row in first] == ["parent", "ordinary", "child"]
+        assert second == first
+        assert first[-1] == child.dict_repr
+
+    def test_pre_2026_9_mapping_container_remains_supported(self, monkeypatch):
+        ordinary = FakeDevice("ordinary", area_id="office")
+
+        class _OldDeviceRegistry:
+            def __init__(self):
+                self.devices = {ordinary.id: ordinary}
+
+            def async_get(self, device_id):
+                return self.devices.get(device_id)
+
+        view = make_view()
+        view.device = _OldDeviceRegistry()
+        monkeypatch.setattr(wsapi, "_resolve_registries", lambda h: view)
+
+        assert wsapi._do_device_list(FakeHass(), {}) == {
+            "devices": [ordinary.dict_repr]
+        }
+
+    def test_conflicting_duplicate_identity_is_not_selected(self, monkeypatch):
+        office = FakeDevice("duplicate", area_id="office")
+        garage = FakeDevice("duplicate", area_id="garage")
+
+        class _ConflictingRegistry:
+            devices = (office, garage)
+            child_devices = ()
+
+            def async_get(self, device_id):
+                return None
+
+        view = make_view()
+        view.device = _ConflictingRegistry()
+        monkeypatch.setattr(wsapi, "_resolve_registries", lambda h: view)
+
         assert wsapi._do_device_list(FakeHass(), {}) == {"devices": []}
 
     def test_skips_unserializable_entry(self, monkeypatch, caplog):

--- a/tests/src/unit/test_component_ws_search.py
+++ b/tests/src/unit/test_component_ws_search.py
@@ -533,11 +533,25 @@ class FakeChildDevice:
         self.disabled_by = disabled_by
 
     def __getattr__(self, name):
-        if name in {"manufacturer", "model", "connections"}:
-            raise AssertionError(
-                f"Core 2026.9 ChildDeviceEntry does not expose {name} as an attribute"
-            )
         raise AttributeError(name)
+
+    @property
+    def manufacturer(self):
+        pytest.fail(
+            "Core 2026.9 ChildDeviceEntry does not expose manufacturer as an attribute"
+        )
+
+    @property
+    def model(self):
+        pytest.fail(
+            "Core 2026.9 ChildDeviceEntry does not expose model as an attribute"
+        )
+
+    @property
+    def connections(self):
+        pytest.fail(
+            "Core 2026.9 ChildDeviceEntry does not expose connections as an attribute"
+        )
 
     @property
     def dict_repr(self):
@@ -576,7 +590,7 @@ class _IterOnlyDeviceCollection:
         raise AssertionError("Core 2026.9 device collections do not support get")
 
     def __getitem__(self, _device_id):
-        raise AssertionError("Core 2026.9 device collections are not subscriptable")
+        raise KeyError("Core 2026.9 device collections are not subscriptable")
 
 
 class FakeDeviceReg:

--- a/tests/src/unit/test_component_ws_search.py
+++ b/tests/src/unit/test_component_ws_search.py
@@ -3210,6 +3210,51 @@ class TestDeviceList:
 
         assert wsapi._do_device_list(FakeHass(), {}) == {"devices": []}
 
+    def test_conflicting_device_cannot_supply_effective_area(self):
+        office = FakeDevice("duplicate", area_id="office")
+        garage = FakeDevice("duplicate", area_id="garage")
+
+        class _ConflictingRegistry:
+            devices = (office, garage)
+            child_devices = ()
+
+            def async_get(self, device_id):
+                return office if device_id == "duplicate" else None
+
+        view = make_view(
+            entity={
+                "sensor.ambiguous": FakeRegEntry(
+                    "sensor.ambiguous", device_id="duplicate"
+                )
+            }
+        )
+        view.device = _ConflictingRegistry()
+
+        assert wsapi._effective_device_area_id(view, office) is None
+        assert (
+            wsapi._effective_area_for_entry(
+                view, view.entity.async_get("sensor.ambiguous")
+            )
+            is None
+        )
+
+    def test_conflicting_parent_cannot_supply_child_effective_area(self):
+        office = FakeDevice("parent", area_id="office")
+        garage = FakeDevice("parent", area_id="garage")
+        child = FakeChildDevice("child", "parent")
+
+        class _ConflictingRegistry:
+            devices = (office, garage)
+            child_devices = (child,)
+
+            def async_get(self, device_id):
+                return {"parent": office, "child": child}.get(device_id)
+
+        view = make_view()
+        view.device = _ConflictingRegistry()
+
+        assert wsapi._effective_device_area_id(view, child) is None
+
     def test_skips_unserializable_entry(self, monkeypatch, caplog):
         class _BadDevice:
             id = "bad"

--- a/tests/src/unit/test_device_registry_semantics.py
+++ b/tests/src/unit/test_device_registry_semantics.py
@@ -11,6 +11,7 @@ from ha_mcp.utils.device_registry_semantics import (
     annotate_device_rows_with_effective_area,
     build_device_registry_snapshot,
     effective_device_area_id,
+    effective_entity_area_id,
 )
 
 
@@ -65,6 +66,24 @@ def test_child_inherits_parent_area_and_direct_area_takes_precedence() -> None:
         "inherited": "office",
         "direct": "garage",
     }
+
+
+@pytest.mark.parametrize("invalid_area", ["", 0, False])
+def test_present_invalid_entity_area_does_not_inherit_device_area(
+    invalid_area: Any,
+) -> None:
+    device_areas = {"child": "office"}
+
+    assert (
+        effective_entity_area_id(
+            {"area_id": invalid_area, "device_id": "child"}, device_areas
+        )
+        is None
+    )
+    assert (
+        effective_entity_area_id({"area_id": None, "device_id": "child"}, device_areas)
+        == "office"
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/src/unit/test_device_registry_semantics.py
+++ b/tests/src/unit/test_device_registry_semantics.py
@@ -62,6 +62,7 @@ def test_child_inherits_parent_area_and_direct_area_takes_precedence() -> None:
         "inherited": "office",
         "direct": "garage",
     }
+    assert snapshot.invalid_area_ids == frozenset()
 
 
 @pytest.mark.parametrize("invalid_area", ["", 0, False])
@@ -91,6 +92,7 @@ def test_empty_device_area_is_invalid_and_does_not_inherit_parent_area() -> None
     snapshot = build_device_registry_snapshot(rows)
 
     assert snapshot.effective_area_by_id["child"] is None
+    assert "child" in snapshot.invalid_area_ids
 
 
 @pytest.mark.parametrize(
@@ -120,6 +122,15 @@ def test_invalid_parent_relationships_do_not_invent_an_area(
     snapshot = build_device_registry_snapshot(rows)
 
     assert snapshot.effective_area_by_id["child"] is None
+
+
+def test_missing_parent_is_retained_as_invalid_area_evidence() -> None:
+    snapshot = build_device_registry_snapshot(
+        [_child("child", "missing"), _child("direct", "missing", area_id="garage")]
+    )
+
+    assert snapshot.invalid_area_ids == frozenset({"child"})
+    assert snapshot.effective_area_by_id["direct"] == "garage"
 
 
 def test_identical_duplicates_collapse_without_reordering() -> None:

--- a/tests/src/unit/test_device_registry_semantics.py
+++ b/tests/src/unit/test_device_registry_semantics.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from typing import Any
 
 import pytest
@@ -40,11 +41,11 @@ def test_core_2026_8_ordinary_rows_remain_unchanged() -> None:
     snapshot = build_device_registry_snapshot(rows)
 
     assert snapshot.rows == tuple(rows)
-    assert snapshot.parent_by_id == {"device-b": None, "device-a": None}
     assert snapshot.effective_area_by_id == {
         "device-b": None,
         "device-a": "office",
     }
+    assert snapshot.conflicting_ids == frozenset()
 
 
 def test_child_inherits_parent_area_and_direct_area_takes_precedence() -> None:
@@ -56,11 +57,6 @@ def test_child_inherits_parent_area_and_direct_area_takes_precedence() -> None:
 
     snapshot = build_device_registry_snapshot(rows)
 
-    assert snapshot.parent_by_id == {
-        "parent": None,
-        "inherited": "parent",
-        "direct": "parent",
-    }
     assert snapshot.effective_area_by_id == {
         "parent": "office",
         "inherited": "office",
@@ -84,6 +80,17 @@ def test_present_invalid_entity_area_does_not_inherit_device_area(
         effective_entity_area_id({"area_id": None, "device_id": "child"}, device_areas)
         == "office"
     )
+
+
+def test_empty_device_area_is_invalid_and_does_not_inherit_parent_area() -> None:
+    rows = [
+        _main("parent", area_id="office"),
+        _child("child", "parent", area_id=""),
+    ]
+
+    snapshot = build_device_registry_snapshot(rows)
+
+    assert snapshot.effective_area_by_id["child"] is None
 
 
 @pytest.mark.parametrize(
@@ -126,21 +133,26 @@ def test_identical_duplicates_collapse_without_reordering() -> None:
     assert snapshot.effective_area_by_id["last"] == "office"
 
 
-def test_conflicting_identity_is_removed_with_dependent_enrichment() -> None:
-    snapshot = build_device_registry_snapshot(
-        [
-            _main("parent", area_id="office"),
-            _main("parent", area_id="garage"),
-            _child("child", "parent"),
-            _main("ordinary", area_id="kitchen"),
-        ]
-    )
+def test_conflicting_identity_is_removed_with_dependent_enrichment(caplog) -> None:
+    with caplog.at_level(logging.WARNING):
+        snapshot = build_device_registry_snapshot(
+            [
+                _main("parent", area_id="office"),
+                _main("parent", area_id="garage"),
+                _child("child", "parent"),
+                _main("ordinary", area_id="kitchen"),
+            ]
+        )
 
     assert [row["id"] for row in snapshot.rows] == ["child", "ordinary"]
     assert snapshot.effective_area_by_id == {
         "child": None,
         "ordinary": "kitchen",
     }
+    assert snapshot.conflicting_ids == frozenset({"parent"})
+    assert any(
+        "conflicting device registry identity" in r.message for r in caplog.records
+    )
 
 
 def test_malformed_rows_and_identities_are_ignored() -> None:

--- a/tests/src/unit/test_device_registry_semantics.py
+++ b/tests/src/unit/test_device_registry_semantics.py
@@ -1,0 +1,154 @@
+"""Tests for Core 2026.9 child-device registry semantics."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from ha_mcp.utils.device_registry_semantics import (
+    EFFECTIVE_AREA_MARKER,
+    annotate_device_rows_with_effective_area,
+    build_device_registry_snapshot,
+    effective_device_area_id,
+)
+
+
+def _main(device_id: str, *, area_id: Any = None, **extra: Any) -> dict[str, Any]:
+    return {"id": device_id, "area_id": area_id, **extra}
+
+
+def _child(
+    device_id: str,
+    parent_device_id: Any,
+    *,
+    area_id: Any = None,
+    **extra: Any,
+) -> dict[str, Any]:
+    return {
+        "id": device_id,
+        "parent_device_id": parent_device_id,
+        "area_id": area_id,
+        **extra,
+    }
+
+
+def test_core_2026_8_ordinary_rows_remain_unchanged() -> None:
+    rows = [_main("device-b", area_id=None), _main("device-a", area_id="office")]
+
+    snapshot = build_device_registry_snapshot(rows)
+
+    assert snapshot.rows == tuple(rows)
+    assert snapshot.parent_by_id == {"device-b": None, "device-a": None}
+    assert snapshot.effective_area_by_id == {
+        "device-b": None,
+        "device-a": "office",
+    }
+
+
+def test_child_inherits_parent_area_and_direct_area_takes_precedence() -> None:
+    rows = [
+        _main("parent", area_id="office"),
+        _child("inherited", "parent"),
+        _child("direct", "parent", area_id="garage"),
+    ]
+
+    snapshot = build_device_registry_snapshot(rows)
+
+    assert snapshot.parent_by_id == {
+        "parent": None,
+        "inherited": "parent",
+        "direct": "parent",
+    }
+    assert snapshot.effective_area_by_id == {
+        "parent": "office",
+        "inherited": "office",
+        "direct": "garage",
+    }
+
+
+@pytest.mark.parametrize(
+    "rows",
+    [
+        [_child("child", "missing")],
+        [_main("parent", area_id=7), _child("child", "parent")],
+        [_main("parent", area_id="office"), _child("child", 7)],
+        [_child("parent", "child"), _child("child", "parent")],
+        [
+            _main("root", area_id="office"),
+            _child("parent", "root"),
+            _child("child", "parent"),
+        ],
+    ],
+    ids=[
+        "missing-parent",
+        "malformed-parent-area",
+        "malformed-parent-id",
+        "cycle",
+        "excessive-depth",
+    ],
+)
+def test_invalid_parent_relationships_do_not_invent_an_area(
+    rows: list[dict[str, Any]],
+) -> None:
+    snapshot = build_device_registry_snapshot(rows)
+
+    assert snapshot.effective_area_by_id["child"] is None
+
+
+def test_identical_duplicates_collapse_without_reordering() -> None:
+    first = _main("first", area_id="office", labels=["alpha"])
+    duplicate = dict(first)
+    last = _child("last", "first")
+
+    snapshot = build_device_registry_snapshot([first, duplicate, last])
+
+    assert [row["id"] for row in snapshot.rows] == ["first", "last"]
+    assert snapshot.effective_area_by_id["last"] == "office"
+
+
+def test_conflicting_identity_is_removed_with_dependent_enrichment() -> None:
+    snapshot = build_device_registry_snapshot(
+        [
+            _main("parent", area_id="office"),
+            _main("parent", area_id="garage"),
+            _child("child", "parent"),
+            _main("ordinary", area_id="kitchen"),
+        ]
+    )
+
+    assert [row["id"] for row in snapshot.rows] == ["child", "ordinary"]
+    assert snapshot.effective_area_by_id == {
+        "child": None,
+        "ordinary": "kitchen",
+    }
+
+
+def test_malformed_rows_and_identities_are_ignored() -> None:
+    snapshot = build_device_registry_snapshot(
+        [None, "bad", {}, {"id": 5}, {"id": ""}, _main("valid", area_id="lab")]
+    )
+
+    assert snapshot.rows == (_main("valid", area_id="lab"),)
+    assert snapshot.effective_area_by_id == {"valid": "lab"}
+
+
+def test_annotation_is_private_and_does_not_mutate_input() -> None:
+    rows = [_main("parent", area_id="office"), _child("child", "parent")]
+
+    annotated = annotate_device_rows_with_effective_area(rows)
+
+    assert EFFECTIVE_AREA_MARKER not in rows[0]
+    assert EFFECTIVE_AREA_MARKER not in rows[1]
+    assert annotated[0][EFFECTIVE_AREA_MARKER] == "office"
+    assert annotated[1][EFFECTIVE_AREA_MARKER] == "office"
+
+
+def test_effective_area_helper_never_recurses_through_a_child_parent() -> None:
+    root = _main("root", area_id="office")
+    parent = _child("parent", "root")
+    child = _child("child", "parent")
+    devices = {row["id"]: row for row in (root, parent, child)}
+
+    assert effective_device_area_id(parent, devices) == "office"
+    assert effective_device_area_id(child, devices) is None

--- a/tests/src/unit/test_ha_get_device_component_routing.py
+++ b/tests/src/unit/test_ha_get_device_component_routing.py
@@ -206,6 +206,36 @@ async def test_single_lookup_served_by_component() -> None:
 
 
 @pytest.mark.asyncio
+async def test_child_component_result_preserves_effective_area_and_ownership() -> None:
+    child = _raw_device(
+        "child-1",
+        parent_device_id="parent-1",
+        area_id=None,
+        config_entries=None,
+        config_entry_id="cfg-child",
+    )
+    child.pop("config_entries")
+    ws = make_ws(
+        "ha_mcp_tools/device_get",
+        info_result=_CAPS_DEVICES,
+        cmd_result={
+            "device": child,
+            "entities": [_entity_row("switch.child", "child-1")],
+            "effective_area_id": "office",
+        },
+    )
+    client = RoutingClient()
+    get_device = _build_get_device(client)
+
+    with patch_ws(ws, component_devices):
+        resp = await get_device(device_id="child-1")
+
+    assert resp["device"]["area_id"] == "office"
+    assert resp["device"]["config_entries"] == ["cfg-child"]
+    assert client.device_list_calls == 0
+
+
+@pytest.mark.asyncio
 async def test_entity_id_lookup_resolves_then_device_get() -> None:
     """entity_id mode resolves the device via a single native
     config/entity_registry/get, then reads the device (and its entities) via
@@ -336,6 +366,30 @@ async def test_pre_child_semantics_component_uses_legacy_device_list() -> None:
         call.args[0] == "ha_mcp_tools/device_list"
         for call in ws.send_command.call_args_list
     )
+
+
+@pytest.mark.asyncio
+async def test_area_filter_matches_child_through_parent_effective_area() -> None:
+    ws = make_ws(
+        "ha_mcp_tools/device_list",
+        info_exc=HomeAssistantCommandError("no info", "unknown_command"),
+    )
+    client = RoutingClient(
+        devices=[
+            _raw_device("parent-1", area_id="office"),
+            _raw_device("child-1", area_id=None, parent_device_id="parent-1"),
+            _raw_device("other", area_id="garage"),
+        ]
+    )
+    get_device = _build_get_device(client)
+
+    with patch_ws(ws, component_devices):
+        resp = await get_device(area_id="office")
+
+    assert {row["device_id"] for row in resp["devices"]} == {
+        "parent-1",
+        "child-1",
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/src/unit/test_ha_get_device_component_routing.py
+++ b/tests/src/unit/test_ha_get_device_component_routing.py
@@ -40,11 +40,19 @@ from ._component_routing_helpers import (
     patch_ws_establish_failure,
 )
 
-_CAPS_DEVICES = {
+_CAPS_PRE_CHILD_SEMANTICS = {
     "schema_version": 1,
     "component_version": "1.1.0",
     "capabilities": ["device_get", "device_list"],
     "limits": {},
+}
+_CAPS_DEVICES = {
+    **_CAPS_PRE_CHILD_SEMANTICS,
+    "capabilities": [
+        "device_get",
+        "device_list",
+        "device_registry_child_semantics",
+    ],
 }
 
 
@@ -292,6 +300,42 @@ async def test_summary_list_uses_device_list_and_skips_entities() -> None:
     assert resp["total_devices"] == 2
     assert client.device_list_calls == 0
     assert client.entity_list_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_pre_child_semantics_component_uses_legacy_device_list() -> None:
+    """The old ``device_list`` capability cannot authorize child-aware results.
+
+    The component and server update independently. A pre-fix component can
+    advertise ``device_list`` while omitting Core 2026.9 child devices, so the
+    server must use Core's authoritative legacy registry list until the component
+    advertises the additive child-device semantic capability.
+    """
+    ws = make_ws(
+        "ha_mcp_tools/device_list",
+        info_result=_CAPS_PRE_CHILD_SEMANTICS,
+        cmd_result={"devices": [_raw_device("parent-1")]},
+    )
+    client = RoutingClient(
+        devices=[
+            _raw_device("parent-1", area_id="office"),
+            _raw_device("child-1", parent_device_id="parent-1"),
+        ]
+    )
+    get_device = _build_get_device(client)
+
+    with patch_ws(ws, component_devices):
+        resp = await get_device()
+
+    assert {row["device_id"] for row in resp["devices"]} == {
+        "parent-1",
+        "child-1",
+    }
+    assert client.device_list_calls == 1
+    assert not any(
+        call.args[0] == "ha_mcp_tools/device_list"
+        for call in ws.send_command.call_args_list
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/src/unit/test_ha_get_entity_component_routing.py
+++ b/tests/src/unit/test_ha_get_entity_component_routing.py
@@ -38,11 +38,15 @@ from ._component_routing_helpers import (
     patch_ws_establish_failure,
 )
 
-_CAPS_ENRICH = {
+_CAPS_PRE_CHILD_SEMANTICS = {
     "schema_version": 1,
     "component_version": "1.1.0",
     "capabilities": ["entity_enrich"],
     "limits": {},
+}
+_CAPS_ENRICH = {
+    **_CAPS_PRE_CHILD_SEMANTICS,
+    "capabilities": ["entity_enrich", "device_registry_child_semantics"],
 }
 _CAPS_NONE = {
     "schema_version": 1,
@@ -210,6 +214,27 @@ async def test_no_capability_leaves_base_shape() -> None:
     client = RoutingClient(
         {"light.a": _raw_entry("light.a", area_id="ar1", labels=["lb1"])}
     )
+    get_entity = _build_get_entity(client)
+
+    with patch_ws(ws, tools_entities):
+        resp = await get_entity("light.a")
+
+    entry = resp["entity_entry"]
+    assert "area" not in entry
+    assert "floor" not in entry
+    assert "label_names" not in entry
+    assert not _enrich_calls(ws)
+
+
+@pytest.mark.asyncio
+async def test_pre_child_semantics_enrichment_capability_leaves_base_shape() -> None:
+    """An old component cannot add potentially stale device-derived placement."""
+    ws = make_ws(
+        "ha_mcp_tools/entity_enrich",
+        info_result=_CAPS_PRE_CHILD_SEMANTICS,
+        cmd_result={"entities": {"light.a": _enrichment("light.a")}},
+    )
+    client = RoutingClient({"light.a": _raw_entry("light.a", area_id=None, labels=[])})
     get_entity = _build_get_entity(client)
 
     with patch_ws(ws, tools_entities):

--- a/tests/src/unit/test_ha_get_entity_exposure_component_routing.py
+++ b/tests/src/unit/test_ha_get_entity_exposure_component_routing.py
@@ -32,11 +32,15 @@ from ._component_routing_helpers import (
     patch_ws_establish_failure,
 )
 
-_CAPS_EXPOSURE = {
+_CAPS_PRE_CHILD_SEMANTICS = {
     "schema_version": 1,
     "component_version": "1.1.0",
     "capabilities": ["exposure"],
     "limits": {},
+}
+_CAPS_EXPOSURE = {
+    **_CAPS_PRE_CHILD_SEMANTICS,
+    "capabilities": ["exposure", "device_registry_child_semantics"],
 }
 _CAPS_NONE = {
     "schema_version": 1,
@@ -199,6 +203,29 @@ async def test_list_mode_entity_info_follows_assistant_filter() -> None:
 async def test_no_capability_uses_legacy_list() -> None:
     """Component without exposure → legacy expose_entity/list, no entity_info."""
     ws = make_ws("ha_mcp_tools/exposure", info_result=_CAPS_NONE)
+    client = RoutingClient(_LEGACY_MAP)
+    exposure = _build_exposure(client)
+
+    with patch_ws(ws, tools_voice_assistant):
+        resp = await exposure()
+
+    assert resp["exposed_entities"] == _LEGACY_MAP
+    assert "entity_info" not in resp
+    assert client.legacy_calls == 1
+    assert not _exposure_calls(ws)
+
+
+@pytest.mark.asyncio
+async def test_pre_child_semantics_exposure_capability_uses_legacy_list() -> None:
+    """An old component cannot publish stale device-derived entity placement."""
+    ws = make_ws(
+        "ha_mcp_tools/exposure",
+        info_result=_CAPS_PRE_CHILD_SEMANTICS,
+        cmd_result={
+            "exposed_entities": _LEGACY_MAP,
+            "entity_info": {"light.a": _INFO_A},
+        },
+    )
     client = RoutingClient(_LEGACY_MAP)
     exposure = _build_exposure(client)
 

--- a/tests/src/unit/test_ha_overview_component_routing.py
+++ b/tests/src/unit/test_ha_overview_component_routing.py
@@ -78,11 +78,15 @@ _CONFIG = {
     "state": "RUNNING",
 }
 
-_CAPS_OVERVIEW = {
+_CAPS_PRE_CHILD_SEMANTICS = {
     "schema_version": 1,
     "component_version": "1.1.0",
     "capabilities": ["overview"],
     "limits": {},
+}
+_CAPS_OVERVIEW = {
+    **_CAPS_PRE_CHILD_SEMANTICS,
+    "capabilities": ["overview", "device_registry_child_semantics"],
 }
 
 
@@ -216,6 +220,32 @@ async def test_component_fast_path_skips_legacy_fetches(tmp_path, monkeypatch) -
         if c.args[0] == "ha_mcp_tools/overview"
     ]
     assert len(overview_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_pre_child_semantics_overview_capability_uses_legacy(
+    tmp_path, monkeypatch
+) -> None:
+    """A pre-fix component's overview cannot authorize device-registry slices."""
+    _setup_visibility_disabled(tmp_path, monkeypatch)
+    _quiet_tail(monkeypatch)
+    ws = make_ws(
+        "ha_mcp_tools/overview",
+        info_result=_CAPS_PRE_CHILD_SEMANTICS,
+        cmd_result=_overview_slices(),
+    )
+    client = OverviewRoutingClient()
+    overview = _build_overview_tool(client)
+
+    with patch_ws(ws, tools_search):
+        resp = await overview(detail_level="standard")
+
+    assert resp["success"] is True
+    assert client.total_legacy_fetches() > 0
+    assert not any(
+        call.args[0] == "ha_mcp_tools/overview"
+        for call in ws.send_command.call_args_list
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/src/unit/test_ha_remove_device_component_routing.py
+++ b/tests/src/unit/test_ha_remove_device_component_routing.py
@@ -144,6 +144,31 @@ async def test_body_served_by_component() -> None:
 
 
 @pytest.mark.asyncio
+async def test_child_singular_config_entry_is_used_for_removal() -> None:
+    child = _raw_device(
+        "child-1",
+        parent_device_id="parent-1",
+        config_entry_id="cfg-child",
+    )
+    child.pop("config_entries")
+    ws = make_ws(
+        "ha_mcp_tools/device_get",
+        info_result=_CAPS_DEVICES,
+        cmd_result={"device": child},
+    )
+    client = RoutingClient()
+    remove_device = _build_remove_device(client)
+
+    with patch_ws(ws, component_devices):
+        resp = await remove_device(device_id="child-1")
+
+    assert resp["success"] is True
+    assert resp["config_entries_removed"] == 1
+    assert client.remove_calls == ["cfg-child"]
+    assert client.device_list_calls == 0
+
+
+@pytest.mark.asyncio
 async def test_body_capsless_uses_legacy_list() -> None:
     """Old component → legacy config/device_registry/list for the body."""
     ws = make_ws(

--- a/tests/src/unit/test_ha_remove_device_component_routing.py
+++ b/tests/src/unit/test_ha_remove_device_component_routing.py
@@ -28,7 +28,11 @@ from ._component_routing_helpers import make_ws, patch_ws
 _CAPS_DEVICES = {
     "schema_version": 1,
     "component_version": "1.1.0",
-    "capabilities": ["device_get", "device_list"],
+    "capabilities": [
+        "device_get",
+        "device_list",
+        "device_registry_child_semantics",
+    ],
     "limits": {},
 }
 

--- a/tests/src/unit/test_ha_search_component_routing.py
+++ b/tests/src/unit/test_ha_search_component_routing.py
@@ -58,15 +58,23 @@ _ENTITY_REGISTRY = {
     ],
 }
 
-_CAPS_SEARCH = {
+_CAPS_PRE_CHILD_SEMANTICS = {
     "schema_version": 1,
     "component_version": "1.1.0",
     "capabilities": ["search"],
     "limits": {},
 }
+_CAPS_SEARCH = {
+    **_CAPS_PRE_CHILD_SEMANTICS,
+    "capabilities": ["search", "device_registry_child_semantics"],
+}
 _CAPS_SEARCH_MEMBERSHIP = {
     **_CAPS_SEARCH,
-    "capabilities": ["search", "search_entity_membership"],
+    "capabilities": [
+        "search",
+        "search_entity_membership",
+        "device_registry_child_semantics",
+    ],
 }
 
 
@@ -176,6 +184,30 @@ async def test_component_fast_path_skips_legacy_fetches(tmp_path, monkeypatch) -
     ]
     assert len(search_calls) == 1
     assert "result_fields" not in search_calls[0].kwargs
+
+
+@pytest.mark.asyncio
+async def test_pre_child_semantics_search_capability_uses_legacy(
+    tmp_path, monkeypatch
+) -> None:
+    """A pre-fix component's search result cannot omit child-device semantics."""
+    _setup_visibility_disabled(tmp_path, monkeypatch)
+    ws = make_ws(
+        "ha_mcp_tools/search",
+        info_result=_CAPS_PRE_CHILD_SEMANTICS,
+        cmd_result=_entity_search_result(),
+    )
+    client = RoutingClient()
+    ha_search = _build_ha_search(client)
+
+    with patch_ws(ws, tools_search):
+        resp = await ha_search(query="kitchen")
+
+    assert resp["success"] is True
+    assert client.get_states_calls == 1
+    assert not any(
+        call.args[0] == "ha_mcp_tools/search" for call in ws.send_command.call_args_list
+    )
 
 
 @pytest.mark.asyncio
@@ -1037,7 +1069,12 @@ class TestDashboardSearchTypesGate:
         caps = {
             "schema_version": 1,
             "component_version": "1.2.4",
-            "capabilities": ["search", "dashboards", "dashboards_doc_search"],
+            "capabilities": [
+                "search",
+                "dashboards",
+                "dashboards_doc_search",
+                "device_registry_child_semantics",
+            ],
             "limits": {},
         }
 

--- a/tests/src/unit/test_ha_search_dashboard_split.py
+++ b/tests/src/unit/test_ha_search_dashboard_split.py
@@ -41,7 +41,12 @@ from .test_ha_search_component_routing import (
 _CAPS_SPLIT = {
     "schema_version": 1,
     "component_version": "2.0.0",
-    "capabilities": ["search", "dashboards", "dashboards_doc_search"],
+    "capabilities": [
+        "search",
+        "dashboards",
+        "dashboards_doc_search",
+        "device_registry_child_semantics",
+    ],
     "limits": {"max_results": 500},
 }
 

--- a/tests/src/unit/test_ha_search_visibility_component_routing.py
+++ b/tests/src/unit/test_ha_search_visibility_component_routing.py
@@ -75,13 +75,17 @@ _WIRE_KEYS = {
 _CAPS_SEARCH = {
     "schema_version": 1,
     "component_version": "1.1.0",
-    "capabilities": ["search"],
+    "capabilities": ["search", "device_registry_child_semantics"],
     "limits": {},
 }
 _CAPS_SEARCH_VIS = {
     "schema_version": 1,
     "component_version": "1.2.0",
-    "capabilities": ["search", "search_visibility"],
+    "capabilities": [
+        "search",
+        "search_visibility",
+        "device_registry_child_semantics",
+    ],
     "limits": {},
 }
 _CAPS_SEARCH_VIS_ALLOW_AUTH = {
@@ -91,6 +95,7 @@ _CAPS_SEARCH_VIS_ALLOW_AUTH = {
         "search",
         "search_visibility",
         "search_visibility_allowlist_authorization",
+        "device_registry_child_semantics",
     ],
     "limits": {},
 }

--- a/tests/src/unit/test_radio_update_entity_component_routing.py
+++ b/tests/src/unit/test_radio_update_entity_component_routing.py
@@ -26,7 +26,11 @@ from ._component_routing_helpers import make_ws, patch_ws
 _CAPS_DEVICES = {
     "schema_version": 1,
     "component_version": "1.1.0",
-    "capabilities": ["device_get", "device_list"],
+    "capabilities": [
+        "device_get",
+        "device_list",
+        "device_registry_child_semantics",
+    ],
     "limits": {},
 }
 

--- a/tests/src/unit/test_radio_zigbee_component_routing.py
+++ b/tests/src/unit/test_radio_zigbee_component_routing.py
@@ -25,7 +25,11 @@ _IEEE = "00:11:22:33:44:55:66:77"
 _CAPS_DEVICES = {
     "schema_version": 1,
     "component_version": "1.1.0",
-    "capabilities": ["device_get", "device_list"],
+    "capabilities": [
+        "device_get",
+        "device_list",
+        "device_registry_child_semantics",
+    ],
     "limits": {},
 }
 

--- a/tests/src/unit/test_search_fields_projection.py
+++ b/tests/src/unit/test_search_fields_projection.py
@@ -1033,18 +1033,34 @@ class TestEntityEnrichmentAliasSentinel:
 
     def test_null_alias_sentinel_is_dropped_not_stringified(self):
         entry = {"aliases": ["Kitchen", None, "Cocina"]}
-        fields = _entity_enrichment_fields(entry, {}, {}, {}, {}, ("aliases",))
+        fields = _entity_enrichment_fields(entry, {}, {}, {}, {}, {}, ("aliases",))
         assert fields["aliases"] == ["Cocina", "Kitchen"]
         assert "None" not in fields["aliases"]
 
     def test_all_string_aliases_unaffected(self):
         entry = {"aliases": ["b", "a"]}
-        fields = _entity_enrichment_fields(entry, {}, {}, {}, {}, ("aliases",))
+        fields = _entity_enrichment_fields(entry, {}, {}, {}, {}, {}, ("aliases",))
         assert fields["aliases"] == ["a", "b"]
 
     def test_missing_aliases_key_yields_empty(self):
-        fields = _entity_enrichment_fields({}, {}, {}, {}, {}, ("aliases",))
+        fields = _entity_enrichment_fields({}, {}, {}, {}, {}, {}, ("aliases",))
         assert fields["aliases"] == []
+
+
+class TestEntityEnrichmentAreaPrecedence:
+    """Entity placement uses Core's presence-based direct-area precedence."""
+
+    def test_present_invalid_area_does_not_inherit_device_area(self):
+        fields = _entity_enrichment_fields(
+            {"area_id": "", "device_id": "child"},
+            {"office": {"name": "Office", "floor_id": "upstairs"}},
+            {"upstairs": {"name": "Upstairs"}},
+            {},
+            {"child": {"id": "child"}},
+            {"child": "office"},
+            ("area", "floor"),
+        )
+        assert fields == {"area": None, "floor": None}
 
 
 class TestHaSearchAreaQueryPrefetchFailure(_SearchToolFixture):

--- a/tests/src/unit/test_search_fields_projection.py
+++ b/tests/src/unit/test_search_fields_projection.py
@@ -1050,6 +1050,19 @@ class TestEntityEnrichmentAliasSentinel:
 class TestEntityEnrichmentAreaPrecedence:
     """Entity placement uses Core's presence-based direct-area precedence."""
 
+    def test_device_effective_area_drives_area_and_floor_projection(self):
+        fields = _entity_enrichment_fields(
+            {"area_id": None, "device_id": "child"},
+            {"office": {"name": "Office", "floor_id": "upstairs"}},
+            {"upstairs": {"name": "Upstairs"}},
+            {},
+            {"child": {"id": "child", "parent_device_id": "parent"}},
+            {"child": "office"},
+            ("area", "floor"),
+        )
+
+        assert fields == {"area": "Office", "floor": "Upstairs"}
+
     def test_present_invalid_area_does_not_inherit_device_area(self):
         fields = _entity_enrichment_fields(
             {"area_id": "", "device_id": "child"},

--- a/tests/src/unit/visibility/test_enforcement.py
+++ b/tests/src/unit/visibility/test_enforcement.py
@@ -1526,6 +1526,42 @@ class TestFallbackScoping:
             )
         assert _error_body(exc)["error"]["code"] == "ENTITY_VISIBILITY_ENFORCED"
 
+    async def test_missing_device_parent_fails_closed_for_area_dimension(
+        self, set_config
+    ):
+        set_config(enabled=True, enforce=True, exclude_areas=["bedroom"])
+        client = FakeClient(
+            registry={
+                "success": True,
+                "result": [
+                    {
+                        "entity_id": "sensor.orphan",
+                        "area_id": None,
+                        "device_id": "child",
+                    }
+                ],
+            },
+            device={
+                "success": True,
+                "result": [
+                    {
+                        "id": "child",
+                        "area_id": None,
+                        "parent_device_id": "missing",
+                    }
+                ],
+            },
+        )
+        mw = make_mw(get_client=lambda: client)
+
+        with pytest.raises(ToolError) as exc:
+            await mw.on_call_tool(
+                make_context("ha_get_state", {"entity_id": "sensor.orphan"}),
+                _unreached_call_next,
+            )
+
+        assert _error_body(exc)["error"]["code"] == "ENTITY_VISIBILITY_ENFORCED"
+
 
 class TestComponentBucketScrub:
     async def test_component_config_buckets_scrubbed_and_totals_adjusted(

--- a/tests/src/unit/visibility/test_resolver.py
+++ b/tests/src/unit/visibility/test_resolver.py
@@ -1,6 +1,8 @@
 import asyncio
 import logging
 
+import pytest
+
 from ha_mcp.visibility import resolver
 from ha_mcp.visibility.model import VisibilityConfig
 from ha_mcp.visibility.persistence import save_visibility_config
@@ -195,6 +197,22 @@ def test_exclude_area_hides_child_device_entity_via_parent_area():
     )
 
     assert _hidden_dev(reg, cfg, dev) == {"sensor.child"}
+
+
+def test_strict_area_filter_rejects_conflicting_device_identity():
+    reg = _reg(
+        {"entity_id": "sensor.ambiguous", "area_id": None, "device_id": "duplicate"}
+    )
+    dev = _dev(
+        {"id": "duplicate", "area_id": "office"},
+        {"id": "duplicate", "area_id": "garage"},
+    )
+    cfg = VisibilityConfig(
+        enabled=True, exclude_categories=[], exclude_areas=["office"]
+    )
+
+    with pytest.raises(resolver.VisibilityDataUnavailable):
+        hidden_entity_ids(reg, cfg, device_registry_result=dev, strict=True)
 
 
 def test_present_invalid_entity_area_blocks_child_device_area_fallback():

--- a/tests/src/unit/visibility/test_resolver.py
+++ b/tests/src/unit/visibility/test_resolver.py
@@ -215,6 +215,34 @@ def test_strict_area_filter_rejects_conflicting_device_identity():
         hidden_entity_ids(reg, cfg, device_registry_result=dev, strict=True)
 
 
+def test_strict_area_filter_rejects_child_with_missing_parent():
+    reg = _reg({"entity_id": "sensor.orphan", "area_id": None, "device_id": "child"})
+    dev = _dev({"id": "child", "area_id": None, "parent_device_id": "missing"})
+    cfg = VisibilityConfig(
+        enabled=True, exclude_categories=[], exclude_areas=["office"]
+    )
+
+    with pytest.raises(
+        resolver.VisibilityDataUnavailable, match="invalid area relationships"
+    ):
+        hidden_entity_ids(reg, cfg, device_registry_result=dev, strict=True)
+
+
+def test_non_strict_area_filter_warns_for_child_with_missing_parent():
+    reg = _reg({"entity_id": "sensor.orphan", "area_id": None, "device_id": "child"})
+    dev = _dev({"id": "child", "area_id": None, "parent_device_id": "missing"})
+    cfg = VisibilityConfig(
+        enabled=True, exclude_categories=[], exclude_areas=["office"]
+    )
+
+    hidden, warnings = hidden_entity_ids(
+        reg, cfg, device_registry_result=dev, strict=False
+    )
+
+    assert hidden == set()
+    assert warnings == [resolver._DEVICE_REGISTRY_INVALID_AREA_WARNING]
+
+
 def test_present_invalid_entity_area_blocks_child_device_area_fallback():
     reg = _reg({"entity_id": "sensor.child", "area_id": "", "device_id": "child"})
     dev = _dev(

--- a/tests/src/unit/visibility/test_resolver.py
+++ b/tests/src/unit/visibility/test_resolver.py
@@ -184,6 +184,19 @@ def test_exclude_area_hides_device_inherited_entity():
     assert _hidden_dev(reg, cfg, dev) == {"light.spot"}
 
 
+def test_exclude_area_hides_child_device_entity_via_parent_area():
+    reg = _reg({"entity_id": "sensor.child", "area_id": None, "device_id": "child"})
+    dev = _dev(
+        {"id": "parent", "area_id": "office"},
+        {"id": "child", "area_id": None, "parent_device_id": "parent"},
+    )
+    cfg = VisibilityConfig(
+        enabled=True, exclude_categories=[], exclude_areas=["office"]
+    )
+
+    assert _hidden_dev(reg, cfg, dev) == {"sensor.child"}
+
+
 def test_allow_area_keeps_device_inherited_entity():
     # The dangerous direction: allow_areas must NOT hide a device-bound entity in
     # the allowed area (the round-4 over-hide that collapsed the overview). A

--- a/tests/src/unit/visibility/test_resolver.py
+++ b/tests/src/unit/visibility/test_resolver.py
@@ -197,6 +197,23 @@ def test_exclude_area_hides_child_device_entity_via_parent_area():
     assert _hidden_dev(reg, cfg, dev) == {"sensor.child"}
 
 
+def test_present_invalid_entity_area_blocks_child_device_area_fallback():
+    reg = _reg({"entity_id": "sensor.child", "area_id": "", "device_id": "child"})
+    dev = _dev(
+        {"id": "parent", "area_id": "office"},
+        {"id": "child", "area_id": None, "parent_device_id": "parent"},
+    )
+    exclude = VisibilityConfig(
+        enabled=True, exclude_categories=[], exclude_areas=["office"]
+    )
+    allow = VisibilityConfig(
+        enabled=True, exclude_categories=[], allow_areas=["office"]
+    )
+
+    assert _hidden_dev(reg, exclude, dev) == set()
+    assert _hidden_dev(reg, allow, dev) == {"sensor.child"}
+
+
 def test_allow_area_keeps_device_inherited_entity():
     # The dangerous direction: allow_areas must NOT hide a device-bound entity in
     # the allowed area (the round-4 over-hide that collapsed the overview). A


### PR DESCRIPTION
## What does this PR do?

Home Assistant Core 2026.9 split reduced child-device records into `DeviceRegistry.child_devices`, while `config/device_registry/list` now returns both the main and child collections. Core resolves a child device's effective area from its own `area_id` when present, otherwise from its main parent's direct `area_id`.

ha-mcp still enumerated only `registry.devices` in the component and resolved only direct device areas in both component and external-server paths. Child devices could disappear from device reads, and entities attached to them could lose effective area/floor enrichment.

This change corrects the shared device-registry acquisition and enrichment boundaries:

- the component enumerates ordinary and child collections while retaining pre-2026.9 mapping compatibility;
- the component advertises additive `device_registry_child_semantics`, and a newer server paired with an older component uses the legacy Core registry path instead of trusting an incomplete component response;
- reduced child rows and `parent_device_id` survive the internal transport unchanged;
- one deterministic snapshot applies Core's direct-area-first, one-parent-hop rule across `ha_get_device`, `ha_get_overview`, `ha_search`, `ha_get_entity`, and `ha_get_entity_exposure`;
- area/floor visibility and `ha_bulk_control` selectors use the same effective placement;
- a present invalid direct area does not silently fall through to inherited placement;
- child `config_entry_id` is represented through the existing `config_entries` response contract and is usable by the existing device-removal path;
- identical duplicates collapse, while conflicting identities are excluded, logged, and fail closed wherever they could grant visibility or bulk-action authority;
- single-device component lookup uses the same request-local conflict-filtered snapshot as list/enrichment paths;
- collection-enumeration failures are logged instead of appearing as unexplained successful empty registries.

The exact source authority is Home Assistant Core 2026.9.0 commit `dfb5a9e690daaf204b542896e4b595e61a11a401`, tree `47d4178cc071773032fd6446c569dc21caf08f1e`, source-archive SHA-256 `ca6ee91306eb48f9ef237c08863744636a416fa27fb4ae3010223b22f2af9793`.

The integrated PR base is upstream `889adb1910a55ec982fc878687b843cdd78ee2e6`; exact head is `619c49c80f19cfbd18de642b99eba3f1eb078fcf`. Component version `2.1.3` is already present in that upstream base, so this diff does not add another version transition.

## Type of change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [x] I have tested these changes with a LLM agent
- [x] All automated unit tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

Regression-first evidence:

- The original tests-only commit failed against untouched production source for the intended omissions: the child was absent from `ha_get_device`, absent from overview area counts, and lost effective area/floor in `ha_search`.
- The older-component routing regression failed before capability gating because the server trusted a pre-child-semantics component response.
- Before the current review corrections, added regressions failed for the reported reasons: conflicting visibility, conflicting single lookup, child bulk selection, child ownership, empty direct-area handling, enumeration logging, conflict diagnostics, and the missing component-fast-path conflict warning. They pass at this head.

Current local evidence:

- Review-focused commands: 225 passed and 349 passed.
- Focused component contracts after the real-Core deprecation correction: 531 passed.
- Device, visibility, component, enforcement, routing, and bulk-selector slice after the invalid-ancestry correction: 704 passed.
- Complete unit target at exact source: 11,927 passed, 364 skipped.
- Complete unit suite: 11,917 passed, 364 skipped. Skips are the repository's Node-unavailable, locale-sync-only, Windows-only, optional NumPy, and promote/reset-only cases.
- Ruff format/check over 759 first-party files: passed.
- Mypy over 242 repository-owned source/app/script files: passed.
- ast-grep: passed.
- E2E module collection: 16 tests collected.

The E2E seed now enables Core's real `kitchen_sink` integration. The new Core 2026.9 test discovers the real power-strip parent and child outlet devices, assigns only the parent to an area, verifies the child's inherited placement through `ha_search`, single-device lookup, and area-filtered device listing, restores the original parent placement, and rejects any `helpers.frame` deprecation log naming `ha_mcp_tools`. The first CI execution exercised this real topology and exposed three child-only missing-attribute warnings; `22b1e1b4` moved those reads to the supported `dict_repr` contract. Its rerun passed the exact-head unit suite and exposed two CodeQL findings confined to exception types in test-double special methods; `c18ee7ec` corrects those contracts while retaining explicit guards against deprecated child attributes. CodeRabbit then identified a stale capability count in the component module documentation; `7c084b1a` aligns it with the unchanged exported 27-capability inventory. `66967596` preserves both body and cleanup failures and scopes the deprecation assertion to a bounded `total_lines`/`offset` window around the three reads; `4f585a89` arms that cleanup before the mutation call itself. The next run passed CodeQL and all completed container lanes except the intentional component-absent lane, where the test unconditionally required the component-only info command. `daff5766` keeps the real child-device semantics test active there through the native Core registry path while limiting component capability/deprecation assertions to component-present lanes; every exact-head CI lane then passed. A fresh exact-head Codex review identified a warning-parity gap: conflicting component device rows were excluded from visibility semantics but not disclosed. `94342a8f` preserves the bounded conflict set and emits the resolver-identical warning only when an area/label dimension depends on it. A replacement review then found that missing-parent ancestry could likewise degrade strict area visibility. `619c49c8` preserves bounded invalid-area evidence, makes strict enforcement fail closed, and emits a bounded server/component warning for non-strict area reads while preserving direct-area precedence and label-only behavior. Every exact-head check for `619c49c8` passes: builds, CodeQL, CodeRabbit, unit, Docker/add-on, Fast, performance, site, all seven container E2E variants, their aggregate gate, and all six HAOS modes. The prior head's first HAOS backend attempt had one unrelated backup creation `upload_failed` after 1,157 passes; its unchanged-head rerun passed.

Local Docker execution is unavailable to this user (`PermissionError: [Errno 13] Permission denied` on the Docker socket), so that runtime test is not claimed locally. Exact-head CI supplied the disposable Core 2026.9 container/HAOS evidence and the repository build, HACS/Hassfest, Node, performance, and CodeQL lanes; all pass.

The default mypy cache under `/tmp` also encountered a full tmpfs. Rerunning the same repository-owned target with an isolated `/var/tmp` cache passed. The only broad lint/type failures came from the separately initialized third-party `skills-vendor` submodule; no submodule file is part of this diff.

## Checklist
- [x] I have updated documentation if needed (no user-facing documentation change is required)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for Home Assistant 2026.9 child-device registries while retaining compatibility with older formats.
  - Child devices now inherit their parent's area and floor when appropriate.
  - Device listings, searches, filtering, visibility checks, and entity details use effective areas consistently.
  - Single-device responses expose effective areas while preserving original device data.

- **Bug Fixes**
  - Improved handling of duplicate, malformed, and conflicting device records.
  - Corrected area precedence for explicitly provided entity areas, including invalid values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
