### PR TITLE
fix: refuse over-nested list-param JSON and fail a merge that strands the component under a released version

### DIFF
--- a/.github/workflows/sync-integration-mirror.yml
+++ b/.github/workflows/sync-integration-mirror.yml
@@ -218,22 +218,32 @@ jobs:
         # already pushed to the mirror's main above, which is fine: HACS
         # installs tags, not main. Failing before the dev pre-release step
         # keeps a v<version>-dev.N tag from being cut under changed content.
-        if: >-
-          github.event_name == 'push' && steps.push.outputs.component_changed == 'true'
+        #
+        # Deliberately NOT gated on steps.push.outputs.component_changed: a
+        # failed first attempt has already pushed the offending snapshot, so
+        # a rerun clones a mirror with nothing left to stage, sees no diff,
+        # and would skip the gate and turn the stranded commit green. The
+        # comparison below reads the mirror's current content against the
+        # tag, so it holds on reruns; it costs one ls-remote per push.
+        #
+        # MIRROR_DIR is only overridden by the unit test that runs this script
+        # against a local stand-in (tests/src/unit/test_mirror_sync_workflow_shape.py).
+        if: github.event_name == 'push'
         env:
           GIT_SSH_COMMAND: ssh -i ~/.ssh/mirror_key -o IdentitiesOnly=yes
         run: |
+          MIRROR_DIR="${MIRROR_DIR:-/tmp/mirror}"
           VER=$(python3 -c "import json; print(json.load(open('custom_components/ha_mcp_tools/manifest.json'))['version'])")
-          existing=$(git -C /tmp/mirror ls-remote --tags origin "refs/tags/v${VER}")
+          existing=$(git -C "$MIRROR_DIR" ls-remote --tags origin "refs/tags/v${VER}")
           if [ -z "$existing" ]; then
             echo "no stable tag v${VER} on the mirror - the component change rides pending ${VER}"
             exit 0
           fi
-          if ! git -C /tmp/mirror fetch --quiet --depth=1 origin "refs/tags/v${VER}:refs/tags/v${VER}"; then
+          if ! git -C "$MIRROR_DIR" fetch --quiet --depth=1 origin "refs/tags/v${VER}:refs/tags/v${VER}"; then
             echo "::warning::mirror tag v${VER} exists but could not be fetched for the post-merge stranded-changes check - the release-time backstop still applies"
             exit 0
           fi
-          if git -C /tmp/mirror diff --quiet "v${VER}" HEAD -- custom_components; then
+          if git -C "$MIRROR_DIR" diff --quiet "v${VER}" HEAD -- custom_components; then
             echo "mirror tag v${VER} exists and the component snapshot is identical - nothing stranded"
             exit 0
           fi

--- a/.github/workflows/sync-integration-mirror.yml
+++ b/.github/workflows/sync-integration-mirror.yml
@@ -205,6 +205,41 @@ jobs:
             git push origin main
           fi
 
+      - name: Fail a merge that changed the component under an already-released version
+        # Post-merge twin of the stranded-changes backstop in the stable-tag
+        # step below, run on the push leg. The PR Component Version Gate only
+        # runs on pull-request events, so a PR opened while a version was
+        # pending and merged after that version's stable tag was cut keeps
+        # its recorded green (#2356 sat open across the v2.1.3 cut and its
+        # gate stayed green on "pending 2.1.3 ahead of released 2.1.2").
+        # Without this step the drift surfaced only on the NEXT stable
+        # release run; here it lands on the merge commit's own run, minutes
+        # after the merge, with the same bump instruction. The snapshot was
+        # already pushed to the mirror's main above, which is fine: HACS
+        # installs tags, not main. Failing before the dev pre-release step
+        # keeps a v<version>-dev.N tag from being cut under changed content.
+        if: >-
+          github.event_name == 'push' && steps.push.outputs.component_changed == 'true'
+        env:
+          GIT_SSH_COMMAND: ssh -i ~/.ssh/mirror_key -o IdentitiesOnly=yes
+        run: |
+          VER=$(python3 -c "import json; print(json.load(open('custom_components/ha_mcp_tools/manifest.json'))['version'])")
+          existing=$(git -C /tmp/mirror ls-remote --tags origin "refs/tags/v${VER}")
+          if [ -z "$existing" ]; then
+            echo "no stable tag v${VER} on the mirror - the component change rides pending ${VER}"
+            exit 0
+          fi
+          if ! git -C /tmp/mirror fetch --quiet --depth=1 origin "refs/tags/v${VER}:refs/tags/v${VER}"; then
+            echo "::warning::mirror tag v${VER} exists but could not be fetched for the post-merge stranded-changes check - the release-time backstop still applies"
+            exit 0
+          fi
+          if git -C /tmp/mirror diff --quiet "v${VER}" HEAD -- custom_components; then
+            echo "mirror tag v${VER} exists and the component snapshot is identical - nothing stranded"
+            exit 0
+          fi
+          echo "::error::master changed custom_components/ha_mcp_tools under version ${VER}, which the mirror already released as v${VER} (the PR gate passed before that tag was cut). Bump manifest.json + const.py (and the parity-test literal) to open the next pending version per docs/agents/custom-component.md#version-cycle."
+          exit 1
+
       - name: Tag mirror for stable release
         # Tags the mirror with the current component version after a successful
         # SemVer Release (or a manual re-run). The tag is ANNOTATED and its

