### PR TITLE
ci: enable Renovate PR checkbox scans and protected auto-merge

### DIFF
--- a/.github/workflows/renovate-auto-merge.yml
+++ b/.github/workflows/renovate-auto-merge.yml
@@ -1,0 +1,64 @@
+name: Renovate auto-merge approval
+
+# Renovate's own token enables native auto-merge according to renovate.json.
+# A separate maintainer account supplies the required, exact-head approval.
+on:
+  pull_request_target:
+    types: [auto_merge_enabled, synchronize]
+    branches: [master]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: renovate-approval-${{ github.repository }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  approve:
+    if: >-
+      github.actor == 'ha-mcp-renovate[bot]' &&
+      github.event.pull_request.user.login == 'ha-mcp-renovate[bot]' &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.event.pull_request.base.ref == 'master' &&
+      github.event.pull_request.state == 'open' &&
+      startsWith(github.event.pull_request.head.ref, 'renovate/')
+    runs-on: ubuntu-latest
+    steps:
+      # No checkout and no PR-controlled code. Read current API state again to
+      # reject obsolete events and human-enabled auto-merge before approving.
+      - name: Approve Renovate-enabled auto-merge at the current head
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        with:
+          # Existing ghhamcp maintainer account's Actions token. The separate
+          # DEPENDABOT_APPROVAL_TOKEN secret remains scoped to Dependabot.
+          github-token: ${{ secrets.GH_TOKEN_CODEX_COMMENT }}
+          script: |
+            const bot = 'ha-mcp-renovate[bot]';
+            const { owner, repo } = context.repo;
+            const pull_number = context.payload.pull_request.number;
+            const { data: pr } = await github.rest.pulls.get({ owner, repo, pull_number });
+            if (pr.state !== 'open' || pr.draft || pr.user.login !== bot ||
+                pr.head.repo?.full_name !== `${owner}/${repo}` ||
+                !pr.head.ref.startsWith('renovate/') || pr.base.ref !== 'master' ||
+                pr.head.sha !== context.payload.pull_request.head.sha ||
+                pr.auto_merge?.enabled_by?.login !== bot ||
+                pr.auto_merge?.merge_method !== 'squash') {
+              core.info('Skipping: stale event or no eligible Renovate-enabled auto-merge.');
+              return;
+            }
+            const { data: account } = await github.rest.users.getAuthenticated();
+            if (account.login !== 'ghhamcp') {
+              throw new Error('Renovate approval requires the ghhamcp maintainer token.');
+            }
+            const reviews = await github.paginate(github.rest.pulls.listReviews,
+              { owner, repo, pull_number, per_page: 100 });
+            if (reviews.some(review => review.user?.login === account.login &&
+                review.commit_id === pr.head.sha && review.state === 'APPROVED')) {
+              core.info('Current head already has the automated approval.');
+              return;
+            }
+            await github.rest.pulls.createReview({
+              owner, repo, pull_number, event: 'APPROVE', commit_id: pr.head.sha,
+              body: 'Automated approval: Renovate enabled auto-merge for this update; required checks remain authoritative.',
+            });

--- a/.github/workflows/renovate-validation.yml
+++ b/.github/workflows/renovate-validation.yml
@@ -43,7 +43,7 @@ jobs:
         with:
           node-version: "24"
           package-manager-cache: false
-      - name: Exercise release policy and dashboard event decisions
+      - name: Exercise release policy and dashboard/PR event decisions
         env:
           ENGINE: ${{ steps.validate.outputs.engine }}
         run: |

--- a/.github/workflows/renovate-validation.yml
+++ b/.github/workflows/renovate-validation.yml
@@ -8,6 +8,7 @@ on:
       - tests/haos_image_build/**
       - tests/src/unit/test_renovate_configuration.py
       - tests/src/unit/test_renovate_vendoring.py
+      - tests/src/unit/test_renovate_auto_merge.py
       - scripts/vendor_websockets.py
       - tests/renovate/**
   workflow_dispatch:
@@ -65,6 +66,7 @@ jobs:
               export RENOVATE_TEST_ROOT
               node /source/tests/renovate/policy.mjs
               node /source/tests/renovate/dashboard-events.mjs
+              node /source/tests/renovate/auto-merge.mjs
             '
       - name: Verify vendored updates with the scanner's executor
         env:

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -7,6 +7,9 @@ on:
     - cron: '17 * * * *'
   issues:
     types: [edited]
+  pull_request_target:
+    types: [edited]
+    branches: [master]
   workflow_dispatch:
     inputs:
       logLevel:
@@ -26,17 +29,30 @@ permissions:
 jobs:
   renovate:
     name: Renovate
-    # Checked boxes explicitly override schedule/age gates. Process human
-    # requests promptly without looping on Renovate's own dashboard edits.
+    # Let Renovate handle native checkbox overrides on its next scan. Wake it
+    # for human requests, not bot edits, unrelated PRs, or an already checked box.
     if: >-
-      github.event_name != 'issues' ||
-      (github.event.issue.title == 'Dependency Dashboard' &&
+      github.event_name == 'schedule' ||
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'issues' &&
+       github.event.issue.title == 'Dependency Dashboard' &&
        github.event.issue.user.login == 'ha-mcp-renovate[bot]' &&
        github.event.sender.type != 'Bot' &&
        github.event.changes.body &&
-       contains(github.event.issue.body, '[x]'))
+       contains(github.event.issue.body, '[x]')) ||
+      (github.event_name == 'pull_request_target' &&
+       github.event.action == 'edited' &&
+       github.event.pull_request.state == 'open' &&
+       github.event.pull_request.user.login == 'ha-mcp-renovate[bot]' &&
+       github.event.pull_request.head.repo.full_name == github.repository &&
+       startsWith(github.event.pull_request.head.ref, 'renovate/') &&
+       github.event.pull_request.base.ref == 'master' &&
+       github.event.sender.type == 'User' &&
+       github.event.changes.body &&
+       contains(github.event.pull_request.body, '[x] <!-- rebase-check -->') &&
+       !contains(github.event.changes.body.from, '[x] <!-- rebase-check -->'))
     # Serialize writers without interrupting a run partway through PR creation.
-    # Job-level concurrency keeps unrelated issue edits out of this queue.
+    # Job-level concurrency keeps unrelated issue/PR edits out of this queue.
     concurrency:
       group: renovate-${{ github.repository }}
       cancel-in-progress: false
@@ -44,6 +60,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          # pull_request_target must never check out the PR head/merge commit.
+          # Only trusted default-branch code may run with the app credentials.
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
 
       # The default GITHUB_TOKEN cannot push commits that modify any file
       # under .github/workflows/ — GitHub blocks workflow-file mutations

--- a/docs/agents/github-workflow.md
+++ b/docs/agents/github-workflow.md
@@ -172,6 +172,7 @@ summary only when the pull request actually reaches that state.
 | `pr.yml` | Pull request | Fast checks and validation orchestration. |
 | `renovate.yml` | Hourly, human dashboard/PR checkbox edit, or manual | Refresh dependency discovery and process eligible updates. |
 | `renovate-validation.yml` | Relevant pull request or manual | Validate configuration with the scanner’s pinned Renovate engine, without credentials. |
+| `renovate-auto-merge.yml` | Renovate enables auto-merge or updates its PR | Approve the verified current head with the separate maintainer account; GitHub enforces merge requirements. |
 | `e2e-tests.yml` | Push to `master` touching code, or manual | Full container-backend E2E validation on the pinned stable Core image. |
 | `haos-e2e-tests.yml` | Pull request or manual | Six HAOS lanes against a baked qcow2; required status checks. |
 | `haos-e2e-beta-tests.yml` | Push to `master`, nightly, or manual | The inaddon and embedded HAOS lanes against the current beta OS, Supervisor, and Core; skipped on push and nightly only when all three equal stable. |
@@ -239,6 +240,25 @@ This dependency retains the ordinary schedule and release-age policy. Source,
 license, manifest, drift, and API checks still gate the update; a failed
 generator is an artifact error, not an accepted pin-only update.
 The credential-free vendoring fixture exercises the pinned Renovate executor.
+
+Renovate enables GitHub-native squash auto-merge for minor, patch, and digest
+updates, and for its ungrouped vulnerability-alert fixes. Ordinary major
+upgrades remain manual. This does not bypass creation schedules or release-age
+gates. Once eligible PRs exist, GitHub merges only when the repository's required
+checks and reviews are satisfied, including required E2E checks.
+
+The approval workflow mirrors Dependabot's separate-account, exact-head
+approval boundary: Renovate's app token enables auto-merge, and the existing
+`ghhamcp` maintainers-team account approves with the Actions secret
+`GH_TOKEN_CODEX_COMMENT`. That token must grant pull-request write access;
+`DEPENDABOT_APPROVAL_TOKEN` remains in Dependabot's separate secret store.
+The workflow executes no checkout or PR code, re-reads the PR, verifies that
+Renovate enabled squash auto-merge and the event head is still current, checks
+the approval token's identity, and skips an existing approval on that head.
+Renovate pushes trigger fresh approval after stale reviews are dismissed.
+Human-enabled auto-merge and human pushes do not issue new automated approvals.
+Toggling auto-merge does not revoke an existing approval of unchanged content.
+No workflow grants a bypass or performs an admin merge.
 
 ## Releases
 

--- a/docs/agents/github-workflow.md
+++ b/docs/agents/github-workflow.md
@@ -170,7 +170,7 @@ summary only when the pull request actually reaches that state.
 | Workflow | Trigger | Purpose |
 |---|---|---|
 | `pr.yml` | Pull request | Fast checks and validation orchestration. |
-| `renovate.yml` | Hourly, human dashboard checkbox edit, or manual | Refresh dependency discovery and process eligible updates. |
+| `renovate.yml` | Hourly, human dashboard/PR checkbox edit, or manual | Refresh dependency discovery and process eligible updates. |
 | `renovate-validation.yml` | Relevant pull request or manual | Validate configuration with the scanner’s pinned Renovate engine, without credentials. |
 | `e2e-tests.yml` | Push to `master` touching code, or manual | Full container-backend E2E validation on the pinned stable Core image. |
 | `haos-e2e-tests.yml` | Pull request or manual | Six HAOS lanes against a baked qcow2; required status checks. |
@@ -214,10 +214,18 @@ stable OS releases. Changes to these builder inputs invalidate the stable
 HAOS image cache. Supervisor still self-updates within its configured channel.
 
 Human checked requests on the Renovate-authored dependency dashboard trigger a
-scan promptly; Renovate's own edits and unrelated issues do not. Native
-dashboard approvals/rebase requests retain their override semantics. Manual
-workflow dispatch starts a scan without globally disabling ordinary policy.
-Runs serialize without cancelling an active writer.
+scan promptly. Checking the native rebase/retry box on an open, same-repository
+Renovate PR targeting master also starts a scan via `pull_request_target: edited`.
+The PR guard requires a human body edit that changes the rebase box from not
+checked to checked; bot edits, unrelated PRs, and edits leaving it checked do not
+start the scanner. Checkout uses trusted default-branch code, never PR code.
+Renovate itself consumes the checkbox and applies its native override semantics;
+the workflow does not rebase branches or force dependency policy globally.
+Manual workflow dispatch likewise starts an ordinary scan. Runs serialize
+without cancelling an active writer. GitHub's scheduled events are best-effort
+and may be delayed or dropped; checkbox events avoid waiting for the hourly scan.
+See [GitHub's event documentation](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows)
+and [Renovate's native rebase documentation](https://docs.renovatebot.com/updating-rebasing/#manual-rebasing).
 
 The action must discover `renovate.json` as repository configuration only.
 Passing the same file as action-global `configurationFile` as well duplicates

--- a/renovate.json
+++ b/renovate.json
@@ -8,6 +8,9 @@
     "after 3pm on tuesday"
   ],
   "updateNotScheduled": false,
+  "automergeType": "pr",
+  "automergeStrategy": "squash",
+  "platformAutomerge": true,
   "minimumReleaseAge": "7 days",
   "minimumReleaseAgeBehaviour": "timestamp-optional",
   "logLevelRemap": [
@@ -29,7 +32,9 @@
     }
   ],
   "vulnerabilityAlerts": {
-    "minimumReleaseAge": null
+    "minimumReleaseAge": null,
+    "groupName": null,
+    "automerge": true
   },
   "enabledManagers": [
     "custom.regex",
@@ -101,6 +106,11 @@
     }
   },
   "packageRules": [
+    {
+      "description": "Approve non-major updates through GitHub auto-merge after all required checks.",
+      "matchUpdateTypes": ["minor", "patch", "digest"],
+      "automerge": true
+    },
     {
       "description": "Regenerate the private websockets tree in the same update as its pin.",
       "matchManagers": [

--- a/tests/renovate/auto-merge.mjs
+++ b/tests/renovate/auto-merge.mjs
@@ -1,0 +1,110 @@
+// Exercise the actual approval guard and github-script body without credentials.
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const engineRequire = createRequire(join(process.env.RENOVATE_TEST_ROOT, 'package.json'));
+const { parse } = engineRequire('yaml');
+const { Lexer, Parser, Evaluator, data } = await import(pathToFileURL(
+  '/tmp/expression-tests/node_modules/@actions/expressions/dist/index.js'
+).href);
+const { truthy } = await import(pathToFileURL(
+  '/tmp/expression-tests/node_modules/@actions/expressions/dist/result.js'
+).href);
+const workflow = parse(readFileSync('/source/.github/workflows/renovate-auto-merge.yml', 'utf8'));
+const job = workflow.jobs.approve;
+const expression = new Parser(new Lexer(job.if).lex().tokens, ['github'], []).parse();
+const bot = 'ha-mcp-renovate[bot]';
+const pr = {
+  number: 123, state: 'open', draft: false, user: { login: bot },
+  head: { ref: 'renovate/websockets-17.x', sha: 'a'.repeat(40), repo: { full_name: 'homeassistant-ai/ha-mcp' } },
+  base: { ref: 'master' },
+  auto_merge: { enabled_by: { login: bot }, merge_method: 'squash' },
+};
+const eventContext = {
+  actor: bot, repository: 'homeassistant-ai/ha-mcp', event: { pull_request: pr },
+};
+const guardCases = [
+  ['Renovate event', () => {}, true],
+  ['human push', (g) => { g.actor = 'maintainer'; }, false],
+  ['other bot', (g) => { g.actor = 'dependabot[bot]'; }, false],
+  ['wrong author', (g) => { g.event.pull_request.user.login = 'maintainer'; }, false],
+  ['fork', (g) => { g.event.pull_request.head.repo.full_name = 'fork/ha-mcp'; }, false],
+  ['deleted repo', (g) => { g.event.pull_request.head.repo = null; }, false],
+  ['wrong base', (g) => { g.event.pull_request.base.ref = 'stable'; }, false],
+  ['closed', (g) => { g.event.pull_request.state = 'closed'; }, false],
+  ['wrong branch', (g) => { g.event.pull_request.head.ref = 'feature/example'; }, false],
+];
+for (const [name, mutate, expected] of guardCases) {
+  const github = structuredClone(eventContext);
+  mutate(github);
+  const context = JSON.parse(JSON.stringify({ github }), data.reviver);
+  assert.equal(truthy(new Evaluator(expression, context).evaluate()), expected, name);
+}
+
+// Stub only GitHub's network boundary; execute the workflow's production body.
+const AsyncFunction = Object.getPrototypeOf(async function () {}).constructor;
+const approve = new AsyncFunction('github', 'context', 'core', job.steps[0].with.script);
+const approval = {
+  user: { login: 'ghhamcp' }, commit_id: 'a'.repeat(40), state: 'APPROVED',
+};
+const scriptCases = [
+  ['current eligible head', () => {}, true],
+  ['closed after event', (s) => { s.live.state = 'closed'; }, false],
+  ['draft after event', (s) => { s.live.draft = true; }, false],
+  ['wrong live author', (s) => { s.live.user.login = 'maintainer'; }, false],
+  ['fork after event', (s) => { s.live.head.repo.full_name = 'fork/ha-mcp'; }, false],
+  ['deleted live repo', (s) => { s.live.head.repo = null; }, false],
+  ['changed head', (s) => { s.live.head.sha = 'b'.repeat(40); }, false],
+  ['changed base', (s) => { s.live.base.ref = 'stable'; }, false],
+  ['changed branch', (s) => { s.live.head.ref = 'feature/example'; }, false],
+  ['disabled auto-merge', (s) => { s.live.auto_merge = null; }, false],
+  ['human-enabled auto-merge', (s) => { s.live.auto_merge.enabled_by.login = 'maintainer'; }, false],
+  ['missing auto-merge actor', (s) => { s.live.auto_merge.enabled_by = null; }, false],
+  ['wrong merge strategy', (s) => { s.live.auto_merge.merge_method = 'merge'; }, false],
+  ['already approved', (s) => { s.reviews = [approval]; }, false],
+  ['old approval', (s) => { s.reviews = [{ ...approval, commit_id: 'b'.repeat(40) }]; }, true],
+  ['dismissed approval', (s) => { s.reviews = [{ ...approval, state: 'DISMISSED' }]; }, true],
+  ['other reviewer', (s) => { s.reviews = [{ ...approval, user: { login: 'other' } }]; }, true],
+  ['wrong approval token identity', (s) => { s.account = 'other'; }, false, /ghhamcp maintainer token/],
+  ['API error', (s) => { s.apiError = true; }, false, /API unavailable/],
+];
+for (const [name, mutate, expected, error] of scriptCases) {
+  const state = { live: structuredClone(pr), account: 'ghhamcp', reviews: [], apiError: false };
+  mutate(state);
+  const writes = [];
+  const coordinates = { owner: 'homeassistant-ai', repo: 'ha-mcp', pull_number: 123 };
+  const listReviews = () => { throw new Error('Use paginated reviews'); };
+  const github = {
+    rest: {
+      pulls: {
+        get: async (args) => {
+          assert.deepEqual(args, coordinates);
+          if (state.apiError) throw new Error('API unavailable');
+          return { data: state.live };
+        },
+        listReviews,
+        createReview: async (args) => { writes.push(args); },
+      },
+      users: { getAuthenticated: async () => ({ data: { login: state.account } }) },
+    },
+    paginate: async (method, args) => {
+      assert.equal(method, listReviews);
+      assert.deepEqual(args, { ...coordinates, per_page: 100 });
+      return state.reviews;
+    },
+  };
+  const run = () => approve(github, {
+    repo: { owner: 'homeassistant-ai', repo: 'ha-mcp' },
+    payload: { pull_request: structuredClone(pr) },
+  }, { info: () => {} });
+  if (error) await assert.rejects(run, error, name);
+  else await run();
+  assert.deepEqual(writes, expected ? [{
+    ...coordinates, event: 'APPROVE', commit_id: 'a'.repeat(40),
+    body: 'Automated approval: Renovate enabled auto-merge for this update; required checks remain authoritative.',
+  }] : [], name);
+}
+console.log(`Renovate approval passed ${guardCases.length} event and ${scriptCases.length} live-state cases.`);

--- a/tests/renovate/dashboard-events.mjs
+++ b/tests/renovate/dashboard-events.mjs
@@ -33,12 +33,60 @@ const cases = [
   ['manual dispatch', (g) => { g.event_name = 'workflow_dispatch'; g.event = {}; }, true],
   ['hourly schedule', (g) => { g.event_name = 'schedule'; g.event = {}; }, true],
 ];
-for (const [name, mutate, expected] of cases) {
-  const github = structuredClone(dashboard);
+const pr = {
+  event_name: 'pull_request_target',
+  repository: 'homeassistant-ai/ha-mcp',
+  event: {
+    action: 'edited',
+    pull_request: {
+      state: 'open',
+      user: { login: 'ha-mcp-renovate[bot]' },
+      head: { ref: 'renovate/websockets-17.x', repo: { full_name: 'homeassistant-ai/ha-mcp' } },
+      base: { ref: 'master' },
+      body: '- [x] <!-- rebase-check -->If you want to rebase/retry this PR, check this box',
+    },
+    sender: { type: 'User' },
+    changes: { body: { from: '- [ ] <!-- rebase-check -->If you want to rebase/retry this PR, check this box' } },
+  },
+};
+const prCases = [
+  ['PR checkbox checked', () => {}, true],
+  ['uppercase PR checkbox', (g) => { g.event.pull_request.body = '- [X] <!-- rebase-check -->retry'; }, true],
+  ['bot PR edit', (g) => { g.event.sender.type = 'Bot'; }, false],
+  ['missing sender', (g) => { delete g.event.sender; }, false],
+  ['human-authored PR', (g) => { g.event.pull_request.user.login = 'someone-else'; }, false],
+  ['fork PR', (g) => { g.event.pull_request.head.repo.full_name = 'someone-else/ha-mcp'; }, false],
+  ['deleted head repository', (g) => { g.event.pull_request.head.repo = null; }, false],
+  ['non-Renovate branch', (g) => { g.event.pull_request.head.ref = 'feature/example'; }, false],
+  ['wrong base', (g) => { g.event.pull_request.base.ref = 'stable'; }, false],
+  ['closed PR', (g) => { g.event.pull_request.state = 'closed'; }, false],
+  ['PR title-only edit', (g) => { g.event.changes = { title: { from: 'old' } }; }, false],
+  ['PR uncheck', (g) => {
+    g.event.pull_request.body = '- [ ] <!-- rebase-check -->retry';
+    g.event.changes.body.from = '- [x] <!-- rebase-check -->retry';
+  }, false],
+  ['already checked PR with unrelated body edit', (g) => {
+    g.event.changes.body.from = '- [x] <!-- rebase-check -->retry';
+  }, false],
+  ['already checked uppercase PR', (g) => {
+    g.event.changes.body.from = '- [X] <!-- rebase-check -->retry';
+  }, false],
+  ['unrelated PR checkbox', (g) => { g.event.pull_request.body = '- [x] tests pass'; }, false],
+  ['empty PR body', (g) => { g.event.pull_request.body = null; }, false],
+  ['PR synchronize', (g) => { g.event.action = 'synchronize'; }, false],
+  ['ordinary pull_request event', (g) => { g.event_name = 'pull_request'; }, false],
+];
+// This fixture evaluates the actual workflow expression, not a rewritten guard.
+// Trigger registration and trusted checkout inputs are covered by the unit test.
+for (const [name, mutate, expected, fixture] of [
+  ...cases.map((entry) => [...entry, dashboard]),
+  ...prCases.map((entry) => [...entry, pr]),
+]) {
+  const github = structuredClone(fixture);
   mutate(github);
   const context = JSON.parse(JSON.stringify({ github }), data.reviver);
   // Logical expressions can short-circuit to null; a job guard uses truthiness,
   // not the string representation of the result.
   assert.equal(truthy(new Evaluator(expression, context).evaluate()), expected, name);
 }
-console.log(`GitHub expression evaluator passed ${cases.length} dashboard-event cases.`);
+console.log(`GitHub expression evaluator passed ${cases.length + prCases.length} dashboard/PR-event cases.`);

--- a/tests/renovate/policy.mjs
+++ b/tests/renovate/policy.mjs
@@ -54,7 +54,26 @@ try {
   assert.equal(checkMinimumReleaseAge(ordinary, age(1)).isPending, true,
     'Tuesday must not bypass the seven-day age gate');
   assert.equal(checkMinimumReleaseAge(ordinary, age(8)).isPending, false);
-  console.log('Pinned Renovate engine passed HA/ordinary scheduling, age, and limit fixtures.');
+  for (const updateType of ['minor', 'patch', 'digest', 'major', 'pin', 'pinDigest', 'replacement']) {
+    const config = await applyPackageRules({
+      ...getConfig(), ...repository, depName: 'astral-sh/uv', packageName: 'astral-sh/uv',
+      datasource: 'github-releases', manager: 'custom.regex', updateType,
+    });
+    assert.equal(config.automerge, ['minor', 'patch', 'digest'].includes(updateType),
+      `${updateType}: ordinary automerge eligibility`);
+    assert.equal(config.automergeType, 'pr');
+    assert.equal(config.automergeStrategy, 'squash');
+    assert.equal(config.platformAutomerge, true);
+    assert.equal(checkMinimumReleaseAge(config, age(1)).isPending, true,
+      'Automerge must not bypass ordinary age gates');
+  }
+  // Renovate merges this object into each alert-driven update; keep native
+  // ungrouped security fixes eligible even if the fix requires a major bump.
+  const security = { ...getConfig().vulnerabilityAlerts, ...repository.vulnerabilityAlerts };
+  assert.equal(security.automerge, true);
+  assert.equal(security.groupName, null);
+  assert.equal(security.minimumReleaseAge, null);
+  console.log('Pinned Renovate engine passed HA/ordinary scheduling, age, limit, and automerge fixtures.');
 } finally {
   globalThis.Date = NativeDate;
 }

--- a/tests/src/unit/test_renovate_auto_merge.py
+++ b/tests/src/unit/test_renovate_auto_merge.py
@@ -1,0 +1,25 @@
+"""Guard the credential boundary of Renovate's separate-account approval."""
+
+from pathlib import Path
+
+import yaml
+
+_ROOT = Path(__file__).resolve().parents[3]
+
+
+def test_renovate_approval_never_executes_pr_code() -> None:
+    path = _ROOT / ".github/workflows/renovate-auto-merge.yml"
+    assert path.is_file(), "Renovate needs its own trusted approval event handler"
+    workflow = yaml.safe_load(path.read_text())
+    assert workflow[True] == {
+        "pull_request_target": {
+            "types": ["auto_merge_enabled", "synchronize"],
+            "branches": ["master"],
+        }
+    }
+    assert workflow["permissions"] == {"contents": "read"}
+    steps = workflow["jobs"]["approve"]["steps"]
+    assert len(steps) == 1
+    assert steps[0]["uses"].startswith("actions/github-script@")
+    assert steps[0]["with"]["github-token"] == ("${{ secrets.GH_TOKEN_CODEX_COMMENT }}")
+    assert "run" not in steps[0]

--- a/tests/src/unit/test_renovate_configuration.py
+++ b/tests/src/unit/test_renovate_configuration.py
@@ -71,8 +71,15 @@ def test_scan_discovers_config_once_and_preserves_manual_events() -> None:
     assert workflow[True]["schedule"] == [{"cron": "17 * * * *"}]
     assert "workflow_dispatch" in workflow[True]
     assert workflow[True]["issues"]["types"] == ["edited"]
+    assert workflow[True]["pull_request_target"] == {
+        "types": ["edited"],
+        "branches": ["master"],
+    }
     job = workflow["jobs"]["renovate"]
     assert job["concurrency"]["cancel-in-progress"] is False
+    checkout = next(s for s in job["steps"] if s.get("name") == "Checkout")
+    assert checkout["with"]["ref"] == "${{ github.event.repository.default_branch }}"
+    assert checkout["with"]["persist-credentials"] is False
     action = next(s for s in job["steps"] if s.get("name") == "Self-hosted Renovate")
     assert "configurationFile" not in action["with"]
     assert "RENOVATE_FORCE" not in action["env"]


### PR DESCRIPTION
## What does this PR do?

Enable prompt native rebase requests and protected auto-merge for Renovate.

Start the existing self-hosted Renovate scan when a human checks the native
rebase/retry checkbox on a Renovate pull request, instead of waiting for the
next scheduled scan. This closes the trigger gap observed on #2384; Renovate
itself already processes the checkbox correctly when it runs.

- Listen for `pull_request_target: edited` on master, admitting only open,
  same-repository, Renovate-authored PRs on `renovate/` branches when the native
  checkbox changes from not checked to checked.
- Ignore bot edits, unrelated checkboxes, and body edits leaving it checked.
- Check out trusted default-branch code, never the PR head or merge commit,
  and preserve the existing serialized scanner and app-token permissions.
- Preserve hourly scans, dashboard requests, manual dispatch, and all existing
  dependency schedules/release-age rules. No dependency bumps.
- Enable Renovate-native squash auto-merge for minor/patch/digest updates and
  ungrouped vulnerability fixes; ordinary major upgrades remain manual.
- Supply exact-head approvals using the existing `ghhamcp` maintainer account,
  mirroring Dependabot's separate-account approval flow. The new handler runs
  without checkout, verifies fresh PR state and Renovate-enabled auto-merge,
  ignores human pushes/enabling, and skips existing exact-head approvals.
  GitHub's required checks (including E2E), reviews, and unresolved-thread rules
  remain authoritative; there is no admin bypass. Dependabot stays unchanged.

The approval handler uses the existing Actions secret `GH_TOKEN_CODEX_COMMENT`
for `ghhamcp`; it must have pull-request write permission. The existing
`DEPENDABOT_APPROVAL_TOKEN` remains in the separate Dependabot secret store.

The scheduled scan [34051202423](https://github.com/homeassistant-ai/ha-mcp/actions/runs/34051202423)
successfully regenerated #2384 after its checkbox was checked. This PR adds the
event-driven wake-up; it does not replace Renovate's native rebase implementation.

References: [GitHub workflow events](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows),
[Renovate manual rebasing](https://docs.renovatebot.com/updating-rebasing/#manual-rebasing).

## Type of change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [x] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing

- Regression coverage for trigger registration and trusted checkout inputs.
- Extend the real GitHub expression-evaluator fixture with PR checkbox and
  negative-event cases, alongside existing dashboard/manual/schedule coverage.
- After merge, verify that checking a Renovate PR's native box starts a
  `pull_request_target` scan and Renovate consumes the request; the new trigger
  cannot be exercised live until the trusted base workflow contains it.
- Credential-free fixtures execute the actual approval script and job guard:
  valid current heads, stale events, bot/fork/author boundaries, disabled or
  human-enabled auto-merge, duplicate approvals, wrong credentials, and API errors.
- Native Renovate policy fixtures cover eligible update types, manual majors,
  security overrides, and retained age gates.
- After merge, verify a native auto-merge event produces a `ghhamcp` approval
  for the current commit and required checks continue to block merging.

- [ ] I have tested these changes with a LLM agent
- [ ] All automated tests pass (`uv run pytest`)
- [ ] Code follows style guidelines (`uv run ruff check`)

## Checklist

- [x] I have updated documentation if needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dependency scans can now be started by checking the native rebase/retry box on an open Renovate pull request targeting the default branch.
  * Manual and Dependency Dashboard scan triggers continue to work, while scheduled scans remain best-effort.
  * Only qualifying human edits to Renovate pull requests initiate this scan.
  * Renovate can automatically squash-merge eligible minor, patch, digest, and vulnerability-alert updates after required checks and reviews.

* **Documentation**
  * Updated workflow documentation to explain pull-request scan triggers, safeguards, manual dispatch, scheduled-run behavior, and automatic merge policies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

