### PR TITLE
fix(locale-sync): retry an unparseable engine answer like a transient status

### DIFF
--- a/scripts/translate_locales.py
+++ b/scripts/translate_locales.py
@@ -751,7 +751,8 @@ def _read_answer(response: httpx.Response) -> tuple[dict[str, Any] | None, str, 
         # call. Failing on the spot marked every string of that chunk failed
         # and counted toward declaring the engine dead. A prompt-level block
         # is the one shape that is deterministic; it is reported at once.
-        blocked = bool((payload.get("promptFeedback") or {}).get("blockReason"))
+        feedback = payload.get("promptFeedback")
+        blocked = isinstance(feedback, dict) and bool(feedback.get("blockReason"))
         return None, _describe_unusable(payload, exc, response.text), not blocked
     return parsed, "", True
 
@@ -765,8 +766,9 @@ def _describe_unusable(payload: dict[str, Any], exc: Exception, body: str) -> st
     reach neither, so a failed run could not say which it had seen. With no
     candidate text to show, the start of the raw body stands in for it.
     """
-    candidates = payload.get("candidates") or [{}]
-    candidate = candidates[0] if isinstance(candidates[0], dict) else {}
+    candidates = payload.get("candidates")
+    first = candidates[0] if isinstance(candidates, list) and candidates else None
+    candidate = first if isinstance(first, dict) else {}
     text = ""
     try:
         text = str(candidate["content"]["parts"][0]["text"])

--- a/scripts/translate_locales.py
+++ b/scripts/translate_locales.py
@@ -711,30 +711,64 @@ def _call_gemini(prompt: str) -> dict[str, Any]:
             print(f"  engine {last_error}; retrying in {delay}s", file=sys.stderr)
             time.sleep(delay)
             continue
-        if response.status_code == 200:
-            payload = response.json()
-            try:
-                text = payload["candidates"][0]["content"]["parts"][0]["text"]
-                parsed: dict[str, Any] = json.loads(text)
-            except (KeyError, IndexError, TypeError, json.JSONDecodeError) as exc:
-                # An empty/filtered candidate list or non-JSON answer should
-                # read like the HTTP failures, not a raw traceback.
-                raise SystemExit(
-                    f"Gemini API returned an unusable response ({exc!r}): "
-                    f"{json.dumps(payload)[:300]}"
-                ) from exc
+        parsed, last_error, retryable = _read_answer(response)
+        if parsed is not None:
             return parsed
-        last_error = f"HTTP {response.status_code}: {response.text[:300]}"
-        if response.status_code in (429, 500, 502, 503, 504):
-            if _out_of_time():
-                last_error += " (time budget exhausted; not retrying)"
-                break
-            delay = 20 * attempt
-            print(f"  engine {last_error}; retrying in {delay}s", file=sys.stderr)
-            time.sleep(delay)
-            continue
-        break
+        if not retryable:
+            break
+        if _out_of_time():
+            last_error += " (time budget exhausted; not retrying)"
+            break
+        delay = 20 * attempt
+        print(f"  engine {last_error}; retrying in {delay}s", file=sys.stderr)
+        time.sleep(delay)
     raise SystemExit(f"Gemini API call failed: {last_error}")
+
+
+def _read_answer(response: httpx.Response) -> tuple[dict[str, Any] | None, str, bool]:
+    """``(parsed, error, retryable)`` for one engine response."""
+    if response.status_code != 200:
+        error = f"HTTP {response.status_code}: {response.text[:300]}"
+        return None, error, response.status_code in (429, 500, 502, 503, 504)
+    payload = response.json()
+    try:
+        text = payload["candidates"][0]["content"]["parts"][0]["text"]
+        parsed: dict[str, Any] = json.loads(text)
+    except (KeyError, IndexError, TypeError, json.JSONDecodeError) as exc:
+        # An empty/filtered candidate list or non-JSON answer reads like the
+        # HTTP failures, not a raw traceback — and retries like them: the
+        # engine has answered a 200 carrying a JSON object cut off a third of
+        # the way in, for a chunk the identical prompt completed on the next
+        # call. Failing on the spot marked every string of that chunk failed
+        # and counted toward declaring the engine dead. A prompt-level block
+        # is the one shape that is deterministic; it is reported at once.
+        blocked = bool((payload.get("promptFeedback") or {}).get("blockReason"))
+        return None, _describe_unusable(payload, exc), not blocked
+    return parsed, "", True
+
+
+def _describe_unusable(payload: dict[str, Any], exc: Exception) -> str:
+    """One line naming why a 200 carried no parseable JSON object.
+
+    The finish reason and token usage are what tell a cut-off answer
+    (MAX_TOKENS, SAFETY, RECITATION) from a malformed one (STOP); the first
+    300 characters of the raw payload, which is what used to be logged,
+    reach neither, so a failed run could not say which it had seen.
+    """
+    candidates = payload.get("candidates") or [{}]
+    candidate = candidates[0] if isinstance(candidates[0], dict) else {}
+    text = ""
+    try:
+        text = str(candidate["content"]["parts"][0]["text"])
+    except (KeyError, IndexError, TypeError):
+        pass
+    return (
+        f"unusable response ({exc!r}); "
+        f"finishReason={candidate.get('finishReason')}; "
+        f"promptFeedback={json.dumps(payload.get('promptFeedback'))}; "
+        f"usageMetadata={json.dumps(payload.get('usageMetadata'))}; "
+        f"text[{len(text)} chars] ends {text[-200:]!r}"
+    )
 
 
 def _chunk(batch: dict[str, str]) -> list[dict[str, str]]:

--- a/scripts/translate_locales.py
+++ b/scripts/translate_locales.py
@@ -730,10 +730,19 @@ def _read_answer(response: httpx.Response) -> tuple[dict[str, Any] | None, str, 
     if response.status_code != 200:
         error = f"HTTP {response.status_code}: {response.text[:300]}"
         return None, error, response.status_code in (429, 500, 502, 503, 504)
-    payload = response.json()
+    try:
+        envelope = response.json()
+    except ValueError as exc:
+        # Not JSON at all — a proxy's HTML error page behind a 200.
+        return None, _describe_unusable({}, exc, response.text), True
+    # A JSON body that is not an object (``[]`` from a proxy) must reach the
+    # same report and retry, not an AttributeError on the lookups below.
+    payload: dict[str, Any] = envelope if isinstance(envelope, dict) else {}
     try:
         text = payload["candidates"][0]["content"]["parts"][0]["text"]
-        parsed: dict[str, Any] = json.loads(text)
+        parsed = json.loads(text)
+        if not isinstance(parsed, dict):
+            raise TypeError(f"answer is a JSON {type(parsed).__name__}, not an object")
     except (KeyError, IndexError, TypeError, json.JSONDecodeError) as exc:
         # An empty/filtered candidate list or non-JSON answer reads like the
         # HTTP failures, not a raw traceback — and retries like them: the
@@ -743,17 +752,18 @@ def _read_answer(response: httpx.Response) -> tuple[dict[str, Any] | None, str, 
         # and counted toward declaring the engine dead. A prompt-level block
         # is the one shape that is deterministic; it is reported at once.
         blocked = bool((payload.get("promptFeedback") or {}).get("blockReason"))
-        return None, _describe_unusable(payload, exc), not blocked
+        return None, _describe_unusable(payload, exc, response.text), not blocked
     return parsed, "", True
 
 
-def _describe_unusable(payload: dict[str, Any], exc: Exception) -> str:
+def _describe_unusable(payload: dict[str, Any], exc: Exception, body: str) -> str:
     """One line naming why a 200 carried no parseable JSON object.
 
     The finish reason and token usage are what tell a cut-off answer
     (MAX_TOKENS, SAFETY, RECITATION) from a malformed one (STOP); the first
     300 characters of the raw payload, which is what used to be logged,
-    reach neither, so a failed run could not say which it had seen.
+    reach neither, so a failed run could not say which it had seen. With no
+    candidate text to show, the start of the raw body stands in for it.
     """
     candidates = payload.get("candidates") or [{}]
     candidate = candidates[0] if isinstance(candidates[0], dict) else {}
@@ -761,13 +771,18 @@ def _describe_unusable(payload: dict[str, Any], exc: Exception) -> str:
     try:
         text = str(candidate["content"]["parts"][0]["text"])
     except (KeyError, IndexError, TypeError):
-        pass
+        pass  # no candidate text at all; the raw body stands in below
+    shown = (
+        f"text[{len(text)} chars] ends {text[-200:]!r}"
+        if text
+        else f"body starts {body[:200]!r}"
+    )
     return (
         f"unusable response ({exc!r}); "
         f"finishReason={candidate.get('finishReason')}; "
         f"promptFeedback={json.dumps(payload.get('promptFeedback'))}; "
         f"usageMetadata={json.dumps(payload.get('usageMetadata'))}; "
-        f"text[{len(text)} chars] ends {text[-200:]!r}"
+        f"{shown}"
     )
 
 

--- a/src/ha_mcp/settings_ui/locales/README.md
+++ b/src/ha_mcp/settings_ui/locales/README.md
@@ -222,9 +222,11 @@ accurate and runs `python scripts/update_locale_baseline.py`.
 ## Sync failures and recovery
 
 The translation workflow uses conservative pacing and retries transient 429,
-5xx, and timeout failures with backoff. A repeatedly failing request records
-its strings as failed and continues; two dead batches stop the run before it
-burns the remaining quota.
+5xx, and timeout failures with backoff, and treats a 200 whose body is not a
+parseable JSON object (a cut-off or malformed answer) the same way; only a
+prompt-level block is reported without a retry. A repeatedly failing request
+records its strings as failed and continues; two dead batches stop the run
+before it burns the remaining quota.
 
 A partial run commits completed translations plus
 `tests/src/unit/locale_sync_progress.json`. Rerun the workflow or wait for the

--- a/tests/src/unit/test_translate_locales.py
+++ b/tests/src/unit/test_translate_locales.py
@@ -948,6 +948,50 @@ class TestCallGeminiRetry:
         assert translate_locales._call_gemini("prompt") == {"s0": "Hallo"}
         assert len(calls) == 2
 
+    def test_non_object_envelope_is_retried_not_a_traceback(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A 200 whose body is JSON but not an object (a proxy answering
+        ``[]``), or not JSON at all (an HTML error page), must reach the same
+        report and retry as a cut-off answer — not an AttributeError or a
+        JSONDecodeError escaping from the envelope parse."""
+
+        def raise_value_error() -> Any:
+            raise json.JSONDecodeError("Expecting value", "<html>", 0)
+
+        calls: list[int] = []
+        responses = [
+            SimpleNamespace(status_code=200, text="[]", json=list),
+            SimpleNamespace(status_code=200, text="<html>", json=raise_value_error),
+            self._response(200),
+        ]
+
+        def fake_post(*_args: Any, **_kwargs: Any) -> Any:
+            calls.append(1)
+            return responses[len(calls) - 1]
+
+        monkeypatch.setattr(translate_locales.httpx, "post", fake_post)
+        assert translate_locales._call_gemini("prompt") == {"s0": "Hallo"}
+        assert len(calls) == 3
+
+    def test_non_object_answer_is_retried(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The candidate text parsing as a JSON list would make every
+        ``response.get`` downstream an AttributeError; it is an unusable
+        answer like any other."""
+        listed = {"candidates": [{"content": {"parts": [{"text": "[]"}]}}]}
+        calls: list[int] = []
+        responses = [self._response(200, listed), self._response(200)]
+
+        def fake_post(*_args: Any, **_kwargs: Any) -> Any:
+            calls.append(1)
+            return responses[len(calls) - 1]
+
+        monkeypatch.setattr(translate_locales.httpx, "post", fake_post)
+        assert translate_locales._call_gemini("prompt") == {"s0": "Hallo"}
+        assert len(calls) == 2
+
     def test_persistently_unparseable_answer_names_the_finish_reason(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/src/unit/test_translate_locales.py
+++ b/tests/src/unit/test_translate_locales.py
@@ -16,7 +16,7 @@ import os
 import sys
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Any
+from typing import Any, ClassVar
 
 import pytest
 
@@ -906,15 +906,66 @@ class TestCallGeminiRetry:
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """HTTP 200 with an empty candidates list (safety-filter block) must
-        read like the other engine failures, not a raw IndexError."""
+        read like the other engine failures, not a raw IndexError — and a
+        prompt-level block is deterministic, so it is not retried."""
         blocked = {"candidates": [], "promptFeedback": {"blockReason": "SAFETY"}}
-        monkeypatch.setattr(
-            translate_locales.httpx,
-            "post",
-            lambda *_a, **_k: self._response(200, blocked),
-        )
-        with pytest.raises(SystemExit, match="unusable response"):
+        calls: list[int] = []
+
+        def fake_post(*_args: Any, **_kwargs: Any) -> Any:
+            calls.append(1)
+            return self._response(200, blocked)
+
+        monkeypatch.setattr(translate_locales.httpx, "post", fake_post)
+        with pytest.raises(SystemExit, match="unusable response") as excinfo:
             translate_locales._call_gemini("prompt")
+        assert len(calls) == 1
+        assert 'promptFeedback={"blockReason": "SAFETY"}' in str(excinfo.value)
+
+    # A 200 whose JSON object stops a third of the way in, as the engine
+    # answered once for a 95-string chunk the identical prompt then
+    # completed on the next call.
+    _CUT_OFF: ClassVar[dict[str, Any]] = {
+        "candidates": [
+            {
+                "content": {"parts": [{"text": '{\n "s0": "你好",\n'}]},
+                "finishReason": "STOP",
+            }
+        ],
+        "usageMetadata": {"candidatesTokenCount": 7},
+    }
+
+    def test_unparseable_answer_is_retried_like_a_transient_status(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        calls: list[int] = []
+        responses = [self._response(200, self._CUT_OFF), self._response(200)]
+
+        def fake_post(*_args: Any, **_kwargs: Any) -> Any:
+            calls.append(1)
+            return responses[len(calls) - 1]
+
+        monkeypatch.setattr(translate_locales.httpx, "post", fake_post)
+        assert translate_locales._call_gemini("prompt") == {"s0": "Hallo"}
+        assert len(calls) == 2
+
+    def test_persistently_unparseable_answer_names_the_finish_reason(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        calls: list[int] = []
+
+        def fake_post(*_args: Any, **_kwargs: Any) -> Any:
+            calls.append(1)
+            return self._response(200, self._CUT_OFF)
+
+        monkeypatch.setattr(translate_locales.httpx, "post", fake_post)
+        with pytest.raises(SystemExit, match="unusable response") as excinfo:
+            translate_locales._call_gemini("prompt")
+        assert len(calls) == 5
+        message = str(excinfo.value)
+        assert "finishReason=STOP" in message
+        assert '"candidatesTokenCount": 7' in message
+        cut_text = self._CUT_OFF["candidates"][0]["content"]["parts"][0]["text"]
+        assert message.endswith(f"ends {cut_text!r}")
 
 
 class TestEngineFailureDegradation:

--- a/tests/src/unit/test_translate_locales.py
+++ b/tests/src/unit/test_translate_locales.py
@@ -974,6 +974,23 @@ class TestCallGeminiRetry:
         assert translate_locales._call_gemini("prompt") == {"s0": "Hallo"}
         assert len(calls) == 3
 
+    def test_odd_shaped_envelope_fields_are_retried_not_a_traceback(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``promptFeedback`` that is not an object and ``candidates`` that is
+        not a list must not raise out of the shape lookups either."""
+        odd = {"candidates": {"not": "a list"}, "promptFeedback": "not an object"}
+        calls: list[int] = []
+        responses = [self._response(200, odd), self._response(200)]
+
+        def fake_post(*_args: Any, **_kwargs: Any) -> Any:
+            calls.append(1)
+            return responses[len(calls) - 1]
+
+        monkeypatch.setattr(translate_locales.httpx, "post", fake_post)
+        assert translate_locales._call_gemini("prompt") == {"s0": "Hallo"}
+        assert len(calls) == 2
+
     def test_non_object_answer_is_retried(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:


### PR DESCRIPTION
## What does this PR do?

Locale Sync run 34586359852 failed 95 zh-Hant strings in one chunk: the
engine answered HTTP 200 with a JSON object cut off a third of the way in
(`JSONDecodeError ... line 25 column 1`). `_call_gemini` raised on the spot,
so every string in the chunk was marked failed and the failure counted toward
the two-strikes engine-dead rule, while 429/5xx and transport errors already
get five attempts with backoff. Replaying the identical chunk (run
34596102392) returned `finishReason: STOP`, 2913 output tokens, and all 95
keys, so the answer was transient, not a size limit: the model's output
ceiling is 65,536 tokens and a full 95-key response needs under 3,000.

- Classify each response in one helper (`_read_answer`); an unparseable 200
  is retried with the same bounded backoff. A prompt-level block
  (`promptFeedback.blockReason`) is still reported without a retry.
- The final error names the finish reason, prompt feedback, token usage and
  the tail of the returned text. The first 300 characters of the raw payload,
  which is what was logged before, reach none of those, so the original run
  could not say what it had received.
- README: the recovery section now states that unparseable answers are
  retried.

## Type of change
- [x] 🐛 Bug fix

## Testing
- [ ] I have tested these changes with a LLM agent
- [x] All automated tests pass (`uv run pytest`) — `tests/src/unit/test_translate_locales.py -k "TestCallGeminiRetry or TestEngineFailureDegradation"`, 10 passed; full suite left to CI
- [x] Code follows style guidelines (`uv run ruff check`)

## Checklist
- [x] I have updated documentation if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Malformed, incomplete, or unexpectedly shaped successful responses are now retried with backoff instead of causing errors.
  - Non-object answers are handled as unusable responses and retried.
  - Persistent failures provide clearer diagnostics, including completion status, usage details, and response text context.
  - Prompt-blocked responses continue to produce a clear error without retrying.

- **Documentation**
  - Updated sync-failure guidance to explain retry behavior and prompt-block handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->