### PR TITLE
ci: build the HAOS image once per run instead of once per lane

### DIFF
--- a/.github/workflows/build-haos-test-image.yml
+++ b/.github/workflows/build-haos-test-image.yml
@@ -11,8 +11,9 @@ name: Build HAOS Test Image (Prime Shared Cache)
 # and push to master that touches any input baked into the qcow2.
 #
 # INVARIANT — the path triggers below MUST mirror the ``git ls-tree`` paths
-# that the six HAOS E2E lanes in ``haos-e2e-tests.yml`` hash into their image
-# cache keys (see each "Compute image cache key" step). The beta lanes in
+# that the six HAOS E2E lanes and their shared ``build-image`` job in
+# ``haos-e2e-tests.yml`` hash into their image cache keys (see each "Compute
+# image cache key" step). The beta lanes in
 # ``haos-e2e-beta-tests.yml`` are NOT part of this invariant: they key a
 # separate ``haos-beta-image-*`` namespace this workflow never primes.
 # When master commits change a baked
@@ -244,7 +245,8 @@ jobs:
         if: github.ref == 'refs/heads/master'
         continue-on-error: true
         # INVARIANT: this git ls-tree must stay byte-IDENTICAL to the
-        # "Compute image cache key" step in all six HAOS E2E lanes —
+        # "Compute image cache key" step in the shared ``build-image`` job and
+        # all six HAOS E2E lanes —
         # otherwise this warms a key the lanes never restore (a wasted prime,
         # not a stale test: the lanes still recompute their own correct key).
         # NOTE the push-trigger paths above are a deliberate SUPERSET (they also

--- a/.github/workflows/haos-e2e-tests.yml
+++ b/.github/workflows/haos-e2e-tests.yml
@@ -9,21 +9,30 @@ name: HAOS E2E Tests
 # The lanes themselves are unchanged: same job ids, same job NAMES (they are
 # required status checks, so the names are a branch-protection contract), same
 # steps, same env, same timeouts, and the same shared ``haos-image-*`` cache
-# key. The external `haos-e2e` lane is still the sole writer of that cache;
-# every other lane restores only.
+# key. A `build-image` job ahead of the lanes writes that cache within a run
+# (#2311); the lanes restore, and each keeps its own local build as the
+# fallback for a miss.
 #
 # One behavioral change comes with the merge: a manual dispatch now runs ALL
 # SIX lanes, where dispatching a single lane's file previously ran that lane
 # alone. Narrow a dispatch with the `pytest_args` / `pytest_paths` inputs
 # rather than by picking a file.
 #
-# Image resolution strategy (per lane, per run):
-#   1. Try GitHub Actions cache (keyed on HAOS version + build inputs)
-#   2. On a cache miss, build locally (build_image.py); only `haos-e2e` saves
+# Image resolution strategy (per run):
+#   1. `build-image` probes the GitHub Actions cache (keyed on HAOS version +
+#      build inputs) without downloading. On a miss it builds locally
+#      (build_image.py) once and saves. The six lanes wait for it.
+#   2. Each lane restores from the cache. If the restore still misses — the
+#      entry was evicted between probe and restore, the save was refused
+#      because another run held the key, or `build-image` itself failed —
+#      the lane builds locally exactly as it always did, so a broken build
+#      job never blocks a lane. Only `haos-e2e` saves on that path.
 #
 # One job per lane on purpose: the qcow2 stays on that runner's local disk
-# through build -> test, so there's no cross-job upload+download of the ~7 GB
-# image (previously cost ~5 min per PR).
+# through restore -> test, so there's no cross-job upload+download of the
+# ~7 GB image (previously cost ~5 min per PR). The cache is the only channel
+# between `build-image` and the lanes. What the job removes is the six-fold
+# BUILD on a miss push, not the per-lane restore.
 
 on:
   # No workflow-level `paths:` filter on purpose. These checks are REQUIRED
@@ -138,9 +147,127 @@ jobs:
           echo "run=$run"
           echo "run=$run" >> "$GITHUB_OUTPUT"
 
