### PR TITLE
ci: stop caching the beta HAOS image, and keep docs out of the stable image key

### DIFF
--- a/.github/workflows/build-haos-test-image.yml
+++ b/.github/workflows/build-haos-test-image.yml
@@ -12,9 +12,10 @@ name: Build HAOS Test Image (Prime Shared Cache)
 #
 # INVARIANT — the path triggers below MUST mirror the ``git ls-tree`` paths
 # that the six HAOS E2E lanes in ``haos-e2e-tests.yml`` hash into their image
-# cache keys (see each "Compute image cache key" step). The beta lanes in
-# ``haos-e2e-beta-tests.yml`` are NOT part of this invariant: they key a
-# separate ``haos-beta-image-*`` namespace this workflow never primes.
+# cache keys (see each "Compute image cache key" step), including the
+# ``*.md`` filter those keys apply. The beta lanes in
+# ``haos-e2e-beta-tests.yml`` are NOT part of this invariant: they use no
+# cache at all and bake their own image whenever they run.
 # When master commits change a baked
 # input that isn't listed here, the master cache-prime stays at the
 # previous state and every subsequent PR on a cache miss builds locally
@@ -34,6 +35,11 @@ on:
       - 'custom_components/ha_mcp_tools/**'
       - 'homeassistant-addon-webhook-proxy/**'
       - 'homeassistant-addon-dev/**'
+      # Markdown under those paths is not baked and is filtered out of the
+      # lanes' cache-key hash, so a doc-only commit leaves the key unchanged.
+      # Without this exclusion the prime would rebuild and then fail to save
+      # over its own still-current key.
+      - '!**/*.md'
       # The workflow itself — bumping the build script or env triggers a cache refresh.
       - '.github/workflows/build-haos-test-image.yml'
   schedule:

--- a/.github/workflows/build-haos-test-image.yml
+++ b/.github/workflows/build-haos-test-image.yml
@@ -264,7 +264,7 @@ jobs:
             tests/initial_test_state \
             custom_components/ha_mcp_tools \
             homeassistant-addon-webhook-proxy \
-            | sha256sum | cut -d' ' -f1 | head -c16)
+            | grep -v '\.md$' | sha256sum | cut -d' ' -f1 | head -c16)
           echo "cache-key=haos-image-$hash" >> "$GITHUB_OUTPUT"
 
       - name: Warm shared Actions cache for E2E lanes (master only)

--- a/.github/workflows/haos-e2e-beta-tests.yml
+++ b/.github/workflows/haos-e2e-beta-tests.yml
@@ -1,14 +1,16 @@
 name: HAOS E2E Tests (beta)
 
-# Both beta HAOS lanes live in this file (#2292 / #2302). They keep their
-# existing job ids, names, steps, and shared ``haos-beta-image-*`` cache key
-# for a qcow2 baked with the current beta OS, Supervisor, and Core.
-# `haos-e2e-inaddon-beta` is the sole writer of that cache;
-# `haos-e2e-embedded-beta` restores only (and can build locally on a miss).
+# Both beta HAOS lanes live in this file (#2292 / #2302). Each bakes its own
+# qcow2 from the current beta OS, Supervisor, and Core on every run.
+#
+# These lanes deliberately do NOT use the Actions cache (#2311). The beta image
+# is ~4.9 GB against a 10 GB repository budget, and holding it evicted both the
+# stable ``haos-image-*`` qcow2 that every pull request restores and the
+# ``ha-image-*`` Home Assistant container images that keep the e2e lanes off the
+# registry. No pull request waits on these lanes, so they pay the build instead.
 #
 # Both lanes run for every user-originated master push, the nightly schedule,
-# and manual dispatch. The embedded lane waits for the cache-writing inaddon
-# lane so a cache miss does not start two identical image builds.
+# and manual dispatch, and they run in parallel.
 
 on:
   # Test committed ha-mcp code against upcoming beta OS, Supervisor, and Core
@@ -35,11 +37,6 @@ on:
         type: string
         required: false
         default: 'src/e2e/'
-      force_local_build:
-        description: 'Build the qcow2 locally even on a cache hit (ignore the cached image)'
-        type: boolean
-        required: false
-        default: false
 
 permissions:
   contents: read