--- a/docs/agents/custom-component.md
+++ b/docs/agents/custom-component.md
@@ -29,16 +29,19 @@ Apply these rules:
 - Raise an existing pending version only to escalate the required bump level,
   such as patch to minor. Do not create never-shipped intermediate versions.
 - The PR Component Version Gate requires a changed component to lead the
-  mirror's released stable version. The mirror release workflow separately
-  rejects content drift under an already-tagged component version.
+  mirror's released stable version. The mirror sync separately rejects
+  content drift under an already-tagged component version, on the
+  push-to-master leg right after a merge and again at release time.
   In the PR gate, equal means a bump is needed to open the pending version;
   behind means a stale tree or bad merge resurrected an older version.
 
 The mirror drift check prevents changes from being stranded under a version
 that already shipped and therefore has no new installable release. The gap it
 catches is a pull request opened while a version was pending but merged after
-that version became stable: no PR check reruns at merge time, so only the
-mirror can detect that the already-tagged content changed.
+that version became stable: a PR check never reruns for an external event,
+so the recorded green stands and the merge goes through. The push-to-master
+sync leg then fails the merge commit's own run with the bump instruction,
+and the stable-tag step repeats the check at release time as the backstop.
 
 One exception overrides the shared pending-version rule: if a change adds a
 component service or argument that the server depends on, open a fresh pending

--- a/docs/agents/custom-component.md
+++ b/docs/agents/custom-component.md
@@ -40,7 +40,8 @@ that already shipped and therefore has no new installable release. The gap it
 catches is a pull request opened while a version was pending but merged after
 that version became stable: a PR check never reruns for an external event,
 so the recorded green stands and the merge goes through. The push-to-master
-sync leg then fails the merge commit's own run with the bump instruction,
+sync leg then fails the merge commit's own run with the bump instruction
+(on every push, so a rerun after the snapshot already landed still fails),
 and the stable-tag step repeats the check at release time as the backstop.
 
 One exception overrides the shared pending-version rule: if a change adds a

--- a/src/ha_mcp/tools/tools_bug_report.py
+++ b/src/ha_mcp/tools/tools_bug_report.py
@@ -29,14 +29,20 @@ from ha_mcp import __version__
 from .._version import get_version, is_embedded, is_running_in_addon
 from ..client.supervisor_client import make_supervisor_httpx_client
 from ..config import Settings, get_global_settings
+from ..errors import create_validation_error
 from ..utils.usage_logger import (
     AVG_LOG_ENTRIES_PER_TOOL,
     get_recent_logs,
     get_startup_logs,
 )
 from .component_api import get_component_caps
