### PR TITLE
fix(policy): consume an approval exactly once across concurrent identical calls

### DIFF
--- a/src/ha_mcp/policy/approval_queue.py
+++ b/src/ha_mcp/policy/approval_queue.py
@@ -33,6 +33,7 @@ class PendingApproval:
     expires_at: datetime
     _decision: Decision = "pending"
     _event: anyio.Event = field(default_factory=anyio.Event)
+    _claimed: bool = False
 
     @property
     def decision(self) -> Decision:
@@ -50,6 +51,26 @@ class PendingApproval:
         """Block until decided; return the final Decision."""
         await self._event.wait()
         return self._decision
+
+    def claim(self) -> bool:
+        """Take exclusive ownership of this approval. False if already taken.
+
+        ``decide()`` wakes every waiter sharing this entry, and each one
+        would otherwise consume it and dispatch — one click authorizing N
+        executions (issue #2387). This is the same one-shot transition
+        ``decide()`` uses, and for the same reason: exactly one caller may
+        act on a given decision.
+
+        The flag lives on the entry rather than on queue membership
+        because ``_sweep_expired`` can drop an approved row (it ignores
+        ``decision``) while a waiter still holds this reference and is
+        legitimately entitled to consume it. There is no ``await`` here,
+        so the check-and-set cannot interleave with another task.
+        """
+        if self._claimed:
+            return False
+        self._claimed = True
+        return True
 
     def __post_init__(self) -> None:
         if self.expires_at <= self.created_at:
@@ -221,10 +242,18 @@ class ApprovalQueue:
 
     def consume_and_maybe_remember(
         self, entry: PendingApproval, *, remember_minutes: int
-    ) -> None:
+    ) -> bool:
+        """Consume one approval. False when another waiter already did.
+
+        A losing caller must not dispatch on this entry, and must not
+        arm the remember-cache from a decision it did not consume.
+        """
+        if not entry.claim():
+            return False
         self.remove(entry.token)
         if remember_minutes > 0:
             self.remember(entry.tool_name, entry.args_hash, minutes=remember_minutes)
+        return True
 
     def _sweep_expired(self) -> None:
         now = datetime.now(UTC)

--- a/src/ha_mcp/policy/middleware.py
+++ b/src/ha_mcp/policy/middleware.py
@@ -56,7 +56,12 @@ class PolicyMiddleware(Middleware):
 
         Loads the policy, evaluates the call, and -- when approval is
         required -- finds or creates a pending queue entry and waits up to
-        the configured window for a decision. A dynamic selector call
+        the configured window for a decision. Identical static calls share
+        one queue entry so the user sees a single approval row, but the
+        approval itself is consumed exactly once
+        (``PendingApproval.claim``): a second waiter woken by the same
+        decision gets its own pending row instead of riding the first
+        call's click. A dynamic selector call
         (``has_dynamic_selector_targets``) never shares or reuses another
         call's pending entry, and is never reissued on TTL eviction: see
         the inline comments above the ``existing =``, ``pending =``, and
@@ -167,36 +172,16 @@ class PolicyMiddleware(Middleware):
         # The accepted cost is that a retry never silently rides an earlier
         # approval: each blocked call gets its own approval row, and only
         # approving the row for the CURRENTLY-blocked call has any effect.
-        existing = None if dynamic_targets else self._queue.find(name, args_hash)
-        if existing and existing.decision == "approved":
-            self._queue.consume_and_maybe_remember(
-                existing,
-                remember_minutes=remember_minutes,
-            )
+        if self._resolve_already_decided(
+            name,
+            args_hash,
+            dynamic_targets=dynamic_targets,
+            remember_minutes=remember_minutes,
+        ):
             return await call_next(context)
-        if existing and existing.decision == "denied":
-            self._queue.remove(existing.token)
-            self._raise_denied_error()
 