@@ -64,8 +61,8 @@ jobs:
   # whenever those change and
   # otherwise lives until cache eviction) is taken to cover it, and
   # both lanes below are skipped on push and schedule; a manual dispatch
-  # always runs. Each lane still resolves the versions itself for its cache
-  # key and build inputs.
+  # always runs. Each lane still resolves the versions itself for its build
+  # inputs.
   resolve-beta:
     name: Resolve beta versions
     runs-on: ubuntu-latest
@@ -174,33 +171,6 @@ jobs:
           echo "supervisor_version=$supervisor_version" >> "$GITHUB_OUTPUT"
           echo "core_version=$core_version" >> "$GITHUB_OUTPUT"
 
-      - name: Compute beta image cache key
-        id: key
-        # Both beta lanes restore this byte-identical image. The three upstream
-        # versions prevent an older beta image from satisfying a newer run;
-        # the hash invalidates it when any hashed repository bake input changes.
-        run: |
-          hash=$(git ls-tree -r HEAD \
-            tests/haos_image_build \
-            tests/initial_test_state \
-            custom_components/ha_mcp_tools \
-            homeassistant-addon-webhook-proxy \
-            | sha256sum | cut -d' ' -f1 | head -c16)
-          echo "cache-key=haos-beta-image-${{ steps.versions.outputs.os_version }}-${{ steps.versions.outputs.supervisor_version }}-${{ steps.versions.outputs.core_version }}-$hash" >> "$GITHUB_OUTPUT"
-
-      - name: Restore image from cache
-        id: restore-cache
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
-        with:
-          path: /tmp/haos-beta-test-image.qcow2
-          key: ${{ steps.key.outputs.cache-key }}
-
-      - name: Report beta image cache result
-        # Reports the cache lookup result; a forced local build may still run
-        # after a hit.
-        run: |
-          echo "::notice title=HAOS image cache::cache-hit=${{ steps.restore-cache.outputs.cache-hit }} key=${{ steps.key.outputs.cache-key }}"
-
       - name: Install QEMU + OVMF + libguestfs
         run: |
           sudo apt-get update
@@ -216,13 +186,11 @@ jobs:
           sudo udevadm trigger --name-match=kvm
 
       - name: Free disk space for the local build
-        # On a cache miss (or a forced rebuild) the qcow2 is built locally;
-        # its download (~1.5 GB xz) + decompress (~7 GB qcow2) + boot +
+        # The qcow2 is baked on every run; its download (~1.5 GB xz) + decompress (~7 GB qcow2) + boot +
         # app install peaks at the edge of the runner's ~14 GB SSD, so
         # prune the ~30 GB of preinstalled tooling the bake does not use.
         # Keep /opt/hostedtoolcache: Python from there is on PATH for
         # build_image.py. See haos-e2e-tests.yml for the full rationale.
-        if: steps.restore-cache.outputs.cache-hit != 'true' || github.event.inputs.force_local_build == 'true'
         run: |
           df -h /
           sudo rm -rf /usr/share/dotnet /usr/share/swift /opt/ghc \
@@ -231,12 +199,10 @@ jobs:
           docker system prune -af --volumes || true
           df -h /
 
-      - name: Install build-script Python deps (cache miss or forced rebuild)
-        if: steps.restore-cache.outputs.cache-hit != 'true' || github.event.inputs.force_local_build == 'true'
+      - name: Install build-script Python deps
         run: pip install -r tests/haos_image_build/requirements.txt
 
-      - name: Build image locally (cache miss or forced rebuild)
-        if: steps.restore-cache.outputs.cache-hit != 'true' || github.event.inputs.force_local_build == 'true'
+      - name: Build the beta image
         env:
           HAOS_BUILD_OS_VERSION: ${{ steps.versions.outputs.os_version }}
           HAOS_BUILD_SUPERVISOR_CHANNEL: beta
@@ -245,28 +211,6 @@ jobs:
         run: |
           python3 tests/haos_image_build/build_image.py --verbose \
             --output /tmp/haos-beta-test-image.qcow2
