### PR TITLE
fix: enforce read-only mode inside ha_call_service

### DIFF
--- a/src/ha_mcp/read_only.py
+++ b/src/ha_mcp/read_only.py
@@ -331,6 +331,12 @@ def _raise_read_only_error(
     )
 
 
+def require_write_access(tool_name: str) -> None:
+    """Reject direct tool execution while Read Only Mode is enabled."""
+    if get_global_settings().read_only_mode:
+        _raise_read_only_error(tool_name)
+
+
 class ReadOnlyToolsTransform(Transform):
     """Hide write-capable tools from the catalog while read-only mode is on.
 

--- a/src/ha_mcp/tools/tools_service.py
+++ b/src/ha_mcp/tools/tools_service.py
@@ -29,6 +29,7 @@ from ..errors import (
     create_error_response,
     create_validation_error,
 )
+from ..read_only import require_write_access
 from ..utils.entity_membership import normalize_member_entity_ids
 from .bulk_selector import (
     _NON_AGGREGATE_ROOT_DOMAINS,
@@ -1816,6 +1817,7 @@ class ServiceTools:
         name="ha_call_service",
         tags={"Service & Device Control"},
         annotations={
+            "readOnlyHint": False,
             "openWorldHint": False,
             "destructiveHint": True,
             "title": "Call Service",
@@ -2000,7 +2002,14 @@ class ServiceTools:
         Only one-shot request/response commands are supported; streaming/two-phase
         and service-invoking commands are rejected, and the other service
         parameters (entity_id, return_response, etc.) don't apply.
+
+        Unavailable in Read Only Mode, including read-like services and WebSocket
+        commands. Use dedicated read tools while that mode is enabled.
         """
+        # Guard the escape hatch itself as well as the MCP catalog/middleware:
+        # direct dispatch must never reach either transport in read-only mode.
+        require_write_access("ha_call_service")
+
         # WebSocket-command escape hatch (issue #1839): reach one-shot WS
         # commands that aren't registered services (e.g. repairs/ignore_issue).
         if ws_command is not None:

--- a/tests/src/e2e/policy/test_readonly_mode.py
+++ b/tests/src/e2e/policy/test_readonly_mode.py
@@ -272,14 +272,24 @@ async def test_overview_reports_read_only_mode(readonly_mcp):
 @pytest.mark.asyncio
 async def test_direct_write_tool_call_blocked(readonly_mcp):
     client, _server = readonly_mcp
-    body = await _expect_read_only_blocked(
-        client,
-        "ha_call_service",
+    for arguments in (
         {"domain": "light", "service": "turn_on", "entity_id": "light.bed_light"},
-    )
-    assert body["tool_name"] == "ha_call_service"
-    # The error must point the user at the toggle.
-    assert "Read Only Mode" in body["error"]["message"]
+        {
+            "domain": "persistent_notification",
+            "service": "create",
+            "data": {"message": "read-only regression"},
+        },
+        {"domain": "weather", "service": "get_forecasts", "return_response": True},
+        {"ws_command": "repairs/list_issues"},
+        {
+            "ws_command": "repairs/ignore_issue",
+            "data": {"domain": "sun", "issue_id": "test", "ignore": True},
+        },
+    ):
+        body = await _expect_read_only_blocked(client, "ha_call_service", arguments)
+        assert body["tool_name"] == "ha_call_service"
+        # The error must point the user at the toggle.
+        assert "Read Only Mode" in body["error"]["message"]
 
 
 @pytest.mark.asyncio

