### PR TITLE
fix(deps): preserve embedded compatibility with supported HA Core

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -41,20 +41,6 @@ updates:
       prefix: "deps"
       include: "scope"
     ignore:
-      # HA owns these versions in the embedded process. Coordinate floor and
-      # lock updates with supported Core versions, not independent PyPI bumps
-      # (#2391). update-types suppresses VERSION updates only: security updates
-      # remain available and must pass the same compatibility/E2E gates.
-      - dependency-name: "pydantic"
-        update-types:
-          - "version-update:semver-major"
-          - "version-update:semver-minor"
-          - "version-update:semver-patch"
-      - dependency-name: "httpx"
-        update-types:
-          - "version-update:semver-major"
-          - "version-update:semver-minor"
-          - "version-update:semver-patch"
       # Held at the pin in pyproject.toml. pydantic-monty 0.0.19 replaced the
       # single-shot `Monty(code, ...)` + `run_async(external_functions=...)`
       # API with a subprocess worker pool (`AsyncMonty` -> `checkout()` ->

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -41,6 +41,20 @@ updates:
       prefix: "deps"
       include: "scope"
     ignore:
+      # HA owns these versions in the embedded process. Coordinate floor and
+      # lock updates with supported Core versions, not independent PyPI bumps
+      # (#2391). update-types suppresses VERSION updates only: security updates
+      # remain available and must pass the same compatibility/E2E gates.
+      - dependency-name: "pydantic"
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"
+      - dependency-name: "httpx"
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"
       # Held at the pin in pyproject.toml. pydantic-monty 0.0.19 replaced the
       # single-shot `Monty(code, ...)` + `run_async(external_functions=...)`
       # API with a subprocess worker pool (`AsyncMonty` -> `checkout()` ->

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -324,9 +324,11 @@ jobs:
       # where HA pins a shared dependency exactly, ha-mcp must admit the pin;
       # where HA is loose, ha-mcp must not pin exactly (an exact pin forces
       # pip to replace the image-shipped copy in place — the torn-install
-      # window). Checked against the same HA version the e2e lanes run
-      # (HA_IMAGE_GHCR, renovate-managed), so drift on either side fails the
-      # PR that introduces it. Rules unit-tested offline in
+      # window). Check the current E2E image AND the HACS minimum: a Core
+      # image update must not silently strand users on the supported floor.
+      # Both versions also get real embedded install/no-stomp E2E coverage.
+      # These are endpoint checks, not proof for every intervening release.
+      # Rules unit-tested offline in
       # tests/src/unit/test_ha_constraint_alignment.py.
       #
       # Exit codes are load-bearing: 1 is a real drift violation and fails
@@ -339,17 +341,21 @@ jobs:
       # problems, and failing open on them would leave this gate green
       # forever while it checked nothing.
       run: |
-        set +e
-        uv run --no-project --with packaging python \
-          scripts/check_ha_constraint_alignment.py \
-          --ha-version "${HA_IMAGE_GHCR##*:}"
-        status=$?
-        set -e
-        if [ "$status" -eq 78 ]; then
-          echo "::warning::could not reach HA's package_constraints.txt - skipping the alignment check (the e2e no-stomp guard still covers the real install)"
-          exit 0
-        fi
-        exit "$status"
+        minimum=$(python3 -c 'import json; print(json.load(open("hacs.json"))["homeassistant"])')
+        [[ "$minimum" =~ ^[0-9]{4}\.[0-9]{1,2}\.[0-9]+$ ]]
+        failed=0
+        for ha_version in "${HA_IMAGE_GHCR##*:}" "$minimum"; do
+          status=0
+          uv run --no-project --with packaging python \
+            scripts/check_ha_constraint_alignment.py \
+            --ha-version "$ha_version" || status=$?
+          if [ "$status" -eq 78 ]; then
+            echo "::warning::could not reach HA ${ha_version} constraints - its embedded E2E no-stomp guard still covers the real install"
+          elif [ "$status" -ne 0 ]; then
+            failed=1
+          fi
+        done
+        exit "$failed"
 
     - name: Install dependencies
       # One install for ruff, ast-grep and mypy. The three folded jobs each ran
