### PR TITLE
fix(ci): regenerate vendored websockets in Renovate updates

### DIFF
--- a/.github/workflows/renovate-validation.yml
+++ b/.github/workflows/renovate-validation.yml
@@ -70,10 +70,12 @@ jobs:
         env:
           ENGINE: ${{ steps.validate.outputs.engine }}
         # No GitHub credentials. The fixture updates a disposable local repo.
+        # Keep the image entrypoint: it loads the containerbase environment and
+        # initializes tools before Node exercises the dynamic-install executor.
         run: |
           docker run --rm -v "$PWD:/source:ro" \
             -e RENOVATE_TEST_ROOT=/usr/local/renovate \
-            --entrypoint node "ghcr.io/renovatebot/renovate:$ENGINE" \
+            "ghcr.io/renovatebot/renovate:$ENGINE" node \
             /source/tests/renovate/vendoring.mjs
       - name: Verify promoted Supervisor lookup produces an update
         if: ${{ !cancelled() && steps.validate.outcome == 'success' }}

--- a/.github/workflows/renovate-validation.yml
+++ b/.github/workflows/renovate-validation.yml
@@ -7,6 +7,8 @@ on:
       - .github/workflows/renovate*.yml
       - tests/haos_image_build/**
       - tests/src/unit/test_renovate_configuration.py
+      - tests/src/unit/test_renovate_vendoring.py
+      - scripts/vendor_websockets.py
       - tests/renovate/**
   workflow_dispatch:
 
@@ -17,7 +19,7 @@ jobs:
   validate:
     name: Validate Renovate configuration
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
@@ -64,6 +66,15 @@ jobs:
               node /source/tests/renovate/policy.mjs
               node /source/tests/renovate/dashboard-events.mjs
             '
+      - name: Verify vendored updates with the scanner's executor
+        env:
+          ENGINE: ${{ steps.validate.outputs.engine }}
+        # No GitHub credentials. The fixture updates a disposable local repo.
+        run: |
+          docker run --rm -v "$PWD:/source:ro" \
+            -e RENOVATE_TEST_ROOT=/usr/local/renovate \
+            --entrypoint node "ghcr.io/renovatebot/renovate:$ENGINE" \
+            /source/tests/renovate/vendoring.mjs
       - name: Verify promoted Supervisor lookup produces an update
         if: ${{ !cancelled() && steps.validate.outcome == 'success' }}
         # Local-platform lookup has no GitHub writer. Work on a disposable copy

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -85,3 +85,6 @@ jobs:
         env:
           LOG_LEVEL: ${{ inputs.logLevel || 'info' }}
           RENOVATE_REPOSITORIES: ${{ github.repository }}
+          # Only this isolated generator may run; it cannot invoke a shell.
+          RENOVATE_ALLOWED_COMMANDS: '["^python3 -I scripts/vendor_websockets\\.py$"]'
+          RENOVATE_ALLOW_SHELL_EXECUTOR_FOR_POST_UPGRADE_COMMANDS: "false"

--- a/docs/agents/github-workflow.md
+++ b/docs/agents/github-workflow.md
@@ -223,6 +223,15 @@ The action must discover `renovate.json` as repository configuration only.
 Passing the same file as action-global `configurationFile` as well duplicates
 custom managers and dependency-dashboard entries.
 
+The private websockets pin has a narrowly scoped post-upgrade task. Renovate
+installs Python 3.13, runs `python3 -I scripts/vendor_websockets.py`, and includes
+only `src/ha_mcp/_vendor/websockets/**` as generated artifacts alongside the pin.
+The scanner allows only that exact command, with shell execution disabled.
+This dependency retains the ordinary schedule and release-age policy. Source,
+license, manifest, drift, and API checks still gate the update; a failed
+generator is an artifact error, not an accepted pin-only update.
+The credential-free vendoring fixture exercises the pinned Renovate executor.
+
 ## Releases
 
 Conventional commit effects:

--- a/renovate.json
+++ b/renovate.json
@@ -56,7 +56,7 @@
       "datasourceTemplate": "{{{datasource}}}"
     },
     {
-      "description": "Vendored library pins. src/ha_mcp/_vendor/ holds third-party code copied verbatim from the pinned sdist, so no package manager sees it: enabledManagers excludes pip_requirements and dependabot's uv ecosystem reads only pyproject.toml/uv.lock. Without this manager a CVE fix would never open a PR. A bump alone does not regenerate the tree \u2014 tests/src/unit/test_vendored_websockets.py fails the renovate PR until scripts/vendor_websockets.py is re-run and the result committed, which is the intended handoff.",
+      "description": "Vendored library pins have no stock package manager. The websockets package rule regenerates its private tree with scripts/vendor_websockets.py before committing; drift, manifest, and API tests remain merge gates.",
       "customType": "regex",
       "managerFilePatterns": [
         "/^src/ha_mcp/_vendor/requirements\\.txt$/"
@@ -101,6 +101,36 @@
     }
   },
   "packageRules": [
+    {
+      "description": "Regenerate the private websockets tree in the same update as its pin.",
+      "matchManagers": [
+        "custom.regex"
+      ],
+      "matchDatasources": [
+        "pypi"
+      ],
+      "matchPackageNames": [
+        "websockets"
+      ],
+      "matchFileNames": [
+        "src/ha_mcp/_vendor/requirements.txt"
+      ],
+      "constraints": {
+        "python": ">=3.13,<3.14"
+      },
+      "postUpgradeTasks": {
+        "commands": [
+          "python3 -I scripts/vendor_websockets.py"
+        ],
+        "fileFilters": [
+          "src/ha_mcp/_vendor/websockets/**"
+        ],
+        "executionMode": "update",
+        "installTools": {
+          "python": {}
+        }
+      }
+    },
     {
       "description": "The setup-uv version pin (github-releases) and the uv container image (docker) must move together: pr.yml's Fast Checks lane and unit-tests job assume the same uv version",
       "matchDepNames": [

--- a/scripts/vendor_websockets.py
+++ b/scripts/vendor_websockets.py
@@ -12,8 +12,9 @@ version production runs.
 
 The pin lives in ``src/ha_mcp/_vendor/requirements.txt`` (a standard
 requirements file so renovate bumps it and dependency scanners read it).
-This script downloads that version's sdist and refreshes the vendored
-tree; ``tests/src/unit/test_vendored_websockets.py`` fails whenever the
+Renovate runs this script before committing a websockets pin update.
+It downloads that version's sdist and refreshes the vendored tree;
+``tests/src/unit/test_vendored_websockets.py`` fails whenever the
 vendored copy drifts from the pin, so a renovate bump that forgets to
 regenerate cannot merge.
 

--- a/src/ha_mcp/_vendor/requirements.txt
+++ b/src/ha_mcp/_vendor/requirements.txt
@@ -1,8 +1,8 @@
 # Vendored-library pins, bumped by the renovate custom manager that matches
 # this exact path (see renovate.json — no stock manager sees this file).
 #
-# A bump lands here FIRST and the tree stays stale, so the drift test in
-# tests/src/unit/test_vendored_websockets.py fails that PR on purpose:
-# run `python scripts/vendor_websockets.py` and commit the regenerated tree
-# to make it green. That red CI is the handoff, not a mistake.
+# Renovate runs scripts/vendor_websockets.py before committing a websockets
+# bump, including the source, license, and manifest in the same update.
+# tests/src/unit/test_vendored_websockets.py still rejects stale or altered trees.
+# For a manual pin change, run the same generator and commit its outputs.
 websockets==17.0.1

--- a/tests/renovate/vendoring.mjs
+++ b/tests/renovate/vendoring.mjs
@@ -13,11 +13,14 @@ import { pathToFileURL } from 'node:url';
 const engine = process.env.RENOVATE_TEST_ROOT;
 assert.ok(engine, 'RENOVATE_TEST_ROOT must name the installed Renovate package');
 const load = (path) => import(pathToFileURL(join(engine, 'dist', path)).href);
+const { init: initLogger } = await load('logger/index.js');
+await initLogger();
 const { getConfig } = await load('config/defaults.js');
 const { GlobalConfig } = await load('config/global.js');
 const { applyPackageRules } = await load('util/package-rules/index.js');
 const { initRepo, syncGit } = await load('util/git/index.js');
 const { isDynamicInstall } = await load('util/exec/containerbase.js');
+const { api: pythonVersioning } = await load('modules/versioning/python/index.js');
 const { default: executePostUpgradeCommands } = await load(
   'workers/repository/update/branch/execute-post-upgrade-commands.js'
 );
@@ -46,6 +49,16 @@ for (const other of [
 }
 assert.equal(matched.minimumReleaseAge, '7 days');
 assert.deepEqual(matched.schedule, ['after 3pm on tuesday']);
+
+// Resolving a Python range uses GitHub GraphQL, which requires authentication.
+// Keep this fixture credential-free: install a published, compatible exact
+// version through the real executor. The live scanner retains its range and
+// authenticated lookup; this fixture does not test that external lookup.
+const fixturePython = '3.13.7';
+assert.ok(pythonVersioning.matches(fixturePython, matched.constraints.python));
+const fixtureUpgrade = {
+  ...matched, constraints: { ...matched.constraints, python: fixturePython },
+};
 
 const scratch = mkdtempSync(join(tmpdir(), 'renovate-vendoring-'));
 const seed = join(scratch, 'seed');
@@ -78,7 +91,7 @@ writeFileSync(join(localDir, 'unrelated.txt'), 'Never include this in the bot co
 
 const branch = (contents) => ({
   ...matched, branchName: 'renovate/websockets-17.x', baseBranch: 'master',
-  upgrades: [{ ...matched, currentValue: '17.0.1', newValue: '17.1' }],
+  upgrades: [{ ...fixtureUpgrade, currentValue: '17.0.1', newValue: '17.1' }],
   updatedPackageFiles: [{ type: 'addition', path: pinFile, contents }],
   updatedArtifacts: [], artifactErrors: [],
 });

--- a/tests/renovate/vendoring.mjs
+++ b/tests/renovate/vendoring.mjs
@@ -1,0 +1,115 @@
+// Exercise the scanner's real post-upgrade executor, including tool installation
+// and artifact collection. Everything writable is a disposable local Git repo;
+// no GitHub token, platform API, or remote PR writer is used.
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { copyFileSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const engine = process.env.RENOVATE_TEST_ROOT;
+assert.ok(engine, 'RENOVATE_TEST_ROOT must name the installed Renovate package');
+const load = (path) => import(pathToFileURL(join(engine, 'dist', path)).href);
+const { getConfig } = await load('config/defaults.js');
+const { GlobalConfig } = await load('config/global.js');
+const { applyPackageRules } = await load('util/package-rules/index.js');
+const { initRepo, syncGit } = await load('util/git/index.js');
+const { isDynamicInstall } = await load('util/exec/containerbase.js');
+const { default: executePostUpgradeCommands } = await load(
+  'workers/repository/update/branch/execute-post-upgrade-commands.js'
+);
+const { parse } = createRequire(join(engine, 'package.json'))('yaml');
+const repository = JSON.parse(readFileSync('/source/renovate.json', 'utf8'));
+const workflow = parse(readFileSync('/source/.github/workflows/renovate.yml', 'utf8'));
+const scannerEnv = workflow.jobs.renovate.steps.find(
+  (step) => step.name === 'Self-hosted Renovate'
+).env;
+const pinFile = 'src/ha_mcp/_vendor/requirements.txt';
+const vendorDir = 'src/ha_mcp/_vendor/websockets';
+const dependency = {
+  depName: 'websockets', packageName: 'websockets', datasource: 'pypi',
+  manager: 'custom.regex', packageFile: pinFile,
+};
+const matched = await applyPackageRules({ ...getConfig(), ...repository, ...dependency });
+assert.ok(matched.postUpgradeTasks.commands.length, 'Vendored updates must regenerate source');
+for (const other of [
+  { ...dependency, packageFile: 'other/requirements.txt' },
+  { ...dependency, depName: 'other', packageName: 'other' },
+  { ...dependency, datasource: 'docker' },
+  { ...dependency, manager: 'pip_requirements' },
+]) {
+  const config = await applyPackageRules({ ...getConfig(), ...repository, ...other });
+  assert.equal(config.postUpgradeTasks.commands.length, 0, 'Unrelated pins must not run vendoring');
+}
+assert.equal(matched.minimumReleaseAge, '7 days');
+assert.deepEqual(matched.schedule, ['after 3pm on tuesday']);
+
+const scratch = mkdtempSync(join(tmpdir(), 'renovate-vendoring-'));
+const seed = join(scratch, 'seed');
+const localDir = join(scratch, 'checkout');
+mkdirSync(join(seed, vendorDir), { recursive: true });
+mkdirSync(join(seed, 'scripts'));
+mkdirSync(localDir);
+copyFileSync('/source/scripts/vendor_websockets.py', join(seed, 'scripts/vendor_websockets.py'));
+writeFileSync(join(seed, pinFile), 'websockets==17.0.1\n');
+writeFileSync(join(seed, vendorDir, 'obsolete.py'), '# Must disappear when the tree is replaced.\n');
+writeFileSync(join(seed, vendorDir, 'VENDORED'), 'websockets==17.0.1\n');
+const git = (cwd, ...args) => execFileSync('git', ['-C', cwd, ...args], { encoding: 'utf8' });
+git(seed, 'init', '-b', 'master');
+git(seed, 'add', '.');
+git(seed, '-c', 'user.name=Fixture', '-c', 'user.email=fixture@example.invalid', 'commit', '-m', 'fixture');
+
+const allowedCommands = JSON.parse(scannerEnv.RENOVATE_ALLOWED_COMMANDS);
+GlobalConfig.set({
+  ...getConfig(), localDir, baseDir: scratch, cacheDir: join(scratch, 'cache'),
+  containerbaseDir: join(scratch, 'containerbase'), binarySource: 'install',
+  allowedCommands,
+  allowShellExecutorForPostUpgradeCommands:
+    scannerEnv.RENOVATE_ALLOW_SHELL_EXECUTOR_FOR_POST_UPGRADE_COMMANDS === 'true',
+});
+assert.ok(isDynamicInstall([{ toolName: 'python', constraint: matched.constraints.python }]),
+  'This fixture must exercise containerbase tool installation, not a preinstalled Python');
+await initRepo({ url: seed, defaultBranch: 'master', currentBranch: 'master', fullClone: true });
+await syncGit(); // Clone only the local seed before writing the changed pin.
+writeFileSync(join(localDir, 'unrelated.txt'), 'Never include this in the bot commit.\n');
+
+const branch = (contents) => ({
+  ...matched, branchName: 'renovate/websockets-17.x', baseBranch: 'master',
+  upgrades: [{ ...matched, currentValue: '17.0.1', newValue: '17.1' }],
+  updatedPackageFiles: [{ type: 'addition', path: pinFile, contents }],
+  updatedArtifacts: [], artifactErrors: [],
+});
+
+// A missing allowlist must report an artifact error and leave the tree stale.
+GlobalConfig.set({ ...GlobalConfig.get(), allowedCommands: [] });
+const denied = await executePostUpgradeCommands(branch('websockets==17.1\n'));
+assert.ok(denied.artifactErrors.length);
+assert.equal(readFileSync(join(localDir, vendorDir, 'VENDORED'), 'utf8'), 'websockets==17.0.1\n');
+GlobalConfig.set({ ...GlobalConfig.get(), allowedCommands });
+
+const result = await executePostUpgradeCommands(branch('websockets==17.1\n'));
+assert.deepEqual(result.artifactErrors, [], 'Tool installation and regeneration must succeed');
+const artifacts = new Map(result.updatedArtifacts.map((file) => [file.path, file]));
+for (const name of ['VENDORED', 'LICENSE', 'MANIFEST.sha256', '__init__.py', 'version.py', 'asyncio/client.py']) {
+  const artifact = artifacts.get(`${vendorDir}/${name}`);
+  assert.equal(artifact?.type, 'addition', `${name} must be committed`);
+  assert.equal(String(artifact.contents), readFileSync(join(localDir, vendorDir, name), 'utf8'));
+}
+assert.equal(artifacts.get(`${vendorDir}/obsolete.py`)?.type, 'deletion');
+assert.ok([...artifacts.keys()].every((path) => path.startsWith(`${vendorDir}/`)),
+  'Only vendored outputs belong in the generated artifacts');
+assert.match(readFileSync(join(localDir, vendorDir, 'version.py'), 'utf8'), /tag = version = commit = ["']17\.1["']/);
+assert.match(readFileSync(join(localDir, vendorDir, 'VENDORED'), 'utf8'), /^websockets==17\.1\n/);
+const manifest = readFileSync(join(localDir, vendorDir, 'MANIFEST.sha256'), 'utf8').trim().split('\n');
+for (const line of manifest) {
+  const [digest, path] = line.split('  ');
+  assert.equal(createHash('sha256').update(readFileSync(join(localDir, vendorDir, path))).digest('hex'), digest);
+}
+// A failed regeneration must stay visible, not silently accept a pin-only bump.
+const failed = await executePostUpgradeCommands(branch('not-a-valid-pin\n'));
+assert.ok(failed.artifactErrors.length, 'A failed generator must report an artifact error');
+assert.match(readFileSync(join(localDir, vendorDir, 'VENDORED'), 'utf8'), /^websockets==17\.1\n/);
+console.log('Pinned Renovate executor regenerated websockets source, license and manifest; collected additions/deletions; rejected unauthorized commands and surfaced generator failures.');

--- a/tests/src/unit/test_renovate_vendoring.py
+++ b/tests/src/unit/test_renovate_vendoring.py
@@ -1,0 +1,64 @@
+"""Guard the executable boundary for automated vendored-library updates."""
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+_ROOT = Path(__file__).resolve().parents[3]
+_COMMAND = "python3 -I scripts/vendor_websockets.py"
+
+
+def _configuration() -> tuple[dict, dict]:
+    config = json.loads((_ROOT / "renovate.json").read_text())
+    workflow = yaml.safe_load((_ROOT / ".github/workflows/renovate.yml").read_text())
+    action = next(
+        step
+        for step in workflow["jobs"]["renovate"]["steps"]
+        if step.get("name") == "Self-hosted Renovate"
+    )
+    return config, action["env"]
+
+
+def test_vendoring_hook_is_scoped_to_the_private_websockets_pin() -> None:
+    config, _ = _configuration()
+    rules = [rule for rule in config["packageRules"] if "postUpgradeTasks" in rule]
+    assert len(rules) == 1, "the vendored pin needs one regeneration hook"
+    rule = rules[0]
+    assert rule["matchManagers"] == ["custom.regex"]
+    assert rule["matchDatasources"] == ["pypi"]
+    assert rule["matchPackageNames"] == ["websockets"]
+    assert rule["matchFileNames"] == ["src/ha_mcp/_vendor/requirements.txt"]
+    assert rule["postUpgradeTasks"]["commands"] == [_COMMAND]
+    assert rule["postUpgradeTasks"]["fileFilters"] == [
+        "src/ha_mcp/_vendor/websockets/**"
+    ]
+    assert rule["postUpgradeTasks"]["installTools"] == {"python": {}}
+    assert rule["constraints"]["python"] == ">=3.13,<3.14"
+    # Update mode retains the matched upgrade's Python constraint in 44.50.1.
+    assert rule["postUpgradeTasks"]["executionMode"] == "update"
+    assert "minimumReleaseAge" not in rule
+    assert "schedule" not in rule
+
+
+@pytest.mark.parametrize(
+    ("command", "allowed"),
+    [
+        (_COMMAND, True),
+        (_COMMAND + " --extra", False),
+        (_COMMAND + "; echo unsafe", False),
+        ("echo unsafe && " + _COMMAND, False),
+        ("python3 -I scripts/vendor_websocketsXpy", False),
+        ("python3 scripts/vendor_websockets.py", False),
+        ("python3 -I scripts/another_script.py", False),
+    ],
+)
+def test_only_the_exact_vendoring_command_is_authorized(
+    command: str, allowed: bool
+) -> None:
+    _, env = _configuration()
+    patterns = json.loads(env.get("RENOVATE_ALLOWED_COMMANDS", "[]"))
+    assert any(re.search(pattern, command) for pattern in patterns) is allowed
+    assert env.get("RENOVATE_ALLOW_SHELL_EXECUTOR_FOR_POST_UPGRADE_COMMANDS") == "false"

--- a/tests/src/unit/test_supply_chain_workflow_shape.py
+++ b/tests/src/unit/test_supply_chain_workflow_shape.py
@@ -290,13 +290,11 @@ def test_python_runtime_automation_is_digest_only() -> None:
         "a pre-lookup enabled=false rule cannot be overridden later for digest updates"
     )
     assert "asdf" not in config.get("enabledManagers", [])
-    assert not any(
-        "asdf" in rule.get("matchManagers", []) or "postUpgradeTasks" in rule
-        for rule in package_rules
-    ), (
+    assert not any("asdf" in rule.get("matchManagers", []) for rule in package_rules), (
         "Python minor-version changes span independent runtime contracts and must "
         "not be rewritten by the old dead asdf task"
     )
+    assert not any("postUpgradeTasks" in rule for rule in python_rules)
 
 
 def test_dev_release_tag_cleanup_uses_authenticated_github_api() -> None:


### PR DESCRIPTION
## What does this PR do?

Automates the manual handoff exposed by #2384: Renovate currently updates the private websockets pin without regenerating its checked-in source.

- Run the existing vendoring script as a post-upgrade task only for `websockets` in `src/ha_mcp/_vendor/requirements.txt`.
- Install Python 3.13 through Renovate, allow only the exact isolated command with shell execution disabled, and collect only the vendored source, license, and manifest.
- Preserve the seven-day/Tuesday policy, immediate Home Assistant exceptions, and existing drift/API checks. No dependency versions are bumped here.
- Add a credential-free fixture using the scanner's pinned Renovate executor to verify generated additions/deletions, manifest contents, command denial, and generator failure reporting.

After this merges, reprocess #2384 through Renovate to verify the live bot produces the complete update; this PR does not manually regenerate that dependency branch.

The implementation follows [Renovate's post-upgrade task contract](https://docs.renovatebot.com/configuration-options/#postupgradetasks) and its [44.50.1 executor implementation](https://github.com/renovatebot/renovate/blob/44.50.1/lib/workers/repository/update/branch/execute-post-upgrade-commands.ts).

## Type of change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing

- [ ] I have tested these changes with a LLM agent
- [ ] All automated tests pass (`uv run pytest`)
- [ ] Code follows style guidelines (`uv run ruff check`)

Focused regression coverage checks hook scope, command authorization, release-policy preservation, generator behavior, and workflow invariants. The Renovate configuration lane exercises the real container executor.

## Checklist

- [x] I have updated documentation if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Dependency Management**
  * Websockets dependency updates now automatically refresh bundled library files in the same change.
  * Updates include source, license, manifest, version, and integrity information.

* **Security & Reliability**
  * Dependency automation is restricted to the approved vendoring action, with shell execution disabled.
  * Validation checks successful regeneration, authorization, integrity, and protection against incomplete updates.
  * Vendoring workflows now run with improved environment initialization and timeout handling.

* **Documentation**
  * Updated dependency-scan guidance to describe the current vendoring and validation workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->