-
-      - name: Compress beta image for Actions cache
-        if: steps.restore-cache.outputs.cache-hit != 'true' || github.event.inputs.force_local_build == 'true'
-        run: |
-          qemu-img convert -c -O qcow2 \
-            /tmp/haos-beta-test-image.qcow2 \
-            /tmp/haos-beta-test-image.qcow2.compressed
-          mv /tmp/haos-beta-test-image.qcow2.compressed \
-            /tmp/haos-beta-test-image.qcow2
-          qemu-img check /tmp/haos-beta-test-image.qcow2
-          bytes=$(stat -c%s /tmp/haos-beta-test-image.qcow2)
-          if [ "$bytes" -lt 1073741824 ]; then
-            echo "::error::Compressed beta qcow2 is suspiciously small: $bytes bytes"
-            exit 1
-          fi
-
-      - name: Save beta image cache
-        if: steps.restore-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
-        with:
-          path: /tmp/haos-beta-test-image.qcow2
-          key: ${{ steps.key.outputs.cache-key }}
 
       - name: Install uv
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
@@ -420,10 +364,8 @@ jobs:
 
   haos-e2e-embedded-beta:
     name: HAOS E2E Tests (embedded beta)
-    # Wait for the sole cache writer to finish priming a new beta image. Still
-    # run if the inaddon suite fails after saving it, and build locally if that
-    # lane failed before the save; only a cancelled workflow suppresses this.
-    needs: [resolve-beta, haos-e2e-inaddon-beta]
+    # Bakes its own image, so it does not wait on the inaddon lane.
+    needs: [resolve-beta]
     if: ${{ !cancelled() && needs.resolve-beta.result == 'success' && (github.event_name == 'workflow_dispatch' || needs.resolve-beta.outputs.superfluous != 'true') }}
     runs-on: ubuntu-22.04
     # The embedded beta lane receives extra headroom for the per-worker runtime
@@ -470,33 +412,6 @@ jobs:
           echo "supervisor_version=$supervisor_version" >> "$GITHUB_OUTPUT"
           echo "core_version=$core_version" >> "$GITHUB_OUTPUT"
 
-      - name: Compute beta image cache key
-        id: key
-        # Both beta lanes restore this byte-identical image. The three upstream
-        # versions prevent an older beta image from satisfying a newer run;
-        # the hash invalidates it when any hashed repository bake input changes.
-        run: |
-          hash=$(git ls-tree -r HEAD \
-            tests/haos_image_build \
-            tests/initial_test_state \
-            custom_components/ha_mcp_tools \
-            homeassistant-addon-webhook-proxy \
-            | sha256sum | cut -d' ' -f1 | head -c16)
-          echo "cache-key=haos-beta-image-${{ steps.versions.outputs.os_version }}-${{ steps.versions.outputs.supervisor_version }}-${{ steps.versions.outputs.core_version }}-$hash" >> "$GITHUB_OUTPUT"
-
-      - name: Restore image from cache
-        id: restore-cache
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
-        with:
-          path: /tmp/haos-beta-test-image.qcow2
-          key: ${{ steps.key.outputs.cache-key }}
-
-      - name: Report beta image cache result
-        # Reports the cache lookup result; a forced local build may still run
-        # after a hit.
-        run: |
-          echo "::notice title=HAOS image cache::cache-hit=${{ steps.restore-cache.outputs.cache-hit }} key=${{ steps.key.outputs.cache-key }}"
-
       - name: Install QEMU + OVMF + libguestfs
         run: |
           sudo apt-get update
@@ -512,13 +427,12 @@ jobs:
           sudo udevadm trigger --name-match=kvm
 
       - name: Free disk space for the local build
-        # On a cache miss (or a forced rebuild) the qcow2 is built locally; its
+        # The qcow2 is baked on every run; its
         # download (~1.5 GB xz) + decompress (~7 GB qcow2) + boot + app install
         # peaks at the edge of the runner's ~14 GB SSD, so prune the ~30 GB of
         # preinstalled tooling the bake does not use. Keep /opt/hostedtoolcache:
         # Python from there is on PATH for build_image.py. See haos-e2e-tests.yml
         # for the full rationale.
