### PR TITLE
fix: default auto-backup dir to <data dir>/backups outside the add-on

### DIFF
--- a/src/ha_mcp/backup_manager.py
+++ b/src/ha_mcp/backup_manager.py
@@ -7,7 +7,11 @@ Storage path resolution
 -----------------------
 ``Settings.auto_backup_dir`` overrides; otherwise defaults to
 ``/data/ha_mcp_backups`` in the add-on (SUPERVISOR_TOKEN set + ``/data``
-exists), else ``${XDG_DATA_HOME:-~/.local/share}/ha_mcp/backups``.
+exists), else ``<data dir>/backups`` where the data dir is what
+``utils.data_paths.get_data_dir`` resolves (``HA_MCP_CONFIG_DIR``,
+``~/.ha-mcp``, or the tmpdir fallback). Installs that still hold snapshots
+under the pre-#2372 default ``${XDG_DATA_HOME:-~/.local/share}/ha_mcp/backups``
+keep using that directory; see ``_resolve_default_dir``.
 
 File format
 -----------
@@ -55,6 +59,7 @@ import yaml  # type: ignore[import-untyped]
 from fastmcp.exceptions import ToolError
 
 from .client.rest_client import HomeAssistantConnectionError, HomeAssistantError
+from .utils.data_paths import get_data_dir
 
 logger = logging.getLogger(__name__)
 
@@ -263,15 +268,58 @@ def _now_iso() -> str:
     return datetime.now(UTC).isoformat()
 
 
-def _resolve_default_dir() -> Path:
-    """Pick a sane default backup directory for the current deployment mode."""
-    # Addon detection: Supervisor sets SUPERVISOR_TOKEN AND /data exists.
-    if os.environ.get("SUPERVISOR_TOKEN") and Path("/data").is_dir():
-        return Path("/data/ha_mcp_backups")
+# Add-on default. Named in the add-on option descriptions, so it stays put.
+_ADDON_BACKUP_DIR = Path("/data/ha_mcp_backups")
+
+
+def _legacy_default_dir() -> Path:
+    """The non-add-on default before #2372: XDG user-data, outside the data dir."""
     xdg = os.environ.get("XDG_DATA_HOME")
     if xdg:
         return Path(xdg) / "ha_mcp" / "backups"
     return (Path.home() / ".local" / "share" / "ha_mcp" / "backups").resolve()
+
+
+def _holds_files(path: Path) -> bool:
+    """Whether ``path`` is a directory with at least one entry.
+
+    An unreadable or missing directory counts as empty: nothing in it can be
+    listed or restored from, so there is nothing to keep using.
+    """
+    try:
+        return any(path.iterdir())
+    except OSError:
+        return False
+
+
+def _resolve_default_dir() -> Path:
+    """Pick a sane default backup directory for the current deployment mode.
+
+    Add-on (Supervisor sets ``SUPERVISOR_TOKEN`` and ``/data`` exists):
+    ``/data/ha_mcp_backups``. Otherwise ``backups/`` inside the data dir, the
+    directory that already holds the settings and that every documented
+    Docker recipe persists as the ``ha-mcp-data`` volume. The previous default,
+    ``${XDG_DATA_HOME:-~/.local/share}/ha_mcp/backups``, sat outside that
+    volume: under a ``read_only`` root it was EROFS, which fails the mandatory
+    pre-write snapshots closed, and on a writable root the snapshots were
+    discarded with the container (#2372).
+
+    An install that already holds snapshots under the previous default keeps
+    using it so its restore points stay listed and rotation keeps counting
+    them; only installs with nothing there move to the data dir.
+    """
+    if os.environ.get("SUPERVISOR_TOKEN") and _ADDON_BACKUP_DIR.parent.is_dir():
+        return _ADDON_BACKUP_DIR
+    legacy = _legacy_default_dir()
+    if _holds_files(legacy):
+        logger.info(
+            "Auto-backup: keeping existing backup dir %s (new installs default "
+            "to %s; set HAMCP_BACKUP_DIR to choose explicitly)",
+            legacy,
+            get_data_dir() / "backups",
+        )
+        return legacy
+    return get_data_dir() / "backups"
 
 
 # Sentinel returned by ``BackupManager._fetch_config_for_snapshot`` when there

--- a/src/ha_mcp/config.py
+++ b/src/ha_mcp/config.py
@@ -400,7 +400,7 @@ class Settings(BaseSettings):
 
     # Backup directory override. Empty ("") resolves at runtime to a
     # deployment-mode default: ``/data/ha_mcp_backups`` in the add-on,