+  build-image:
+    name: Build HAOS image (shared)
+    needs: changes
+    # Same skip rule as the lanes below: a docs-only PR must not boot a runner
+    # here either, and a classifier that did not succeed must not skip the
+    # build the lanes are about to wait for. Both halves are pinned by
+    # tests/src/unit/test_haos_image_workflow_shape.py.
+    if: ${{ !cancelled() && (needs.changes.result != 'success' || needs.changes.outputs.run != 'false') }}
+    runs-on: ubuntu-22.04
+    # A local build takes 6-9 minutes; the lanes' 45 covers build + suite,
+    # this job never runs the suite.
+    timeout-minutes: 30
+
+    # One image build per run instead of one per lane (#2311). All six lanes
+    # compute the same key and restore the same qcow2, and the only writer
+    # used to be `haos-e2e` — whose save landed long after the other five
+    # lanes, started in parallel, had already missed and built for
+    # themselves. So a miss push built the identical image six times. This
+    # job runs first: on a hit it is a metadata probe (seconds); on a miss it
+    # is the single build and the single save, and the lanes restore it.
+    #
+    # The lanes keep every local-build step they had. They fall back to it
+    # when this job failed (their `if:` is `!cancelled()`, not `success()`),
+    # when the save here was refused ("another job may be creating this
+    # cache"), or when the entry was evicted between the probe and their
+    # restore — a rebuild inside the lane is faster than any retry.
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+          # No submodules and no history: the bake stages
+          # homeassistant-addon-dev, the webhook proxy and custom_components
+          # (build_image.py's stage_* functions), none of them a submodule,
+          # and `git ls-tree -r HEAD` reads the tree, not a checkout. The
+          # lanes fetch more only for their own test suite.
+
+      - name: Compute image cache key
+        id: key
+        # INVARIANT: byte-identical to the lanes' step of the same name
+        # (test_haos_image_workflow_shape.py pins it). A key computed
+        # differently here primes an entry the lanes never restore.
+        run: |
+          hash=$(git ls-tree -r HEAD \
+            tests/haos_image_build \
+            tests/initial_test_state \
+            custom_components/ha_mcp_tools \
+            homeassistant-addon-webhook-proxy \
+            | sha256sum | cut -d' ' -f1 | head -c16)
+          echo "cache-key=haos-image-$hash" >> "$GITHUB_OUTPUT"
+
+      - name: Probe image cache (metadata only, no download)
+        id: restore-cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+        with:
+          path: /tmp/haos-test-image.qcow2
+          key: ${{ steps.key.outputs.cache-key }}
+          # The entry is several GB and this job never boots the image; it
+          # only needs to know whether the key exists.
+          lookup-only: true
+
+      - name: Report image-acquisition path
+        run: |
+          echo "::notice title=HAOS image cache::cache-hit=${{ steps.restore-cache.outputs.cache-hit }} key=${{ steps.key.outputs.cache-key }}"
+
+      - name: Install QEMU + OVMF + libguestfs
+        if: steps.restore-cache.outputs.cache-hit != 'true'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            qemu-system-x86 qemu-utils ovmf xz-utils curl libguestfs-tools sshpass
+          # Ubuntu installs the kernel image as 0600 root:root, but
+          # libguestfs's supermin appliance builder needs to read it as
+          # the invoking (unprivileged) user. Documented at
+          # https://libguestfs.org/guestfs-faq.1.html#kernel-permissions
+          # (search "kernel image is not readable") — workaround is to
+          # relax perms on /boot/vmlinuz-*.
+          sudo chmod +r /boot/vmlinuz-*
+
+      - name: Enable KVM group perms
+        if: steps.restore-cache.outputs.cache-hit != 'true'
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' \
+            | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
+      - name: Free disk space for the local build
+        # Same pruning as the lanes: the bake peaks at the edge of the
+        # runner's ~14 GB SSD, see the comment on the ``haos-e2e`` step.
+        if: steps.restore-cache.outputs.cache-hit != 'true'
+        run: |
+          df -h /
+          sudo rm -rf /usr/share/dotnet /usr/share/swift /opt/ghc \
+            /usr/local/lib/android /usr/local/.ghcup
+          sudo apt-get clean
+          docker system prune -af --volumes || true
+          df -h /
+
+      - name: Install build-script Python deps (cache miss only)
+        if: steps.restore-cache.outputs.cache-hit != 'true'
+        run: pip install -r tests/haos_image_build/requirements.txt
+
+      - name: Build image locally (cache miss only)
+        # `force_local_build` is deliberately not honoured here: it asks each
+        # lane to ignore the cached image and rebuild for itself, and a save
+        # cannot replace an existing entry under the same key anyway.
+        if: steps.restore-cache.outputs.cache-hit != 'true'
+        run: |
+          python3 tests/haos_image_build/build_image.py --verbose \
+            --output /tmp/haos-test-image.qcow2
+
+      - name: Save image to cache (cache miss only)
+        if: steps.restore-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+        with:
+          path: /tmp/haos-test-image.qcow2
+          key: ${{ steps.key.outputs.cache-key }}
+
   haos-e2e:
     name: HAOS E2E Tests
