### PR TITLE
fix(visibility): fail closed on invalid device placement

### DIFF
--- a/custom_components/ha_mcp_tools/const.py
+++ b/custom_components/ha_mcp_tools/const.py
@@ -25,7 +25,7 @@ DOMAIN = "ha_mcp_tools"
 # in CI. The
 # capability negotiation — not this version — gates each WS command (see
 # ``websocket_api.CAPABILITIES``).
-COMPONENT_VERSION = "2.1.3"
+COMPONENT_VERSION = "2.1.4"
 
 # Config-entry discriminator (``entry.data[CONF_ENTRY_TYPE]``). A missing value
 # means "tools" so the pre-existing services entry keeps working across the

--- a/custom_components/ha_mcp_tools/manifest.json
+++ b/custom_components/ha_mcp_tools/manifest.json
@@ -23,5 +23,5 @@
         "ruamel.yaml>=0.18.0",
         "voluptuous-openapi>=0.4.1"
     ],
-    "version": "2.1.3"
+    "version": "2.1.4"
 }

--- a/custom_components/ha_mcp_tools/websocket_api.py
+++ b/custom_components/ha_mcp_tools/websocket_api.py
@@ -2966,9 +2966,19 @@ def _overview_entity_registry(view: _RegistryView) -> list[dict[str, Any]]:
 
 
 def _overview_device_registry(view: _RegistryView) -> list[dict[str, Any]]:
-    """Device registry as a bare list (id + area + labels + name/manufacturer/model)."""
+    """Device registry as a bare list, or raise when projection would lose evidence.
+
+    The overview projection cannot represent conflicting identities or invalid
+    ancestry. Raising marks this slice degraded so the server uses its existing
+    native registry fallback, which retains that evidence for visibility.
+    """
+    devices = _all_device_entries(view)
+    if _conflicting_device_ids(view):
+        raise ValueError("device registry contains conflicting identities")
+    if _invalid_device_area_ids(view):
+        raise ValueError("device registry contains invalid area evidence")
     out: list[dict[str, Any]] = []
-    for dev in _all_device_entries(view):
+    for dev in devices:
         dev_row = _device_dict_repr(dev)
         if dev_row is None:
             continue

--- a/src/ha_mcp/tools/bulk_selector.py
+++ b/src/ha_mcp/tools/bulk_selector.py
@@ -290,6 +290,11 @@ def _validate_device_registry_rows(
             "Home Assistant device registry returned a conflicting device identity",
             cause=InfrastructureErrorCause.MALFORMED_DEVICE_REGISTRY,
         )
+    if snapshot.invalid_area_ids:
+        raise BulkSelectorInfrastructureError(
+            "Home Assistant device registry returned invalid device area evidence",
+            cause=InfrastructureErrorCause.MALFORMED_DEVICE_REGISTRY,
+        )
     return snapshot
 
 

--- a/tests/src/unit/test_bulk_selector.py
+++ b/tests/src/unit/test_bulk_selector.py
@@ -203,6 +203,39 @@ async def test_conflicting_device_identity_fails_before_action_selection() -> No
 
 
 @pytest.mark.asyncio