-        if: steps.restore-cache.outputs.cache-hit != 'true' || github.event.inputs.force_local_build == 'true'
         run: |
           df -h /
           sudo rm -rf /usr/share/dotnet /usr/share/swift /opt/ghc \
@@ -527,12 +441,10 @@ jobs:
           docker system prune -af --volumes || true
           df -h /
 
-      - name: Install build-script Python deps (cache miss or forced rebuild)
-        if: steps.restore-cache.outputs.cache-hit != 'true' || github.event.inputs.force_local_build == 'true'
+      - name: Install build-script Python deps
         run: pip install -r tests/haos_image_build/requirements.txt
 
-      - name: Build image locally (cache miss or forced rebuild)
-        if: steps.restore-cache.outputs.cache-hit != 'true' || github.event.inputs.force_local_build == 'true'
+      - name: Build the beta image
         env:
           HAOS_BUILD_OS_VERSION: ${{ steps.versions.outputs.os_version }}
           HAOS_BUILD_SUPERVISOR_CHANNEL: beta

--- a/.github/workflows/haos-e2e-beta-tests.yml
+++ b/.github/workflows/haos-e2e-beta-tests.yml
@@ -454,10 +454,6 @@ jobs:
           python3 tests/haos_image_build/build_image.py --verbose \
             --output /tmp/haos-beta-test-image.qcow2
 
-      # The inaddon beta lane is the sole saver for this shared beta key. This
-      # dependent lane restores the primed image, or builds locally if the
-      # writer failed before saving it.
-
       - name: Install uv
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:

--- a/.github/workflows/haos-e2e-tests.yml
+++ b/.github/workflows/haos-e2e-tests.yml
@@ -185,7 +185,7 @@ jobs:
             tests/initial_test_state \
             custom_components/ha_mcp_tools \
             homeassistant-addon-webhook-proxy \
-            | sha256sum | cut -d' ' -f1 | head -c16)
+            | grep -v '\.md$' | sha256sum | cut -d' ' -f1 | head -c16)
           echo "cache-key=haos-image-$hash" >> "$GITHUB_OUTPUT"
 
       - name: Restore image from cache
@@ -420,7 +420,7 @@ jobs:
             tests/initial_test_state \
             custom_components/ha_mcp_tools \
             homeassistant-addon-webhook-proxy \
-            | sha256sum | cut -d' ' -f1 | head -c16)
+            | grep -v '\.md$' | sha256sum | cut -d' ' -f1 | head -c16)
           echo "cache-key=haos-image-$hash" >> "$GITHUB_OUTPUT"
 
       - name: Restore image from cache
@@ -647,7 +647,7 @@ jobs:
             tests/initial_test_state \
             custom_components/ha_mcp_tools \
             homeassistant-addon-webhook-proxy \
-            | sha256sum | cut -d' ' -f1 | head -c16)
+            | grep -v '\.md$' | sha256sum | cut -d' ' -f1 | head -c16)
           echo "cache-key=haos-image-$hash" >> "$GITHUB_OUTPUT"
 
       - name: Restore image from cache
@@ -911,7 +911,7 @@ jobs:
             tests/initial_test_state \
             custom_components/ha_mcp_tools \
             homeassistant-addon-webhook-proxy \
-            | sha256sum | cut -d' ' -f1 | head -c16)
+            | grep -v '\.md$' | sha256sum | cut -d' ' -f1 | head -c16)
           echo "cache-key=haos-image-$hash" >> "$GITHUB_OUTPUT"
 
       - name: Restore image from cache
@@ -1109,7 +1109,7 @@ jobs:
             tests/initial_test_state \
             custom_components/ha_mcp_tools \
             homeassistant-addon-webhook-proxy \
-            | sha256sum | cut -d' ' -f1 | head -c16)
+            | grep -v '\.md$' | sha256sum | cut -d' ' -f1 | head -c16)
           echo "cache-key=haos-image-$hash" >> "$GITHUB_OUTPUT"
 
       - name: Restore image from cache
@@ -1344,7 +1344,7 @@ jobs:
             tests/initial_test_state \
             custom_components/ha_mcp_tools \
             homeassistant-addon-webhook-proxy \