@@ -702,8 +708,8 @@ jobs:
   # server-under-test is the in-process MCP server (ha_mcp_tools entry) running inside
   # each worker's testcontainer (E2E_BACKEND=embedded), driven over its ingress
   # webhook. Matrixed x64 + arm64 to mirror e2e-validation (the container matrix);
-  # ``needs.e2e-validation-embedded.result`` aggregates the variants, so the
-  # e2e-validation-gate below fails if EITHER arch fails. Gated the same way as
+  # A focused x64 variant also exercises the HACS minimum Core. The aggregate
+  # ``needs.e2e-validation-embedded.result`` fails if ANY variant fails. Gated the same way as
   # e2e-validation: skips on docs/website-only PRs (needs.changes) and folds into
   # the required gate. -n2/-n3 (vs the container matrix's 3/4) because each worker
   # additionally builds a ha-mcp wheel and its container preinstalls the fastmcp
@@ -711,7 +717,7 @@ jobs:
   # concurrent-pip pressure in check (arm gets +1 like the container matrix does);
   # the larger timeout covers that per-worker preinstall window.
   e2e-validation-embedded:
-    name: E2E Validation (embedded, ${{ matrix.os }})
+    name: E2E Validation (embedded, ${{ matrix.hacs_minimum && 'HACS minimum, ' || '' }}${{ matrix.os }})
     needs: changes
     # A skipped job reports Success, so a docs/website-only PR doesn't wedge the
     # gate waiting on this lane (mirrors e2e-validation).
@@ -725,20 +731,31 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os:
-          - ubuntu-latest           # Linux x64
-          - ubuntu-24.04-arm        # Linux ARM64
         include:
           - os: ubuntu-latest
             pytest_workers: 2
           - os: ubuntu-24.04-arm
             pytest_workers: 3
+          # Real install and runtime no-stomp guards on the oldest supported
+          # Core, including transitives. Current Core keeps the full suite.
+          - os: ubuntu-latest
+            pytest_workers: 1
+            hacs_minimum: true
 
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       with:
         persist-credentials: false
         submodules: true
+
+    - name: Select HACS minimum image
+      if: matrix.hacs_minimum
+      run: |
+        minimum=$(python3 -c 'import json; print(json.load(open("hacs.json"))["homeassistant"])')
+        [[ "$minimum" =~ ^[0-9]{4}\.[0-9]{1,2}\.[0-9]+$ ]]
+        image="ghcr.io/home-assistant/home-assistant:${minimum}"
+        echo "HA_IMAGE_GHCR=$image" >> "$GITHUB_ENV"
+        echo "HA_TEST_IMAGE=$image" >> "$GITHUB_ENV"
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4
@@ -788,17 +805,21 @@ jobs:
         done
         echo "All registries failed" && exit 1
 
-    - name: Run full E2E test suite (embedded backend)
+    - name: Run E2E tests (embedded backend)
       run: |
-        echo "🚀 Running full E2E suite through the in-process MCP server (embedded backend) with ${{ matrix.pytest_workers }} workers..."
+        paths=(src/e2e/)
+        if [ "$HACS_MINIMUM" = "true" ]; then
+          paths=(src/e2e/basic/test_connection.py src/e2e/workflows/embedded/test_embedded_no_stomp.py)
+        fi
+        echo "Running embedded tests against ${HA_IMAGE_GHCR}: ${paths[*]}"
         cd tests
-        uv run pytest src/e2e/ \
+        uv run pytest "${paths[@]}" \
           -n${{ matrix.pytest_workers }} \
           --dist loadscope \
           --tb=short \
           -v
-        echo "✅ Full E2E test suite (embedded backend) passed"
       env:
+        HACS_MINIMUM: ${{ matrix.hacs_minimum && 'true' || 'false' }}
         E2E_BACKEND: "embedded"
         HAMCP_ENV_FILE: "tests/.env.test"
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -326,8 +326,8 @@ jobs:
       # pip to replace the image-shipped copy in place — the torn-install
       # window). Check the current E2E image AND the HACS minimum: a Core
       # image update must not silently strand users on the supported floor.