-    # otherwise ``${XDG_DATA_HOME:-~/.local/share}/ha_mcp/backups``.
+    # otherwise ``<data dir>/backups`` (see ``backup_manager._resolve_default_dir``).
     auto_backup_dir: str = Field("", alias="HAMCP_BACKUP_DIR")
 
     # Calendar event backups query an ahead-of-now window to locate the
@@ -776,8 +776,8 @@ FEATURE_FLAG_FIELDS: tuple[FeatureFlagField, ...] = (
 )
 
 # Override-file location is the same data dir that holds tool_config.json
-# (resolved via ``utils.data_paths.get_data_dir`` — addon ``/data``,
-# ``HA_MCP_CONFIG_DIR``, ``XDG_DATA_HOME``, or a tmpdir fallback).
+# (resolved via ``utils.data_paths.get_data_dir`` — ``HA_MCP_CONFIG_DIR``,
+# addon ``/data``, ``~/.ha-mcp``, or a tmpdir fallback).
 # Imported lazily inside helpers to avoid a circular import at module
 # load.
 _FEATURE_FLAG_OVERRIDE_FILENAME = "feature_flags.json"
@@ -1656,8 +1656,8 @@ BACKUP_OVERRIDE_FIELDS: tuple[BackupOverrideField, ...] = (
 )
 
 # Override-file location is the same data dir that holds tool_config.json
-# (resolved via ``utils.data_paths.get_data_dir`` — addon ``/data``,
-# ``HA_MCP_CONFIG_DIR``, ``XDG_DATA_HOME``, or a tmpdir fallback).
+# (resolved via ``utils.data_paths.get_data_dir`` — ``HA_MCP_CONFIG_DIR``,
+# addon ``/data``, ``~/.ha-mcp``, or a tmpdir fallback).
 # Imported lazily inside helpers to avoid a circular import at module
 # load (``utils.data_paths`` imports from ``_version`` which imports
 # from ``config`` transitively in some test layouts).

--- a/src/ha_mcp/settings_ui/locales/en.json
+++ b/src/ha_mcp/settings_ui/locales/en.json
@@ -251,7 +251,7 @@
     "backup.fields.auto_backup_retain_per_entity.label": "Retain per entity",
     "backup.fields.auto_backup_retain_per_entity.help": "Maximum snapshots kept per entity (1–10000). Older ones rotate out.",
     "backup.fields.auto_backup_dir.label": "Backup directory override",
-    "backup.fields.auto_backup_dir.help": "Leave empty for the default: /data/ha_mcp_backups in the App (add-on), otherwise the backups/ subdirectory of the ha-mcp data directory. Or enter an absolute path.",
+    "backup.fields.auto_backup_dir.help": "Leave empty for the default: /data/ha_mcp_backups in the App (add-on), otherwise the backups/ subdirectory of the ha-mcp data directory; an install that already holds snapshots under the earlier default keeps using it. The directory in use is shown in the backup status. Or enter an absolute path.",
     "backup.fields.auto_backup_calendar_lookahead_days.label": "Calendar lookahead (days)",
     "backup.fields.auto_backup_calendar_lookahead_days.help": "How far ahead to query calendar events for pre-edit snapshots. Range 1–365.",
     "backup.fields.enable_snapshot_delete.label": "Allow snapshot deletion",

--- a/src/ha_mcp/settings_ui/locales/en.json
+++ b/src/ha_mcp/settings_ui/locales/en.json
@@ -251,7 +251,7 @@
     "backup.fields.auto_backup_retain_per_entity.label": "Retain per entity",
     "backup.fields.auto_backup_retain_per_entity.help": "Maximum snapshots kept per entity (1–10000). Older ones rotate out.",
     "backup.fields.auto_backup_dir.label": "Backup directory override",
-    "backup.fields.auto_backup_dir.help": "Leave empty to use the default directory; otherwise enter an absolute path.",
+    "backup.fields.auto_backup_dir.help": "Leave empty for the default: /data/ha_mcp_backups in the App (add-on), otherwise the backups/ subdirectory of the ha-mcp data directory. Or enter an absolute path.",
     "backup.fields.auto_backup_calendar_lookahead_days.label": "Calendar lookahead (days)",
     "backup.fields.auto_backup_calendar_lookahead_days.help": "How far ahead to query calendar events for pre-edit snapshots. Range 1–365.",
     "backup.fields.enable_snapshot_delete.label": "Allow snapshot deletion",