-            | sha256sum | cut -d' ' -f1 | head -c16)
+            | grep -v '\.md$' | sha256sum | cut -d' ' -f1 | head -c16)
           echo "cache-key=haos-image-$hash" >> "$GITHUB_OUTPUT"
 
       - name: Restore image from cache

--- a/tests/haos_image_build/README.md
+++ b/tests/haos_image_build/README.md
@@ -56,8 +56,8 @@ Beta lanes independently read `beta.json`: `hassos.ova`, `supervisor`, and
 for explicit local builds. OS prerelease versions such as `18.2.rc1` select
 the corresponding release qcow2 instead of the stable OS pin.
 
-The beta lanes do not use the Actions cache: each bakes its own qcow2 on every
-run, so a ~4.9 GB image never competes for the repository cache budget with the
+The beta lanes do not use the Actions cache: each bakes its own qcow2 whenever it
+runs, so a ~4.9 GB image never competes for the repository cache budget with the
 stable qcow2 and the Home Assistant container images. Automatic beta runs skip
 only when all three channel versions equal stable, so an OS-only beta release
 still runs. Manual dispatch always runs, and the beta canary checks the booted

--- a/tests/haos_image_build/README.md
+++ b/tests/haos_image_build/README.md
@@ -56,9 +56,9 @@ Beta lanes independently read `beta.json`: `hassos.ova`, `supervisor`, and
 for explicit local builds. OS prerelease versions such as `18.2.rc1` select
 the corresponding release qcow2 instead of the stable OS pin.
 
-The shared beta cache key includes all three resolved versions plus repository
-bake inputs. Only the in-app beta lane writes that cache; the embedded beta
-lane restores it or builds on a miss. Automatic beta runs skip only when all
-three channel versions equal stable, so an OS-only beta release still runs.
-Manual dispatch always runs, and the beta canary checks the booted VM's OS,
-Supervisor channel/minimum, and exact Core version.
+The beta lanes do not use the Actions cache: each bakes its own qcow2 on every
+run, so a ~4.9 GB image never competes for the repository cache budget with the
+stable qcow2 and the Home Assistant container images. Automatic beta runs skip
+only when all three channel versions equal stable, so an OS-only beta release
+still runs. Manual dispatch always runs, and the beta canary checks the booted
+VM's OS, Supervisor channel/minimum, and exact Core version.

--- a/tests/src/unit/test_haos_image_workflow_shape.py
+++ b/tests/src/unit/test_haos_image_workflow_shape.py
@@ -313,6 +313,10 @@ def test_beta_lanes_share_a_current_supervisor_and_core_image() -> None:
         build = next(
             step for step in steps if step.get("name") == "Build the beta image"
         )