-      # Both versions also get real embedded install/no-stomp E2E coverage.
-      # These are endpoint checks, not proof for every intervening release.
+      # This is direct-dependency coverage at the endpoints. Existing current
+      # Core/beta E2E lanes cover actual installs and runtime compatibility.
       # Rules unit-tested offline in
       # tests/src/unit/test_ha_constraint_alignment.py.
       #
@@ -350,7 +350,7 @@ jobs:
             scripts/check_ha_constraint_alignment.py \
             --ha-version "$ha_version" || status=$?
           if [ "$status" -eq 78 ]; then
-            echo "::warning::could not reach HA ${ha_version} constraints - its embedded E2E no-stomp guard still covers the real install"
+            echo "::warning::could not reach HA ${ha_version} constraints - dependency alignment for this version was not verified"
           elif [ "$status" -ne 0 ]; then
             failed=1
           fi
@@ -708,8 +708,8 @@ jobs:
   # server-under-test is the in-process MCP server (ha_mcp_tools entry) running inside
   # each worker's testcontainer (E2E_BACKEND=embedded), driven over its ingress
   # webhook. Matrixed x64 + arm64 to mirror e2e-validation (the container matrix);
-  # A focused x64 variant also exercises the HACS minimum Core. The aggregate
-  # ``needs.e2e-validation-embedded.result`` fails if ANY variant fails. Gated the same way as
+  # ``needs.e2e-validation-embedded.result`` aggregates the variants, so the
+  # e2e-validation-gate below fails if EITHER arch fails. Gated the same way as
   # e2e-validation: skips on docs/website-only PRs (needs.changes) and folds into
   # the required gate. -n2/-n3 (vs the container matrix's 3/4) because each worker
   # additionally builds a ha-mcp wheel and its container preinstalls the fastmcp
@@ -717,7 +717,7 @@ jobs:
   # concurrent-pip pressure in check (arm gets +1 like the container matrix does);
   # the larger timeout covers that per-worker preinstall window.
   e2e-validation-embedded:
-    name: E2E Validation (embedded, ${{ matrix.hacs_minimum && 'HACS minimum, ' || '' }}${{ matrix.os }})
+    name: E2E Validation (embedded, ${{ matrix.os }})
     needs: changes
     # A skipped job reports Success, so a docs/website-only PR doesn't wedge the
     # gate waiting on this lane (mirrors e2e-validation).
@@ -731,31 +731,20 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        os:
+          - ubuntu-latest           # Linux x64
+          - ubuntu-24.04-arm        # Linux ARM64
         include:
           - os: ubuntu-latest
             pytest_workers: 2
           - os: ubuntu-24.04-arm
             pytest_workers: 3
-          # Real install and runtime no-stomp guards on the oldest supported
-          # Core, including transitives. Current Core keeps the full suite.
-          - os: ubuntu-latest
-            pytest_workers: 1
-            hacs_minimum: true
 
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       with:
         persist-credentials: false
         submodules: true
-
-    - name: Select HACS minimum image
-      if: matrix.hacs_minimum
-      run: |
-        minimum=$(python3 -c 'import json; print(json.load(open("hacs.json"))["homeassistant"])')
-        [[ "$minimum" =~ ^[0-9]{4}\.[0-9]{1,2}\.[0-9]+$ ]]
-        image="ghcr.io/home-assistant/home-assistant:${minimum}"
-        echo "HA_IMAGE_GHCR=$image" >> "$GITHUB_ENV"
-        echo "HA_TEST_IMAGE=$image" >> "$GITHUB_ENV"
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4
@@ -805,21 +794,17 @@ jobs:
         done
         echo "All registries failed" && exit 1
 
-    - name: Run E2E tests (embedded backend)
+    - name: Run full E2E test suite (embedded backend)
       run: |
-        paths=(src/e2e/)
-        if [ "$HACS_MINIMUM" = "true" ]; then
-          paths=(src/e2e/basic/test_connection.py src/e2e/workflows/embedded/test_embedded_no_stomp.py)
-        fi
-        echo "Running embedded tests against ${HA_IMAGE_GHCR}: ${paths[*]}"
+        echo "🚀 Running full E2E suite through the in-process MCP server (embedded backend) with ${{ matrix.pytest_workers }} workers..."
         cd tests