-    needs: changes
+    needs: [changes, build-image]
     # A skipped job reports Success to the required status check (unlike a
     # workflow-level path-skip, which never reports). See the `changes` job.
     # Skipping requires a classifier that SUCCEEDED and said `false` out loud.
@@ -251,12 +378,13 @@ jobs:
             --output /tmp/haos-test-image.qcow2
 
       - name: Save image to cache (cache miss only)
-        # Save whenever the runtime cache missed so the locally-built
-        # qcow2 populates the shared key and future runs restore it
-        # instead of rebuilding. This is the sole writer for the shared
-        # cache key (#1407 + #1428); the other five lanes intentionally
-        # don't save, see the block comment at the same position in
-        # the ``haos-e2e-inaddon`` job below.
+        # The shared key is normally written by ``build-image`` before this
+        # lane starts. This save covers the fallback path only: the lane
+        # restored nothing (entry evicted, save refused, or the build job
+        # failed) and built for itself, so the key is repopulated for the
+        # next run. It stays the only LANE that saves (#1407 + #1428); the
+        # other five intentionally don't, see the block comment at the same
+        # position in the ``haos-e2e-inaddon`` job below.
         if: steps.restore-cache.outputs.cache-hit != 'true'
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
@@ -373,7 +501,7 @@ jobs:
 
   haos-e2e-embedded:
     name: HAOS E2E Tests (embedded)
-    needs: changes
+    needs: [changes, build-image]
     # A skipped job reports Success to the required status check (unlike a
     # workflow-level path-skip, which never reports). See the `changes` job.
     # Skipping requires a classifier that SUCCEEDED and said `false` out loud.
@@ -474,9 +602,10 @@ jobs:
           python3 tests/haos_image_build/build_image.py --verbose \
             --output /tmp/haos-test-image.qcow2
 
-      # No cache-save step here on purpose. The external lane (``haos-e2e``)
-      # computes the same cache key (#1407) and is the SOLE saver of the
-      # shared qcow2; the other five lanes only restore from that shared
+      # No cache-save step here on purpose. The ``build-image`` job writes the
+      # shared key before any lane starts; on the fallback path the external
+      # lane (``haos-e2e``) computes the same cache key (#1407) and is the SOLE
+      # lane that saves the shared qcow2; the other five lanes only restore from that shared
       # key. All six lanes start in parallel on the same PR
       # push, so having only one saver avoids the "another job may be creating
       # this cache" race + the wasted tar+zstd write of a 12 GB image. The
@@ -609,7 +738,7 @@ jobs:
 
   haos-e2e-inaddon:
     name: HAOS E2E Tests (inaddon)
-    needs: changes
+    needs: [changes, build-image]
     # A skipped job reports Success to the required status check (unlike a
     # workflow-level path-skip, which never reports). See the `changes` job.
     # Skipping requires a classifier that SUCCEEDED and said `false` out loud.
@@ -704,9 +833,10 @@ jobs:
           python3 tests/haos_image_build/build_image.py --verbose \
             --output /tmp/haos-test-image.qcow2
 
-      # No cache-save step here on purpose. The external lane (``haos-e2e``)
-      # computes the same cache key (#1407) and always tries to save the
-      # same qcow2; all six lanes start in
+      # No cache-save step here on purpose. The ``build-image`` job writes the
+      # shared key before any lane starts; on the fallback path the external
+      # lane (``haos-e2e``) computes the same cache key (#1407) and always
+      # tries to save the same qcow2; all six lanes start in
       # parallel on the same PR push, so whichever lost the save race
       # was burning ~25s on a tar+zstd-write of a 12 GB qcow2 that
       # the actions/cache service then refused with
@@ -882,7 +1012,7 @@ jobs:
 
   haos-e2e-stdio:
     name: HAOS E2E Tests (stdio)