-        # find_or_create serialises the create — two concurrent calls with
-        # the same args_hash share one pending entry, so the user only sees
-        # one approval row and approving it releases every waiter. Dynamic
-        # selector calls must NOT share a pending entry: two concurrent
-        # identical calls can still resolve to different (or overlapping)
-        # target sets by the time each one dispatches, so folding them onto
-        # one approval would let a single click authorize more executions
-        # than the user saw. Skip the sharing and always mint a fresh entry.
-        pending = (
-            self._queue.create(
-                name, args_hash, args, ttl_minutes=policy.approval_ttl_minutes
-            )
-            if dynamic_targets
-            else await self._queue.find_or_create(
-                name,
-                args_hash,
-                args,
-                ttl_minutes=policy.approval_ttl_minutes,
-            )
+        pending = await self._new_pending(
+            name, args_hash, args, policy=policy, dynamic_targets=dynamic_targets
         )
 
         wait = (
@@ -207,11 +192,20 @@ class PolicyMiddleware(Middleware):
         await self._wait_for_decision(context, pending, wait)
 
         if pending.decision == "approved":
-            self._queue.consume_and_maybe_remember(
-                pending,
-                remember_minutes=remember_minutes,
+            if self._claim_approval(
+                pending, name, args_hash, remember_minutes=remember_minutes
+            ):
+                return await call_next(context)
+            # Another waiter on this shared entry consumed the approval
+            # first. This call has none of its own, so it must not ride
+            # that click: mint a fresh row and tell the caller to get it
+            # approved. Its wait budget is already spent, so it does not
+            # wait again here -- re-waiting would also let a steady
+            # stream of identical calls starve one another.
+            pending = await self._new_pending(
+                name, args_hash, args, policy=policy, dynamic_targets=dynamic_targets
             )
-            return await call_next(context)
+            self._raise_pending_error(pending, rule, dynamic_targets=dynamic_targets)
         if pending.decision == "denied":
             self._queue.remove(pending.token)
             self._raise_denied_error()
@@ -221,6 +215,98 @@ class PolicyMiddleware(Middleware):
         )
         self._raise_pending_error(pending, rule, dynamic_targets=dynamic_targets)
         return None  # py/mixed-returns: explicit terminal; error handlers above always raise (NoReturn), unreachable
+
+    def _resolve_already_decided(
+        self,
+        name: str,
+        args_hash: str,
+        *,
+        dynamic_targets: bool,
+        remember_minutes: int,
+    ) -> bool:
+        """Act on an entry this call did not create. True means dispatch now.
+
+        A dynamic selector call must never consume an entry it did not
+        itself create and is not itself still waiting on, so it skips this
+        lookup entirely -- see the creator-only binding rationale above the
+        call site in ``on_call_tool``.
+
+        The claim cannot currently fail on this path: consuming an entry
+        also removes it, and there is no ``await`` between the ``find()``
+        and the claim, so no other task can interleave. It is checked
+        anyway so that adding an await to this stretch degrades into an
+        extra approval prompt rather than silently restoring the double
+        dispatch the claim exists to stop.
+        """
+        if dynamic_targets:
+            return False
+        existing = self._queue.find(name, args_hash)
+        if existing is None:
+            return False
+        if existing.decision == "approved":
+            return self._claim_approval(
+                existing, name, args_hash, remember_minutes=remember_minutes
+            )
+        if existing.decision == "denied":
+            self._queue.remove(existing.token)
+            self._raise_denied_error()
+        return False
+
+    def _claim_approval(
+        self,
+        entry: PendingApproval,
+        name: str,
+        args_hash: str,
+        *,
+        remember_minutes: int,
+    ) -> bool:
+        """Consume an approved entry for this invocation.
+
+        Exactly one caller may act on a given approval (see
+        ``PendingApproval.claim``). A caller that loses the claim still
+        proceeds when the winner's ``remember_minutes`` armed a
+        remember-cache entry covering this exact call: that window is the
+        user saying "stop asking for this", so re-prompting would
+        contradict the rule they configured. The ``is_remembered`` gate
+        earlier in ``on_call_tool`` ran before the approval existed, which
+        is why it has to be re-checked here rather than relied upon.
+        """
+        if self._queue.consume_and_maybe_remember(
+            entry, remember_minutes=remember_minutes
+        ):
+            return True
+        return self._queue.is_remembered(name, args_hash)
+
+    async def _new_pending(
+        self,
+        name: str,
+        args_hash: str,
+        args: dict[str, Any],
+        *,
+        policy: Policy,
+        dynamic_targets: bool,
+    ) -> PendingApproval:
+        """Mint the pending entry this invocation will wait on.
+
+        ``find_or_create`` serialises the create -- two concurrent calls
+        with the same args_hash share one pending entry, so the user only
+        sees one approval row. Sharing the row is safe; sharing the
+        *decision* is not, which is what ``_claim_approval`` enforces.
+
+        Dynamic selector calls must NOT share a pending entry at all: two
+        concurrent identical calls can still resolve to different (or
+        overlapping) target sets by the time each one dispatches, so
+        folding them onto one approval would let a single click authorize
+        a broader effect than the user saw. Skip the sharing and always
+        mint a fresh entry.
+        """
+        if dynamic_targets:
+            return self._queue.create(
+                name, args_hash, args, ttl_minutes=policy.approval_ttl_minutes
+            )
+        return await self._queue.find_or_create(
+            name, args_hash, args, ttl_minutes=policy.approval_ttl_minutes
+        )
 
     def _finalize_timed_out_pending(
         self,

--- a/src/ha_mcp/policy/middleware.py
+++ b/src/ha_mcp/policy/middleware.py
@@ -193,7 +193,11 @@ class PolicyMiddleware(Middleware):
 
         if pending.decision == "approved":
             if self._claim_approval(
-                pending, name, args_hash, remember_minutes=remember_minutes
+                pending,
+                name,
+                args_hash,
+                dynamic_targets=dynamic_targets,
+                remember_minutes=remember_minutes,
             ):
                 return await call_next(context)
             # Another waiter on this shared entry consumed the approval
@@ -245,7 +249,11 @@ class PolicyMiddleware(Middleware):
             return False
         if existing.decision == "approved":
             return self._claim_approval(
-                existing, name, args_hash, remember_minutes=remember_minutes
+                existing,
+                name,
+                args_hash,
+                dynamic_targets=dynamic_targets,
+                remember_minutes=remember_minutes,
             )
         if existing.decision == "denied":
             self._queue.remove(existing.token)
@@ -258,6 +266,7 @@ class PolicyMiddleware(Middleware):
         name: str,
         args_hash: str,
         *,
+        dynamic_targets: bool,
         remember_minutes: int,
     ) -> bool:
         """Consume an approved entry for this invocation.
@@ -270,11 +279,24 @@ class PolicyMiddleware(Middleware):
         contradict the rule they configured. The ``is_remembered`` gate
         earlier in ``on_call_tool`` ran before the approval existed, which
         is why it has to be re-checked here rather than relied upon.
+
+        A dynamic selector call never reads the remember-cache -- that
+        same gate skips the lookup for it, and ``remember_minutes`` is
+        forced to 0 -- so it must not consult one here either. No
+        reachable case arms such a key today (``has_dynamic_selector_targets``
+        is a pure function of the name and args that also produce
+        ``args_hash``, so static and dynamic calls cannot collide on one
+        key), but the guard keeps this branch degrading the same
+        direction as the defensive claim check in
+        ``_resolve_already_decided``: toward an extra prompt, never
+        toward a dispatch the caller was not entitled to.
         """
         if self._queue.consume_and_maybe_remember(
             entry, remember_minutes=remember_minutes
         ):
             return True
+        if dynamic_targets:
+            return False
         return self._queue.is_remembered(name, args_hash)
 
     async def _new_pending(

--- a/tests/src/unit/policy/test_approval_overlap.py
+++ b/tests/src/unit/policy/test_approval_overlap.py
@@ -1,0 +1,130 @@
+"""Approval cardinality at the MCP call/progress and public approval seams.
+
+Reproduction contributed by @abdulla2010 in issue #2387; retained as a
+regression test because it exercises the real FastMCP server and both the
+direct and ``ha_call_write_tool`` routes, which the unit-level middleware
+tests do not.
+
+Real FastMCP and PolicyMiddleware; only the terminal action is synthetic.
+No HA connection, queue internals, clock patching, or race-by-sleep assertions.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+import pytest
+from fastmcp import Client, FastMCP
+from fastmcp.client.client import CallToolResult
+from mcp.types import TextContent
+
+from ha_mcp.policy.approval_queue import ApprovalQueue
+from ha_mcp.policy.middleware import PolicyMiddleware
+from ha_mcp.policy.model import Policy, Rule
+from ha_mcp.transforms.categorized_search import CategorizedSearchTransform
+
+ARGS = {"domain": "light", "service": "turn_on", "entity_id": "light.synthetic"}
+
+
+def policy_server(
+    queue: ApprovalQueue, *, remember_minutes: int = 0, wait_seconds: int = 5
+) -> tuple[FastMCP, list[dict[str, Any]]]:
+    server = FastMCP("single-use-approval-test")
+    dispatched: list[dict[str, Any]] = []
+
+    @server.tool(name="ha_call_service", annotations={"readOnlyHint": False})
+    async def action(domain: str, service: str, entity_id: str) -> dict[str, bool]:
+        dispatched.append(
+            {"domain": domain, "service": service, "entity_id": entity_id}
+        )
+        return {"fake_dispatch": True}
+
+    @server.tool(name="ha_bulk_control", annotations={"readOnlyHint": False})
+    async def bulk(selector: dict[str, Any], action: str) -> dict[str, bool]:
+        dispatched.append({"selector": selector, "action": action})
+        return {"fake_dispatch": True}
+
+    policy = Policy(rules=[Rule(tool_name="*", remember_minutes=remember_minutes)])
+    server.add_middleware(
+        PolicyMiddleware(
+            policy_provider=lambda: policy, queue=queue, wait_seconds=wait_seconds
+        )
+    )
+    server.add_transform(CategorizedSearchTransform())
+    return server, dispatched
+
+
+def envelope(route: str, args: dict[str, Any] = ARGS) -> tuple[str, dict[str, Any]]:
+    if route == "direct":
+        return "ha_call_service", dict(args)
+    return "ha_call_write_tool", {"name": "ha_call_service", "arguments": dict(args)}
+
+
+def assert_approval_required(result: CallToolResult) -> None:
+    assert result.is_error
+    assert isinstance(result.content[0], TextContent)
+    assert '"USER_APPROVAL_REQUIRED"' in result.content[0].text
+
+
+async def wait_for_approval_progress(
+    *events: asyncio.Event,
+) -> None:
+    await asyncio.gather(*(event.wait() for event in events))
+
+
+def progress_setter(
+    event: asyncio.Event,
+) -> Callable[[float, float | None, str | None], Awaitable[None]]:
+    async def handler(
+        progress: float, total: float | None, message: str | None
+    ) -> None:
+        assert message and "Awaiting user approval" in message
+        event.set()
+
+    return handler
+
+
+@pytest.mark.parametrize("route", ["direct", "write-proxy"])
+async def test_one_approval_dispatches_only_one_overlapping_static_call(
+    route: str,
+) -> None:
+    queue = ApprovalQueue()
+    server, dispatched = policy_server(queue)
+    ready = [asyncio.Event(), asyncio.Event()]
+    name, arguments = envelope(route)
+    async with asyncio.timeout(10), Client(server) as first, Client(server) as second:
+        async with asyncio.TaskGroup() as tasks:
+            calls = [
+                tasks.create_task(
+                    first.call_tool(
+                        name,
+                        arguments,
+                        progress_handler=progress_setter(ready[0]),
+                        raise_on_error=False,
+                    )
+                ),
+                tasks.create_task(
+                    second.call_tool(
+                        name,
+                        arguments,
+                        progress_handler=progress_setter(ready[1]),
+                        raise_on_error=False,
+                    )
+                ),
+            ]
+            await wait_for_approval_progress(*ready)
+            pending = queue.list_pending()
+            assert len(pending) == 1
+            assert dispatched == []
+            assert queue.approve(pending[0].token)
+        results = [call.result() for call in calls]
+
+    assert dispatched == [ARGS], "one approval must authorize only one execution"
+    assert sum(not result.is_error for result in results) == 1
+    assert_approval_required(next(result for result in results if result.is_error))
+    assert len(queue.list_pending()) == 1
+    assert queue.list_pending()[0].token != pending[0].token
+
+

--- a/tests/src/unit/policy/test_approval_overlap.py
+++ b/tests/src/unit/policy/test_approval_overlap.py
@@ -126,5 +126,3 @@ async def test_one_approval_dispatches_only_one_overlapping_static_call(
     assert_approval_required(next(result for result in results if result.is_error))
     assert len(queue.list_pending()) == 1
     assert queue.list_pending()[0].token != pending[0].token
-
-

--- a/tests/src/unit/policy/test_approval_queue.py
+++ b/tests/src/unit/policy/test_approval_queue.py
@@ -367,3 +367,47 @@ async def test_find_or_create_lock_blocks_concurrent_create_under_real_race():
     # Silence the slow_find reference so ruff doesn't complain about
     # the unused helper — kept in the source for future strengthening.
     _ = slow_find
+
+
+# --- Issue #2387: consumption is one-shot ---
+
+
+def test_consume_claims_the_entry_exactly_once():
+    """Two waiters woken by one ``decide()`` must not both consume it."""
+    q = ApprovalQueue()
+    entry = q.create("ha_x", "abc", {}, ttl_minutes=5)
+    entry.decide("approved")
+    assert q.consume_and_maybe_remember(entry, remember_minutes=0) is True
+    assert q.consume_and_maybe_remember(entry, remember_minutes=0) is False
+    assert q.get(entry.token) is None
+
+
+def test_swept_approved_entry_is_still_claimable_by_its_waiter():
+    """The claim lives on the entry, not on queue membership.
+
+    ``_sweep_expired`` drops entries by ``expires_at`` regardless of
+    decision and runs on every ``find``/``get``/``list_pending`` — which
+    the settings UI polls. A waiter holding its own reference to an
+    approved entry must still be able to consume it after such a sweep;
+    keying the claim on dict membership would turn a legitimate approval
+    into a spurious re-prompt.
+    """
+    q = ApprovalQueue()
+    entry = q.create("ha_x", "abc", {}, ttl_minutes=5)
+    entry.decide("approved")
+    entry.expires_at = datetime.now(UTC) - timedelta(seconds=1)
+    q._sweep_expired()
+    assert q.get(entry.token) is None
+    assert q.consume_and_maybe_remember(entry, remember_minutes=0) is True
+
+
+def test_consume_populates_remember_cache_only_for_the_winner():
+    """A losing claim must not extend or re-arm the remember window."""
+    q = ApprovalQueue()
+    entry = q.create("ha_x", "abc", {}, ttl_minutes=5)
+    entry.decide("approved")
+    assert q.consume_and_maybe_remember(entry, remember_minutes=10) is True
+    assert q.is_remembered("ha_x", "abc") is True
+    q.clear_remember_cache()
+    assert q.consume_and_maybe_remember(entry, remember_minutes=10) is False
+    assert q.is_remembered("ha_x", "abc") is False

--- a/tests/src/unit/policy/test_middleware.py
+++ b/tests/src/unit/policy/test_middleware.py
@@ -906,12 +906,14 @@ async def _attach_counting_find_or_create(queue, monkeypatch, counter: list[int]
     monkeypatch.setattr(queue, "find_or_create", counting)
 
 
-async def _wait_until_both_attached(counter: list[int]) -> None:
+async def _wait_until_attached(counter: list[int], expected: int) -> None:
     for _ in range(500):
-        if len(counter) >= 2:
+        if len(counter) >= expected:
             return
         await anyio.sleep(0.01)
-    raise AssertionError("both calls never attached to the shared pending entry")
+    raise AssertionError(
+        f"only {len(counter)} of {expected} calls attached to the shared entry"
+    )
 
 
 @pytest.mark.anyio
@@ -949,7 +951,7 @@ async def test_concurrent_static_calls_consume_one_approval_once(
             outcomes.append("error")
 
     async def approve_the_shared_row():
-        await _wait_until_both_attached(attached)
+        await _wait_until_attached(attached, 2)
         pending = queue.list_pending()
         assert len(pending) == 1, "identical static calls must share one row"
         approved_token.append(pending[0].token)
@@ -998,7 +1000,7 @@ async def test_remembered_window_lets_the_losing_waiter_proceed(
         )
 
     async def approve_the_shared_row():
-        await _wait_until_both_attached(attached)
+        await _wait_until_attached(attached, 2)
         pending = queue.list_pending()
         assert len(pending) == 1
         queue.approve(pending[0].token)
@@ -1011,3 +1013,63 @@ async def test_remembered_window_lets_the_losing_waiter_proceed(
     assert outcomes == ["ok", "ok"]
     assert call_next.await_count == 2
     assert queue.list_pending() == []
+
+
+@pytest.mark.anyio
+async def test_losing_waiters_share_one_replacement_row(
+    queue, monkeypatch: pytest.MonkeyPatch
+):
+    """Three concurrent identical calls: one dispatch, one replacement row.
+
+    A losing waiter mints its row through ``find_or_create`` like any
+    other call, so a burst does not fan the queue out to one row per
+    caller -- draining N identical calls costs N clicks across N rounds,
+    never N simultaneous rows.
+
+    Two callers cannot pin that bound: there is exactly one loser, so
+    ``len(...) == 1`` holds whether losers share a row or each mint their
+    own. Three callers discriminate, which is what keeps a later refactor
+    from quietly routing the loser path around ``find_or_create``.
+    """
+    args = {"domain": "lock", "service": "unlock"}
+    policy = Policy(rules=[Rule(tool_name="ha_call_service")])
+    mw = PolicyMiddleware(policy_provider=lambda: policy, queue=queue, wait_seconds=5)
+    call_next = AsyncMock(return_value="ok")
+    attached: list[int] = []
+    outcomes: list[object] = []
+    codes: list[str] = []
+    approved_token: list[str] = []
+
+    await _attach_counting_find_or_create(queue, monkeypatch, attached)
+
+    async def call():
+        try:
+            outcomes.append(
+                await mw.on_call_tool(
+                    make_context("ha_call_service", dict(args)), call_next
+                )
+            )
+        except ToolError as exc:
+            codes.append(json.loads(exc.args[0])["error"]["code"])
+            outcomes.append("error")
+
+    async def approve_the_shared_row():
+        await _wait_until_attached(attached, 3)
+        pending = queue.list_pending()
+        assert len(pending) == 1, "identical static calls must share one row"
+        approved_token.append(pending[0].token)
+        queue.approve(pending[0].token)
+
+    async with anyio.create_task_group() as tg:
+        tg.start_soon(call)
+        tg.start_soon(call)
+        tg.start_soon(call)
+        tg.start_soon(approve_the_shared_row)
+
+    call_next.assert_awaited_once()
+    assert sorted(str(o) for o in outcomes) == ["error", "error", "ok"]
+    assert codes == ["USER_APPROVAL_REQUIRED"] * 2
+    # Both losers land on ONE replacement row, not one row each.
+    leftover = queue.list_pending()
+    assert len(leftover) == 1
+    assert leftover[0].token != approved_token[0]

--- a/tests/src/unit/policy/test_middleware.py
+++ b/tests/src/unit/policy/test_middleware.py
@@ -882,3 +882,132 @@ class TestApprovalManagementExemptionMiddleware:
         body = json.loads(ei.value.args[0])
         assert body["error"]["code"] == "USER_APPROVAL_REQUIRED"
         call_next.assert_not_called()
+
+
+# --- Issue #2387: one approval must authorize exactly one execution ---
+
+
+async def _attach_counting_find_or_create(queue, monkeypatch, counter: list[int]):
+    """Wrap ``queue.find_or_create`` so a test can tell when both calls
+    have attached to the shared pending entry.
+
+    Approving on a timer instead would be racy: the approval could land
+    before the second call reached ``find_or_create``, in which case it
+    would take the already-approved fast path rather than the
+    two-waiters-on-one-entry path these tests exist to cover.
+    """
+    real = queue.find_or_create
+
+    async def counting(*args, **kwargs):
+        entry = await real(*args, **kwargs)
+        counter.append(1)
+        return entry
+
+    monkeypatch.setattr(queue, "find_or_create", counting)
+
+
+async def _wait_until_both_attached(counter: list[int]) -> None:
+    for _ in range(500):
+        if len(counter) >= 2:
+            return
+        await anyio.sleep(0.01)
+    raise AssertionError("both calls never attached to the shared pending entry")
+
+
+@pytest.mark.anyio
+async def test_concurrent_static_calls_consume_one_approval_once(
+    queue, monkeypatch: pytest.MonkeyPatch
+):
+    """Two concurrent identical static calls share one row; one click runs one call.
+
+    Regression for #2387. ``find_or_create`` deliberately folds identical
+    static calls onto a single approval row so the user sees one prompt.
+    Before the claim check, ``decide()`` woke every waiter and each one
+    consumed the same entry and dispatched — one click, N executions, for
+    a non-idempotent call such as ``button.press`` or ``script.turn_on``.
+    """
+    args = {"domain": "lock", "service": "unlock"}
+    policy = Policy(rules=[Rule(tool_name="ha_call_service")])
+    mw = PolicyMiddleware(policy_provider=lambda: policy, queue=queue, wait_seconds=5)
+    call_next = AsyncMock(return_value="ok")
+    attached: list[int] = []
+    outcomes: list[object] = []
+    codes: list[str] = []
+    approved_token: list[str] = []
+
+    await _attach_counting_find_or_create(queue, monkeypatch, attached)
+
+    async def call():
+        try:
+            outcomes.append(
+                await mw.on_call_tool(
+                    make_context("ha_call_service", dict(args)), call_next
+                )
+            )
+        except ToolError as exc:
+            codes.append(json.loads(exc.args[0])["error"]["code"])
+            outcomes.append("error")
+
+    async def approve_the_shared_row():
+        await _wait_until_both_attached(attached)
+        pending = queue.list_pending()
+        assert len(pending) == 1, "identical static calls must share one row"
+        approved_token.append(pending[0].token)
+        queue.approve(pending[0].token)
+
+    async with anyio.create_task_group() as tg:
+        tg.start_soon(call)
+        tg.start_soon(call)
+        tg.start_soon(approve_the_shared_row)
+
+    call_next.assert_awaited_once()
+    assert sorted(str(o) for o in outcomes) == ["error", "ok"]
+    assert codes == ["USER_APPROVAL_REQUIRED"]
+    # The loser gets its own approval to wait on rather than silently
+    # riding the winner's click.
+    leftover = queue.list_pending()
+    assert len(leftover) == 1
+    assert leftover[0].token != approved_token[0]
+
+
+@pytest.mark.anyio
+async def test_remembered_window_lets_the_losing_waiter_proceed(
+    queue, monkeypatch: pytest.MonkeyPatch
+):
+    """A positive ``remember_minutes`` still authorizes every identical call.
+
+    The claim check must not re-prompt here: the winner's consumption
+    populates the remember-cache, and that window is exactly the user
+    saying "don't ask me again for this call" — so the losing waiter
+    proceeds instead of minting a second row.
+    """
+    args = {"domain": "lock", "service": "unlock"}
+    policy = Policy(rules=[Rule(tool_name="ha_call_service", remember_minutes=10)])
+    mw = PolicyMiddleware(policy_provider=lambda: policy, queue=queue, wait_seconds=5)
+    call_next = AsyncMock(return_value="ok")
+    attached: list[int] = []
+    outcomes: list[object] = []
+
+    await _attach_counting_find_or_create(queue, monkeypatch, attached)
+
+    async def call():
+        outcomes.append(
+            await mw.on_call_tool(
+                make_context("ha_call_service", dict(args)), call_next
+            )
+        )
+
+    async def approve_the_shared_row():
+        await _wait_until_both_attached(attached)
+        pending = queue.list_pending()
+        assert len(pending) == 1
+        queue.approve(pending[0].token)
+
+    async with anyio.create_task_group() as tg:
+        tg.start_soon(call)
+        tg.start_soon(call)
+        tg.start_soon(approve_the_shared_row)
+
+    assert outcomes == ["ok", "ok"]
+    assert call_next.await_count == 2
+    assert queue.list_pending() == []


### PR DESCRIPTION
## What does this PR do?

Fixes #2387. Two concurrent identical static calls share one approval row (`ApprovalQueue.find_or_create`), and `decide()` wakes every waiter. Each woken waiter then called `consume_and_maybe_remember`, whose `remove()` is a `pop(token, None)` that discards its result — so every waiter dispatched. One click authorized N executions.

Harmless for an idempotent call like `light.turn_on`, not harmless for `button.press`, `script.turn_on`, `cover.toggle`, or adding a todo item. It is also the same concern that already justified excluding dynamic selectors from sharing in #2246 ("a single click authorizing more executions than the user saw") — that carve-out addressed target resolution, this addresses execution count on the static path.

Sharing the *row* is preserved and still deliberate: the user sees one prompt. Sharing the *decision* is what stops. `PendingApproval.claim()` is a one-shot transition, mirroring `decide()`. The winner dispatches; a losing waiter gets its own pending row and a `USER_APPROVAL_REQUIRED` error instead of riding the click.

Two behaviours the claim must not break, both covered by tests:

- **Remembered approvals.** A positive `remember_minutes` means "stop asking for this call". The winner's consumption arms the remember-cache, so a losing waiter re-checks `is_remembered` and proceeds rather than re-prompting. The `is_remembered` gate at the top of `on_call_tool` ran before the approval existed and cannot cover this.
- **TTL sweeps.** `_sweep_expired` drops entries by `expires_at` regardless of decision and runs on every `find`/`get`/`list_pending`, which the settings UI polls. The claim flag therefore lives on the entry, not on queue membership — keying it on `pop()` would turn a legitimate approval into a spurious re-prompt.

A losing waiter does not wait again on its new row: its wait budget is spent, and re-waiting would let a steady stream of identical calls starve one another. It returns the standard "re-call after the user approves" error.

`on_call_tool` exceeded the C901 complexity limit with the added branch, so the already-decided lookup moved into `_resolve_already_decided` and the pending-entry mint into `_new_pending` (shared by the normal path and the losing-waiter path). No behaviour change from either extraction.

**Behaviour change:** two concurrent identical calls now cost two approval clicks instead of one. That is the fix.

## Type of change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

Regression tests that fail on master and pass here:

- `test_concurrent_static_calls_consume_one_approval_once` — fails on master with `Expected mock to have been awaited once. Awaited 2 times.`
- `test_remembered_window_lets_the_losing_waiter_proceed`
- `test_consume_claims_the_entry_exactly_once`
- `test_swept_approved_entry_is_still_claimable_by_its_waiter`
- `test_consume_populates_remember_cache_only_for_the_winner`
- `test_approval_overlap.py` — the reporter's end-to-end reproduction (real FastMCP, two clients, both the direct and `ha_call_write_tool` routes), committed as contributed with the unused constants and helper trimmed.

Scope run locally: `tests/src/unit/policy/` 248 passed; `ruff check` and `ruff format` clean on `src/ tests/`; `mypy src/ha_mcp/policy/` clean. Full suite left to CI.

The LLM-agent box is unchecked deliberately: the defect needs two clients calling identically inside the same wait window, which a single agent session cannot produce — verified against a live Home Assistant instance, where sequential calls each correctly got their own approval row.

## Checklist
- [x] I have updated documentation if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed approval handling for concurrent requests so a single approval authorizes only one execution.
  * Ensured other waiting requests either receive a new approval prompt or proceed through the configured “remember” option.
  * Prevented dynamic-selector requests from using another caller’s approval.
  * Improved handling of expired, single-use approvals with clearer retry guidance.
* **Tests**
  * Added coverage for overlapping requests, approval reuse, remembered approvals, dynamic requests, and expiration scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->