-        uv run pytest "${paths[@]}" \
+        uv run pytest src/e2e/ \
           -n${{ matrix.pytest_workers }} \
           --dist loadscope \
           --tb=short \
           -v
+        echo "✅ Full E2E test suite (embedded backend) passed"
       env:
-        HACS_MINIMUM: ${{ matrix.hacs_minimum && 'true' || 'false' }}
         E2E_BACKEND: "embedded"
         HAMCP_ENV_FILE: "tests/.env.test"
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/agents/custom-component.md
+++ b/docs/agents/custom-component.md
@@ -87,17 +87,15 @@ When updating either library, coordinate the requirement and standalone lock
 with Core's pins. Never fix an embedded resolver failure by dropping HA's
 constraints or eagerly upgrading its shared packages.
 
-PR checks cover the current Core image and the `hacs.json` minimum:
+Fast Checks verifies direct dependency alignment against both the current
+Core image and the `hacs.json` minimum, without adding E2E lanes. Existing
+current-Core embedded E2E on x64/ARM64 covers transitive installation and
+preinstall/runtime replacement of HA-governed packages; nightly beta E2E
+provides advance notice of upcoming Core regressions.
 
-- Fast Checks verifies direct dependency alignment at both endpoints.
-- The current embedded lanes run the full suite on x64 and ARM64.
-- A focused x64 minimum-Core variant boots the real embedded server and runs
-  the connection and no-stomp tests, covering transitive installation and both
-  preinstall/runtime replacement of HA-governed packages.
-- Existing nightly beta E2E lanes detect upcoming Core regressions.
-
-These checks cover those versions and installation paths, not every intervening
-release, every installed third-party integration, or future API compatibility.
+The minimum-version check does not prove transitive installability or runtime
+behavior there. These checks also do not cover every intervening release,
+every installed third-party integration, or future API compatibility.
 Keep the HACS minimum honest; passing current-Core E2E alone does not justify
 raising a dependency floor past versions older supported Core releases need.
 

--- a/docs/agents/custom-component.md
+++ b/docs/agents/custom-component.md
@@ -74,18 +74,20 @@ live-test it promptly on the development server before the next stable cut.
 
 The embedded server installs into Home Assistant's Python environment using
 Core's `package_constraints.txt`. The standalone `uv.lock` is not the embedded
-installation contract. For HA-owned libraries, keep package requirements as
+installation contract. For libraries shared with HA, keep package requirements as
 bounded compatibility ranges that admit supported Core versions. Preserve the
 standalone lock's selected versions when widening a range; widen or raise a
 floor only with compatibility evidence. Pydantic follows its major-version
 boundary; HTTPX is pre-1.0, so its minor-version boundary remains capped.
 
-Dependabot defers routine Pydantic and HTTPX version updates. Its `update-types`
-ignore rules leave security updates enabled; those still need compatibility
-review. Renovate advances the Core E2E image, not these package requirements.
-When updating either library, coordinate the requirement and standalone lock
-with Core's pins. Never fix an embedded resolver failure by dropping HA's
-constraints or eagerly upgrading its shared packages.
+Dependabot continues updating Pydantic and HTTPX for standalone, Docker, and
+app installations. Their standalone lock versions may advance independently
+of Core's pins while the package requirements still admit those pins. Review
+requirement changes against supported Core versions; an incompatible floor
+must fail alignment checks rather than silently strand embedded users.
+Renovate advances the Core E2E image, not these package requirements. Never
+fix an embedded resolver failure by dropping HA's constraints or eagerly
+upgrading its shared packages.
 
 Fast Checks verifies direct dependency alignment against both the current
 Core image and the `hacs.json` minimum, without adding E2E lanes. Existing

--- a/docs/agents/custom-component.md
+++ b/docs/agents/custom-component.md
@@ -70,6 +70,37 @@ caller and does not know to demand the new component.
 A component path cannot be fully exercised by pre-merge CI. After merge,
 live-test it promptly on the development server before the next stable cut.
 