-    needs: changes
+    needs: [changes, build-image]
     # A skipped job reports Success to the required status check. Skipping
     # therefore requires the classifier to have succeeded and explicitly said
     # false. The status function is also deliberate: without !cancelled(), an
@@ -959,9 +1089,10 @@ jobs:
           python3 tests/haos_image_build/build_image.py --verbose \
             --output /tmp/haos-test-image.qcow2
 
-      # The external HAOS lane is the sole writer for this shared key. A
-      # simultaneous cache miss can build here, but this parallel lane must not
-      # race it with a second cache save.
+      # The ``build-image`` job writes this shared key before the lanes start;
+      # on the fallback path the external HAOS lane is the only lane that
+      # saves. A simultaneous cache miss can build here, but this parallel
+      # lane must not race it with a second cache save.
 
       - name: Install uv
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
@@ -1061,7 +1192,7 @@ jobs:
 
   haos-e2e-embedded-no-tools:
     name: HAOS E2E Tests (embedded, no tools entry)
-    needs: changes
+    needs: [changes, build-image]
     # A skipped job reports Success to the required status check (unlike a
     # workflow-level path-skip, which never reports). See the `changes` job.
     # Skipping requires a classifier that SUCCEEDED and said `false` out loud.
@@ -1163,9 +1294,10 @@ jobs:
           python3 tests/haos_image_build/build_image.py --verbose \
             --output /tmp/haos-test-image.qcow2
 
-      # No cache-save step here on purpose. The external lane (``haos-e2e``)
-      # computes the same cache key (#1407) and is the SOLE saver of the
-      # shared qcow2; the other five lanes — this one, the two inaddon lanes,
+      # No cache-save step here on purpose. The ``build-image`` job writes the
+      # shared key before any lane starts; on the fallback path the external
+      # lane (``haos-e2e``) computes the same cache key (#1407) and is the SOLE
+      # lane that saves the shared qcow2; the other five lanes — this one, the two inaddon lanes,
       # the stdio lane and the component-present embedded lane — only restore
       # from that shared key. They all start in parallel on the same PR
       # push, so having only one saver avoids the "another job may be creating
@@ -1305,7 +1437,7 @@ jobs:
 
   haos-e2e-inaddon-no-tools:
     name: HAOS E2E Tests (inaddon, no tools entry)
-    needs: changes
+    needs: [changes, build-image]
     # A skipped job reports Success to the required status check (unlike a
     # workflow-level path-skip, which never reports). See the `changes` job.
     # Skipping requires a classifier that SUCCEEDED and said `false` out loud.
@@ -1401,9 +1533,10 @@ jobs:
           python3 tests/haos_image_build/build_image.py --verbose \
             --output /tmp/haos-test-image.qcow2
 
-      # No cache-save step here on purpose. The external lane (``haos-e2e``)
-      # computes the same cache key (#1407) and always tries to save the
-      # same qcow2; all six HAOS lanes start in
+      # No cache-save step here on purpose. The ``build-image`` job writes the
+      # shared key before any lane starts; on the fallback path the external
+      # lane (``haos-e2e``) computes the same cache key (#1407) and always
+      # tries to save the same qcow2; all six HAOS lanes start in
       # parallel on the same PR push, so whichever lost the save race
       # was burning ~25s on a tar+zstd-write of a 12 GB qcow2 that
       # the actions/cache service then refused with

--- a/.github/workflows/haos-e2e-tests.yml
+++ b/.github/workflows/haos-e2e-tests.yml
@@ -177,11 +177,13 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
-          # No submodules and no history: the bake stages
-          # homeassistant-addon-dev, the webhook proxy and custom_components
-          # (build_image.py's stage_* functions), none of them a submodule,
-          # and `git ls-tree -r HEAD` reads the tree, not a checkout. The
-          # lanes fetch more only for their own test suite.
+          # The bake copies all of src/ha_mcp into the dev app's build
+          # context (build_image.py, stage_dev_addon_source), and that tree
+          # includes the vendored skills submodule at
+          # src/ha_mcp/resources/skills-vendor, which pyproject.toml packages.
+          # Same checkout as build-haos-test-image.yml. No fetch-depth: the
+          # cache key is `git ls-tree -r HEAD`, which reads the tree.
+          submodules: true
 
       - name: Compute image cache key
         id: key