+        assert "if" not in build, (
+            f"{beta_job_id} bakes its own image on every run: a conditional here "
+            "would leave the lane with no qcow2 (#2311)"
+        )
         assert build["env"] == {
             "HAOS_BUILD_OS_VERSION": "${{ steps.versions.outputs.os_version }}",
             "HAOS_BUILD_SUPERVISOR_CHANNEL": "beta",

--- a/tests/src/unit/test_haos_image_workflow_shape.py
+++ b/tests/src/unit/test_haos_image_workflow_shape.py
@@ -199,18 +199,19 @@ def test_beta_lane_discovery_does_not_depend_on_attestation(tmp_path: Path) -> N
 
 
 def test_beta_lanes_share_a_current_supervisor_and_core_image() -> None:
-    """Both beta lanes share one workflow and one manifest-keyed qcow2 cache.
+    """Both beta lanes bake the same beta OS, Supervisor, and Core.
 
     The lanes live in a single workflow file for each user-originated master
-    update, nightly schedule, or manual dispatch. The cache-writing inaddon
-    lane runs first, then the embedded lane consumes its image.
+    update, nightly schedule, or manual dispatch, and each bakes its own qcow2.
+    Neither touches the Actions cache: a ~4.9 GB image in a 10 GB repository
+    budget evicted the stable qcow2 and the Home Assistant container images
+    that the pull-request lanes restore (#2311).
     """
     lane_specs = (
         ("haos-e2e-inaddon-beta", "inaddon", "haos-e2e-inaddon"),
         ("haos-e2e-embedded-beta", "embedded", "haos-e2e-embedded"),
     )
     beta_resolvers: list[str] = []
-    beta_cache_keys: list[str] = []
     # The container beta workflow's resolver job is the only other beta.json
     # consumer; it has no HAOS mode and is pinned down by
     # test_container_beta_lane_resolves_the_beta_core_image_once below.
@@ -275,8 +276,9 @@ def test_beta_lanes_share_a_current_supervisor_and_core_image() -> None:
             assert job["needs"] == "resolve-beta"
             assert job["if"] == skip_guard
         else:
-            assert job["needs"] == ["resolve-beta", "haos-e2e-inaddon-beta"], (
-                "the embedded lane must wait for the sole cache writer"
+            assert job["needs"] == ["resolve-beta"], (
+                "the embedded lane bakes its own image, so it must not wait "
+                "on the inaddon lane (#2311)"
             )
             assert job["if"] == (
                 "${{ !cancelled() && needs.resolve-beta.result == 'success' "
@@ -299,20 +301,17 @@ def test_beta_lanes_share_a_current_supervisor_and_core_image() -> None:
         assert '["homeassistant"]["qemux86-64"]' in resolve["run"]
         beta_resolvers.append(resolve["run"])
 
-        cache_key = next(
-            step for step in steps if step.get("name") == "Compute beta image cache key"
+        assert not any(
+            str(step.get("uses", "")).partition("@")[0] in _CACHE_ACTIONS
+            for step in steps
+        ), (
+            f"{beta_job_id} must not use the Actions cache: a ~4.9 GB beta "
+            "image evicts the stable qcow2 and the HA container images that "
+            "the pull-request lanes restore (#2311)"
         )
-        cache_script = cache_key["run"]
-        assert "haos-beta-image-" in cache_script
-        assert "steps.versions.outputs.supervisor_version" in cache_script
-        assert "steps.versions.outputs.core_version" in cache_script
-        assert "steps.versions.outputs.os_version" in cache_script
-        beta_cache_keys.append(cache_script)
 
         build = next(
-            step
-            for step in steps
-            if step.get("name") == "Build image locally (cache miss or forced rebuild)"
+            step for step in steps if step.get("name") == "Build the beta image"
         )
         assert build["env"] == {
             "HAOS_BUILD_OS_VERSION": "${{ steps.versions.outputs.os_version }}",
@@ -322,11 +321,6 @@ def test_beta_lanes_share_a_current_supervisor_and_core_image() -> None:
             ),
             "HAOS_BUILD_CORE_VERSION": "${{ steps.versions.outputs.core_version }}",
         }
-
-        restore = next(
-            step for step in steps if step.get("name") == "Restore image from cache"
-        )
-        assert restore["with"]["path"] == "/tmp/haos-beta-test-image.qcow2"
 
         run_step = next(
             step for step in steps if step.get("env", {}).get("HAOS_TEST_MODE")
@@ -378,7 +372,6 @@ def test_beta_lanes_share_a_current_supervisor_and_core_image() -> None:
         assert "env" not in stable_build
 
     assert beta_resolvers[0] == beta_resolvers[1]
-    assert beta_cache_keys[0] == beta_cache_keys[1]
 
 
 def test_container_beta_lane_resolves_the_beta_core_image_once() -> None:

--- a/tests/src/unit/test_haos_image_workflow_shape.py
+++ b/tests/src/unit/test_haos_image_workflow_shape.py
@@ -29,7 +29,7 @@ _CACHE_KEY_COMMAND = """hash=$(git ls-tree -r HEAD \\
   tests/initial_test_state \\
   custom_components/ha_mcp_tools \\
   homeassistant-addon-webhook-proxy \\
-  | sha256sum | cut -d' ' -f1 | head -c16)
+  | grep -v '\\.md$' | sha256sum | cut -d' ' -f1 | head -c16)
 echo "cache-key=haos-image-$hash" >> "$GITHUB_OUTPUT"
 """
 


### PR DESCRIPTION
## What does this PR do?

Two changes to how the HAOS qcow2 images use the Actions cache.

**The beta lanes stop using the cache entirely.** Each now bakes its own qcow2 whenever it runs.

The beta image is ~4.9 GB and the repository cache budget is the 10 GB free-plan default. The stable `haos-image-*` qcow2 is another ~4.9 GB, so the two images alone fill the budget and evict everything else. A reading during this work found the repository holding 5 entries at 10.71 GB, of which the two qcow2 images were 9.80 GB (91%), with the x64 `ha-image-*` Home Assistant container image gone and only the ARM64 copy left. Five pull-request lanes restore that key, so the x64 ones re-pull from GHCR.

Nothing waits on the beta lanes. They run on master push, the nightly schedule and manual dispatch, never on `pull_request`. The pull-request lanes are the ones that wait on a cache hit, so the beta image gives up its space to them.

- both lanes drop the cache restore, save, and compress-for-cache steps, and build unconditionally
- `haos-e2e-embedded-beta` no longer `needs` `haos-e2e-inaddon-beta`. That dependency existed only so the cache write landed before the second lane restored it. The lanes now run in parallel
- the `force_local_build` dispatch input is removed. Every run is a local build
- `test_beta_lanes_share_a_current_supervisor_and_core_image` pins the new contract: neither beta lane may use `actions/cache/*`, and the build step may carry no `if:`

Each beta run now bakes two images instead of one, about 6.5 minutes each on lanes where nobody is waiting. Beta workflow wall clock improves, because the two lanes no longer run back to back.

**Markdown no longer invalidates the stable image cache key.** The key hashes `git ls-tree` over four bake-input directories, six of whose tracked files are markdown (`AGENTS.md`, `CHANGELOG.md`, `CLAUDE.md`, `DOCS.md` and two `README.md`). `build_image.py` reads none of them, so editing prose in those directories changed the key and made all six HAOS lanes rebuild the image.

This branch demonstrated it. The commit that edited only `tests/haos_image_build/README.md` moved the key from `haos-image-6105abf11f2df39a` to `haos-image-0e45732575a2a152`; with `*.md` filtered out of the hash, both commits produce `haos-image-8279557ff4891107`. At a median lane build of 6.5 minutes that is about 39 runner-minutes, and on the 21/21 sample in #2311 a miss push runs 21.6 minutes wall clock against 13.6 for a hit.

All seven consumers of the hash gain `| grep -v '\.md$'`: six lanes in `haos-e2e-tests.yml` and the primer in `build-haos-test-image.yml`. `test_haos_image_cache_key_command_matches_every_consumer` pins the command byte-for-byte, so its expected string moves with them. The blocks run under GitHub's default `bash -e` with no `pipefail`, and `grep -v` exits non-zero only if every tracked file under the four paths is markdown.

This does not change the master-prime side: since 2026-09-01, 15 of 112 master commits touched a hashed path and none was doc-only. It removes a cause of misses on pull-request branches only.

Contributes to #2311.

## Type of change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [x] 🔧 Maintenance/refactor
- [ ] 🧪 Tests only
- [ ] 💥 Breaking change

## Testing
- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`)
- [x] Code follows style guidelines (`uv run ruff check`)

111 passed across `test_haos_image_workflow_shape.py`, `test_e2e_skip_gate_shape.py`, `test_e2e_lane_env_shape.py`, `test_supply_chain_workflow_shape.py` and `test_codeql_workflow_shape.py`.

Each new assertion was checked against the regression it exists to catch: a reintroduced `actions/cache/restore` step in the inaddon beta lane, an `if:` added to a beta build step, and one of the six lanes left without the `*.md` filter. All three failed as intended and were reverted.

## Checklist
- [x] I have updated documentation if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Build Improvements**
  - Beta test environments now build their own images consistently, improving isolation and reducing competition for shared build resources.
  - Documentation-only changes no longer invalidate image reuse or trigger unnecessary image preparation workflows.

- **Testing**
  - Automated checks were updated to verify that beta images are built unconditionally and independently.
  - Image cache handling now ignores Markdown-only changes, helping keep test runs efficient without affecting functional inputs.

- **Documentation**
  - Updated beta testing guidance to reflect the current image-building behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->