+## Dependencies shared with Core
+
+The embedded server installs into Home Assistant's Python environment using
+Core's `package_constraints.txt`. The standalone `uv.lock` is not the embedded
+installation contract. For HA-owned libraries, keep package requirements as
+bounded compatibility ranges that admit supported Core versions. Preserve the
+standalone lock's selected versions when widening a range; widen or raise a
+floor only with compatibility evidence. Pydantic follows its major-version
+boundary; HTTPX is pre-1.0, so its minor-version boundary remains capped.
+
+Dependabot defers routine Pydantic and HTTPX version updates. Its `update-types`
+ignore rules leave security updates enabled; those still need compatibility
+review. Renovate advances the Core E2E image, not these package requirements.
+When updating either library, coordinate the requirement and standalone lock
+with Core's pins. Never fix an embedded resolver failure by dropping HA's
+constraints or eagerly upgrading its shared packages.
+
+PR checks cover the current Core image and the `hacs.json` minimum:
+
+- Fast Checks verifies direct dependency alignment at both endpoints.
+- The current embedded lanes run the full suite on x64 and ARM64.
+- A focused x64 minimum-Core variant boots the real embedded server and runs
+  the connection and no-stomp tests, covering transitive installation and both
+  preinstall/runtime replacement of HA-governed packages.
+- Existing nightly beta E2E lanes detect upcoming Core regressions.
+
+These checks cover those versions and installation paths, not every intervening
+release, every installed third-party integration, or future API compatibility.
+Keep the HACS minimum honest; passing current-Core E2E alone does not justify
+raising a dependency floor past versions older supported Core releases need.
+
 ## Two entries, one command surface
 
 The integration has two config-entry types:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,9 +31,9 @@ dependencies = [
     "fastmcp==3.4.7",
     # Shared with the embedded HA process: admit Core's versions, including
     # compatible updates, instead of requiring it to keep our exact pin.
-    # uv.lock retains the standalone versions; HA's own constraints select
+    # uv.lock selects standalone versions; HA's own constraints select
     # the embedded versions. Check both the HACS minimum and current Core
-    # before raising these floors. Dependabot defers routine updates for them.
+    # before raising these floors; standalone lock updates can move independently.
     "httpx[socks]>=0.28.1,<0.29",
     "pydantic>=2.13.4,<3",
     "python-dotenv==1.2.3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,8 +29,13 @@ classifiers = [
 
 dependencies = [
     "fastmcp==3.4.7",
-    "httpx[socks]==0.28.1",
-    "pydantic==2.13.4",
+    # Shared with the embedded HA process: admit Core's versions, including
+    # compatible updates, instead of requiring it to keep our exact pin.
+    # uv.lock retains the standalone versions; HA's own constraints select
+    # the embedded versions. Check both the HACS minimum and current Core
+    # before raising these floors. Dependabot defers routine updates for them.
+    "httpx[socks]>=0.28.1,<0.29",
+    "pydantic>=2.13.4,<3",
     "python-dotenv==1.2.3",
     "truststore==0.10.4",
     # websockets is deliberately ABSENT from this list: ha-mcp ships its own

--- a/tests/src/unit/test_ha_dependency_policy.py
+++ b/tests/src/unit/test_ha_dependency_policy.py
@@ -1,0 +1,129 @@
+"""Keep HA-owned dependencies compatible across component-supported Core versions."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tomllib
+from pathlib import Path
+
+import pytest
+import yaml
+from packaging.requirements import Requirement
+
+_ROOT = Path(__file__).resolve().parents[3]
+
+
+@pytest.mark.parametrize(
+    ("name", "current", "next_patch", "breaking"),
+    [
+        ("pydantic", "2.13.4", "2.13.5", "3.0.0"),
+        ("httpx", "0.28.1", "0.28.2", "0.29.0"),
+    ],
+)
+def test_ha_owned_requirements_allow_core_patch_updates(
+    name, current, next_patch, breaking
+):
+    project = tomllib.loads((_ROOT / "pyproject.toml").read_text())
+    deps = {dep.name: dep for dep in map(Requirement, project["project"]["dependencies"])}
+    assert current in deps[name].specifier
+    assert next_patch in deps[name].specifier
+    assert breaking not in deps[name].specifier
+    if name == "httpx":
+        assert deps[name].extras == {"socks"}
+
+
+@pytest.mark.parametrize("name", ["pydantic", "httpx"])
+def test_dependabot_defers_version_updates_without_suppressing_security(name):
+    config = yaml.safe_load((_ROOT / ".github/dependabot.yml").read_text())
+    uv = next(item for item in config["updates"] if item["package-ecosystem"] == "uv")
+    rule = next(item for item in uv["ignore"] if item["dependency-name"] == name)
+    assert set(rule["update-types"]) == {
+        "version-update:semver-major",
+        "version-update:semver-minor",
+        "version-update:semver-patch",
+    }
+    assert "versions" not in rule
+
+
+@pytest.mark.parametrize(
+    ("current_status", "floor_status", "expected"),
+    [
+        (0, 0, 0),
+        (0, 1, 1),
+        (1, 0, 1),
+        (78, 1, 1),
+        (1, 78, 1),
+        (0, 2, 1),
+        (78, 0, 0),
+        (0, 78, 0),
+    ],
+)
+def test_alignment_checks_both_versions_and_preserves_failures(
+    tmp_path, current_status, floor_status, expected
+):
+    workflow = yaml.safe_load((_ROOT / ".github/workflows/pr.yml").read_text())
+    step = next(
+        step
+        for step in workflow["jobs"]["fast-checks"]["steps"]
+        if step.get("name") == "Check dependency alignment with HA core constraints"
+    )
+    (tmp_path / "hacs.json").write_text(json.dumps({"homeassistant": "2026.8.0"}))
+    (tmp_path / "python3").symlink_to(sys.executable)
+    uv = tmp_path / "uv"
+    uv.write_text(
+        f"#!{sys.executable}\n"
+        "import sys\n"
+        "from pathlib import Path\n"
+        "version = sys.argv[-1]\n"
+        "with Path('checked').open('a') as output:\n"
+        "    output.write(version + '\\n')\n"
+        f"sys.exit({{'2026.9.1': {current_status}, '2026.8.0': {floor_status}}}[version])\n"
+    )
+    uv.chmod(0o755)
+    result = subprocess.run(
+        ["bash", "-e", "-c", step["run"]],
+        cwd=tmp_path,
+        env={
+            **os.environ,
+            "PATH": f"{tmp_path}{os.pathsep}{os.environ['PATH']}",
+            "HA_IMAGE_GHCR": "ghcr.io/home-assistant/home-assistant:2026.9.1",
+        },
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == expected, result.stdout + result.stderr
+    assert set((tmp_path / "checked").read_text().splitlines()) == {
+        "2026.8.0",
+        "2026.9.1",
+    }
+
+
+def test_hacs_minimum_embedded_install_is_part_of_required_e2e_gate():
+    workflow = yaml.safe_load((_ROOT / ".github/workflows/pr.yml").read_text())
+    jobs = workflow["jobs"]
+    embedded = jobs["e2e-validation-embedded"]
+    variants = embedded["strategy"]["matrix"]["include"]
+    assert {row["os"] for row in variants if not row.get("hacs_minimum")} == {
+        "ubuntu-latest",
+        "ubuntu-24.04-arm",
+    }
+    floor = [row for row in variants if row.get("hacs_minimum")]
+    assert len(floor) == 1
+    assert floor[0]["pytest_workers"] == 1
+    steps = embedded["steps"]
+    select = next(step for step in steps if step.get("name") == "Select HACS minimum image")
+    assert "matrix.hacs_minimum" in select["if"]
+    assert "hacs.json" in select["run"]
+    assert "HA_IMAGE_GHCR=" in select["run"]
+    assert "HA_TEST_IMAGE=" in select["run"]
+    cache = next(step for step in steps if step.get("name") == "Cache HA Docker image")
+    assert steps.index(select) < steps.index(cache)
+    run = next(step for step in steps if "uv run pytest" in step.get("run", ""))
+    assert "test_embedded_no_stomp.py" in run["run"]
+    assert "test_connection.py" in run["run"]
+    assert run["env"]["E2E_BACKEND"] == "embedded"
+    assert "e2e-validation-embedded" in jobs["e2e-validation-gate"]["needs"]

--- a/tests/src/unit/test_ha_dependency_policy.py
+++ b/tests/src/unit/test_ha_dependency_policy.py
@@ -27,7 +27,9 @@ def test_ha_owned_requirements_allow_core_patch_updates(
     name, current, next_patch, breaking
 ):
     project = tomllib.loads((_ROOT / "pyproject.toml").read_text())
-    deps = {dep.name: dep for dep in map(Requirement, project["project"]["dependencies"])}
+    deps = {
+        dep.name: dep for dep in map(Requirement, project["project"]["dependencies"])
+    }
     assert current in deps[name].specifier
     assert next_patch in deps[name].specifier
     assert breaking not in deps[name].specifier
@@ -115,7 +117,9 @@ def test_hacs_minimum_embedded_install_is_part_of_required_e2e_gate():
     assert len(floor) == 1
     assert floor[0]["pytest_workers"] == 1
     steps = embedded["steps"]
-    select = next(step for step in steps if step.get("name") == "Select HACS minimum image")
+    select = next(
+        step for step in steps if step.get("name") == "Select HACS minimum image"
+    )
     assert "matrix.hacs_minimum" in select["if"]
     assert "hacs.json" in select["run"]
     assert "HA_IMAGE_GHCR=" in select["run"]

--- a/tests/src/unit/test_ha_dependency_policy.py
+++ b/tests/src/unit/test_ha_dependency_policy.py
@@ -37,19 +37,6 @@ def test_ha_owned_requirements_allow_core_patch_updates(
         assert deps[name].extras == {"socks"}
 
 
-@pytest.mark.parametrize("name", ["pydantic", "httpx"])
-def test_dependabot_defers_version_updates_without_suppressing_security(name):
-    config = yaml.safe_load((_ROOT / ".github/dependabot.yml").read_text())
-    uv = next(item for item in config["updates"] if item["package-ecosystem"] == "uv")
-    rule = next(item for item in uv["ignore"] if item["dependency-name"] == name)
-    assert set(rule["update-types"]) == {
-        "version-update:semver-major",
-        "version-update:semver-minor",
-        "version-update:semver-patch",
-    }
-    assert "versions" not in rule
-
-
 @pytest.mark.parametrize(
     ("current_status", "floor_status", "expected"),
     [

--- a/tests/src/unit/test_ha_dependency_policy.py
+++ b/tests/src/unit/test_ha_dependency_policy.py
@@ -102,32 +102,3 @@ def test_alignment_checks_both_versions_and_preserves_failures(
         "2026.8.0",
         "2026.9.1",
     }
-
-
-def test_hacs_minimum_embedded_install_is_part_of_required_e2e_gate():
-    workflow = yaml.safe_load((_ROOT / ".github/workflows/pr.yml").read_text())
-    jobs = workflow["jobs"]
-    embedded = jobs["e2e-validation-embedded"]
-    variants = embedded["strategy"]["matrix"]["include"]
-    assert {row["os"] for row in variants if not row.get("hacs_minimum")} == {
-        "ubuntu-latest",
-        "ubuntu-24.04-arm",
-    }
-    floor = [row for row in variants if row.get("hacs_minimum")]
-    assert len(floor) == 1
-    assert floor[0]["pytest_workers"] == 1
-    steps = embedded["steps"]
-    select = next(
-        step for step in steps if step.get("name") == "Select HACS minimum image"
-    )
-    assert "matrix.hacs_minimum" in select["if"]
-    assert "hacs.json" in select["run"]
-    assert "HA_IMAGE_GHCR=" in select["run"]
-    assert "HA_TEST_IMAGE=" in select["run"]
-    cache = next(step for step in steps if step.get("name") == "Cache HA Docker image")
-    assert steps.index(select) < steps.index(cache)
-    run = next(step for step in steps if "uv run pytest" in step.get("run", ""))
-    assert "test_embedded_no_stomp.py" in run["run"]
-    assert "test_connection.py" in run["run"]
-    assert run["env"]["E2E_BACKEND"] == "embedded"
-    assert "e2e-validation-embedded" in jobs["e2e-validation-gate"]["needs"]

--- a/uv.lock
+++ b/uv.lock
@@ -780,9 +780,9 @@ dev = [
 requires-dist = [
     { name = "cryptography", specifier = ">=48.0.0,<51" },
     { name = "fastmcp", specifier = "==3.4.7" },
-    { name = "httpx", extras = ["socks"], specifier = "==0.28.1" },
+    { name = "httpx", extras = ["socks"], specifier = ">=0.28.1,<0.29" },
     { name = "packaging", specifier = ">=24.0" },
-    { name = "pydantic", specifier = "==2.13.4" },
+    { name = "pydantic", specifier = ">=2.13.4,<3" },
     { name = "pydantic-monty", specifier = "==0.0.18" },
     { name = "python-dotenv", specifier = "==1.2.3" },
     { name = "truststore", specifier = "==0.10.4" },


### PR DESCRIPTION
## What does this PR do?

PR #2391 changes our exact Pydantic requirement to 2.13.5 while HA Core 2026.9.1 requires 2.13.4, so the embedded installation cannot resolve both requirements. Exact shared-library requirements can also conflict when Core changes its own pin.

Replace the exact requirements with `pydantic>=2.13.4,<3` and `httpx[socks]>=0.28.1,<0.29`. The lower bounds are inclusive: Pydantic 2.13.4 and HTTPX 0.28.1 remain allowed. This PR keeps those selected versions in `uv.lock`; only its requirement metadata changes. The existing embedded installer continues to honor HA's constraints and scope upgrades to the server distribution.

Dependabot configuration is unchanged, so dependency updates continue across standalone, Docker, app (add-on), and binary installations. A subsequent lockfile update can select Pydantic 2.13.5 while an embedded installation retains Core's 2.13.4, provided the package requirement still admits both. After this PR merges, #2391 needs to be refreshed against the new ranges and pass CI; this PR does not itself apply or validate that refreshed update. A proposed requirement floor that excludes supported Core pins fails alignment checks. Releases outside the bounds require compatibility review before widening them. Renovate continues managing Core's E2E image.

Extend the existing Fast Checks step to check direct dependency alignment against both the current CI image and the minimum Core version read from `hacs.json`. Check both targets and accumulate failures so a successful check cannot hide a violation for the other version. Preserve the existing warning behavior for transient constraint-fetch failures. No additional CI jobs or E2E variants are introduced. Stable E2E remains on Core 2026.9.1, with the existing conditional post-merge/nightly beta workflows unchanged.

Existing container and HAOS E2E exercise installation and runtime behavior, including transitive dependencies and replacement of HA packages. The minimum-version alignment check covers direct requirements, not transitive installability or runtime behavior on that version. Neither endpoint checks nor current/beta E2E prove every intervening Core release or future API compatibility. Document these dependency rules and validation limits beside the component compatibility guidance.

Related: #2391.

## Type of change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [x] 📚 Documentation
- [x] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

Regression coverage checks compatible patch admission, incompatible-version bounds, and mixed alignment exit statuses. Validated on `a471b674`: GitHub Actions passed Fast Checks (including Ruff), unit tests, Docker/app validation, every container E2E variant, and all six HAOS E2E variants. Stable E2E uses Core 2026.9.1.

## Checklist
- [x] I have updated documentation if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified dependency compatibility requirements for embedded installations.
  - Documented how standalone dependency updates relate to Home Assistant Core versions.
  - Expanded guidance on supported Pydantic and HTTPX version boundaries.
  - Clarified validation coverage across current and minimum supported Core versions, including embedded and nightly testing.

- **Maintenance**
  - Improved compatibility checks to validate both current and minimum supported versions.
  - Dependency ranges remain unchanged while standalone lockfile updates can advance independently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