--- a/docs/agents/github-workflow.md
+++ b/docs/agents/github-workflow.md
@@ -174,7 +174,7 @@ summary only when the pull request actually reaches that state.
 | `renovate-validation.yml` | Relevant pull request or manual | Validate configuration with the scanner’s pinned Renovate engine, without credentials. |
 | `renovate-auto-merge.yml` | Renovate enables auto-merge or updates its PR | Approve the verified current head with the separate maintainer account; GitHub enforces merge requirements. |
 | `e2e-tests.yml` | Push to `master` touching code, or manual | Full container-backend E2E validation on the pinned stable Core image. |
-| `haos-e2e-tests.yml` | Pull request or manual | Six HAOS lanes against a baked qcow2; required status checks. |
+| `haos-e2e-tests.yml` | Pull request or manual | One shared image-build job, then six HAOS lanes against the baked qcow2 it cached; the lanes are required status checks. |
 | `haos-e2e-beta-tests.yml` | Push to `master`, nightly, or manual | The inaddon and embedded HAOS lanes against the current beta OS, Supervisor, and Core; skipped on push and nightly only when all three equal stable. |
 | `e2e-beta-tests.yml` | Push to `master`, nightly, or manual | The container-backend E2E jobs against the current beta Core image; skipped on push and nightly when beta equals the stable lane's pin. |
 | `publish-dev.yml` | Push to `master` | Development `.devN` release. |

--- a/tests/haos_image_build/README.md
+++ b/tests/haos_image_build/README.md
@@ -30,8 +30,10 @@ run it uploads the qcow2 as a workflow artifact (reviewer sanity-check). On
 shared Actions cache used by all six E2E lanes. They all live in
 `haos-e2e-tests.yml` as the jobs `haos-e2e`, `haos-e2e-inaddon`,
 `haos-e2e-inaddon-no-tools`, `haos-e2e-embedded`,
-`haos-e2e-embedded-no-tools`, and `haos-e2e-stdio`; each restores the qcow2
-from that cache and falls back to a local build on a miss.
+`haos-e2e-embedded-no-tools`, and `haos-e2e-stdio`. A `build-image` job
+ahead of them probes that cache and, on a miss, builds and saves the qcow2
+once; each lane then restores it and falls back to its own local build if the
+restore still misses.
 
 ## Version pinning
 

--- a/tests/src/unit/test_haos_image_workflow_shape.py
+++ b/tests/src/unit/test_haos_image_workflow_shape.py
@@ -14,9 +14,14 @@ _WORKFLOW_DIR = _REPO_ROOT / ".github" / "workflows"
 _STABLE_WORKFLOW = "haos-e2e-tests.yml"
 _BETA_WORKFLOW = "haos-e2e-beta-tests.yml"
 _CONTAINER_BETA_WORKFLOW = "e2e-beta-tests.yml"