+async def test_invalid_device_ancestry_fails_before_action_selection() -> None:
+    """An area selector must not silently omit a child with invalid ancestry."""
+    client = SelectorClient(
+        states=[_state("switch.safe"), _state("switch.orphan")],
+        entities=[
+            {
+                "entity_id": "switch.safe",
+                "area_id": "salon",
+                "device_id": None,
+            },
+            {
+                "entity_id": "switch.orphan",
+                "area_id": None,
+                "device_id": "child",
+            },
+        ],
+        devices=[{"id": "child", "area_id": None, "parent_device_id": "missing"}],
+    )
+
+    with pytest.raises(
+        BulkSelectorInfrastructureError, match="invalid device area evidence"
+    ):
+        await resolve_bulk_selector(
+            client,
+            {"domain": "switch", "area_ids": ["salon"]},
+            action="off",
+            parameters=None,
+            timeout_seconds=None,
+            validate_first=True,
+        )
+
+
+@pytest.mark.asyncio
 async def test_membership_cycle_fails_before_returning_operations() -> None:
     """A cyclic aggregate graph is an all-or-nothing preflight failure."""
     client = SelectorClient(

--- a/tests/src/unit/test_component_readapi_contract.py
+++ b/tests/src/unit/test_component_readapi_contract.py
@@ -36,6 +36,9 @@ from ha_mcp.tools.radio.zigbee import _resolve_ieee
 from ha_mcp.tools.tools_config_automations import AutomationConfigTools
 from ha_mcp.tools.tools_config_scenes import ConfigSceneTools
 from ha_mcp.tools.tools_config_scripts import ConfigScriptTools
+from ha_mcp.visibility import resolver
+from ha_mcp.visibility.model import VisibilityConfig
+from ha_mcp.visibility.persistence import save_visibility_config
 
 from ._component_routing_helpers import patch_ws
 from .test_component_ws_search import (
@@ -354,6 +357,103 @@ class TestOverviewSeam:
         assert resp["success"] is True
         assert resp["area_analysis"]["office"]["count"] == 1
         assert client.total_legacy_fetches() == 0
+
+    @pytest.mark.parametrize("evidence", ["conflict", "invalid_ancestry"])
+    def test_ambiguous_device_evidence_invalidates_overview_slice(
+        self, monkeypatch, evidence
+    ) -> None:
+        """The component must force legacy fallback instead of losing evidence."""
+        if evidence == "conflict":
+            office = FakeDevice("duplicate", area_id="office")
+            garage = FakeDevice("duplicate", area_id="garage")
+
+            class _ConflictingRegistry:
+                devices = (office, garage)
+                child_devices = ()
+
+            view = make_view()
+            view.device = _ConflictingRegistry()
+        else:
+            view = make_view(
+                child_devices=[FakeChildDevice("child", "missing")],
+            )
+        monkeypatch.setattr(wsapi, "_resolve_registries", lambda h: view)
+
+        result = wsapi._do_overview(self._hass(), {})
+
+        assert result["device_registry"] == []
+        assert result["slice_errors"] == ["device_registry"]
+
+    def test_direct_area_precedes_missing_parent_in_overview_slice(
+        self, monkeypatch
+    ) -> None:
+        """A valid direct area remains authoritative despite invalid ancestry."""
+        view = make_view(
+            child_devices=[FakeChildDevice("child", "missing", area_id="office")],
+        )
+        monkeypatch.setattr(wsapi, "_resolve_registries", lambda h: view)
+
+        result = wsapi._do_overview(self._hass(), {})
+
+        assert result["slice_errors"] == []
+        assert result["device_registry"] == [
+            {
+                "id": "child",
+                "area_id": "office",
+                "labels": [],
+                "name": None,
+                "name_by_user": None,
+                "manufacturer": None,
+                "model": None,
+            }
+        ]
+
+    @pytest.mark.asyncio
+    async def test_conflicting_device_overview_falls_back_with_warning(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        """The real component/server seam preserves conflict evidence via fallback."""
+        office = FakeDevice("duplicate", area_id="office")
+        garage = FakeDevice("duplicate", area_id="garage")
+
+        class _ConflictingRegistry:
+            devices = (office, garage)
+            child_devices = ()
+
+        view = make_view()
+        view.device = _ConflictingRegistry()
+        monkeypatch.setattr(wsapi, "_resolve_registries", lambda h: view)
+        save_visibility_config(
+            tmp_path,
+            VisibilityConfig(enabled=True, exclude_areas=["office"]),
+        )
+        monkeypatch.setattr(resolver, "get_data_dir", lambda: tmp_path)
+
+        class _ConflictClient(OverviewRoutingClient):
+            async def send_websocket_message(self, msg):
+                if msg.get("type") == "config/device_registry/list":
+                    self.ws_types[msg["type"]] += 1
+                    return {
+                        "success": True,
+                        "result": [
+                            {"id": "duplicate", "area_id": "office"},
+                            {"id": "duplicate", "area_id": "garage"},
+                        ],
+                    }
+                return await super().send_websocket_message(msg)
+
+        client = _ConflictClient()
+        tool = _build_overview_tool(client)
+        with patch_ws(_real_component_ws(self._hass()), tools_search):
+            response = await tool()
+
+        assert response["success"] is True
+        assert client.total_legacy_fetches() > 0
+        assert resolver._DEVICE_REGISTRY_CONFLICT_WARNING in response["warnings"]
+        assert any(
+            "component overview returned malformed slices" in warning
+            for warning in response["warnings"]
+        )
 
 
 # --- search ---------------------------------------------------------------------

--- a/tests/src/unit/test_component_ws_search.py
+++ b/tests/src/unit/test_component_ws_search.py
@@ -902,7 +902,7 @@ class TestInfo:
                 _REPO_ROOT / "custom_components" / "ha_mcp_tools" / "manifest.json"
             ).read_text(encoding="utf-8")
         )
-        assert manifest["version"] == COMPONENT_VERSION == "2.1.3"
+        assert manifest["version"] == COMPONENT_VERSION == "2.1.4"
 
 
 # =============================================================================


### PR DESCRIPTION
## What does this PR do?

Closes the two exact-head review gaps found after #2366 merged:

- An area/floor `ha_bulk_control` selector now rejects invalid device ancestry before returning any operation rows, preventing a silent partial bulk action.
- The component overview path now marks its device slice degraded when its bounded projection would erase conflicting identities or invalid-area ancestry. The server then uses the existing native registry fallback, preserving visibility warnings and fail-closed semantics.

Core's direct-area precedence remains unchanged: a child with a valid direct area is still accepted even if its parent reference is unavailable.

Regression-first evidence against the uncorrected merged code was 3 failures: the bulk selector returned operations, and both ambiguous component overview cases returned an apparently clean slice.

## Type of change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

Exact rebased head: `b2db279e22410277a8157034b01f277811d635e9`, based on upstream `47582a700b0889a355033ade36de7c3077780b48`.

Validation:

- Focused regression: 3 passed.
- Exact-head affected bulk/component/overview/visibility and component-version slice: 358 passed.
- Complete unit suite on equivalent production/test content before the non-overlapping upstream release-metadata rebase: 11,931 passed, 364 skipped.
- Exact-head repository hook unit lane: 11,972 passed, 364 skipped.
- Component version parity: passed; the pending component version is `2.1.4`, strictly ahead of released mirror `v2.1.3`.
- Ruff format/check: passed for all changed Python files.
- ast-grep: passed.
- Mypy: both changed production files passed. The repository-wide hook retains 13 pre-existing errors in the pinned `skills-vendor` submodule, so the commit was recorded with `--no-verify` after all other hook lanes completed.
- Exact-head CI: 28 passed, 1 intentionally skipped (Dependabot), 0 pending, 0 failed, including all build, Unit, CodeQL, E2E, and HAOS topology lanes.
- Exact-head reviews: CodeRabbit completed with no actionable comments; manual Codex review completed with no major issues at `b2db279e22410277a8157034b01f277811d635e9`.

No Home Assistant writes or live-system access were used. No public schema, route, permission, release, or fallback behavior changes.

Fixes https://github.com/homeassistant-ai/ha-mcp/pull/2366#discussion_r3938549197
Fixes https://github.com/homeassistant-ai/ha-mcp/pull/2366#discussion_r3938549201

## Checklist
- [x] Documentation is not needed; behavior and regression rationale are documented in code/tests and this PR.