--- a/src/ha_mcp/settings_ui/settings.js
+++ b/src/ha_mcp/settings_ui/settings.js
@@ -1438,7 +1438,7 @@ const BACKUP_FIELD_LABELS = {
   },
   auto_backup_dir: {
     label: 'Backup directory override',
-    help: 'Empty = default (/data/ha_mcp_backups in the App (add-on), $XDG_DATA_HOME/ha_mcp/backups otherwise). Override with an absolute path.',
+    help: 'Empty = default (/data/ha_mcp_backups in the App (add-on), the backups/ subdirectory of the ha-mcp data directory otherwise). Override with an absolute path.',
   },
   auto_backup_calendar_lookahead_days: {
     label: 'Calendar lookahead (days)',

--- a/src/ha_mcp/settings_ui/settings.js
+++ b/src/ha_mcp/settings_ui/settings.js
@@ -1438,7 +1438,7 @@ const BACKUP_FIELD_LABELS = {
   },
   auto_backup_dir: {
     label: 'Backup directory override',
-    help: 'Empty = default (/data/ha_mcp_backups in the App (add-on), the backups/ subdirectory of the ha-mcp data directory otherwise). Override with an absolute path.',
+    help: 'Leave empty for the default: /data/ha_mcp_backups in the App (add-on), otherwise the backups/ subdirectory of the ha-mcp data directory. Or enter an absolute path.',
   },
   auto_backup_calendar_lookahead_days: {
     label: 'Calendar lookahead (days)',

--- a/src/ha_mcp/settings_ui/settings.js
+++ b/src/ha_mcp/settings_ui/settings.js
@@ -1438,7 +1438,7 @@ const BACKUP_FIELD_LABELS = {
   },
   auto_backup_dir: {
     label: 'Backup directory override',
-    help: 'Leave empty for the default: /data/ha_mcp_backups in the App (add-on), otherwise the backups/ subdirectory of the ha-mcp data directory. Or enter an absolute path.',
+    help: 'Leave empty for the default: /data/ha_mcp_backups in the App (add-on), otherwise the backups/ subdirectory of the ha-mcp data directory; an install that already holds snapshots under the earlier default keeps using it. The directory in use is shown in the backup status. Or enter an absolute path.',
   },
   auto_backup_calendar_lookahead_days: {
     label: 'Calendar lookahead (days)',

--- a/tests/src/unit/test_advanced_settings_coverage.py
+++ b/tests/src/unit/test_advanced_settings_coverage.py
@@ -202,7 +202,7 @@ ENV_ONLY: dict[str, str] = {
     "SUPERVISOR_BASE_URL": "Supervisor API base; bootstrap before any settings exist",
     "HAMCP_ENV_FILE": "Selects which .env file to load — read before Settings is built",
     "HA_MCP_CONFIG_DIR": "Resolves the data dir that *holds* the override files (path)",
-    "XDG_DATA_HOME": "Data-dir fallback root (path)",
+    "XDG_DATA_HOME": "Root of the pre-#2372 auto-backup default; honoured only while snapshots remain there (path)",
     "HA_MCP_BUILD_VERSION": "Build metadata stamped at image build (bootstrap)",
     "HA_MCP_DISABLE_SETTINGS_UI": "Kill-switch for the settings sidecar itself (chicken-and-egg)",
     "MCP_HOST": "HTTP listener bind address — configured before the server is up",

--- a/tests/src/unit/test_backup_manager.py
+++ b/tests/src/unit/test_backup_manager.py
@@ -1296,6 +1296,99 @@ class TestFactory:
             )
 
 
+# ---------------------------------------------------------------- default dir
+
+
+@pytest.fixture
+def _standalone_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """A non-add-on process whose data dir is ``tmp_path / "data"``.
+
+    ``get_data_dir`` is memoized, so the cache is cleared on both sides:
+    before, so an earlier test's directory is not returned here, and after,
+    so this test's tmpdir does not leak into the next one.
+    """
+    monkeypatch.delenv("SUPERVISOR_TOKEN", raising=False)
+    monkeypatch.delenv("XDG_DATA_HOME", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    monkeypatch.setenv("HA_MCP_CONFIG_DIR", str(tmp_path / "data"))
+    bm.get_data_dir.cache_clear()
+    yield tmp_path / "data"
+    bm.get_data_dir.cache_clear()
+
+
+class TestDefaultDir:
+    """#2372: the default must live in the directory the data volume persists."""
+
+    def test_new_install_defaults_under_data_dir(self, _standalone_env: Path) -> None:
+        assert bm._resolve_default_dir() == _standalone_env / "backups"
+
+    def test_manager_creates_default_under_data_dir(
+        self, _standalone_env: Path
+    ) -> None:
+        mgr = BackupManager(_StubSettings(auto_backup_dir=""), _StubClient())
+        assert mgr.backup_dir == _standalone_env / "backups"
+        assert mgr.backup_dir.is_dir()
+        assert mgr.init_dir_error is None
+        assert mgr.enabled
+
+    def test_existing_home_snapshots_keep_their_dir(
+        self, _standalone_env: Path, tmp_path: Path
+    ) -> None:
+        legacy = tmp_path / "home" / ".local" / "share" / "ha_mcp" / "backups"
+        legacy.mkdir(parents=True)
+        (legacy / "automation.kitchen.20260101_000000.yaml").write_text("x")
+        assert bm._resolve_default_dir() == legacy.resolve()
+
+    def test_existing_xdg_snapshots_keep_their_dir(
+        self, _standalone_env: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "xdg"))
+        legacy = tmp_path / "xdg" / "ha_mcp" / "backups"
+        legacy.mkdir(parents=True)
+        (legacy / "script.morning.20260101_000000.yaml").write_text("x")
+        assert bm._resolve_default_dir() == legacy
+
+    def test_empty_legacy_dir_moves_to_data_dir(
+        self, _standalone_env: Path, tmp_path: Path
+    ) -> None:
+        # An empty directory has nothing to list or restore from, so keeping
+        # it would only preserve the ephemeral location the issue is about.
+        (tmp_path / "home" / ".local" / "share" / "ha_mcp" / "backups").mkdir(
+            parents=True
+        )
+        assert bm._resolve_default_dir() == _standalone_env / "backups"
+
+    def test_unreadable_legacy_dir_counts_as_empty(
+        self, _standalone_env: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def boom(_self: Path) -> Any:
+            raise PermissionError("denied")
+
+        monkeypatch.setattr(Path, "iterdir", boom)
+        assert bm._resolve_default_dir() == _standalone_env / "backups"
+
+    def test_addon_dir_unchanged(
+        self, _standalone_env: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # The add-on path is named in the add-on option descriptions; the
+        # data-dir default must not displace it even when snapshots exist
+        # under the legacy path.
+        addon_dir = tmp_path / "addon-data" / "ha_mcp_backups"
+        addon_dir.parent.mkdir()
+        monkeypatch.setattr(bm, "_ADDON_BACKUP_DIR", addon_dir)
+        monkeypatch.setenv("SUPERVISOR_TOKEN", "token")
+        assert bm._resolve_default_dir() == addon_dir
+
+    def test_addon_requires_data_dir(
+        self, _standalone_env: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # SUPERVISOR_TOKEN alone is not the add-on: the HA core container
+        # carries it too. Without /data the data-dir default applies.
+        monkeypatch.setattr(bm, "_ADDON_BACKUP_DIR", tmp_path / "missing" / "b")
+        monkeypatch.setenv("SUPERVISOR_TOKEN", "token")
+        assert bm._resolve_default_dir() == _standalone_env / "backups"
+
+
 # ---------------------------------------------------------------- bookkeeping
 
 


### PR DESCRIPTION
## What does this PR do?

Outside the add-on the auto-backup directory defaulted to `${XDG_DATA_HOME:-~/.local/share}/ha_mcp/backups`, a location no documented Docker recipe persists. Under the documented `read_only: true` hardening the `mkdir` hits EROFS, so `ha_write_file`, `ha_delete_file` and `ha_config_set_yaml` (mandatory snapshots) fail closed; on a writable root the snapshots land in the container's writable layer and vanish on recreate.

The default now resolves to `backups/` inside the data dir that `get_data_dir()` returns: `HA_MCP_CONFIG_DIR`, `~/.ha-mcp` (the `ha-mcp-data` volume), or the tmpdir fallback, with the same write probe. `HAMCP_BACKUP_DIR` and the settings UI override are unchanged.

Per flavor:
- **Add-on:** unchanged, `/data/ha_mcp_backups` (named in the option descriptions).
- **Docker / uvx:** new installs get `<data dir>/backups`. An install that already holds snapshots under the previous default keeps using it so existing restore points stay listed and rotation keeps counting them. An empty legacy directory moves.
- **Embedded:** follows `HA_MCP_CONFIG_DIR`, which the component sets to its config subdirectory. Same keep-if-non-empty rule applies.

Also corrects the `config.py` comments and the settings UI fallback help text that described `XDG_DATA_HOME` as a data-dir fallback root; only the backup path ever read it.

Closes #2372

## Type of change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

New unit tests cover: new-install default under the data dir, manager creating it, non-empty legacy dir kept (HOME and `XDG_DATA_HOME` forms), empty legacy dir moving, unreadable legacy dir treated as empty, add-on path unchanged, and `SUPERVISOR_TOKEN` without `/data` not being treated as the add-on.

## Checklist
- [x] I have updated documentation if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changes**
  * New installations now use the application data directory’s `backups/` subdirectory by default.
  * Existing installations with backups in the legacy location continue using that location.
  * Add-on installations retain their existing backup location when available.
  * Empty or unavailable legacy locations fall back to the new data-directory location.

* **Documentation**
  * Updated configuration and settings guidance to describe current backup-directory resolution rules and show the active backup location.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->