-from .helpers import log_tool_usage, register_tool_methods
-from .util_helpers import ANSI_ESCAPE_RE, JSON_STRING_COERCION, project_fields
+from .helpers import log_tool_usage, raise_tool_error, register_tool_methods
+from .util_helpers import (
+    ANSI_ESCAPE_RE,
+    JSON_STRING_COERCION,
+    parse_string_list_param,
+    project_fields,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -948,6 +954,19 @@ class BugReportTools:
           usual cause, and refreshing the MCP connection is the fix
         - `suggested_title`, `duplicate_check_urls`, `anonymization_guide`
         """
+        # Validate fields= before anything is collected: the projection at the
+        # end was the only parse, outside any ValueError handler, so a
+        # malformed value reached FastMCP as a bare exception after the whole
+        # report had been assembled.
+        parsed_fields: list[str] | None = None
+        if fields is not None:
+            try:
+                parsed_fields = parse_string_list_param(
+                    fields, "fields", allow_csv=True
+                )
+            except ValueError as exc:
+                raise_tool_error(create_validation_error(str(exc), parameter="fields"))
+
         # Detect installation method, platform, and runtime config.
         install_method = _detect_installation_method()
         platform_info = _detect_platform()
@@ -1166,7 +1185,7 @@ class BugReportTools:
                 "CRITICAL: Always ANONYMIZE the report BEFORE presenting it in markdown code blocks!"
             ),
         }
-        return project_fields(result, fields)
+        return project_fields(result, parsed_fields)
 
 
 def register_bug_report_tools(mcp: Any, client: Any, **kwargs: Any) -> None:

--- a/src/ha_mcp/tools/tools_search.py
+++ b/src/ha_mcp/tools/tools_search.py
@@ -4121,7 +4121,10 @@ class SearchTools:
         )
         include_dismissed_repairs_bool = bool(include_dismissed_repairs)
 
-        parsed_domains = parse_string_list_param(domains, "domains", allow_csv=True)
+        try:
+            parsed_domains = parse_string_list_param(domains, "domains", allow_csv=True)
+        except ValueError as exc:
+            raise_tool_error(create_validation_error(str(exc), parameter="domains"))
 
         result = await self._collect_overview(
             _OverviewInputs(

--- a/src/ha_mcp/tools/util_helpers.py
+++ b/src/ha_mcp/tools/util_helpers.py
@@ -205,7 +205,9 @@ def _parse_json_to_str_list(s: str, param_name: str) -> list[str]:
         if not all(isinstance(item, str) for item in parsed):
             raise ValueError(f"{param_name} must be a JSON array of strings")
         return parsed
-    except json.JSONDecodeError as e:
+    except (json.JSONDecodeError, RecursionError) as e:
+        # RecursionError: nested past the interpreter's limit is still
+        # "not valid JSON" to the caller, which expects ValueError here.
         raise ValueError(f"Invalid JSON in {param_name}: {e}") from e
 
 

--- a/tests/src/unit/test_bug_report_fields_validation.py
+++ b/tests/src/unit/test_bug_report_fields_validation.py
@@ -1,0 +1,58 @@
+"""``ha_report_issue`` validates ``fields`` before it collects anything.
+
+The projection at the end of the tool was the only place ``fields`` was parsed,
+outside any ``ValueError`` handler, so a malformed value reached FastMCP as a
+bare exception after the whole report had been assembled (Codex, PR #2375).
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from fastmcp.exceptions import ToolError
+
+from ha_mcp.tools.tools_bug_report import register_bug_report_tools
+
+
+def _build_tool(client: Any) -> Any:
+    registered: dict[str, Any] = {}
+
+    def capture_add_tool(method: Any) -> None:
+        name = (
+            method.__fastmcp__.name
+            if hasattr(method, "__fastmcp__")
+            else method.__name__
+        )
+        registered[name] = method
+
+    mcp = MagicMock()
+    mcp.add_tool = capture_add_tool
+    register_bug_report_tools(mcp, client)
+    return registered["ha_report_issue"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "fields",
+    [
+        pytest.param("[" * 20_000, id="over-nested"),
+        pytest.param("[not json", id="invalid-json"),
+    ],
+)
+async def test_malformed_fields_is_a_validation_error_before_collection(
+    fields: str,
+) -> None:
+    client = MagicMock()
+    tool = _build_tool(client)
+
+    with pytest.raises(ToolError) as exc:
+        await tool(fields=fields)
+
+    payload = json.loads(str(exc.value))
+    assert payload["error"]["code"].startswith("VALIDATION")
+    assert "fields" in str(payload)
+    # Refused before the report was assembled: the client was never consulted.
+    assert client.method_calls == []

--- a/tests/src/unit/test_ha_overview_component_routing.py
+++ b/tests/src/unit/test_ha_overview_component_routing.py
@@ -18,11 +18,13 @@ the component path.
 
 from __future__ import annotations
 
+import json
 from collections import Counter
 from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
+from fastmcp.exceptions import ToolError
 
 from ha_mcp.client.rest_client import (
     HomeAssistantCommandError,
@@ -666,3 +668,26 @@ async def test_component_and_legacy_response_parity(tmp_path, monkeypatch) -> No
     assert component == legacy
     # And the component path did not touch the legacy fetch inventory.
     assert client_component.total_legacy_fetches() == 0
+
+
+@pytest.mark.asyncio
+async def test_over_nested_domains_string_is_a_validation_error(
+    tmp_path, monkeypatch
+) -> None:
+    """``domains`` was the one list parameter parsed outside a ``ValueError``
+    handler, so a string nested past the recursion limit escaped the tool as a
+    bare exception and FastMCP reported generic tool text (Codex, PR #2375).
+    It is refused as a structured validation error naming the parameter, and
+    nothing is fetched."""
+    _setup_visibility_disabled(tmp_path, monkeypatch)
+    _quiet_tail(monkeypatch)
+    client = OverviewRoutingClient()
+    overview = _build_overview_tool(client)
+
+    with pytest.raises(ToolError) as exc:
+        await overview(domains="[" * 20_000)
+
+    payload = json.loads(str(exc.value))
+    assert payload["error"]["code"].startswith("VALIDATION")
+    assert payload.get("parameter") == "domains" or "domains" in str(payload)
+    assert client.total_legacy_fetches() == 0

--- a/tests/src/unit/test_mirror_sync_workflow_shape.py
+++ b/tests/src/unit/test_mirror_sync_workflow_shape.py
@@ -61,8 +61,6 @@ class TestShape:
 
 # ------------------------------------------------------------------ behaviour
 
-_MANIFEST = Path("custom_components/ha_mcp_tools/manifest.json")
-
 
 def _git(cwd: Path, *args: str) -> str:
     return subprocess.run(

--- a/tests/src/unit/test_mirror_sync_workflow_shape.py
+++ b/tests/src/unit/test_mirror_sync_workflow_shape.py
@@ -1,0 +1,170 @@
+"""Guard the post-merge stranded-component gate in the mirror sync workflow.
+
+The gate runs only on a push to master that the mirror sync picks up, so PR
+CI never executes it. These tests pin its shape from the workflow file and run
+its script against a local stand-in for the mirror through every outcome
+(PR #2375; Codex asked for committed coverage).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_WORKFLOW = _REPO_ROOT / ".github" / "workflows" / "sync-integration-mirror.yml"
+_GATE = "Fail a merge that changed the component under an already-released version"
+
+
+def _sync_steps() -> list[dict[str, Any]]:
+    data = yaml.safe_load(_WORKFLOW.read_text(encoding="utf-8"))
+    return list(data["jobs"]["sync"]["steps"])
+
+
+def _gate_step() -> dict[str, Any]:
+    return next(s for s in _sync_steps() if s.get("name") == _GATE)
+
+
+class TestShape:
+    def test_runs_after_the_snapshot_push_and_before_any_tag(self) -> None:
+        names = [s.get("name") for s in _sync_steps()]
+        i = names.index(_GATE)
+        assert names[i - 1] == "Commit and push"
+        assert names[i + 1] == "Tag mirror for stable release"
+        assert names.index("Tag mirror dev pre-release") > i
+
+    def test_runs_on_every_push_regardless_of_the_cached_diff(self) -> None:
+        """Gating on ``component_changed`` opened a rerun hole: a failed first
+        attempt has already pushed the offending snapshot, so a rerun sees no
+        diff, skips the gate and turns the stranded commit green (Codex)."""
+        cond = _gate_step()["if"]
+        assert "github.event_name == 'push'" in cond
+        assert "component_changed" not in cond
+        assert "workflow_run" not in cond
+
+    def test_a_failure_stops_the_tag_steps(self) -> None:
+        gate = _gate_step()
+        assert "continue-on-error" not in gate
+        for step in _sync_steps():
+            if step.get("name", "").startswith("Tag mirror"):
+                assert "always()" not in str(step.get("if", ""))
+                assert "failure()" not in str(step.get("if", ""))
+
+
+# ------------------------------------------------------------------ behaviour
+
+_MANIFEST = Path("custom_components/ha_mcp_tools/manifest.json")
+
+
+def _git(cwd: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", "-c", "user.name=t", "-c", "user.email=t@example.com", *args],
+        cwd=cwd,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout
+
+
+def _write_component(root: Path, version: str, body: str) -> None:
+    comp = root / "custom_components" / "ha_mcp_tools"
+    comp.mkdir(parents=True, exist_ok=True)
+    (comp / "manifest.json").write_text(
+        json.dumps({"domain": "ha_mcp_tools", "version": version}), encoding="utf-8"
+    )
+    (comp / "__init__.py").write_text(body, encoding="utf-8")
+
+
+@pytest.fixture
+def mirror_world(tmp_path: Path) -> dict[str, Path]:
+    """A bare 'mirror' origin whose v2.1.3 tag holds one component snapshot, a
+    clone of it (what the sync job works in), and a repo checkout to stage."""
+    origin = tmp_path / "origin.git"
+    seed = tmp_path / "seed"
+    mirror = tmp_path / "mirror"
+    checkout = tmp_path / "checkout"
+    _git(tmp_path, "init", "--bare", "-b", "main", str(origin))
+    seed.mkdir()
+    _git(seed, "init", "-b", "main")
+    _write_component(seed, "2.1.3", "RELEASED = True\n")
+    _git(seed, "add", "-A")
+    _git(seed, "commit", "-q", "-m", "v2.1.3 snapshot")
+    _git(seed, "tag", "v2.1.3")
+    _git(seed, "remote", "add", "origin", str(origin))
+    _git(seed, "push", "-q", "origin", "main", "v2.1.3")
+    _git(tmp_path, "clone", "-q", str(origin), str(mirror))
+    checkout.mkdir()
+    return {"mirror": mirror, "checkout": checkout}
+
+
+def _stage(world: dict[str, Path]) -> None:
+    """What 'Stage snapshot' + 'Commit and push' leave in the mirror clone."""
+    dest = world["mirror"] / "custom_components"
+    shutil.rmtree(dest, ignore_errors=True)
+    shutil.copytree(world["checkout"] / "custom_components", dest)
+    _git(world["mirror"], "add", "-A")
+    _git(world["mirror"], "commit", "-q", "--allow-empty", "-m", "snapshot")
+
+
+def _run_gate(world: dict[str, Path]) -> subprocess.CompletedProcess[str]:
+    script = _gate_step()["run"]
+    return subprocess.run(
+        ["bash", "-eo", "pipefail", "-c", script],
+        cwd=world["checkout"],
+        env={**os.environ, "MIRROR_DIR": str(world["mirror"])},
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32" or shutil.which("bash") is None,
+    reason="runs the workflow's bash script; CI's ubuntu runner has bash",
+)
+class TestBehaviour:
+    def test_pending_version_with_no_stable_tag_passes(self, mirror_world) -> None:
+        _write_component(mirror_world["checkout"], "2.1.4", "NEW = True\n")
+        _stage(mirror_world)
+        done = _run_gate(mirror_world)
+        assert done.returncode == 0, done.stdout + done.stderr
+        assert "no stable tag v2.1.4" in done.stdout
+
+    def test_identical_content_under_the_released_version_passes(
+        self, mirror_world
+    ) -> None:
+        _write_component(mirror_world["checkout"], "2.1.3", "RELEASED = True\n")
+        _stage(mirror_world)
+        done = _run_gate(mirror_world)
+        assert done.returncode == 0, done.stdout + done.stderr
+        assert "identical" in done.stdout
+
+    def test_changed_content_under_the_released_version_fails(
+        self, mirror_world
+    ) -> None:
+        _write_component(mirror_world["checkout"], "2.1.3", "CHANGED = True\n")
+        _stage(mirror_world)
+        done = _run_gate(mirror_world)
+        assert done.returncode == 1, done.stdout + done.stderr
+        assert "::error::" in done.stdout
+        assert "v2.1.3" in done.stdout and "Bump manifest.json" in done.stdout
+
+    def test_rerun_after_the_snapshot_already_landed_still_fails(
+        self, mirror_world
+    ) -> None:
+        """A rerun clones a mirror that already holds the offending snapshot, so
+        nothing is staged; the gate still compares against the tag and fails."""
+        _write_component(mirror_world["checkout"], "2.1.3", "CHANGED = True\n")
+        _stage(mirror_world)
+        assert _run_gate(mirror_world).returncode == 1
+        # Second attempt: same checkout, mirror unchanged, no new commit.
+        done = _run_gate(mirror_world)
+        assert done.returncode == 1, done.stdout + done.stderr

--- a/tests/src/unit/test_util_helpers.py
+++ b/tests/src/unit/test_util_helpers.py
@@ -97,6 +97,13 @@ class TestParseStringListParam:
         with pytest.raises(ValueError, match="Invalid JSON"):
             parse_string_list_param("not valid json")
 
+    def test_deeply_nested_json_raises_the_same_error(self):
+        """A string nested past the recursion limit makes ``json.loads`` raise
+        ``RecursionError``, which callers do not expect; it is refused as
+        invalid JSON like any other unparseable string (Patch76, PR #2356)."""
+        with pytest.raises(ValueError, match="Invalid JSON"):
+            parse_string_list_param("[" * 20_000)
+
     def test_json_object_raises_error(self):
         """JSON object (not array) raises ValueError."""
         with pytest.raises(ValueError, match="must be a JSON array"):


### PR DESCRIPTION
## What does this PR do?

Two findings from the #2356 review that landed after its approval.

`_parse_json_to_str_list` caught only `JSONDecodeError`, so a list parameter string nested past the interpreter's recursion limit escaped `parse_string_list_param` as `RecursionError` and reached the client as `INTERNAL_ERROR` with a logged traceback, where every caller expects the `Invalid JSON in <param>` validation error. It now refuses that input the same way, matching `loads_if_json_container_str` fifty lines up. Regression test: a 20k-deep string. Two tools parsed a list parameter outside any `ValueError` handler, so even a converted error reached FastMCP as generic tool text (`log_tool_usage` re-raises): `ha_get_overview`'s `domains` is now wrapped like its `fields` sibling, and `ha_report_issue` validates `fields` before it collects anything instead of only in the final projection. Both are tested through the tool.

The PR Component Version Gate runs only on pull-request events, so a PR opened while a component version was pending and merged after that version's stable tag was cut keeps its recorded green: #2356 sat open across the v2.1.3 cut with its gate green on "pending 2.1.3 ahead of released 2.1.2", and only the reviewer noticed. The only stranded-changes check lived in the mirror sync's stable-tag step, so the drift would have surfaced on the next release run. The push-to-master sync leg now runs the same comparison right after the snapshot push and fails the merge commit's own run with the bump instruction, before the dev pre-release tag step; the release-time step is unchanged as the backstop. The gate runs on every push rather than only when the cached diff saw a component change, so a rerun after a failed first attempt (whose snapshot already landed on the mirror) cannot skip it. `docs/agents/custom-component.md` describes both.

## Type of change
- [x] 🐛 Bug fix

## Testing
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

The workflow step only runs on the push-to-master sync, so PR CI does not execute it live. `tests/src/unit/test_mirror_sync_workflow_shape.py` pins its position and condition from the workflow file and runs its script under bash against a local stand-in mirror through every outcome (no tag yet; identical content; differing content; rerun with nothing left to stage). It was also checked with `actionlint` and run by hand against a clone of the public mirror.

## Checklist
- [x] I have updated documentation if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Invalid, deeply nested JSON input now returns a clear “Invalid JSON” error instead of an internal recursion error.
  - Malformed report fields and overview domain values now return structured validation errors before processing begins.
  - Release synchronization now checks component content on every push and detects changes after a version is tagged, blocking the merge until the version is updated.

- **Documentation**
  - Updated version-cycle guidance to explain component version checks during synchronization and release tagging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