--- a/tests/src/unit/test_call_service_read_only.py
+++ b/tests/src/unit/test_call_service_read_only.py
@@ -1,0 +1,113 @@
+"""Call Service is unavailable in read-only mode, including direct dispatch."""
+
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastmcp import Client, FastMCP
+from fastmcp.exceptions import ToolError
+
+from ha_mcp.config import get_global_settings
+from ha_mcp.read_only import ReadOnlyMiddleware, ReadOnlyToolsTransform
+from ha_mcp.tools.tools_service import ServiceTools, register_service_tools
+from ha_mcp.transforms.categorized_search import CategorizedSearchTransform
+
+
+@pytest.fixture
+def service_tools():
+    client = MagicMock()
+    client.call_service = AsyncMock(return_value=[])
+    client.send_websocket_message = AsyncMock(return_value={"success": True})
+    return ServiceTools(client, MagicMock())
+
+
+@pytest.mark.parametrize(
+    "arguments",
+    [
+        {
+            "domain": "persistent_notification",
+            "service": "create",
+            "data": {"message": "read-only regression"},
+        },
+        {"domain": "weather", "service": "get_forecasts", "return_response": True},
+        {
+            "ws_command": "repairs/ignore_issue",
+            "data": {"domain": "sun", "issue_id": "test", "ignore": True},
+        },
+        {"ws_command": "repairs/list_issues"},
+        {},
+    ],
+)
+async def test_direct_dispatch_blocks_every_mode(monkeypatch, service_tools, arguments):
+    """Removing the tool-body guard must fail even without MCP middleware."""
+    monkeypatch.setattr(get_global_settings(), "read_only_mode", True)
+    with pytest.raises(ToolError) as exc:
+        await service_tools.ha_call_service(**arguments)
+    body = json.loads(str(exc.value))
+    assert body["error"]["code"] == "READ_ONLY_MODE"
+    assert body["tool_name"] == "ha_call_service"
+    service_tools._client.call_service.assert_not_awaited()
+    service_tools._client.send_websocket_message.assert_not_awaited()
+
+
+async def test_direct_dispatch_observes_live_toggle(monkeypatch, service_tools):
+    settings = get_global_settings()
+    monkeypatch.setattr(settings, "read_only_mode", False)
+    assert (await service_tools.ha_call_service(ws_command="repairs/list_issues"))[
+        "success"
+    ]
+    settings.read_only_mode = True
+    with pytest.raises(ToolError, match="READ_ONLY_MODE"):
+        await service_tools.ha_call_service(ws_command="repairs/list_issues")
+    settings.read_only_mode = False
+    assert (await service_tools.ha_call_service(ws_command="repairs/list_issues"))[
+        "success"
+    ]
+    assert service_tools._client.send_websocket_message.await_count == 2
+
+
+@pytest.mark.parametrize("tool_search", [False, True])
+async def test_registered_tool_hidden_and_calls_rejected(
+    monkeypatch, service_tools, tool_search
+):
+    """Exercise real tool metadata, filtering, and middleware with an MCP client."""
+    settings = get_global_settings()
+    monkeypatch.setattr(settings, "read_only_mode", False)
+    mcp = FastMCP("call-service-read-only-test")
+    register_service_tools(mcp, service_tools._client, device_tools=MagicMock())
+    mcp.add_transform(ReadOnlyToolsTransform())
+    mcp.add_middleware(ReadOnlyMiddleware(list_tools=mcp.local_provider._list_tools))
+    if tool_search:
+        mcp.add_transform(
+            CategorizedSearchTransform(always_visible=["ha_call_service"])
+        )
+    async with Client(mcp) as client:
+        assert "ha_call_service" in {t.name for t in await client.list_tools()}
+        settings.read_only_mode = True
+        assert "ha_call_service" not in {t.name for t in await client.list_tools()}
+        with pytest.raises(ToolError, match="READ_ONLY_MODE"):
+            await client.call_tool(
+                "ha_call_service", {"ws_command": "repairs/list_issues"}
+            )
+        if tool_search:
+            for proxy in (
+                "ha_call_read_tool",
+                "ha_call_write_tool",
+                "ha_call_delete_tool",
+            ):
+                with pytest.raises(ToolError, match="READ_ONLY_MODE"):
+                    await client.call_tool(
+                        proxy,
+                        {
+                            "name": "ha_call_service",
+                            "arguments": {
+                                "domain": "persistent_notification",
+                                "service": "create",
+                                "data": {"message": "read-only regression"},
+                            },
+                        },
+                    )
+        settings.read_only_mode = False
+        assert "ha_call_service" in {t.name for t in await client.list_tools()}
+    service_tools._client.call_service.assert_not_awaited()
+    service_tools._client.send_websocket_message.assert_not_awaited()


### PR DESCRIPTION
## What does this PR do?

Reject every `ha_call_service` invocation at the tool entry point while Read Only Mode is enabled, before service validation or either REST/component or WebSocket dispatch. This includes read-like services, response-returning calls, and read-only WebSocket commands. The tool explicitly declares `readOnlyHint: false` and remains hidden by the existing catalog filter.

The existing catalog filter and middleware already classify this tool as a non-exempt write tool. The new guard also protects direct tool invocation without that middleware. Regression tests cover the reported `persistent_notification.create` call, both transport modes, live toggles, catalog hiding with and without tool search, and all three call proxies.

Related to #2410. The report also says `ha_get_overview` did not show the runtime read-only flag. This change does not establish why that embedded instance failed to observe the setting, so it does not automatically close the issue.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Maintenance/refactor
- [ ] Tests only
- [ ] Breaking change

## Testing

- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

The five new direct-dispatch cases failed before the guard was added. After the fix, 420 focused tests pass across read-only enforcement/wiring, Call Service read-only behavior, WebSocket commands, component routing, and categorized search. Ruff check, format check, and `git diff --check` pass. Expanded the existing read-only E2E test to cover notification creation and read/write WebSocket requests; remote CI passed on fe7b46a040cd4aebe474f8f0266d1c2aa6f02381, including the full unit suite and all container and HAOS E2E lanes. All 29 completed checks passed (two checks were skipped). CodeRabbit and both Codex reviews reported no actionable findings, and there are no unresolved review threads.

## Checklist

- [x] I have updated documentation if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Service calls and raw commands are now blocked when Read-Only Mode is enabled.
  - Blocked attempts return a clear read-only error and identify the affected tool.
  - Read-only status is checked live, so changing the setting takes effect immediately.
  - The service tool is hidden from available tools while Read-Only Mode is active.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->