-# 7 actual consumers (the six HAOS lanes + the image builder); the floor is what
-# catches a lane that silently loses its image-cache step.
-_CACHE_KEY_CONSUMER_FLOOR = 7
+# 8 actual consumers (the six HAOS lanes, their shared build job and the
+# master image builder); the floor is what catches a lane that silently loses
+# its image-cache step.
+_CACHE_KEY_CONSUMER_FLOOR = 8
+# The job that builds the qcow2 once per run and writes the shared key before
+# any lane starts (#2311).
+_SHARED_BUILD_JOB = "build-image"
+_BUILD_COMMAND = "python3 tests/haos_image_build/build_image.py"
 _CACHE_KEY_OUTPUT_MARKER = "cache-key=haos-image-"
 _HAOS_IMAGE_CACHE_PATH = "/tmp/haos-test-image.qcow2"
 _CACHE_ACTIONS = {
@@ -173,6 +178,93 @@ def test_cache_key_consumer_discovery_tracks_jobs_individually(
     assert _cache_key_consumers(tmp_path) == [
         (path, f"lane-{index}") for index in range(_CACHE_KEY_CONSUMER_FLOOR)
     ]
+
+
+def _stable_jobs() -> dict[str, dict[str, Any]]:
+    jobs = _workflow(_WORKFLOW_DIR / _STABLE_WORKFLOW)["jobs"]
+    return {str(job_id): job for job_id, job in jobs.items() if isinstance(job, dict)}
+
+
+def _stable_lanes() -> dict[str, dict[str, Any]]:
+    """The six HAOS lanes: every stable job that restores the image, minus the build job."""
+    lanes = {
+        job_id: job
+        for job_id, job in _stable_jobs().items()
+        if job_id != _SHARED_BUILD_JOB and _uses_haos_image_cache(job)
+    }
+    assert len(lanes) >= 6, sorted(lanes)
+    return lanes
+
+
+def _needs(job: dict[str, Any]) -> list[str]:
+    needs = job.get("needs") or []
+    return [needs] if isinstance(needs, str) else [str(need) for need in needs]
+
+
+def _steps_using(job: dict[str, Any], action: str) -> list[dict[str, Any]]:
+    return [
+        step
+        for step in _job_steps(job)
+        if str(step.get("uses", "")).partition("@")[0] == action
+    ]
+
+
+def _build_steps(job: dict[str, Any]) -> list[dict[str, Any]]:
+    """Steps that invoke the bake — matched on the command, not the script
+    name, which the diagnostics step's prose also mentions."""
+    return [
+        step for step in _job_steps(job) if _BUILD_COMMAND in str(step.get("run", ""))
+    ]
+
+
+def test_every_stable_lane_waits_for_the_shared_image_build() -> None:
+    """A lane that starts before ``build-image`` builds the image again for itself.
+
+    That is the six-fold build on a miss push that #2311 removes, and it comes
+    back the moment a new lane is copied from a pre-#2311 template.
+    """
+    jobs = _stable_jobs()
+    assert _SHARED_BUILD_JOB in jobs, sorted(jobs)
+    assert _needs(jobs[_SHARED_BUILD_JOB]) == ["changes"]
+    for job_id, job in _stable_lanes().items():
+        assert _SHARED_BUILD_JOB in _needs(job), f"{job_id} does not wait for the build"
+
+
+def test_shared_image_build_probes_without_downloading_and_writes_once() -> None:
+    job = _stable_jobs()[_SHARED_BUILD_JOB]
+    restores = _steps_using(job, "actions/cache/restore")
+    assert len(restores) == 1, "one probe"
+    assert restores[0]["with"].get("lookup-only") is True, (
+        "the probe must not download a multi-GB image it never boots"
+    )
+    saves = _steps_using(job, "actions/cache/save")
+    assert len(saves) == 1, "one writer"
+    assert "cache-hit != 'true'" in str(saves[0].get("if")), "save on a miss only"
+    builds = _build_steps(job)
+    assert len(builds) == 1, "one build"
+    assert "cache-hit != 'true'" in str(builds[0].get("if")), "build on a miss only"
+
+
+def test_shared_image_build_skips_exactly_when_the_lanes_skip() -> None:
+    """Docs-only PRs must not boot a runner for the build either."""
+    build_if = str(_stable_jobs()[_SHARED_BUILD_JOB].get("if"))
+    lane_ifs = {str(job.get("if")) for job in _stable_lanes().values()}
+    assert lane_ifs == {build_if}, (build_if, lane_ifs)
+
+
+def test_every_stable_lane_keeps_its_local_build_fallback() -> None:
+    """The cache can still miss after ``build-image`` ran (eviction, refused
+    save, or the job failed), and a rebuild inside the lane is faster than
+    any retry — the lanes' own build step stays (#2311).
+    """
+    for job_id, job in _stable_lanes().items():
+        builds = _build_steps(job)
+        assert len(builds) == 1, f"{job_id} lost its local build"
+        assert "cache-hit != 'true'" in str(builds[0].get("if")), job_id
+        assert "!cancelled()" in str(job.get("if")), (
+            f"{job_id} would be skipped by a failed build job instead of "
+            "building for itself"
+        )
 
 
 def test_beta_lane_discovery_does_not_depend_on_attestation(tmp_path: Path) -> None:


### PR DESCRIPTION
Part of #2311 (the shared build job from the 2026-09-05 measurement).

## What does this PR do?

Builds the HAOS test image once per run instead of once per lane.

All six HAOS E2E lanes compute the same cache key and restore the same qcow2, but the only writer was the `haos-e2e` lane, whose save landed after the other five lanes had already missed and built the identical image for themselves. On the current lane set, half of all pushes miss and a miss push runs six builds: of the 42 pull-request pushes whose six HAOS lanes ran between 2026-09-01 21:00Z and 2026-09-04 21:00Z (252 HAOS jobs), 21 missed, for 126 lane builds at a median of 6.5 min each.

A `build-image` job now runs ahead of the lanes:

- it probes the key with `lookup-only: true` (no download of the multi-GB entry), builds and saves once on a miss, and every lane lists it in `needs:`;
- the lanes keep every local-build step they had, as the fallback for a restore that still misses: an entry evicted between probe and restore, a refused save (`another job may be creating this cache`), or a failed build job. Their `if:` is `!cancelled()`, so a failed build job runs the lanes rather than turning six required checks into skips;
- `haos-e2e` keeps its save for that fallback path, so an evicted key is repopulated by the next miss.

The job skips exactly when the lanes skip (same classifier predicate), so a docs-only PR boots no runner for it.

GitHub-side behaviour this relies on, read today from the current docs: a job whose `needs` failed or was skipped is itself skipped "unless the jobs use a conditional expression that causes the job to continue" ([workflow syntax, `jobs.<job_id>.needs`](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idneeds)), and `if: ${{ !cancelled() }}` is the documented way to run "regardless of its success or failure" ([expressions, status check functions](https://docs.github.com/en/actions/reference/workflows-and-actions/expressions#status-check-functions)). `lookup-only: true` "only checks if cache entry exists and skips download" ([actions/cache restore README](https://github.com/actions/cache/blob/main/restore/README.md)).

Measured in a fork against the byte-identical baseline workflow, both arms started cold with a cache-key buster and the suite narrowed to one file:

| | baseline, cold | shared build, cold | baseline, warm | shared build, warm |
|---|---|---|---|---|
| wall clock | 15.3 min | 16.9 min | 4.7 min | 5.4 min |
| runner-minutes | 64.2 | 35.0 | 23.0 | 23.8 |
| image builds | 6 (5.9-9.2 min each) | 1 (8.2 min) | 0 | 0 |

Runs: [33915596884](https://github.com/Patch76/ha-mcp/actions/runs/33915596884), [33915603048](https://github.com/Patch76/ha-mcp/actions/runs/33915603048), [33917057675](https://github.com/Patch76/ha-mcp/actions/runs/33917057675), [33917059594](https://github.com/Patch76/ha-mcp/actions/runs/33917059594). One run per cell: the compute delta (29.2 runner-minutes on a miss push) is far outside the 5.9-9.2 min spread of build times within a single run; the wall-clock delta (+1.6 min on a miss, +0.7 on a hit) is not, and this PR's own runs are the next data points for it.

Shape-test pins added in `test_haos_image_workflow_shape.py`, each fault-injected and seen red before commit: every lane waits for the build job and the build job waits only for the classifier; the probe is metadata-only and the job builds and saves exactly once, each on a miss only; the job skips exactly when the lanes skip; every lane keeps its miss-guarded local build and its `!cancelled()` predicate. The consumer floor rises from 7 to 8. The cache-key command is byte-identical to the lanes' (the existing test pins that too).

`force_local_build` is not honoured by the build job: it asks each lane to rebuild for itself and ignore the cache, and a save cannot replace an existing entry under the same key ("You cannot change the contents of an existing cache", [dependency caching reference](https://docs.github.com/en/actions/reference/workflows-and-actions/dependency-caching)).

Not in this PR: PR 4 from the plan (folding the no-tools twins), which removes two of the six lanes and compounds with this change; and the image size, which drives the miss rate itself.

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [x] Maintenance/refactor
- [ ] Tests only
- [ ] Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`): 12925 passed locally; the 13 failures in `test_codex_workflow_contracts.py` and `test_mirror_sync_workflow_shape.py` are host-only (BusyBox `realpath`, tag signing) and identical on the base commit
- [x] Code follows style guidelines (`uv run ruff check`)

## Checklist
- [x] I have updated documentation if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **CI Improvements**
  - HAOS end-to-end testing now builds the required image once and shares it across all test lanes, reducing duplicate work and improving build efficiency.
  - Test lanes retain a local-build fallback when the shared image is unavailable.

- **Documentation**
  - Updated workflow and image-build documentation to describe the shared image strategy.

- **Tests**
  - Added coverage validating shared image caching, job dependencies, skip conditions, and fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->